### PR TITLE
[feature](cloud) export fdb client busyness

### DIFF
--- a/cloud/src/common/bvars.cpp
+++ b/cloud/src/common/bvars.cpp
@@ -177,6 +177,7 @@ bvar::Status<int64_t> g_bvar_fdb_workload_transactions_committed_hz(
         "fdb_workload_transactions_committed_hz", BVAR_FDB_INVALID_VALUE);
 bvar::Status<int64_t> g_bvar_fdb_workload_transactions_rejected_hz(
         "fdb_workload_transactions_rejected_hz", BVAR_FDB_INVALID_VALUE);
+bvar::Status<double> g_bvar_fdb_client_thread_busyness("fdb_client_thread_busyness", 0.0);
 
 // checker's bvars
 BvarStatusWithTag<long> g_bvar_checker_num_scanned("checker", "num_scanned");

--- a/cloud/src/common/bvars.cpp
+++ b/cloud/src/common/bvars.cpp
@@ -177,7 +177,8 @@ bvar::Status<int64_t> g_bvar_fdb_workload_transactions_committed_hz(
         "fdb_workload_transactions_committed_hz", BVAR_FDB_INVALID_VALUE);
 bvar::Status<int64_t> g_bvar_fdb_workload_transactions_rejected_hz(
         "fdb_workload_transactions_rejected_hz", BVAR_FDB_INVALID_VALUE);
-bvar::Status<double> g_bvar_fdb_client_thread_busyness("fdb_client_thread_busyness", 0.0);
+bvar::Status<int64_t> g_bvar_fdb_client_thread_busyness_percent(
+        "fdb_client_thread_busyness_percent", BVAR_FDB_INVALID_VALUE);
 
 // checker's bvars
 BvarStatusWithTag<long> g_bvar_checker_num_scanned("checker", "num_scanned");

--- a/cloud/src/common/bvars.h
+++ b/cloud/src/common/bvars.h
@@ -234,6 +234,7 @@ extern bvar::Status<int64_t> g_bvar_fdb_workload_written_bytes_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_started_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_committed_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_rejected_hz;
+extern bvar::Status<double> g_bvar_fdb_client_thread_busyness;
 
 // checker
 extern BvarStatusWithTag<long> g_bvar_checker_num_scanned;

--- a/cloud/src/common/bvars.h
+++ b/cloud/src/common/bvars.h
@@ -234,7 +234,7 @@ extern bvar::Status<int64_t> g_bvar_fdb_workload_written_bytes_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_started_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_committed_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_rejected_hz;
-extern bvar::Status<double> g_bvar_fdb_client_thread_busyness;
+extern bvar::Status<int64_t> g_bvar_fdb_client_thread_busyness_percent;
 
 // checker
 extern BvarStatusWithTag<long> g_bvar_checker_num_scanned;

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -229,15 +229,14 @@ static void export_fdb_status_details(const std::string& status_str) {
 }
 
 void FdbMetricExporter::export_fdb_metrics(TxnKv* txn_kv) {
-    double busyness = 0.0;
+    int busyness = 0.0;
     std::string fdb_status = get_fdb_status(txn_kv);
     export_fdb_status_details(fdb_status);
     if (auto* kv = dynamic_cast<FdbTxnKv*>(txn_kv); kv != nullptr) {
-        busyness = kv->get_client_thread_busyness();
-        g_bvar_fdb_client_thread_busyness.set_value(busyness);
+        busyness = static_cast<int64_t>(kv->get_client_thread_busyness() * 100);
+        g_bvar_fdb_client_thread_busyness_percent.set_value(busyness);
     }
-    LOG(INFO) << "finish to collect fdb metric, client busyness: "
-              << static_cast<int>(busyness * 100) << "%";
+    LOG(INFO) << "finish to collect fdb metric, client busyness: " << busyness << "%";
 }
 
 FdbMetricExporter::~FdbMetricExporter() {

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "common/bvars.h"
+#include "meta-service/txn_kv.h"
 #include "meta-service/txn_kv_error.h"
 
 namespace doris::cloud {
@@ -228,8 +229,15 @@ static void export_fdb_status_details(const std::string& status_str) {
 }
 
 void FdbMetricExporter::export_fdb_metrics(TxnKv* txn_kv) {
+    double busyness = 0.0;
     std::string fdb_status = get_fdb_status(txn_kv);
     export_fdb_status_details(fdb_status);
+    if (auto* kv = dynamic_cast<FdbTxnKv*>(txn_kv); kv != nullptr) {
+        busyness = kv->get_client_thread_busyness();
+        g_bvar_fdb_client_thread_busyness.set_value(busyness);
+    }
+    LOG(INFO) << "finish to collect fdb metric, client busyness: "
+              << static_cast<int>(busyness * 100) << "%";
 }
 
 FdbMetricExporter::~FdbMetricExporter() {
@@ -250,7 +258,6 @@ int FdbMetricExporter::start() {
             std::unique_lock l(running_mtx_);
             running_cond_.wait_for(l, std::chrono::milliseconds(sleep_interval_ms_),
                                    [this]() { return !running_.load(std::memory_order_acquire); });
-            LOG(INFO) << "finish to collect fdb metric";
         }
     });
     return 0;

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -229,7 +229,7 @@ static void export_fdb_status_details(const std::string& status_str) {
 }
 
 void FdbMetricExporter::export_fdb_metrics(TxnKv* txn_kv) {
-    int busyness = 0.0;
+    int busyness = 0;
     std::string fdb_status = get_fdb_status(txn_kv);
     export_fdb_status_details(fdb_status);
     if (auto* kv = dynamic_cast<FdbTxnKv*>(txn_kv); kv != nullptr) {

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -229,7 +229,7 @@ static void export_fdb_status_details(const std::string& status_str) {
 }
 
 void FdbMetricExporter::export_fdb_metrics(TxnKv* txn_kv) {
-    int busyness = 0;
+    int64_t busyness = 0;
     std::string fdb_status = get_fdb_status(txn_kv);
     export_fdb_status_details(fdb_status);
     if (auto* kv = dynamic_cast<FdbTxnKv*>(txn_kv); kv != nullptr) {

--- a/cloud/src/meta-service/txn_kv.cpp
+++ b/cloud/src/meta-service/txn_kv.cpp
@@ -140,6 +140,10 @@ TxnErrorCode FdbTxnKv::get_partition_boundaries(std::vector<std::string>* bounda
     return TxnErrorCode::TXN_OK;
 }
 
+double FdbTxnKv::get_client_thread_busyness() const {
+    return fdb_database_get_main_thread_busyness(database_->db());
+}
+
 } // namespace doris::cloud
 
 namespace doris::cloud::fdb {

--- a/cloud/src/meta-service/txn_kv.h
+++ b/cloud/src/meta-service/txn_kv.h
@@ -333,6 +333,10 @@ public:
     // Return the partition boundaries of the database.
     TxnErrorCode get_partition_boundaries(std::vector<std::string>* boundaries);
 
+    // Returns a value where 0 indicates that the client is idle and 1 (or larger) indicates that
+    // the client is saturated. This value is updated every second.
+    double get_client_thread_busyness() const;
+
     static std::string_view fdb_partition_key_prefix() { return "\xff/keyServers/"; }
     static std::string_view fdb_partition_key_end() {
         // '0' is the next byte after '/' in the ASCII table


### PR DESCRIPTION
a new bvar `fdb_client_thread_busyness_percent` (integer between 0 and 100) will be present when 
```
curl ms_ip:ms_port/vars
```