### PR TITLE
[Bug](compatibility) fix agg functions coredump when upgrade

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_covar.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.h
@@ -120,8 +120,6 @@ struct BaseData {
         count += 1;
     }
 
-    static DataTypePtr get_return_type() { return std::make_shared<DataTypeNumber<Float64>>(); }
-
     double sum_x;
     double sum_y;
     double sum_xy;
@@ -134,6 +132,7 @@ struct PopData : Data {
         auto& col = assert_cast<ColumnFloat64&>(to);
         col.get_data().push_back(this->get_pop_result());
     }
+    static DataTypePtr get_return_type() { return std::make_shared<DataTypeNumber<Float64>>(); }
 };
 
 template <typename T, typename Data>
@@ -148,6 +147,9 @@ struct SampData_OLDER : Data {
             nullable_column.get_null_map_data().push_back(0);
         }
     }
+    static DataTypePtr get_return_type() {
+        return make_nullable(std::make_shared<DataTypeNumber<Float64>>());
+    }
 };
 
 template <typename T, typename Data>
@@ -160,6 +162,7 @@ struct SampData : Data {
             col.get_data().push_back(this->get_samp_result());
         }
     }
+    static DataTypePtr get_return_type() { return std::make_shared<DataTypeNumber<Float64>>(); }
 };
 
 template <typename Data>
@@ -184,17 +187,7 @@ public:
 
     String get_name() const override { return Data::name(); }
 
-    DataTypePtr get_return_type() const override {
-        if constexpr (is_pop) {
-            return Data::get_return_type();
-        } else {
-            if (IAggregateFunction::version < AGG_FUNCTION_NULLABLE) {
-                return make_nullable(Data::get_return_type());
-            } else {
-                return Data::get_return_type();
-            }
-        }
-    }
+    DataTypePtr get_return_type() const override { return Data::get_return_type(); }
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -162,13 +162,6 @@ public:
 
     String get_name() const override { return "percentile_approx"; }
 
-    DataTypePtr get_return_type() const override {
-        if (IAggregateFunction::version < AGG_FUNCTION_NULLABLE) {
-            return make_nullable(std::make_shared<DataTypeFloat64>());
-        }
-        return std::make_shared<DataTypeFloat64>();
-    }
-
     void reset(AggregateDataPtr __restrict place) const override {
         AggregateFunctionPercentileApprox::data(place).reset();
     }
@@ -186,30 +179,6 @@ public:
     void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
                      Arena*) const override {
         AggregateFunctionPercentileApprox::data(place).read(buf);
-    }
-
-    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
-        if (IAggregateFunction::version < AGG_FUNCTION_NULLABLE) {
-            ColumnNullable& nullable_column = assert_cast<ColumnNullable&>(to);
-            double result = AggregateFunctionPercentileApprox::data(place).get();
-
-            if (std::isnan(result)) {
-                nullable_column.insert_default();
-            } else {
-                auto& col = assert_cast<ColumnFloat64&>(nullable_column.get_nested_column());
-                col.get_data().push_back(result);
-                nullable_column.get_null_map_data().push_back(0);
-            }
-        } else {
-            auto& col = assert_cast<ColumnFloat64&>(to);
-            double result = AggregateFunctionPercentileApprox::data(place).get();
-
-            if (std::isnan(result)) {
-                col.insert_default();
-            } else {
-                col.get_data().push_back(result);
-            }
-        }
     }
 };
 
@@ -256,6 +225,23 @@ public:
             this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
         }
     }
+
+    DataTypePtr get_return_type() const override {
+        return make_nullable(std::make_shared<DataTypeFloat64>());
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& nullable_column = assert_cast<ColumnNullable&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            nullable_column.insert_default();
+        } else {
+            auto& col = assert_cast<ColumnFloat64&>(nullable_column.get_nested_column());
+            col.get_data().push_back(result);
+            nullable_column.get_null_map_data().push_back(0);
+        }
+    }
 };
 
 class AggregateFunctionPercentileApproxTwoParams : public AggregateFunctionPercentileApprox {
@@ -270,6 +256,19 @@ public:
                 assert_cast<const ColumnFloat64&, TypeCheckOnRelease::DISABLE>(*columns[1]);
         this->data(place).init();
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
+    }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& col = assert_cast<ColumnFloat64&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            col.insert_default();
+        } else {
+            col.get_data().push_back(result);
+        }
     }
 };
 
@@ -319,6 +318,23 @@ public:
             this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
         }
     }
+
+    DataTypePtr get_return_type() const override {
+        return make_nullable(std::make_shared<DataTypeFloat64>());
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& nullable_column = assert_cast<ColumnNullable&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            nullable_column.insert_default();
+        } else {
+            auto& col = assert_cast<ColumnFloat64&>(nullable_column.get_nested_column());
+            col.get_data().push_back(result);
+            nullable_column.get_null_map_data().push_back(0);
+        }
+    }
 };
 
 class AggregateFunctionPercentileApproxThreeParams : public AggregateFunctionPercentileApprox {
@@ -336,6 +352,19 @@ public:
 
         this->data(place).init(compression.get_element(row_num));
         this->data(place).add(sources.get_element(row_num), quantile.get_element(row_num));
+    }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& col = assert_cast<ColumnFloat64&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            col.insert_default();
+        } else {
+            col.get_data().push_back(result);
+        }
     }
 };
 
@@ -390,6 +419,23 @@ public:
                                               quantile.get_element(row_num));
         }
     }
+
+    DataTypePtr get_return_type() const override {
+        return make_nullable(std::make_shared<DataTypeFloat64>());
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& nullable_column = assert_cast<ColumnNullable&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            nullable_column.insert_default();
+        } else {
+            auto& col = assert_cast<ColumnFloat64&>(nullable_column.get_nested_column());
+            col.get_data().push_back(result);
+            nullable_column.get_null_map_data().push_back(0);
+        }
+    }
 };
 
 class AggregateFunctionPercentileApproxWeightedThreeParams
@@ -410,6 +456,19 @@ public:
         this->data(place).init();
         this->data(place).add_with_weight(sources.get_element(row_num), weight.get_element(row_num),
                                           quantile.get_element(row_num));
+    }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& col = assert_cast<ColumnFloat64&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            col.insert_default();
+        } else {
+            col.get_data().push_back(result);
+        }
     }
 };
 
@@ -467,6 +526,23 @@ public:
                                               quantile.get_element(row_num));
         }
     }
+
+    DataTypePtr get_return_type() const override {
+        return make_nullable(std::make_shared<DataTypeFloat64>());
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& nullable_column = assert_cast<ColumnNullable&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            nullable_column.insert_default();
+        } else {
+            auto& col = assert_cast<ColumnFloat64&>(nullable_column.get_nested_column());
+            col.get_data().push_back(result);
+            nullable_column.get_null_map_data().push_back(0);
+        }
+    }
 };
 
 class AggregateFunctionPercentileApproxWeightedFourParams
@@ -488,6 +564,19 @@ public:
         this->data(place).init(compression.get_element(row_num));
         this->data(place).add_with_weight(sources.get_element(row_num), weight.get_element(row_num),
                                           quantile.get_element(row_num));
+    }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeFloat64>(); }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        auto& col = assert_cast<ColumnFloat64&>(to);
+        double result = AggregateFunctionPercentileApprox::data(place).get();
+
+        if (std::isnan(result)) {
+            col.insert_default();
+        } else {
+            col.get_data().push_back(result);
+        }
     }
 };
 

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -213,12 +213,6 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
         _function = transform_to_sort_agg_function(_function, _argument_types_with_sort,
                                                    _sort_description, state);
     }
-    if (!_function->get_return_type()->equals(*_data_type)) {
-        return Status::InternalError(
-                "Agg Function {} return type is not equal: FE plan return type: {}, BE get return "
-                "type: {} ",
-                _fn.signature, _data_type->get_name(), _function->get_return_type()->get_name());
-    }
     _expr_name = fmt::format("{}({})", _fn.name.function_name, child_expr_name);
     return Status::OK();
 }

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -213,6 +213,12 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
         _function = transform_to_sort_agg_function(_function, _argument_types_with_sort,
                                                    _sort_description, state);
     }
+    if (!_function->get_return_type()->equals(*_data_type)) {
+        return Status::InternalError(
+                "Agg Function {} return type is not equal: FE plan return type: {}, BE get return "
+                "type: {} ",
+                _fn.signature, _data_type->get_name(), _function->get_return_type()->get_name());
+    }
     _expr_name = fmt::format("{}({})", _fn.name.function_name, child_expr_name);
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes
before use check (IAggregateFunction::version < AGG_FUNCTION_NULLABLE)
and then choose the return type and insert method.

but the version maybe update in the same branch-version，and get wrong type
so put those function to all of object class alone. 


<!--Describe your changes.-->

