### PR TITLE
[fix](Nereids) datetimev2 literal equals should compare microsecond (#40121)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -100,6 +100,11 @@ public class DateTimeV2Literal extends DateTimeLiteral {
     }
 
     @Override
+    public double getDouble() {
+        return super.getDouble() + microSecond / 1000000.0;
+    }
+
+    @Override
     public String toString() {
         return getStringValue();
     }
@@ -233,6 +238,6 @@ public class DateTimeV2Literal extends DateTimeLiteral {
             return false;
         }
         DateTimeV2Literal literal = (DateTimeV2Literal) o;
-        return Objects.equals(dataType, literal.dataType);
+        return Objects.equals(dataType, literal.dataType) && Objects.equals(microSecond, literal.microSecond);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -485,4 +485,14 @@ class DateTimeLiteralTest {
         Assertions.assertEquals(1, literal.roundCeiling(0).month);
         Assertions.assertEquals(2001, literal.roundCeiling(0).year);
     }
+
+    @Test
+    void testEquals() {
+        DateTimeV2Literal l1 = new DateTimeV2Literal(1, 1, 1, 1, 1, 1, 1);
+        DateTimeV2Literal l2 = new DateTimeV2Literal(1, 1, 1, 1, 1, 1, 1);
+        DateTimeV2Literal l3 = new DateTimeV2Literal(1, 1, 1, 1, 1, 1, 2);
+
+        Assertions.assertEquals(l1, l2);
+        Assertions.assertNotEquals(l1, l3);
+    }
 }


### PR DESCRIPTION
pick from master #40121
