### PR TITLE
[Enhancement](be-logger) Support custom date time format functionality in be log.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -236,6 +236,12 @@ DEFINE_Int32(sys_log_verbose_level, "10");
 DEFINE_Int32(sys_log_verbose_flags_v, "-1");
 // log buffer level
 DEFINE_String(log_buffer_level, "");
+// log enable custom date time format
+DEFINE_Bool(sys_log_enable_custom_date_time_format, "false");
+// log custom date time format (https://en.cppreference.com/w/cpp/io/manip/put_time)
+DEFINE_String(sys_log_custom_date_time_format, "%Y-%m-%d %H:%M:%S");
+// log custom date time milliseconds format (fmt::format)
+DEFINE_String(sys_log_custom_date_time_ms_format, ",{:03d}");
 
 // number of threads available to serve backend execution requests
 DEFINE_Int32(be_service_threads, "64");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -288,6 +288,12 @@ DECLARE_Int32(sys_log_verbose_level);
 DECLARE_Int32(sys_log_verbose_flags_v);
 // log buffer level
 DECLARE_String(log_buffer_level);
+// log enable custom date time format
+DECLARE_Bool(sys_log_enable_custom_date_time_format);
+// log custom date time format (https://en.cppreference.com/w/cpp/io/manip/put_time)
+DECLARE_String(sys_log_custom_date_time_format);
+// log custom date time milliseconds format (fmt::format)
+DECLARE_String(sys_log_custom_date_time_ms_format);
 
 // number of threads available to serve backend execution requests
 DECLARE_Int32(be_service_threads);

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -49,21 +49,40 @@ static bool iequals(const std::string& a, const std::string& b) {
     return true;
 }
 
-void custom_prefix(std::ostream& s, const google::LogMessageInfo& l, void*) {
-    // Add prefix "RuntimeLogger ".
-    s << "RuntimeLogger ";
-    // Same as in fe.log
-    // The following is same as default log format. eg:
-    // I20240605 15:25:15.677153 1763151 wal_manager.cpp:481] msg...
+// if custom_date_time_format = false, same format as in be.log
+// The following is same as default log format. eg:
+// I20240605 15:25:15.677153 1763151 wal_manager.cpp:481] msg...
+template <bool add_runtime_logger_prefix = false, bool custom_date_time_format = false>
+void custom_prefix(std::ostream& s, const google::LogMessageInfo& l, void* arg) {
+    if constexpr (add_runtime_logger_prefix) {
+        // Add prefix "RuntimeLogger ".
+        s << "RuntimeLogger ";
+    }
     s << l.severity[0];
-    s << std::setw(4) << 1900 + l.time.year();
-    s << std::setw(2) << 1 + l.time.month();
-    s << std::setw(2) << l.time.day();
-    s << ' ';
-    s << std::setw(2) << l.time.hour() << ':';
-    s << std::setw(2) << l.time.min() << ':';
-    s << std::setw(2) << l.time.sec() << ".";
-    s << std::setw(6) << l.time.usec();
+
+    // Add a space if custom_date_time_format.
+    if constexpr (custom_date_time_format) {
+        s << ' ';
+    }
+
+    std::tm tm_time = {};
+    tm_time.tm_year = l.time.year();
+    tm_time.tm_mon = l.time.month();
+    tm_time.tm_mday = l.time.day();
+    tm_time.tm_hour = l.time.hour();
+    tm_time.tm_min = l.time.min();
+    tm_time.tm_sec = l.time.sec();
+
+    if constexpr (custom_date_time_format) {
+        s << std::put_time(&tm_time, config::sys_log_custom_date_time_format.c_str());
+        if (!config::sys_log_custom_date_time_ms_format.empty()) {
+            s << fmt::format(config::sys_log_custom_date_time_ms_format, l.time.usec() / 1000);
+        }
+    } else {
+        s << std::put_time(&tm_time, "%Y%m%d %H:%M:%S");
+        s << "." << std::setw(6) << l.time.usec();
+    }
+
     s << ' ';
     s << std::setfill(' ') << std::setw(5);
     s << l.thread_id << std::setfill('0');
@@ -173,10 +192,18 @@ bool init_glog(const char* basename) {
     }
 
     if (log_to_console) {
-        // Only add prefix if log output to stderr
-        google::InitGoogleLogging(basename, &custom_prefix);
+        // Add prefix if log output to stderr
+        if (config::sys_log_enable_custom_date_time_format) {
+            google::InitGoogleLogging(basename, &custom_prefix<true, true>);
+        } else {
+            google::InitGoogleLogging(basename, &custom_prefix<true, false>);
+        }
     } else {
-        google::InitGoogleLogging(basename);
+        if (config::sys_log_enable_custom_date_time_format) {
+            google::InitGoogleLogging(basename, &custom_prefix<false, true>);
+        } else {
+            google::InitGoogleLogging(basename);
+        }
     }
 
     logging_initialized = true;


### PR DESCRIPTION
## Proposed changes

Add these configurations to control it.

```
// log enable custom date time format
DEFINE_Bool(sys_log_enable_custom_date_time_format, "false");
// log custom date time format (https://en.cppreference.com/w/cpp/io/manip/put_time)
DEFINE_String(sys_log_custom_date_time_format, "%Y-%m-%d %H:%M:%S");
// log custom date time milliseconds format (fmt::format)
DEFINE_String(sys_log_custom_date_time_ms_format, ",{:03d}");
```

