### PR TITLE
[fix](mtmv) Fix partition trace wrong when partition name is same from both side of join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -429,6 +429,20 @@ public class MaterializedViewUtils {
                         + "but now is %s", relation.getClass().getSimpleName()));
                 return null;
             }
+            SlotReference contextPartitionColumn = getContextPartitionColumn(context);
+            if (contextPartitionColumn == null) {
+                context.addFailReason(String.format("mv partition column is not from table when relation check, "
+                        + "mv partition column is %s", context.getMvPartitionColumn()));
+                return null;
+            }
+            // Check the table which mv partition column which is belonged to is same as the current check relation
+            if (!((LogicalCatalogRelation) relation).getTable().getFullQualifiers().equals(
+                    contextPartitionColumn.getTable().map(TableIf::getFullQualifiers).orElse(ImmutableList.of()))) {
+                context.addFailReason(String.format("mv partition column name is not belonged to current check , "
+                                + "table, current table is %s",
+                        ((LogicalCatalogRelation) relation).getTable().getFullQualifiers()));
+                return null;
+            }
             LogicalCatalogRelation logicalCatalogRelation = (LogicalCatalogRelation) relation;
             TableIf table = logicalCatalogRelation.getTable();
             // if self join, self join can not partition track now, remove the partition column correspondingly
@@ -457,10 +471,6 @@ public class MaterializedViewUtils {
                 return null;
             }
             Set<Column> partitionColumnSet = new HashSet<>(relatedTable.getPartitionColumns());
-            SlotReference contextPartitionColumn = getContextPartitionColumn(context);
-            if (contextPartitionColumn == null) {
-                return null;
-            }
             Column mvReferenceColumn = contextPartitionColumn.getColumn().get();
             Expr definExpr = mvReferenceColumn.getDefineExpr();
             if (definExpr instanceof SlotRef) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -435,7 +435,7 @@ public class MaterializedViewUtils {
                         + "mv partition column is %s", context.getMvPartitionColumn()));
                 return null;
             }
-            // Check the table which mv partition column which is belonged to is same as the current check relation
+            // Check the table which mv partition column belonged to is same as the current check relation or not
             if (!((LogicalCatalogRelation) relation).getTable().getFullQualifiers().equals(
                     contextPartitionColumn.getTable().map(TableIf::getFullQualifiers).orElse(ImmutableList.of()))) {
                 context.addFailReason(String.format("mv partition column name is not belonged to current check , "

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateMTMVInfo.java
@@ -381,7 +381,9 @@ public class CreateMTMVInfo {
         List<Expression> functionCollectResult = MaterializedViewUtils.extractNondeterministicFunction(plan);
         if (!CollectionUtils.isEmpty(functionCollectResult)) {
             throw new AnalysisException(String.format(
-                    "can not contain invalid expression, the expression is %s",
+                    "can not contain nonDeterministic expression, the expression is %s. "
+                            + "Should add 'enable_nondeterministic_function'  = 'true' property "
+                            + "when create materialized view if you know the property real meaning entirely",
                     functionCollectResult.stream().map(Expression::toString).collect(Collectors.joining(","))));
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -538,9 +538,6 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
 
     @Override
     public void computeEqualSet(DataTrait.Builder builder) {
-        if (getTable() instanceof MTMV && getTable().getName().equals("mv1")) {
-            System.out.println();
-        }
         if (getTable() instanceof MTMV) {
             MTMV mtmv = (MTMV) getTable();
             MTMVCache cache = mtmv.getCache();

--- a/regression-test/suites/mtmv_p0/test_enable_date_non_deterministic_function_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_enable_date_non_deterministic_function_mtmv.groovy
@@ -57,7 +57,7 @@ suite("test_enable_date_non_deterministic_function_mtmv","mtmv") {
         Assert.fail();
     } catch (Exception e) {
         logger.info(e.getMessage())
-        assertTrue(e.getMessage().contains("can not contain invalid expression"));
+        assertTrue(e.getMessage().contains("can not contain nonDeterministic expression"));
     }
     sql """drop materialized view if exists ${mvName};"""
 
@@ -75,7 +75,7 @@ suite("test_enable_date_non_deterministic_function_mtmv","mtmv") {
         Assert.fail();
     } catch (Exception e) {
         logger.info(e.getMessage())
-        assertTrue(e.getMessage().contains("can not contain invalid expression"));
+        assertTrue(e.getMessage().contains("can not contain nonDeterministic expression"));
     }
     sql """drop materialized view if exists ${mvName};"""
 
@@ -128,7 +128,7 @@ suite("test_enable_date_non_deterministic_function_mtmv","mtmv") {
         Assert.fail();
     } catch (Exception e) {
         logger.info(e.getMessage())
-        assertTrue(e.getMessage().contains("can not contain invalid expression"));
+        assertTrue(e.getMessage().contains("can not contain nonDeterministic expression"));
     }
 
     sql """drop table if exists `${tableName}`"""


### PR DESCRIPTION
## Proposed changes

This is brought by https://github.com/apache/doris/pull/35562
if partition mv def is as following:
```sql
        CREATE MATERIALIZED VIEW mv1
        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
        PARTITION BY (upgrade_day)
        DISTRIBUTED BY RANDOM BUCKETS 2
        PROPERTIES ('replication_num' = '1') 
        AS
       select t1.upgrade_day, t2.batch_no, count(*) 
       from test2 t2 join test1 t1 on
       t1.upgrade_day = t2.upgrade_day
       group by t1.upgrade_day, t2.batch_no;
```
the mv related partition table should `test1`, but now is `test2`, this pr fix this.

