### PR TITLE
[enhance](mtmv)Optimize the speed of obtaining the last update time of Hive

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -572,9 +572,9 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
             case ICEBERG:
                 if (GlobalVariable.enableFetchIcebergStats) {
                     return StatisticsUtil.getIcebergColumnStats(colName,
-                            Env.getCurrentEnv().getExtMetaCacheMgr().getIcebergMetadataCache().getIcebergTable(
-                                    catalog, dbName, name
-                            ));
+                        Env.getCurrentEnv().getExtMetaCacheMgr().getIcebergMetadataCache().getIcebergTable(
+                            catalog, dbName, name
+                        ));
                 } else {
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -521,6 +521,10 @@ public class HiveMetaStoreCache {
         return fileLists;
     }
 
+    public HivePartition getHivePartition(String dbName, String name, List<String> partitionValues) {
+        return partitionCache.get(new PartitionCacheKey(dbName, name, partitionValues));
+    }
+
     public List<HivePartition> getAllPartitionsWithCache(String dbName, String name,
             List<List<String>> partitionValuesList) {
         return getAllPartitions(dbName, name, partitionValuesList, true);


### PR DESCRIPTION
Previously, to obtain the last update time of a hive table, it was necessary to obtain the last update time of all partitions under the table, which required generating a large map.


