### PR TITLE
[fix](execution) fix wrong check when blocking result sink

### DIFF
--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -312,12 +312,12 @@ void PipBufferControlBlock::set_dependency(
 }
 
 void PipBufferControlBlock::_update_dependency() {
-    if (_result_sink_dependency &&
-        (_batch_queue_empty || _buffer_rows < _buffer_limit || _is_cancelled)) {
-        _result_sink_dependency->set_ready();
-    } else if (_result_sink_dependency &&
-               (!_batch_queue_empty && _buffer_rows >= _buffer_limit && !_is_cancelled)) {
-        _result_sink_dependency->block();
+    if (_result_sink_dependency) {
+        if (_batch_queue_empty || _buffer_rows < _buffer_limit || _is_cancelled) {
+            _result_sink_dependency->set_ready();
+        } else {
+            _result_sink_dependency->block();
+        }
     }
 }
 

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -316,7 +316,7 @@ void PipBufferControlBlock::_update_dependency() {
         (_batch_queue_empty || _buffer_rows < _buffer_limit || _is_cancelled)) {
         _result_sink_dependency->set_ready();
     } else if (_result_sink_dependency &&
-               (!_batch_queue_empty && _buffer_rows < _buffer_limit && !_is_cancelled)) {
+               (!_batch_queue_empty && _buffer_rows >= _buffer_limit && !_is_cancelled)) {
         _result_sink_dependency->block();
     }
 }


### PR DESCRIPTION
Otherwise, when client stop fetch result data, the result sink will still adding batch to the result queue,
which causing BE OOM.