### PR TITLE
[Improvement](sort) do not sort partitial when spill disabled

### DIFF
--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -177,8 +177,8 @@ public:
 
 private:
     bool _reach_limit() {
-        return _state->unsorted_block_->rows() > buffered_block_size_ ||
-               _state->unsorted_block_->bytes() > buffered_block_bytes_;
+        return _enable_spill && (_state->unsorted_block_->rows() > buffered_block_size_ ||
+                                 _state->unsorted_block_->bytes() > buffered_block_bytes_);
     }
 
     Status _do_sort();


### PR DESCRIPTION
## Proposed changes
do not sort partitial when spill disabled
SELECT count() from (select BrowserLanguage from hits_10m order by BrowserLanguage limit 10000000)t;
2s -> 0.3s