### PR TITLE
[opt](scan) merge small tablets into one scanner

### DIFF
--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -46,7 +46,7 @@ struct RowSetSplits {
     std::vector<RowRanges> segment_row_ranges;
 
     RowSetSplits(RowsetReaderSharedPtr rs_reader_)
-            : rs_reader(rs_reader_), segment_offsets({0, 0}) {}
+            : rs_reader(std::move(rs_reader_)), segment_offsets({0, 0}) {}
     RowSetSplits() = default;
 };
 

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -330,9 +330,8 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::VScannerSPtr>* s
 
         RETURN_IF_ERROR(scanner_builder.build_scanners(*scanners));
         for (auto& scanner : *scanners) {
-            auto* olap_scanner = assert_cast<vectorized::NewOlapScanner*>(scanner.get());
-            RETURN_IF_ERROR(olap_scanner->prepare(state(), _conjuncts));
-            olap_scanner->set_compound_filters(_compound_filters);
+            RETURN_IF_ERROR(scanner->prepare(state(), _conjuncts));
+            scanner->set_compound_filters(_compound_filters);
         }
         return Status::OK();
     }

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/PaloInternalService_types.h>
-#include <stdint.h>
 
 #include <memory>
 #include <string>
@@ -51,6 +50,7 @@ struct FilterPredicates;
 namespace vectorized {
 
 class Block;
+class UnionScanner;
 
 class NewOlapScanner : public VScanner {
     ENABLE_FACTORY_CREATOR(NewOlapScanner);
@@ -75,11 +75,12 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    void set_compound_filters(const std::vector<TCondition>& compound_filters);
+    void set_compound_filters(const std::vector<TCondition>& compound_filters) override;
 
     doris::TabletStorageType get_storage_type() override;
 
 protected:
+    friend class UnionScanner;
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
     void _collect_profile_before_close() override;
 

--- a/be/src/vec/exec/scan/union_scanner.cpp
+++ b/be/src/vec/exec/scan/union_scanner.cpp
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exec/scan/union_scanner.h"
+
+namespace doris::vectorized {
+
+Status UnionScanner::init() {
+    for (auto& scanner : _olap_scanners) {
+        RETURN_IF_ERROR(scanner->init());
+    }
+    _is_init = true;
+    return Status::OK();
+}
+
+Status UnionScanner::prepare(RuntimeState* state, const VExprContextSPtrs& conjuncts) {
+    RETURN_IF_ERROR(VScanner::prepare(state, conjuncts));
+    for (auto& scanner : _olap_scanners) {
+        RETURN_IF_ERROR(scanner->prepare(state, conjuncts));
+    }
+    return Status::OK();
+}
+
+Status UnionScanner::open(RuntimeState* state) {
+    RETURN_IF_ERROR(_olap_scanners[0]->open(state));
+    return Status::OK();
+}
+
+Status UnionScanner::close(RuntimeState* state) {
+    if (_scanner_cursor != _olap_scanners.size()) {
+        RETURN_IF_ERROR(_olap_scanners[_scanner_cursor]->close(state));
+    }
+
+    return Status::OK();
+}
+
+void UnionScanner::set_compound_filters(const std::vector<TCondition>& compound_filters) {
+    for (auto& scanner : _olap_scanners) {
+        scanner->set_compound_filters(compound_filters);
+    }
+}
+
+TabletStorageType UnionScanner::get_storage_type() {
+    return _olap_scanners[0]->get_storage_type();
+}
+
+Status UnionScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eos) {
+    if (_scanner_cursor == _olap_scanners.size()) [[unlikely]] {
+        *eos = true;
+        return Status::OK();
+    }
+
+    do {
+        auto& scanner = _olap_scanners[_scanner_cursor];
+        bool inner_eos = false;
+        *eos = false;
+        RETURN_IF_ERROR(scanner->get_block(state, block, &inner_eos));
+
+        if (inner_eos) {
+            scanner->_collect_profile_before_close();
+            RETURN_IF_ERROR(scanner->close(state));
+            _scanner_cursor++;
+            if (_scanner_cursor != _olap_scanners.size()) {
+                RETURN_IF_ERROR(_olap_scanners[_scanner_cursor]->open(state));
+            } else {
+                break;
+            }
+        }
+    } while (block->empty());
+    return Status::OK();
+}
+
+void UnionScanner::_collect_profile_before_close() {
+    if (_scanner_cursor != _olap_scanners.size()) {
+        _olap_scanners[_scanner_cursor]->_collect_profile_before_close();
+    }
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/scan/union_scanner.h
+++ b/be/src/vec/exec/scan/union_scanner.h
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/factory_creator.h"
+#include "common/status.h"
+#include "vec/exec/scan/new_olap_scanner.h"
+#include "vec/exec/scan/vscanner.h"
+
+namespace doris::vectorized {
+
+/**
+ `UnionScanner` contains more than 1 `NewOlapScanner`
+ */
+class UnionScanner : public VScanner {
+    ENABLE_FACTORY_CREATOR(UnionScanner)
+public:
+    UnionScanner(RuntimeState* state, pipeline::ScanLocalStateBase* local_state, int64_t limit,
+                 RuntimeProfile* profile)
+            : VScanner(state, local_state, limit, profile) {
+        _is_init = false;
+    }
+
+    void add_scanner(std::shared_ptr<NewOlapScanner> scanners) {
+        _olap_scanners.emplace_back(std::move(scanners));
+    }
+
+    [[nodiscard]] std::shared_ptr<NewOlapScanner> get_single_scanner() {
+        DCHECK_EQ(_olap_scanners.size(), 1);
+        return std::move(_olap_scanners[0]);
+    }
+
+    [[nodiscard]] size_t get_scanners_count() const { return _olap_scanners.size(); }
+
+    Status init() override;
+
+    Status prepare(RuntimeState* state, const VExprContextSPtrs& conjuncts) override;
+
+    Status open(RuntimeState* state) override;
+
+    Status close(RuntimeState* state) override;
+
+    void set_compound_filters(const std::vector<TCondition>& compound_filters) override;
+
+    doris::TabletStorageType get_storage_type() override;
+
+    std::string get_name() override { return "UnionScanner"; }
+
+protected:
+    Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
+    void _collect_profile_before_close() override;
+
+private:
+    size_t _scanner_cursor {0};
+    std::vector<std::shared_ptr<NewOlapScanner>> _olap_scanners;
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -83,6 +83,8 @@ public:
 
     virtual std::string get_name() { return ""; }
 
+    virtual void set_compound_filters(const std::vector<TCondition>& compound_filters) {}
+
     // return the readable name of current scan range.
     // eg, for file scanner, return the current file path.
     virtual std::string get_current_scan_range_name() { return "not implemented"; }


### PR DESCRIPTION
## Proposed changes

If the rows of tablets are small, merge these tablets into one scanner to avoid having many scanners due to the large number of tablets.

In further development, it is possible to implement the dynamic reduction of the number of scanners by merging scanners using `UnionScanner` in high-concurrency scenarios, thus reducing scheduling costs.

