### PR TITLE
[fix](memory) Fix `sum_of_all_trackers` duplicated contain reserved memory

### DIFF
--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -146,8 +146,6 @@ public:
 
     // Creates and adds the tracker to the mem_tracker_pool.
     MemTracker(const std::string& label, MemTrackerLimiter* parent = nullptr);
-    // For MemTrackerLimiter
-    MemTracker() { _parent_group_num = -1; }
 
     virtual ~MemTracker();
 
@@ -203,6 +201,9 @@ public:
     }
 
 protected:
+    // Only used by MemTrackerLimiter
+    MemTracker() { _parent_group_num = -1; }
+
     void bind_parent(MemTrackerLimiter* parent);
 
     Type _type;

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -336,7 +336,6 @@ void MemTrackerLimiter::make_process_snapshots(std::vector<MemTracker::Snapshot>
     snapshot.cur_consumption = GlobalMemoryArbitrator::process_reserved_memory();
     snapshot.peak_consumption = -1;
     (*snapshots).emplace_back(snapshot);
-    all_trackers_mem_sum += GlobalMemoryArbitrator::process_reserved_memory();
 
     snapshot.type = "overview";
     snapshot.label = "sum_of_all_trackers"; // is virtual memory


### PR DESCRIPTION
Reserved memory is already contained in Query Memory Tracker, so it is already contained in `sum_of_all_trackers` and should not be double-counted.