### PR TITLE
[fix](spill) should call set_ready after changing the status

### DIFF
--- a/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp
@@ -227,7 +227,6 @@ Status PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(Runtime
             }
             Base::_shared_state->in_mem_shared_state->aggregate_data_container->init_once();
             _is_merging = false;
-            _dependency->Dependency::set_ready();
         }};
         bool has_agg_data = false;
         auto& parent = Base::_parent->template cast<Parent>();
@@ -286,6 +285,7 @@ Status PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(Runtime
         if (!status.ok()) {
             _status = status;
         }
+        _dependency->set_ready();
     };
 
     DBUG_EXECUTE_IF("fault_inject::partitioned_agg_source::submit_func", {

--- a/be/src/pipeline/exec/spill_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/spill_sort_sink_operator.cpp
@@ -231,12 +231,6 @@ Status SpillSortSinkLocalState::revoke_memory(RuntimeState* state) {
             }
 
             _spilling_stream.reset();
-            if (_eos) {
-                _dependency->set_ready_to_read();
-                _finish_dependency->set_ready();
-            } else {
-                _dependency->Dependency::set_ready();
-            }
         }};
 
         _shared_state->sink_status =
@@ -279,6 +273,13 @@ Status SpillSortSinkLocalState::revoke_memory(RuntimeState* state) {
         _shared_state->sink_status = [&]() {
             RETURN_IF_CATCH_EXCEPTION({ return spill_func(); });
         }();
+
+        if (_eos) {
+            _dependency->set_ready_to_read();
+            _finish_dependency->set_ready();
+        } else {
+            _dependency->Dependency::set_ready();
+        }
     };
 
     DBUG_EXECUTE_IF("fault_inject::spill_sort_sink::revoke_memory_submit_func", {

--- a/be/src/pipeline/exec/spill_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/spill_sort_source_operator.cpp
@@ -102,7 +102,6 @@ Status SpillSortLocalState::initiate_merge_sort_spill_streams(RuntimeState* stat
                 VLOG_DEBUG << "query " << print_id(query_id) << " sort node " << _parent->node_id()
                            << " merge spill data finish";
             }
-            _dependency->Dependency::set_ready();
         }};
         vectorized::Block merge_sorted_block;
         vectorized::SpillStreamSPtr tmp_stream;
@@ -175,6 +174,7 @@ Status SpillSortLocalState::initiate_merge_sort_spill_streams(RuntimeState* stat
 
     auto exception_catch_func = [this, spill_func]() {
         _status = [&]() { RETURN_IF_CATCH_EXCEPTION({ return spill_func(); }); }();
+        _dependency->Dependency::set_ready();
     };
 
     DBUG_EXECUTE_IF("fault_inject::spill_sort_source::merge_sort_spill_data_submit_func", {


### PR DESCRIPTION
## Proposed changes

After `set_ready` is called, other threads will access the `Status` variable, so to avoid conflicts, we should call `set_ready` after setting `Status`.

```
==15749==ERROR: AddressSanitizer: heap-use-after-free on address 0x606000793160 at pc 0x55d4f350092d bp 0x7f15320f5750 sp 0x7f15320f4f18
READ of size 48 at 0x606000793160 thread T1311 (Pipe_normal [wo)
    #0 0x55d4f350092c in __asan_memcpy (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb4592c) (BuildId: faf5e280102bc969)
    #1 0x55d4f356126f in std::char_traits<char>::copy(char*, char const*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/char_traits.h:409:33
    #2 0x55d4f356126f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_copy(char*, char const*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:351:4
    #3 0x55d4f356126f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_copy_chars(char*, char*, char*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:393:9
    #4 0x55d4f356126f in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<char*>(char*, char*, std::forward_iterator_tag) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:225:6
    #5 0x55d4f389843b in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct_aux<char*>(char*, char*, std::__false_type) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:247:11
    #6 0x55d4f389843b in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<char*>(char*, char*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:266:4
    #7 0x55d4f389843b in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:451:9
    #8 0x55d4f389843b in doris::Status::ErrMsg::ErrMsg(doris::Status::ErrMsg const&) /root/doris/be/src/common/status.h:552:12
    #9 0x55d4f389843b in std::_MakeUniq<doris::Status::ErrMsg>::__single_object std::make_unique<doris::Status::ErrMsg, doris::Status::ErrMsg&>(doris::Status::ErrMsg&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:962:34
    #10 0x55d4f38980d6 in doris::Status::operator=(doris::Status const&) /root/doris/be/src/common/status.h:380:24
    #11 0x55d5281fc948 in doris::Status::Status(doris::Status const&) /root/doris/be/src/common/status.h:371:39
    #12 0x55d5281fc948 in doris::pipeline::PartitionedAggSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) /root/doris/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp:137:5
    #13 0x55d524e72746 in doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) /root/doris/be/src/pipeline/exec/operator.cpp:335:12
    #14 0x55d529430db1 in doris::pipeline::PipelineTask::execute(bool*) /root/doris/be/src/pipeline/pipeline_task.cpp:353:13
    #15 0x55d52946d6b3 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:138:9
    #16 0x55d4f7c2af5d in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
    #17 0x55d4f7c0419e in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #18 0x55d4f7c0419e in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #19 0x7f16e7e09608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #20 0x7f16e80b6132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x606000793160 is located 0 bytes inside of 49-byte region [0x606000793160,0x606000793191)
freed by thread T549 (SpillIOThreadPo) here:
    #0 0x55d4f353c80d in operator delete(void*) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb8180d) (BuildId: faf5e280102bc969)
    #1 0x55d4f38981a7 in __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:139:2
    #2 0x55d4f38981a7 in std::allocator<char>::deallocate(char*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:187:27
    #3 0x55d4f38981a7 in std::allocator_traits<std::allocator<char>>::deallocate(std::allocator<char>&, char*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:492:13
    #4 0x55d4f38981a7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_destroy(unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:237:9
    #5 0x55d4f38981a7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_dispose() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:232:4
    #6 0x55d4f38981a7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::~basic_string() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:658:9
    #7 0x55d4f38981a7 in doris::Status::ErrMsg::~ErrMsg() /root/doris/be/src/common/status.h:552:12
    #8 0x55d4f38981a7 in std::default_delete<doris::Status::ErrMsg>::operator()(doris::Status::ErrMsg*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #9 0x55d4f38981a7 in std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>>::reset(doris::Status::ErrMsg*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182:4
    #10 0x55d4f38981a7 in std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>>::operator=(std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:167:2
    #11 0x55d4f38981a7 in std::__uniq_ptr_data<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>, true, true>::operator=(std::__uniq_ptr_data<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>, true, true>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:212:61
    #12 0x55d4f38981a7 in std::unique_ptr<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>>::operator=(std::unique_ptr<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:371:51
    #13 0x55d4f38981a7 in doris::Status::operator=(doris::Status const&) /root/doris/be/src/common/status.h:380:22
    #14 0x55d528203e1a in doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1::operator()() const /root/doris/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp:287:21
    #15 0x55d528203e1a in void std::__invoke_impl<void, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&>(std::__invoke_other, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #16 0x55d528203e1a in std::enable_if<is_invocable_r_v<void, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&>, void>::type std::__invoke_r<void, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&>(doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #17 0x55d528203e1a in std::_Function_handler<void (), doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1>::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #18 0x55d5281f3506 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #19 0x55d5281f3506 in doris::pipeline::SpillRunnable::run() /root/doris/be/src/pipeline/exec/spill_utils.h:63:9
    #20 0x55d4f7c2af5d in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
    #21 0x55d4f7c0419e in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #22 0x55d4f7c0419e in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #23 0x7f16e7e09608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8

previously allocated by thread T549 (SpillIOThreadPo) here:
    #0 0x55d4f353bfad in operator new(unsigned long) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb80fad) (BuildId: faf5e280102bc969)
    #1 0x55d4f355ec2d in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:307:21
    #2 0x55d4f35601a7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_replace(unsigned long, unsigned long, char const*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:498:8
    #3 0x55d4f358aad2 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::assign(char const*, unsigned long) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:1429:9
    #4 0x55d4f358aad2 in std::enable_if<__and_<std::is_convertible<std::basic_string_view<char, std::char_traits<char>> const&, std::basic_string_view<char, std::char_traits<char>>>, std::__not_<std::is_convertible<std::basic_string_view<char, std::char_traits<char>> const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const*>>, std::__not_<std::is_convertible<std::basic_string_view<char, std::char_traits<char>> const&, char const*>>>::value, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&>::type std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::assign<std::basic_string_view<char, std::char_traits<char>>>(std::basic_string_view<char, std::char_traits<char>> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:1502:17
    #5 0x55d4f358aad2 in std::enable_if<__and_<std::is_convertible<std::basic_string_view<char, std::char_traits<char>> const&, std::basic_string_view<char, std::char_traits<char>>>, std::__not_<std::is_convertible<std::basic_string_view<char, std::char_traits<char>> const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const*>>, std::__not_<std::is_convertible<std::basic_string_view<char, std::char_traits<char>> const&, char const*>>>::value, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&>::type std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::operator=<std::basic_string_view<char, std::char_traits<char>>>(std::basic_string_view<char, std::char_traits<char>> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:786:23
    #6 0x55d4f358aad2 in doris::Status doris::Status::Error<3, true>(std::basic_string_view<char, std::char_traits<char>>) /root/doris/be/src/common/status.h:414:35
    #7 0x55d524db0477 in doris::vectorized::SpillStream::read_next_block_sync(doris::vectorized::Block*, bool*) /root/doris/be/src/vec/spill/spill_stream.cpp:134:5
    #8 0x55d528202564 in doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_0::operator()() const /root/doris/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp:252:47
    #9 0x55d528202564 in doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1::operator()() const::'lambda'()::operator()() const /root/doris/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp:284:31
    #10 0x55d528202564 in doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1::operator()() const /root/doris/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp:284:23
    #11 0x55d528202564 in void std::__invoke_impl<void, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&>(std::__invoke_other, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #12 0x55d528202564 in std::enable_if<is_invocable_r_v<void, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&>, void>::type std::__invoke_r<void, doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&>(doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #13 0x55d528202564 in std::_Function_handler<void (), doris::pipeline::PartitionedAggLocalState::initiate_merge_spill_partition_agg_data(doris::RuntimeState*)::$_1>::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #14 0x55d5281f3506 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #15 0x55d5281f3506 in doris::pipeline::SpillRunnable::run() /root/doris/be/src/pipeline/exec/spill_utils.h:63:9
    #16 0x55d4f7c2af5d in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
    #17 0x55d4f7c0419e in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #18 0x55d4f7c0419e in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #19 0x7f16e7e09608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8

Thread T1311 (Pipe_normal [wo) created by T1307 here:
    #0 0x55d4f34e9caa in pthread_create (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb2ecaa) (BuildId: faf5e280102bc969)
    #1 0x55d4f7c03190 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:449:15
    #2 0x55d4f7c326c1 in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:56:16
    #3 0x55d4f7c29525 in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:611:12
    #4 0x55d4f7c28fce in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:265:25
    #5 0x55d4f363bafa in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /root/doris/be/src/util/threadpool.h:121:13
    #6 0x55d52946b13c in doris::pipeline::TaskScheduler::start() /root/doris/be/src/pipeline/task_scheduler.cpp:55:5
    #7 0x55d4f770dfcd in doris::WorkloadGroup::upsert_task_scheduler(doris::WorkloadGroupInfo*, doris::ExecEnv*) /root/doris/be/src/runtime/workload_group/workload_group.cpp:442:47
    #8 0x55d4f36af10f in doris::WorkloadGroupListener::handle_topic_info(std::vector<doris::TopicInfo, std::allocator<doris::TopicInfo>> const&) /root/doris/be/src/agent/workload_group_listener.cpp:62:13
    #9 0x55d4f3684d11 in doris::TopicSubscriber::handle_topic_info(doris::TPublishTopicRequest const&) /root/doris/be/src/agent/topic_subscriber.cpp:48:35
    #10 0x55d4f7fbc03d in doris::BackendServiceProcessor::process_publish_topic_info(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) /root/doris/gensrc/build/gen_cpp/BackendService.cpp:8317:13
    #11 0x55d4f7f71439 in doris::BackendServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, int, void*) /root/doris/gensrc/build/gen_cpp/BackendService.cpp:6886:3
    #12 0x55d4f8022423 in apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*) /var/local/thirdparty/installed/include/thrift/TDispatchProcessor.h:121:12
    #13 0x55d529e86a73 in apache::thrift::server::TConnectedClient::run() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664cba73) (BuildId: faf5e280102bc969)
    #14 0x55d529e87e55 in apache::thrift::server::TThreadedServer::TConnectedClientRunner::run() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664cce55) (BuildId: faf5e280102bc969)
    #15 0x55d529e8d1db in apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d21db) (BuildId: faf5e280102bc969)
    #16 0x55d529e8c9f5 in void std::__invoke_impl<void, void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(std::__invoke_other, void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d19f5) (BuildId: faf5e280102bc969)
    #17 0x55d529e8c96c in std::__invoke_result<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>::type std::__invoke<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>(void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d196c) (BuildId: faf5e280102bc969)
    #18 0x55d529e8c941 in void std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d1941) (BuildId: faf5e280102bc969)
    #19 0x55d529e8c904 in std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>::operator()() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d1904) (BuildId: faf5e280102bc969)
    #20 0x55d529e8c768 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>>>>::_M_run() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d1768) (BuildId: faf5e280102bc969)
    #21 0x55d52c78b64f in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18

Thread T1307 created by T627 here:
    #0 0x55d4f34e9caa in pthread_create (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb2ecaa) (BuildId: faf5e280102bc969)
    #1 0x55d52c78b775 in __gthread_create /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x55d52c78b775 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x55d529e8be12 in apache::thrift::concurrency::Thread::start() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664d0e12) (BuildId: faf5e280102bc969)
    #4 0x55d529e87b36 in apache::thrift::server::TThreadedServer::onClientConnected(std::shared_ptr<apache::thrift::server::TConnectedClient> const&) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664ccb36) (BuildId: faf5e280102bc969)
    #5 0x55d529e83e34 in apache::thrift::server::TServerFramework::newlyConnectedClient(std::shared_ptr<apache::thrift::server::TConnectedClient> const&) (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664c8e34) (BuildId: faf5e280102bc969)
    #6 0x55d529e8382e in apache::thrift::server::TServerFramework::serve() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664c882e) (BuildId: faf5e280102bc969)
    #7 0x55d529e87898 in apache::thrift::server::TThreadedServer::serve() (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x664cc898) (BuildId: faf5e280102bc969)
    #8 0x55d4f7c51546 in doris::ThriftServer::ThriftServerEventProcessor::supervise() /root/doris/be/src/util/thrift_server.cpp:187:34
    #9 0x55d52c78b64f in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18

Thread T627 created by T0 here:
    #0 0x55d4f34e9caa in pthread_create (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb2ecaa) (BuildId: faf5e280102bc969)
    #1 0x55d52c78b775 in __gthread_create /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x55d52c78b775 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:147:37
    #3 0x55d4f7c4fd97 in std::_MakeUniq<std::thread>::__single_object std::make_unique<std::thread, void (doris::ThriftServer::ThriftServerEventProcessor::*)(), doris::ThriftServer::ThriftServerEventProcessor*>(void (doris::ThriftServer::ThriftServerEventProcessor::*&&)(), doris::ThriftServer::ThriftServerEventProcessor*&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:962:34
    #4 0x55d4f7c4fd97 in doris::ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() /root/doris/be/src/util/thrift_server.cpp:152:38
    #5 0x55d4f7c575ba in doris::ThriftServer::start() /root/doris/be/src/util/thrift_server.cpp:402:5
    #6 0x55d4f3544e78 in main /root/doris/be/src/service/doris_main.cpp:566:25
    #7 0x7f16e7fbb082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

Thread T549 (SpillIOThreadPo) created by T0 here:
    #0 0x55d4f34e9caa in pthread_create (/home/work/unlimit_teamcity/work/60183217f6ee2a9c/output/be/lib/doris_be+0x2fb2ecaa) (BuildId: faf5e280102bc969)
    #1 0x55d4f7c03190 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:449:15
    #2 0x55d4f7c326c1 in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:56:16
    #3 0x55d4f7c29525 in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:611:12
    #4 0x55d4f7c28fce in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:265:25
    #5 0x55d4f363bafa in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /root/doris/be/src/util/threadpool.h:121:13
    #6 0x55d524d91233 in doris::vectorized::SpillStreamManager::init() /root/doris/be/src/vec/spill/spill_stream_manager.cpp:80:32
    #7 0x55d4f70aaeae in doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&, std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) /root/doris/be/src/runtime/exec_env_init.cpp:367:5
    #8 0x55d4f70a543d in doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&, std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) /root/doris/be/src/runtime/exec_env_init.cpp:187:17
    #9 0x55d4f3543fb7 in main /root/doris/be/src/service/doris_main.cpp:532:14
    #10 0x7f16e7fbb082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16
```
