### PR TITLE
[fix](mysql catalog) Fixed exception in dorisTypeToDoris when using MySQL catalog.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -375,6 +375,10 @@ public class JdbcMySQLClient extends JdbcClient {
             }
             case "CHAR":
             case "VARCHAR": {
+                if (openParen == -1) {
+                    return baseType.equals("CHAR")
+                            ? ScalarType.createCharType(255) : ScalarType.createVarcharType(65533);
+                }
                 int length = Integer.parseInt(upperType.substring(openParen + 1, upperType.length() - 1));
                 return baseType.equals("CHAR")
                     ? ScalarType.createCharType(length) : ScalarType.createVarcharType(length);


### PR DESCRIPTION
When using specific MySQL JDBC packages (such as mysql-connector-java-8.3.0), their `CHAR` or `VARCHAR` metadata strings lack the (len) suffix. 
Consequently, related queries will result in errors due to attempts at converting `CHAR` to int.
![clipboard](https://github.com/user-attachments/assets/c8b3688b-83bf-4b43-9fe9-8963117735d7)

This pr ensures compatibility with the metadata formats of both `CHAR` and `VARCHAR` types by providing the maximum lengths.
