### PR TITLE
[opt](spill) avoid query blocked when reserving failed

### DIFF
--- a/be/src/pipeline/common/agg_utils.h
+++ b/be/src/pipeline/common/agg_utils.h
@@ -275,15 +275,17 @@ public:
         using IteratorBase<ConstIterator, true>::IteratorBase;
     };
 
-    ConstIterator begin() const { return ConstIterator(this, 0); }
+    ConstIterator begin() const { return {this, 0}; }
 
     ConstIterator cbegin() const { return begin(); }
 
-    Iterator begin() { return Iterator(this, 0); }
+    Iterator begin() { return {this, 0}; }
 
-    ConstIterator end() const { return ConstIterator(this, _total_count); }
+    ConstIterator end() const { return {this, _total_count}; }
     ConstIterator cend() const { return end(); }
-    Iterator end() { return Iterator(this, _total_count); }
+    Iterator end() { return {this, _total_count}; }
+
+    [[nodiscard]] uint32_t total_count() const { return _total_count; }
 
     void init_once() {
         if (_inited) {

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -177,8 +177,8 @@ struct ExchangeRpcContext {
 // Each ExchangeSinkOperator have one ExchangeSinkBuffer
 class ExchangeSinkBuffer final : public HasTaskExecutionCtx {
 public:
-    ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_id, int send_id, int be_number,
-                       RuntimeState* state, ExchangeSinkLocalState* parent);
+    ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_id, int send_id, PlanNodeId node_id,
+                       int be_number, RuntimeState* state, ExchangeSinkLocalState* parent);
     ~ExchangeSinkBuffer() override = default;
     void register_sink(TUniqueId);
 
@@ -235,6 +235,7 @@ private:
     PlanNodeId _dest_node_id;
     // Sender instance id, unique within a fragment. StreamSender save the variable
     int _sender_id;
+    PlanNodeId _node_id;
     int _be_number;
     std::atomic<int64_t> _rpc_count = 0;
     RuntimeState* _state = nullptr;

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -131,8 +131,8 @@ Status ExchangeSinkLocalState::open(RuntimeState* state) {
     PUniqueId id;
     id.set_hi(_state->query_id().hi);
     id.set_lo(_state->query_id().lo);
-    _sink_buffer = std::make_unique<ExchangeSinkBuffer>(id, p._dest_node_id, _sender_id,
-                                                        _state->be_number(), state, this);
+    _sink_buffer = std::make_unique<ExchangeSinkBuffer>(
+            id, p._dest_node_id, _sender_id, _parent->node_id(), _state->be_number(), state, this);
 
     register_channels(_sink_buffer.get());
     _queue_dependency = Dependency::create_shared(_parent->operator_id(), _parent->node_id(),

--- a/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp
@@ -245,6 +245,7 @@ size_t PartitionedAggSinkOperatorX::get_reserve_mem_size(RuntimeState* state) {
 }
 
 Status PartitionedAggSinkLocalState::revoke_memory(RuntimeState* state) {
+    const auto size_to_revoke = _parent->revocable_mem_size(state);
     VLOG_DEBUG << "query " << print_id(state->query_id()) << " agg node "
                << Base::_parent->node_id()
                << " revoke_memory, size: " << _parent->revocable_mem_size(state)
@@ -282,7 +283,7 @@ Status PartitionedAggSinkLocalState::revoke_memory(RuntimeState* state) {
     state->get_query_ctx()->increase_revoking_tasks_count();
     auto spill_runnable = std::make_shared<SpillRunnable>(
             state, _shared_state->shared_from_this(),
-            [this, &parent, state, query_id, submit_timer] {
+            [this, &parent, state, query_id, size_to_revoke, submit_timer] {
                 DBUG_EXECUTE_IF("fault_inject::partitioned_agg_sink::revoke_memory_cancel", {
                     auto st = Status::InternalError(
                             "fault_inject partitioned_agg_sink "
@@ -316,17 +317,17 @@ Status PartitionedAggSinkLocalState::revoke_memory(RuntimeState* state) {
                 }};
                 auto* runtime_state = _runtime_state.get();
                 auto* agg_data = parent._agg_sink_operator->get_agg_data(runtime_state);
-                Base::_shared_state->sink_status =
-                        std::visit(vectorized::Overload {
-                                           [&](std::monostate& arg) -> Status {
-                                               return Status::InternalError("Unit hash table");
-                                           },
-                                           [&](auto& agg_method) -> Status {
-                                               auto& hash_table = *agg_method.hash_table;
-                                               RETURN_IF_CATCH_EXCEPTION(return _spill_hash_table(
-                                                       state, agg_method, hash_table, _eos));
-                                           }},
-                                   agg_data->method_variant);
+                Base::_shared_state->sink_status = std::visit(
+                        vectorized::Overload {
+                                [&](std::monostate& arg) -> Status {
+                                    return Status::InternalError("Unit hash table");
+                                },
+                                [&](auto& agg_method) -> Status {
+                                    auto& hash_table = *agg_method.hash_table;
+                                    RETURN_IF_CATCH_EXCEPTION(return _spill_hash_table(
+                                            state, agg_method, hash_table, size_to_revoke, _eos));
+                                }},
+                        agg_data->method_variant);
                 RETURN_IF_ERROR(Base::_shared_state->sink_status);
                 Base::_shared_state->sink_status =
                         parent._agg_sink_operator->reset_hash_table(runtime_state);

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -107,7 +107,12 @@ Status Channel<Parent>::open(RuntimeState* state) {
     _brpc_request->set_sender_id(_parent->sender_id());
     _brpc_request->set_be_number(_be_number);
 
-    _brpc_timeout_ms = std::min(3600, state->execution_timeout()) * 1000;
+    const auto& query_options = state->query_options();
+    if (query_options.__isset.query_timeout) {
+        _brpc_timeout_ms = query_options.query_timeout * 1000;
+    } else {
+        _brpc_timeout_ms = std::min(3600, state->execution_timeout()) * 1000;
+    }
 
     _serializer.set_is_local(_is_local);
 


### PR DESCRIPTION
1. Trigger revoking proactively when revocable size is big and reserving failed.
2. Set the brpc timeout as the query timeout.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

