### PR TITLE
[fix](table-func) fix explode-func with old pipeline 

### DIFF
--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -200,7 +200,7 @@ Status VTableFunctionNode::_get_expanded_block(RuntimeState* state, Block* outpu
 
             DCHECK_LE(1, _fn_num);
             auto repeat_times = _fns[_fn_num - 1]->get_value(
-                    columns[_child_slots.size()],
+                    columns[_child_slots.size() + _fn_num - 1],
                     state->batch_size() - columns[_child_slots.size()]->size());
             _current_row_insert_times += repeat_times;
             for (int i = 0; i < _fn_num - 1; i++) {


### PR DESCRIPTION
## Proposed changes
if we use 2.0 fe and 2.1 be where pipeline use old logic may meet a core like
```
22:44:04   F20240905 22:31:46.818060 25429 assert_cast.h:45] Bad cast from type:doris::vectorized::ColumnVector<int>* to doris::vectorized::ColumnVector<double>*
22:44:04   *** Check failure stack trace: ***
22:44:04       @     0x560836b66586  google::LogMessage::SendToLog()
22:44:04       @     0x560836b62fd0  google::LogMessage::Flush()
22:44:04       @     0x560836b66dc9  google::LogMessageFatal::~LogMessageFatal()
22:44:04       @     0x5608197f8013  assert_cast<>()
22:44:04       @     0x5608220349af  doris::vectorized::VExplodeJsonArrayTableFunction<>::_insert_values_into_column()
22:44:04       @     0x5608220345d9  doris::vectorized::VExplodeJsonArrayTableFunction<>::get_value()
22:44:04       @     0x560822007812  doris::vectorized::VTableFunctionNode::_get_expanded_block()
22:44:04       @     0x560822009506  doris::vectorized::VTableFunctionNode::pull()
22:44:04       @     0x5608365c4cc4  _ZNSt5_BindIFMN5doris8ExecNodeEFNS0_6StatusEPNS0_12RuntimeStateEPNS0_10vectorized5BlockEPbEPNS5_18VTableFunctionNodeESt12_PlaceholderILi1EESD_ILi2EESD_ILi3EEEE6__callIS2_JOS4_OS7_OS8_EJLm0ELm1ELm2ELm3EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
22:44:04       @     0x5608365c47b6  std::_Function_handler<>::_M_invoke()
22:44:04       @     0x560810bcb5b0  doris::ExecNode::get_next_after_projects()
22:44:04       @     0x5608365bf958  doris::pipeline::StatefulOperator<>::get_block()
22:44:04       @     0x5608366bfe9d  doris::pipeline::PipelineTask::execute()
22:44:04       @     0x560836b3de7d  doris::pipeline::TaskScheduler::_do_work()
22:44:04       @     0x56081115a470  doris::ThreadPool::dispatch_thread()
22:44:04       @     0x5608111399f9  doris::Thread::supervise_thread()
22:44:04       @     0x7f43991edac3  (unknown)
```
Issue Number: close #xxx

<!--Describe your changes.-->

