### PR TITLE
[fix] (compaction) fix compaction score in time series policy

### DIFF
--- a/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
@@ -404,7 +404,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calc_cumulative_compaction_scor
     const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
                                                           cumulative_compaction_policy);
 
-    EXPECT_EQ(0, score);
+    EXPECT_EQ(9, score);
 }
 
 TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calc_cumulative_compaction_score_big_rowset) {


### PR DESCRIPTION
### BEFORE

The compaction score is 0 when the merge conditions are not met in the time series policy.

### AFTER

The compaction score is the sum of the compaction scores of the rowsets to be merged.


