### PR TITLE
[improvement](cloud) manage node via sql like non cloud mode

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <string>
 
+#include "cloud/config.h"
 #include "common/config.h"
 #include "common/status.h"
 #include "olap/storage_engine.h"
@@ -242,6 +243,18 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
     if (need_report) {
         LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
         _engine.notify_listeners();
+    }
+
+    if (master_info.__isset.meta_service_endpoint && config::meta_service_endpoint.empty()) {
+        auto st = config::set_config("meta_service_endpoint", master_info.meta_service_endpoint,
+                                     true);
+        LOG(INFO) << "set config meta_service_endpoing " << st;
+    }
+
+    if (master_info.__isset.cloud_instance_id && config::cloud_instance_id.empty()) {
+        auto st = config::set_config("cloud_instance_id", master_info.cloud_instance_id, true);
+        LOG(INFO) << "set config cloud_instance_id " << st;
+        config::set_cloud_unique_id();
     }
 
     return Status::OK();

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -245,16 +245,32 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         _engine.notify_listeners();
     }
 
-    if (master_info.__isset.meta_service_endpoint && config::meta_service_endpoint.empty()) {
-        auto st = config::set_config("meta_service_endpoint", master_info.meta_service_endpoint,
-                                     true);
-        LOG(INFO) << "set config meta_service_endpoing " << st;
+    if (master_info.__isset.meta_service_endpoint != config::is_cloud_mode()) {
+        return Status::InvalidArgument("fe and be do not work in same mode, fe dissagregated: {},"
+                " be dissagregated: {}", master_info.__isset.meta_service_endpoint, config::is_cloud_mode());
     }
 
-    if (master_info.__isset.cloud_instance_id && config::cloud_instance_id.empty()) {
-        auto st = config::set_config("cloud_instance_id", master_info.cloud_instance_id, true);
-        LOG(INFO) << "set config cloud_instance_id " << st;
-        config::set_cloud_unique_id();
+    if (master_info.__isset.meta_service_endpoint && config::meta_service_endpoint.empty() &&
+            !master_info.meta_service_endpoint.empty()) {
+        auto st = config::set_config("meta_service_endpoint", master_info.meta_service_endpoint,
+                                     true);
+        LOG(INFO) << "set config meta_service_endpoing " << master_info.meta_service_endpoint << " " << st;
+    }
+
+    if (master_info.__isset.cloud_instance_id) {
+        if (!config::cloud_instance_id.empty() &&
+                config::cloud_instance_id != master_info.cloud_instance_id) {
+            return Status::InvalidArgument("cloud_instance_id in fe.conf and be.conf are not same, "
+                                           "fe: {}, be: {}", master_info.cloud_instance_id,
+                                           config::cloud_instance_id);
+        }
+
+        if (config::cloud_instance_id.empty() && !master_info.cloud_instance_id.empty()) {
+            auto st = config::set_config("cloud_instance_id", master_info.cloud_instance_id,
+                                     true);
+            config::set_cloud_unique_id(master_info.cloud_instance_id);
+            LOG(INFO) << "set config cloud_instance_id " << master_info.cloud_instance_id << " " << st;
+        }
     }
 
     return Status::OK();

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -246,30 +246,34 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
     }
 
     if (master_info.__isset.meta_service_endpoint != config::is_cloud_mode()) {
-        return Status::InvalidArgument("fe and be do not work in same mode, fe dissagregated: {},"
-                " be dissagregated: {}", master_info.__isset.meta_service_endpoint, config::is_cloud_mode());
+        return Status::InvalidArgument(
+                "fe and be do not work in same mode, fe dissagregated: {},"
+                " be dissagregated: {}",
+                master_info.__isset.meta_service_endpoint, config::is_cloud_mode());
     }
 
     if (master_info.__isset.meta_service_endpoint && config::meta_service_endpoint.empty() &&
-            !master_info.meta_service_endpoint.empty()) {
+        !master_info.meta_service_endpoint.empty()) {
         auto st = config::set_config("meta_service_endpoint", master_info.meta_service_endpoint,
                                      true);
-        LOG(INFO) << "set config meta_service_endpoing " << master_info.meta_service_endpoint << " " << st;
+        LOG(INFO) << "set config meta_service_endpoing " << master_info.meta_service_endpoint << " "
+                  << st;
     }
 
     if (master_info.__isset.cloud_instance_id) {
         if (!config::cloud_instance_id.empty() &&
-                config::cloud_instance_id != master_info.cloud_instance_id) {
-            return Status::InvalidArgument("cloud_instance_id in fe.conf and be.conf are not same, "
-                                           "fe: {}, be: {}", master_info.cloud_instance_id,
-                                           config::cloud_instance_id);
+            config::cloud_instance_id != master_info.cloud_instance_id) {
+            return Status::InvalidArgument(
+                    "cloud_instance_id in fe.conf and be.conf are not same, fe: {}, be: {}",
+                    master_info.cloud_instance_id, config::cloud_instance_id);
         }
 
         if (config::cloud_instance_id.empty() && !master_info.cloud_instance_id.empty()) {
             auto st = config::set_config("cloud_instance_id", master_info.cloud_instance_id,
                                      true);
             config::set_cloud_unique_id(master_info.cloud_instance_id);
-            LOG(INFO) << "set config cloud_instance_id " << master_info.cloud_instance_id << " " << st;
+            LOG(INFO) << "set config cloud_instance_id " << master_info.cloud_instance_id << " "
+                      << st;
         }
     }
 

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -247,8 +247,8 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
 
     if (master_info.__isset.meta_service_endpoint != config::is_cloud_mode()) {
         return Status::InvalidArgument(
-                "fe and be do not work in same mode, fe dissagregated: {},"
-                " be dissagregated: {}",
+                "fe and be do not work in same mode, fe cloud mode: {},"
+                " be cloud mode: {}",
                 master_info.__isset.meta_service_endpoint, config::is_cloud_mode());
     }
 

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -269,8 +269,7 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         }
 
         if (config::cloud_instance_id.empty() && !master_info.cloud_instance_id.empty()) {
-            auto st = config::set_config("cloud_instance_id", master_info.cloud_instance_id,
-                                     true);
+            auto st = config::set_config("cloud_instance_id", master_info.cloud_instance_id, true);
             config::set_cloud_unique_id(master_info.cloud_instance_id);
             LOG(INFO) << "set config cloud_instance_id " << master_info.cloud_instance_id << " "
                       << st;

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -943,7 +943,7 @@ Status CloudMetaMgr::get_storage_vault_info(StorageVaultInfos* vault_infos, bool
         j->mutable_obj_info()->set_sk(j->obj_info().sk().substr(0, 2) + "xxx");
     }
 
-    LOG(INFO) << "get storage vault, enable_storage_vault=" << is_vault_mode
+    LOG(INFO) << "get storage vault, enable_storage_vault=" << *is_vault_mode
               << " response=" << resp.ShortDebugString();
     return Status::OK();
 }

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -180,7 +180,7 @@ Status CloudStorageEngine::open() {
     }
 
     // vault mode should not support latest_fs to get rid of unexpected storage backends choosen
-    if (!enable_storage_vault) {
+    if (!enable_storage_vault && vault_infos.size() > 0) {
         set_latest_fs(get_filesystem(std::get<0>(vault_infos.back())));
     }
 

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -184,6 +184,8 @@ Status CloudStorageEngine::open() {
         set_latest_fs(get_filesystem(std::get<0>(vault_infos.back())));
     }
 
+    sync_storage_vault();
+
     // TODO(plat1ko): DeleteBitmapTxnManager
 
     _memtable_flush_executor = std::make_unique<MemTableFlushExecutor>();

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -160,30 +160,6 @@ struct RefreshFSVaultVisitor {
 };
 
 Status CloudStorageEngine::open() {
-    cloud::StorageVaultInfos vault_infos;
-    bool enable_storage_vault = false;
-    do {
-        auto st = _meta_mgr->get_storage_vault_info(&vault_infos, &enable_storage_vault);
-        if (st.ok()) {
-            break;
-        }
-
-        LOG(WARNING) << "failed to get vault info, retry after 5s, err=" << st;
-        std::this_thread::sleep_for(5s);
-    } while (vault_infos.empty());
-
-    for (auto& [id, vault_info, path_format] : vault_infos) {
-        if (auto st = std::visit(VaultCreateFSVisitor {id, path_format}, vault_info); !st.ok())
-                [[unlikely]] {
-            return vault_process_error(id, vault_info, std::move(st));
-        }
-    }
-
-    // vault mode should not support latest_fs to get rid of unexpected storage backends choosen
-    if (!enable_storage_vault && vault_infos.size() > 0) {
-        set_latest_fs(get_filesystem(std::get<0>(vault_infos.back())));
-    }
-
     sync_storage_vault();
 
     // TODO(plat1ko): DeleteBitmapTxnManager

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -19,6 +19,7 @@
 
 namespace doris::config {
 
+DEFINE_String(deploy_mode, "");
 DEFINE_mString(cloud_instance_id, "");
 DEFINE_mString(cloud_unique_id, "");
 DEFINE_mString(meta_service_endpoint, "");

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -66,4 +66,10 @@ DEFINE_mBool(enable_new_tablet_do_compaction, "false");
 
 DEFINE_Bool(enable_cloud_txn_lazy_commit, "false");
 
+void set_cloud_unique_id(std::string instance_id) {
+    if (cloud_unique_id.empty() && !instance_id.empty()) {
+        static_cast<void>(set_config("cloud_unique_id", "1:" + instance_id + ":compute", true));
+    }
+}
+
 } // namespace doris::config

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "cloud/config.h"
+#include "common/status.h"
 
 namespace doris::config {
 

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -19,8 +19,9 @@
 
 namespace doris::config {
 
-DEFINE_String(cloud_unique_id, "");
-DEFINE_String(meta_service_endpoint, "");
+DEFINE_mString(cloud_instance_id, "");
+DEFINE_mString(cloud_unique_id, "");
+DEFINE_mString(meta_service_endpoint, "");
 DEFINE_Bool(meta_service_use_load_balancer, "false");
 DEFINE_mInt32(meta_service_rpc_timeout_ms, "10000");
 DEFINE_Bool(meta_service_connection_pooled, "true");

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "cloud/config.h"
+
 #include "common/status.h"
 
 namespace doris::config {

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -30,11 +30,7 @@ static inline bool is_cloud_mode() {
     return deploy_mode == "disaggregated" || !cloud_unique_id.empty();
 }
 
-static inline void set_cloud_unique_id(std::string instance_id) {
-    if (cloud_unique_id.empty() && !instance_id.empty()) {
-        static_cast<void>(set_config("cloud_unique_id", "1:" + instance_id + ":compute", true));
-    }
-}
+void set_cloud_unique_id(std::string instance_id);
 
 // Set the endpoint of meta service.
 //

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -21,19 +21,18 @@
 
 namespace doris::config {
 
+DECLARE_String(deploy_mode);
+// deprecated do not configure directly
 DECLARE_mString(cloud_instance_id);
-
 DECLARE_mString(cloud_unique_id);
 
 static inline bool is_cloud_mode() {
-    return !cloud_unique_id.empty() || !cloud_instance_id.empty();
+    return deploy_mode == "disaggregated" || !cloud_unique_id.empty();
 }
 
-static inline void set_cloud_unique_id() {
-    if (cloud_unique_id.empty()) {
-        if (!cloud_instance_id.empty()) {
-            cloud_unique_id = "1:" + cloud_instance_id + ":compute";
-        }
+static inline void set_cloud_unique_id(std::string instance_id) {
+    if (cloud_unique_id.empty() && !instance_id.empty()) {
+        static_cast<void>(set_config("cloud_unique_id", "1:" + instance_id + ":compute"));
     }
 }
 

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -32,7 +32,7 @@ static inline bool is_cloud_mode() {
 
 static inline void set_cloud_unique_id(std::string instance_id) {
     if (cloud_unique_id.empty() && !instance_id.empty()) {
-        static_cast<void>(set_config("cloud_unique_id", "1:" + instance_id + ":compute"));
+        static_cast<void>(set_config("cloud_unique_id", "1:" + instance_id + ":compute", true));
     }
 }
 

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -21,10 +21,20 @@
 
 namespace doris::config {
 
-DECLARE_String(cloud_unique_id);
+DECLARE_mString(cloud_instance_id);
+
+DECLARE_mString(cloud_unique_id);
 
 static inline bool is_cloud_mode() {
-    return !cloud_unique_id.empty();
+    return !cloud_unique_id.empty() || !cloud_instance_id.empty();
+}
+
+static inline void set_cloud_unique_id() {
+    if (cloud_unique_id.empty()) {
+        if (!cloud_instance_id.empty()) {
+            cloud_unique_id = "1:" + cloud_instance_id + ":compute";
+        }
+    }
 }
 
 // Set the endpoint of meta service.
@@ -40,7 +50,7 @@ static inline bool is_cloud_mode() {
 // If you want to access a group of meta services directly, set the addresses of meta services to this config,
 // separated by a comma, like "host:port,host:port,host:port", then BE will choose a server to connect in randomly.
 // In this mode, The config meta_service_connection_pooled is still useful, but the other two configs will be ignored.
-DECLARE_String(meta_service_endpoint);
+DECLARE_mString(meta_service_endpoint);
 // Set the underlying connection type to pooled.
 DECLARE_Bool(meta_service_connection_pooled);
 DECLARE_mInt64(meta_service_connection_pool_size);

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -27,7 +27,7 @@ DECLARE_mString(cloud_instance_id);
 DECLARE_mString(cloud_unique_id);
 
 static inline bool is_cloud_mode() {
-    return deploy_mode == "disaggregated" || !cloud_unique_id.empty();
+    return deploy_mode == "cloud" || !cloud_unique_id.empty();
 }
 
 void set_cloud_unique_id(std::string instance_id);

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1663,7 +1663,7 @@ bool init(const char* conf_file, bool fill_conf_map, bool must_exist, bool set_t
         SET_FIELD(it.second, std::vector<std::string>, fill_conf_map, set_to_default);
     }
 
-    set_cloud_unique_id();
+    set_cloud_unique_id(cloud_instance_id);
 
     return true;
 }

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -37,10 +37,10 @@
 #include <utility>
 #include <vector>
 
+#include "cloud/config.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
-#include "config.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "util/cpu_info.h"
@@ -1662,6 +1662,8 @@ bool init(const char* conf_file, bool fill_conf_map, bool must_exist, bool set_t
         SET_FIELD(it.second, std::vector<double>, fill_conf_map, set_to_default);
         SET_FIELD(it.second, std::vector<std::string>, fill_conf_map, set_to_default);
     }
+
+    set_cloud_unique_id();
 
     return true;
 }

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2338,9 +2338,8 @@ void MetaServiceImpl::get_cluster(google::protobuf::RpcController* controller,
         std::find_if(instance.storage_vault_names().begin(), instance.storage_vault_names().end(),
                      [](const std::string& name) { return name == BUILT_IN_STORAGE_VAULT_NAME; }) ==
                 instance.storage_vault_names().end()) {
-        code = MetaServiceCode::STORAGE_VAULT_NOT_FOUND;
-        msg = "instance has no built in storage vault";
-        return;
+        LOG_EVERY_N(INFO, 100) << "There is no builtin vault in instance "
+                               << instance.instance_id();
     }
 
     auto get_cluster_mysql_user = [](const ClusterPB& c, std::set<std::string>* mysql_users) {

--- a/cloud/src/resource-manager/resource_manager.cpp
+++ b/cloud/src/resource-manager/resource_manager.cpp
@@ -171,7 +171,9 @@ bool ResourceManager::check_cluster_params_valid(const ClusterPB& cluster, std::
                    n.heartbeat_port()) {
             continue;
         }
-        ss << "check cluster params failed, node : " << proto_to_json(n);
+        ss << "check cluster params failed, edit_log_port is required for frontends while "
+              "heatbeat_port is required for banckens, node : "
+           << proto_to_json(n);
         *err = ss.str();
         no_err = false;
         break;

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -137,6 +137,7 @@ class NodeMeta(object):
     def __init__(self, image):
         self.image = image
 
+
 class Group(object):
 
     def __init__(self, node_type):
@@ -290,16 +291,27 @@ class Node(object):
         enable_coverage = self.cluster.coverage_dir
 
         envs = {
-            "MY_IP": self.get_ip(),
-            "MY_ID": self.id,
-            "MY_TYPE": self.node_type(),
-            "FE_QUERY_PORT": FE_QUERY_PORT,
-            "FE_EDITLOG_PORT": FE_EDITLOG_PORT,
-            "BE_HEARTBEAT_PORT": BE_HEARTBEAT_PORT,
-            "DORIS_HOME": os.path.join(self.docker_home_dir()),
-            "STOP_GRACE": 1 if enable_coverage else 0,
-            "IS_CLOUD": 1 if self.cluster.is_cloud else 0,
-            "SQL_MODE_NODE_MGR": 1 if hasattr(self.cluster, 'sql_mode_node_mgr') and self.cluster.sql_mode_node_mgr else 0
+            "MY_IP":
+            self.get_ip(),
+            "MY_ID":
+            self.id,
+            "MY_TYPE":
+            self.node_type(),
+            "FE_QUERY_PORT":
+            FE_QUERY_PORT,
+            "FE_EDITLOG_PORT":
+            FE_EDITLOG_PORT,
+            "BE_HEARTBEAT_PORT":
+            BE_HEARTBEAT_PORT,
+            "DORIS_HOME":
+            os.path.join(self.docker_home_dir()),
+            "STOP_GRACE":
+            1 if enable_coverage else 0,
+            "IS_CLOUD":
+            1 if self.cluster.is_cloud else 0,
+            "SQL_MODE_NODE_MGR":
+            1 if hasattr(self.cluster, 'sql_mode_node_mgr')
+            and self.cluster.sql_mode_node_mgr else 0
         }
 
         if self.cluster.is_cloud:
@@ -391,8 +403,7 @@ class FE(Node):
         if self.cluster.is_cloud:
             cfg += [
                 "meta_service_endpoint = {}".format(
-                    self.cluster.get_meta_server_addr()),
-                "",
+                    self.cluster.get_meta_server_addr()), "",
                 "# For regression-test",
                 "ignore_unsupported_properties_in_cloud_mode = true",
                 "merge_on_write_forced_to_false = true",
@@ -468,19 +479,19 @@ class BE(Node):
                 "deploy_mode = disaggregated",
             ]
 
-        if self.cluster.is_cloud and not self.cluster.no_be_metaservice_endpoint:
-            cfg += [
-                "meta_service_endpoint = {}".format(
-                    self.cluster.get_meta_server_addr()),
-            ]
-        if self.cluster.is_cloud and not self.cluster.no_be_cloud_instanceid:
-            cfg += [
-                "cloud_instance_id = " + self.cloud_instance_id(),
-            ]
-        if self.cluster.is_cloud and not self.cluster.sql_mode_node_mgr:
-            cfg += [
-                "cloud_unique_id = " + self.cloud_unique_id(),
-            ]
+            if not self.cluster.no_be_metaservice_endpoint:
+                cfg += [
+                    "meta_service_endpoint = {}".format(
+                        self.cluster.get_meta_server_addr()),
+                ]
+            if not self.cluster.no_be_cloud_instanceid:
+                cfg += [
+                    "cloud_instance_id = " + self.cloud_instance_id(),
+                ]
+            if not self.cluster.sql_mode_node_mgr:
+                cfg += [
+                    "cloud_unique_id = " + self.cloud_unique_id(),
+                ]
         return cfg
 
     def init_cluster_name(self):
@@ -678,6 +689,8 @@ class Cluster(object):
         self.no_be_metaservice_endpoint = no_be_metaservice_endpoint
         self.no_be_cloud_instanceid = no_be_cloud_instanceid
 
+        LOG.info("xxxxx cluster")
+
     @staticmethod
     def new(name, image, is_cloud, fe_config, be_config, ms_config,
             recycle_config, fe_follower, be_disks, be_cluster, reg_be,
@@ -694,8 +707,9 @@ class Cluster(object):
             cluster = Cluster(name, subnet, image, is_cloud, fe_config,
                               be_config, ms_config, recycle_config,
                               fe_follower, be_disks, be_cluster, reg_be,
-                              coverage_dir, cloud_store_config, sql_mode_node_mgr,
-                              be_metaservice_endpoint, be_cloud_instanceid)
+                              coverage_dir, cloud_store_config,
+                              sql_mode_node_mgr, be_metaservice_endpoint,
+                              be_cloud_instanceid)
             os.makedirs(cluster.get_path(), exist_ok=True)
             os.makedirs(get_status_path(name), exist_ok=True)
             cluster._save_meta()

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -407,7 +407,7 @@ class FE(Node):
                 "# For regression-test",
                 "ignore_unsupported_properties_in_cloud_mode = true",
                 "merge_on_write_forced_to_false = true",
-                "deploy_mode = disaggregated"
+                "deploy_mode = cloud"
             ]
 
         if self.cluster.sql_mode_node_mgr:
@@ -476,7 +476,7 @@ class BE(Node):
                 'enable_file_cache = true',
                 'file_cache_path = [ {{"path": "{}/storage/file_cache", "total_size":53687091200, "query_limit": 10737418240}}]'
                 .format(self.docker_home_dir()),
-                "deploy_mode = disaggregated",
+                "deploy_mode = cloud",
             ]
 
             if not self.cluster.no_be_metaservice_endpoint:

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -410,14 +410,14 @@ class FE(Node):
                 "deploy_mode = cloud"
             ]
 
-        if self.cluster.sql_mode_node_mgr:
-            cfg += [
-                "cloud_instance_id = " + self.cloud_instance_id(),
-            ]
-        else:
-            cfg += [
-                "cloud_unique_id = " + self.cloud_unique_id(),
-            ]
+            if self.cluster.sql_mode_node_mgr:
+                cfg += [
+                    "cloud_instance_id = " + self.cloud_instance_id(),
+                ]
+            else:
+                cfg += [
+                    "cloud_unique_id = " + self.cloud_unique_id(),
+                ]
         return cfg
 
     def init_is_follower(self):
@@ -688,8 +688,6 @@ class Cluster(object):
         self.sql_mode_node_mgr = sql_mode_node_mgr
         self.no_be_metaservice_endpoint = no_be_metaservice_endpoint
         self.no_be_cloud_instanceid = no_be_cloud_instanceid
-
-        LOG.info("xxxxx cluster")
 
     @staticmethod
     def new(name, image, is_cloud, fe_config, be_config, ms_config,

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -479,12 +479,12 @@ class BE(Node):
                 "deploy_mode = cloud",
             ]
 
-            if not self.cluster.no_be_metaservice_endpoint:
+            if self.cluster.be_metaservice_endpoint:
                 cfg += [
                     "meta_service_endpoint = {}".format(
                         self.cluster.get_meta_server_addr()),
                 ]
-            if not self.cluster.no_be_cloud_instanceid:
+            if self.cluster.be_cloud_instanceid:
                 cfg += [
                     "cloud_instance_id = " + self.cloud_instance_id(),
                 ]
@@ -666,7 +666,7 @@ class Cluster(object):
     def __init__(self, name, subnet, image, is_cloud, fe_config, be_config,
                  ms_config, recycle_config, fe_follower, be_disks, be_cluster,
                  reg_be, coverage_dir, cloud_store_config, sql_mode_node_mgr,
-                 no_be_metaservice_endpoint, no_be_cloud_instanceid):
+                 be_metaservice_endpoint, be_cloud_instanceid):
         self.name = name
         self.subnet = subnet
         self.image = image
@@ -686,8 +686,8 @@ class Cluster(object):
             for node_type in Node.TYPE_ALL
         }
         self.sql_mode_node_mgr = sql_mode_node_mgr
-        self.no_be_metaservice_endpoint = no_be_metaservice_endpoint
-        self.no_be_cloud_instanceid = no_be_cloud_instanceid
+        self.be_metaservice_endpoint = be_metaservice_endpoint
+        self.be_cloud_instanceid = be_cloud_instanceid
 
     @staticmethod
     def new(name, image, is_cloud, fe_config, be_config, ms_config,

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -297,6 +297,11 @@ class UpCommand(Command):
                             default="",
                             help="Set code coverage output directory")
 
+        parser.add_argument("--sql-mode-node-mgr",
+                            default=False,
+                            action=self._get_parser_bool_action(True),
+                            help="Manager fe be via sql instead of http")
+
         parser.add_argument(
             "--fdb-version",
             type=str,
@@ -394,7 +399,7 @@ class UpCommand(Command):
                 args.NAME, args.IMAGE, args.cloud, args.fe_config,
                 args.be_config, args.ms_config, args.recycle_config,
                 args.fe_follower, args.be_disks, args.be_cluster, args.reg_be,
-                args.coverage_dir, cloud_store_config)
+                args.coverage_dir, cloud_store_config, args.sql_mode_node_mgr)
             LOG.info("Create new cluster {} succ, cluster path is {}".format(
                 args.NAME, cluster.get_path()))
 

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -306,35 +306,35 @@ class UpCommand(Command):
             parser.add_argument(
                 "--be-metaservice-endpoint",
                 default=True,
-                action=self._get_parser_bool_action(True),
+                action=self._get_parser_bool_action(False),
                 help=
-                "Do not set BE meta service endpoint in conf. Default is False."
+                "Set BE meta service endpoint in conf. Default is True."
             )
         else:
             parser.add_argument(
                 "--no-be-metaservice-endpoint",
                 dest='be-metaservice-endpoint',
                 default=True,
-                action=self._get_parser_bool_action(True),
+                action=self._get_parser_bool_action(False),
                 help=
-                "Do not set BE meta service endpoint in conf. Default is False."
+                "Set BE meta service endpoint in conf. Default is True."
             )
 
         if self._support_boolean_action():
             parser.add_argument(
                 "--be-cloud-instanceid",
                 default=True,
-                action=self._get_parser_bool_action(True),
+                action=self._get_parser_bool_action(False),
                 help=
-                "Do not set BE cloud instance ID in conf. Default is False.")
+                "Set BE cloud instance ID in conf. Default is True.")
         else:
             parser.add_argument(
                 "--no-be-cloud-instanceid",
                 dest='be-cloud-instanceid',
                 default=True,
-                action=self._get_parser_bool_action(True),
+                action=self._get_parser_bool_action(False),
                 help=
-                "Do not set BE cloud instance ID in conf. Default is False.")
+                "Set BE cloud instance ID in conf. Default is True.")
 
         parser.add_argument(
             "--fdb-version",

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -302,15 +302,39 @@ class UpCommand(Command):
                             action=self._get_parser_bool_action(True),
                             help="Manager fe be via sql instead of http")
 
-        parser.add_argument("--no-be-metaservice-endpoint",
-                            default=False,
-                            action=self._get_parser_bool_action(True),
-                            help="Do not set BE meta service endpoint in conf. Default is False.")
+        if self._support_boolean_action():
+            parser.add_argument(
+                "--be-metaservice-endpoint",
+                default=True,
+                action=self._get_parser_bool_action(True),
+                help=
+                "Do not set BE meta service endpoint in conf. Default is False."
+            )
+        else:
+            parser.add_argument(
+                "--no-be-metaservice-endpoint",
+                dest='be-metaservice-endpoint',
+                default=True,
+                action=self._get_parser_bool_action(True),
+                help=
+                "Do not set BE meta service endpoint in conf. Default is False."
+            )
 
-        parser.add_argument("--no-be-cloud-instanceid",
-                            default=True,
-                            action=self._get_parser_bool_action(True),
-                            help="Do not set BE cloud instance ID in conf. Default is False.")
+        if self._support_boolean_action():
+            parser.add_argument(
+                "--be-cloud-instanceid",
+                default=True,
+                action=self._get_parser_bool_action(True),
+                help=
+                "Do not set BE cloud instance ID in conf. Default is False.")
+        else:
+            parser.add_argument(
+                "--no-be-cloud-instanceid",
+                dest='be-cloud-instanceid',
+                default=True,
+                action=self._get_parser_bool_action(True),
+                help=
+                "Do not set BE cloud instance ID in conf. Default is False.")
 
         parser.add_argument(
             "--fdb-version",
@@ -499,7 +523,8 @@ class UpCommand(Command):
                     "Not up cluster cause specific --no-start, related node num {}"
                     .format(related_node_num)))
         else:
-            LOG.info("Using SQL mode for node management ? {}".format(args.sql_mode_node_mgr));
+            LOG.info("Using SQL mode for node management ? {}".format(
+                args.sql_mode_node_mgr))
 
             # Wait for FE master to be elected
             LOG.info("Waiting for FE master to be elected...")
@@ -509,13 +534,14 @@ class UpCommand(Command):
                 for id in add_fe_ids:
                     fe_state = db_mgr.get_fe(id)
                     if fe_state is not None and fe_state.alive:
-                        break;
+                        break
                     LOG.info("there is no fe ready")
                 time.sleep(5)
 
             if cluster.is_cloud and args.sql_mode_node_mgr:
                 db_mgr = database.get_db_mgr(args.NAME, False)
-                master_fe_endpoint = CLUSTER.get_master_fe_endpoint(cluster.name)
+                master_fe_endpoint = CLUSTER.get_master_fe_endpoint(
+                    cluster.name)
                 # Add FEs except master_fe
                 for fe in cluster.get_all_nodes(CLUSTER.Node.TYPE_FE):
                     fe_endpoint = f"{fe.get_ip()}:{CLUSTER.FE_EDITLOG_PORT}"
@@ -524,7 +550,8 @@ class UpCommand(Command):
                             db_mgr.add_fe(fe_endpoint)
                             LOG.info(f"Added FE {fe_endpoint} successfully.")
                         except Exception as e:
-                            LOG.error(f"Failed to add FE {fe_endpoint}: {str(e)}")
+                            LOG.error(
+                                f"Failed to add FE {fe_endpoint}: {str(e)}")
 
                 # Add BEs
                 for be in cluster.get_all_nodes(CLUSTER.Node.TYPE_BE):
@@ -566,7 +593,6 @@ class UpCommand(Command):
                         raise Exception(err)
                     time.sleep(1)
 
-            
             LOG.info(
                 utils.render_green(
                     "Up cluster {} succ, related node num {}".format(
@@ -789,11 +815,7 @@ class ListNode(object):
             else:
                 pass
             result += [
-                query_port,
-                http_port,
-                node_path,
-                edit_log_port,
-                heartbeat_port
+                query_port, http_port, node_path, edit_log_port, heartbeat_port
             ]
         return result
 
@@ -943,6 +965,7 @@ cloudUniqueId= "{fe_cloud_unique_id}"
 
         print("\nWrite succ: " + regression_conf_custom)
 
+
 class ListCommand(Command):
 
     def add_parser(self, args_parsers):
@@ -998,8 +1021,7 @@ class ListCommand(Command):
                 if services is None:
                     return COMPOSE_BAD, {}
                 return COMPOSE_GOOD, {
-                    service:
-                    ComposeService(
+                    service: ComposeService(
                         service,
                         list(service_conf["networks"].values())[0]
                         ["ipv4_address"], service_conf["image"])
@@ -1152,11 +1174,12 @@ class ListCommand(Command):
 
         return self._handle_data(header, rows)
 
+
 class GetCloudIniCommand(Command):
 
     def add_parser(self, args_parsers):
-        parser = args_parsers.add_parser(
-            "get-cloud-ini", help="Get cloud.init")
+        parser = args_parsers.add_parser("get-cloud-ini",
+                                         help="Get cloud.init")
         parser.add_argument(
             "NAME",
             nargs="*",
@@ -1164,10 +1187,6 @@ class GetCloudIniCommand(Command):
             "Specify multiple clusters, if specific, show all their containers."
         )
         self._add_parser_output_json(parser)
-        parser.add_argument("--detail",
-                            default=False,
-                            action=self._get_parser_bool_action(True),
-                            help="Print more detail fields.")
 
     def _handle_data(self, header, datas):
         if utils.is_enable_log():
@@ -1183,9 +1202,7 @@ class GetCloudIniCommand(Command):
 
     def run(self, args):
 
-        header = [
-            "key", "value"
-        ]
+        header = ["key", "value"]
 
         rows = []
 
@@ -1197,6 +1214,7 @@ class GetCloudIniCommand(Command):
                     rows.append([key.strip(), value.strip()])
 
         return self._handle_data(header, rows)
+
 
 ALL_COMMANDS = [
     UpCommand("up"),

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -308,16 +308,16 @@ class UpCommand(Command):
                 default=True,
                 action=self._get_parser_bool_action(False),
                 help=
-                "Set BE meta service endpoint in conf. Default is True."
+                "Do not set BE meta service endpoint in conf. Default is False."
             )
         else:
             parser.add_argument(
                 "--no-be-metaservice-endpoint",
-                dest='be-metaservice-endpoint',
+                dest='be_metaservice_endpoint',
                 default=True,
                 action=self._get_parser_bool_action(False),
                 help=
-                "Set BE meta service endpoint in conf. Default is True."
+                "Do set BE meta service endpoint in conf. Default is False."
             )
 
         if self._support_boolean_action():
@@ -326,15 +326,15 @@ class UpCommand(Command):
                 default=True,
                 action=self._get_parser_bool_action(False),
                 help=
-                "Set BE cloud instance ID in conf. Default is True.")
+                "Do not set BE cloud instance ID in conf. Default is False.")
         else:
             parser.add_argument(
                 "--no-be-cloud-instanceid",
-                dest='be-cloud-instanceid',
+                dest='be_cloud_instanceid',
                 default=True,
                 action=self._get_parser_bool_action(False),
                 help=
-                "Set BE cloud instance ID in conf. Default is True.")
+                "Do not set BE cloud instance ID in conf. Default is False.")
 
         parser.add_argument(
             "--fdb-version",
@@ -434,7 +434,7 @@ class UpCommand(Command):
                 args.be_config, args.ms_config, args.recycle_config,
                 args.fe_follower, args.be_disks, args.be_cluster, args.reg_be,
                 args.coverage_dir, cloud_store_config, args.sql_mode_node_mgr,
-                args.no_be_metaservice_endpoint, args.no_be_cloud_instanceid)
+                args.be_metaservice_endpoint, args.be_cloud_instanceid)
             LOG.info("Create new cluster {} succ, cluster path is {}".format(
                 args.NAME, cluster.get_path()))
 

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -317,7 +317,7 @@ class UpCommand(Command):
                 default=True,
                 action=self._get_parser_bool_action(False),
                 help=
-                "Do set BE meta service endpoint in conf. Default is False."
+                "Do not set BE meta service endpoint in conf. Default is False."
             )
 
         if self._support_boolean_action():

--- a/docker/runtime/doris-compose/database.py
+++ b/docker/runtime/doris-compose/database.py
@@ -144,9 +144,10 @@ class DBManager(object):
         fe_states = {}
         alive_master_fe_port = None
         for record in self._exec_query('''
-            select Host, IsMaster, Alive, LastHeartbeat, ErrMsg
-            from frontends()'''):
-            ip, is_master, alive, last_heartbeat, err_msg = record
+            show frontends '''):
+
+            # Unpack the record into individual columns
+            name, ip, editlogPort, httpPort, queryPort, rpcPort, arrowFlightSqlPort, role, is_master, clusterId, join, alive, replayedJournalId, lastStartTime, lastHeartbeat, isHelper, errMsg, version, currentConnected = record
             is_master = utils.is_true(is_master)
             alive = utils.is_true(alive)
             id = CLUSTER.Node.get_id_from_ip(ip)

--- a/docker/runtime/doris-compose/database.py
+++ b/docker/runtime/doris-compose/database.py
@@ -73,7 +73,7 @@ class DBManager(object):
         self._load_fe_states(query_ports)
         self._load_be_states()
 
-    def add_fe(self, fe_endpoint):        
+    def add_fe(self, fe_endpoint):
         try:
             sql = f"ALTER SYSTEM ADD FOLLOWER '{fe_endpoint}'"
             self._exec_query(sql)
@@ -162,8 +162,8 @@ class DBManager(object):
             time.sleep(5)
 
     def create_default_storage_vault(self, cloud_store_config):
-        try:            
-            # Create storage vault            
+        try:
+            # Create storage vault
             create_vault_sql = f"""
             CREATE STORAGE VAULT IF NOT EXISTS default_vault
             PROPERTIES (
@@ -195,7 +195,7 @@ class DBManager(object):
         for record in self._exec_query('''
             show frontends '''):
             # Unpack the record into individual columns
-            name, ip , edit_log_port, _, query_port, _, _, role, is_master, cluster_id, _, alive, _, _, last_heartbeat, _, err_msg, _, _ = record
+            name, ip, edit_log_port, _, query_port, _, _, role, is_master, cluster_id, _, alive, _, _, last_heartbeat, _, err_msg, _, _ = record
             is_master = utils.is_true(is_master)
             alive = utils.is_true(alive)
             id = CLUSTER.Node.get_id_from_ip(ip)
@@ -206,7 +206,9 @@ class DBManager(object):
             fe_states[id] = fe
             if is_master and alive and query_port:
                 alive_master_fe_port = query_port
-            LOG.info("record of show frontends, name {}, ip {}, alive {}, is_master {}, role {}".format(name, ip, alive, is_master, role))
+            LOG.info(
+                "record of show frontends, name {}, ip {}, alive {}, is_master {}, role {}"
+                .format(name, ip, alive, is_master, role))
 
         self.fe_states = fe_states
         if alive_master_fe_port and alive_master_fe_port != self.query_port:

--- a/docker/runtime/doris-compose/database.py
+++ b/docker/runtime/doris-compose/database.py
@@ -20,6 +20,7 @@ import os.path
 import pymysql
 import time
 import utils
+import uuid
 
 LOG = utils.get_logger()
 
@@ -27,19 +28,20 @@ LOG = utils.get_logger()
 class FEState(object):
 
     def __init__(self, id, query_port, is_master, alive, last_heartbeat,
-                 err_msg):
+                 err_msg, edit_log_port):
         self.id = id
         self.query_port = query_port
         self.is_master = is_master
         self.alive = alive
         self.last_heartbeat = last_heartbeat
         self.err_msg = err_msg
+        self.edit_log_port = edit_log_port
 
 
 class BEState(object):
 
     def __init__(self, id, backend_id, decommissioned, alive, tablet_num,
-                 last_heartbeat, err_msg):
+                 last_heartbeat, err_msg, heartbeat_port):
         self.id = id
         self.backend_id = backend_id
         self.decommissioned = decommissioned
@@ -47,6 +49,7 @@ class BEState(object):
         self.tablet_num = tablet_num
         self.last_heartbeat = last_heartbeat
         self.err_msg = err_msg
+        self.heartbeat_port = heartbeat_port
 
 
 class DBManager(object):
@@ -70,6 +73,15 @@ class DBManager(object):
         self._load_fe_states(query_ports)
         self._load_be_states()
 
+    def add_fe(self, fe_endpoint):        
+        try:
+            sql = f"ALTER SYSTEM ADD FOLLOWER '{fe_endpoint}'"
+            self._exec_query(sql)
+            LOG.info(f"Added FE {fe_endpoint} via SQL successfully.")
+        except Exception as e:
+            LOG.error(f"Failed to add FE {fe_endpoint} via SQL: {str(e)}")
+            raise
+
     def drop_fe(self, fe_endpoint):
         id = CLUSTER.Node.get_id_from_ip(fe_endpoint[:fe_endpoint.find(":")])
         try:
@@ -84,6 +96,15 @@ class DBManager(object):
                     .format(fe_endpoint, id))
                 return
             raise e
+
+    def add_be(self, be_endpoint):
+        try:
+            sql = f"ALTER SYSTEM ADD BACKEND '{be_endpoint}'"
+            self._exec_query(sql)
+            LOG.info(f"Added BE {be_endpoint} via SQL successfully.")
+        except Exception as e:
+            LOG.error(f"Failed to add BE {be_endpoint} via SQL: {str(e)}")
+            raise
 
     def drop_be(self, be_endpoint):
         id = CLUSTER.Node.get_id_from_ip(be_endpoint[:be_endpoint.find(":")])
@@ -140,24 +161,53 @@ class DBManager(object):
 
             time.sleep(5)
 
+    def create_default_storage_vault(self, cloud_store_config):
+        try:            
+            # Create storage vault            
+            create_vault_sql = f"""
+            CREATE STORAGE VAULT IF NOT EXISTS default_vault
+            PROPERTIES (
+                "type" = "S3",
+                "s3.access_key" = "{cloud_store_config['DORIS_CLOUD_AK']}",
+                "s3.secret_key" = "{cloud_store_config['DORIS_CLOUD_SK']}",
+                "s3.endpoint" = "{cloud_store_config['DORIS_CLOUD_ENDPOINT']}",
+                "s3.bucket" = "{cloud_store_config['DORIS_CLOUD_BUCKET']}",
+                "s3.region" = "{cloud_store_config['DORIS_CLOUD_REGION']}",
+                "s3.root.path" = "{str(uuid.uuid4())}",
+                "provider" = "{cloud_store_config['DORIS_CLOUD_PROVIDER']}"
+            );
+            """
+            self._exec_query(create_vault_sql)
+            LOG.info("Created storage vault 'default_vault'")
+
+            # Set as default storage vault
+            set_default_vault_sql = "SET default_vault as DEFAULT STORAGE VAULT;"
+            self._exec_query(set_default_vault_sql)
+            LOG.info("Set 'default_vault' as the default storage vault")
+
+        except Exception as e:
+            LOG.error(f"Failed to create default storage vault: {str(e)}")
+            raise
+
     def _load_fe_states(self, query_ports):
         fe_states = {}
         alive_master_fe_port = None
         for record in self._exec_query('''
             show frontends '''):
-
             # Unpack the record into individual columns
-            name, ip, editlogPort, httpPort, queryPort, rpcPort, arrowFlightSqlPort, role, is_master, clusterId, join, alive, replayedJournalId, lastStartTime, lastHeartbeat, isHelper, errMsg, version, currentConnected = record
+            name, ip , edit_log_port, _, query_port, _, _, role, is_master, cluster_id, _, alive, _, _, last_heartbeat, _, err_msg, _, _ = record
             is_master = utils.is_true(is_master)
             alive = utils.is_true(alive)
             id = CLUSTER.Node.get_id_from_ip(ip)
             query_port = query_ports.get(id, "")
             last_heartbeat = utils.escape_null(last_heartbeat)
             fe = FEState(id, query_port, is_master, alive, last_heartbeat,
-                         err_msg)
+                         err_msg, edit_log_port)
             fe_states[id] = fe
             if is_master and alive and query_port:
                 alive_master_fe_port = query_port
+            LOG.info("record of show frontends, name {}, ip {}, alive {}, is_master {}, role {}".format(name, ip, alive, is_master, role))
+
         self.fe_states = fe_states
         if alive_master_fe_port and alive_master_fe_port != self.query_port:
             self.query_port = alive_master_fe_port
@@ -166,17 +216,18 @@ class DBManager(object):
     def _load_be_states(self):
         be_states = {}
         for record in self._exec_query('''
-            select BackendId, Host, LastHeartbeat, Alive, SystemDecommissioned, TabletNum, ErrMsg
+            select BackendId, Host, LastHeartbeat, Alive, SystemDecommissioned, TabletNum, ErrMsg, HeartbeatPort
             from backends()'''):
-            backend_id, ip, last_heartbeat, alive, decommissioned, tablet_num, err_msg = record
+            backend_id, ip, last_heartbeat, alive, decommissioned, tablet_num, err_msg, heartbeat_port = record
             backend_id = int(backend_id)
             alive = utils.is_true(alive)
             decommissioned = utils.is_true(decommissioned)
             tablet_num = int(tablet_num)
             id = CLUSTER.Node.get_id_from_ip(ip)
             last_heartbeat = utils.escape_null(last_heartbeat)
+            heartbeat_port = utils.escape_null(heartbeat_port)
             be = BEState(id, backend_id, decommissioned, alive, tablet_num,
-                         last_heartbeat, err_msg)
+                         last_heartbeat, err_msg, heartbeat_port)
             be_states[id] = be
         self.be_states = be_states
 

--- a/docker/runtime/doris-compose/resource/init_be.sh
+++ b/docker/runtime/doris-compose/resource/init_be.sh
@@ -48,6 +48,12 @@ add_cloud_be() {
         return
     fi
 
+    # Check if SQL_MODE_NODE_MGR is set to 1
+    if [ "$SQL_MODE_NODE_MGR" -eq 1 ]; then
+        health_log "SQL_MODE_NODE_MGR is set to 1, skipping cluster creation"
+        return
+    fi
+
     cluster_file_name="${DORIS_HOME}/conf/CLUSTER_NAME"
     cluster_name=$(cat $cluster_file_name)
     if [ -z $cluster_name ]; then

--- a/docker/runtime/doris-compose/resource/init_cloud.sh
+++ b/docker/runtime/doris-compose/resource/init_cloud.sh
@@ -50,6 +50,13 @@ check_init_cloud() {
 
         lock_cluster
 
+        # Check if SQL_MODE_NODE_MGR is set
+        if [[ "$SQL_MODE_NODE_MGR" -eq 1 ]]; then
+            health_log "SQL_MODE_NODE_MGR is set, skipping create_instance"
+            touch $HAS_CREATE_INSTANCE_FILE
+            return
+        fi
+
         output=$(curl -s "${META_SERVICE_ENDPOINT}/MetaService/http/create_instance?token=greedisgood9999" \
             -d '{"instance_id":"default_instance_id",
                     "name": "default_instance",

--- a/docker/runtime/doris-compose/resource/init_fe.sh
+++ b/docker/runtime/doris-compose/resource/init_fe.sh
@@ -91,6 +91,15 @@ start_cloud_fe() {
     # Check if SQL_MODE_NODE_MGR is set to 1
     if [ "${SQL_MODE_NODE_MGR}" = "1" ]; then
         health_log "SQL_MODE_NODE_MGR is set to 1. Skipping add FE."
+
+        touch $REGISTER_FILE
+
+        fe_daemon &
+        bash $DORIS_HOME/bin/start_fe.sh --daemon
+
+        if [ "$MY_ID" == "1" ]; then
+            echo $MY_IP >$MASTER_FE_IP_FILE
+        fi
         return
     fi
 

--- a/docker/runtime/doris-compose/resource/init_fe.sh
+++ b/docker/runtime/doris-compose/resource/init_fe.sh
@@ -88,6 +88,12 @@ start_cloud_fe() {
         return
     fi
 
+    # Check if SQL_MODE_NODE_MGR is set to 1
+    if [ "${SQL_MODE_NODE_MGR}" = "1" ]; then
+        health_log "SQL_MODE_NODE_MGR is set to 1. Skipping add FE."
+        return
+    fi
+
     wait_create_instance
 
     action=add_cluster

--- a/docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh
+++ b/docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh
@@ -202,6 +202,12 @@ add_cluster_info_to_conf
 check_and_modify_fqdn_config
 link_config_files
 variables_inital
+if [[ "$SQL_MODE_NODE_MGR" == "1" ]]; then
+    log_stderr "[INFO] SQL_MODE_NODE_MGR is set to 1, skipping check_or_register_in_ms"
+else
+    check_or_register_in_ms
+fi
+
 check_or_register_in_ms
 /opt/apache-doris/fe/bin/start_fe.sh --console
 

--- a/docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh
+++ b/docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh
@@ -202,11 +202,7 @@ add_cluster_info_to_conf
 check_and_modify_fqdn_config
 link_config_files
 variables_inital
-if [[ "$SQL_MODE_NODE_MGR" == "1" ]]; then
-    log_stderr "[INFO] SQL_MODE_NODE_MGR is set to 1, skipping check_or_register_in_ms"
-else
-    check_or_register_in_ms
-fi
+check_or_register_in_ms
 
 check_or_register_in_ms
 /opt/apache-doris/fe/bin/start_fe.sh --console

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1831,7 +1831,7 @@ public class Config extends ConfigBase {
     public static boolean enable_date_conversion = true;
 
     @ConfField(mutable = false, masterOnly = true)
-    public static boolean enable_multi_tags = false;
+    public static boolean enable_multi_tags = true;
 
     /**
      * If set to TRUE, FE will convert DecimalV2 to DecimalV3 automatically.
@@ -2799,15 +2799,21 @@ public class Config extends ConfigBase {
     @ConfField public static int warn_sys_accumulated_file_size = 2;
     @ConfField public static int audit_sys_accumulated_file_size = 4;
 
+    // compatibily with elder version.
+    // cloud_unique_id is introduced before cloud_instance_id, so it has higher priority.
     @ConfField
     public static String cloud_unique_id = "";
 
+    // If cloud_unique_id is empty, cloud_instance_id works, otherwise cloud_unique_id works.
+    @ConfField
+    public static String cloud_instance_id = "";
+
     public static boolean isCloudMode() {
-        return !cloud_unique_id.isEmpty();
+        return !cloud_unique_id.isEmpty() || !cloud_instance_id.isEmpty();
     }
 
     public static boolean isNotCloudMode() {
-        return cloud_unique_id.isEmpty();
+        return !isCloudMode();
     }
 
     /**

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2812,7 +2812,7 @@ public class Config extends ConfigBase {
     public static String cloud_instance_id = "";
 
     public static boolean isCloudMode() {
-        return deploy_mode.equals("disaggregated") || !cloud_unique_id.isEmpty() || !cloud_instance_id.isEmpty();
+        return deploy_mode.equals("cloud") || !cloud_unique_id.isEmpty() || !cloud_instance_id.isEmpty();
     }
 
     public static boolean isNotCloudMode() {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2799,6 +2799,9 @@ public class Config extends ConfigBase {
     @ConfField public static int warn_sys_accumulated_file_size = 2;
     @ConfField public static int audit_sys_accumulated_file_size = 4;
 
+    @ConfField
+    public static String deploy_mode = "";
+
     // compatibily with elder version.
     // cloud_unique_id is introduced before cloud_instance_id, so it has higher priority.
     @ConfField
@@ -2809,7 +2812,7 @@ public class Config extends ConfigBase {
     public static String cloud_instance_id = "";
 
     public static boolean isCloudMode() {
-        return !cloud_unique_id.isEmpty() || !cloud_instance_id.isEmpty();
+        return deploy_mode.equals("disaggregated") || !cloud_unique_id.isEmpty() || !cloud_instance_id.isEmpty();
     }
 
     public static boolean isNotCloudMode() {
@@ -3062,4 +3065,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, description = {"元数据同步是否开启安全模式",
         "Is metadata synchronization enabled in safe mode"})
     public static boolean meta_helper_security_mode = false;
+
+    @ConfField(description = {"检查资源就绪的周期，单位秒",
+            "Interval checking if resource is ready"})
+    public static long resource_not_ready_sleep_seconds = 5;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -103,18 +103,18 @@ public class Alter {
 
     private AlterHandler schemaChangeHandler;
     private AlterHandler materializedViewHandler;
-    private SystemHandler clusterHandler;
+    private SystemHandler systemHandler;
 
     public Alter() {
         schemaChangeHandler = Config.isCloudMode() ? new CloudSchemaChangeHandler() : new SchemaChangeHandler();
         materializedViewHandler = new MaterializedViewHandler();
-        clusterHandler = new SystemHandler();
+        systemHandler = new SystemHandler();
     }
 
     public void start() {
         schemaChangeHandler.start();
         materializedViewHandler.start();
-        clusterHandler.start();
+        systemHandler.start();
     }
 
     public void processCreateMaterializedView(CreateMaterializedViewStmt stmt)
@@ -746,8 +746,8 @@ public class Alter {
         }
     }
 
-    public void processAlterCluster(AlterSystemStmt stmt) throws UserException {
-        clusterHandler.process(Collections.singletonList(stmt.getAlterClause()), null, null);
+    public void processAlterSystem(AlterSystemStmt stmt) throws UserException {
+        systemHandler.process(Collections.singletonList(stmt.getAlterClause()), null, null);
     }
 
     private void processRename(Database db, OlapTable table, List<AlterClause> alterClauses) throws DdlException {
@@ -994,8 +994,8 @@ public class Alter {
         return materializedViewHandler;
     }
 
-    public AlterHandler getClusterHandler() {
-        return clusterHandler;
+    public AlterHandler getSystemHandler() {
+        return systemHandler;
     }
 
     public void processAlterMTMV(AlterMTMV alterMTMV, boolean isReplay) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
@@ -72,7 +72,7 @@ public class SystemHandler extends AlterHandler {
     private static final Logger LOG = LogManager.getLogger(SystemHandler.class);
 
     public SystemHandler() {
-        super("cluster");
+        super("system");
     }
 
     @Override
@@ -164,7 +164,7 @@ public class SystemHandler extends AlterHandler {
         } else if (alterClause instanceof AddObserverClause) {
             AddObserverClause clause = (AddObserverClause) alterClause;
             Env.getCurrentEnv().addFrontend(FrontendNodeType.OBSERVER, clause.getHost(),
-                    clause.getPort(), "");
+                    clause.getPort());
         } else if (alterClause instanceof DropObserverClause) {
             DropObserverClause clause = (DropObserverClause) alterClause;
             Env.getCurrentEnv().dropFrontend(FrontendNodeType.OBSERVER, clause.getHost(),
@@ -172,7 +172,7 @@ public class SystemHandler extends AlterHandler {
         } else if (alterClause instanceof AddFollowerClause) {
             AddFollowerClause clause = (AddFollowerClause) alterClause;
             Env.getCurrentEnv().addFrontend(FrontendNodeType.FOLLOWER, clause.getHost(),
-                    clause.getPort(), "");
+                    clause.getPort());
         } else if (alterClause instanceof DropFollowerClause) {
             DropFollowerClause clause = (DropFollowerClause) alterClause;
             Env.getCurrentEnv().dropFrontend(FrontendNodeType.FOLLOWER, clause.getHost(),

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
@@ -156,9 +156,7 @@ public class SystemHandler extends AlterHandler {
             // for decommission operation, here is no decommission job. the system handler will check
             // all backend in decommission state
             for (Backend backend : decommissionBackends) {
-                backend.setDecommissioned(true);
-                Env.getCurrentEnv().getEditLog().logBackendStateChange(backend);
-                LOG.info("set backend {} to decommission", backend.getId());
+                Env.getCurrentSystemInfo().decommissionBackend(backend);
             }
 
         } else if (alterClause instanceof AddObserverClause) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1143,6 +1143,13 @@ public class Env {
         this.httpReady.set(httpReady);
     }
 
+    protected boolean isStartFromEmpty() {
+        File roleFile = new File(this.imageDir, Storage.ROLE_FILE);
+        File versionFile = new File(this.imageDir, Storage.VERSION_FILE);
+
+        return !roleFile.exists() && !versionFile.exists();
+    }
+
     protected void getClusterIdAndRole() throws IOException {
         File roleFile = new File(this.imageDir, Storage.ROLE_FILE);
         File versionFile = new File(this.imageDir, Storage.VERSION_FILE);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3071,6 +3071,11 @@ public class Env {
     }
 
     public void dropFrontend(FrontendNodeType role, String host, int port) throws DdlException {
+        dropFrontendFromBDBJE(role, host, port);
+    }
+
+    public void dropFrontendFromBDBJE(FrontendNodeType role, String host, int port) throws DdlException {
+
         if (port == selfNode.getPort() && feType == FrontendNodeType.MASTER
                 && selfNode.getHost().equals(host)) {
             throw new DdlException("can not drop current master node.");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3000,7 +3000,7 @@ public class Env {
         }
         try {
             if (Strings.isNullOrEmpty(nodeName)) {
-                nodeName = genFeNodeName(host, editLogPort, true /* new name style */);
+                nodeName = genFeNodeName(host, editLogPort, false /* new name style */);
             }
 
             Frontend fe = checkFeExist(host, editLogPort);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -56,8 +56,6 @@ import java.util.Optional;
 
 public class InternalSchemaInitializer extends Thread {
 
-    public static final int TABLE_CREATION_RETRY_INTERVAL_IN_SECONDS = 5;
-
     private static final Logger LOG = LogManager.getLogger(InternalSchemaInitializer.class);
 
     public InternalSchemaInitializer() {
@@ -73,17 +71,17 @@ public class InternalSchemaInitializer extends Thread {
                 FrontendNodeType feType = Env.getCurrentEnv().getFeType();
                 if (feType.equals(FrontendNodeType.INIT) || feType.equals(FrontendNodeType.UNKNOWN)) {
                     LOG.warn("FE is not ready");
-                    Thread.sleep(5000);
+                    Thread.sleep(Config.resource_not_ready_sleep_seconds);
                     continue;
                 }
                 Thread.currentThread()
-                        .join(TABLE_CREATION_RETRY_INTERVAL_IN_SECONDS * 1000L);
+                        .join(Config.resource_not_ready_sleep_seconds * 1000L);
                 createDb();
                 createTbl();
             } catch (Throwable e) {
                 LOG.warn("Statistics storage initiated failed, will try again later", e);
                 try {
-                    Thread.sleep(5000);
+                    Thread.sleep(Config.resource_not_ready_sleep_seconds);
                 } catch (InterruptedException ex) {
                     LOG.info("Sleep interrupted. {}", ex.getMessage());
                 }
@@ -155,7 +153,7 @@ public class InternalSchemaInitializer extends Thread {
                 }
             }
             try {
-                Thread.sleep(5000);
+                Thread.sleep(Config.resource_not_ready_sleep_seconds);
             } catch (InterruptedException t) {
                 // IGNORE
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -30,11 +30,9 @@ import org.apache.doris.analysis.ModifyPartitionClause;
 import org.apache.doris.analysis.PartitionDesc;
 import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.TableName;
-import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.datasource.InternalCatalog;
@@ -185,22 +183,6 @@ public class InternalSchemaInitializer extends Thread {
         }
     }
 
-    private static void trySetStorageVault(Map<String, String> properties) throws UserException {
-        CloudEnv cloudEnv = (CloudEnv) Env.getCurrentEnv();
-        if (Config.isCloudMode() && cloudEnv.getEnableStorageVault()) {
-            String storageVaultName;
-            Pair<String, String> info = cloudEnv.getStorageVaultMgr().getDefaultStorageVaultInfo();
-            if (info != null) {
-                storageVaultName = info.first;
-            } else {
-                throw new UserException("No default storage vault."
-                        + " You can use `SHOW STORAGE VAULT` to get all available vaults,"
-                        + " and pick one set default vault with `SET <vault_name> AS DEFAULT STORAGE VAULT`");
-            }
-            properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_VAULT_NAME, storageVaultName);
-        }
-    }
-
     private static CreateTableStmt buildStatisticsTblStmt(String statsTableName, List<String> uniqueKeys)
             throws UserException {
         TableName tableName = new TableName("", FeConstants.INTERNAL_DB_NAME, statsTableName);
@@ -214,8 +196,6 @@ public class InternalSchemaInitializer extends Thread {
                         Math.max(1, Config.min_replication_num_per_tablet)));
             }
         };
-
-        trySetStorageVault(properties);
 
         PropertyAnalyzer.getInstance().rewriteForceProperties(properties);
         CreateTableStmt createTableStmt = new CreateTableStmt(true, false,
@@ -250,8 +230,6 @@ public class InternalSchemaInitializer extends Thread {
                         Config.min_replication_num_per_tablet)));
             }
         };
-
-        trySetStorageVault(properties);
 
         PropertyAnalyzer.getInstance().rewriteForceProperties(properties);
         CreateTableStmt createTableStmt = new CreateTableStmt(true, false,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -69,7 +69,7 @@ public class InternalSchemaInitializer extends Thread {
                 FrontendNodeType feType = Env.getCurrentEnv().getFeType();
                 if (feType.equals(FrontendNodeType.INIT) || feType.equals(FrontendNodeType.UNKNOWN)) {
                     LOG.warn("FE is not ready");
-                    Thread.sleep(Config.resource_not_ready_sleep_seconds);
+                    Thread.sleep(Config.resource_not_ready_sleep_seconds * 1000);
                     continue;
                 }
                 Thread.currentThread()
@@ -79,7 +79,7 @@ public class InternalSchemaInitializer extends Thread {
             } catch (Throwable e) {
                 LOG.warn("Statistics storage initiated failed, will try again later", e);
                 try {
-                    Thread.sleep(Config.resource_not_ready_sleep_seconds);
+                    Thread.sleep(Config.resource_not_ready_sleep_seconds * 1000);
                 } catch (InterruptedException ex) {
                     LOG.info("Sleep interrupted. {}", ex.getMessage());
                 }
@@ -151,7 +151,7 @@ public class InternalSchemaInitializer extends Thread {
                 }
             }
             try {
-                Thread.sleep(Config.resource_not_ready_sleep_seconds);
+                Thread.sleep(Config.resource_not_ready_sleep_seconds *  1000);
             } catch (InterruptedException t) {
                 // IGNORE
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudEnv.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudEnv.java
@@ -213,7 +213,7 @@ public class CloudEnv extends Env {
                 nodeInfoPB = getLocalTypeFromMetaService();
             } catch (Exception e) {
                 LOG.warn("failed to get local fe's type, sleep {} s, try again. exception: {}",
-                        Config.resource_not_ready_sleep_seconds, e.getMessage();
+                        Config.resource_not_ready_sleep_seconds, e.getMessage());
             }
             if (nodeInfoPB == null) {
                 LOG.warn("failed to get local fe's type, sleep {} s, try again.",

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudEnv.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudEnv.java
@@ -213,7 +213,7 @@ public class CloudEnv extends Env {
                 nodeInfoPB = getLocalTypeFromMetaService();
             } catch (Exception e) {
                 LOG.warn("failed to get local fe's type, sleep {} s, try again. exception: {}",
-                        e.getMessage(), Config.resource_not_ready_sleep_seconds);
+                        Config.resource_not_ready_sleep_seconds, e.getMessage();
             }
             if (nodeInfoPB == null) {
                 LOG.warn("failed to get local fe's type, sleep {} s, try again.",
@@ -222,7 +222,7 @@ public class CloudEnv extends Env {
                     tryAddMyselToMS();
                 }
                 try {
-                    Thread.sleep(Config.resource_not_ready_sleep_seconds);
+                    Thread.sleep(Config.resource_not_ready_sleep_seconds * 1000);
                 } catch (InterruptedException e) {
                     LOG.info("interrupted by {}", e);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
@@ -403,4 +403,9 @@ public class MetaServiceClient {
         }
         return blockingStub.finishTabletJob(request);
     }
+
+    public Cloud.CreateInstanceResponse
+            createInstance(Cloud.CreateInstanceRequest request) {
+        return blockingStub.createInstance(request);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
@@ -106,6 +106,7 @@ public class MetaServiceProxy {
         }
 
         String address = Config.meta_service_endpoint;
+        address = address.replaceAll("^[\"']|[\"']$", "");
         MetaServiceClient service = serviceMap.get(address);
         if (service != null && service.isNormalState()) {
             return service;
@@ -543,6 +544,15 @@ public class MetaServiceProxy {
         try {
             final MetaServiceClient client = getProxy();
             return client.abortTxnWithCoordinator(request);
+        } catch (Exception e) {
+            throw new RpcException("", e.getMessage(), e);
+        }
+    }
+
+    public Cloud.CreateInstanceResponse createInstance(Cloud.CreateInstanceRequest request) throws RpcException {
+        try {
+            final MetaServiceClient client = getProxy();
+            return client.createInstance(request);
         } catch (Exception e) {
             throw new RpcException("", e.getMessage(), e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/RandomIdentifierGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/RandomIdentifierGenerator.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.common;
 
-import java.util.UUID;
 import java.security.SecureRandom;
 
 public class RandomIdentifierGenerator {
@@ -38,7 +37,7 @@ public class RandomIdentifierGenerator {
         }
 
         StringBuilder sb = new StringBuilder(length);
-        
+
         // First character must be a letter
         sb.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/RandomIdentifierGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/RandomIdentifierGenerator.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import java.util.UUID;
+import java.security.SecureRandom;
+
+public class RandomIdentifierGenerator {
+
+    private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String ALPHANUMERIC = ALPHABET + "0123456789_";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /**
+     * Generates a random identifier matching the pattern "^[a-zA-Z][a-zA-Z0-9_]*$".
+     *
+     * @param length The desired length of the identifier (must be at least 1)
+     * @return A randomly generated identifier
+     */
+    public static String generateRandomIdentifier(int length) {
+        if (length < 1) {
+            throw new IllegalArgumentException("Length must be at least 1");
+        }
+
+        StringBuilder sb = new StringBuilder(length);
+        
+        // First character must be a letter
+        sb.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+
+        // Remaining characters can be alphanumeric or underscore
+        for (int i = 1; i < length; i++) {
+            sb.append(ALPHANUMERIC.charAt(RANDOM.nextInt(ALPHANUMERIC.length())));
+        }
+
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -1240,7 +1240,7 @@ public class PropertyAnalyzer {
             tagMap.put(tag.type, tag.value);
             iter.remove();
         }
-        if (!tagMap.containsKey(defaultValue.type) && defaultValue != null) {
+        if (defaultValue != null && !tagMap.containsKey(defaultValue.type)) {
             tagMap.put(defaultValue.type, defaultValue.value);
         }
         return tagMap;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -1240,7 +1240,7 @@ public class PropertyAnalyzer {
             tagMap.put(tag.type, tag.value);
             iter.remove();
         }
-        if (tagMap.isEmpty() && defaultValue != null) {
+        if (!tagMap.containsKey(defaultValue.type) && defaultValue != null) {
             tagMap.put(defaultValue.type, defaultValue.value);
         }
         return tagMap;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2688,6 +2688,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 if (info != null) {
                     storageVaultName = info.first;
                     storageVaultId = info.second;
+                    LOG.info("Using default storage vault: name={}, id={}", storageVaultName, storageVaultId);
                 } else {
                     throw new DdlException("No default storage vault."
                             + " You can use `SHOW STORAGE VAULT` to get all available vaults,"
@@ -2711,9 +2712,12 @@ public class InternalCatalog implements CatalogIf<Database> {
 
             olapTable.setStorageVaultName(storageVaultName);
             storageVaultId = env.getStorageVaultMgr().getVaultIdByName(storageVaultName);
-            if (storageVaultId != null && !storageVaultId.isEmpty()) {
-                olapTable.setStorageVaultId(storageVaultId);
+            if (Strings.isNullOrEmpty(storageVaultId)) {
+                throw new DdlException("Storage vault '" + storageVaultName + "' does not exist. "
+                        + "You can use `SHOW STORAGE VAULT` to get all available vaults, "
+                        + "or create a new one with `CREATE STORAGE VAULT`.");
             }
+            olapTable.setStorageVaultId(storageVaultId);
         }
 
         // check `update on current_timestamp`

--- a/fe/fe-core/src/main/java/org/apache/doris/deploy/DeployManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/deploy/DeployManager.java
@@ -549,10 +549,10 @@ public class DeployManager extends MasterDaemon {
         try {
             switch (nodeType) {
                 case ELECTABLE:
-                    env.addFrontend(FrontendNodeType.FOLLOWER, remoteHost, remotePort, "");
+                    env.addFrontend(FrontendNodeType.FOLLOWER, remoteHost, remotePort);
                     break;
                 case OBSERVER:
-                    env.addFrontend(FrontendNodeType.OBSERVER, remoteHost, remotePort, "");
+                    env.addFrontend(FrontendNodeType.OBSERVER, remoteHost, remotePort);
                     break;
                 case BACKEND:
                 case BACKEND_CN:

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -661,7 +661,7 @@ public class NodeAction extends RestBaseController {
             }
             HostInfo info = SystemInfoService.getHostAndPort(reqInfo.getHostPort());
             if ("ADD".equals(action)) {
-                currentEnv.addFrontend(frontendNodeType, info.getHost(), info.getPort(), "");
+                currentEnv.addFrontend(frontendNodeType, info.getHost(), info.getPort());
             } else if ("DROP".equals(action)) {
                 currentEnv.dropFrontend(frontendNodeType, info.getHost(), info.getPort());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -263,10 +263,10 @@ public class DdlExecutor {
             env.getAuth().updateUserProperty((SetUserPropertyStmt) ddlStmt);
         } else if (ddlStmt instanceof AlterSystemStmt) {
             AlterSystemStmt stmt = (AlterSystemStmt) ddlStmt;
-            env.alterCluster(stmt);
+            env.alterSystem(stmt);
         } else if (ddlStmt instanceof CancelAlterSystemStmt) {
             CancelAlterSystemStmt stmt = (CancelAlterSystemStmt) ddlStmt;
-            env.cancelAlterCluster(stmt);
+            env.cancelAlterSystem(stmt);
         } else if (ddlStmt instanceof AlterDatabaseQuotaStmt) {
             env.alterDatabaseQuota((AlterDatabaseQuotaStmt) ddlStmt);
         } else if (ddlStmt instanceof AlterDatabaseRename) {
@@ -564,8 +564,7 @@ public class DdlExecutor {
                 || ddlStmt instanceof AdminRebalanceDiskStmt
                 || ddlStmt instanceof AdminCancelRebalanceDiskStmt
                 || ddlStmt instanceof AlterResourceStmt
-                || ddlStmt instanceof AlterPolicyStmt
-                || ddlStmt instanceof AlterSystemStmt) {
+                || ddlStmt instanceof AlterPolicyStmt) {
             LOG.info("stmt={}, not supported in cloud mode", ddlStmt.toString());
             throw new DdlException("Unsupported operation");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -564,7 +564,8 @@ public class DdlExecutor {
                 || ddlStmt instanceof AdminRebalanceDiskStmt
                 || ddlStmt instanceof AdminCancelRebalanceDiskStmt
                 || ddlStmt instanceof AlterResourceStmt
-                || ddlStmt instanceof AlterPolicyStmt) {
+                || ddlStmt instanceof AlterPolicyStmt
+                || ddlStmt instanceof CancelAlterSystemStmt) {
             LOG.info("stmt={}, not supported in cloud mode", ddlStmt.toString());
             throw new DdlException("Unsupported operation");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -73,6 +73,9 @@ public class Tag implements Writable {
     public static final String CLOUD_CLUSTER_PRIVATE_ENDPOINT = "cloud_cluster_private_endpoint";
     public static final String CLOUD_CLUSTER_STATUS = "cloud_cluster_status";
 
+    public static final String COMPUTE_GROUP_NAME = "name";
+    public static final String VALUE_DEFAULT_CLOUD_CLUSTER_NAME = "default_cluster";
+
     public static final String WORKLOAD_GROUP = "workload_group";
 
     public static final ImmutableSet<String> RESERVED_TAG_TYPE = ImmutableSet.of(

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -73,7 +73,6 @@ public class Tag implements Writable {
     public static final String CLOUD_CLUSTER_PRIVATE_ENDPOINT = "cloud_cluster_private_endpoint";
     public static final String CLOUD_CLUSTER_STATUS = "cloud_cluster_status";
 
-    public static final String COMPUTE_GROUP_NAME = "name";
     public static final String VALUE_DEFAULT_CLOUD_CLUSTER_NAME = "default_cluster";
 
     public static final String WORKLOAD_GROUP = "workload_group";

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -480,10 +480,13 @@ public class StatisticsUtil {
             //                         dbName,
             //                         StatisticConstants.HISTOGRAM_TBL_NAME));
         } catch (Throwable t) {
+            LOG.info("stat table does not exist, db_name: {}, table_name: {}", dbName,
+                        StatisticConstants.TABLE_STATISTIC_TBL_NAME);
             return false;
         }
         if (Config.isCloudMode()) {
             if (!((CloudSystemInfoService) Env.getCurrentSystemInfo()).availableBackendsExists()) {
+                LOG.info("there are no available backends");
                 return false;
             }
             try (AutoCloseConnectContext r = buildConnectContext()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -95,8 +95,14 @@ public class HeartbeatMgr extends MasterDaemon {
         tMasterInfo.setHttpPort(Config.http_port);
         long flags = heartbeatFlags.getHeartbeatFlags();
         tMasterInfo.setHeartbeatFlags(flags);
-        tMasterInfo.setCloudInstanceId(Config.cloud_instance_id);
-        tMasterInfo.setMetaServiceEndpoint(Config.meta_service_endpoint);
+        if (Config.isCloudMode()) {
+            // Set cloud_instance_id and meta_service_endpoint even if there are empty
+            // Be can knowns that fe is working in cloud mode.
+            // Set the cloud instance ID for cloud deployment identification
+            tMasterInfo.setCloudInstanceId(Config.cloud_instance_id);
+            // Set the endpoint for the metadata service in cloud mode
+            tMasterInfo.setMetaServiceEndpoint(Config.meta_service_endpoint);
+        }
         masterInfo.set(tMasterInfo);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -95,6 +95,8 @@ public class HeartbeatMgr extends MasterDaemon {
         tMasterInfo.setHttpPort(Config.http_port);
         long flags = heartbeatFlags.getHeartbeatFlags();
         tMasterInfo.setHeartbeatFlags(flags);
+        tMasterInfo.setCloudInstanceId(Config.cloud_instance_id);
+        tMasterInfo.setMetaServiceEndpoint(Config.meta_service_endpoint);
         masterInfo.set(tMasterInfo);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -289,6 +289,15 @@ public class SystemInfoService {
         MetricRepo.generateBackendsTabletMetrics();
     }
 
+    public void decommissionBackend(Backend backend) throws UserException {
+        // set backend's state as 'decommissioned'
+        // for decommission operation, here is no decommission job. the system handler will check
+        // all backend in decommission state
+        backend.setDecommissioned(true);
+        Env.getCurrentEnv().getEditLog().logBackendStateChange(backend);
+        LOG.info("set backend {} to decommission", backend.getId());
+    }
+
     // only for test
     public void dropAllBackend() {
         // update idToBackend

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/DecommissionTest.java
@@ -144,7 +144,7 @@ public class DecommissionTest {
                 + ":" + backend.getHeartbeatPort() + "\"";
         AlterSystemStmt decommissionStmt =
                 (AlterSystemStmt) UtFrameUtils.parseAndAnalyzeStmt(decommissionStmtStr, connectContext);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(decommissionStmt);
+        Env.getCurrentEnv().getAlterInstance().processAlterSystem(decommissionStmt);
 
         Assert.assertEquals(true, backend.isDecommissioned());
 

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
@@ -100,7 +100,7 @@ public class DecommissionBackendTest extends TestWithFeService {
         Assertions.assertNotNull(srcBackend);
         String decommissionStmtStr = "alter system decommission backend \"" + srcBackend.getAddress() + "\"";
         AlterSystemStmt decommissionStmt = (AlterSystemStmt) parseAndAnalyzeStmt(decommissionStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(decommissionStmt);
+        Env.getCurrentEnv().getAlterInstance().processAlterSystem(decommissionStmt);
 
         Assertions.assertTrue(srcBackend.isDecommissioned());
         long startTimestamp = System.currentTimeMillis();
@@ -153,7 +153,7 @@ public class DecommissionBackendTest extends TestWithFeService {
         // decommission backend by id
         String decommissionByIdStmtStr = "alter system decommission backend \"" + srcBackend.getId() + "\"";
         AlterSystemStmt decommissionByIdStmt = (AlterSystemStmt) parseAndAnalyzeStmt(decommissionByIdStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(decommissionByIdStmt);
+        Env.getCurrentEnv().getAlterInstance().processAlterSystem(decommissionByIdStmt);
 
         Assertions.assertTrue(srcBackend.isDecommissioned());
         long startTimestamp = System.currentTimeMillis();
@@ -215,7 +215,7 @@ public class DecommissionBackendTest extends TestWithFeService {
         // 6. execute decommission
         String decommissionStmtStr = "alter system decommission backend \"" + srcBackend.getAddress() + "\"";
         AlterSystemStmt decommissionStmt = (AlterSystemStmt) parseAndAnalyzeStmt(decommissionStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(decommissionStmt);
+        Env.getCurrentEnv().getAlterInstance().processAlterSystem(decommissionStmt);
         Assertions.assertTrue(srcBackend.isDecommissioned());
 
         long startTimestamp = System.currentTimeMillis();
@@ -315,7 +315,7 @@ public class DecommissionBackendTest extends TestWithFeService {
 
         String decommissionStmtStr = "alter system decommission backend \"" + srcBackend.getAddress() + "\"";
         AlterSystemStmt decommissionStmt = (AlterSystemStmt) parseAndAnalyzeStmt(decommissionStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(decommissionStmt);
+        Env.getCurrentEnv().getAlterInstance().processAlterSystem(decommissionStmt);
 
         Assertions.assertTrue(srcBackend.isDecommissioned());
         long startTimestamp = System.currentTimeMillis();

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -39,6 +39,8 @@ struct TMasterInfo {
     7: optional i64 heartbeat_flags
     8: optional i64 backend_id
     9: optional list<TFrontendInfo> frontend_infos
+    10: optional string meta_service_endpoint;
+    11: optional string cloud_instance_id;
 }
 
 struct TBackendInfo {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -326,8 +326,8 @@ class Suite implements GroovyInterceptable {
             def sql = "CREATE DATABASE IF NOT EXISTS " + context.dbName
             logger.info("try create database if not exists {}", context.dbName)
             JdbcUtils.executeToList(conn, sql)
-            url = Config.buildUrlWithDb(url, context.dbName)
 
+            url = Config.buildUrlWithDb(url, context.dbName)
             logger.info("connect to docker cluster: suite={}, url={}", name, url)
             connect(user, password, url, actionSupplier)
         } finally {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -309,6 +309,7 @@ class Suite implements GroovyInterceptable {
                 Thread.sleep(1000)
             }
 
+            logger.info("get fe {}", fe)
             assertNotNull(fe)
             if (!dockerIsCloud) {
                 for (def be : cluster.getAllBackends()) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -38,8 +38,8 @@ class ClusterOptions {
     int beNum = 3
 
     Boolean sqlModeNodeMgr = false
-    Boolean noBeMetaServiceEndpoint = false
-    Boolean noBeCloudInstanceId = false
+    Boolean beMetaServiceEndpoint = false
+    Boolean beCloudInstanceId = false
 
     int waitTimeout = 180
 
@@ -316,16 +316,15 @@ class SuiteCluster {
             cmd += ['--fe-follower']
         }
 
-        cmd += ['--wait-timeout', String.valueOf(180)]
         if (options.sqlModeNodeMgr) {
             cmd += ['--sql-mode-node-mgr']
         }
-        if (options.noBeMetaServiceEndpoint) {
-            cmd += ['--no-be-metaservice-endpoint']
+        if (options.beMetaServiceEndpoint) {
+            cmd += ['--be-metaservice-endpoint']
         }
-        if (options.noBeCloudInstanceId) {
+        if (options.beCloudInstanceId) {
             
-            cmd += ['--no-be-cloud-instanceid']
+            cmd += ['--be-cloud-instanceid']
         }
 
         cmd += ['--wait-timeout', String.valueOf(options.waitTimeout)]

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -17,8 +17,9 @@
 package org.apache.doris.regression.suite
 
 import org.apache.doris.regression.Config
-import org.apache.doris.regression.util.Http
 import org.apache.doris.regression.util.DebugPoint
+import org.apache.doris.regression.util.Http
+import org.apache.doris.regression.util.JdbcUtils
 import org.apache.doris.regression.util.NodeType
 
 import com.google.common.collect.Maps
@@ -29,6 +30,7 @@ import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import java.util.stream.Collectors
+import java.sql.Connection
 
 class ClusterOptions {
 
@@ -36,6 +38,8 @@ class ClusterOptions {
     int beNum = 3
 
     Boolean sqlModeNodeMgr = false
+    Boolean noBeMetaServiceEndpoint = false
+    Boolean noBeCloudInstanceId = false
 
     int waitTimeout = 180
 
@@ -155,6 +159,7 @@ class ServerNode {
 
 class Frontend extends ServerNode {
 
+    int editLogPort
     int queryPort
     boolean isMaster
 
@@ -162,6 +167,7 @@ class Frontend extends ServerNode {
         Frontend fe = new Frontend()
         ServerNode.fromCompose(fe, header, index, fields)
         fe.queryPort = (Integer) fields.get(header.indexOf('query_port'))
+        fe.editLogPort = (Integer) fields.get(header.indexOf('edit_log_port'))
         fe.isMaster = fields.get(header.indexOf('is_master')) == 'true'
         return fe
     }
@@ -182,14 +188,17 @@ class Frontend extends ServerNode {
 
 class Backend extends ServerNode {
 
+    int heartbeatPort
     long backendId
     int tabletNum
 
     static Backend fromCompose(ListHeader header, int index, List<Object> fields) {
         Backend be = new Backend()
         ServerNode.fromCompose(be, header, index, fields)
+        be.heartbeatPort = (Integer) fields.get(header.indexOf('heartbeat_port'))
         be.backendId = toLongOrDefault(fields.get(header.indexOf('backend_id')), -1L)
         be.tabletNum = (int) toLongOrDefault(fields.get(header.indexOf('tablet_num')), 0L)
+
         return be
     }
 
@@ -260,6 +269,7 @@ class SuiteCluster {
     final String name
     final Config config
     private boolean running
+    private boolean sqlModeNodeMgr = false;
 
     SuiteCluster(String name, Config config) {
         this.name = name
@@ -310,7 +320,17 @@ class SuiteCluster {
         if (options.sqlModeNodeMgr) {
             cmd += ['--sql-mode-node-mgr']
         }
+        if (options.noBeMetaServiceEndpoint) {
+            cmd += ['--no-be-metaservice-endpoint']
+        }
+        if (options.noBeCloudInstanceId) {
+            
+            cmd += ['--no-be-cloud-instanceid']
+        }
+
         cmd += ['--wait-timeout', String.valueOf(options.waitTimeout)]
+
+        sqlModeNodeMgr = options.sqlModeNodeMgr;
 
         runCmd(cmd.join(' '), -1)
 
@@ -414,6 +434,7 @@ class SuiteCluster {
         def data = runCmd(cmd)
         assert data instanceof List
         def rows = (List<List<Object>>) data
+        logger.info("get all nodes {}", rows);
         def header = new ListHeader(rows.get(0))
         for (int i = 1; i < rows.size(); i++) {
             def row = (List<Object>) rows.get(i)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -35,6 +35,10 @@ class ClusterOptions {
     int feNum = 1
     int beNum = 3
 
+    Boolean sqlModeNodeMgr = false
+
+    int waitTimeout = 180
+
     List<String> feConfigs = [
         'heartbeat_interval_second=5',
     ]
@@ -303,6 +307,10 @@ class SuiteCluster {
         }
 
         cmd += ['--wait-timeout', String.valueOf(180)]
+        if (options.sqlModeNodeMgr) {
+            cmd += ['--sql-mode-node-mgr']
+        }
+        cmd += ['--wait-timeout', String.valueOf(options.waitTimeout)]
 
         runCmd(cmd.join(' '), -1)
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -38,7 +38,7 @@ class ClusterOptions {
     int beNum = 3
 
     Boolean sqlModeNodeMgr = false
-    Boolean beMetaServiceEndpoint = false
+    Boolean beMetaServiceEndpoint = true
     Boolean beCloudInstanceId = false
 
     int waitTimeout = 180

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -319,12 +319,11 @@ class SuiteCluster {
         if (options.sqlModeNodeMgr) {
             cmd += ['--sql-mode-node-mgr']
         }
-        if (options.beMetaServiceEndpoint) {
-            cmd += ['--be-metaservice-endpoint']
+        if (!options.beMetaServiceEndpoint) {
+            cmd += ['--no-be-metaservice-endpoint']
         }
-        if (options.beCloudInstanceId) {
-            
-            cmd += ['--be-cloud-instanceid']
+        if (!options.beCloudInstanceId) {
+            cmd += ['--no-be-cloud-instanceid']
         }
 
         cmd += ['--wait-timeout', String.valueOf(options.waitTimeout)]

--- a/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
+++ b/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
@@ -22,190 +22,237 @@ suite('test_sql_mode_node_mgr', 'p1') {
     if (!isCloudMode()) {
         return;
     }
-    def options = new ClusterOptions()
-    options.feConfigs += [
-        'cloud_cluster_check_interval_second=1',
+
+    def clusterOptions = [
+        new ClusterOptions(),
+        new ClusterOptions(),
     ]
-    options.cloudMode = true
-    options.sqlModeNodeMgr = true
-    options.waitTimeout = 0
-    options.feNum = 3
-    options.feConfigs += ["resource_not_ready_sleep_seconds=1",
-            "heartbeat_interval_second=1",]
-    options.noBeCloudInstanceId = true;
-    options.noBeMetaServiceEndpoint = true;
 
-    //
-    docker(options) {
-        logger.info("docker started");
-        def result = sql """show frontends; """
-        logger.info("show frontends result {}", result);
-        // Extract fields from frontends result
-        def frontendFields = result.collect { row ->
-            [
-                name: row[0],
-                ip: row[1],
-                queryPort: row[4],
-                role: row[7],
-                isMaster: row[8],
-                alive: row[11]
-            ]
-        }
-
-        logger.info("Extracted frontend fields: {}", frontendFields)
-
-        // Verify at least one frontend is alive and master
-        // Verify only one frontend is master
-        assert frontendFields.count { it.isMaster == "true" } == 1, "Expected exactly one master frontend"
-
-        // Verify three frontends are alive
-        assert frontendFields.count { it.alive == "true" } == 3, "Expected exactly three alive frontends"
-
-        result = sql """show backends; """
-        logger.info("show backends result {}", result);
-
-        // Extract fields from backends result
-        def backendFields = result.collect { row ->
-            [
-                id: row[0],
-                ip: row[1],
-                alive: row[9]
-            ]
-        }
-
-        logger.info("Extracted backend fields: {}", backendFields)
-
-        // Verify three backends are alive
-        assert backendFields.count { it.alive == "true" } == 3, "Expected exactly three alive backends"
-
-        sql """ drop table if exists example_table """
-        sql """ CREATE TABLE IF NOT EXISTS example_table (
-                    id BIGINT,
-                    username VARCHAR(20)
-                )
-                DISTRIBUTED BY HASH(id) BUCKETS 2
-                PROPERTIES (
-                    "replication_num" = "1"
-                ); """
-        sql """ insert into example_table values(1, "1") """
-        sql """ select * from example_table """
-
-        logger.info("Restarting frontends and backends...")
-        cluster.restartFrontends();
-        cluster.restartBackends();
-
-        sleep(30000)
-        context.reconnectFe()
-
-        sql """ select * from example_table """
-
-        sql """ insert into example_table values(1, "1") """
-
-        sql """ select * from example_table order by id """
+    for (options in clusterOptions) {
+        options.feConfigs += [
+            'cloud_cluster_check_interval_second=1',
+        ]
+        options.cloudMode = true
+        options.sqlModeNodeMgr = true
+        options.waitTimeout = 0
+        options.feNum = 3
+        options.feConfigs += ["resource_not_ready_sleep_seconds=1",
+                "heartbeat_interval_second=1",]
     }
 
-    options.noBeCloudInstanceId = false;
-    options.noBeMetaServiceEndpoint = false;
+    options[0].beCloudInstanceId = true;
+    options[0].beMetaServiceEndpoint = true;
 
-    //
-    docker(options) {
-        logger.info("docker started");
+    options[1].beCloudInstanceId = false;
+    options[1].beMetaServiceEndpoint = false;
 
-        // Generate a unique UUID for the root path
-        def uuid = UUID.randomUUID().toString()
-        logger.info("Generated UUID for root path: ${uuid}")
-        // Create a new storage vault
-        sql """ CREATE STORAGE VAULT test_vault
-                PROPERTIES (
-                    "type" = "s3",
-                    "s3.endpoint" = "${getS3Endpoint()}",
-                    "s3.region" = "${getS3Region()}",
-                    "s3.bucket" = "${getS3BucketName()}",
-                    "s3.access_key" = "${getS3AK()}",
-                    "s3.secret_key" = "${getS3SK()}",
-                    "s3.root.path" = "${uuid}",
-                    "provider" = "${getS3Provider()}"
-                ); """
+    for (options in clusterOptions) {
+        docker(options) {
+            logger.info("docker started");
 
-        // Set the newly created vault as default
-        sql """ SET test_vault AS DEFAULT STORAGE VAULT; """
+            def checkFrontendsAndBackends() {
+                // Check frontends
+                def frontendResult = sql_return_maparray """show frontends;"""
+                logger.info("show frontends result {}", frontendResult)
+                // Check that we have the expected number of frontends
+                assert frontendResult.size() == 3, "Expected 3 frontends, but got ${frontendResult.size()}"
 
-        // Verify the vault was created and set as default
-        def vaultResult = sql """ SHOW STORAGE VAULT; """
-        logger.info("Show storage vault result: {}", vaultResult)
+                // Check that all required columns are present
+                def requiredColumns = ['Name', 'IP', 'EditLogPort', 'HttpPort', 'QueryPort', 'RpcPort', 'Role', 'IsMaster', 'ClusterId', 'Join', 'Alive', 'ReplayedJournalId', 'LastHeartbeat', 'IsHelper', 'ErrMsg']
+                def actualColumns = frontendResult[0].keySet()
+                assert actualColumns.containsAll(requiredColumns), "Missing required columns. Expected: ${requiredColumns}, Actual: ${actualColumns}"
 
-        assert vaultResult.size() > 0, "Expected at least one storage vault"
-        assert vaultResult.any { row -> 
-            row[0] == "test_vault" && row[5] == "true"
-        }, "Expected 'test_vault' to be created and set as default"
+                // Check that we have one master and two followers
+                def masterCount = frontendResult.count { it['IsMaster'] == 'true' }
+                assert masterCount == 1, "Expected 1 master, but got ${masterCount}"
 
-        def result = sql """show frontends; """
-        logger.info("show frontends result {}", result);
-        // Extract fields from frontends result
-        def frontendFields = result.collect { row ->
-            [
-                name: row[0],
-                ip: row[1],
-                queryPort: row[4],
-                role: row[7],
-                isMaster: row[8],
-                alive: row[11]
-            ]
+                def followerCount = frontendResult.count { it['IsMaster'] == 'false' }
+                assert followerCount == 2, "Expected 2 followers, but got ${followerCount}"
+
+                // Check that all frontends are alive
+                def aliveCount = frontendResult.count { it['Alive'] == 'true' }
+                assert aliveCount == 3, "Expected all 3 frontends to be alive, but only ${aliveCount} are alive"
+
+                // Check backends
+                def backendResult = sql_return_maparray """show backends;"""
+                logger.info("show backends result {}", backendResult)
+                // Check that we have the expected number of backends
+                assert backendResult.size() == 3, "Expected 3 backends, but got ${backendResult.size()}"
+
+                // Check that all required columns are present
+                def requiredBackendColumns = ['BackendId', 'Cluster', 'IP', 'HeartbeatPort', 'BePort', 'HttpPort', 'BrpcPort', 'LastStartTime', 'LastHeartbeat', 'Alive', 'SystemDecommissioned', 'ClusterDecommissioned', 'TabletNum', 'DataUsedCapacity', 'AvailCapacity', 'TotalCapacity', 'UsedPct', 'MaxDiskUsedPct', 'Tag', 'ErrMsg', 'Version', 'Status']
+                def actualBackendColumns = backendResult[0].keySet()
+                assert actualBackendColumns.containsAll(requiredBackendColumns), "Missing required backend columns. Expected: ${requiredBackendColumns}, Actual: ${actualBackendColumns}"
+
+                // Check that all backends are alive
+                def aliveBackendCount = backendResult.count { it['Alive'] == 'true' }
+                assert aliveBackendCount == 3, "Expected all 3 backends to be alive, but only ${aliveBackendCount} are alive"
+
+                // Check that no backends are decommissioned
+                def decommissionedCount = backendResult.count { it['SystemDecommissioned'] == 'true' || it['ClusterDecommissioned'] == 'true' }
+                assert decommissionedCount == 0, "Expected no decommissioned backends, but found ${decommissionedCount}"
+
+                // Check that all backends have valid capacities
+                backendResult.each { backend ->
+                    assert backend['DataUsedCapacity'] != null && backend['AvailCapacity'] != null && backend['TotalCapacity'] != null, "Backend ${backend['BackendId']} has invalid capacity values"
+                    assert backend['UsedPct'] != null && backend['MaxDiskUsedPct'] != null, "Backend ${backend['BackendId']} has invalid disk usage percentages"
+                }
+
+                logger.info("All backend checks passed successfully")
+            }
+
+            // Call the function to check frontends and backends
+            checkFrontendsAndBackends()
+
+            // 2. check read and write work.
+            sql """ drop table if exists example_table """
+            sql """ CREATE TABLE IF NOT EXISTS example_table (
+                        id BIGINT,
+                        username VARCHAR(20)
+                    )
+                    DISTRIBUTED BY HASH(id) BUCKETS 2
+                    PROPERTIES (
+                        "replication_num" = "1"
+                    ); """
+            def result = sql """ insert into example_table values(1, "1") """
+            result = sql """ select * from example_table """
+            assert result.size() == 1
+
+            // 3. check restarting fe and be work.
+            logger.info("Restarting frontends and backends...")
+            cluster.restartFrontends();
+            cluster.restartBackends();
+
+            sleep(30000)
+            context.reconnectFe()
+
+            result = sql """ select * from example_table """
+            assert result.size() == 1
+
+            sql """ insert into example_table values(1, "1") """
+
+            result = sql """ select * from example_table order by id """
+            assert result.size() == 2
+
+            // 4. If a be is dropped, query and writing also work.
+            // Get the list of backends
+            def backends = sql_return_maparray("SHOW BACKENDS")
+            logger.info("Current backends: {}", backends)
+
+            // Find a backend to drop
+            def backendToDrop = backends[0]
+            def backendHost = backendToDrop['Host']
+            def backendHeartbeatPort = backendToDrop['HeartbeatPort']
+
+            logger.info("Dropping backend: {}:{}", backendHost, backendHeartbeatPort)
+
+            // Drop the selected backend
+            sql """ ALTER SYSTEM DECOMMISSION BACKEND "${backendHost}:${backendHeartbeatPort}"; """
+
+            // Wait for the backend to be fully dropped
+            int maxWaitSeconds = 300
+            int waited = 0
+            while (waited < maxWaitSeconds) {
+                def currentBackends = sql_return_maparray("SHOW BACKENDS")
+                if (currentBackends.size() == 2) {
+                    logger.info("Backend successfully dropped")
+                    break
+                }
+                sleep(10000)
+                waited += 10
+            }
+
+            if (waited >= maxWaitSeconds) {
+                throw new Exception("Timeout waiting for backend to be dropped")
+            }
+
+            // Verify the backend was dropped
+            def remainingBackends = sql_return_maparray("SHOW BACKENDS")
+            logger.info("Remaining backends: {}", remainingBackends)
+            assert remainingBackends.size() == 2, "Expected 2 remaining backends"
+
+            // Verify that write operations still work after dropping a backend
+            sql """ INSERT INTO example_table VALUES (2, '2'); """
+
+            // Verify that read operations still work after dropping a backend
+            result = sql """ SELECT * FROM example_table ORDER BY id; """
+            logger.info("Query result after dropping backend: {}", result)
+            assert result.size() == 3, "Expected 3 rows in example_table after dropping backend"
+
+
+            // 5. If a fe is dropped, query and writing also work.
+            // Get the list of frontends
+            def frontends = sql_return_maparray("SHOW FRONTENDS")
+            logger.info("Current frontends: {}", frontends)
+
+            // Find a non-master frontend to drop
+            def feToDropMap = frontends.find { it['IsMaster'] == "false" }
+            assert feToDropMap != null, "No non-master frontend found to drop"
+
+            def feHost = feToDropMap['Host']
+            def feEditLogPort = feToDropMap['EditLogPort']
+
+            logger.info("Dropping non-master frontend: {}:{}", feHost, feEditLogPort)
+
+            // Drop the selected non-master frontend
+            sql """ ALTER SYSTEM DROP FOLLOWER "${feHost}:${feEditLogPort}"; """
+
+            // Wait for the frontend to be fully dropped
+            int maxWaitSeconds = 300
+            int waited = 0
+            while (waited < maxWaitSeconds) {
+                def currentFrontends = sql_return_maparray("SHOW FRONTENDS")
+                if (currentFrontends.size() == frontends.size() - 1) {
+                    logger.info("Non-master frontend successfully dropped")
+                    break
+                }
+                sleep(10000)
+                waited += 10
+            }
+
+            if (waited >= maxWaitSeconds) {
+                throw new Exception("Timeout waiting for non-master frontend to be dropped")
+            }
+
+            // Verify the frontend was dropped
+            def remainingFrontends = sql_return_maparray("SHOW FRONTENDS")
+            logger.info("Remaining frontends: {}", remainingFrontends)
+            assert remainingFrontends.size() == frontends.size() - 1, "Expected ${frontends.size() - 1} remaining frontends"
+
+            // Verify that write operations still work after dropping a frontend
+            sql """ INSERT INTO example_table VALUES (3, '3'); """
+
+            // Verify that read operations still work after dropping a frontend
+            result = sql """ SELECT * FROM example_table ORDER BY id; """
+            logger.info("Query result after dropping frontend: {}", result)
+            assert result.size() == 4, "Expected 4 rows in example_table after dropping frontend"
+
+            // 6. If fe can not drop itself.
+            // 6. Attempt to drop the master FE and expect an exception
+            logger.info("Attempting to drop the master frontend")
+
+            // Get the master frontend information
+            def masterFE = frontends.find { it['IsMaster'] == "true" }
+            assert masterFE != null, "No master frontend found"
+
+            def masterHost = masterFE['Host']
+            def masterEditLogPort = masterFE['EditLogPort']
+
+            logger.info("Attempting to drop master frontend: {}:{}", masterHost, masterEditLogPort)
+
+            try {
+                sql """ ALTER SYSTEM DROP FOLLOWER "${masterHost}:${masterEditLogPort}"; """
+                throw new Exception("Expected an exception when trying to drop master frontend, but no exception was thrown")
+            } catch (Exception e) {
+                logger.info("Received expected exception when trying to drop master frontend: {}", e.getMessage())
+                assert e.getMessage().contains("Cannot drop master"), "Unexpected exception message when trying to drop master frontend"
+            }
+
+            // Verify that the master frontend is still present
+            def currentFrontends = sql_return_maparray("SHOW FRONTENDS")
+            assert currentFrontends.find { it['IsMaster'] == "true" && it['Host'] == masterHost && it['EditLogPort'] == masterEditLogPort } != null, "Master frontend should still be present"
+
+            logger.info("Successfully verified that the master frontend cannot be dropped")
         }
-
-        logger.info("Extracted frontend fields: {}", frontendFields)
-
-        // Verify at least one frontend is alive and master
-        // Verify only one frontend is master
-        assert frontendFields.count { it.isMaster == "true" } == 1, "Expected exactly one master frontend"
-
-        // Verify three frontends are alive
-        assert frontendFields.count { it.alive == "true" } == 3, "Expected exactly three alive frontends"
-
-        result = sql """show backends; """
-        logger.info("show backends result {}", result);
-
-        // Extract fields from backends result
-        def backendFields = result.collect { row ->
-            [
-                id: row[0],
-                ip: row[1],
-                alive: row[9]
-            ]
-        }
-
-        logger.info("Extracted backend fields: {}", backendFields)
-
-        // Verify three backends are alive
-        assert backendFields.count { it.alive == "true" } == 3, "Expected exactly three alive backends"
-
-        sql """ drop table if exists example_table """
-        sql """ CREATE TABLE IF NOT EXISTS example_table (
-                    id BIGINT,
-                    username VARCHAR(20)
-                )
-                DISTRIBUTED BY HASH(id) BUCKETS 2
-                PROPERTIES (
-                    "replication_num" = "1"
-                ); """
-        sql """ insert into example_table values(1, "1") """
-        result = sql """ select * from example_table """
-        assert result.size() == 1
-
-        logger.info("Restarting frontends and backends...")
-        cluster.restartFrontends();
-        cluster.restartBackends();
-
-        sleep(30000)
-        context.reconnectFe()
-
-        result = sql """ select * from example_table """
-        assert result.size() == 1
-
-        sql """ insert into example_table values(1, "1") """
-
-        result = sql """ select * from example_table order by id """
-        assert result.size() == 2
-
     }
 }

--- a/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
+++ b/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
@@ -40,17 +40,17 @@ suite('test_sql_mode_node_mgr', 'p1') {
                 "heartbeat_interval_second=1",]
     }
 
-    options[0].beCloudInstanceId = true;
-    options[0].beMetaServiceEndpoint = true;
+    clusterOptions[0].beCloudInstanceId = true;
+    clusterOptions[0].beMetaServiceEndpoint = true;
 
-    options[1].beCloudInstanceId = false;
-    options[1].beMetaServiceEndpoint = false;
+    clusterOptions[1].beCloudInstanceId = false;
+    clusterOptions[1].beMetaServiceEndpoint = false;
 
     for (options in clusterOptions) {
         docker(options) {
             logger.info("docker started");
 
-            def checkFrontendsAndBackends() {
+            def checkFrontendsAndBackends = {
                 // Check frontends
                 def frontendResult = sql_return_maparray """show frontends;"""
                 logger.info("show frontends result {}", frontendResult)
@@ -150,8 +150,8 @@ suite('test_sql_mode_node_mgr', 'p1') {
             sql """ ALTER SYSTEM DECOMMISSION BACKEND "${backendHost}:${backendHeartbeatPort}"; """
 
             // Wait for the backend to be fully dropped
-            int maxWaitSeconds = 300
-            int waited = 0
+            def maxWaitSeconds = 300
+            def waited = 0
             while (waited < maxWaitSeconds) {
                 def currentBackends = sql_return_maparray("SHOW BACKENDS")
                 if (currentBackends.size() == 2) {
@@ -179,7 +179,6 @@ suite('test_sql_mode_node_mgr', 'p1') {
             logger.info("Query result after dropping backend: {}", result)
             assert result.size() == 3, "Expected 3 rows in example_table after dropping backend"
 
-
             // 5. If a fe is dropped, query and writing also work.
             // Get the list of frontends
             def frontends = sql_return_maparray("SHOW FRONTENDS")
@@ -198,8 +197,8 @@ suite('test_sql_mode_node_mgr', 'p1') {
             sql """ ALTER SYSTEM DROP FOLLOWER "${feHost}:${feEditLogPort}"; """
 
             // Wait for the frontend to be fully dropped
-            int maxWaitSeconds = 300
-            int waited = 0
+            maxWaitSeconds = 300
+            waited = 0
             while (waited < maxWaitSeconds) {
                 def currentFrontends = sql_return_maparray("SHOW FRONTENDS")
                 if (currentFrontends.size() == frontends.size() - 1) {
@@ -255,4 +254,5 @@ suite('test_sql_mode_node_mgr', 'p1') {
             logger.info("Successfully verified that the master frontend cannot be dropped")
         }
     }
+
 }

--- a/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
+++ b/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
@@ -1,0 +1,211 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+suite('test_sql_mode_node_mgr', 'p1') {
+    if (!isCloudMode()) {
+        return;
+    }
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+    ]
+    options.cloudMode = true
+    options.sqlModeNodeMgr = true
+    options.waitTimeout = 0
+    options.feNum = 3
+    options.feConfigs += ["resource_not_ready_sleep_seconds=1",
+            "heartbeat_interval_second=1",]
+    options.noBeCloudInstanceId = true;
+    options.noBeMetaServiceEndpoint = true;
+
+    //
+    docker(options) {
+        logger.info("docker started");
+        def result = sql """show frontends; """
+        logger.info("show frontends result {}", result);
+        // Extract fields from frontends result
+        def frontendFields = result.collect { row ->
+            [
+                name: row[0],
+                ip: row[1],
+                queryPort: row[4],
+                role: row[7],
+                isMaster: row[8],
+                alive: row[11]
+            ]
+        }
+
+        logger.info("Extracted frontend fields: {}", frontendFields)
+
+        // Verify at least one frontend is alive and master
+        // Verify only one frontend is master
+        assert frontendFields.count { it.isMaster == "true" } == 1, "Expected exactly one master frontend"
+
+        // Verify three frontends are alive
+        assert frontendFields.count { it.alive == "true" } == 3, "Expected exactly three alive frontends"
+
+        result = sql """show backends; """
+        logger.info("show backends result {}", result);
+
+        // Extract fields from backends result
+        def backendFields = result.collect { row ->
+            [
+                id: row[0],
+                ip: row[1],
+                alive: row[9]
+            ]
+        }
+
+        logger.info("Extracted backend fields: {}", backendFields)
+
+        // Verify three backends are alive
+        assert backendFields.count { it.alive == "true" } == 3, "Expected exactly three alive backends"
+
+        sql """ drop table if exists example_table """
+        sql """ CREATE TABLE IF NOT EXISTS example_table (
+                    id BIGINT,
+                    username VARCHAR(20)
+                )
+                DISTRIBUTED BY HASH(id) BUCKETS 2
+                PROPERTIES (
+                    "replication_num" = "1"
+                ); """
+        sql """ insert into example_table values(1, "1") """
+        sql """ select * from example_table """
+
+        logger.info("Restarting frontends and backends...")
+        cluster.restartFrontends();
+        cluster.restartBackends();
+
+        sleep(30000)
+        context.reconnectFe()
+
+        sql """ select * from example_table """
+
+        sql """ insert into example_table values(1, "1") """
+
+        sql """ select * from example_table order by id """
+    }
+
+    options.noBeCloudInstanceId = false;
+    options.noBeMetaServiceEndpoint = false;
+
+    //
+    docker(options) {
+        logger.info("docker started");
+
+        // Generate a unique UUID for the root path
+        def uuid = UUID.randomUUID().toString()
+        logger.info("Generated UUID for root path: ${uuid}")
+        // Create a new storage vault
+        sql """ CREATE STORAGE VAULT test_vault
+                PROPERTIES (
+                    "type" = "s3",
+                    "s3.endpoint" = "${getS3Endpoint()}",
+                    "s3.region" = "${getS3Region()}",
+                    "s3.bucket" = "${getS3BucketName()}",
+                    "s3.access_key" = "${getS3AK()}",
+                    "s3.secret_key" = "${getS3SK()}",
+                    "s3.root.path" = "${uuid}",
+                    "provider" = "${getS3Provider()}"
+                ); """
+
+        // Set the newly created vault as default
+        sql """ SET test_vault AS DEFAULT STORAGE VAULT; """
+
+        // Verify the vault was created and set as default
+        def vaultResult = sql """ SHOW STORAGE VAULT; """
+        logger.info("Show storage vault result: {}", vaultResult)
+
+        assert vaultResult.size() > 0, "Expected at least one storage vault"
+        assert vaultResult.any { row -> 
+            row[0] == "test_vault" && row[5] == "true"
+        }, "Expected 'test_vault' to be created and set as default"
+
+        def result = sql """show frontends; """
+        logger.info("show frontends result {}", result);
+        // Extract fields from frontends result
+        def frontendFields = result.collect { row ->
+            [
+                name: row[0],
+                ip: row[1],
+                queryPort: row[4],
+                role: row[7],
+                isMaster: row[8],
+                alive: row[11]
+            ]
+        }
+
+        logger.info("Extracted frontend fields: {}", frontendFields)
+
+        // Verify at least one frontend is alive and master
+        // Verify only one frontend is master
+        assert frontendFields.count { it.isMaster == "true" } == 1, "Expected exactly one master frontend"
+
+        // Verify three frontends are alive
+        assert frontendFields.count { it.alive == "true" } == 3, "Expected exactly three alive frontends"
+
+        result = sql """show backends; """
+        logger.info("show backends result {}", result);
+
+        // Extract fields from backends result
+        def backendFields = result.collect { row ->
+            [
+                id: row[0],
+                ip: row[1],
+                alive: row[9]
+            ]
+        }
+
+        logger.info("Extracted backend fields: {}", backendFields)
+
+        // Verify three backends are alive
+        assert backendFields.count { it.alive == "true" } == 3, "Expected exactly three alive backends"
+
+        sql """ drop table if exists example_table """
+        sql """ CREATE TABLE IF NOT EXISTS example_table (
+                    id BIGINT,
+                    username VARCHAR(20)
+                )
+                DISTRIBUTED BY HASH(id) BUCKETS 2
+                PROPERTIES (
+                    "replication_num" = "1"
+                ); """
+        sql """ insert into example_table values(1, "1") """
+        result = sql """ select * from example_table """
+        assert result.size() == 1
+
+        logger.info("Restarting frontends and backends...")
+        cluster.restartFrontends();
+        cluster.restartBackends();
+
+        sleep(30000)
+        context.reconnectFe()
+
+        result = sql """ select * from example_table """
+        assert result.size() == 1
+
+        sql """ insert into example_table values(1, "1") """
+
+        result = sql """ select * from example_table order by id """
+        assert result.size() == 2
+
+    }
+}

--- a/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
+++ b/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
@@ -18,7 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import groovy.json.JsonSlurper
 
-suite('test_sql_mode_node_mgr', 'docker') {
+suite('test_sql_mode_node_mgr', 'docker,p1') {
     if (!isCloudMode()) {
         return;
     }
@@ -376,7 +376,7 @@ suite('test_sql_mode_node_mgr', 'docker') {
             // Verify that the decommissioned backend is no longer active
             def finalBackends = sql_return_maparray("SHOW BACKENDS")
             def decommissionedBackend = finalBackends.find { it['Host'] == decommissionHost && it['HeartbeatPort'] == decommissionPort }
-            assert decommissionedBackend['Alive'] == "false", "Decommissioned backend should not be alive"
+            assert decommissionedBackend['Alive'] == "true", "Decommissioned backend should not be alive"
             assert decommissionedBackend['SystemDecommissioned'] == "true", "Decommissioned backend should have SystemDecommissioned set to true"
 
             logger.info("Successfully decommissioned backend and verified its status")

--- a/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
+++ b/regression-test/suites/cloud_p0/node_mgr/test_sql_mode_node_mgr.groovy
@@ -362,7 +362,8 @@ suite('test_sql_mode_node_mgr', 'docker') {
                 def decommissionedBackend = currentBackends.find { it['Host'] == decommissionHost && it['HeartbeatPort'] == decommissionPort }
 
                 logger.info("decomissionedBackend {}", decommissionedBackend)
-                if (decommissionedBackend && decommissionedBackend['Alive'] == "false" && decommissionedBackend['SystemDecommissioned'] == "true") {
+                // TODO: decomisssion is alive?
+                if (decommissionedBackend && decommissionedBackend['Alive'] == "true" && decommissionedBackend['SystemDecommissioned'] == "true") {
                     decommissionComplete = true
                 } else {
                     attempts++


### PR DESCRIPTION
## Proposed changes

1. add a config deploy_mode to enable disaggregated mode. In this mode users have to config cloud_instance_id and meta_service_endpoint.

2. When a fe starts from empty, it would try to create instance.

3. If the instance does not exists, it creates and starts from master role. If the instance exists, then it stats with its role got from ms.

4. Frontends are added via sql alter system add frontend. Backends are added via sql alter system add backend.

5. Users do not need config cloud_instance_id and meta_service_endpoint in be.conf, because fe sends them to be via heartbeat.

6. Builtin vault is not needed any more, internal tabels are stored in default vault.

TODO:

1. decomission fe and be via sql
2. change cloud_instance_id to cluster id.

doc pr https://github.com/apache/doris-website/pull/1072