### PR TITLE
[opt](inverted index) cache result sign is initialized only once

### DIFF
--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -617,7 +617,14 @@ bool VExpr::fast_execute(Block& block, const ColumnNumbers& arguments, size_t re
         return false;
     }
 
-    std::string result_column_name = gen_predicate_result_sign(block, arguments, function_name);
+    // cache value is initialized only once.
+    if (result_column_name.empty()) {
+        static std::once_flag once_flag;
+        std::call_once(once_flag, [&]() {
+            result_column_name = gen_predicate_result_sign(block, arguments, function_name);
+        });
+    }
+
     if (!block.has(result_column_name)) {
         DBUG_EXECUTE_IF("segment_iterator.fast_execute", {
             auto debug_col_name = DebugPoints::instance()->get_debug_param_or_default<std::string>(

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -332,6 +332,7 @@ protected:
     bool _can_fast_execute = false;
     bool _enable_inverted_index_query = true;
     uint32_t _in_list_value_count_threshold = 10;
+    std::string result_column_name;
 };
 
 } // namespace vectorized


### PR DESCRIPTION
## Proposed changes

1. optimize the performance issue caused by slow result sign generation due to too many values in the in condition.

<!--Describe your changes.-->

