### PR TITLE
[fix](decimaltype) handle exception with tablet init 

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1029,10 +1029,10 @@ static void* periodic_send_batch(void* writer) {
 Status VTabletWriter::open(doris::RuntimeState* state, doris::RuntimeProfile* profile) {
     // if we set enable_decimal_conversion=false && disable_decimalv2=false in config
     // and we create nested type with decimal like array<text,decimal(28,12)>
-    // nereids planner will throw exception with precision should in (0, 27], but real precision is 28 
+    // nereids planner will throw exception with precision should in (0, 27], but real precision is 28
     // but in 2.1 we can fall back to old planner which make this behavior possible
-    // so in _init() we will meet slot has decimalv2 type with has precision 28 and exception will 
-    // throw from func check_type_precision() , so here we catch exception to avoid be core.    
+    // so in _init() we will meet slot has decimalv2 type with has precision 28 and exception will
+    // throw from func check_type_precision() , so here we catch exception to avoid be core.
     RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_init(state, profile));
     signal::set_signal_task_id(_load_id);
     SCOPED_TIMER(profile->total_time_counter());

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -247,7 +247,13 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
 }
 
 Status VTabletWriterV2::open(RuntimeState* state, RuntimeProfile* profile) {
-    RETURN_IF_ERROR(_init(state, profile));
+    // if we set enable_decimal_conversion=false && disable_decimalv2=false in config
+    // and we create nested type with decimal like array<text,decimal(28,12)>
+    // nereids planner will throw exception with precision should in (0, 27], but real precision is 28 
+    // but in 2.1 we can fall back to old planner which make this behavior possible
+    // so in _init() we will meet slot has decimalv2 type with has precision 28 and exception will 
+    // throw from func check_type_precision() , so here we catch exception to avoid be core.	
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_init(state, profile));
     LOG(INFO) << "opening olap table sink, load_id=" << print_id(_load_id) << ", txn_id=" << _txn_id
               << ", sink_id=" << _sender_id;
     _timeout_watch.start();

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -249,10 +249,10 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
 Status VTabletWriterV2::open(RuntimeState* state, RuntimeProfile* profile) {
     // if we set enable_decimal_conversion=false && disable_decimalv2=false in config
     // and we create nested type with decimal like array<text,decimal(28,12)>
-    // nereids planner will throw exception with precision should in (0, 27], but real precision is 28 
+    // nereids planner will throw exception with precision should in (0, 27], but real precision is 28
     // but in 2.1 we can fall back to old planner which make this behavior possible
-    // so in _init() we will meet slot has decimalv2 type with has precision 28 and exception will 
-    // throw from func check_type_precision() , so here we catch exception to avoid be core.	
+    // so in _init() we will meet slot has decimalv2 type with has precision 28 and exception will
+    // throw from func check_type_precision() , so here we catch exception to avoid be core.
     RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_init(state, profile));
     LOG(INFO) << "opening olap table sink, load_id=" << print_id(_load_id) << ", txn_id=" << _txn_id
               << ", sink_id=" << _sender_id;


### PR DESCRIPTION
## Proposed changes
to avoid be core like 
```
terminate called after throwing an instance of 'doris::Exception'
  what():  [E6] meet invalid precision: real_precision=28, max_decimal_precision=27, min_decimal_precision=1

        0#  doris::Exception::Exception(int, std::basic_string_view<char, std::char_traits<char> > const&) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/exception
.cpp:0
        1#  doris::Exception::Exception<unsigned int const&, unsigned long>(int, std::basic_string_view<char, std::char_traits<char> > const&, unsigned int const&, unsigned long&
&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
        2#  doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> >::DataTypeDecimal(unsigned int, unsigned int, unsigned int, unsigned int) at /home/zcp/repo_c
enter/doris_branch-3.0/doris/be/src/vec/data_types/data_type_decimal.h:0
        3#  doris::vectorized::DataTypeFactory::create_data_type(doris::TypeDescriptor const&, bool) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/data_types/data_ty
pe_factory.cpp:0
        4#  doris::vectorized::DataTypeFactory::create_data_type(doris::TypeDescriptor const&, bool) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/data_types/data_ty
pe_factory.cpp:0
        5#  doris::vectorized::DataTypeFactory::create_data_type(doris::TypeDescriptor const&, bool) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/data_types/data_ty
pe_factory.cpp:0
        6#  doris::SlotDescriptor::get_empty_mutable_column() const at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base
.h:1295
        7#  doris::VOlapTablePartitionParam::VOlapTablePartitionParam(std::shared_ptr<doris::OlapTableSchemaParam>&, doris::TOlapTablePartitionParam const&) at /home/zcp/repo_cen
ter/doris_branch-3.0/doris/be/src/vec/common/cow.h:154
        8#  doris::vectorized::VTabletWriter::_init(doris::RuntimeState*, doris::RuntimeProfile*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/sink/writer/vtablet_w
riter.cpp:1177
        9#  doris::vectorized::VTabletWriter::open(doris::RuntimeState*, doris::RuntimeProfile*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/status.h:488
        10# doris::vectorized::AsyncResultWriter::process_block(doris::RuntimeState*, doris::RuntimeProfile*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/status
.h:488
        11# std::_Function_handler<void (), doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0>::_M_invoke(std::_Any_data const
&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/atomicity.h:98
        12# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/threadpool.cpp:0
        13# doris::Thread::supervise_thread(void*) at /var/local/ldb-toolchain/bin/../usr/include/pthread.h:562
        14# ?
```

Issue Number: close #xxx

<!--Describe your changes.-->

