### PR TITLE
[improvement](statistics)Return -1 to neredis if report olap table row count for new table is not done for all tablets.

### DIFF
--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1065,6 +1065,7 @@ void TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>* 
         t_tablet_stat.__set_row_count(tablet_info.row_count);
         t_tablet_stat.__set_total_version_count(tablet_info.total_version_count);
         t_tablet_stat.__set_visible_version_count(tablet_info.visible_version_count);
+        t_tablet_stat.__set_visible_version(tablet_info.version);
     };
     for_each_tablet(handler, filter_all_tablets);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CloudTabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CloudTabletStatMgr.java
@@ -199,6 +199,7 @@ public class CloudTabletStatMgr extends MasterDaemon {
                                 tableRowsetCount += tabletRowsetCount;
                                 tableSegmentCount += tabletSegmentCount;
                             } // end for tablets
+                            index.setRowCountReported(true);
                             index.setRowCount(indexRowCount);
                         } // end for indices
                     } // end for partitions

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
@@ -73,6 +73,8 @@ public class MaterializedIndex extends MetaObject implements GsonPostProcessable
     @SerializedName(value = "rollupFinishedVersion")
     private long rollupFinishedVersion;
 
+    private boolean rowCountReported = false;
+
     public MaterializedIndex() {
         this.state = IndexState.NORMAL;
         this.idToTablets = new HashMap<>();
@@ -204,6 +206,14 @@ public class MaterializedIndex extends MetaObject implements GsonPostProcessable
             idx++;
         }
         return -1;
+    }
+
+    public void setRowCountReported(boolean reported) {
+        this.rowCountReported = reported;
+    }
+
+    public boolean getRowCountReported() {
+        return this.rowCountReported;
     }
 
     @Deprecated

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1564,13 +1564,16 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
 
     @Override
     public long fetchRowCount() {
-        return getRowCountForIndex(baseIndexId);
+        return getRowCountForIndex(baseIndexId, false);
     }
 
-    public long getRowCountForIndex(long indexId) {
+    public long getRowCountForIndex(long indexId, boolean strict) {
         long rowCount = 0;
         for (Map.Entry<Long, Partition> entry : idToPartition.entrySet()) {
             MaterializedIndex index = entry.getValue().getIndex(indexId);
+            if (strict && !index.getRowCountReported()) {
+                return -1;
+            }
             rowCount += (index == null || index.getRowCount() == -1) ? 0 : index.getRowCount();
         }
         return rowCount;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -177,6 +177,8 @@ public class Replica {
 
     private long userDropTime = -1;
 
+    private long lastReportVersion = 0;
+
     public Replica() {
     }
 
@@ -838,5 +840,13 @@ public class Replica {
     public boolean isScheduleAvailable() {
         return Env.getCurrentSystemInfo().checkBackendScheduleAvailable(backendId)
             && !isUserDrop();
+    }
+
+    public void setLastReportVersion(long version) {
+        this.lastReportVersion = version;
+    }
+
+    public long getLastReportVersion() {
+        return lastReportVersion;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -128,6 +128,7 @@ public class TabletStatMgr extends MasterDaemon {
                         long version = partition.getVisibleVersion();
                         for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                             long indexRowCount = 0L;
+                            boolean indexReported = true;
                             for (Tablet tablet : index.getTablets()) {
 
                                 Long tabletDataSize = 0L;
@@ -135,9 +136,26 @@ public class TabletStatMgr extends MasterDaemon {
 
                                 Long tabletRowCount = 0L;
 
+                                boolean tabletReported = false;
                                 for (Replica replica : tablet.getReplicas()) {
+                                    LOG.debug("Table {} replica {} current version {}, report version {}",
+                                            olapTable.getName(), replica.getId(),
+                                            replica.getVersion(), replica.getLastReportVersion());
                                     if (replica.checkVersionCatchUp(version, false)
-                                            && replica.getRowCount() > tabletRowCount) {
+                                            && replica.getRowCount() >= tabletRowCount) {
+                                        // 1. If replica version and reported replica version are all equal to
+                                        // PARTITION_INIT_VERSION, set tabletReported to true, which indicates this
+                                        // tablet is empty for sure when previous report.
+                                        // 2. If last report version is larger than PARTITION_INIT_VERSION, set
+                                        // tabletReported to true as well. That is, we only guarantee all replicas of
+                                        // the tablet are reported for the init version.
+                                        // e.g. When replica version is 2, but last reported version is 1,
+                                        // tabletReported would be false.
+                                        if (replica.getVersion() == Partition.PARTITION_INIT_VERSION
+                                                && replica.getLastReportVersion() == Partition.PARTITION_INIT_VERSION
+                                                || replica.getLastReportVersion() > Partition.PARTITION_INIT_VERSION) {
+                                            tabletReported = true;
+                                        }
                                         tabletRowCount = replica.getRowCount();
                                     }
 
@@ -157,8 +175,14 @@ public class TabletStatMgr extends MasterDaemon {
 
                                 tableRowCount += tabletRowCount;
                                 indexRowCount += tabletRowCount;
+                                // Only when all tablets of this index are reported, we set indexReported to true.
+                                indexReported = indexReported && tabletReported;
                             } // end for tablets
+                            index.setRowCountReported(indexReported);
                             index.setRowCount(indexRowCount);
+                            LOG.debug("Table {} index {} all tablets reported[{}], row count {}",
+                                    olapTable.getName(), olapTable.getIndexNameById(index.getId()),
+                                    indexReported, tableRowCount);
                         } // end for indices
                     } // end for partitions
 
@@ -193,6 +217,9 @@ public class TabletStatMgr extends MasterDaemon {
                         replica.setTotalVersionCount(stat.getTotalVersionCount());
                         replica.setVisibleVersionCount(stat.isSetVisibleVersionCount() ? stat.getVisibleVersionCount()
                                 : stat.getTotalVersionCount());
+                        // Older version BE doesn't set visible version. Set it to max for compatibility.
+                        replica.setLastReportVersion(stat.isSetVisibleVersion() ? stat.getVisibleVersion()
+                                : Long.MAX_VALUE);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -366,7 +366,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
 
     private Statistics computeOlapScan(OlapScan olapScan) {
         OlapTable olapTable = olapScan.getTable();
-        double tableRowCount = olapTable.getRowCountForIndex(olapScan.getSelectedIndexId());
+        double tableRowCount = olapTable.getRowCountForIndex(olapScan.getSelectedIndexId(), true);
         if (tableRowCount <= 0) {
             AnalysisManager analysisManager = Env.getCurrentEnv().getAnalysisManager();
             TableStatsMeta tableMeta = analysisManager.findTableStatsStatus(olapScan.getTable().getId());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2725,14 +2725,7 @@ public class ShowExecutor {
             return;
         }
         TableStatsMeta tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(tableIf.getId());
-        /*
-           tableStats == null means it's not analyzed, in this case show the estimated row count.
-         */
-        if (tableStats == null) {
-            resultSet = showTableStatsStmt.constructResultSet(tableIf);
-        } else {
-            resultSet = showTableStatsStmt.constructResultSet(tableStats, tableIf);
-        }
+        resultSet = showTableStatsStmt.constructResultSet(tableStats, tableIf);
     }
 
     private void handleShowColumnStats() throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3319,6 +3319,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             partitionNames = new PartitionNames(false, new ArrayList<>(target.partitions));
         }
         if (target.isTruncate) {
+            if (partitionNames == null || partitionNames.isStar() || partitionNames.getPartitionNames() == null) {
+                tableStats.clearIndexesRowCount();
+            }
             analysisManager.submitAsyncDropStatsTask(target.catalogId, target.dbId,
                     target.tableId, tableStats, partitionNames);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -198,7 +198,6 @@ public class AnalysisInfo implements Writable {
     public final boolean enablePartition;
 
     public final ConcurrentMap<Long, Long> indexesRowCount = new ConcurrentHashMap<>();
-    public final ConcurrentMap<Long, Long> indexesRowCountUpdateTime = new ConcurrentHashMap<>();
 
     public AnalysisInfo(long jobId, long taskId, List<Long> taskIds, long catalogId, long dbId, long tblId,
             Set<Pair<String, String>> jobColumns, Set<String> partitionNames, String colName, Long indexId,
@@ -357,9 +356,5 @@ public class AnalysisInfo implements Writable {
 
     public void addIndexRowCount(long indexId, long rowCount) {
         indexesRowCount.put(indexId, rowCount);
-    }
-
-    public void addIndexUpdateRowCountTime(long indexId, long time) {
-        indexesRowCountUpdateTime.put(indexId, time);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -682,6 +682,9 @@ public class AnalysisManager implements Writable {
         long catalogId = table.getDatabase().getCatalog().getId();
         long dbId = table.getDatabase().getId();
         long tableId = table.getId();
+        if (partitionNames == null || partitionNames.isStar() || partitionNames.getPartitionNames() == null) {
+            tableStats.clearIndexesRowCount();
+        }
         submitAsyncDropStatsTask(catalogId, dbId, tableId, tableStats, partitionNames);
         // Drop stats ddl is master only operation.
         Set<String> partitions = null;
@@ -810,6 +813,8 @@ public class AnalysisManager implements Writable {
         }
         if (allColumn && allPartition) {
             tableStats.removeAllColumn();
+            tableStats.clearIndexesRowCount();
+            removeTableStats(tableId);
         }
         tableStats.updatedTime = 0;
         tableStats.userInjected = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -498,7 +498,6 @@ public abstract class BaseAnalysisTask {
         try (AutoCloseConnectContext a  = StatisticsUtil.buildConnectContext()) {
             stmtExecutor = new StmtExecutor(a.connectContext, sql);
             ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0));
-            long analyzeTimestamp = System.currentTimeMillis();
             // Update index row count after analyze.
             if (this instanceof OlapAnalysisTask) {
                 AnalysisInfo jobInfo = Env.getCurrentEnv().getAnalysisManager().findJobInfo(job.getJobInfo().jobId);
@@ -506,7 +505,6 @@ public abstract class BaseAnalysisTask {
                 jobInfo = jobInfo == null ? job.jobInfo : jobInfo;
                 long indexId = info.indexId == -1 ? ((OlapTable) tbl).getBaseIndexId() : info.indexId;
                 jobInfo.addIndexRowCount(indexId, colStatsData.count);
-                jobInfo.addIndexUpdateRowCountTime(indexId, analyzeTimestamp);
             }
             Env.getCurrentEnv().getStatisticsCache().syncColStats(colStatsData);
             queryId = DebugUtil.printId(stmtExecutor.getContext().queryId());

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -101,7 +101,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         List<Long> tabletIds = pair.first;
         long totalRowCount = info.indexId == -1
                 ? tbl.getRowCount()
-                : ((OlapTable) tbl).getRowCountForIndex(info.indexId);
+                : ((OlapTable) tbl).getRowCountForIndex(info.indexId, false);
         double scaleFactor = (double) totalRowCount / (double) pair.second;
         // might happen if row count in fe metadata hasn't been updated yet
         if (Double.isInfinite(scaleFactor) || Double.isNaN(scaleFactor)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -392,7 +392,6 @@ public class StatisticsRepository {
             if (objects.table instanceof OlapTable) {
                 indexId = indexId == -1 ? ((OlapTable) objects.table).getBaseIndexId() : indexId;
                 mockedJobInfo.addIndexRowCount(indexId, (long) Double.parseDouble(rowCount));
-                mockedJobInfo.addIndexUpdateRowCountTime(indexId, timestamp);
             }
             Env.getCurrentEnv().getAnalysisManager().updateTableStatsForAlterStats(mockedJobInfo, objects.table);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -2294,6 +2294,9 @@ public class DatabaseTransactionMgr {
                                         replica.getId(), newVersion, lastFailedVersion, lastSuccessVersion);
                             }
                             replica.updateVersionWithFailed(newVersion, lastFailedVersion, lastSuccessVersion);
+                            if (newVersion == Partition.PARTITION_INIT_VERSION + 1) {
+                                index.setRowCountReported(false);
+                            }
                             Set<Long> partitionIds = backendPartitions.get(replica.getBackendId());
                             if (partitionIds == null) {
                                 partitionIds = Sets.newHashSet();

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -38,6 +38,7 @@ struct TTabletStat {
     4: optional i64 total_version_count
     5: optional i64 remote_data_size
     6: optional i64 visible_version_count
+    7: optional i64 visible_version
 }
 
 struct TTabletStatResult {

--- a/regression-test/suites/statistics/analyze_stats.groovy
+++ b/regression-test/suites/statistics/analyze_stats.groovy
@@ -2743,7 +2743,7 @@ PARTITION `p599` VALUES IN (599)
     assertEquals("true", alter_result[0][7])
     sql """drop stats alter_test"""
     alter_result = sql """show table stats alter_test"""
-    assertEquals("false", alter_result[0][7])
+    assertEquals("", alter_result[0][7])
     sql """alter table alter_test modify column id set stats ('row_count'='100', 'ndv'='0', 'num_nulls'='0.0', 'data_size'='2.69975443E8', 'min_value'='1', 'max_value'='2');"""
     alter_result = sql """show column stats alter_test(id)"""
     logger.info("show column alter_test(id) stats: " + alter_result)

--- a/regression-test/suites/statistics/test_analyze_mv.groovy
+++ b/regression-test/suites/statistics/test_analyze_mv.groovy
@@ -127,39 +127,45 @@ suite("test_analyze_mv") {
             "replication_num" = "1"
         )
     """
+    def result_row
+    if (!isCloudMode()) {
+        // Test row count report and report for nereids
+        result_row = sql """show index stats mvTestDup mvTestDup"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mvTestDup", result_row[0][1])
+        assertEquals("0", result_row[0][3])
+        assertEquals("-1", result_row[0][4])
+    }
+
     createMV("create materialized view mv1 as select key1 from mvTestDup;")
     createMV("create materialized view mv2 as select key2 from mvTestDup;")
     createMV("create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from mvTestDup group by key1, key2;")
     sql """insert into mvTestDup values (1, 2, 3, 4, 5), (1, 2, 3, 4, 5), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
 
-    def timestamp = System.currentTimeMillis();
     sql """analyze table mvTestDup with sync;"""
 
     // Test show index row count
-    def result_row = sql """show index stats mvTestDup mvTestDup"""
+    result_row = sql """show index stats mvTestDup mvTestDup"""
     assertEquals(1, result_row.size())
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mvTestDup", result_row[0][1])
     assertEquals("6", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
     result_row = sql """show index stats mvTestDup mv1"""
     assertEquals(1, result_row.size())
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mv1", result_row[0][1])
     assertEquals("6", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
     result_row = sql """show index stats mvTestDup mv2"""
     assertEquals(1, result_row.size())
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mv2", result_row[0][1])
     assertEquals("6", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
     result_row = sql """show index stats mvTestDup mv3"""
     assertEquals(1, result_row.size())
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mv3", result_row[0][1])
     assertEquals("4", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
 
     // Compare show whole table column stats result with show single column.
     def result_all = sql """show column stats mvTestDup"""
@@ -438,27 +444,21 @@ suite("test_analyze_mv") {
     assertEquals("FULL", result_sample[0][9])
 
     // Test alter table index row count.
-    timestamp = System.currentTimeMillis();
     sql """alter table mvTestDup modify column `value2` set stats ('row_count'='1.5E8', 'ndv'='3.0', 'num_nulls'='0.0', 'data_size'='1.5E8', 'min_value'='1', 'max_value'='10');"""
     result_row = sql """show index stats mvTestDup mvTestDup;"""
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mvTestDup", result_row[0][1])
     assertEquals("150000000", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
-    timestamp = System.currentTimeMillis();
     sql """alter table mvTestDup index mv1 modify column `mv_key1` set stats ('row_count'='3443', 'ndv'='3.0', 'num_nulls'='0.0', 'data_size'='1.5E8', 'min_value'='1', 'max_value'='10');"""
     result_row = sql """show index stats mvTestDup mv1;"""
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mv1", result_row[0][1])
     assertEquals("3443", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
-    timestamp = System.currentTimeMillis();
     sql """alter table mvTestDup index mv3 modify column `mva_MAX__``value2``` set stats ('row_count'='234234', 'ndv'='3.0', 'num_nulls'='0.0', 'data_size'='1.5E8', 'min_value'='1', 'max_value'='10');"""
     result_row = sql """show index stats mvTestDup mv3;"""
     assertEquals("mvTestDup", result_row[0][0])
     assertEquals("mv3", result_row[0][1])
     assertEquals("234234", result_row[0][2])
-    assertTrue(Long.parseLong(result_row[0][3]) >= timestamp)
 
     sql """drop stats mvTestDup"""
     result_sample = sql """show column stats mvTestDup"""
@@ -474,6 +474,35 @@ suite("test_analyze_mv") {
         logger.info(e.getMessage());
         return;
     }
+
+    if (!isCloudMode()) {
+        // Test row count report and report for nereids
+        result_row = sql """show index stats mvTestDup mvTestDup"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mvTestDup", result_row[0][1])
+        assertEquals("6", result_row[0][3])
+        assertEquals("6", result_row[0][4])
+        result_row = sql """show index stats mvTestDup mv1"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mv1", result_row[0][1])
+        assertEquals("6", result_row[0][3])
+        assertEquals("6", result_row[0][4])
+        result_row = sql """show index stats mvTestDup mv2"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mv2", result_row[0][1])
+        assertEquals("6", result_row[0][3])
+        assertEquals("6", result_row[0][4])
+        result_row = sql """show index stats mvTestDup mv3"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mv3", result_row[0][1])
+        assertEquals("4", result_row[0][3])
+        assertEquals("4", result_row[0][4])
+    }
+
     sql """analyze table mvTestDup with sample rows 4000000"""
     wait_analyze_finish("mvTestDup")
     result_sample = sql """SHOW ANALYZE mvTestDup;"""
@@ -620,6 +649,38 @@ suite("test_analyze_mv") {
     verifyTaskStatus(result_sample, "mva_MAX__`value2`", "mv3")
     verifyTaskStatus(result_sample, "mva_MIN__`value3`", "mv3")
     verifyTaskStatus(result_sample, "mva_SUM__CAST(`value1` AS bigint)", "mv3")
+
+    if (!isCloudMode()) {
+        // Test row count report and report for nereids
+        sql """truncate table mvTestDup"""
+        result_row = sql """show index stats mvTestDup mv3"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mv3", result_row[0][1])
+        assertEquals("0", result_row[0][3])
+        assertEquals("-1", result_row[0][4])
+
+        for (int i = 0; i < 120; i++) {
+            result_row = sql """show index stats mvTestDup mv3"""
+            logger.info("mv3 stats: " + result_row)
+            if (result_row[0][4] == "0") {
+                break;
+            }
+            Thread.sleep(5000)
+        }
+        result_row = sql """show index stats mvTestDup mv3"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mv3", result_row[0][1])
+        assertEquals("0", result_row[0][3])
+        assertEquals("0", result_row[0][4])
+        sql """insert into mvTestDup values (1, 2, 3, 4, 5), (1, 2, 3, 4, 5), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
+        result_row = sql """show index stats mvTestDup mv3"""
+        assertEquals(1, result_row.size())
+        assertEquals("mvTestDup", result_row[0][0])
+        assertEquals("mv3", result_row[0][1])
+        assertEquals("-1", result_row[0][4])
+    }
 
     // Test alter column stats
     sql """drop stats mvTestDup"""


### PR DESCRIPTION
Return -1 to neredis if report olap table row count for new table is not done for all tablets.
After this change, nereids could know new table is empty or not. When it's not empty but not reported yet, return -1 as row count to nereids.