### PR TITLE
[feat](Authenticator) Pluginization of Authenticator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -742,7 +742,7 @@ public class Env {
 
         this.auth = new Auth();
         this.accessManager = new AccessControllerManager(auth);
-        this.authenticatorManager = new AuthenticatorManager(AuthenticateType.getAuthTypeConfig());
+        this.authenticatorManager = new AuthenticatorManager(AuthenticateType.getAuthTypeConfigString());
         this.domainResolver = new DomainResolver(auth);
 
         this.metaContext = new MetaContext();

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/AuthenticateType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/AuthenticateType.java
@@ -40,4 +40,22 @@ public enum AuthenticateType {
                 return DEFAULT;
         }
     }
+
+    public static String getAuthTypeConfigString() {
+        String authType = Config.authentication_type.toLowerCase();
+
+        if (LdapConfig.ldap_authentication_enabled) {
+            return LDAP.name();
+        }
+
+        switch (authType) {
+            case "default":
+                return DEFAULT.toString();
+            case "ldap":
+                return LDAP.toString();
+            default:
+                return authType;
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/AuthenticatorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/AuthenticatorFactory.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.mysql.authenticate;
 
-import org.apache.doris.common.ConfigBase;
+import java.util.Properties;
 
 public interface AuthenticatorFactory {
     /**
@@ -25,7 +25,7 @@ public interface AuthenticatorFactory {
      *
      * @return an instance of Authenticator
      */
-    Authenticator create(ConfigBase config);
+    Authenticator create(Properties initProps);
 
     /**
      * Returns the identifier for the factory, such as "ldap" or "default".
@@ -33,17 +33,5 @@ public interface AuthenticatorFactory {
      * @return the factory identifier
      */
     String factoryIdentifier();
-
-    /**
-     * Retrieves the configuration template associated with this authenticator.
-     * <p>
-     * This method provides a default configuration template that can be used
-     * as a base for initializing the authenticator. The returned configuration
-     * can be modified as needed before passing it to the `create` method to
-     * instantiate an authenticator.
-     *
-     * @return the configuration template for the authenticator
-     */
-    ConfigBase getAuthenticatorConfig();
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/AuthenticatorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/AuthenticatorFactory.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.authenticate;
+
+import org.apache.doris.common.ConfigBase;
+
+public interface AuthenticatorFactory {
+    /**
+     * Creates a new instance of Authenticator.
+     *
+     * @return an instance of Authenticator
+     */
+    Authenticator create(ConfigBase config);
+
+    /**
+     * Returns the identifier for the factory, such as "ldap" or "default".
+     *
+     * @return the factory identifier
+     */
+    String factoryIdentifier();
+
+    /**
+     * Retrieves the configuration template associated with this authenticator.
+     * <p>
+     * This method provides a default configuration template that can be used
+     * as a base for initializing the authenticator. The returned configuration
+     * can be modified as needed before passing it to the `create` method to
+     * instantiate an authenticator.
+     *
+     * @return the configuration template for the authenticator
+     */
+    ConfigBase getAuthenticatorConfig();
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/DefaultAuthenticatorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/DefaultAuthenticatorFactory.java
@@ -17,21 +17,16 @@
 
 package org.apache.doris.mysql.authenticate;
 
-import org.apache.doris.common.ConfigBase;
+import java.util.Properties;
 
 public class DefaultAuthenticatorFactory implements AuthenticatorFactory {
     @Override
-    public Authenticator create(ConfigBase config) {
+    public DefaultAuthenticator create(Properties initProps) {
         return new DefaultAuthenticator();
     }
 
     @Override
     public String factoryIdentifier() {
         return "default";
-    }
-
-    @Override
-    public ConfigBase getAuthenticatorConfig() {
-        return null;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/DefaultAuthenticatorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/DefaultAuthenticatorFactory.java
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.authenticate;
+
+import org.apache.doris.common.ConfigBase;
+
+public class DefaultAuthenticatorFactory implements AuthenticatorFactory {
+    @Override
+    public Authenticator create(ConfigBase config) {
+        return new DefaultAuthenticator();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return "default";
+    }
+
+    @Override
+    public ConfigBase getAuthenticatorConfig() {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
@@ -75,10 +75,11 @@ public class LdapAuthenticator implements Authenticator {
         if (qualifiedUser.equals(Auth.ROOT_USER) || qualifiedUser.equals(Auth.ADMIN_USER)) {
             return false;
         }
-        if (!Env.getCurrentEnv().getAuth().getLdapManager().doesUserExist(qualifiedUser)) {
-            return false;
-        }
-        return true;
+        // Fixme Note: LdapManager should be managed internally within the Ldap plugin
+        // and not be placed inside the Env class. This ensures that Ldap-related
+        // logic and dependencies are encapsulated within the plugin, promoting
+        // better modularity and maintainability.
+        return Env.getCurrentEnv().getAuth().getLdapManager().doesUserExist(qualifiedUser);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorFactory.java
@@ -17,15 +17,15 @@
 
 package org.apache.doris.mysql.authenticate.ldap;
 
-import org.apache.doris.common.ConfigBase;
-import org.apache.doris.common.LdapConfig;
 import org.apache.doris.mysql.authenticate.AuthenticatorFactory;
+
+import java.util.Properties;
 
 public class LdapAuthenticatorFactory implements AuthenticatorFactory {
 
 
     @Override
-    public LdapAuthenticator create(ConfigBase config) {
+    public LdapAuthenticator create(Properties initProps) {
         return new LdapAuthenticator();
     }
 
@@ -34,8 +34,4 @@ public class LdapAuthenticatorFactory implements AuthenticatorFactory {
         return "ldap";
     }
 
-    @Override
-    public LdapConfig getAuthenticatorConfig() {
-        return new LdapConfig();
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorFactory.java
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.authenticate.ldap;
+
+import org.apache.doris.common.ConfigBase;
+import org.apache.doris.common.LdapConfig;
+import org.apache.doris.mysql.authenticate.AuthenticatorFactory;
+
+public class LdapAuthenticatorFactory implements AuthenticatorFactory {
+
+
+    @Override
+    public LdapAuthenticator create(ConfigBase config) {
+        return new LdapAuthenticator();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return "ldap";
+    }
+
+    @Override
+    public LdapConfig getAuthenticatorConfig() {
+        return new LdapConfig();
+    }
+}

--- a/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.authenticate.AuthenticatorFactory
+++ b/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.authenticate.AuthenticatorFactory
@@ -1,2 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.mysql.authenticate.DefaultAuthenticatorFactory
 org.apache.doris.mysql.authenticate.ldap.LdapAuthenticatorFactory

--- a/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.authenticate.AuthenticatorFactory
+++ b/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.authenticate.AuthenticatorFactory
@@ -1,0 +1,2 @@
+org.apache.doris.mysql.authenticate.DefaultAuthenticatorFactory
+org.apache.doris.mysql.authenticate.ldap.LdapAuthenticatorFactory


### PR DESCRIPTION
 ## abstract
introduces the pluginization of the Authenticator component, enabling greater flexibility and modularity within the authentication system. By refactoring the Authenticator into a pluggable SPI (Service Provider Interface), we allow for custom authentication mechanisms to be seamlessly integrated and managed.

## Key Changes
AuthenticatorFactory Interface:

This interface defines the create method, which is used to create an Authenticator instance based on initialization properties, enabling support for various authentication mechanisms.
The factoryIdentifier method provides an identifier for the factory, allowing differentiation between various AuthenticatorFactory implementations (e.g., LDAP, default).
Implemented Specific Authentication Factories:

We have implemented factories for different authentication mechanisms (such as LDAP), providing the necessary configuration support for each.


## eg

In your Maven pom.xml, add the fe-core dependency:

```
        <dependency>
            <groupId>org.apache.doris</groupId>
            <artifactId>fe-core</artifactId>
            <version>1.2-SNAPSHOT</version>
            <scope>provided</scope>
        </dependency>

```

```
import org.apache.doris.common.ConfigBase;

public class LocalAuthenticatorFactory implements AuthenticatorFactory {


    @Override
    public LocalAuthenticator create(Properties initProps) {
        return new LocalAuthenticator();
    }

    @Override
    public String factoryIdentifier() {
        return "local";
    }
}
import java.util.HashMap;
import java.util.Map;

public class LocalAuthenticator implements Authenticator {
    private Map<String, String> userStore = new HashMap<>();

    public LocalAuthenticator() {
        // Hardcoded usernames and passwords
        userStore.put("user1", "password1");
        userStore.put("user2", "password2");
        userStore.put("admin", "adminpass");
    }

    @Override
    public boolean authenticate(String username, String password) {
        // Authenticate by checking the hardcoded user store
        String storedPassword = userStore.get(username);
        return storedPassword != null && storedPassword.equals(password);
    }
}




```
To integrate with the SPI (Service Provider Interface) mechanism, we created a file at **src/main/resources/META-INF/services/org.apache.doris.mysql.authenticate.AuthenticatorFactory** containing **org.example.LocalAuthenticatorFactory,** which allows the system to dynamically load and utilize the LocalAuthenticatorFactory implementation.



Your plugin needs to include all necessary dependencies, and it is generally recommended to package them into an Uber JAR (also known as a Fat JAR) to ensure that the plugin can run independently without additional dependency management. Once packaged, this JAR can be placed directly in the **fe/custom_lib** directory.

