### PR TITLE
[fix](array/map) Fix semi-structure data column

### DIFF
--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -232,6 +232,10 @@ public:
                        ->get_number_of_dimensions(); /// Every modern C++ compiler optimizes tail recursion.
     }
 
+    bool is_exclusive() const override {
+        return IColumn::is_exclusive() && data->is_exclusive() && offsets->is_exclusive();
+    }
+
 private:
     // [2,1,5,9,1]\n[1,2,4] --> data column [2,1,5,9,1,1,2,4], offset[-1] = 0, offset[0] = 5, offset[1] = 8
     // [[2,1,5],[9,1]]\n[[1,2]] --> data column [3 column array], offset[-1] = 0, offset[0] = 2, offset[1] = 3

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -206,6 +206,11 @@ public:
         return IColumn::convert_column_if_overflow();
     }
 
+    bool is_exclusive() const override {
+        return IColumn::is_exclusive() && keys_column->is_exclusive() &&
+               values_column->is_exclusive() && offsets_column->is_exclusive();
+    }
+
 private:
     friend class COWHelper<IColumn, ColumnMap>;
 


### PR DESCRIPTION
## Proposed changes

Function `convert_to_full_column_if_const` will return a shared pointer with the origin column and add 1 to `use count` of this column if it is not a Array/Map column.

For Array/Map columns, `convert_to_full_column_if_const` will return a new pointer which shares the internal nested columns with the origin columns.

During execution, a column which is exclusive means it is not shared by another pointer so we can use this column as we want otherwise we should copy the data into another exclusive column.

Because `convert_to_full_column_if_const` will return a new pointer for Array/Map columns, we can not just `use count == 1` to decide if the column is exclusive.

<!--Describe your changes.-->

