### PR TITLE
[Enhancement](DDL) check illegal partition exprs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/PartitionTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/PartitionTableInfo.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.nereids.analyzer.UnboundFunction;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -269,6 +270,14 @@ public class PartitionTableInfo {
 
             try {
                 ArrayList<Expr> exprs = convertToLegacyAutoPartitionExprs(partitionList);
+
+                // only auto partition support partition expr
+                if (!isAutoPartition) {
+                    if (exprs.stream().anyMatch(expr -> expr instanceof FunctionCallExpr)) {
+                        throw new DdlException("Non-auto partition table not support partition expr!");
+                    }
+                }
+
                 // here we have already extracted identifierPartitionColumns
                 if (partitionType.equals(PartitionType.RANGE.name())) {
                     if (isAutoPartition) {

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -407,4 +407,18 @@ suite("test_auto_partition_behavior") {
     sql """ insert into test_change values ("20001212"); """
     part_result = sql " show tablets from test_change "
     assertEquals(part_result.size, 52 * replicaNum)
+
+    test {
+        sql """
+            CREATE TABLE not_auto_expr (
+                `TIME_STAMP` date NOT NULL
+            )
+            partition by range (date_trunc(`TIME_STAMP`, 'day'))()
+            DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
+            PROPERTIES (
+                "replication_allocation" = "tag.location.default: 1"
+            );
+        """
+        exception "Non-auto partition table not support partition expr!"
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:
```sql
mysql> CREATE TABLE not_auto_expr (
    ->     `TIME_STAMP` date NOT NULL
    -> )
    -> partition by range (date_trunc(`TIME_STAMP`, 'day'))()
    -> DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
    -> PROPERTIES (
    ->     "replication_allocation" = "tag.location.default: 1"
    -> );
Query OK, 0 rows affected (0.14 sec)
```
now:
```sql
mysql> CREATE TABLE not_auto_expr (
    ->     `TIME_STAMP` date NOT NULL
    -> )
    -> partition by range (date_trunc(`TIME_STAMP`, 'day'))()
    -> DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
    -> PROPERTIES (
    ->     "replication_allocation" = "tag.location.default: 1"
    -> );
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = Non-auto partition table not support partition expr!
```
