### PR TITLE
[improvement](mtmv) Support to add use_for_rewrite property when create materialized view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -245,14 +245,14 @@ public class MTMV extends OlapTable {
         }
     }
 
-    public Optional<Boolean> isUseForRewrite() {
+    public boolean isUseForRewrite() {
         readMvLock();
         try {
             if (!StringUtils.isEmpty(mvProperties.get(PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE))) {
-                return Optional.of(Boolean.valueOf(mvProperties.get(PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE)));
+                return Boolean.valueOf(mvProperties.get(PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE));
             }
             // default is true
-            return Optional.of(true);
+            return true;
         } finally {
             readMvUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -245,6 +245,19 @@ public class MTMV extends OlapTable {
         }
     }
 
+    public Optional<Boolean> isUseForRewrite() {
+        readMvLock();
+        try {
+            if (!StringUtils.isEmpty(mvProperties.get(PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE))) {
+                return Optional.of(Boolean.valueOf(mvProperties.get(PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE)));
+            }
+            // default is true
+            return Optional.of(true);
+        } finally {
+            readMvUnlock();
+        }
+    }
+
     public int getRefreshPartitionNum() {
         readMvLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -187,8 +187,8 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION =
             "enable_nondeterministic_function";
 
-    public static final String PROPERTIES_IS_USED_IN_REWRITE =
-            "is_used_in_rewrite";
+    public static final String PROPERTIES_USE_FOR_REWRITE =
+            "use_for_rewrite";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_REFRESH_PARTITION_NUM = "refresh_partition_num";
     public static final String PROPERTIES_WORKLOAD_GROUP = "workload_group";

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -186,6 +186,9 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION =
             "enable_nondeterministic_function";
+
+    public static final String PROPERTIES_IS_USED_IN_REWRITE =
+            "is_used_in_rewritten";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_REFRESH_PARTITION_NUM = "refresh_partition_num";
     public static final String PROPERTIES_WORKLOAD_GROUP = "workload_group";

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -188,7 +188,7 @@ public class PropertyAnalyzer {
             "enable_nondeterministic_function";
 
     public static final String PROPERTIES_IS_USED_IN_REWRITE =
-            "is_used_in_rewritten";
+            "is_used_in_rewrite";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_REFRESH_PARTITION_NUM = "refresh_partition_num";
     public static final String PROPERTIES_WORKLOAD_GROUP = "workload_group";

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPropertyUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPropertyUtil.java
@@ -66,8 +66,10 @@ public class MTMVPropertyUtil {
                 analyzePartitionSyncLimit(value);
                 break;
             case PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION:
+                analyzeBooleanProperty(value, PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION);
                 break;
             case PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE:
+                analyzeBooleanProperty(value, PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE);
                 break;
             default:
                 throw new AnalysisException("illegal key:" + key);
@@ -141,4 +143,12 @@ public class MTMVPropertyUtil {
         }
     }
 
+    private static void analyzeBooleanProperty(String propertyValue, String propertyName) {
+        if (StringUtils.isEmpty(propertyValue)) {
+            return;
+        }
+        if (!"true".equalsIgnoreCase(propertyValue) && !"false".equalsIgnoreCase(propertyValue)) {
+            throw new AnalysisException(String.format("valid property %s fail", propertyName));
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPropertyUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPropertyUtil.java
@@ -38,7 +38,8 @@ public class MTMVPropertyUtil {
             PropertyAnalyzer.PROPERTIES_PARTITION_SYNC_LIMIT,
             PropertyAnalyzer.PROPERTIES_PARTITION_TIME_UNIT,
             PropertyAnalyzer.PROPERTIES_PARTITION_DATE_FORMAT,
-            PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION
+            PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION,
+            PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE
     );
 
     public static void analyzeProperty(String key, String value) {
@@ -65,6 +66,8 @@ public class MTMVPropertyUtil {
                 analyzePartitionSyncLimit(value);
                 break;
             case PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION:
+                break;
+            case PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE:
                 break;
             default:
                 throw new AnalysisException("illegal key:" + key);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPropertyUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPropertyUtil.java
@@ -39,7 +39,7 @@ public class MTMVPropertyUtil {
             PropertyAnalyzer.PROPERTIES_PARTITION_TIME_UNIT,
             PropertyAnalyzer.PROPERTIES_PARTITION_DATE_FORMAT,
             PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION,
-            PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE
+            PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE
     );
 
     public static void analyzeProperty(String key, String value) {
@@ -67,7 +67,7 @@ public class MTMVPropertyUtil {
                 break;
             case PropertyAnalyzer.PROPERTIES_ENABLE_NONDETERMINISTIC_FUNCTION:
                 break;
-            case PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE:
+            case PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE:
                 break;
             default:
                 throw new AnalysisException("illegal key:" + key);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -140,7 +140,7 @@ public class InitMaterializationContextHook implements PlannerHook {
                 mtmvCache = materializedView.getOrGenerateCache(cascadesContext.getConnectContext());
                 // If mv property use_for_rewrite is set false, should not partition in
                 // query rewrite by materialized view
-                if (!materializedView.isUseForRewrite().orElse(true)) {
+                if (!materializedView.isUseForRewrite()) {
                     LOG.debug("mv doesn't part in query rewrite process because "
                             + "use_for_rewrite is false, mv is {}", materializedView.getName());
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -26,7 +26,6 @@ import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.mtmv.MTMVCache;
 import org.apache.doris.mtmv.MTMVUtil;
@@ -42,7 +41,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -142,9 +140,7 @@ public class InitMaterializationContextHook implements PlannerHook {
                 mtmvCache = materializedView.getOrGenerateCache(cascadesContext.getConnectContext());
                 // If mv property use_for_rewrite is set false, should not partition in
                 // query rewrite by materialized view
-                String usedForRewrite = materializedView.getMvProperties().get(
-                        PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE);
-                if (!StringUtils.isEmpty(usedForRewrite) && !Boolean.parseBoolean(usedForRewrite)) {
+                if (!materializedView.isUseForRewrite().orElse(true)) {
                     LOG.debug("mv doesn't part in query rewrite process because "
                             + "use_for_rewrite is false, mv is {}", materializedView.getName());
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -131,8 +131,8 @@ public class InitMaterializationContextHook implements PlannerHook {
             Set<TableIf> usedTables) {
         Set<MTMV> availableMTMVs = getAvailableMTMVs(usedTables, cascadesContext);
         if (availableMTMVs.isEmpty()) {
-            LOG.debug(String.format("Enable materialized view rewrite but availableMTMVs is empty, current queryId "
-                    + "is %s", cascadesContext.getConnectContext().getQueryIdentifier()));
+            LOG.debug("Enable materialized view rewrite but availableMTMVs is empty, current queryId "
+                    + "is {}", cascadesContext.getConnectContext().getQueryIdentifier());
             return ImmutableList.of();
         }
         List<MaterializationContext> asyncMaterializationContext = new ArrayList<>();
@@ -145,9 +145,8 @@ public class InitMaterializationContextHook implements PlannerHook {
                 String usedForRewrite = materializedView.getMvProperties().get(
                         PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE);
                 if (!StringUtils.isEmpty(usedForRewrite) && !Boolean.parseBoolean(usedForRewrite)) {
-                    LOG.debug(String.format("mv doesn't part in query rewrite process because "
-                            + "use_for_rewrite is false, mv is %s",
-                            materializedView.getName()));
+                    LOG.debug("mv doesn't part in query rewrite process because "
+                            + "use_for_rewrite is false, mv is {}", materializedView.getName());
                     continue;
                 }
                 if (mtmvCache == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -140,13 +140,13 @@ public class InitMaterializationContextHook implements PlannerHook {
             MTMVCache mtmvCache = null;
             try {
                 mtmvCache = materializedView.getOrGenerateCache(cascadesContext.getConnectContext());
-                // If mv property is_used_in_rewrite is set false, should not partition in
+                // If mv property use_for_rewrite is set false, should not partition in
                 // query rewrite by materialized view
-                String isUsedByRewrite = materializedView.getMvProperties().get(
-                        PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE);
-                if (!StringUtils.isEmpty(isUsedByRewrite) && !Boolean.parseBoolean(isUsedByRewrite)) {
+                String usedForRewrite = materializedView.getMvProperties().get(
+                        PropertyAnalyzer.PROPERTIES_USE_FOR_REWRITE);
+                if (!StringUtils.isEmpty(usedForRewrite) && !Boolean.parseBoolean(usedForRewrite)) {
                     LOG.debug(String.format("mv doesn't part in query rewrite process because "
-                            + "is_used_in_rewrite is false, mv is %s",
+                            + "use_for_rewrite is false, mv is %s",
                             materializedView.getName()));
                     continue;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -142,10 +142,10 @@ public class InitMaterializationContextHook implements PlannerHook {
                 mtmvCache = materializedView.getOrGenerateCache(cascadesContext.getConnectContext());
                 // If mv property is_used_in_rewritten_by_materialized_view is set false, should not partition in
                 // query rewrite by materialized view
-                String isUsedByRewritten = materializedView.getMvProperties().get(
+                String isUsedByRewrite = materializedView.getMvProperties().get(
                         PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE);
-                if (!StringUtils.isEmpty(isUsedByRewritten) && !Boolean.parseBoolean(isUsedByRewritten)) {
-                    LOG.debug(String.format("mv doesn't part in query rewrite because "
+                if (!StringUtils.isEmpty(isUsedByRewrite) && !Boolean.parseBoolean(isUsedByRewrite)) {
+                    LOG.debug(String.format("mv doesn't part in query rewrite process because "
                             + "is_used_in_rewrite is false, mv is %s",
                             materializedView.getName()));
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -140,7 +140,7 @@ public class InitMaterializationContextHook implements PlannerHook {
             MTMVCache mtmvCache = null;
             try {
                 mtmvCache = materializedView.getOrGenerateCache(cascadesContext.getConnectContext());
-                // If mv property is_used_in_rewritten_by_materialized_view is set false, should not partition in
+                // If mv property is_used_in_rewrite is set false, should not partition in
                 // query rewrite by materialized view
                 String isUsedByRewrite = materializedView.getMvProperties().get(
                         PropertyAnalyzer.PROPERTIES_IS_USED_IN_REWRITE);

--- a/regression-test/suites/mtmv_p0/test_is_used_in_rewrite.groovy
+++ b/regression-test/suites/mtmv_p0/test_is_used_in_rewrite.groovy
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_is_used_in_rewrite","mtmv") {
+    String suiteName = "test_is_used_rewritten"
+    String tableName = "${suiteName}_table"
+    String mvName = "${suiteName}_mv"
+    String db = context.config.getDbNameByFile(context.file)
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+
+    sql """
+        CREATE TABLE ${tableName}
+        (
+            k1 TINYINT,
+            k2 INT not null,
+            k3 DATE NOT NULL
+        )
+        COMMENT "my first table"
+        DISTRIBUTED BY HASH(k2) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+     sql """
+        insert into ${tableName} values(1,1, '2024-05-01'),(2,2, '2024-05-02'),(3,3, '2024-05-03'),
+        (1,1, '2024-05-01'),(2,2, '2024-05-02'), (3,3, '2024-05-03');
+        """
+
+    // when not set is_used_in_rewrite, should rewrite successfully
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1'
+        )
+        AS
+        SELECT k1, k2, count(*) from ${tableName} group by k1, k2;
+        """
+
+    waitingMTMVTaskFinished(getJobName(db, mvName))
+    mv_rewrite_success_without_check_chosen("""
+    SELECT k2, count(*) from ${tableName} group by k2;
+    """ ,mvName)
+    sql """drop materialized view if exists ${mvName};"""
+
+
+    // when set is_used_in_rewrite = true, should rewrite successfully
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1',
+        'is_used_in_rewrite' = 'true'
+        )
+        AS
+        SELECT k1, k2, count(*) from ${tableName} group by k1, k2;
+        """
+
+    waitingMTMVTaskFinished(getJobName(db, mvName))
+    mv_rewrite_success_without_check_chosen("""
+    SELECT k2, count(*) from ${tableName} group by k2;
+    """ ,mvName)
+
+
+    // when set is_used_in_rewrite = false, should not partition in rewritten
+    sql """drop materialized view if exists ${mvName};"""
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1',
+        'is_used_in_rewrite' = 'false'
+        )
+        AS
+        SELECT k1, k2, count(*) from ${tableName} group by k1, k2;
+        """
+
+    waitingMTMVTaskFinished(getJobName(db, mvName))
+    mv_not_part_in("""
+    SELECT k2, count(*) from ${tableName} group by k2;
+    """ ,mvName)
+
+    sql """drop materialized view if exists ${mvName};"""
+    sql """drop table if exists `${tableName}`"""
+}

--- a/regression-test/suites/mtmv_p0/test_use_for_rewrite.groovy
+++ b/regression-test/suites/mtmv_p0/test_use_for_rewrite.groovy
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_is_used_in_rewrite","mtmv") {
-    String suiteName = "test_is_used_rewritten"
+suite("test_use_for_rewrite","mtmv") {
+    String suiteName = "test_use_for_rewrite"
     String tableName = "${suiteName}_table"
     String mvName = "${suiteName}_mv"
     String db = context.config.getDbNameByFile(context.file)
@@ -41,7 +41,7 @@ suite("test_is_used_in_rewrite","mtmv") {
         (1,1, '2024-05-01'),(2,2, '2024-05-02'), (3,3, '2024-05-03');
         """
 
-    // when not set is_used_in_rewrite, should rewrite successfully
+    // when not set use_for_rewrite, should rewrite successfully
     sql """
         CREATE MATERIALIZED VIEW ${mvName}
         BUILD IMMEDIATE REFRESH AUTO ON MANUAL
@@ -60,14 +60,14 @@ suite("test_is_used_in_rewrite","mtmv") {
     sql """drop materialized view if exists ${mvName};"""
 
 
-    // when set is_used_in_rewrite = true, should rewrite successfully
+    // when set use_for_rewrite = true, should rewrite successfully
     sql """
         CREATE MATERIALIZED VIEW ${mvName}
         BUILD IMMEDIATE REFRESH AUTO ON MANUAL
         DISTRIBUTED BY RANDOM BUCKETS 2
         PROPERTIES (
         'replication_num' = '1',
-        'is_used_in_rewrite' = 'true'
+        'use_for_rewrite' = 'true'
         )
         AS
         SELECT k1, k2, count(*) from ${tableName} group by k1, k2;
@@ -79,7 +79,7 @@ suite("test_is_used_in_rewrite","mtmv") {
     """ ,mvName)
 
 
-    // when set is_used_in_rewrite = false, should not partition in rewritten
+    // when set use_for_rewrite = false, should not partition in rewritten
     sql """drop materialized view if exists ${mvName};"""
     sql """
         CREATE MATERIALIZED VIEW ${mvName}
@@ -87,7 +87,7 @@ suite("test_is_used_in_rewrite","mtmv") {
         DISTRIBUTED BY RANDOM BUCKETS 2
         PROPERTIES (
         'replication_num' = '1',
-        'is_used_in_rewrite' = 'false'
+        'use_for_rewrite' = 'false'
         )
         AS
         SELECT k1, k2, count(*) from ${tableName} group by k1, k2;


### PR DESCRIPTION
## Proposed changes

Add  `use_for_rewrite` property when create mv. Default true;
If `use_for_rewrite` is false which means the mv would not partion in query rewrite.
Such as mv def is as following:
```sql
        CREATE MATERIALIZED VIEW mv1
        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
        DISTRIBUTED BY RANDOM BUCKETS 2
        PROPERTIES (
        'replication_num' = '1',
        'use_for_rewrite' = 'false'
        )
        AS
        SELECT k1, k2, count(*) from t1 group by k1, k2;
```

if we run query as following, this mv would not partition in the query rewrite:
```sql
SELECT k2, count(*) from t1 group by k2;
```
