### PR TITLE
[fix](restore) Reset next version for remote table when restore

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -770,6 +770,9 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                         return;
                     }
 
+                    // reset next version to visible version for all partitions
+                    remoteOlapTbl.resetVersionForRestore();
+
                     // Reset properties to correct values.
                     remoteOlapTbl.resetPropertiesForRestore(reserveDynamicPartitionEnable, reserveReplica,
                                                             replicaAlloc, isBeingSynced);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -770,7 +770,7 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                         return;
                     }
 
-                    // reset next version to visible version for all partitions
+                    // reset next version to visible version + 1 for all partitions
                     remoteOlapTbl.resetVersionForRestore();
 
                     // Reset properties to correct values.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -631,7 +631,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
 
     public void resetVersionForRestore() {
         for (Partition partition : idToPartition.values()) {
-            partition.setNextVersion(partition.getVisibleVersion());
+            partition.setNextVersion(partition.getVisibleVersion() + 1);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -629,6 +629,12 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         setColocateGroup(null);
     }
 
+    public void resetVersionForRestore() {
+        for (Partition partition : idToPartition.values()) {
+            partition.setNextVersion(partition.getVisibleVersion());
+        }
+    }
+
     public Status resetIdsForRestore(Env env, Database db, ReplicaAllocation restoreReplicaAlloc,
             boolean reserveReplica) {
         // ATTN: The meta of the restore may come from different clusters, so the


### PR DESCRIPTION
We should reset next version to visible version + 1 for all partitions of remote table, when restoring table that do not exist locally.

在高并发insert场景，CCR源端表的next version可能比visible version大比较多，目标集群restore全量快照后，切换到增量binlog后，commit事务时使用的version（来自next version）就可能比当前visible version大比较多。

此时，对于MoW表，就会出现publish version不连续，增量binlog一直无法publish的问题。事务状态会一直是`COMMITTED`，并伴随类似ErrMsg `wait for publishing partition 15027 version 1037597. self version: 1037627. table 15025`。