### PR TITLE
[fix](jdbc catalog) Fix type recognition error when using `query` tvf to query doris

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchema.java
@@ -47,6 +47,19 @@ public class JdbcFieldSchema {
     protected int charOctetLength;
     protected boolean isAllowNull;
 
+
+    public JdbcFieldSchema(JdbcFieldSchema other) {
+        this.columnName = other.columnName;
+        this.dataType = other.dataType;
+        this.dataTypeName = other.dataTypeName;
+        this.columnSize = other.columnSize;
+        this.decimalDigits = other.decimalDigits;
+        this.numPrecRadix = other.numPrecRadix;
+        this.remarks = other.remarks;
+        this.charOctetLength = other.charOctetLength;
+        this.isAllowNull = other.isAllowNull;
+    }
+
     public JdbcFieldSchema(ResultSet rs) throws SQLException {
         this.columnName = rs.getString("COLUMN_NAME");
         this.dataType = getInteger(rs, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null"));

--- a/regression-test/data/external_table_p0/jdbc/test_doris_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_doris_jdbc_catalog.out
@@ -125,6 +125,23 @@ g1	1	2	3	4	p1
 g2	1	2	3	4	p2
 
 -- !sql --
+bool_col	tinyint	Yes	true	\N	NONE
+tinyint_col	tinyint	Yes	true	\N	NONE
+smallint_col	smallint	Yes	true	\N	NONE
+int_col	int	Yes	true	\N	NONE
+bigint_col	bigint	Yes	true	\N	NONE
+largeint_col	char(85)	Yes	true	\N	NONE
+float_col	float	Yes	true	\N	NONE
+double_col	double	Yes	true	\N	NONE
+decimal_col	decimal(10,5)	Yes	true	\N	NONE
+decimal_col2	decimal(30,10)	Yes	true	\N	NONE
+date_col	date	Yes	true	\N	NONE
+datetime_col	datetime(6)	Yes	true	\N	NONE
+char_col	char(85)	Yes	true	\N	NONE
+varchar_col	char(85)	Yes	true	\N	NONE
+json_col	text	Yes	true	\N	NONE
+
+-- !sql --
 doris_jdbc_catalog
 
 -- !sql --

--- a/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
@@ -228,6 +228,9 @@ suite("test_doris_jdbc_catalog", "p0,external,doris,external_docker,external_doc
     sql """insert into test_insert_order(gameid,did,cid,bid,aid,pname) select 'g2',4,3,2,1,'p2'""";
     qt_sql """select * from test_insert_order order by gameid, aid, bid, cid, did;"""
 
+    // test query tvf
+    qt_sql """desc function query("catalog" = "doris_jdbc_catalog", "query" = "select * from regression_test_jdbc_catalog_p0.base");"""
+
     //clean
     qt_sql """select current_catalog()"""
     sql "switch internal"


### PR DESCRIPTION
Using string to match Doris type will not work with query tvf, so use field matching instead