### PR TITLE
[opt](memory) Refactor memory maintenance thread

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -95,6 +95,9 @@ DEFINE_String(mem_limit, "90%");
 // Soft memory limit as a fraction of hard memory limit.
 DEFINE_Double(soft_mem_limit_frac, "0.9");
 
+// Cache capacity reduce mem limit as a fraction of soft mem limit.
+DEFINE_mDouble(cache_capacity_reduce_mem_limit_frac, "0.6");
+
 // Schema change memory limit as a fraction of soft memory limit.
 DEFINE_Double(schema_change_mem_limit_frac, "0.6");
 
@@ -275,7 +278,7 @@ DEFINE_mInt32(exchg_buffer_queue_capacity_factor, "64");
 DEFINE_mInt64(memory_limitation_per_thread_for_schema_change_bytes, "2147483648");
 
 DEFINE_mInt32(cache_prune_interval_sec, "10");
-DEFINE_mInt32(cache_periodic_prune_stale_sweep_sec, "300");
+DEFINE_mInt32(cache_periodic_prune_stale_sweep_sec, "60");
 // the clean interval of tablet lookup cache
 DEFINE_mInt32(tablet_lookup_cache_stale_sweep_time_sec, "30");
 DEFINE_mInt32(point_query_row_cache_stale_sweep_time_sec, "300");
@@ -554,7 +557,7 @@ DEFINE_String(pprof_profile_dir, "${DORIS_HOME}/log");
 // for jeprofile in jemalloc
 DEFINE_mString(jeprofile_dir, "${DORIS_HOME}/log");
 DEFINE_mBool(enable_je_purge_dirty_pages, "true");
-DEFINE_mString(je_dirty_pages_mem_limit_percent, "5%");
+DEFINE_mString(je_dirty_pages_mem_limit_percent, "2%");
 
 // to forward compatibility, will be removed later
 DEFINE_mBool(enable_token_check, "true");
@@ -571,16 +574,11 @@ DEFINE_Int32(num_cores, "0");
 DEFINE_Bool(ignore_broken_disk, "false");
 
 // Sleep time in milliseconds between memory maintenance iterations
-DEFINE_mInt32(memory_maintenance_sleep_time_ms, "100");
+DEFINE_mInt32(memory_maintenance_sleep_time_ms, "5");
 
 // After full gc, no longer full gc and minor gc during sleep.
 // After minor gc, no minor gc during sleep, but full gc is possible.
 DEFINE_mInt32(memory_gc_sleep_time_ms, "500");
-
-// Sleep time in milliseconds between memtbale flush mgr refresh iterations
-DEFINE_mInt64(memtable_mem_tracker_refresh_interval_ms, "5");
-
-DEFINE_mInt64(wg_weighted_memory_ratio_refresh_interval_ms, "50");
 
 // percent of (active memtables size / all memtables size) when reach hard limit
 DEFINE_mInt32(memtable_hard_limit_active_percent, "50");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -574,7 +574,7 @@ DEFINE_Int32(num_cores, "0");
 DEFINE_Bool(ignore_broken_disk, "false");
 
 // Sleep time in milliseconds between memory maintenance iterations
-DEFINE_mInt32(memory_maintenance_sleep_time_ms, "5");
+DEFINE_mInt32(memory_maintenance_sleep_time_ms, "20");
 
 // After full gc, no longer full gc and minor gc during sleep.
 // After minor gc, no minor gc during sleep, but full gc is possible.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -133,6 +133,9 @@ DECLARE_String(mem_limit);
 // Soft memory limit as a fraction of hard memory limit.
 DECLARE_Double(soft_mem_limit_frac);
 
+// Cache capacity reduce mem limit as a fraction of soft mem limit.
+DECLARE_mDouble(cache_capacity_reduce_mem_limit_frac);
+
 // Schema change memory limit as a fraction of soft memory limit.
 DECLARE_Double(schema_change_mem_limit_frac);
 
@@ -634,12 +637,6 @@ DECLARE_mInt32(memory_maintenance_sleep_time_ms);
 // After full gc, no longer full gc and minor gc during sleep.
 // After minor gc, no minor gc during sleep, but full gc is possible.
 DECLARE_mInt32(memory_gc_sleep_time_ms);
-
-// Sleep time in milliseconds between memtbale flush mgr memory refresh iterations
-DECLARE_mInt64(memtable_mem_tracker_refresh_interval_ms);
-
-// Sleep time in milliseconds between refresh iterations of workload group weighted memory ratio
-DECLARE_mInt64(wg_weighted_memory_ratio_refresh_interval_ms);
 
 // percent of (active memtables size / all memtables size) when reach hard limit
 DECLARE_mInt32(memtable_hard_limit_active_percent);

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -204,42 +204,110 @@ void Daemon::tcmalloc_gc_thread() {
 #endif
 }
 
+void refresh_process_memory_metrics() {
+    doris::PerfCounters::refresh_proc_status();
+    doris::MemInfo::refresh_proc_meminfo();
+    doris::GlobalMemoryArbitrator::reset_refresh_interval_memory_growth();
+    ExecEnv::GetInstance()->brpc_iobuf_block_memory_tracker()->set_consumption(
+            butil::IOBuf::block_memory());
+}
+
+void refresh_allocator_memory_metrics() {
+#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
+    doris::MemInfo::refresh_allocator_mem();
+    if (config::enable_system_metrics) {
+        DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
+    }
+#endif
+    MemInfo::refresh_memory_bvar();
+}
+
+void refresh_memory_log_after_memory_change(int64_t& last_print_proc_mem) {
+    if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {
+        last_print_proc_mem = PerfCounters::get_vm_rss();
+        doris::MemTrackerLimiter::clean_tracker_limiter_group();
+        doris::MemTrackerLimiter::enable_print_log_process_usage();
+        // Refresh mem tracker each type counter.
+        doris::MemTrackerLimiter::refresh_global_counter();
+        LOG(INFO) << doris::GlobalMemoryArbitrator::
+                        process_mem_log_str(); // print mem log when memory state by 256M
+    }
+}
+
+void refresh_cache_capacity(int32_t& refresh_cache_capacity_sleep_time_ms,
+                            int32_t interval_milliseconds) {
+    if (refresh_cache_capacity_sleep_time_ms <= 0) {
+        auto cache_capacity_reduce_mem_limit = uint64_t(
+                doris::MemInfo::mem_limit() * config::cache_capacity_reduce_mem_limit_frac);
+        int64_t process_memory_usage = doris::GlobalMemoryArbitrator::process_memory_usage();
+        double new_cache_capacity_adjust_weighted =
+                process_memory_usage <= cache_capacity_reduce_mem_limit
+                        ? 1
+                        : std::min<double>(
+                                  1 - (process_memory_usage - cache_capacity_reduce_mem_limit) /
+                                                  (doris::MemInfo::mem_limit() -
+                                                   cache_capacity_reduce_mem_limit),
+                                  0);
+        if (new_cache_capacity_adjust_weighted !=
+            doris::GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted) {
+            doris::GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted =
+                    new_cache_capacity_adjust_weighted;
+            doris::GlobalMemoryArbitrator::notify_cache_adjust_capacity();
+            refresh_cache_capacity_sleep_time_ms = config::memory_gc_sleep_time_ms;
+        }
+    }
+    refresh_cache_capacity_sleep_time_ms -= interval_milliseconds;
+}
+
+void je_purge_dirty_pages(int32_t& je_purge_dirty_pages_sleep_time_ms,
+                          int32_t interval_milliseconds) {
+#ifdef USE_JEMALLOC
+    if (je_purge_dirty_pages_sleep_time_ms <= 0 &&
+        doris::MemInfo::je_dirty_pages_mem() > doris::MemInfo::je_dirty_pages_mem_limit() &&
+        GlobalMemoryArbitrator::is_exceed_soft_mem_limit()) {
+        doris::MemInfo::notify_je_purge_dirty_pages();
+        je_purge_dirty_pages_sleep_time_ms = config::memory_gc_sleep_time_ms;
+    }
+    je_purge_dirty_pages_sleep_time_ms -= interval_milliseconds;
+#endif
+}
+
 void Daemon::memory_maintenance_thread() {
     int32_t interval_milliseconds = config::memory_maintenance_sleep_time_ms;
     int64_t last_print_proc_mem = PerfCounters::get_vm_rss();
+    int32_t refresh_cache_capacity_sleep_time_ms = 0;
+    int32_t je_purge_dirty_pages_sleep_time_ms = 0;
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::milliseconds(interval_milliseconds))) {
-        // Refresh process memory metrics.
-        doris::PerfCounters::refresh_proc_status();
-        doris::MemInfo::refresh_proc_meminfo();
-        doris::GlobalMemoryArbitrator::reset_refresh_interval_memory_growth();
-        ExecEnv::GetInstance()->brpc_iobuf_block_memory_tracker()->set_consumption(
-                butil::IOBuf::block_memory());
-        // Refresh allocator memory metrics.
-#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
-        doris::MemInfo::refresh_allocator_mem();
-#ifdef USE_JEMALLOC
-        if (doris::MemInfo::je_dirty_pages_mem() > doris::MemInfo::je_dirty_pages_mem_limit() &&
-            GlobalMemoryArbitrator::is_exceed_soft_mem_limit()) {
-            doris::MemInfo::notify_je_purge_dirty_pages();
-        }
-#endif
-        if (config::enable_system_metrics) {
-            DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
-        }
-#endif
-        MemInfo::refresh_memory_bvar();
+        // step 1. Refresh process memory metrics.
+        refresh_process_memory_metrics();
 
-        // Update and print memory stat when the memory changes by 256M.
-        if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {
-            last_print_proc_mem = PerfCounters::get_vm_rss();
-            doris::MemTrackerLimiter::clean_tracker_limiter_group();
-            doris::MemTrackerLimiter::enable_print_log_process_usage();
-            // Refresh mem tracker each type counter.
-            doris::MemTrackerLimiter::refresh_global_counter();
-            LOG(INFO) << doris::GlobalMemoryArbitrator::
-                            process_mem_log_str(); // print mem log when memory state by 256M
-        }
+        // step 2. Refresh allocator memory metrics.
+        refresh_allocator_memory_metrics();
+
+        // step 3. Update and print memory stat when the memory changes by 256M.
+        refresh_memory_log_after_memory_change(last_print_proc_mem);
+
+        // step 4. Asyn Refresh cache capacity
+        // TODO adjust cache capacity based on smoothstep (smooth gradient).
+        refresh_cache_capacity(refresh_cache_capacity_sleep_time_ms, interval_milliseconds);
+
+        // step 5. Cancel top memory task when process memory exceed hard limit.
+        // TODO replace memory_gc_thread.
+
+        // step 6. Refresh weighted memory ratio of workload groups
+        doris::ExecEnv::GetInstance()->workload_group_mgr()->refresh_wg_weighted_memory_limit();
+
+        // step 7. Analyze blocking queries
+        // TODO sort the operators that can spill, wake up the pipeline task spill
+        // or continue execution according to certain rules or cancel query.
+
+        // step 8. Flush memtable
+        doris::GlobalMemoryArbitrator::notify_memtable_memory_refresh();
+        // TODO notify flush memtable
+
+        // step 9. Jemalloc purge all arena dirty pages
+        je_purge_dirty_pages(je_purge_dirty_pages_sleep_time_ms, interval_milliseconds);
     }
 }
 
@@ -301,10 +369,21 @@ void Daemon::memory_gc_thread() {
 void Daemon::memtable_memory_refresh_thread() {
     // Refresh the memory statistics of the load channel tracker more frequently,
     // which helps to accurately control the memory of LoadChannelMgr.
-    while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(config::memtable_mem_tracker_refresh_interval_ms))) {
+    do {
+        std::unique_lock<std::mutex> l(doris::GlobalMemoryArbitrator::memtable_memory_refresh_lock);
+        while (_stop_background_threads_latch.count() != 0 &&
+               !doris::GlobalMemoryArbitrator::memtable_memory_refresh_notify.load(
+                       std::memory_order_relaxed)) {
+            doris::GlobalMemoryArbitrator::memtable_memory_refresh_cv.wait_for(
+                    l, std::chrono::seconds(1));
+        }
+        if (_stop_background_threads_latch.count() == 0) {
+            break;
+        }
         doris::ExecEnv::GetInstance()->memtable_memory_limiter()->refresh_mem_tracker();
-    }
+        doris::GlobalMemoryArbitrator::memtable_memory_refresh_notify.store(
+                false, std::memory_order_relaxed);
+    } while (true);
 }
 
 /*
@@ -396,6 +475,34 @@ void Daemon::je_purge_dirty_pages_thread() const {
     } while (true);
 }
 
+void Daemon::cache_adjust_capacity_thread() {
+    std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("");
+    do {
+        std::unique_lock<std::mutex> l(doris::GlobalMemoryArbitrator::cache_adjust_capacity_lock);
+        while (_stop_background_threads_latch.count() != 0 &&
+               !doris::GlobalMemoryArbitrator::cache_adjust_capacity_notify.load(
+                       std::memory_order_relaxed)) {
+            doris::GlobalMemoryArbitrator::cache_adjust_capacity_cv.wait_for(
+                    l, std::chrono::seconds(1));
+        }
+        if (_stop_background_threads_latch.count() == 0) {
+            break;
+        }
+        if (config::disable_memory_gc) {
+            continue;
+        }
+        auto freed_mem = CacheManager::instance()->for_each_cache_refresh_capacity(
+                GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted, profile.get());
+        std::stringstream ss;
+        profile->pretty_print(&ss);
+        LOG(INFO) << fmt::format(
+                "[MemoryGC] refresh cache capacity end, free memory {}, details: {}",
+                PrettyPrinter::print(freed_mem, TUnit::BYTES), ss.str());
+        doris::GlobalMemoryArbitrator::cache_adjust_capacity_notify.store(
+                false, std::memory_order_relaxed);
+    } while (true);
+}
+
 void Daemon::cache_prune_stale_thread() {
     int32_t interval = config::cache_periodic_prune_stale_sweep_sec;
     while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval))) {
@@ -408,14 +515,6 @@ void Daemon::cache_prune_stale_thread() {
             continue;
         }
         CacheManager::instance()->for_each_cache_prune_stale();
-    }
-}
-
-void Daemon::wg_weighted_memory_ratio_refresh_thread() {
-    // Refresh weighted memory ratio of workload groups
-    while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(config::wg_weighted_memory_ratio_refresh_interval_ms))) {
-        doris::ExecEnv::GetInstance()->workload_group_mgr()->refresh_wg_weighted_memory_limit();
     }
 }
 
@@ -456,6 +555,10 @@ void Daemon::start() {
             [this]() { this->je_purge_dirty_pages_thread(); }, &_threads.emplace_back());
     CHECK(st.ok()) << st;
     st = Thread::create(
+            "Daemon", "cache_adjust_capacity_thread",
+            [this]() { this->cache_adjust_capacity_thread(); }, &_threads.emplace_back());
+    CHECK(st.ok()) << st;
+    st = Thread::create(
             "Daemon", "cache_prune_stale_thread", [this]() { this->cache_prune_stale_thread(); },
             &_threads.emplace_back());
     CHECK(st.ok()) << st;
@@ -463,11 +566,6 @@ void Daemon::start() {
             "Daemon", "query_runtime_statistics_thread",
             [this]() { this->report_runtime_query_statistics_thread(); }, &_threads.emplace_back());
     CHECK(st.ok()) << st;
-
-    st = Thread::create(
-            "Daemon", "wg_weighted_memory_ratio_refresh_thread",
-            [this]() { this->wg_weighted_memory_ratio_refresh_thread(); },
-            &_threads.emplace_back());
 
     if (config::enable_be_proc_monitor) {
         st = Thread::create(

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -43,9 +43,9 @@ private:
     void memtable_memory_refresh_thread();
     void calculate_metrics_thread();
     void je_purge_dirty_pages_thread() const;
+    void cache_adjust_capacity_thread();
     void cache_prune_stale_thread();
     void report_runtime_query_statistics_thread();
-    void wg_weighted_memory_ratio_refresh_thread();
     void be_proc_monitor_thread();
 
     CountDownLatch _stop_background_threads_latch;

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -220,7 +220,6 @@ size_t LRUCache::get_capacity() {
 size_t LRUCache::get_element_count() {
     std::lock_guard l(_mutex);
     return _table.element_count();
-    ;
 }
 
 bool LRUCache::_unref(LRUHandle* e) {

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -177,6 +177,52 @@ LRUCache::~LRUCache() {
     prune();
 }
 
+PrunedInfo LRUCache::set_capacity(size_t capacity) {
+    LRUHandle* last_ref_list = nullptr;
+    {
+        std::lock_guard l(_mutex);
+        _capacity = capacity;
+        _evict_from_lru(0, &last_ref_list);
+    }
+
+    int64_t pruned_count = 0;
+    int64_t pruned_size = 0;
+    while (last_ref_list != nullptr) {
+        ++pruned_count;
+        pruned_size += last_ref_list->total_size;
+        LRUHandle* next = last_ref_list->next;
+        last_ref_list->free();
+        last_ref_list = next;
+    }
+    return {pruned_count, pruned_size};
+}
+
+uint64_t LRUCache::get_lookup_count() {
+    std::lock_guard l(_mutex);
+    return _lookup_count;
+}
+
+uint64_t LRUCache::get_hit_count() {
+    std::lock_guard l(_mutex);
+    return _hit_count;
+}
+
+size_t LRUCache::get_usage() {
+    std::lock_guard l(_mutex);
+    return _usage;
+}
+
+size_t LRUCache::get_capacity() {
+    std::lock_guard l(_mutex);
+    return _capacity;
+}
+
+size_t LRUCache::get_element_count() {
+    std::lock_guard l(_mutex);
+    return _table.element_count();
+    ;
+}
+
 bool LRUCache::_unref(LRUHandle* e) {
     DCHECK(e->refs > 0);
     e->refs--;
@@ -515,19 +561,19 @@ inline uint32_t ShardedLRUCache::_hash_slice(const CacheKey& s) {
     return s.hash(s.data(), s.size(), 0);
 }
 
-ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
+ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t capacity, LRUCacheType type,
                                  uint32_t num_shards, uint32_t total_element_count_capacity)
         : _name(name),
           _num_shard_bits(Bits::FindLSBSetNonZero(num_shards)),
           _num_shards(num_shards),
           _shards(nullptr),
           _last_id(1),
-          _total_capacity(total_capacity) {
+          _capacity(capacity) {
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)
             << "num_shards should be power of two, but got " << num_shards;
 
-    const size_t per_shard = (total_capacity + (_num_shards - 1)) / _num_shards;
+    const size_t per_shard = (capacity + (_num_shards - 1)) / _num_shards;
     const size_t per_shard_element_count_capacity =
             (total_element_count_capacity + (_num_shards - 1)) / _num_shards;
     LRUCache** shards = new (std::nothrow) LRUCache*[_num_shards];
@@ -557,12 +603,12 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
             "doris_cache", _name + "_persecond", _lookup_count_bvar.get(), 60));
 }
 
-ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
+ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t capacity, LRUCacheType type,
                                  uint32_t num_shards,
                                  CacheValueTimeExtractor cache_value_time_extractor,
                                  bool cache_value_check_timestamp,
                                  uint32_t total_element_count_capacity)
-        : ShardedLRUCache(name, total_capacity, type, num_shards, total_element_count_capacity) {
+        : ShardedLRUCache(name, capacity, type, num_shards, total_element_count_capacity) {
     for (int s = 0; s < _num_shards; s++) {
         _shards[s]->set_cache_value_time_extractor(cache_value_time_extractor);
         _shards[s]->set_cache_value_check_timestamp(cache_value_check_timestamp);
@@ -578,6 +624,24 @@ ShardedLRUCache::~ShardedLRUCache() {
         }
         delete[] _shards;
     }
+}
+
+PrunedInfo ShardedLRUCache::set_capacity(size_t capacity) {
+    std::lock_guard l(_mutex);
+    PrunedInfo pruned_info;
+    const size_t per_shard = (capacity + (_num_shards - 1)) / _num_shards;
+    for (int s = 0; s < _num_shards; s++) {
+        PrunedInfo info = _shards[s]->set_capacity(per_shard);
+        pruned_info.pruned_count += info.pruned_count;
+        pruned_info.pruned_size += info.pruned_size;
+    }
+    _capacity = capacity;
+    return pruned_info;
+}
+
+size_t ShardedLRUCache::get_capacity() {
+    std::lock_guard l(_mutex);
+    return _capacity;
 }
 
 Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t charge,
@@ -638,25 +702,25 @@ int64_t ShardedLRUCache::get_usage() {
 }
 
 void ShardedLRUCache::update_cache_metrics() const {
-    size_t total_capacity = 0;
+    size_t capacity = 0;
     size_t total_usage = 0;
     size_t total_lookup_count = 0;
     size_t total_hit_count = 0;
     size_t total_element_count = 0;
     for (int i = 0; i < _num_shards; i++) {
-        total_capacity += _shards[i]->get_capacity();
+        capacity += _shards[i]->get_capacity();
         total_usage += _shards[i]->get_usage();
         total_lookup_count += _shards[i]->get_lookup_count();
         total_hit_count += _shards[i]->get_hit_count();
         total_element_count += _shards[i]->get_element_count();
     }
 
-    cache_capacity->set_value(total_capacity);
+    cache_capacity->set_value(capacity);
     cache_usage->set_value(total_usage);
     cache_element_count->set_value(total_element_count);
     cache_lookup_count->set_value(total_lookup_count);
     cache_hit_count->set_value(total_hit_count);
-    cache_usage_ratio->set_value(total_capacity == 0 ? 0 : ((double)total_usage / total_capacity));
+    cache_usage_ratio->set_value(capacity == 0 ? 0 : ((double)total_usage / capacity));
     cache_hit_ratio->set_value(
             total_lookup_count == 0 ? 0 : ((double)total_hit_count / total_lookup_count));
 }

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -72,7 +72,7 @@ int64_t CacheManager::for_each_cache_refresh_capacity(double adjust_weighted,
         if (!cache_policy->enable_prune()) {
             continue;
         }
-        cache_policy->set_capacity(adjust_weighted);
+        cache_policy->adjust_capacity_weighted(adjust_weighted);
         freed_size += cache_policy->profile()->get_counter("FreedMemory")->value();
         if (cache_policy->profile()->get_counter("FreedMemory")->value() != 0 && profile) {
             profile->add_child(cache_policy->profile(), true, nullptr);

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -66,4 +66,22 @@ int64_t CacheManager::cache_prune_all(CachePolicy::CacheType type, bool force) {
     return cache_policy->profile()->get_counter("FreedMemory")->value();
 }
 
+int64_t CacheManager::for_each_cache_refresh_capacity(double adjust_weighted,
+                                                      RuntimeProfile* profile) {
+    int64_t freed_size = 0;
+    std::lock_guard<std::mutex> l(_caches_lock);
+    for (const auto& pair : _caches) {
+        auto* cache_policy = pair.second;
+        if (!cache_policy->enable_prune()) {
+            continue;
+        }
+        cache_policy->set_capacity(adjust_weighted);
+        freed_size += cache_policy->profile()->get_counter("FreedMemory")->value();
+        if (cache_policy->profile()->get_counter("FreedMemory")->value() != 0 && profile) {
+            profile->add_child(cache_policy->profile(), true, nullptr);
+        }
+    }
+    return freed_size;
+}
+
 } // namespace doris

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -59,9 +59,6 @@ int64_t CacheManager::for_each_cache_prune_all(RuntimeProfile* profile, bool for
 int64_t CacheManager::cache_prune_all(CachePolicy::CacheType type, bool force) {
     std::lock_guard<std::mutex> l(_caches_lock);
     auto* cache_policy = _caches[type];
-    if (!cache_policy->enable_prune()) {
-        return -1;
-    }
     cache_policy->prune_all(force);
     return cache_policy->profile()->get_counter("FreedMemory")->value();
 }

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -81,6 +81,9 @@ public:
         return false;
     }
 
+    int64_t for_each_cache_refresh_capacity(double adjust_weighted,
+                                            RuntimeProfile* profile = nullptr);
+
 private:
     std::mutex _caches_lock;
     std::unordered_map<CachePolicy::CacheType, CachePolicy*> _caches;

--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -21,8 +21,12 @@
 
 namespace doris {
 
-CachePolicy::CachePolicy(CacheType type, uint32_t stale_sweep_time_s, bool enable_prune)
-        : _type(type), _stale_sweep_time_s(stale_sweep_time_s), _enable_prune(enable_prune) {
+CachePolicy::CachePolicy(CacheType type, size_t capacity, uint32_t stale_sweep_time_s,
+                         bool enable_prune)
+        : _type(type),
+          _initial_capacity(capacity),
+          _stale_sweep_time_s(stale_sweep_time_s),
+          _enable_prune(enable_prune) {
     CacheManager::instance()->register_cache(this);
     init_profile();
 }

--- a/be/src/runtime/memory/global_memory_arbitrator.cpp
+++ b/be/src/runtime/memory/global_memory_arbitrator.cpp
@@ -38,6 +38,13 @@ bvar::PassiveStatus<int64_t> g_sys_mem_avail(
 
 std::atomic<int64_t> GlobalMemoryArbitrator::_s_process_reserved_memory = 0;
 std::atomic<int64_t> GlobalMemoryArbitrator::refresh_interval_memory_growth = 0;
+std::mutex GlobalMemoryArbitrator::cache_adjust_capacity_lock;
+std::condition_variable GlobalMemoryArbitrator::cache_adjust_capacity_cv;
+std::atomic<bool> GlobalMemoryArbitrator::cache_adjust_capacity_notify {false};
+std::atomic<double> GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted {1};
+std::mutex GlobalMemoryArbitrator::memtable_memory_refresh_lock;
+std::condition_variable GlobalMemoryArbitrator::memtable_memory_refresh_cv;
+std::atomic<bool> GlobalMemoryArbitrator::memtable_memory_refresh_notify {false};
 
 bool GlobalMemoryArbitrator::try_reserve_process_memory(int64_t bytes) {
     if (sys_mem_available() - bytes < MemInfo::sys_mem_available_warning_water_mark()) {

--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -173,6 +173,23 @@ public:
     // avoid multiple threads starting at the same time and causing OOM.
     static std::atomic<int64_t> refresh_interval_memory_growth;
 
+    static std::mutex cache_adjust_capacity_lock;
+    static std::condition_variable cache_adjust_capacity_cv;
+    static std::atomic<bool> cache_adjust_capacity_notify;
+    static std::atomic<double> last_cache_capacity_adjust_weighted;
+    static void notify_cache_adjust_capacity() {
+        cache_adjust_capacity_notify.store(true, std::memory_order_relaxed);
+        cache_adjust_capacity_cv.notify_all();
+    }
+
+    static std::mutex memtable_memory_refresh_lock;
+    static std::condition_variable memtable_memory_refresh_cv;
+    static std::atomic<bool> memtable_memory_refresh_notify;
+    static void notify_memtable_memory_refresh() {
+        memtable_memory_refresh_notify.store(true, std::memory_order_relaxed);
+        memtable_memory_refresh_cv.notify_all();
+    }
+
 private:
     static std::atomic<int64_t> _s_process_reserved_memory;
 

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -37,7 +37,8 @@ public:
                    uint32_t stale_sweep_time_s, uint32_t num_shards = DEFAULT_LRU_CACHE_NUM_SHARDS,
                    uint32_t element_count_capacity = DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY,
                    bool enable_prune = true)
-            : CachePolicy(type, stale_sweep_time_s, enable_prune), _lru_cache_type(lru_cache_type) {
+            : CachePolicy(type, capacity, stale_sweep_time_s, enable_prune),
+              _lru_cache_type(lru_cache_type) {
         if (check_capacity(capacity, num_shards)) {
             _cache = std::shared_ptr<ShardedLRUCache>(
                     new ShardedLRUCache(type_string(type), capacity, lru_cache_type, num_shards,
@@ -53,7 +54,8 @@ public:
                    uint32_t element_count_capacity,
                    CacheValueTimeExtractor cache_value_time_extractor,
                    bool cache_value_check_timestamp, bool enable_prune = true)
-            : CachePolicy(type, stale_sweep_time_s, enable_prune), _lru_cache_type(lru_cache_type) {
+            : CachePolicy(type, capacity, stale_sweep_time_s, enable_prune),
+              _lru_cache_type(lru_cache_type) {
         if (check_capacity(capacity, num_shards)) {
             _cache = std::shared_ptr<ShardedLRUCache>(
                     new ShardedLRUCache(type_string(type), capacity, lru_cache_type, num_shards,
@@ -106,18 +108,19 @@ public:
 
     int64_t get_usage() { return _cache->get_usage(); }
 
-    size_t get_total_capacity() { return _cache->get_total_capacity(); }
+    size_t get_capacity() override { return _cache->get_capacity(); }
 
     uint64_t new_id() { return _cache->new_id(); };
 
     // Subclass can override this method to determine whether to do the minor or full gc
     virtual bool exceed_prune_limit() {
-        return _lru_cache_type == LRUCacheType::SIZE ? mem_consumption() > CACHE_MIN_FREE_SIZE
-                                                     : get_usage() > CACHE_MIN_FREE_NUMBER;
+        return _lru_cache_type == LRUCacheType::SIZE ? mem_consumption() > CACHE_MIN_SIZE
+                                                     : get_usage() > CACHE_MIN_NUMBER;
     }
 
     // Try to prune the cache if expired.
     void prune_stale() override {
+        std::lock_guard<std::mutex> l(_lock);
         COUNTER_SET(_freed_entrys_counter, (int64_t)0);
         COUNTER_SET(_freed_memory_counter, (int64_t)0);
         if (_stale_sweep_time_s <= 0 && _cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
@@ -125,7 +128,6 @@ public:
         }
         if (exceed_prune_limit()) {
             COUNTER_SET(_cost_timer, (int64_t)0);
-            SCOPED_TIMER(_cost_timer);
             const int64_t curtime = UnixMillis();
             auto pred = [this, curtime](const LRUHandle* handle) -> bool {
                 return static_cast<bool>((handle->last_visit_time + _stale_sweep_time_s * 1000) <
@@ -134,33 +136,38 @@ public:
 
             LOG(INFO) << fmt::format("[MemoryGC] {} prune stale start, consumption {}, usage {}",
                                      type_string(_type), mem_consumption(), get_usage());
-            // Prune cache in lazy mode to save cpu and minimize the time holding write lock
-            PrunedInfo pruned_info = _cache->prune_if(pred, true);
-            COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
-            COUNTER_SET(_freed_memory_counter, pruned_info.pruned_size);
+            {
+                SCOPED_TIMER(_cost_timer);
+                // Prune cache in lazy mode to save cpu and minimize the time holding write lock
+                PrunedInfo pruned_info = _cache->prune_if(pred, true);
+                COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
+                COUNTER_SET(_freed_memory_counter, pruned_info.pruned_size);
+            }
             COUNTER_UPDATE(_prune_stale_number_counter, 1);
             LOG(INFO) << fmt::format(
-                    "[MemoryGC] {} prune stale {} entries, {} bytes, {} times prune",
+                    "[MemoryGC] {} prune stale {} entries, {} bytes, cost {}, {} times prune",
                     type_string(_type), _freed_entrys_counter->value(),
-                    _freed_memory_counter->value(), _prune_stale_number_counter->value());
+                    _freed_memory_counter->value(), _cost_timer->value(),
+                    _prune_stale_number_counter->value());
         } else {
             if (_lru_cache_type == LRUCacheType::SIZE) {
                 LOG(INFO) << fmt::format(
                         "[MemoryGC] {} not need prune stale, LRUCacheType::SIZE consumption {} "
                         "less "
-                        "than CACHE_MIN_FREE_SIZE {}",
-                        type_string(_type), mem_consumption(), CACHE_MIN_FREE_SIZE);
+                        "than CACHE_MIN_SIZE {}",
+                        type_string(_type), mem_consumption(), CACHE_MIN_SIZE);
             } else if (_lru_cache_type == LRUCacheType::NUMBER) {
                 LOG(INFO) << fmt::format(
                         "[MemoryGC] {} not need prune stale, LRUCacheType::NUMBER usage {} less "
                         "than "
-                        "CACHE_MIN_FREE_NUMBER {}",
-                        type_string(_type), get_usage(), CACHE_MIN_FREE_NUMBER);
+                        "CACHE_MIN_NUMBER {}",
+                        type_string(_type), get_usage(), CACHE_MIN_NUMBER);
             }
         }
     }
 
     void prune_all(bool force) override {
+        std::lock_guard<std::mutex> l(_lock);
         COUNTER_SET(_freed_entrys_counter, (int64_t)0);
         COUNTER_SET(_freed_memory_counter, (int64_t)0);
         if (_cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
@@ -168,37 +175,72 @@ public:
         }
         if ((force && mem_consumption() != 0) || exceed_prune_limit()) {
             COUNTER_SET(_cost_timer, (int64_t)0);
-            SCOPED_TIMER(_cost_timer);
             LOG(INFO) << fmt::format("[MemoryGC] {} prune all start, consumption {}, usage {}",
                                      type_string(_type), mem_consumption(), get_usage());
-            PrunedInfo pruned_info = _cache->prune();
-            COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
-            COUNTER_SET(_freed_memory_counter, pruned_info.pruned_size);
+            {
+                SCOPED_TIMER(_cost_timer);
+                PrunedInfo pruned_info = _cache->prune();
+                COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
+                COUNTER_SET(_freed_memory_counter, pruned_info.pruned_size);
+            }
             COUNTER_UPDATE(_prune_all_number_counter, 1);
             LOG(INFO) << fmt::format(
-                    "[MemoryGC] {} prune all {} entries, {} bytes, {} times prune, is force: {}",
+                    "[MemoryGC] {} prune all {} entries, {} bytes, cost {}, {} times prune, is "
+                    "force: {}",
                     type_string(_type), _freed_entrys_counter->value(),
-                    _freed_memory_counter->value(), _prune_all_number_counter->value(), force);
+                    _freed_memory_counter->value(), _cost_timer->value(),
+                    _prune_all_number_counter->value(), force);
         } else {
             if (_lru_cache_type == LRUCacheType::SIZE) {
                 LOG(INFO) << fmt::format(
                         "[MemoryGC] {} not need prune all, force is {}, LRUCacheType::SIZE "
                         "consumption {}, "
-                        "CACHE_MIN_FREE_SIZE {}",
-                        type_string(_type), force, mem_consumption(), CACHE_MIN_FREE_SIZE);
+                        "CACHE_MIN_SIZE {}",
+                        type_string(_type), force, mem_consumption(), CACHE_MIN_SIZE);
             } else if (_lru_cache_type == LRUCacheType::NUMBER) {
                 LOG(INFO) << fmt::format(
                         "[MemoryGC] {} not need prune all, force is {}, LRUCacheType::NUMBER "
-                        "usage {}, CACHE_MIN_FREE_NUMBER {}",
-                        type_string(_type), force, get_usage(), CACHE_MIN_FREE_NUMBER);
+                        "usage {}, CACHE_MIN_NUMBER {}",
+                        type_string(_type), force, get_usage(), CACHE_MIN_NUMBER);
             }
         }
+    }
+
+    void set_capacity(double adjust_weighted) override {
+        std::lock_guard<std::mutex> l(_lock);
+        auto capacity = std::min<size_t>(
+                static_cast<size_t>(_initial_capacity * adjust_weighted),
+                _lru_cache_type == LRUCacheType::SIZE ? CACHE_MIN_SIZE : CACHE_MIN_NUMBER);
+        COUNTER_SET(_freed_entrys_counter, (int64_t)0);
+        COUNTER_SET(_freed_memory_counter, (int64_t)0);
+        COUNTER_SET(_cost_timer, (int64_t)0);
+        if (_cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
+            return;
+        }
+
+        LOG(INFO) << fmt::format(
+                "[MemoryGC] {} update capacity, current capacity {}, adjust_weighted {}, new "
+                "capacity {}, consumption {}, usage {}",
+                type_string(_type), get_capacity(), adjust_weighted, capacity, mem_consumption(),
+                get_usage());
+        {
+            SCOPED_TIMER(_cost_timer);
+            PrunedInfo pruned_info = _cache->set_capacity(capacity);
+            COUNTER_SET(_freed_entrys_counter, pruned_info.pruned_count);
+            COUNTER_SET(_freed_memory_counter, pruned_info.pruned_size);
+        }
+        COUNTER_UPDATE(_set_capacity_number_counter, 1);
+        LOG(INFO) << fmt::format(
+                "[MemoryGC] {} update capacity prune {} entries, {} bytes, cost {}, {} times prune",
+                type_string(_type), _freed_entrys_counter->value(), _freed_memory_counter->value(),
+                _cost_timer->value(), _set_capacity_number_counter->value());
     }
 
 protected:
     // if check_capacity failed, will return dummy lru cache,
     // compatible with ShardedLRUCache usage, but will not actually cache.
     std::shared_ptr<Cache> _cache;
+    std::mutex _lock;
     LRUCacheType _lru_cache_type;
 };
 

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -218,11 +218,9 @@ public:
             return;
         }
 
-        LOG(INFO) << fmt::format(
-                "[MemoryGC] {} update capacity, current capacity {}, adjust_weighted {}, new "
-                "capacity {}, consumption {}, usage {}",
-                type_string(_type), get_capacity(), adjust_weighted, capacity, mem_consumption(),
-                get_usage());
+        size_t old_capacity = get_capacity();
+        int64_t old_mem_consumption = mem_consumption();
+        int64_t old_usage = get_usage();
         {
             SCOPED_TIMER(_cost_timer);
             PrunedInfo pruned_info = _cache->set_capacity(capacity);
@@ -231,9 +229,13 @@ public:
         }
         COUNTER_UPDATE(_set_capacity_number_counter, 1);
         LOG(INFO) << fmt::format(
-                "[MemoryGC] {} update capacity prune {} entries, {} bytes, cost {}, {} times prune",
-                type_string(_type), _freed_entrys_counter->value(), _freed_memory_counter->value(),
-                _cost_timer->value(), _set_capacity_number_counter->value());
+                "[MemoryGC] {} update capacity, old <capacity {}, consumption {}, usage {}>, "
+                "adjust_weighted {}, new <capacity {}, consumption {}, usage {}>, prune {} "
+                "entries, {} bytes, cost {}, {} times prune",
+                type_string(_type), old_capacity, old_mem_consumption, old_usage, adjust_weighted,
+                get_capacity(), mem_consumption(), get_usage(), _freed_entrys_counter->value(),
+                _freed_memory_counter->value(), _cost_timer->value(),
+                _set_capacity_number_counter->value());
     }
 
 protected:

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -727,10 +727,10 @@ int64_t MemTrackerLimiter::free_top_overcommit_query(
         LOG(INFO) << log_prefix << "finished, no task need be canceled.";
         return 0;
     }
-    if (query_consumption.size() == 1) {
+    if (small_num == 0 && canceling_task.empty() && query_consumption.size() == 1) {
         auto iter = query_consumption.begin();
-        LOG(INFO) << log_prefix << "finished, only one task: " << iter->first
-                  << ", memory consumption: " << iter->second << ", no cancel.";
+        LOG(INFO) << log_prefix << "finished, only one overcommit task: " << iter->first
+                  << ", memory consumption: " << iter->second << ", no other tasks, so no cancel.";
         return 0;
     }
 

--- a/be/src/runtime/memory/memory_reclamation.cpp
+++ b/be/src/runtime/memory/memory_reclamation.cpp
@@ -37,7 +37,6 @@ bool MemoryReclamation::process_minor_gc(std::string mem_info) {
     std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("");
 
     Defer defer {[&]() {
-        MemInfo::notify_je_purge_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -45,11 +44,6 @@ bool MemoryReclamation::process_minor_gc(std::string mem_info) {
                 PrettyPrinter::print(freed_mem, TUnit::BYTES), watch.elapsed_time() / 1000,
                 ss.str());
     }};
-
-    freed_mem += CacheManager::instance()->for_each_cache_prune_stale(profile.get());
-    if (freed_mem > MemInfo::process_minor_gc_size()) {
-        return true;
-    }
 
     if (config::enable_workload_group_memory_gc) {
         RuntimeProfile* tg_profile = profile->create_child("WorkloadGroup", true, true);
@@ -87,7 +81,6 @@ bool MemoryReclamation::process_full_gc(std::string mem_info) {
     std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("");
 
     Defer defer {[&]() {
-        MemInfo::notify_je_purge_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -95,11 +88,6 @@ bool MemoryReclamation::process_full_gc(std::string mem_info) {
                 PrettyPrinter::print(freed_mem, TUnit::BYTES), watch.elapsed_time() / 1000,
                 ss.str());
     }};
-
-    freed_mem += CacheManager::instance()->for_each_cache_prune_all(profile.get());
-    if (freed_mem > MemInfo::process_full_gc_size()) {
-        return true;
-    }
 
     if (config::enable_workload_group_memory_gc) {
         RuntimeProfile* tg_profile = profile->create_child("WorkloadGroup", true, true);

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -241,8 +241,8 @@ private:
         auto* value = new CacheValue;
         value->item = item;
         LOG(INFO) << "Add item mem"
-                  << ", cache_capacity: " << get_total_capacity()
-                  << ", cache_usage: " << get_usage() << ", mem_consum: " << mem_consumption();
+                  << ", cache_capacity: " << get_capacity() << ", cache_usage: " << get_usage()
+                  << ", mem_consum: " << mem_consumption();
         auto* lru_handle = insert(key, value, 1, sizeof(Reusable), CachePriority::NORMAL);
         release(lru_handle);
     }

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -106,9 +106,6 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
             return;
         }
 
-        // no significant impact on performance is expected.
-        doris::MemInfo::notify_je_purge_dirty_pages();
-
         if (doris::thread_context()->thread_mem_tracker_mgr->is_attach_query() &&
             doris::thread_context()->thread_mem_tracker_mgr->wait_gc()) {
             int64_t wait_milliseconds = 0;


### PR DESCRIPTION
step 1. Refresh process memory metrics.
step 2. Refresh allocator memory metrics.
step 3. Update and print memory stat when the memory changes by 256M.
step 4. Asyn Refresh cache capacity
step 5. Cancel top memory task when process memory exceed hard limit.
step 6. Refresh weighted memory ratio of workload groups.
step 7. Analyze blocking queries.
step 8. Flush memtable.
step 9. Jemalloc purge all arena dirty pages.

`memory_maintenance_thread` execute once cost:
- 3ms (cluster idle)
- 20ms (cluster high concurrency, CPU full)

`memory_maintenance_thread` CPU usage:
- 10%-20% (default memory_maintenance_sleep_time_ms=20ms)
- 20%-30% (memory_maintenance_sleep_time_ms=10ms)
- 30%+ (memory_maintenance_sleep_time_ms=5ms)