### PR TITLE
[Fix]only publish topic to alive be

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/publish/TopicPublisherThread.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/publish/TopicPublisherThread.java
@@ -85,10 +85,13 @@ public class TopicPublisherThread extends MasterDaemon {
         }
         AckResponseHandler handler = new AckResponseHandler(nodesToPublish);
         for (Backend be : nodesToPublish) {
-            executor.submit(new TopicPublishWorker(request, be, handler));
+            if (be.isAlive()) {
+                executor.submit(new TopicPublishWorker(request, be, handler));
+            }
         }
         try {
             int timeoutMs = Config.publish_topic_info_interval_ms / 3 * 2;
+            timeoutMs = timeoutMs <= 0 ? 3000 : timeoutMs;
             if (!handler.awaitAllInMs(timeoutMs)) {
                 Backend[] backends = handler.pendingNodes();
                 if (backends.length > 0) {


### PR DESCRIPTION
## Proposed changes
Fix strange core stack when BE not start correctly, and FE send publish topic request.

before
```
BRPC service did not start correctly, exiting
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1725862245 (unix time) try "date -d @1725862245" if you are using GNU date ***
*** Current BE git commitID: 903c05b3af ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 2983204 (TID 2983204 OR 0x7f70dd18ca80) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/wangbo/git/doris/be/src/common/signal_handler.h:421
 1# 0x00007F70DB554B50 in /lib64/libc.so.6
 2# __GI___pthread_mutex_lock in /lib64/libpthread.so.0
 3# rocksdb::ThreadPoolImpl::Impl::UnSchedule(void*) in /mnt/disk2/wangbo/runtime/tmp/be/lib/doris_be
 4# rocksdb::DBImpl::CloseHelper() in /mnt/disk2/wangbo/runtime/tmp/be/lib/doris_be
 5# rocksdb::DBImpl::Close() in /mnt/disk2/wangbo/runtime/tmp/be/lib/doris_be
 6# std::_Function_handler<void (rocksdb::DB*), doris::OlapMeta::init()::$_0>::_M_invoke(std::_Any_data const&, rocksdb::DB*&&) at /mnt/disk2/wangbo/tools/ldb/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 7# doris::OlapMeta::~OlapMeta() at /mnt/disk2/wangbo/git/doris/be/src/olap/olap_meta.cpp:66
 8# doris::DataDir::~DataDir() at /mnt/disk2/wangbo/git/doris/be/src/olap/data_dir.cpp:142
 9# std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<doris::DataDir, std::default_delete<doris::DataDir> > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<doris::DataDir, std::default_delete<doris::DataDir> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<doris::DataDir, std::default_delete<doris::DataDir> > > > >::_M_erase(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<doris::DataDir, std::default_delete<doris::DataDir> > > >*) at /mnt/disk2/wangbo/tools/ldb/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1889
10# doris::StorageEngine::~StorageEngine() at /mnt/disk2/wangbo/git/doris/be/src/olap/storage_engine.cpp:224
11# doris::StorageEngine::~StorageEngine() at /mnt/disk2/wangbo/git/doris/be/src/olap/storage_engine.cpp:222
12# doris::ExecEnv::destroy() at /mnt/disk2/wangbo/git/doris/be/src/runtime/exec_env_init.cpp:669
13# doris::ExecEnv::~ExecEnv() at /mnt/disk2/wangbo/git/doris/be/src/runtime/exec_env.cpp:45
14# __run_exit_handlers in /lib64/libc.so.6
15# on_exit in /lib64/libc.so.6
16# 0x000055A48A9DC9CA at /mnt/disk2/wangbo/git/doris/be/src/service/doris_main.cpp:548
17# main at /mnt/disk2/wangbo/git/doris/be/src/service/doris_main.cpp:576
18# __libc_start_main in /lib64/libc.so.6
19# _start in /mnt/disk2/wangbo/runtime/tmp/be/lib/doris_be
```

after:
```
start BE in local mode
BRPC service did not start correctly, exiting
```