### PR TITLE
[fix](DCHECK) Fix the DCHECK failure when the query is canceled. 

### DIFF
--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
@@ -506,8 +506,12 @@ Status DistinctStreamingAggLocalState::close(RuntimeState* state) {
     _aggregated_block->clear();
     // If the limit is reached, there may still be remaining data in the cache block.
     // If the limit is not reached, the cache block must be empty.
-    DCHECK(_reach_limit || _aggregated_block->empty());
-    DCHECK(_reach_limit || _cache_block.empty());
+    // If the query is canceled, it might not satisfy the above conditions.
+    if (!state->is_cancelled()) {
+        if (!_reach_limit && !_cache_block.empty()) {
+            LOG_WARNING("If the limit is not reached, the cache block must be empty.");
+        }
+    }
     _cache_block.clear();
     return Base::close(state);
 }


### PR DESCRIPTION
## Proposed changes

This does not affect the correctness of the RELEASE version.
 If the query is canceled, it might not satisfy the above conditions.
```
 *** SIGABRT unknown detail explain (@0x220739) received by PID 2230073 (TID 2231910 OR 0x7f9b068ae640) from PID 2230073; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007FA34785C520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x0000559EAC9162CD in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 6# 0x0000559EAC908A2A in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/disk1/STRESS_ENV/be/lib/doris_be
10# doris::pipeline::DistinctStreamingAggLocalState::close(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp:559
11# doris::pipeline::OperatorXBase::close(doris::RuntimeState*) in /mnt/disk1/STRESS_ENV/be/lib/doris_be
12# doris::pipeline::PipelineXTask::close(doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:419
13# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:246
14# doris::pipeline::TaskScheduler::_do_work(unsigned long) in /mnt/disk1/STRESS_ENV/be/lib/doris_be

```

<!--Describe your changes.-->

