### PR TITLE
[opt](scan) unify the local and remote scan bytes stats for all scanners

### DIFF
--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -106,16 +106,15 @@ void CloudWarmUpManager::handle_jobs() {
                     }
 
                     wait->add_count();
+                    io::IOContext io_ctx;
+                    io_ctx.expiration_time = expiration_time;
                     _engine.file_cache_block_downloader().submit_download_task(
                             io::DownloadFileMeta {
                                     .path = storage_resource.value()->remote_segment_path(*rs,
                                                                                           seg_id),
                                     .file_size = rs->segment_file_size(seg_id),
                                     .file_system = storage_resource.value()->fs,
-                                    .ctx =
-                                            {
-                                                    .expiration_time = expiration_time,
-                                            },
+                                    .ctx = io_ctx,
                                     .download_done =
                                             [wait](Status st) {
                                                 if (!st) {
@@ -125,15 +124,14 @@ void CloudWarmUpManager::handle_jobs() {
                                             },
                             });
 
+                    io::IOContext io_ctx2;
+                    io_ctx2.expiration_time = expiration_time;
                     auto download_idx_file = [&](const io::Path& idx_path) {
                         io::DownloadFileMeta meta {
                                 .path = idx_path,
                                 .file_size = -1,
                                 .file_system = storage_resource.value()->fs,
-                                .ctx =
-                                        {
-                                                .expiration_time = expiration_time,
-                                        },
+                                .ctx = io_ctx2,
                                 .download_done =
                                         [wait](Status st) {
                                             if (!st) {

--- a/be/src/exec/schema_scanner/schema_backend_active_tasks.cpp
+++ b/be/src/exec/schema_scanner/schema_backend_active_tasks.cpp
@@ -34,6 +34,8 @@ std::vector<SchemaScanner::ColumnDesc> SchemaBackendActiveTasksScanner::_s_tbls_
         {"TASK_CPU_TIME_MS", TYPE_BIGINT, sizeof(int64_t), false},
         {"SCAN_ROWS", TYPE_BIGINT, sizeof(int64_t), false},
         {"SCAN_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
+        {"LOCAL_SCAN_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
+        {"REMOTE_SCAN_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
         {"BE_PEAK_MEMORY_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
         {"CURRENT_USED_MEMORY_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
         {"SHUFFLE_SEND_BYTES", TYPE_BIGINT, sizeof(int64_t), false},

--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -178,6 +178,9 @@ void FileCacheBlockDownloader::download_file_cache_block(
             }
         };
 
+        IOContext io_ctx;
+        io_ctx.is_index_data = meta.cache_type() == ::doris::FileCacheType::INDEX;
+        io_ctx.expiration_time = meta.expiration_time();
         DownloadFileMeta download_meta {
                 .path = storage_resource.value()->remote_segment_path(*find_it->second,
                                                                       meta.segment_id()),
@@ -186,11 +189,7 @@ void FileCacheBlockDownloader::download_file_cache_block(
                 .offset = meta.offset(),
                 .download_size = meta.size(),
                 .file_system = storage_resource.value()->fs,
-                .ctx =
-                        {
-                                .is_index_data = meta.cache_type() == ::doris::FileCacheType::INDEX,
-                                .expiration_time = meta.expiration_time(),
-                        },
+                .ctx = io_ctx,
                 .download_done = std::move(download_done),
         };
         download_segment_file(download_meta);

--- a/be/src/io/cache/cached_remote_file_reader.h
+++ b/be/src/io/cache/cached_remote_file_reader.h
@@ -67,10 +67,11 @@ private:
     std::shared_mutex _mtx;
     std::map<size_t, FileBlockSPtr> _cache_file_readers;
 
+    // Used to record read/write timer and cache related metrics.
+    // These metrics will finally be saved in FileCacheStatistics.
     struct ReadStatistics {
         bool hit_cache = true;
         bool skip_cache = false;
-        int64_t bytes_read = 0;
         int64_t bytes_write_into_file_cache = 0;
         int64_t remote_read_timer = 0;
         int64_t local_read_timer = 0;

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -157,8 +157,8 @@ Status FileBlock::finalize() {
     return st;
 }
 
-Status FileBlock::read(Slice buffer, size_t read_offset) {
-    return _mgr->_storage->read(_key, read_offset, buffer);
+Status FileBlock::read(Slice buffer, size_t read_offset, const IOContext* io_ctx) {
+    return _mgr->_storage->read(_key, read_offset, buffer, io_ctx);
 }
 
 Status FileBlock::change_cache_type_between_ttl_and_others(FileCacheType new_type) {

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -95,7 +95,7 @@ public:
     [[nodiscard]] Status append(Slice data);
 
     // read data from cache file
-    [[nodiscard]] Status read(Slice buffer, size_t read_offset);
+    [[nodiscard]] Status read(Slice buffer, size_t read_offset, const IOContext* io_ctx);
 
     // finish write, release the file writer
     [[nodiscard]] Status finalize();

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -52,7 +52,8 @@ public:
     // finalize the block
     virtual Status finalize(const FileCacheKey& key) = 0;
     // read the block
-    virtual Status read(const FileCacheKey& key, size_t value_offset, Slice result) = 0;
+    virtual Status read(const FileCacheKey& key, size_t value_offset, Slice result,
+                        const IOContext* io_ctx) = 0;
     // remove the block
     virtual Status remove(const FileCacheKey& key) = 0;
     // change the block meta

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -152,7 +152,8 @@ Status FSFileCacheStorage::finalize(const FileCacheKey& key) {
     return fs->rename(file_writer->path(), true_file);
 }
 
-Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Slice buffer) {
+Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Slice buffer,
+                                const IOContext* io_ctx) {
     AccessKeyAndOffset fd_key = std::make_pair(key.hash, key.offset);
     FileReaderSPtr file_reader = FDCache::instance()->get_file_reader(fd_key);
     if (!file_reader) {
@@ -184,7 +185,7 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
         FDCache::instance()->insert_file_reader(fd_key, file_reader);
     }
     size_t bytes_read = 0;
-    auto s = file_reader->read_at(value_offset, buffer, &bytes_read);
+    auto s = file_reader->read_at(value_offset, buffer, &bytes_read, io_ctx);
     if (!s.ok()) {
         LOG(WARNING) << "read file failed, file=" << file_reader->path()
                      << ", error=" << s.to_string();

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -63,7 +63,8 @@ public:
     Status init(BlockFileCache* _mgr) override;
     Status append(const FileCacheKey& key, const Slice& value) override;
     Status finalize(const FileCacheKey& key) override;
-    Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
+    Status read(const FileCacheKey& key, size_t value_offset, Slice buffer,
+                const IOContext* io_ctx) override;
     Status remove(const FileCacheKey& key) override;
     Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) override;
     Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;

--- a/be/src/io/fs/file_reader.cpp
+++ b/be/src/io/fs/file_reader.cpp
@@ -41,7 +41,7 @@ Status FileReader::read_at(size_t offset, Slice result, size_t* bytes_read,
 Result<FileReaderSPtr> create_cached_file_reader(FileReaderSPtr raw_reader,
                                                  const FileReaderOptions& opts) {
     switch (opts.cache_type) {
-    case io::FileCachePolicy::NO_CACHE:
+    case FileCachePolicy::NO_CACHE:
         return raw_reader;
     case FileCachePolicy::FILE_BLOCK_CACHE:
         return std::make_shared<CachedRemoteFileReader>(std::move(raw_reader), opts);

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -116,7 +116,7 @@ Status HdfsFileReader::close() {
 
 #ifdef USE_HADOOP_HDFS
 Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
-                                    const IOContext* /*io_ctx*/) {
+                                    const IOContext* io_ctx) {
     if (closed()) [[unlikely]] {
         return Status::InternalError("read closed file: {}", _path.native());
     }
@@ -163,6 +163,9 @@ Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_r
     *bytes_read = has_read;
     hdfs_bytes_read_total << *bytes_read;
     hdfs_bytes_per_read << *bytes_read;
+    if (io_ctx && io_ctx->file_cache_stats) {
+        io_ctx->file_cache_stats->bytes_read_from_remote += bytes_req;
+    }
     return Status::OK();
 }
 

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -103,7 +103,7 @@ Status S3FileReader::close() {
 }
 
 Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
-                                  const IOContext* /*io_ctx*/) {
+                                  const IOContext* io_ctx) {
     DCHECK(!closed());
     if (offset > _file_size) {
         return Status::InternalError(
@@ -167,6 +167,9 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
         if (retry_count > 0) {
             LOG(INFO) << fmt::format("read s3 file {} succeed after {} times with {} ms sleeping",
                                      _path.native(), retry_count, total_sleep_time);
+        }
+        if (io_ctx && io_ctx->file_cache_stats) {
+            io_ctx->file_cache_stats->bytes_read_from_remote += bytes_req;
         }
         return Status::OK();
     }

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -19,6 +19,8 @@
 
 #include <gen_cpp/Types_types.h>
 
+#include <sstream>
+
 namespace doris {
 
 enum class ReaderType : uint8_t {
@@ -45,6 +47,38 @@ struct FileCacheStatistics {
     int64_t write_cache_io_timer = 0;
     int64_t bytes_write_into_cache = 0;
     int64_t num_skip_cache_io_total = 0;
+
+    void update(const FileCacheStatistics& other) {
+        num_local_io_total += other.num_local_io_total;
+        num_remote_io_total += other.num_remote_io_total;
+        local_io_timer += other.local_io_timer;
+        bytes_read_from_local += other.bytes_read_from_local;
+        bytes_read_from_remote += other.bytes_read_from_remote;
+        remote_io_timer += other.remote_io_timer;
+        write_cache_io_timer += other.write_cache_io_timer;
+        write_cache_io_timer += other.write_cache_io_timer;
+        bytes_write_into_cache += other.bytes_write_into_cache;
+        num_skip_cache_io_total += other.num_skip_cache_io_total;
+    }
+
+    void reset() {
+        num_local_io_total = 0;
+        num_remote_io_total = 0;
+        local_io_timer = 0;
+        bytes_read_from_local = 0;
+        bytes_read_from_remote = 0;
+        remote_io_timer = 0;
+        write_cache_io_timer = 0;
+        bytes_write_into_cache = 0;
+        num_skip_cache_io_total = 0;
+    }
+
+    std::string debug_string() const {
+        std::stringstream ss;
+        ss << "bytes_read_from_local: " << bytes_read_from_local
+           << ", bytes_read_from_remote: " << bytes_read_from_remote;
+        return ss.str();
+    }
 };
 
 struct IOContext {
@@ -60,6 +94,45 @@ struct IOContext {
     int64_t expiration_time = 0;
     const TUniqueId* query_id = nullptr;             // Ref
     FileCacheStatistics* file_cache_stats = nullptr; // Ref
+
+    IOContext() = default;
+
+    IOContext(const IOContext& other) {
+        reader_type = other.reader_type;
+        is_disposable = other.is_disposable;
+        is_index_data = other.is_index_data;
+        read_file_cache = other.read_file_cache;
+        is_persistent = other.is_persistent;
+        should_stop = other.should_stop;
+        expiration_time = other.expiration_time;
+        query_id = other.query_id;
+        file_cache_stats = other.file_cache_stats;
+    }
+
+    IOContext& operator=(const IOContext& other) {
+        if (this == &other) {
+            return *this;
+        }
+
+        reader_type = other.reader_type;
+        is_disposable = other.is_disposable;
+        is_index_data = other.is_index_data;
+        read_file_cache = other.read_file_cache;
+        is_persistent = other.is_persistent;
+        should_stop = other.should_stop;
+        expiration_time = other.expiration_time;
+        query_id = other.query_id;
+        file_cache_stats = other.file_cache_stats;
+        return *this;
+    }
+
+    std::string debug_string() const {
+        if (file_cache_stats != nullptr) {
+            return file_cache_stats->debug_string();
+        } else {
+            return "no file cache stats";
+        }
+    }
 };
 
 } // namespace io

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -82,12 +82,14 @@ Status _get_segment_column_iterator(const BetaRowsetSharedPtr& rowset, uint32_t 
     }
     segment_v2::SegmentSharedPtr segment = *it;
     RETURN_IF_ERROR(segment->new_column_iterator(target_column, column_iterator, nullptr));
+    io::IOContext ctx;
+    ctx.reader_type = ReaderType::READER_QUERY;
+    ctx.file_cache_stats = &stats->file_cache_stats;
     segment_v2::ColumnIteratorOptions opt {
             .use_page_cache = !config::disable_storage_page_cache,
             .file_reader = segment->file_reader().get(),
             .stats = stats,
-            .io_ctx = io::IOContext {.reader_type = ReaderType::READER_QUERY,
-                                     .file_cache_stats = &stats->file_cache_stats},
+            .io_ctx = ctx,
     };
     RETURN_IF_ERROR((*column_iterator)->init(opt));
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -121,6 +121,9 @@ Status IndexedColumnReader::read_page(const PagePointer& pp, PageHandle* handle,
                                       OlapReaderStatistics* stats) const {
     OlapReaderStatistics tmp_stats;
     OlapReaderStatistics* stats_ptr = stats != nullptr ? stats : &tmp_stats;
+    io::IOContext ctx;
+    ctx.is_index_data = true;
+    ctx.file_cache_stats = &stats_ptr->file_cache_stats;
     PageReadOptions opts {
             .use_page_cache = _use_page_cache,
             .kept_in_memory = _kept_in_memory,
@@ -131,8 +134,7 @@ Status IndexedColumnReader::read_page(const PagePointer& pp, PageHandle* handle,
             .codec = codec,
             .stats = stats_ptr,
             .encoding_info = _encoding_info,
-            .io_ctx = io::IOContext {.is_index_data = true,
-                                     .file_cache_stats = &stats_ptr->file_cache_stats},
+            .io_ctx = ctx,
     };
     if (_is_pk_index) {
         opts.type = PRIMARY_KEY_INDEX_PAGE;

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -88,6 +88,8 @@ Status OrdinalIndexReader::_load(bool use_page_cache, bool kept_in_memory,
     }
     // need to read index page
     OlapReaderStatistics tmp_stats;
+    io::IOContext ctx;
+    ctx.is_index_data = true;
     PageReadOptions opts {
             .use_page_cache = use_page_cache,
             .kept_in_memory = kept_in_memory,
@@ -97,7 +99,7 @@ Status OrdinalIndexReader::_load(bool use_page_cache, bool kept_in_memory,
             // ordinal index page uses NO_COMPRESSION right now
             .codec = nullptr,
             .stats = &tmp_stats,
-            .io_ctx = io::IOContext {.is_index_data = true},
+            .io_ctx = ctx,
     };
 
     // read index page

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -43,6 +43,8 @@ public:
             : scan_rows(0),
               scan_bytes(0),
               cpu_nanos(0),
+              _scan_bytes_from_local_storage(0),
+              _scan_bytes_from_remote_storage(0),
               returned_rows(0),
               max_peak_memory_bytes(0),
               current_used_memory_bytes(0),

--- a/be/src/runtime/runtime_query_statistics_mgr.cpp
+++ b/be/src/runtime/runtime_query_statistics_mgr.cpp
@@ -521,28 +521,39 @@ void RuntimeQueryStatisticsMgr::get_active_be_tasks_block(vectorized::Block* blo
     int64_t be_id = ExecEnv::GetInstance()->cluster_info()->backend_id;
 
     // block's schema come from SchemaBackendActiveTasksScanner::_s_tbls_columns
+    // before 2.1.6, there are 12 columns in "backend_active_tasks" table.
+    // after 2.1.7, 2 new columns added.
+    // check this to make it compatible with version before 2.1.6
+    bool need_local_and_remote_bytes = (block->columns() > 12);
     for (auto& [query_id, qs_ctx_ptr] : _query_statistics_ctx_map) {
+        int col_idx = 0;
         TQueryStatistics tqs;
         qs_ctx_ptr->collect_query_statistics(&tqs);
-        SchemaScannerHelper::insert_int64_value(0, be_id, block);
-        SchemaScannerHelper::insert_string_value(1, qs_ctx_ptr->_fe_addr.hostname, block);
-        SchemaScannerHelper::insert_string_value(2, query_id, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, be_id, block);
+        SchemaScannerHelper::insert_string_value(col_idx++, qs_ctx_ptr->_fe_addr.hostname, block);
+        SchemaScannerHelper::insert_string_value(col_idx++, query_id, block);
 
         int64_t task_time = qs_ctx_ptr->_is_query_finished
                                     ? qs_ctx_ptr->_query_finish_time - qs_ctx_ptr->_query_start_time
                                     : MonotonicMillis() - qs_ctx_ptr->_query_start_time;
-        SchemaScannerHelper::insert_int64_value(3, task_time, block);
-        SchemaScannerHelper::insert_int64_value(4, tqs.cpu_ms, block);
-        SchemaScannerHelper::insert_int64_value(5, tqs.scan_rows, block);
-        SchemaScannerHelper::insert_int64_value(6, tqs.scan_bytes, block);
-        SchemaScannerHelper::insert_int64_value(7, tqs.max_peak_memory_bytes, block);
-        SchemaScannerHelper::insert_int64_value(8, tqs.current_used_memory_bytes, block);
-        SchemaScannerHelper::insert_int64_value(9, tqs.shuffle_send_bytes, block);
-        SchemaScannerHelper::insert_int64_value(10, tqs.shuffle_send_rows, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, task_time, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.cpu_ms, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.scan_rows, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.scan_bytes, block);
+        if (need_local_and_remote_bytes) {
+            SchemaScannerHelper::insert_int64_value(col_idx++, tqs.scan_bytes_from_local_storage,
+                                                    block);
+            SchemaScannerHelper::insert_int64_value(col_idx++, tqs.scan_bytes_from_remote_storage,
+                                                    block);
+        }
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.max_peak_memory_bytes, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.current_used_memory_bytes, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.shuffle_send_bytes, block);
+        SchemaScannerHelper::insert_int64_value(col_idx++, tqs.shuffle_send_rows, block);
 
         std::stringstream ss;
         ss << qs_ctx_ptr->_query_type;
-        SchemaScannerHelper::insert_string_value(11, ss.str(), block);
+        SchemaScannerHelper::insert_string_value(col_idx++, ss.str(), block);
     }
 }
 

--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -34,6 +34,7 @@ class Block;
 class GenericReader : public ProfileCollector {
 public:
     GenericReader() : _push_down_agg_type(TPushAggOp::type::NONE) {}
+
     void set_push_down_agg_type(TPushAggOp::type push_down_agg_type) {
         _push_down_agg_type = push_down_agg_type;
     }

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -690,7 +690,6 @@ public:
     io::FileReaderSPtr& get_inner_reader() { return _inner_reader; }
 
 protected:
-    void _collect_profile_at_runtime() override {};
     void _collect_profile_before_close() override;
 
 private:

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -81,6 +81,8 @@ protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
     void _collect_profile_before_close() override;
 
+    void _update_bytes_and_rows_read() override;
+
 private:
     void _update_realtime_counters();
 

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -1238,4 +1238,19 @@ void VFileScanner::_collect_profile_before_close() {
     }
 }
 
+void VFileScanner::_update_bytes_and_rows_read() {
+    VScanner::_update_bytes_and_rows_read();
+    if (_query_statistics && _io_ctx.get() && _io_ctx->file_cache_stats) {
+        int64_t delta_local =
+                _io_ctx->file_cache_stats->bytes_read_from_local - _bytes_read_from_local;
+        int64_t delta_remote =
+                _io_ctx->file_cache_stats->bytes_read_from_remote - _bytes_read_from_remote;
+        _query_statistics->add_scan_bytes_from_local_storage(delta_local);
+        _query_statistics->add_scan_bytes_from_remote_storage(delta_remote);
+        _query_statistics->add_scan_bytes(delta_local + delta_remote);
+        _bytes_read_from_local = _io_ctx->file_cache_stats->bytes_read_from_local;
+        _bytes_read_from_remote = _io_ctx->file_cache_stats->bytes_read_from_remote;
+    }
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -95,6 +95,8 @@ protected:
     // and the current load is a flexible partial update
     bool _should_process_skip_bitmap_col() const { return _skip_bitmap_col_idx != -1; }
 
+    void _update_bytes_and_rows_read() override;
+
 protected:
     const TFileScanRangeParams* _params = nullptr;
     std::shared_ptr<vectorized::SplitSourceConnector> _split_source;

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -103,8 +103,7 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
         }
     }
 
-    int64_t old_scan_rows = _num_rows_read;
-    int64_t old_scan_bytes = _num_byte_read;
+    _prev_num_rows_read = _num_rows_read;
     {
         do {
             // if step 2 filter all rows of block, and block will be reused to get next rows,
@@ -122,7 +121,6 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
                     break;
                 }
                 _num_rows_read += block->rows();
-                _num_byte_read += block->allocated_bytes();
             }
 
             // 2. Filter the output block finally.
@@ -136,10 +134,7 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
                  _num_rows_read < rows_read_threshold);
     }
 
-    if (_query_statistics) {
-        _query_statistics->add_scan_rows(_num_rows_read - old_scan_rows);
-        _query_statistics->add_scan_bytes(_num_byte_read - old_scan_bytes);
-    }
+    _update_bytes_and_rows_read();
 
     if (state->is_cancelled()) {
         // TODO: Should return the specific ErrorStatus instead of just Cancelled.
@@ -263,6 +258,13 @@ void VScanner::update_scan_cpu_timer() {
     _query_statistics->add_cpu_nanos(cpu_time);
     if (_state && _state->get_query_ctx()) {
         _state->get_query_ctx()->update_wg_cpu_adder(cpu_time);
+    }
+}
+
+void VScanner::_update_bytes_and_rows_read() {
+    if (_query_statistics) {
+        _query_statistics->add_scan_rows(_num_rows_read - _prev_num_rows_read);
+        _prev_num_rows_read = _num_rows_read;
     }
 }
 

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -164,6 +164,10 @@ protected:
         _conjuncts.clear();
     }
 
+    // update the bytes and rows read at each round in query statistics.
+    // so that we can get runtime statistics for each query.
+    virtual void _update_bytes_and_rows_read();
+
     RuntimeState* _state = nullptr;
     pipeline::ScanLocalStateBase* _local_state = nullptr;
     QueryStatistics* _query_statistics = nullptr;
@@ -205,8 +209,12 @@ protected:
 
     // num of rows read from scanner
     int64_t _num_rows_read = 0;
-
-    int64_t _num_byte_read = 0;
+    // save the current _num_rows_read before next round,
+    // so that we can get delta rows between each round.
+    int64_t _prev_num_rows_read = 0;
+    // bytes read from local and remote fs
+    int64_t _bytes_read_from_local = 0;
+    int64_t _bytes_read_from_remote = 0;
 
     // num of rows return from scanner, after filter block
     int64_t _num_rows_return = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -137,14 +137,6 @@ public class InternalSchema {
         AUDIT_SCHEMA
                 .add(new ColumnDef("scan_bytes", TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA.add(new ColumnDef("scan_rows", TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
-        AUDIT_SCHEMA.add(new ColumnDef("local_scan_bytes",
-                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
-        AUDIT_SCHEMA.add(new ColumnDef("remote_scan_bytes",
-                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
-        AUDIT_SCHEMA.add(new ColumnDef("shuffle_bytes",
-                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
-        AUDIT_SCHEMA.add(new ColumnDef("shuffle_rows",
-                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA
                 .add(new ColumnDef("return_rows", TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -137,6 +137,14 @@ public class InternalSchema {
         AUDIT_SCHEMA
                 .add(new ColumnDef("scan_bytes", TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA.add(new ColumnDef("scan_rows", TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+        AUDIT_SCHEMA.add(new ColumnDef("local_scan_bytes",
+                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+        AUDIT_SCHEMA.add(new ColumnDef("remote_scan_bytes",
+                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+        AUDIT_SCHEMA.add(new ColumnDef("shuffle_bytes",
+                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
+        AUDIT_SCHEMA.add(new ColumnDef("shuffle_rows",
+                TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA
                 .add(new ColumnDef("return_rows", TypeDef.create(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -456,6 +456,8 @@ public class SchemaTable extends Table {
                                     .column("TASK_CPU_TIME_MS", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("SCAN_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("SCAN_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("LOCAL_SCAN_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("REMOTE_SCAN_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("BE_PEAK_MEMORY_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("CURRENT_USED_MEMORY_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("SHUFFLE_SEND_BYTES", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
@@ -151,10 +151,6 @@ public class AuditLoader extends Plugin implements AuditPlugin {
         logBuffer.append(event.queryTime).append("\t");
         logBuffer.append(event.scanBytes).append("\t");
         logBuffer.append(event.scanRows).append("\t");
-        logBuffer.append(event.scanBytesFromLocalStorage).append("\t");
-        logBuffer.append(event.scanBytesFromRemoteStorage).append("\t");
-        logBuffer.append(event.shuffleSendBytes).append("\t");
-        logBuffer.append(event.shuffleSendRows).append("\t");
         logBuffer.append(event.returnRows).append("\t");
         logBuffer.append(event.shuffleSendRows).append("\t");
         logBuffer.append(event.shuffleSendBytes).append("\t");

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
@@ -151,6 +151,10 @@ public class AuditLoader extends Plugin implements AuditPlugin {
         logBuffer.append(event.queryTime).append("\t");
         logBuffer.append(event.scanBytes).append("\t");
         logBuffer.append(event.scanRows).append("\t");
+        logBuffer.append(event.scanBytesFromLocalStorage).append("\t");
+        logBuffer.append(event.scanBytesFromRemoteStorage).append("\t");
+        logBuffer.append(event.shuffleSendBytes).append("\t");
+        logBuffer.append(event.shuffleSendRows).append("\t");
         logBuffer.append(event.returnRows).append("\t");
         logBuffer.append(event.shuffleSendRows).append("\t");
         logBuffer.append(event.shuffleSendBytes).append("\t");

--- a/regression-test/suites/query_p0/schema_table/test_backend_active_tasks.groovy
+++ b/regression-test/suites/query_p0/schema_table/test_backend_active_tasks.groovy
@@ -22,19 +22,19 @@ suite("test_backend_active_tasks") {
             sql "set experimental_enable_pipeline_engine=false"
             sql "set experimental_enable_pipeline_x_engine=false"
             sql "select * from information_schema.backend_active_tasks"
-            sql "select BE_ID,FE_HOST,QUERY_ID,SCAN_ROWS from information_schema.backend_active_tasks"
+            sql "select BE_ID,FE_HOST,QUERY_ID,SCAN_ROWS,LOCAL_SCAN_BYTES,REMOTE_SCAN_BYTES from information_schema.backend_active_tasks"
 
             // pipeline
             sql "set experimental_enable_pipeline_engine=true"
             sql "set experimental_enable_pipeline_x_engine=false"
             sql "select * from information_schema.backend_active_tasks"
-            sql "select BE_ID,FE_HOST,QUERY_ID,SCAN_ROWS from information_schema.backend_active_tasks"
+            sql "select BE_ID,FE_HOST,QUERY_ID,SCAN_ROWS,LOCAL_SCAN_BYTES,REMOTE_SCAN_BYTES from information_schema.backend_active_tasks"
 
             // pipelinex
             sql "set experimental_enable_pipeline_engine=true"
             sql "set experimental_enable_pipeline_x_engine=true"
             sql "select * from information_schema.backend_active_tasks"
-            sql "select BE_ID,FE_HOST,QUERY_ID,SCAN_ROWS from information_schema.backend_active_tasks"
+            sql "select BE_ID,FE_HOST,QUERY_ID,SCAN_ROWS,LOCAL_SCAN_BYTES,REMOTE_SCAN_BYTES from information_schema.backend_active_tasks"
             Thread.sleep(1000)
         }
     })


### PR DESCRIPTION
Previously, only olap table's query has local and remote bytes read statistics.
This PR add these stats for all scanners.

1. Use `CachedRemoteFileReader` no matter `enable_file_cache` is true or false

	Previously, if `enable_file_cache` is true, we use `CachedRemoteFileReader`.
	Otherwise, we use raw file reader to read data.
	
	In order to unify the query stats, in this PR, I use `CachedRemoteFileReader`
	no matter `enable_file_cache` is true or false.
	
	When reading data, if cache is disable, `CachedRemoteFileReader` will use
	the raw file reader in it directly.
	
2. Add `_update_bytes_and_rows_read()` interface in `VScanner`

	This method will be called after each `get_block()` method.
	It will update the scan bytes and rows in query statistics.
	So that we can get real time statistics when querying system table `backend_active_tasks`
	
3. Add `REMOTE_SCAN_BYTES` and `LOCAL_SCAN_BYTES` columns in `backend_active_tasks`

	`REMOTE_SCAN_BYTES` is bytes read from remote fs.
	`LOCAL_SCAN_BYTES` is bytes read from local disks.
	
	And `SCAN_BYTES` is now the sum of  `REMOTE_SCAN_BYTES` and `LOCAL_SCAN_BYTES`

4. Add new columns for audit log table

	- `local_scan_bytes`
	- `remote_scan_bytes`
	- `shuffle_bytes`
	- `shuffle_rows`
	- `cloud_cluster_name`