### PR TITLE
[Bug](compatibility) fix stddev_samp function coredump when upgrade

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -126,8 +126,6 @@ struct BaseData {
         count += 1;
     }
 
-    static DataTypePtr get_return_type() { return std::make_shared<DataTypeNumber<Float64>>(); }
-
     double mean;
     double m2;
     int64_t count;
@@ -145,6 +143,8 @@ struct PopData : Data {
             col.get_data().push_back(this->get_pop_result());
         }
     }
+
+    static DataTypePtr get_return_type() { return std::make_shared<DataTypeNumber<Float64>>(); }
 };
 
 // For this series of functions, the Decimal type is not supported
@@ -189,6 +189,10 @@ struct SampData_OLDER : Data {
             nullable_column.get_null_map_data().push_back(0);
         }
     }
+
+    static DataTypePtr get_return_type() {
+        return make_nullable(std::make_shared<DataTypeNumber<Float64>>());
+    }
 };
 
 template <typename T, typename Data>
@@ -207,6 +211,8 @@ struct SampData : Data {
             }
         }
     }
+
+    static DataTypePtr get_return_type() { return std::make_shared<DataTypeNumber<Float64>>(); }
 };
 
 template <bool is_pop, typename Data, bool is_nullable>
@@ -221,17 +227,7 @@ public:
 
     String get_name() const override { return Data::name(); }
 
-    DataTypePtr get_return_type() const override {
-        if constexpr (is_pop) {
-            return Data::get_return_type();
-        } else {
-            if (IAggregateFunction::version < AGG_FUNCTION_NULLABLE) {
-                return make_nullable(Data::get_return_type());
-            } else {
-                return Data::get_return_type();
-            }
-        }
-    }
+    DataTypePtr get_return_type() const override { return Data::get_return_type(); }
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {


### PR DESCRIPTION
## Proposed changes

```
            if (IAggregateFunction::version < AGG_FUNCTION_NULLABLE) {
                return make_nullable(Data::get_return_type());
            } else {
                return Data::get_return_type();
            }
```

before check two version , and then get return type,
but now in branch-21, the IAggregateFunction::version have update to 5,
and also AGG_FUNCTION_NEW=5
so the check will not get right return type.


<!--Describe your changes.-->

