### PR TITLE
[bugfix](hms)add default value check for hms catalog with dlf

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -647,7 +647,12 @@ public class Util {
         String rootCause = "unknown";
         Throwable p = t;
         while (p != null) {
-            rootCause = p.getClass().getName() + ": " + p.getMessage();
+            String message = p.getMessage();
+            if (message == null) {
+                rootCause = p.getClass().getName();
+            } else {
+                rootCause = p.getClass().getName() + ": " + p.getMessage();
+            }
             p = p.getCause();
         }
         return rootCause;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.HashDistributionDesc;
 import org.apache.doris.analysis.PartitionDesc;
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.catalog.PartitionType;
@@ -38,6 +39,7 @@ import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.jdbc.client.JdbcClient;
 import org.apache.doris.datasource.jdbc.client.JdbcClientConfig;
 import org.apache.doris.datasource.operations.ExternalMetadataOps;
+import org.apache.doris.datasource.property.constants.HMSProperties;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -191,6 +193,15 @@ public class HiveMetadataOps implements ExternalMetadataOps {
                     throw new UserException("Partition values expressions is not supported in hive catalog.");
                 }
 
+            }
+            Map<String, String> properties = catalog.getProperties();
+            if (properties.containsKey(HMSProperties.HIVE_METASTORE_TYPE)
+                    && properties.get(HMSProperties.HIVE_METASTORE_TYPE).equals(HMSProperties.DLF_TYPE)) {
+                for (Column column : stmt.getColumns()) {
+                    if (column.hasDefaultValue()) {
+                        throw new UserException("Default values are not supported with `DLF` catalog.");
+                    }
+                }
             }
             String comment = stmt.getComment();
             Optional<String> location = Optional.ofNullable(props.getOrDefault(LOCATION_URI_KEY, null));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -296,7 +296,7 @@ public class HiveMetadataOps implements ExternalMetadataOps {
 
     @Override
     public boolean databaseExist(String dbName) {
-        return listDatabaseNames().contains(dbName);
+        return listDatabaseNames().contains(dbName.toLowerCase());
     }
 
     @Override

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_database.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_database.groovy
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_hive_database", "p0,external,hive,external_docker,external_docker_hive") {
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String hms_port = context.config.otherConfigs.get("hive2HmsPort")
+        String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
+        String catalog_name = "test_hive_database"
+        String prefix = catalog_name
+
+        sql """drop catalog if exists ${catalog_name};"""
+
+        sql """
+            create catalog if not exists ${catalog_name} properties (
+                'type'='hms',
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
+                'use_meta_cache' = 'true'
+            );
+        """
+
+        // Database names are case insensitive
+        logger.info("catalog " + catalog_name + " created")
+        sql """switch ${catalog_name};"""
+        logger.info("switched to catalog " + catalog_name)
+
+        sql """ drop database if exists ${prefix}_db1 """
+        sql """ create database ${prefix}_Db1 """
+        def ret1 = sql """ show databases """
+        assertTrue(ret1.toString().contains("${prefix}_db1"))
+
+        test {
+            sql """ create database ${prefix}_dB1 """
+            exception "database exists"
+        }
+        sql """ drop database if exists ${prefix}_db1 """
+    }
+}


### PR DESCRIPTION
## Proposed changes

1. `dlf` is not supported default values, so throw an exception.
2. The database name needs to be case-insensitive and consistent with hive
3. Improve error message prompt information

