### PR TITLE
[fix](jdbc catalog) Fix incorrect format of FullDriverUrl under Windows

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -291,7 +291,11 @@ public class JdbcResource extends Resource {
             String schema = uri.getScheme();
             checkCloudWhiteList(driverUrl);
             if (schema == null && !driverUrl.startsWith("/")) {
-                return "file://" + Config.jdbc_drivers_dir + "/" + driverUrl;
+                String protocol = "file://";
+                if (!Config.jdbc_drivers_dir.startsWith("/")) {
+                    protocol += "/";
+                }
+                return protocol + Config.jdbc_drivers_dir + "/" + driverUrl;
             }
 
             if ("*".equals(Config.jdbc_driver_secure_path)) {


### PR DESCRIPTION
When debugging in a Windows environment, the `jdbc_drivers_dir` format is `D:\xxx\xxx`. 
The `getFullDriverUrl()` will return `file://D:\xxx\xxx`, 
![image](https://github.com/user-attachments/assets/b1c04a7a-2d13-40b2-958a-61319eb91092)
which does not comply with URI format specifications and will prevent the JDBC jar from being loaded in Windows. 
The correct FullDriverUrl format should be `file:///D:\xxx\xxx`.

