### PR TITLE
[opt](nereids)stats derive for min()/max() agg function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -342,14 +342,9 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
         if (columnStat.isUnKnown) {
             return ColumnStatistic.UNKNOWN;
         }
-        /*
-        we keep columnStat.min and columnStat.max, but set ndv=1.
-        if there is group-by keys, we will update count when visiting group clause
-        */
-        double width = min.child().getDataType().width();
-        return new ColumnStatisticBuilder().setCount(1).setNdv(1).setAvgSizeByte(width)
-                .setMinValue(columnStat.minValue).setMinExpr(columnStat.minExpr)
-                .setMaxValue(columnStat.maxValue).setMaxExpr(columnStat.maxExpr).build();
+        // if this is scalar agg, we will update count and ndv to 1 when visiting group clause
+        return new ColumnStatisticBuilder(columnStat)
+                .build();
     }
 
     @Override
@@ -359,14 +354,8 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
         if (columnStat.isUnKnown) {
             return ColumnStatistic.UNKNOWN;
         }
-        /*
-        we keep columnStat.min and columnStat.max, but set ndv=1.
-        if there is group-by keys, we will update count when visiting group clause
-        */
-        int width = max.child().getDataType().width();
-        return new ColumnStatisticBuilder().setCount(1D).setNdv(1D).setAvgSizeByte(width)
-                .setMinValue(columnStat.minValue).setMinExpr(columnStat.minExpr)
-                .setMaxValue(columnStat.maxValue).setMaxExpr(columnStat.maxExpr)
+        // if this is scalar agg, we will update count and ndv to 1 when visiting group clause
+        return new ColumnStatisticBuilder(columnStat)
                 .build();
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
@@ -72,7 +72,7 @@ class ExpressionEstimationTest {
         ColumnStatistic estimated = ExpressionEstimation.estimate(max, stat);
         Assertions.assertEquals(0, estimated.minValue);
         Assertions.assertEquals(500, estimated.maxValue);
-        Assertions.assertEquals(1, estimated.ndv);
+        Assertions.assertEquals(500, estimated.ndv);
     }
 
     // MIN(a)
@@ -95,7 +95,7 @@ class ExpressionEstimationTest {
         ColumnStatistic estimated = ExpressionEstimation.estimate(max, stat);
         Assertions.assertEquals(0, estimated.minValue);
         Assertions.assertEquals(1000, estimated.maxValue);
-        Assertions.assertEquals(1, estimated.ndv);
+        Assertions.assertEquals(500, estimated.ndv);
     }
 
     // a + b


### PR DESCRIPTION
## Proposed changes
the column stats for min(A) agg function is estimated as column stats of A.
in current version, min(A).ndv is 1, this is error-prone.

Issue Number: close #xxx

<!--Describe your changes.-->

