### PR TITLE
[fix](memory) Fix ThreadMemTrackerMgr consumer tracker remove reserve memory 

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -173,7 +173,6 @@ public:
     std::vector<TrackerLimiterGroup> mem_tracker_limiter_pool;
     void init_mem_tracker();
     std::shared_ptr<MemTrackerLimiter> orphan_mem_tracker() { return _orphan_mem_tracker; }
-    MemTrackerLimiter* orphan_mem_tracker_raw() { return _orphan_mem_tracker_raw; }
     MemTrackerLimiter* details_mem_tracker_set() { return _details_mem_tracker_set.get(); }
     std::shared_ptr<MemTracker> page_no_cache_mem_tracker() { return _page_no_cache_mem_tracker; }
     MemTracker* brpc_iobuf_block_memory_tracker() { return _brpc_iobuf_block_memory_tracker.get(); }
@@ -355,7 +354,6 @@ private:
     // Ideally, all threads are expected to attach to the specified tracker, so that "all memory has its own ownership",
     // and the consumption of the orphan mem tracker is close to 0, but greater than 0.
     std::shared_ptr<MemTrackerLimiter> _orphan_mem_tracker;
-    MemTrackerLimiter* _orphan_mem_tracker_raw = nullptr;
     std::shared_ptr<MemTrackerLimiter> _details_mem_tracker_set;
     // page size not in cache, data page/index page/etc.
     std::shared_ptr<MemTracker> _page_no_cache_mem_tracker;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -587,7 +587,6 @@ void ExecEnv::init_mem_tracker() {
     _s_tracking_memory = true;
     _orphan_mem_tracker =
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "Orphan");
-    _orphan_mem_tracker_raw = _orphan_mem_tracker.get();
     _details_mem_tracker_set =
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "DetailsTrackerSet");
     _page_no_cache_mem_tracker =

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -525,7 +525,7 @@ std::string MemTrackerLimiter::tracker_limit_exceeded_str() {
         err_msg += fmt::format(
                 " exec node:<{}>, can `set exec_mem_limit=8G` to change limit, details see "
                 "be.INFO.",
-                doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker());
+                doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label());
     } else if (_type == Type::SCHEMA_CHANGE) {
         err_msg += fmt::format(
                 " can modify `memory_limitation_per_thread_for_schema_change_bytes` in be.conf to "

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -55,7 +55,6 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(
         _untracked_mem = 0;
     }
     _limiter_tracker = mem_tracker;
-    _limiter_tracker_raw = mem_tracker.get();
 }
 
 void ThreadMemTrackerMgr::detach_limiter_tracker(
@@ -67,7 +66,6 @@ void ThreadMemTrackerMgr::detach_limiter_tracker(
     _reserved_mem = _reserved_mem_stack.back();
     _reserved_mem_stack.pop_back();
     _limiter_tracker = old_mem_tracker;
-    _limiter_tracker_raw = old_mem_tracker.get();
 }
 
 void ThreadMemTrackerMgr::cancel_query(const std::string& exceed_msg) {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -82,10 +82,16 @@
 #endif
 
 #if defined(USE_MEM_TRACKER) && !defined(BE_TEST)
-// Count a code segment memory (memory malloc - memory free) to int64_t
-// Usage example: int64_t scope_mem = 0; { SCOPED_MEM_COUNT_BY_HOOK(&scope_mem); xxx; xxx; }
-#define SCOPED_MEM_COUNT_BY_HOOK(scope_mem) \
-    auto VARNAME_LINENUM(scope_mem_count) = doris::ScopeMemCountByHook(scope_mem)
+// Count a code segment memory
+// Usage example:
+//      int64_t peak_mem = 0;
+//      {
+//          SCOPED_PEAK_MEM(&peak_mem);
+//          xxxx
+//      }
+//      LOG(INFO) << *peak_mem;
+#define SCOPED_PEAK_MEM(peak_mem) \
+    auto VARNAME_LINENUM(scope_peak_mem) = doris::ScopedPeakMem(peak_mem)
 
 // Count a code segment memory (memory malloc - memory free) to MemTracker.
 // Compared to count `scope_mem`, MemTracker is easier to observe from the outside and is thread-safe.
@@ -94,8 +100,8 @@
 #define SCOPED_CONSUME_MEM_TRACKER_BY_HOOK(mem_tracker) \
     auto VARNAME_LINENUM(add_mem_consumer) = doris::AddThreadMemTrackerConsumerByHook(mem_tracker)
 #else
-#define SCOPED_MEM_COUNT_BY_HOOK(scope_mem) \
-    auto VARNAME_LINENUM(scoped_tls_mcbh) = doris::ScopedInitThreadContext()
+#define SCOPED_PEAK_MEM() \
+    auto VARNAME_LINENUM(scoped_tls_pm) = doris::ScopedInitThreadContext()
 #define SCOPED_CONSUME_MEM_TRACKER_BY_HOOK(mem_tracker) \
     auto VARNAME_LINENUM(scoped_tls_cmtbh) = doris::ScopedInitThreadContext()
 #endif
@@ -402,23 +408,22 @@ public:
     std::weak_ptr<WorkloadGroup> wg_wptr;
 };
 
-class ScopeMemCountByHook {
+class ScopedPeakMem {
 public:
-    explicit ScopeMemCountByHook(int64_t* scope_mem) {
+    explicit ScopedPeakMem(int64* peak_mem) : _peak_mem(peak_mem), _mem_tracker("ScopedPeakMem") {
         ThreadLocalHandle::create_thread_local_if_not_exits();
-        _scope_mem = scope_mem;
-        thread_context()->thread_mem_tracker_mgr->start_count_scope_mem();
-        use_mem_hook = true;
+        thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(&_mem_tracker);
     }
 
-    ~ScopeMemCountByHook() {
-        use_mem_hook = false;
-        *_scope_mem += thread_context()->thread_mem_tracker_mgr->stop_count_scope_mem();
+    ~ScopedPeakMem() {
+        thread_context()->thread_mem_tracker_mgr->pop_consumer_tracker();
+        *_peak_mem += _mem_tracker.peak_consumption();
         ThreadLocalHandle::del_thread_local_if_count_is_zero();
     }
 
 private:
-    int64_t* _scope_mem = nullptr;
+    int64* _peak_mem;
+    MemTracker _mem_tracker;
 };
 
 // only hold thread context in scope.

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -90,7 +90,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
                 size, doris::thread_context()->thread_mem_tracker()->label(),
                 doris::thread_context()->thread_mem_tracker()->peak_consumption(),
                 doris::thread_context()->thread_mem_tracker()->consumption(),
-                doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker(),
+                doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(),
                 doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
 
         if (doris::config::stacktrace_in_alloc_large_memory_bytes > 0 &&

--- a/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
+++ b/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
@@ -181,8 +181,8 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
 
     bool rt = thread_context->thread_mem_tracker_mgr->push_consumer_tracker(t2.get());
     EXPECT_EQ(rt, true);
-    EXPECT_EQ(t1->consumption(), size1 + size2);
-    EXPECT_EQ(t2->consumption(), -size1); // _untracked_mem = size1
+    EXPECT_EQ(t1->consumption(), size1 + size2); // _untracked_mem = size1
+    EXPECT_EQ(t2->consumption(), 0);
 
     thread_context->consume_memory(size2);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2);
@@ -200,13 +200,13 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
     thread_context->consume_memory(size2);
     thread_context->consume_memory(-size1); // _untracked_mem = -size1
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2 + size1 + size2);
-    EXPECT_EQ(t2->consumption(), size2 + size2 + size1 + size2);
-    EXPECT_EQ(t3->consumption(), size1 + size2);
+    EXPECT_EQ(t2->consumption(), size2 + size2 + size2);
+    EXPECT_EQ(t3->consumption(), size2);
 
     thread_context->thread_mem_tracker_mgr->pop_consumer_tracker();
-    EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2 + size1 + size2 - size1);
-    EXPECT_EQ(t2->consumption(), size2 + size2 + size1 + size2 - size1);
-    EXPECT_EQ(t3->consumption(), size1 + size2 - size1);
+    EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2 + size1 + size2);
+    EXPECT_EQ(t2->consumption(), size2 + size2 + size2);
+    EXPECT_EQ(t3->consumption(), size2);
 
     thread_context->consume_memory(-size2);
     thread_context->consume_memory(size2);
@@ -214,14 +214,14 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
     thread_context->thread_mem_tracker_mgr->pop_consumer_tracker();
     EXPECT_EQ(t1->consumption(),
               size1 + size2 + size1 + size2 + size2 + size1 + size2 - size1 - size2);
-    EXPECT_EQ(t2->consumption(), size2 + size2 + size1 + size2 - size1 - size2);
-    EXPECT_EQ(t3->consumption(), size1 + size2 - size1);
+    EXPECT_EQ(t2->consumption(), size2 + size2);
+    EXPECT_EQ(t3->consumption(), size2);
 
     thread_context->consume_memory(-t1->consumption());
     thread_context->detach_task(); // detach t1
     EXPECT_EQ(t1->consumption(), 0);
-    EXPECT_EQ(t2->consumption(), size2 + size2 + size1 + size2 - size1 - size2);
-    EXPECT_EQ(t3->consumption(), size1 + size2 - size1);
+    EXPECT_EQ(t2->consumption(), size2 + size2);
+    EXPECT_EQ(t3->consumption(), size2);
 }
 
 TEST_F(ThreadMemTrackerMgrTest, ReserveMemory) {

--- a/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
+++ b/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
@@ -265,7 +265,7 @@ TEST_F(ThreadMemTrackerMgrTest, ReserveMemory) {
     EXPECT_EQ(t->consumption(), size1 + size2);
 
     auto st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);
 
@@ -304,7 +304,7 @@ TEST_F(ThreadMemTrackerMgrTest, ReserveMemory) {
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), 0);
 
     st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);
 
@@ -355,7 +355,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedReserveMemory) {
 
     thread_context->attach_task(TUniqueId(), t, workload_group);
     auto st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);
 
@@ -367,7 +367,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedReserveMemory) {
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
     st = thread_context->try_reserve_memory(size2);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     // ThreadMemTrackerMgr _reserved_mem = size3 - size2 + size2
     // ThreadMemTrackerMgr _untracked_mem = 0
     EXPECT_EQ(t->consumption(), size3 + size2);
@@ -375,9 +375,9 @@ TEST_F(ThreadMemTrackerMgrTest, NestedReserveMemory) {
               size3); // size3 - size2 + size2
 
     st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     thread_context->consume_memory(size3);
     thread_context->consume_memory(size2);
     thread_context->consume_memory(size3);
@@ -412,14 +412,14 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTrackerReserveMemory) {
 
     thread_context->attach_task(TUniqueId(), t1, workload_group);
     auto st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     thread_context->consume_memory(size2);
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t2);
     st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(t2->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2 + size3);
@@ -431,7 +431,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTrackerReserveMemory) {
 
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t3);
     st = thread_context->try_reserve_memory(size3);
-    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(t2->consumption(), size3 + size2);
     EXPECT_EQ(t3->consumption(), size3);

--- a/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
+++ b/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
@@ -224,32 +224,6 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
     EXPECT_EQ(t3->consumption(), size1 + size2 - size1);
 }
 
-TEST_F(ThreadMemTrackerMgrTest, ScopedCount) {
-    std::unique_ptr<ThreadContext> thread_context = std::make_unique<ThreadContext>();
-    std::shared_ptr<MemTrackerLimiter> t1 =
-            MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER, "UT-ScopedCount");
-
-    int64_t size1 = 4 * 1024;
-    int64_t size2 = 4 * 1024 * 1024;
-
-    thread_context->attach_task(TUniqueId(), t1, workload_group);
-    thread_context->thread_mem_tracker_mgr->start_count_scope_mem();
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size1);
-    int64_t scope_mem = thread_context->thread_mem_tracker_mgr->stop_count_scope_mem();
-    EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size1);
-    EXPECT_EQ(t1->consumption(), scope_mem);
-
-    thread_context->consume_memory(-size2);
-    thread_context->consume_memory(-size1);
-    thread_context->consume_memory(-size2);
-    EXPECT_EQ(t1->consumption(), size1 + size1);
-    EXPECT_EQ(scope_mem, size1 + size2 + size1 + size2 + size1);
-}
-
 TEST_F(ThreadMemTrackerMgrTest, ReserveMemory) {
     std::unique_ptr<ThreadContext> thread_context = std::make_unique<ThreadContext>();
     std::shared_ptr<MemTrackerLimiter> t =


### PR DESCRIPTION
`count_scope_mem` and `consumer_tracker` not support reserve memory and not require use `_untracked_mem` to batch consume, because `count_scope_mem` is thread local, `consumer_tracker` will not be bound by many threads, so there is no performance problem.