### PR TITLE
[improvement](jdbc catalog)Optimize JDBC Catalog refresh to reduce frequent client creation.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -104,7 +104,6 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     public void notifyPropertiesUpdated(Map<String, String> updatedProps) {
         super.notifyPropertiesUpdated(updatedProps);
         this.onClose();
-        initLocalObjectsImpl();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -101,11 +101,10 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public void onRefresh(boolean invalidCache) {
-        super.onRefresh(invalidCache);
-        if (jdbcClient != null) {
-            jdbcClient.closeClient();
-        }
+    public void notifyPropertiesUpdated(Map<String, String> updatedProps) {
+        super.notifyPropertiesUpdated(updatedProps);
+        this.onClose();
+        initLocalObjectsImpl();
     }
 
     @Override
@@ -113,6 +112,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
         super.onClose();
         if (jdbcClient != null) {
             jdbcClient.closeClient();
+            jdbcClient = null;
         }
     }
 
@@ -205,6 +205,9 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     @Override
     protected void initLocalObjectsImpl() {
+        if (jdbcClient != null) {
+            return;
+        }
         JdbcClientConfig jdbcClientConfig = new JdbcClientConfig()
                 .setCatalog(this.name)
                 .setUser(getJdbcUser())


### PR DESCRIPTION
In the previous JDBC Catalog refresh behavior, each refresh would close and recreate the JdbcClient. During this process, we observed that some JDBC drivers create classloader-level shared threads when the JdbcClient is repeatedly instantiated. These threads cannot be garbage collected. Since we use the JdbcClient as the context class loader for the JDBC driver, frequent creation leads to a buildup of non-recyclable shared threads in the JVM. This PR changes the refresh behavior to update the cache only, rather than recreating the client. Recreating the client is unnecessary when the Catalog configuration has not changed.
