### PR TITLE
[fix](profile) fix possible coredump of rpc verbose profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -712,7 +712,7 @@ public class SessionVariable implements Serializable, Writable {
     public boolean enableProfile = false;
 
     @VariableMgr.VarAttr(name = ENABLE_VERBOSE_PROFILE, needForward = true)
-    public boolean enableVerboseProfile = true;
+    public boolean enableVerboseProfile = false;
 
     @VariableMgr.VarAttr(name = RPC_VERBOSE_PROFILE_MAX_INSTANCE_COUNT, needForward = true)
     public int rpcVerboseProfileMaxInstanceCount = 5;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`_instance_to_rpc_stats_vec` may be updated when sorting in `ExchangeSinkBuffer<Parent>::update_profile`, which may cause coredump.

