### PR TITLE
[feature](cast) add enable_strict_cast_mode

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -575,6 +575,11 @@ public:
                _query_options.enable_local_merge_sort;
     }
 
+    bool enable_strict_cast_mode() const {
+        return _query_options.__isset.enable_strict_cast_mode &&
+               _query_options.enable_strict_cast_mode;
+    }
+
     int64_t min_revocable_mem() const {
         if (_query_options.__isset.min_revocable_mem) {
             return std::max(_query_options.min_revocable_mem, (int64_t)1);

--- a/be/src/udf/udf.cpp
+++ b/be/src/udf/udf.cpp
@@ -130,6 +130,10 @@ int FunctionContext::get_num_args() const {
     return _arg_types.size();
 }
 
+bool FunctionContext::enable_strict_cast_mode() const {
+    return state()->enable_strict_cast_mode();
+}
+
 const doris::TypeDescriptor& FunctionContext::get_return_type() const {
     return _return_type;
 }

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -73,12 +73,15 @@ public:
     void set_constant_cols(const std::vector<std::shared_ptr<doris::ColumnPtrWrapper>>& cols);
 
     RuntimeState* state() { return _state; }
+    const RuntimeState* state() const { return _state; }
 
     bool check_overflow_for_decimal() const { return _check_overflow_for_decimal; }
 
     bool set_check_overflow_for_decimal(bool check_overflow_for_decimal) {
         return _check_overflow_for_decimal = check_overflow_for_decimal;
     }
+
+    bool enable_strict_cast_mode() const;
 
     void set_string_as_jsonb_string(bool string_as_jsonb_string) {
         _string_as_jsonb_string = string_as_jsonb_string;
@@ -177,6 +180,7 @@ private:
     std::vector<std::shared_ptr<doris::ColumnPtrWrapper>> _constant_cols;
 
     bool _check_overflow_for_decimal = false;
+    bool _enable_strict_cast_mode = false;
 
     bool _string_as_jsonb_string = false;
     bool _jsonb_string_as_string = false;

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1686,16 +1686,6 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
-        RETURN_IF_ERROR(_execute_impl(context, block, arguments, result, input_rows_count));
-        if (context->enable_strict_cast_mode()) {
-            RETURN_IF_ERROR(strict_cast_check(block.get_by_position(arguments[0]),
-                                              block.get_by_position(result)));
-        }
-        return Status::OK();
-    }
-
-    Status _execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                         size_t result, size_t input_rows_count) const {
         const IDataType* from_type = block.get_by_position(arguments[0]).type.get();
 
         if (check_and_get_data_type<DataTypeString>(from_type)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -275,6 +275,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String FORCE_TO_LOCAL_SHUFFLE = "force_to_local_shuffle";
 
     public static final String ENABLE_LOCAL_MERGE_SORT = "enable_local_merge_sort";
+    public static final String ENABLE_STRICT_CAST_MODE = "enable_strict_cast_mode";
 
     public static final String ENABLE_AGG_STATE = "enable_agg_state";
 
@@ -1065,6 +1066,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_LOCAL_MERGE_SORT)
     private boolean enableLocalMergeSort = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_STRICT_CAST_MODE)
+    private boolean enableStrictCastMode = false;
 
     @VariableMgr.VarAttr(name = ENABLE_AGG_STATE, fuzzy = false, varType = VariableAnnotation.EXPERIMENTAL,
             needForward = true)
@@ -3754,6 +3758,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setDataQueueMaxBlocks(dataQueueMaxBlocks);
 
         tResult.setEnableLocalMergeSort(enableLocalMergeSort);
+        tResult.setEnableStrictCastMode(enableStrictCastMode);
         tResult.setEnableParallelResultSink(enableParallelResultSink);
         tResult.setEnableShortCircuitQueryAccessColumnStore(enableShortCircuitQueryAcessColumnStore);
         tResult.setReadCsvEmptyLineAsNull(readCsvEmptyLineAsNull);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -342,7 +342,11 @@ struct TQueryOptions {
   130: optional bool enable_adaptive_pipeline_task_serial_read_on_limit = true;
   131: optional i32 adaptive_pipeline_task_serial_read_on_limit = 10000;
 
+
   132: optional i32 parallel_prepare_threshold = 0;
+
+  133: optional bool enable_strict_cast_mode = true;
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
## Proposed changes

```
mysql [(none)]>set enable_strict_cast_mode = false;
Query OK, 0 rows affected (0.01 sec)

mysql [(none)]>select cast('1.a' as int);
+--------------------+
| cast('1.a' as INT) |
+--------------------+
|               NULL |
+--------------------+
1 row in set (0.12 sec)

mysql [(none)]>set enable_strict_cast_mode = true;
Query OK, 0 rows affected (0.01 sec)

mysql [(none)]>select cast('1.a' as int);
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]Bad cast from String to Int32 with value : 1.a


mysql [test]>set enable_strict_cast_mode = false;
Query OK, 0 rows affected (0.00 sec)

mysql [test]>select cast(k2 as int) from testdb;
+-----------------+
| cast(k2 as INT) |
+-----------------+
|     -2147483648 |
+-----------------+
1 row in set (0.02 sec)

mysql [test]>set enable_strict_cast_mode = true;
Query OK, 0 rows affected (0.00 sec)

mysql [test]>select cast(k2 as int) from testdb;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]Cast to type Int32 ,out of range 9.2173984e+18
```

<!--Describe your changes.-->

