### PR TITLE
[Opt](scanner-scheduler) Opt scanner scheduler starvation issue by yield signal.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -252,6 +252,10 @@ DEFINE_Int32(remote_split_source_batch_size, "10240");
 DEFINE_Int32(doris_max_remote_scanner_thread_pool_thread_num, "-1");
 // number of olap scanner thread pool queue size
 DEFINE_Int32(doris_scanner_thread_pool_queue_size, "102400");
+// number of scanner yield signal thread
+DEFINE_Int32(doris_scanner_yield_signal_thread_num, "3");
+// max run seconds of scanner yield signal thread
+DEFINE_Int32(doris_scanner_yield_signal_max_run_seconds, "1");
 // default thrift client connect timeout(in seconds)
 DEFINE_mInt32(thrift_connect_timeout_seconds, "3");
 DEFINE_mInt32(fetch_rpc_timeout_seconds, "30");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -305,6 +305,10 @@ DECLARE_mInt32(remote_split_source_batch_size);
 DECLARE_Int32(doris_max_remote_scanner_thread_pool_thread_num);
 // number of olap scanner thread pool queue size
 DECLARE_Int32(doris_scanner_thread_pool_queue_size);
+// number of scanner yield signal thread
+DECLARE_Int32(doris_scanner_yield_signal_thread_num);
+// max run seconds of scanner yield signal thread
+DECLARE_Int32(doris_scanner_yield_signal_max_run_seconds);
 // default thrift client connect timeout(in seconds)
 DECLARE_mInt32(thrift_connect_timeout_seconds);
 DECLARE_mInt32(fetch_rpc_timeout_seconds);

--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -28,6 +28,7 @@
 namespace doris::vectorized {
 
 class Block;
+class YieldSignal;
 // This a reader interface for all file readers.
 // A GenericReader is responsible for reading a file and return
 // a set of blocks with specified schema,
@@ -37,6 +38,10 @@ public:
     void set_push_down_agg_type(TPushAggOp::type push_down_agg_type) {
         _push_down_agg_type = push_down_agg_type;
     }
+
+    const YieldSignal* yield_signal() const { return _yield_signal; }
+
+    void set_yield_signal(const YieldSignal* yield_signal) { _yield_signal = yield_signal; }
 
     virtual Status get_next_block(Block* block, size_t* read_rows, bool* eof) = 0;
 
@@ -73,6 +78,7 @@ protected:
     /// Whether the underlying FileReader has filled the partition&missing columns
     bool _fill_all_columns = false;
     TPushAggOp::type _push_down_agg_type;
+    const YieldSignal* _yield_signal;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -520,6 +520,9 @@ Status RowGroupReader::_do_lazy_read(Block* block, size_t batch_size, size_t* re
             if (!pre_eof) {
                 // If continuous batches are skipped, we can cache them to skip a whole page
                 _cached_filtered_rows += pre_read_rows;
+                if (_lazy_read_ctx.yield_signal->is_set()) {
+                    break;
+                }
             } else { // pre_eof
                 // If select_vector_ptr->filter_all() and pre_eof, we can skip whole row group.
                 *read_rows = 0;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -49,6 +49,7 @@ struct IOContext;
 namespace vectorized {
 class Block;
 class FieldDescriptor;
+class YieldSignal;
 } // namespace vectorized
 } // namespace doris
 namespace tparquet {
@@ -99,6 +100,7 @@ public:
         std::unordered_map<std::string, VExprContextSPtr> missing_columns;
         // should turn off filtering by page index, lazy read and dict filter if having complex type
         bool has_complex_type = false;
+        const YieldSignal* yield_signal = nullptr;
     };
 
     /**

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -658,6 +658,7 @@ Status ParquetReader::_next_row_group_reader() {
                                               _profile, _file_reader, io_ranges)
                                     : _file_reader;
     }
+    _lazy_read_ctx.yield_signal = _yield_signal;
     _current_group_reader.reset(new RowGroupReader(
             group_file_reader, _read_columns, row_group_index.row_group_id, row_group, _ctz,
             _io_ctx, position_delete_ctx, _lazy_read_ctx, _state));

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <atomic>
+#include <boost/asio.hpp>
 #include <memory>
 
 #include "common/status.h"
@@ -72,7 +73,8 @@ public:
 
 private:
     static void _scanner_scan(std::shared_ptr<ScannerContext> ctx,
-                              std::shared_ptr<ScanTask> scan_task);
+                              std::shared_ptr<ScanTask> scan_task,
+                              boost::asio::io_context* io_context);
 
     void _register_metrics();
 
@@ -85,6 +87,12 @@ private:
     std::unique_ptr<vectorized::SimplifiedScanScheduler> _local_scan_thread_pool;
     std::unique_ptr<vectorized::SimplifiedScanScheduler> _remote_scan_thread_pool;
     std::unique_ptr<ThreadPool> _limited_scan_thread_pool;
+
+    // yield signal asio executor service
+    std::unique_ptr<boost::asio::io_context> _io_context;
+    std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>
+            _work_guard;
+    std::vector<std::thread> _yield_signal_threads;
 
     // true is the scheduler is closed.
     std::atomic_bool _is_closed = {false};

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -335,6 +335,9 @@ Status VFileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool*
             }
             break;
         }
+        if (_yield_signal.is_set()) {
+            break;
+        }
     } while (true);
 
     // Update filtered rows and unselected rows for load, reset counter.
@@ -957,6 +960,7 @@ Status VFileScanner::_get_next_reader() {
             return Status::InternalError("Not supported file format: {}", _params->format_type);
         }
 
+        _cur_reader->set_yield_signal(&_yield_signal);
         COUNTER_UPDATE(_file_counter, 1);
         // The VFileScanner for external table may try to open not exist files,
         // Because FE file cache for external table may out of date.

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -133,6 +133,9 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
             }
             // record rows return (after filter) for _limit check
             _num_rows_return += block->rows();
+            if (_yield_signal.is_set()) {
+                break;
+            }
         } while (!_should_stop && !state->is_cancelled() && block->rows() == 0 && !(*eof) &&
                  _num_rows_read < rows_read_threshold);
     }

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -28,6 +28,7 @@
 #include "runtime/runtime_state.h"
 #include "util/stopwatch.hpp"
 #include "vec/core/block.h"
+#include "vec/exec/scan/yield_signal.h"
 
 namespace doris {
 class RuntimeProfile;
@@ -155,6 +156,10 @@ public:
         _query_statistics = query_statistics;
     }
 
+    const YieldSignal& yield_signal() const { return _yield_signal; }
+
+    YieldSignal& yield_signal() { return _yield_signal; }
+
 protected:
     void _discard_conjuncts() {
         for (auto& conjunct : _conjuncts) {
@@ -229,6 +234,8 @@ protected:
     int64_t _projection_timer = 0;
 
     bool _should_stop = false;
+
+    YieldSignal _yield_signal;
 };
 
 using VScannerSPtr = std::shared_ptr<VScanner>;

--- a/be/src/vec/exec/scan/yield_signal.cpp
+++ b/be/src/vec/exec/scan/yield_signal.cpp
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exec/scan/yield_signal.h"
+
+#include <glog/logging.h>
+
+#include <boost/asio.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <iostream>
+
+namespace doris::vectorized {
+
+YieldSignal::YieldSignal() : _yield(false), _running_sequence(0), _termination_started(false) {}
+
+YieldSignal::~YieldSignal() {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _termination_started = true;
+    _yield.store(true);
+    if (_yield_timer != nullptr) {
+        _yield_timer->cancel();
+        _yield_timer.reset();
+    }
+}
+
+void YieldSignal::set_with_delay(std::chrono::nanoseconds max_run_nanos,
+                                 boost::asio::io_context* io_context) {
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    // Increment running sequence and create a new timer
+    _running_sequence++;
+    long expected_running_sequence = _running_sequence;
+
+    _yield_timer = std::make_shared<boost::asio::steady_timer>(*io_context);
+    _yield_timer->expires_after(max_run_nanos);
+
+    _yield_timer->async_wait(
+            [this, expected_running_sequence](const boost::system::error_code& ec) {
+                std::unique_lock<std::mutex> lock(_mutex);
+                if (!ec && expected_running_sequence == _running_sequence) {
+                    _yield.store(true);
+                }
+            });
+}
+
+void YieldSignal::reset() {
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_termination_started) {
+        return;
+    }
+    DCHECK(_yield_timer != nullptr) << "No ongoing yield to reset";
+
+    // Reset yield state and cancel all timers
+    _yield.store(false);
+    _yield_timer->cancel();
+    _yield_timer.reset();
+}
+
+bool YieldSignal::is_set() const {
+    return _yield.load();
+}
+
+void YieldSignal::yield_immediately_for_termination() {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _termination_started = true;
+    _yield.store(true);
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/scan/yield_signal.h
+++ b/be/src/vec/exec/scan/yield_signal.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <mutex>
+
+namespace doris::vectorized {
+
+class YieldSignal {
+public:
+    YieldSignal();
+    ~YieldSignal();
+
+    void set_with_delay(std::chrono::nanoseconds max_run_nanos,
+                        boost::asio::io_context* io_context);
+    void reset();
+    bool is_set() const;
+    void yield_immediately_for_termination();
+
+private:
+    std::atomic<bool> _yield;
+    long _running_sequence;
+    bool _termination_started;
+    std::shared_ptr<boost::asio::steady_timer> _yield_timer;
+    mutable std::mutex _mutex;
+};
+
+} // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes

### Issue
When a scanner scheduler is stuck in executing a scan task, other scan tasks will starve and have no chance to execute, which will affect other queries. Currently, the scan task hopes to scan as much data as possible to reduce the overhead of scheduling switching. Currently, it hopes to obtain up to 10MB of data in `doris_scanner_row_bytes`. However, if a query scans a table with many rows of data, but the filtering rate is very high, the filter will eventually filter out a lot of data and will never get 10MB of data. It will keep getting and executing expression filtering, which will cause other scan tasks to starve.

### Solution
The current solution is to set a yield signal. After executing for a maximum of 1s, the state will be set to yield. When the scan task executes some time-consuming tasks, it needs to slice to do it. Each slice area checks the yield signal. If it is found to be in the yield state, it will exit early and make room for other scan tasks to execute.
We originally used the original number of rows in some places in the code to express similar semantics, but I feel that it is not accurate in time. The parquet reader may skip many rows due to indexes, but sometimes it does not.

