### PR TITLE
[feature](docker suite) Docker suite use independent executor

### DIFF
--- a/docker/runtime/doris-compose/Readme.md
+++ b/docker/runtime/doris-compose/Readme.md
@@ -64,6 +64,12 @@ For example, if user export LOCAL_DORIS_PATH=/mydoris, then the cluster's direct
 
 And cluster's directory will contains all its containers's logs and data, like fe-1, fe-2, be-1, ..., etc.
 
+If there are multiple users run doris-compose on the same machine, suggest don't change LOCAL_DORIS_PATH or they should export the same LOCAL_DORIS_PATH.
+
+Because when create a new cluster, doris-compose will search the local doris path, and choose a docker network which is different with this path's clusters.
+
+So if multiple users use different LOCAL_DORIS_PATH, their clusters may have docker network conflict!!!
+
 ### Create a cluster or recreate its containers
 
 ```

--- a/docker/runtime/doris-compose/Readme.md
+++ b/docker/runtime/doris-compose/Readme.md
@@ -23,7 +23,16 @@ Use doris compose to create doris docker compose clusters.
 
 ## Requirements
 
-1. The doris image should contains:
+##### 1. Make sure you have docker permissions
+
+ run:
+```
+docker run hello-world
+```
+
+if have problem with permission denied, then [add-docker-permission](https://docs.docker.com/engine/install/linux-postinstall/).
+
+##### 2. The doris image should contains
 
 ```
 /opt/apache-doris/{fe, be, cloud}
@@ -32,16 +41,14 @@ Use doris compose to create doris docker compose clusters.
 if don't create cloud cluster, the image no need to contains the cloud pkg.
 
 
-if build doris use `sh build.sh --fe --be --cloud`, then its output satisfy with all above, then run command in doris root
+if build doris use `sh build.sh --fe --be --cloud`, then its output satisfy with all above, then run command in doris root directory
+ will generate such a image.
 
 ```
 docker build -f docker/runtime/doris-compose/Dockerfile -t <image> .
 ```
 
-will generate a image.
-
-2. Install the dependent python library in 'docker/runtime/doris-compose/requirements.txt'
-
+##### 3. Install the dependent python library in 'docker/runtime/doris-compose/requirements.txt'
 
 ```
 python -m pip install --user -r docker/runtime/doris-compose/requirements.txt
@@ -65,9 +72,11 @@ add fe/be nodes with the specific image, or update existing nodes with `--fe-id`
 
 
 For create a cloud cluster, steps are as below:
+
 1. Write cloud s3 store config file, its default path is '/tmp/doris/cloud.ini'.
    It's defined in environment variable DORIS_CLOUD_CFG_FILE, user can change this env var to change its path.
    A Example file is locate in 'docker/runtime/doris-compose/resource/cloud.ini.example'.
+
 2. Use doris compose up command with option '--cloud' to create a new cloud cluster.
 
 The simplest way to create a cloud cluster:

--- a/docker/runtime/doris-compose/Readme.md
+++ b/docker/runtime/doris-compose/Readme.md
@@ -56,6 +56,14 @@ python -m pip install --user -r docker/runtime/doris-compose/requirements.txt
 
 ## Usage
 
+### Notice
+
+Each cluster will have a directory in '/tmp/doris/{cluster-name}', user can set env LOCAL_DORIS_PATH to change its directory.
+
+For example, if user export LOCAL_DORIS_PATH=/mydoris, then the cluster's directory is '/mydoris/{cluster-name}'.
+
+And cluster's directory will contains all its containers's logs and data, like fe-1, fe-2, be-1, ..., etc.
+
 ### Create a cluster or recreate its containers
 
 ```
@@ -136,7 +144,7 @@ Generate regression-conf-custom.groovy to connect to the specific docker cluster
 
 steps:
 
-1. Create a new cluster:  `python doris-compose.py up my-cluster  my-image  --add-fe-num 2  --add-be-num 4 --cloud`
-2. Generate regression-conf-custom.groovy: `python doris-compose.py config my-cluster  <doris-root-path> --connect-follow-fe`
+1. Create a new cluster:  `python docker/runtime/doris-compose/doris-compose.py up my-cluster  my-image  --add-fe-num 2  --add-be-num 4 --cloud`
+2. Generate regression-conf-custom.groovy: `python docker/runtime/doris-compose/doris-compose.py config my-cluster  <doris-root-path> --connect-follow-fe`
 3. Run regression test: `bash run-regression-test.sh --run -times 1 -parallel 1 -suiteParallel 1 -d cloud/multi_cluster`
 

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -859,7 +859,7 @@ cloudUniqueId= "{fe_cloud_unique_id}"
                     in_annotation = False
                     annotation_end_line_idx = line_idx
                 elif not in_annotation:
-                    if line or line_idx == annotation_end_line_idx + 1:
+                    if line or line_idx != annotation_end_line_idx + 1:
                         f.write(line + "\n")
 
         print("\nWrite succ: " + regression_conf_custom)

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -826,7 +826,7 @@ cloudUniqueId= "{fe_cloud_unique_id}"
                 old_contents = f.readlines()
         with open(regression_conf_custom, "w") as f:
             # write auto gen config
-            f.write(annotation_start + "\n")
+            f.write(annotation_start)
             f.write(base_conf.format(fe_ip=fe_ip))
             if cluster.is_cloud:
                 multi_cluster_bes = ",".join([
@@ -845,7 +845,7 @@ cloudUniqueId= "{fe_cloud_unique_id}"
                         multi_cluster_bes=multi_cluster_bes,
                         fe_cloud_unique_id=cluster.get_node(
                             CLUSTER.Node.TYPE_FE, 1).cloud_unique_id()))
-            f.write(annotation_end + "\n")
+            f.write(annotation_end + "\n\n")
 
             # write not-auto gen config
             in_annotation = False

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -846,17 +846,21 @@ cloudUniqueId= "{fe_cloud_unique_id}"
                         fe_cloud_unique_id=cluster.get_node(
                             CLUSTER.Node.TYPE_FE, 1).cloud_unique_id()))
             f.write(annotation_end + "\n\n")
+            annotation_end_line_count = -1
 
             # write not-auto gen config
             in_annotation = False
-            for line in old_contents:
+            annotation_end_line_idx = -100
+            for line_idx, line in enumerate(old_contents):
                 line = line.rstrip()
                 if line == annotation_start:
                     in_annotation = True
                 elif line == annotation_end:
                     in_annotation = False
+                    annotation_end_line_idx = line_idx
                 elif not in_annotation:
-                    f.write(line + "\n")
+                    if line or line_idx == annotation_end_line_idx + 1:
+                        f.write(line + "\n")
 
         print("\nWrite succ: " + regression_conf_custom)
 

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -817,7 +817,16 @@ cloudUniqueId= "{fe_cloud_unique_id}"
                 print("\nNo write regression custom file.")
                 return
 
+        annotation_start = "//---------- Start auto generate by doris-compose.py---------"
+        annotation_end = "//---------- End auto generate by doris-compose.py---------"
+
+        old_contents = []
+        if os.path.exists(regression_conf_custom):
+            with open(regression_conf_custom, "r") as f:
+                old_contents = f.readlines()
         with open(regression_conf_custom, "w") as f:
+            # write auto gen config
+            f.write(annotation_start + "\n")
             f.write(base_conf.format(fe_ip=fe_ip))
             if cluster.is_cloud:
                 multi_cluster_bes = ",".join([
@@ -836,6 +845,19 @@ cloudUniqueId= "{fe_cloud_unique_id}"
                         multi_cluster_bes=multi_cluster_bes,
                         fe_cloud_unique_id=cluster.get_node(
                             CLUSTER.Node.TYPE_FE, 1).cloud_unique_id()))
+            f.write(annotation_end + "\n")
+
+            # write not-auto gen config
+            in_annotation = False
+            for line in old_contents:
+                line = line.rstrip()
+                if line == annotation_start:
+                    in_annotation = True
+                elif line == annotation_end:
+                    in_annotation = False
+                elif not in_annotation:
+                    f.write(line + "\n")
+
         print("\nWrite succ: " + regression_conf_custom)
 
 

--- a/docker/runtime/doris-compose/resource/common.sh
+++ b/docker/runtime/doris-compose/resource/common.sh
@@ -23,7 +23,7 @@ export LOG_FILE=$DORIS_HOME/log/health.out
 export LOCK_FILE=$DORIS_HOME/status/token
 
 health_log() {
-    echo "$(date +'%Y-%m-%d %H:%M:%S') $@" >>$LOG_FILE
+    echo "$(date +'%Y-%m-%d %H:%M:%S') $@" | tee -a $LOG_FILE
 }
 
 # concurrent write meta service server will failed due to fdb txn conflict.

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -117,6 +117,7 @@ class Config {
     public InetSocketAddress recycleServiceHttpInetSocketAddress
     public Integer parallel
     public Integer suiteParallel
+    public Integer dockerSuiteParallel
     public Integer actionParallel
     public Integer times
     public boolean withOutLoadData
@@ -467,6 +468,7 @@ class Config {
         config.forceGenerateOutputFile = cmd.hasOption(forceGenOutOpt)
         config.parallel = Integer.parseInt(cmd.getOptionValue(parallelOpt, "10"))
         config.suiteParallel = Integer.parseInt(cmd.getOptionValue(suiteParallelOpt, "10"))
+        config.dockerSuiteParallel = Integer.parseInt(cmd.getOptionValue(dockerSuiteParallelOpt, "1"))
         config.actionParallel = Integer.parseInt(cmd.getOptionValue(actionParallelOpt, "10"))
         config.times = Integer.parseInt(cmd.getOptionValue(timesOpt, "1"))
         config.randomOrder = cmd.hasOption(randomOrderOpt)
@@ -886,6 +888,11 @@ class Config {
         if (config.suiteParallel == null) {
             config.suiteParallel = 1
             log.info("Set suiteParallel to 1 because not specify.".toString())
+        }
+
+        if (config.dockerSuiteParallel == null) {
+            config.dockerSuiteParallel = 1
+            log.info("Set dockerSuiteParallel to 1 because not specify.".toString())
         }
 
         if (config.actionParallel == null) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -67,6 +67,7 @@ class ConfigOptions {
     static Option forceGenOutOpt
     static Option parallelOpt
     static Option suiteParallelOpt
+    static Option dockerSuiteParallelOpt
     static Option actionParallelOpt
     static Option randomOrderOpt
     static Option stopWhenFailOpt
@@ -425,6 +426,14 @@ class ConfigOptions {
                 .longOpt("suiteParallel")
                 .desc("the num of threads running for suites")
                 .build()
+        dockerSuiteParallelOpt = Option.builder("dockerSuiteParallel")
+                .argName("dockerSuiteParallel")
+                .required(false)
+                .hasArg(true)
+                .type(String.class)
+                .longOpt("dockerSuiteParallel")
+                .desc("the num of threads running for docker suites")
+                .build()
         actionParallelOpt = Option.builder("actionParallel")
                 .argName("parallel")
                 .required(false)
@@ -607,6 +616,7 @@ class ConfigOptions {
                 .addOption(forceGenOutOpt)
                 .addOption(parallelOpt)
                 .addOption(suiteParallelOpt)
+                .addOption(dockerSuiteParallelOpt)
                 .addOption(actionParallelOpt)
                 .addOption(randomOrderOpt)
                 .addOption(stopWhenFailOpt)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -480,7 +480,7 @@ class RegressionTest {
                     + "output: ${sout.toString()}, error: ${serr.toString()}")
         }
 
-        def pipList = 'pip list'.execute().text
+        def pipList = 'python -m pip list'.execute().text
         log.info("python library: ${pipList}")
     }
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -52,16 +52,22 @@ import java.util.function.Predicate
 @CompileStatic
 class RegressionTest {
 
+    static enum SuiteType {
+        NORMAL,
+        SINGLE,
+        DOCKER,
+    }
+
     static ClassLoader classloader
     static CompilerConfiguration compileConfig
     static GroovyShell shell
     static ExecutorService scriptExecutors
-    static ExecutorService suiteExecutors
-    static ExecutorService singleSuiteExecutors
     static ExecutorService actionExecutors
+    static Map<SuiteType, ExecutorService> suiteExecutors
     static ThreadLocal<Integer> threadLoadedClassNum = new ThreadLocal<>()
     static final int cleanLoadedClassesThreshold = 20
     static String nonConcurrentTestGroup = "nonConcurrent"
+    static String dockerTestGroup = "docker"
 
     static {
         ch.qos.logback.classic.Logger loggerOfSuite =
@@ -113,8 +119,9 @@ class RegressionTest {
             }
         }
         actionExecutors.shutdown()
-        suiteExecutors.shutdown()
-        singleSuiteExecutors.shutdown()
+        for (ExecutorService suiteExecutor : suiteExecutors.values()) {
+            suiteExecutor.shutdown()
+        }
         scriptExecutors.shutdown()
         log.info("Test finished")
         if (!success) {
@@ -135,17 +142,24 @@ class RegressionTest {
             .build();
         scriptExecutors = Executors.newFixedThreadPool(config.parallel, scriptFactory)
 
+        suiteExecutors = [:]
         BasicThreadFactory suiteFactory = new BasicThreadFactory.Builder()
             .namingPattern("suite-thread-%d")
             .priority(Thread.MAX_PRIORITY)
             .build();
-        suiteExecutors = Executors.newFixedThreadPool(config.suiteParallel, suiteFactory)
+        suiteExecutors[SuiteType.NORMAL] = Executors.newFixedThreadPool(config.suiteParallel, suiteFactory)
 
         BasicThreadFactory singleSuiteFactory = new BasicThreadFactory.Builder()
             .namingPattern("non-concurrent-thread-%d")
             .priority(Thread.MAX_PRIORITY)
             .build();
-        singleSuiteExecutors = Executors.newFixedThreadPool(1, singleSuiteFactory)
+        suiteExecutors[SuiteType.SINGLE] = Executors.newFixedThreadPool(1, singleSuiteFactory)
+
+        BasicThreadFactory dockerSuiteFactory = new BasicThreadFactory.Builder()
+            .namingPattern("docker-suite-thread-%d")
+            .priority(Thread.MAX_PRIORITY)
+            .build();
+        suiteExecutors[SuiteType.DOCKER] = Executors.newFixedThreadPool(config.dockerSuiteParallel, dockerSuiteFactory)
 
         BasicThreadFactory actionFactory = new BasicThreadFactory.Builder()
             .namingPattern("action-thread-%d")
@@ -198,9 +212,9 @@ class RegressionTest {
         return sources
     }
 
-    static void runScript(Config config, ScriptSource source, Recorder recorder, boolean isSingleThreadScript) {
+    static void runScript(Config config, ScriptSource source, Recorder recorder, SuiteType suiteType) {
         def suiteFilter = { String suiteName, String groupName ->
-            canRun(config, suiteName, groupName, isSingleThreadScript)
+            canRun(config, suiteName, groupName, suiteType)
         }
         def file = source.getFile()
         int failureLimit = Integer.valueOf(config.otherConfigs.getOrDefault("max_failure_num", "-1").toString());
@@ -211,12 +225,7 @@ class RegressionTest {
             return;
         }
         def eventListeners = getEventListeners(config, recorder)
-        ExecutorService executors = null
-        if (isSingleThreadScript) {
-            executors = singleSuiteExecutors
-        } else {
-            executors = suiteExecutors
-        }
+        ExecutorService executors = suiteExecutors[suiteType]
 
         new ScriptContext(file, executors, actionExecutors,
                 config, eventListeners, suiteFilter).start { scriptContext ->
@@ -242,7 +251,15 @@ class RegressionTest {
         scriptSources.eachWithIndex { source, i ->
 //            log.info("Prepare scripts [${i + 1}/${totalFile}]".toString())
             def future = scriptExecutors.submit {
-                runScript(config, source, recorder, false)
+                runScript(config, source, recorder, SuiteType.NORMAL)
+            }
+            futures.add(future)
+        }
+
+        scriptSources.eachWithIndex { source, i ->
+//            log.info("Prepare scripts [${i + 1}/${totalFile}]".toString())
+            def future = scriptExecutors.submit {
+                runScript(config, source, recorder, SuiteType.DOCKER)
             }
             futures.add(future)
         }
@@ -261,7 +278,7 @@ class RegressionTest {
         scriptSources.eachWithIndex { source, i ->
 //            log.info("Prepare scripts [${i + 1}/${totalFile}]".toString())
             def future = scriptExecutors.submit {
-                runScript(config, source, recorder, true)
+                runScript(config, source, recorder, SuiteType.SINGLE)
             }
             futures.add(future)
         }
@@ -323,19 +340,19 @@ class RegressionTest {
         return true
     }
 
-    static boolean canRun(Config config, String suiteName, String group, boolean isSingleThreadScript) {
-        Set<String> suiteGroups = group.split(',').collect { g -> g.trim() }.toSet();
-        if (isSingleThreadScript) {
-            if (!suiteGroups.contains(nonConcurrentTestGroup)) {
-                return false
-            }
-        } else {
-            if (suiteGroups.contains(nonConcurrentTestGroup)) {
-                return false
-            }
-        }
+    static boolean canRun(Config config, String suiteName, String group, SuiteType suiteType) {
+        return getSuiteType(group) == suiteType && filterGroups(config, group) && filterSuites(config, suiteName)
+    }
 
-        return filterGroups(config, group) && filterSuites(config, suiteName)
+    static SuiteType getSuiteType(String group) {
+        Set<String> suiteGroups = group.split(',').collect { g -> g.trim() }.toSet();
+        if (suiteGroups.contains(nonConcurrentTestGroup)) {
+            return SuiteType.SINGLE
+        } else if (suiteGroups.contains(dockerTestGroup)) {
+            return SuiteType.DOCKER
+        } else {
+            return SuiteType.NORMAL
+        }
     }
 
     static List<EventListener> getEventListeners(Config config, Recorder recorder) {
@@ -421,7 +438,7 @@ class RegressionTest {
         }
         pluginPath.eachFileRecurse({ it ->
             if (it.name.endsWith(".groovy")) {
-                ScriptContext context = new ScriptContext(it, suiteExecutors, actionExecutors,
+                ScriptContext context = new ScriptContext(it, suiteExecutors[SuiteType.NORMAL], actionExecutors,
                         config, [], { name -> true })
                 File pluginFile = it
                 context.start({

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -256,12 +256,13 @@ class RegressionTest {
             futures.add(future)
         }
 
+        List<Future> dockerFutures = Lists.newArrayList()
         scriptSources.eachWithIndex { source, i ->
 //            log.info("Prepare scripts [${i + 1}/${totalFile}]".toString())
             def future = scriptExecutors.submit {
                 runScript(config, source, recorder, SuiteType.DOCKER)
             }
-            futures.add(future)
+            dockerFutures.add(future)
         }
 
         // wait all scripts
@@ -284,6 +285,14 @@ class RegressionTest {
         }
 
         // wait all scripts
+        for (Future future : dockerFutures) {
+            try {
+                future.get()
+            } catch (Throwable t) {
+                // do nothing, because already save to Recorder
+            }
+        }
+
         for (Future future : futures) {
             try {
                 future.get()

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -29,6 +29,7 @@ import groovy.json.JsonSlurper
 import com.google.common.collect.ImmutableList
 import org.apache.commons.lang3.ObjectUtils
 import org.apache.doris.regression.Config
+import org.apache.doris.regression.RegressionTest
 import org.apache.doris.regression.action.BenchmarkAction
 import org.apache.doris.regression.action.ProfileAction
 import org.apache.doris.regression.action.WaitForAction
@@ -274,6 +275,10 @@ class Suite implements GroovyInterceptable {
     public void docker(ClusterOptions options = new ClusterOptions(), Closure actionSupplier) throws Exception {
         if (context.config.excludeDockerTest) {
             return
+        }
+
+        if (RegressionTest.getSuiteType(group) != RegressionTest.SuiteType.DOCKER) {
+            throw new Exception("Need add 'docker' to docker suite's belong groups")
         }
 
         boolean pipelineIsCloud = isCloudMode()

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -277,7 +277,7 @@ class Suite implements GroovyInterceptable {
             return
         }
 
-        if (RegressionTest.getSuiteType(group) != RegressionTest.SuiteType.DOCKER) {
+        if (RegressionTest.getGroupExecType(group) != RegressionTest.GroupExecType.DOCKER) {
             throw new Exception("Need to add 'docker' to docker suite's belong groups, "
                     + "see example demo_p0/docker_action.groovy")
         }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -278,7 +278,8 @@ class Suite implements GroovyInterceptable {
         }
 
         if (RegressionTest.getSuiteType(group) != RegressionTest.SuiteType.DOCKER) {
-            throw new Exception("Need add 'docker' to docker suite's belong groups")
+            throw new Exception("Need to add 'docker' to docker suite's belong groups, "
+                    + "see example demo_p0/docker_action.groovy")
         }
 
         boolean pipelineIsCloud = isCloudMode()

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -40,6 +40,7 @@ class ClusterOptions {
     ]
 
     List<String> beConfigs = [
+        'max_sys_mem_available_low_water_mark_bytes=0', //no check mem available memory
         'report_disk_state_interval_seconds=2',
         'report_random_wait=false',
     ]

--- a/regression-test/suites/clone_p0/test_clone_missing_version.groovy
+++ b/regression-test/suites/clone_p0/test_clone_missing_version.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite('test_clone_missing_version') {
+suite('test_clone_missing_version', 'docker') {
     def options = new ClusterOptions()
     options.feConfigs += [
         'disable_tablet_scheduler=true',

--- a/regression-test/suites/clone_p0/test_clone_no_missing_version.groovy
+++ b/regression-test/suites/clone_p0/test_clone_no_missing_version.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite('test_clone_no_missing_version') {
+suite('test_clone_no_missing_version', 'docker') {
     def tbl = 'tbl_test_clone_no_missing_version'
     def options = new ClusterOptions()
     options.feConfigs += [

--- a/regression-test/suites/clone_p0/test_decommission_mtmv.groovy
+++ b/regression-test/suites/clone_p0/test_decommission_mtmv.groovy
@@ -17,7 +17,7 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite('test_decommission_mtmv') {
+suite('test_decommission_mtmv', 'docker') {
     def options = new ClusterOptions()
     options.feConfigs += [
         'disable_balance=true',

--- a/regression-test/suites/clone_p0/test_drop_clone_tablet_path_race.groovy
+++ b/regression-test/suites/clone_p0/test_drop_clone_tablet_path_race.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.junit.Assert
 
-suite('test_drop_clone_tablet_path_race') {
+suite('test_drop_clone_tablet_path_race', 'docker') {
     if (isCloudMode()) {
         return
     }

--- a/regression-test/suites/cloud_p0/multi_cluster/test_rebalance.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/test_rebalance.groovy
@@ -20,7 +20,7 @@ import groovy.json.JsonSlurper
 import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-suite('test_rebalance_in_cloud', 'multi_cluster') {
+suite('test_rebalance_in_cloud', 'multi_cluster,docker') {
     if (!isCloudMode()) {
         return;
     }

--- a/regression-test/suites/cloud_p0/multi_cluster/test_tvf.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/test_tvf.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import groovy.json.JsonSlurper
 
-suite('test_tvf_in_cloud', 'multi_cluster') {
+suite('test_tvf_in_cloud', 'multi_cluster,docker') {
     if (!isCloudMode()) {
         return;
     }

--- a/regression-test/suites/cloud_p0/query_retry/test_retry_e-230.groovy
+++ b/regression-test/suites/cloud_p0/query_retry/test_retry_e-230.groovy
@@ -18,7 +18,7 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 import org.apache.doris.regression.suite.SuiteCluster
 
-suite("test_retry_e-230") {
+suite("test_retry_e-230", 'docker') {
     if (!isCloudMode()) {
         return
     }

--- a/regression-test/suites/cloud_p0/schema_change/compaction10/test_schema_change_with_compaction10.groovy
+++ b/regression-test/suites/cloud_p0/schema_change/compaction10/test_schema_change_with_compaction10.groovy
@@ -20,7 +20,7 @@ import org.apache.http.NoHttpResponseException
 import org.apache.doris.regression.util.DebugPoint
 import org.apache.doris.regression.util.NodeType
 
-suite('test_schema_change_with_compaction10') {
+suite('test_schema_change_with_compaction10', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/cloud_p0/schema_change/compaction11/test_schema_change_with_compaction11.groovy
+++ b/regression-test/suites/cloud_p0/schema_change/compaction11/test_schema_change_with_compaction11.groovy
@@ -20,7 +20,7 @@ import org.apache.http.NoHttpResponseException
 import org.apache.doris.regression.util.DebugPoint
 import org.apache.doris.regression.util.NodeType
 
-suite('test_schema_change_with_compaction11') {
+suite('test_schema_change_with_compaction11', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/cloud_p0/schema_change/compaction5/test_schema_change_with_compaction5.groovy
+++ b/regression-test/suites/cloud_p0/schema_change/compaction5/test_schema_change_with_compaction5.groovy
@@ -20,7 +20,7 @@ import org.apache.http.NoHttpResponseException
 import org.apache.doris.regression.util.DebugPoint
 import org.apache.doris.regression.util.NodeType
 
-suite('test_schema_change_with_compaction5', 'nonConcurrent') {
+suite('test_schema_change_with_compaction5', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/cloud_p0/schema_change/compaction6/test_schema_change_with_compaction6.groovy
+++ b/regression-test/suites/cloud_p0/schema_change/compaction6/test_schema_change_with_compaction6.groovy
@@ -20,7 +20,7 @@ import org.apache.http.NoHttpResponseException
 import org.apache.doris.regression.util.DebugPoint
 import org.apache.doris.regression.util.NodeType
 
-suite('test_schema_change_with_compaction6', 'nonConcurrent') {
+suite('test_schema_change_with_compaction6', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/cloud_p0/schema_change/compaction9/test_schema_change_with_compaction9.groovy
+++ b/regression-test/suites/cloud_p0/schema_change/compaction9/test_schema_change_with_compaction9.groovy
@@ -20,7 +20,7 @@ import org.apache.http.NoHttpResponseException
 import org.apache.doris.regression.util.DebugPoint
 import org.apache.doris.regression.util.NodeType
 
-suite('test_schema_change_with_compaction9') {
+suite('test_schema_change_with_compaction9', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/compaction/test_compaction_with_visible_version.groovy
+++ b/regression-test/suites/compaction/test_compaction_with_visible_version.groovy
@@ -19,7 +19,7 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.Http
 import org.apache.doris.regression.util.NodeType
 
-suite('test_compaction_with_visible_version') {
+suite('test_compaction_with_visible_version', 'docker') {
     def options = new ClusterOptions()
     def compaction_keep_invisible_version_min_count = 50L
     options.feConfigs += [

--- a/regression-test/suites/demo_p0/docker_action.groovy
+++ b/regression-test/suites/demo_p0/docker_action.groovy
@@ -17,7 +17,8 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite('docker_action') {
+// need add 'docker' to suite's group
+suite('docker_action', 'docker') {
     // run a new docker
     docker {
         sql '''create table tb1 (k int) DISTRIBUTED BY HASH(k) BUCKETS 10'''

--- a/regression-test/suites/demo_p0/docker_action.groovy
+++ b/regression-test/suites/demo_p0/docker_action.groovy
@@ -17,7 +17,14 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-// need add 'docker' to suite's group
+// run docker suite steps:
+// 1. Read 'docker/runtime/doris-compose/Readme.md', make sure you can setup a doris docker cluster;
+// 2. update regression-conf-custom.groovy with config:
+//    image = "xxxx"                // your doris docker image
+//    excludeDockerTest = false     // do run docker suite, default is false
+//    dockerEndDeleteFiles = false  // after run docker suite, whether delete contains's log and data in directory '/tmp/doris/<suite-name>'
+
+// need add 'docker' to suite's group, and don't add 'nonConcurrent' to it
 suite('docker_action', 'docker') {
     // run a new docker
     docker {

--- a/regression-test/suites/insert_p0/group_commit/replay_wal_restart_fe.groovy
+++ b/regression-test/suites/insert_p0/group_commit/replay_wal_restart_fe.groovy
@@ -21,7 +21,7 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite("replay_wal_restart_fe") {
+suite("replay_wal_restart_fe", 'docker') {
     def check_schema_change = { state ->
         for (int i = 0; i < 30; i++) {
             def jobs = sql_return_maparray "SHOW ALTER TABLE COLUMN WHERE TableName = 'tbl_2' order by CreateTime desc;"

--- a/regression-test/suites/insert_p0/transaction/txn_insert_restart_fe.groovy
+++ b/regression-test/suites/insert_p0/transaction/txn_insert_restart_fe.groovy
@@ -22,7 +22,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite("txn_insert_restart_fe") {
+suite("txn_insert_restart_fe", 'docker') {
     def get_observer_fe_url = {
         def fes = sql_return_maparray "show frontends"
         logger.info("frontends: ${fes}")

--- a/regression-test/suites/insert_p0/transaction/txn_insert_restart_fe_with_schema_change.groovy
+++ b/regression-test/suites/insert_p0/transaction/txn_insert_restart_fe_with_schema_change.groovy
@@ -22,7 +22,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite("txn_insert_restart_fe_with_schema_change") {
+suite("txn_insert_restart_fe_with_schema_change", 'docker') {
     def getAlterTableState = { dbName, show_sql ->
         def retry = 0
         sql "use ${dbName};"

--- a/regression-test/suites/inverted_index_p0/index_change/test_build_index_with_clone_by_docker.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_build_index_with_clone_by_docker.groovy
@@ -19,7 +19,7 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 import org.apache.doris.regression.suite.SuiteCluster
 
-suite("test_build_index_with_clone_by_docker"){
+suite("test_build_index_with_clone_by_docker", 'docker'){
     if (isCloudMode()) {
         return 
     }

--- a/regression-test/suites/load/insert/test_min_load_replica_num_complicate.groovy
+++ b/regression-test/suites/load/insert/test_min_load_replica_num_complicate.groovy
@@ -34,7 +34,7 @@ class InjectCase {
 
 }
 
-suite('test_min_load_replica_num_complicate') {
+suite('test_min_load_replica_num_complicate', 'docker') {
     def beCloneCostMs = 3000
 
     def random = new Random()

--- a/regression-test/suites/load/insert/test_publish_one_succ.groovy
+++ b/regression-test/suites/load/insert/test_publish_one_succ.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite('test_publish_one_succ') {
+suite('test_publish_one_succ', 'docker') {
     def options = new ClusterOptions()
     options.enableDebugPoints()
     docker(options) {

--- a/regression-test/suites/load/insert/test_publish_slow_not_wait.groovy
+++ b/regression-test/suites/load/insert/test_publish_slow_not_wait.groovy
@@ -17,7 +17,7 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite('test_publish_slow_not_wait') {
+suite('test_publish_slow_not_wait', 'docker') {
     def options = new ClusterOptions()
     options.beNum = 3
     options.feConfigs.add('disable_tablet_scheduler=true')

--- a/regression-test/suites/load_p0/insert/test_min_load_replica_num_simple.groovy
+++ b/regression-test/suites/load_p0/insert/test_min_load_replica_num_simple.groovy
@@ -17,7 +17,7 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite('test_min_load_replica_num_simple') {
+suite('test_min_load_replica_num_simple', 'docker') {
     def options = new ClusterOptions()
     options.feConfigs.add('tablet_checker_interval_ms=1000')
     docker(options) {

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_restart_fe.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_restart_fe.groovy
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.ProducerConfig
 
-suite("test_routine_load_restart_fe", "p0, nonConcurrent") {
+suite("test_routine_load_restart_fe", "docker") {
     def kafkaCsvTpoics = [
                   "test_out_of_range",
                 ]

--- a/regression-test/suites/load_p0/stream_load/test_coordidator_be_restart.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_coordidator_be_restart.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_coordidator_be_restart') {
+suite('test_coordidator_be_restart', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = false
     options.enableDebugPoints()

--- a/regression-test/suites/migrate_p0/test_migrate_disk_with_publish_version.groovy
+++ b/regression-test/suites/migrate_p0/test_migrate_disk_with_publish_version.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite('test_migrate_disk_with_publish_version') {
+suite('test_migrate_disk_with_publish_version', 'docker') {
     if (isCloudMode()) {
         return
     }

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_mod_distribution_key.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_mod_distribution_key.groovy
@@ -18,7 +18,7 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite("test_dynamic_partition_mod_distribution_key") {
+suite("test_dynamic_partition_mod_distribution_key", "docker") {
     def options = new ClusterOptions()
     options.setFeNum(2)
     docker(options) {

--- a/regression-test/suites/partition_p0/test_create_table_exception.groovy
+++ b/regression-test/suites/partition_p0/test_create_table_exception.groovy
@@ -18,7 +18,7 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 import org.apache.doris.regression.suite.SuiteCluster
 
-suite("test_create_table_exception") {
+suite("test_create_table_exception", "docker") {
     def options = new ClusterOptions()
     options.enableDebugPoints()
     options.setFeNum(3)

--- a/regression-test/suites/partition_p0/test_partition_create_tablet_rr.groovy
+++ b/regression-test/suites/partition_p0/test_partition_create_tablet_rr.groovy
@@ -18,7 +18,7 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 import org.apache.doris.regression.suite.SuiteCluster
 
-suite("test_partition_create_tablet_rr") {
+suite("test_partition_create_tablet_rr", "docker") {
     def options = new ClusterOptions()
     options.beNum = 1
     options.feConfigs.add('disable_balance=true')

--- a/regression-test/suites/query_p0/test_forward_qeury.groovy
+++ b/regression-test/suites/query_p0/test_forward_qeury.groovy
@@ -19,7 +19,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite("test_forward_query") {
+suite("test_forward_query", 'docker') {
     def options = new ClusterOptions()
     options.enableDebugPoints()
     options.setFeNum(2)

--- a/regression-test/suites/schema_change/test_schema_change_concurrent_with_txn.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_concurrent_with_txn.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 
-suite('test_schema_change_concurrent_with_txn') {
+suite('test_schema_change_concurrent_with_txn', 'docker') {
     def options = new ClusterOptions()
     options.enableDebugPoints()
     options.feConfigs.add('publish_wait_time_second=-1')

--- a/regression-test/suites/schema_change_p0/test_abort_txn_by_be_cloud1.groovy
+++ b/regression-test/suites/schema_change_p0/test_abort_txn_by_be_cloud1.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_abort_txn_by_be_cloud1') {
+suite('test_abort_txn_by_be_cloud1', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/schema_change_p0/test_abort_txn_by_be_cloud2.groovy
+++ b/regression-test/suites/schema_change_p0/test_abort_txn_by_be_cloud2.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_abort_txn_by_be_cloud2') {
+suite('test_abort_txn_by_be_cloud2', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/schema_change_p0/test_abort_txn_by_be_local5.groovy
+++ b/regression-test/suites/schema_change_p0/test_abort_txn_by_be_local5.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_abort_txn_by_be_local5') {
+suite('test_abort_txn_by_be_local5', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = false
     options.skipRunWhenPipelineDiff = false

--- a/regression-test/suites/schema_change_p0/test_abort_txn_by_be_local6.groovy
+++ b/regression-test/suites/schema_change_p0/test_abort_txn_by_be_local6.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_abort_txn_by_be_local6') {
+suite('test_abort_txn_by_be_local6', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = false
     options.skipRunWhenPipelineDiff = true

--- a/regression-test/suites/schema_change_p0/test_abort_txn_by_fe_cloud4.groovy
+++ b/regression-test/suites/schema_change_p0/test_abort_txn_by_fe_cloud4.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_abort_txn_by_fe_cloud4') {
+suite('test_abort_txn_by_fe_cloud4', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = true
     options.enableDebugPoints()

--- a/regression-test/suites/schema_change_p0/test_abort_txn_by_fe_local3.groovy
+++ b/regression-test/suites/schema_change_p0/test_abort_txn_by_fe_local3.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.http.NoHttpResponseException
 
-suite('test_abort_txn_by_fe_local3') {
+suite('test_abort_txn_by_fe_local3', 'docker') {
     def options = new ClusterOptions()
     options.cloudMode = false
     options.skipRunWhenPipelineDiff = false

--- a/regression-test/suites/storage_medium_p0/test_partition_default_medium.groovy
+++ b/regression-test/suites/storage_medium_p0/test_partition_default_medium.groovy
@@ -18,7 +18,7 @@ import org.apache.doris.regression.suite.ClusterOptions
 import org.apache.doris.regression.util.NodeType
 import org.apache.doris.regression.suite.SuiteCluster
 
-suite("test_partition_default_medium") {
+suite("test_partition_default_medium", 'docker') {
     def options = new ClusterOptions()
     options.feConfigs += [
         'default_storage_medium=HDD',

--- a/regression-test/suites/storage_medium_p0/test_storage_medium_has_disk.groovy
+++ b/regression-test/suites/storage_medium_p0/test_storage_medium_has_disk.groovy
@@ -17,7 +17,7 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite('test_storage_medium_has_disk') {
+suite('test_storage_medium_has_disk', 'docker') {
     if (isCloudMode()) {
         return
     }

--- a/regression-test/suites/trash_p0/clean_trash.groovy
+++ b/regression-test/suites/trash_p0/clean_trash.groovy
@@ -17,7 +17,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import org.junit.Assert
 
-suite("test_clean_trash", "p0") {
+suite("test_clean_trash", "docker") {
     if (isCloudMode()) {
         return
     }

--- a/regression-test/suites/unique_with_mow_c_p0/test_mow_full_clone_exception.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/test_mow_full_clone_exception.groovy
@@ -29,7 +29,7 @@ import org.apache.doris.regression.util.NodeType
 //
 // the bug is fixed in #37001
 
-suite('test_full_clone_exception') {
+suite('test_full_clone_exception', 'docker') {
     def options = new ClusterOptions()
     options.feConfigs += [
         'disable_tablet_scheduler=true',

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_conflict_be_restart.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_conflict_be_restart.groovy
@@ -35,7 +35,7 @@ import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.util.EntityUtils
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite("test_partial_update_conflict_be_restart") {
+suite("test_partial_update_conflict_be_restart", 'docker') {
     def dbName = context.config.getDbNameByFile(context.file)
 
     def options = new ClusterOptions()

--- a/regression-test/suites/unique_with_mow_p0/test_mow_full_clone_exception.groovy
+++ b/regression-test/suites/unique_with_mow_p0/test_mow_full_clone_exception.groovy
@@ -29,7 +29,7 @@ import org.apache.doris.regression.util.NodeType
 //
 // the bug is fixed in #37001
 
-suite('test_full_clone_exception') {
+suite('test_full_clone_exception', 'docker') {
     def options = new ClusterOptions()
     options.feConfigs += [
         'disable_tablet_scheduler=true',

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -43,6 +43,7 @@ Usage: $0 <shell_options> <framework_options>
      -genOut                           generate .out file if not exist
      -forceGenOut                      delete and generate .out file
      -parallel                         run tests using specified threads
+     -dockerSuiteParallel              run docker tests using specified threads
      -randomOrder                      run tests in a random order
      -noKillDocker                     don't kill container when finish docker suites
      -times                            rum tests {times} times


### PR DESCRIPTION
If many docker suites run parallel,  the docker containers take a lot memory,  so use independent executor for them to control the memory usage.

Use options  or config  dockerSuiteParallel  to set the docker suite parallel,  default is 1.

