### PR TITLE
[opt](function)Optimize the performance of the pad function under UTF-8.

### DIFF
--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -187,6 +187,19 @@ public:
         return p;
     }
 
+    static inline std::pair<size_t, size_t> skip_leading_utf8(const char* begin, const char* end,
+                                                              size_t n) {
+        const char* p = begin;
+        int char_size = 0;
+
+        size_t i = 0;
+        for (; i < n && p < end; ++i, p += char_size) {
+            char_size = UTF8_BYTE_LENGTH[static_cast<uint8_t>(*p)];
+        }
+
+        return {p - begin, i};
+    }
+
     // Gcc will do auto simd in this function
     static bool is_ascii(const StringRef& str) {
 #ifdef __AVX2__

--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -187,8 +187,12 @@ public:
         return p;
     }
 
-    static inline std::pair<size_t, size_t> skip_leading_utf8(const char* begin, const char* end,
-                                                              size_t n) {
+    // Iterate a UTF-8 string without exceeding a given length n.
+    // The function returns two values:
+    // the first represents the byte length traversed, and the second represents the char length traversed.
+    static inline std::pair<size_t, size_t> iterate_utf8_with_limit_length(const char* begin,
+                                                                           const char* end,
+                                                                           size_t n) {
         const char* p = begin;
         int char_size = 0;
 


### PR DESCRIPTION
## Proposed changes

1. Removed the calculation of str_index.
2. If pad is constant, calculate pad_index only once.
3. Do not insert res_chars inside the loop; instead, insert them all together after the loop completes.
```
mysql [test]>select count(lpad(Title, 100, "abc")) from hits_10m;
+--------------------------------+
| count(lpad(Title, 100, 'abc')) |
+--------------------------------+
|                       10000000 |
+--------------------------------+
1 row in set (3.97 sec)

mysql [test]>select count(lpad(Title, 100, "abc")) from hits_10m;
+--------------------------------+
| count(lpad(Title, 100, 'abc')) |
+--------------------------------+
|                       10000000 |
+--------------------------------+
1 row in set (2.87 sec)
```



<!--Describe your changes.-->

