### PR TITLE
[Chore](status) Disable stack trace printing for NotFound error status

### DIFF
--- a/be/src/io/fs/s3_obj_storage_client.cpp
+++ b/be/src/io/fs/s3_obj_storage_client.cpp
@@ -255,7 +255,7 @@ ObjectStorageHeadResponse S3ObjStorageClient::head_object(const ObjectStoragePat
         return {.resp = {convert_to_obj_response(Status::OK())},
                 .file_size = outcome.GetResult().GetContentLength()};
     } else if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
-        return {.resp = {convert_to_obj_response(Status::NotFound(""))}};
+        return {.resp = {convert_to_obj_response(Status::Error<ErrorCode::NOT_FOUND, false>(""))}};
     } else {
         return {.resp = {convert_to_obj_response(
                                  s3fs_error(outcome.GetError(),


### PR DESCRIPTION
## Proposed changes

Fix annoying error log message like this
```
meet error status: [NOT_FOUND]

        0#  doris::io::S3ObjStorageClient::head_object(doris::io::ObjectStoragePathOptions const&) at /root/doris/be/src/common/status.h:0
        1#  doris::io::S3FileSystem::exists_impl(std::filesystem::__cxx11::path const&, bool*) const at /root/doris/be/src/io/fs/s3_file_system.cpp:264
        2#  doris::io::FileSystem::exists(std::filesystem::__cxx11::path const&, bool*) const at /root/doris/be/src/common/status.h:387
        3#  doris::segment_v2::DorisFSDirectory::createOutput(char const*) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/fs_path.h:310
        4#  doris::segment_v2::InvertedIndexFileWriter::write_v2() at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp:0
        5#  doris::segment_v2::InvertedIndexFileWriter::close() at /root/doris/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp:140
        6#  doris::segment_v2::VerticalSegmentWriter::_write_inverted_index() at /root/doris/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp:0
        7#  doris::segment_v2::VerticalSegmentWriter::finalize_columns_index(unsigned long*) at /root/doris/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp:0
        8#  doris::segment_v2::VerticalSegmentWriter::finalize(unsigned long*, unsigned long*) at /root/doris/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp:1047
```

