### PR TITLE
[optimize](short circuit) avoid set cacheId when non prepared execute

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
@@ -267,7 +267,10 @@ public class PointQueryExecutor implements CoordInterface {
             if (snapshotVisibleVersions != null && !snapshotVisibleVersions.isEmpty()) {
                 requestBuilder.setVersion(snapshotVisibleVersions.get(0));
             }
-            if (shortCircuitQueryContext.cacheID != null) {
+            // Only set cacheID for prepared statement excute phase,
+            // otherwise leading to many redundant cost in BE side
+            if (shortCircuitQueryContext.cacheID != null
+                        && ConnectContext.get().command == MysqlCommand.COM_STMT_EXECUTE) {
                 InternalService.UUID.Builder uuidBuilder = InternalService.UUID.newBuilder();
                 uuidBuilder.setUuidHigh(shortCircuitQueryContext.cacheID.getMostSignificantBits());
                 uuidBuilder.setUuidLow(shortCircuitQueryContext.cacheID.getLeastSignificantBits());


### PR DESCRIPTION
Only set cacheID for prepared statement excute phase, otherwise leading to many redundant cost in BE side

