### PR TITLE
[enhancement](cloud) clarify codes and make TTL expiration work after abnormal cache type transition

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -997,6 +997,8 @@ DEFINE_mInt64(file_cache_ttl_valid_check_interval_second, "0"); // zero for not 
 // If true, evict the ttl cache using LRU when full.
 // Otherwise, only expiration can evict ttl and new data won't add to cache when full.
 DEFINE_Bool(enable_ttl_cache_evict_using_lru, "true");
+// rename ttl filename to new format during read, with some performance cost
+DEFINE_mBool(translate_to_new_ttl_format_during_read, "false");
 
 DEFINE_mInt32(index_cache_entry_stay_time_after_lookup_s, "1800");
 DEFINE_mInt32(inverted_index_cache_stale_sweep_time_sec, "600");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1046,6 +1046,8 @@ DECLARE_mInt64(file_cache_ttl_valid_check_interval_second);
 // If true, evict the ttl cache using LRU when full.
 // Otherwise, only expiration can evict ttl and new data won't add to cache when full.
 DECLARE_Bool(enable_ttl_cache_evict_using_lru);
+// rename ttl filename to new format during read, with some performance cost
+DECLARE_Bool(translate_to_new_ttl_format_during_read);
 
 // inverted index searcher cache
 // cache entry stay time after lookup

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -330,7 +330,8 @@ FileBlocks BlockFileCache::get_impl(const UInt128Wrapper& hash, const CacheConte
             for (auto& [_, cell] : file_blocks) {
                 auto cache_type = cell.file_block->cache_type();
                 if (cache_type != FileCacheType::TTL) continue;
-                auto st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::NORMAL);
+                auto st = cell.file_block->change_cache_type_between_ttl_and_others(
+                        FileCacheType::NORMAL);
                 if (st.ok()) {
                     if (config::enable_ttl_cache_evict_using_lru) {
                         auto& ttl_queue = get_queue(FileCacheType::TTL);
@@ -1024,7 +1025,8 @@ bool BlockFileCache::remove_if_ttl_file_unlock(const UInt128Wrapper& file_key, b
                 }
 
                 if (cell.file_block->cache_type() == FileCacheType::NORMAL) continue;
-                auto st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::NORMAL);
+                auto st = cell.file_block->change_cache_type_between_ttl_and_others(
+                        FileCacheType::NORMAL);
                 if (st.ok()) {
                     if (config::enable_ttl_cache_evict_using_lru) {
                         ttl_queue.remove(cell.queue_iterator.value(), cache_lock);
@@ -1623,7 +1625,7 @@ void BlockFileCache::modify_expiration_time(const UInt128Wrapper& hash,
 
             FileCacheType origin_type = cell.file_block->cache_type();
             if (origin_type == FileCacheType::TTL) continue;
-            auto st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::TTL);
+            st = cell.file_block->change_cache_type_between_ttl_and_others(FileCacheType::TTL);
             if (st.ok()) {
                 auto& queue = get_queue(origin_type);
                 queue.remove(cell.queue_iterator.value(), cache_lock);

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1397,6 +1397,21 @@ std::string BlockFileCache::dump_structure_unlocked(const UInt128Wrapper& hash,
     return result.str();
 }
 
+std::string BlockFileCache::dump_single_cache_type(const UInt128Wrapper& hash, size_t offset) {
+    std::lock_guard cache_lock(_mutex);
+    return dump_single_cache_type_unlocked(hash, offset, cache_lock);
+}
+
+std::string BlockFileCache::dump_single_cache_type_unlocked(const UInt128Wrapper& hash,
+                                                            size_t offset,
+                                                            std::lock_guard<std::mutex>&) {
+    std::stringstream result;
+    const auto& cells_by_offset = _files[hash];
+    const auto& cell = cells_by_offset.find(offset);
+
+    return cache_type_to_string(cell->second.file_block->cache_type());
+}
+
 void BlockFileCache::change_cache_type(const UInt128Wrapper& hash, size_t offset,
                                        FileCacheType new_type,
                                        std::lock_guard<std::mutex>& cache_lock) {

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -130,7 +130,7 @@ public:
     [[nodiscard]] std::vector<std::tuple<size_t, size_t, FileCacheType, uint64_t>>
     get_hot_blocks_meta(const UInt128Wrapper& hash) const;
 
-    [[nodiscard]] bool get_lazy_open_success() const { return _lazy_open_done; }
+    [[nodiscard]] bool get_async_open_success() const { return _async_open_done; }
 
     BlockFileCache& operator=(const BlockFileCache&) = delete;
     BlockFileCache(const BlockFileCache&) = delete;
@@ -338,7 +338,7 @@ private:
                              const CacheContext& context, size_t offset, size_t size,
                              std::lock_guard<std::mutex>& cache_lock);
 
-    bool try_reserve_for_lazy_load(size_t size, std::lock_guard<std::mutex>& cache_lock);
+    bool try_reserve_during_async_load(size_t size, std::lock_guard<std::mutex>& cache_lock);
 
     std::vector<FileCacheType> get_other_cache_type(FileCacheType cur_cache_type);
 
@@ -413,7 +413,7 @@ private:
     std::mutex _close_mtx;
     std::condition_variable _close_cv;
     std::thread _cache_background_thread;
-    std::atomic_bool _lazy_open_done {false};
+    std::atomic_bool _async_open_done {false};
     bool _async_clear_file_cache {false};
     // disk space or inode is less than the specified value
     bool _disk_resource_limit_mode {false};

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -104,8 +104,9 @@ public:
     std::string reset_capacity(size_t new_capacity);
 
     std::map<size_t, FileBlockSPtr> get_blocks_by_key(const UInt128Wrapper& hash);
-    /// For debug.
+    /// For debug and UT
     std::string dump_structure(const UInt128Wrapper& hash);
+    std::string dump_single_cache_type(const UInt128Wrapper& hash, size_t offset);
 
     [[nodiscard]] size_t get_used_cache_size(FileCacheType type) const;
 
@@ -357,6 +358,9 @@ private:
 
     std::string dump_structure_unlocked(const UInt128Wrapper& hash,
                                         std::lock_guard<std::mutex>& cache_lock);
+
+    std::string dump_single_cache_type_unlocked(const UInt128Wrapper& hash, size_t offset,
+                                                std::lock_guard<std::mutex>& cache_lock);
 
     void fill_holes_with_empty_file_blocks(FileBlocks& file_blocks, const UInt128Wrapper& hash,
                                            const CacheContext& context,

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -161,32 +161,27 @@ Status FileBlock::read(Slice buffer, size_t read_offset) {
     return _mgr->_storage->read(_key, read_offset, buffer);
 }
 
-Status FileBlock::change_cache_type_by_mgr(FileCacheType new_type) {
+Status FileBlock::change_cache_type_between_ttl_and_others(FileCacheType new_type) {
     std::lock_guard block_lock(_mutex);
     DCHECK(new_type != _key.meta.type);
+    DCHECK(new_type == FileCacheType::TTL || _key.meta.type == FileCacheType::TTL);
     if (_download_state == State::DOWNLOADED) {
-        KeyMeta new_meta;
-        new_meta.expiration_time = _key.meta.expiration_time;
-        new_meta.type = new_type;
-        auto st = _mgr->_storage->change_key_meta(_key, new_meta);
+        // change cache type between TTL to others don't need to rename the filename suffix
         TEST_SYNC_POINT_CALLBACK("FileBlock::change_cache_type", &st);
-        if (!st.ok()) return st;
     }
     _key.meta.type = new_type;
     return Status::OK();
 }
 
-Status FileBlock::change_cache_type_self(FileCacheType new_type) {
+Status FileBlock::change_cache_type_between_normal_and_index(FileCacheType new_type) {
     std::lock_guard cache_lock(_mgr->_mutex);
     std::lock_guard block_lock(_mutex);
+    DCHECK(new_type != FileCacheType::TTL && _key.meta.type != FileCacheType::TTL);
     if (_key.meta.type == FileCacheType::TTL || new_type == _key.meta.type) {
         return Status::OK();
     }
     if (_download_state == State::DOWNLOADED) {
-        KeyMeta new_meta;
-        new_meta.expiration_time = _key.meta.expiration_time;
-        new_meta.type = new_type;
-        RETURN_IF_ERROR(_mgr->_storage->change_key_meta(_key, new_meta));
+        RETURN_IF_ERROR(_mgr->_storage->change_key_meta_type(_key, new_type);
     }
     _mgr->change_cache_type(_key.hash, _block_range.left, new_type, cache_lock);
     _key.meta.type = new_type;
@@ -196,10 +191,7 @@ Status FileBlock::change_cache_type_self(FileCacheType new_type) {
 Status FileBlock::update_expiration_time(uint64_t expiration_time) {
     std::lock_guard block_lock(_mutex);
     if (_download_state == State::DOWNLOADED) {
-        KeyMeta new_meta;
-        new_meta.expiration_time = expiration_time;
-        new_meta.type = _key.meta.type;
-        auto st = _mgr->_storage->change_key_meta(_key, new_meta);
+        auto st = _mgr->_storage->change_key_meta_expiration(_key, expiration_time);
         if (!st.ok() && !st.is<ErrorCode::NOT_FOUND>()) {
             return st;
         }

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -165,10 +165,8 @@ Status FileBlock::change_cache_type_between_ttl_and_others(FileCacheType new_typ
     std::lock_guard block_lock(_mutex);
     DCHECK(new_type != _key.meta.type);
     DCHECK(new_type == FileCacheType::TTL || _key.meta.type == FileCacheType::TTL);
-    if (_download_state == State::DOWNLOADED) {
-        // change cache type between TTL to others don't need to rename the filename suffix
-        TEST_SYNC_POINT_CALLBACK("FileBlock::change_cache_type", &st);
-    }
+
+    // change cache type between TTL to others don't need to rename the filename suffix
     _key.meta.type = new_type;
     return Status::OK();
 }
@@ -181,7 +179,9 @@ Status FileBlock::change_cache_type_between_normal_and_index(FileCacheType new_t
         return Status::OK();
     }
     if (_download_state == State::DOWNLOADED) {
-        RETURN_IF_ERROR(_mgr->_storage->change_key_meta_type(_key, new_type);
+        Status st;
+        TEST_SYNC_POINT_CALLBACK("FileBlock::change_cache_type", &st);
+        RETURN_IF_ERROR(_mgr->_storage->change_key_meta_type(_key, new_type));
     }
     _mgr->change_cache_type(_key.hash, _block_range.left, new_type, cache_lock);
     _key.meta.type = new_type;

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -115,9 +115,9 @@ public:
 
     std::string get_info_for_log() const;
 
-    [[nodiscard]] Status change_cache_type_by_mgr(FileCacheType new_type);
+    [[nodiscard]] Status change_cache_type_between_ttl_and_others(FileCacheType new_type);
 
-    [[nodiscard]] Status change_cache_type_self(FileCacheType new_type);
+    [[nodiscard]] Status change_cache_type_between_normal_and_index(FileCacheType new_type);
 
     [[nodiscard]] Status update_expiration_time(uint64_t expiration_time);
 

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -40,7 +40,9 @@ public:
     // remove the block
     virtual Status remove(const FileCacheKey& key) = 0;
     // change the block meta
-    virtual Status change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) = 0;
+    virtual Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) = 0;
+    virtual Status change_key_meta_expiration(const FileCacheKey& key,
+                                              const uint64_t expiration) = 0;
     // use when lazy load cache
     virtual void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                                std::lock_guard<std::mutex>& cache_lock) {}

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -553,6 +553,7 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
     };
     std::error_code ec;
     if constexpr (USE_CACHE_VERSION2) {
+        TEST_SYNC_POINT_CALLBACK("BlockFileCache::BeforeScan");
         std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
         if (ec) {
             LOG(WARNING) << ec.message();

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -81,7 +81,7 @@ private:
 
     Status read_file_cache_version(std::string* buffer) const;
 
-    Status parse_filename_sufix_to_cache_type(const std::shared_ptr<LocalFileSystem>& fs,
+    Status parse_filename_suffix_to_cache_type(const std::shared_ptr<LocalFileSystem>& fs,
                                               const Path& file_path, long expiration_time,
                                               size_t size, size_t* offset, bool* is_tmp,
                                               FileCacheType* cache_type) const;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -65,13 +65,19 @@ public:
     Status finalize(const FileCacheKey& key) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
     Status remove(const FileCacheKey& key) override;
-    Status change_key_meta(const FileCacheKey& key, const KeyMeta& new_meta) override;
+    Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) override;
+    Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                        std::lock_guard<std::mutex>& cache_lock) override;
 
     [[nodiscard]] static std::string get_path_in_local_cache(const std::string& dir, size_t offset,
                                                              FileCacheType type,
                                                              bool is_tmp = false);
+
+    [[nodiscard]] static std::string get_path_in_local_cache_old_ttl_format(const std::string& dir,
+                                                                            size_t offset,
+                                                                            FileCacheType type,
+                                                                            bool is_tmp = false);
 
     [[nodiscard]] std::string get_path_in_local_cache(const UInt128Wrapper&,
                                                       uint64_t expiration_time) const;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -88,9 +88,9 @@ private:
     Status read_file_cache_version(std::string* buffer) const;
 
     Status parse_filename_suffix_to_cache_type(const std::shared_ptr<LocalFileSystem>& fs,
-                                              const Path& file_path, long expiration_time,
-                                              size_t size, size_t* offset, bool* is_tmp,
-                                              FileCacheType* cache_type) const;
+                                               const Path& file_path, long expiration_time,
+                                               size_t size, size_t* offset, bool* is_tmp,
+                                               FileCacheType* cache_type) const;
 
     Status write_file_cache_version() const;
 

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -81,6 +81,11 @@ private:
 
     Status read_file_cache_version(std::string* buffer) const;
 
+    Status parse_filename_sufix_to_cache_type(const std::shared_ptr<LocalFileSystem>& fs,
+                                              const Path& file_path, long expiration_time,
+                                              size_t size, size_t* offset, bool* is_tmp,
+                                              FileCacheType* cache_type) const;
+
     Status write_file_cache_version() const;
 
     [[nodiscard]] std::string get_version_path() const;

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -77,7 +77,7 @@ public:
                                                       uint64_t expiration_time) const;
 
 private:
-    Status rebuild_data_structure() const;
+    Status upgrade_cache_dir_if_necessary() const;
 
     Status read_file_cache_version(std::string* buffer) const;
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -1062,7 +1062,7 @@ Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size
         auto size = *index_size + *segment_file_size;
         auto holder = cache_builder->allocate_cache_holder(index_start, size);
         for (auto& segment : holder->file_blocks) {
-            static_cast<void>(segment->change_cache_type_self(io::FileCacheType::INDEX));
+            static_cast<void>(segment->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
         }
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -1062,7 +1062,8 @@ Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size
         auto size = *index_size + *segment_file_size;
         auto holder = cache_builder->allocate_cache_holder(index_start, size);
         for (auto& segment : holder->file_blocks) {
-            static_cast<void>(segment->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
+            static_cast<void>(
+                    segment->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
         }
     }
     return Status::OK();

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -1030,7 +1030,8 @@ TEST_F(BlockFileCacheTest, change_cache_type) {
         std::string data(size, '0');
         Slice result(data.data(), size);
         ASSERT_TRUE(blocks[0]->append(result).ok());
-        ASSERT_TRUE(blocks[0]->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
+        ASSERT_TRUE(
+                blocks[0]->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
         ASSERT_TRUE(blocks[0]->finalize().ok());
         auto key_str = key.to_string();
         auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
@@ -2684,7 +2685,8 @@ TEST_F(BlockFileCacheTest, append_many_time) {
             EXPECT_TRUE(fs::exists(storage->get_path_in_local_cache(dir, blocks[0]->offset(),
                                                                     blocks[0]->cache_type())));
         }
-        ASSERT_TRUE(blocks[0]->change_cache_type_between_normal_and_index(FileCacheType::INDEX).ok());
+        ASSERT_TRUE(
+                blocks[0]->change_cache_type_between_normal_and_index(FileCacheType::INDEX).ok());
         auto sp = SyncPoint::get_instance();
         sp->enable_processing();
         SyncPoint::CallbackGuard guard1;
@@ -2697,7 +2699,9 @@ TEST_F(BlockFileCacheTest, append_many_time) {
                 },
                 &guard1);
         {
-            ASSERT_FALSE(blocks[0]->change_cache_type_between_normal_and_index(FileCacheType::NORMAL).ok());
+            ASSERT_FALSE(blocks[0]
+                                 ->change_cache_type_between_normal_and_index(FileCacheType::NORMAL)
+                                 .ok());
             EXPECT_EQ(blocks[0]->cache_type(), FileCacheType::INDEX);
             std::string buffer;
             buffer.resize(5);
@@ -2705,7 +2709,9 @@ TEST_F(BlockFileCacheTest, append_many_time) {
             EXPECT_EQ(buffer, std::string(5, '0'));
         }
         {
-            EXPECT_FALSE(blocks[0]->change_cache_type_between_ttl_and_others(FileCacheType::NORMAL).ok());
+            EXPECT_FALSE(blocks[0]
+                                 ->change_cache_type_between_ttl_and_others(FileCacheType::NORMAL)
+                                 .ok());
             EXPECT_EQ(blocks[0]->cache_type(), FileCacheType::INDEX);
             std::string buffer;
             buffer.resize(5);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -3466,7 +3466,7 @@ TEST_F(BlockFileCacheTest, test_lazy_load_with_error_file_1) {
         ASSERT_TRUE(writer->append(Slice("111", 3)).ok());
         ASSERT_TRUE(writer->close().ok());
     });
-    sp->set_call_back("BlockFileCache::REMOVE_FILE_2", [&](auto&& args) {
+    sp->set_call_back("BlockFileCache::REMOVE_FILE", [&](auto&& args) {
         if (*try_any_cast<std::string*>(args[0]) == "30086_idx") {
             static_cast<void>(global_local_filesystem()->delete_file(dir / "30086_idx"));
         }
@@ -3538,7 +3538,7 @@ TEST_F(BlockFileCacheTest, test_lazy_load_with_error_file_2) {
         while (!flag1) {
         }
     });
-    sp->set_call_back("BlockFileCache::REMOVE_FILE_1", [&](auto&& args) {
+    sp->set_call_back("BlockFileCache::REMOVE_FILE", [&](auto&& args) {
         if (*try_any_cast<std::string*>(args[0]) == "30086_idx") {
             static_cast<void>(global_local_filesystem()->delete_file(dir / "30086_idx"));
         }

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -1030,7 +1030,7 @@ TEST_F(BlockFileCacheTest, change_cache_type) {
         std::string data(size, '0');
         Slice result(data.data(), size);
         ASSERT_TRUE(blocks[0]->append(result).ok());
-        ASSERT_TRUE(blocks[0]->change_cache_type_self(io::FileCacheType::INDEX));
+        ASSERT_TRUE(blocks[0]->change_cache_type_between_normal_and_index(io::FileCacheType::INDEX));
         ASSERT_TRUE(blocks[0]->finalize().ok());
         auto key_str = key.to_string();
         auto subdir = fs::path(cache_base_path) / key_str.substr(0, 3) /
@@ -2684,7 +2684,7 @@ TEST_F(BlockFileCacheTest, append_many_time) {
             EXPECT_TRUE(fs::exists(storage->get_path_in_local_cache(dir, blocks[0]->offset(),
                                                                     blocks[0]->cache_type())));
         }
-        ASSERT_TRUE(blocks[0]->change_cache_type_self(FileCacheType::INDEX).ok());
+        ASSERT_TRUE(blocks[0]->change_cache_type_between_normal_and_index(FileCacheType::INDEX).ok());
         auto sp = SyncPoint::get_instance();
         sp->enable_processing();
         SyncPoint::CallbackGuard guard1;
@@ -2697,7 +2697,7 @@ TEST_F(BlockFileCacheTest, append_many_time) {
                 },
                 &guard1);
         {
-            ASSERT_FALSE(blocks[0]->change_cache_type_self(FileCacheType::NORMAL).ok());
+            ASSERT_FALSE(blocks[0]->change_cache_type_between_normal_and_index(FileCacheType::NORMAL).ok());
             EXPECT_EQ(blocks[0]->cache_type(), FileCacheType::INDEX);
             std::string buffer;
             buffer.resize(5);
@@ -2705,7 +2705,7 @@ TEST_F(BlockFileCacheTest, append_many_time) {
             EXPECT_EQ(buffer, std::string(5, '0'));
         }
         {
-            EXPECT_FALSE(blocks[0]->change_cache_type_by_mgr(FileCacheType::NORMAL).ok());
+            EXPECT_FALSE(blocks[0]->change_cache_type_between_ttl_and_others(FileCacheType::NORMAL).ok());
             EXPECT_EQ(blocks[0]->cache_type(), FileCacheType::INDEX);
             std::string buffer;
             buffer.resize(5);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -248,7 +248,7 @@ void test_file_cache(io::FileCacheType cache_type) {
         ASSERT_TRUE(mgr.initialize().ok());
 
         for (int i = 0; i < 100; i++) {
-            if (mgr.get_lazy_open_success()) {
+            if (mgr.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -586,7 +586,7 @@ void test_file_cache(io::FileCacheType cache_type) {
         io::BlockFileCache cache2(cache_base_path, settings);
         ASSERT_TRUE(cache2.initialize().ok());
         for (int i = 0; i < 100; i++) {
-            if (cache2.get_lazy_open_success()) {
+            if (cache2.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -624,7 +624,7 @@ void test_file_cache(io::FileCacheType cache_type) {
         io::BlockFileCache cache2(cache_path2, settings2);
         ASSERT_TRUE(cache2.initialize().ok());
         for (int i = 0; i < 100; i++) {
-            if (cache2.get_lazy_open_success()) {
+            if (cache2.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -677,7 +677,7 @@ TEST_F(BlockFileCacheTest, resize) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -711,12 +711,12 @@ TEST_F(BlockFileCacheTest, max_ttl_size) {
     ASSERT_TRUE(cache.initialize());
     int i = 0;
     for (; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    ASSERT_TRUE(cache.get_lazy_open_success());
+    ASSERT_TRUE(cache.get_async_open_success());
     int64_t offset = 0;
     for (; offset < 100000000; offset += 100000) {
         auto holder = cache.get_or_set(key1, offset, 100000, context);
@@ -759,7 +759,7 @@ TEST_F(BlockFileCacheTest, query_limit_heap_use_after_free) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -844,7 +844,7 @@ TEST_F(BlockFileCacheTest, query_limit_dcheck) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -961,7 +961,7 @@ TEST_F(BlockFileCacheTest, reset_range) {
     EXPECT_EQ(cache.capacity(), 15);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1011,7 +1011,7 @@ TEST_F(BlockFileCacheTest, change_cache_type) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1061,7 +1061,7 @@ TEST_F(BlockFileCacheTest, fd_cache_remove) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1143,7 +1143,7 @@ TEST_F(BlockFileCacheTest, fd_cache_evict) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1289,7 +1289,7 @@ void test_file_cache_run_in_resource_limit(io::FileCacheType cache_type) {
         cache._index_queue.hot_data_interval = 0;
         ASSERT_TRUE(cache.initialize());
         for (int i = 0; i < 100; i++) {
-            if (cache.get_lazy_open_success()) {
+            if (cache.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1471,7 +1471,7 @@ TEST_F(BlockFileCacheTest, test_lazy_load) {
     ASSERT_TRUE(blocks[0]->finalize());
     flag1 = true;
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1533,7 +1533,7 @@ TEST_F(BlockFileCacheTest, test_lazy_load_with_limit) {
     ASSERT_TRUE(blocks[0]->finalize());
     flag1 = true;
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1576,7 +1576,7 @@ TEST_F(BlockFileCacheTest, ttl_normal) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1671,7 +1671,7 @@ TEST_F(BlockFileCacheTest, ttl_modify) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1746,7 +1746,7 @@ TEST_F(BlockFileCacheTest, ttl_change_to_normal) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1810,7 +1810,7 @@ TEST_F(BlockFileCacheTest, ttl_change_expiration_time) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1873,12 +1873,12 @@ TEST_F(BlockFileCacheTest, ttl_reverse) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    ASSERT_TRUE(cache.get_lazy_open_success());
+    ASSERT_TRUE(cache.get_async_open_success());
     for (size_t offset = 0; offset < 30; offset += 6) {
         auto holder = cache.get_or_set(key2, offset, 6, context);
         auto blocks = fromHolder(holder);
@@ -1925,7 +1925,7 @@ TEST_F(BlockFileCacheTest, io_error) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2081,7 +2081,7 @@ TEST_F(BlockFileCacheTest, remove_directly_when_normal_change_to_ttl) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2157,7 +2157,7 @@ TEST_F(BlockFileCacheTest, recyle_cache_async) {
     sp->enable_processing();
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2228,7 +2228,7 @@ TEST_F(BlockFileCacheTest, recyle_cache_async_ttl) {
     sp->enable_processing();
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2291,7 +2291,7 @@ TEST_F(BlockFileCacheTest, remove_directly) {
     context.expiration_time = UnixSeconds() + 3600;
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2368,7 +2368,7 @@ TEST_F(BlockFileCacheTest, test_factory_1) {
     auto cache = FileCacheFactory::instance()->get_by_path(key1);
     int i = 0;
     while (i++ < 1000) {
-        if (cache->get_lazy_open_success()) {
+        if (cache->get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2434,7 +2434,7 @@ TEST_F(BlockFileCacheTest, test_factory_2) {
     auto cache = FileCacheFactory::instance()->get_by_path(key);
     int i = 0;
     while (i++ < 1000) {
-        if (cache->get_lazy_open_success()) {
+        if (cache->get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2469,7 +2469,7 @@ TEST_F(BlockFileCacheTest, test_factory_3) {
     auto cache = FileCacheFactory::instance()->get_by_path(key);
     int i = 0;
     while (i++ < 1000) {
-        if (cache->get_lazy_open_success()) {
+        if (cache->get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2545,7 +2545,7 @@ TEST_F(BlockFileCacheTest, test_disposable) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2593,7 +2593,7 @@ TEST_F(BlockFileCacheTest, test_query_limit) {
         auto cache = FileCacheFactory::instance()->get_by_path(key);
         int i = 0;
         while (i++ < 1000) {
-            if (cache->get_lazy_open_success()) {
+            if (cache->get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2656,7 +2656,7 @@ TEST_F(BlockFileCacheTest, append_many_time) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2776,7 +2776,7 @@ TEST_F(BlockFileCacheTest, query_file_cache) {
         io::BlockFileCache cache(cache_base_path, settings);
         ASSERT_TRUE(cache.initialize());
         for (int i = 0; i < 100; i++) {
-            if (cache.get_lazy_open_success()) {
+            if (cache.get_async_open_success()) {
                 break;
             };
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2787,7 +2787,7 @@ TEST_F(BlockFileCacheTest, query_file_cache) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -2844,7 +2844,7 @@ TEST_F(BlockFileCacheTest, query_file_cache_reserve) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3085,7 +3085,7 @@ TEST_F(BlockFileCacheTest, cached_remote_file_reader_error_handle) {
     ASSERT_TRUE(FileCacheFactory::instance()->create_file_cache(cache_base_path, settings).ok());
     auto cache = FileCacheFactory::instance()->_caches[0].get();
     for (int i = 0; i < 100; i++) {
-        if (cache->get_lazy_open_success()) {
+        if (cache->get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3356,7 +3356,7 @@ TEST_F(BlockFileCacheTest, test_hot_data) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3439,7 +3439,7 @@ TEST_F(BlockFileCacheTest, test_lazy_load_with_error_file_1) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3562,7 +3562,7 @@ TEST_F(BlockFileCacheTest, test_lazy_load_with_error_file_2) {
     ASSERT_TRUE(blocks[0]->finalize());
     flag1 = true;
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3588,7 +3588,7 @@ TEST_F(BlockFileCacheTest, test_check_disk_reource_limit_1) {
             config::file_cache_exit_disk_resource_limit_mode_percent = 50;
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3618,7 +3618,7 @@ TEST_F(BlockFileCacheTest, test_check_disk_reource_limit_2) {
     config::file_cache_exit_disk_resource_limit_mode_percent = 1;
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3649,7 +3649,7 @@ TEST_F(BlockFileCacheTest, test_check_disk_reource_limit_3) {
     config::file_cache_exit_disk_resource_limit_mode_percent = 98;
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3749,7 +3749,7 @@ TEST_F(BlockFileCacheTest, remove_if_cached_when_isnt_releasable) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3898,7 +3898,7 @@ TEST_F(BlockFileCacheTest, remove_from_other_queue_1) {
 
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3969,7 +3969,7 @@ TEST_F(BlockFileCacheTest, remove_from_other_queue_2) {
 
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4088,7 +4088,7 @@ TEST_F(BlockFileCacheTest, recyle_unvalid_ttl_async) {
     sp->enable_processing();
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4143,7 +4143,7 @@ TEST_F(BlockFileCacheTest, ttl_reserve_wo_evict_using_lru) {
 
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4206,7 +4206,7 @@ TEST_F(BlockFileCacheTest, ttl_reserve_with_evict_using_lru) {
 
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4275,7 +4275,7 @@ TEST_F(BlockFileCacheTest, ttl_reserve_with_evict_using_lru_meet_max_ttl_cache_r
 
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4350,7 +4350,7 @@ TEST_F(BlockFileCacheTest, reset_capacity) {
     sp->enable_processing();
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4419,7 +4419,7 @@ TEST_F(BlockFileCacheTest, change_cache_type1) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4493,7 +4493,7 @@ TEST_F(BlockFileCacheTest, change_cache_type2) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4577,7 +4577,7 @@ TEST_F(BlockFileCacheTest, load_cache1) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -4624,7 +4624,7 @@ TEST_F(BlockFileCacheTest, load_cache2) {
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     for (int i = 0; i < 100; i++) {
-        if (cache.get_lazy_open_success()) {
+        if (cache.get_async_open_success()) {
             break;
         };
         std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -625,7 +625,7 @@ TEST_F(S3FileWriterTest, multi_part_open_error) {
 //     auto cache = std::make_unique<io::BlockFileCache>(cache_base_path, settings);
 //     ASSERT_TRUE(cache->initialize());
 //     while (true) {
-//         if (cache->get_lazy_open_success()) {
+//         if (cache->get_async_open_success()) {
 //             break;
 //         };
 //         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -710,7 +710,7 @@ TEST_F(S3FileWriterTest, multi_part_open_error) {
 //     auto cache = std::make_unique<io::BlockFileCache>(cache_base_path, settings);
 //     ASSERT_TRUE(cache->initialize());
 //     while (true) {
-//         if (cache->get_lazy_open_success()) {
+//         if (cache->get_async_open_success()) {
 //             break;
 //         };
 //         std::this_thread::sleep_for(std::chrono::milliseconds(1));


### PR DESCRIPTION
current TTL embeds the expiration time and type into filename and path. Maintaining both is buggy for lack of atomicity. I simplify this by using only expiration time to infer the type so that we need only expiration time.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

