### PR TITLE
[opt](memory) Refactor memory maintenance thread (retry)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -95,6 +95,9 @@ DEFINE_String(mem_limit, "90%");
 // Soft memory limit as a fraction of hard memory limit.
 DEFINE_Double(soft_mem_limit_frac, "0.9");
 
+// Cache capacity reduce mem limit as a fraction of soft mem limit.
+DEFINE_mDouble(cache_capacity_reduce_mem_limit_frac, "0.6");
+
 // Schema change memory limit as a fraction of soft memory limit.
 DEFINE_Double(schema_change_mem_limit_frac, "0.6");
 
@@ -286,7 +289,7 @@ DEFINE_mInt32(exchg_buffer_queue_capacity_factor, "64");
 DEFINE_mInt64(memory_limitation_per_thread_for_schema_change_bytes, "2147483648");
 
 DEFINE_mInt32(cache_prune_interval_sec, "10");
-DEFINE_mInt32(cache_periodic_prune_stale_sweep_sec, "300");
+DEFINE_mInt32(cache_periodic_prune_stale_sweep_sec, "60");
 // the clean interval of tablet lookup cache
 DEFINE_mInt32(tablet_lookup_cache_stale_sweep_time_sec, "30");
 DEFINE_mInt32(point_query_row_cache_stale_sweep_time_sec, "300");
@@ -565,7 +568,7 @@ DEFINE_String(pprof_profile_dir, "${DORIS_HOME}/log");
 // for jeprofile in jemalloc
 DEFINE_mString(jeprofile_dir, "${DORIS_HOME}/log");
 DEFINE_mBool(enable_je_purge_dirty_pages, "true");
-DEFINE_mString(je_dirty_pages_mem_limit_percent, "5%");
+DEFINE_mString(je_dirty_pages_mem_limit_percent, "2%");
 
 // to forward compatibility, will be removed later
 DEFINE_mBool(enable_token_check, "true");
@@ -582,16 +585,11 @@ DEFINE_Int32(num_cores, "0");
 DEFINE_Bool(ignore_broken_disk, "false");
 
 // Sleep time in milliseconds between memory maintenance iterations
-DEFINE_mInt32(memory_maintenance_sleep_time_ms, "100");
+DEFINE_mInt32(memory_maintenance_sleep_time_ms, "20");
 
 // After full gc, no longer full gc and minor gc during sleep.
 // After minor gc, no minor gc during sleep, but full gc is possible.
 DEFINE_mInt32(memory_gc_sleep_time_ms, "500");
-
-// Sleep time in milliseconds between memtbale flush mgr refresh iterations
-DEFINE_mInt64(memtable_mem_tracker_refresh_interval_ms, "5");
-
-DEFINE_mInt64(wg_weighted_memory_ratio_refresh_interval_ms, "50");
 
 // percent of (active memtables size / all memtables size) when reach hard limit
 DEFINE_mInt32(memtable_hard_limit_active_percent, "50");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -133,6 +133,9 @@ DECLARE_String(mem_limit);
 // Soft memory limit as a fraction of hard memory limit.
 DECLARE_Double(soft_mem_limit_frac);
 
+// Cache capacity reduce mem limit as a fraction of soft mem limit.
+DECLARE_mDouble(cache_capacity_reduce_mem_limit_frac);
+
 // Schema change memory limit as a fraction of soft memory limit.
 DECLARE_Double(schema_change_mem_limit_frac);
 
@@ -640,12 +643,6 @@ DECLARE_mInt32(memory_maintenance_sleep_time_ms);
 // After full gc, no longer full gc and minor gc during sleep.
 // After minor gc, no minor gc during sleep, but full gc is possible.
 DECLARE_mInt32(memory_gc_sleep_time_ms);
-
-// Sleep time in milliseconds between memtbale flush mgr memory refresh iterations
-DECLARE_mInt64(memtable_mem_tracker_refresh_interval_ms);
-
-// Sleep time in milliseconds between refresh iterations of workload group weighted memory ratio
-DECLARE_mInt64(wg_weighted_memory_ratio_refresh_interval_ms);
 
 // percent of (active memtables size / all memtables size) when reach hard limit
 DECLARE_mInt32(memtable_hard_limit_active_percent);

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -73,6 +73,12 @@
 namespace doris {
 namespace {
 
+int64_t last_print_proc_mem = 0;
+int32_t refresh_cache_capacity_sleep_time_ms = 0;
+#ifdef USE_JEMALLOC
+int32_t je_purge_dirty_pages_sleep_time_ms = 0;
+#endif
+
 void update_rowsets_and_segments_num_metrics() {
     if (config::is_cloud_mode()) {
         // TODO(plat1ko): CloudStorageEngine
@@ -204,42 +210,104 @@ void Daemon::tcmalloc_gc_thread() {
 #endif
 }
 
-void Daemon::memory_maintenance_thread() {
-    int32_t interval_milliseconds = config::memory_maintenance_sleep_time_ms;
-    int64_t last_print_proc_mem = PerfCounters::get_vm_rss();
-    while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(interval_milliseconds))) {
-        // Refresh process memory metrics.
-        doris::PerfCounters::refresh_proc_status();
-        doris::MemInfo::refresh_proc_meminfo();
-        doris::GlobalMemoryArbitrator::reset_refresh_interval_memory_growth();
-        ExecEnv::GetInstance()->brpc_iobuf_block_memory_tracker()->set_consumption(
-                butil::IOBuf::block_memory());
-        // Refresh allocator memory metrics.
-#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
-        doris::MemInfo::refresh_allocator_mem();
-#ifdef USE_JEMALLOC
-        if (doris::MemInfo::je_dirty_pages_mem() > doris::MemInfo::je_dirty_pages_mem_limit() &&
-            GlobalMemoryArbitrator::is_exceed_soft_mem_limit()) {
-            doris::MemInfo::notify_je_purge_dirty_pages();
-        }
-#endif
-        if (config::enable_system_metrics) {
-            DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
-        }
-#endif
-        MemInfo::refresh_memory_bvar();
+void refresh_process_memory_metrics() {
+    doris::PerfCounters::refresh_proc_status();
+    doris::MemInfo::refresh_proc_meminfo();
+    doris::GlobalMemoryArbitrator::reset_refresh_interval_memory_growth();
+    ExecEnv::GetInstance()->brpc_iobuf_block_memory_tracker()->set_consumption(
+            butil::IOBuf::block_memory());
+}
 
-        // Update and print memory stat when the memory changes by 256M.
-        if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {
-            last_print_proc_mem = PerfCounters::get_vm_rss();
-            doris::MemTrackerLimiter::clean_tracker_limiter_group();
-            doris::MemTrackerLimiter::enable_print_log_process_usage();
-            // Refresh mem tracker each type counter.
-            doris::MemTrackerLimiter::refresh_global_counter();
-            LOG(INFO) << doris::GlobalMemoryArbitrator::
-                            process_mem_log_str(); // print mem log when memory state by 256M
+void refresh_common_allocator_metrics() {
+#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
+    doris::MemInfo::refresh_allocator_mem();
+    if (config::enable_system_metrics) {
+        DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
+    }
+#endif
+    MemInfo::refresh_memory_bvar();
+}
+
+void refresh_memory_state_after_memory_change() {
+    if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {
+        last_print_proc_mem = PerfCounters::get_vm_rss();
+        doris::MemTrackerLimiter::clean_tracker_limiter_group();
+        doris::MemTrackerLimiter::enable_print_log_process_usage();
+        // Refresh mem tracker each type counter.
+        doris::MemTrackerLimiter::refresh_global_counter();
+        LOG(INFO) << doris::GlobalMemoryArbitrator::
+                        process_mem_log_str(); // print mem log when memory state by 256M
+    }
+}
+
+void refresh_cache_capacity() {
+    if (refresh_cache_capacity_sleep_time_ms <= 0) {
+        auto cache_capacity_reduce_mem_limit = uint64_t(
+                doris::MemInfo::soft_mem_limit() * config::cache_capacity_reduce_mem_limit_frac);
+        int64_t process_memory_usage = doris::GlobalMemoryArbitrator::process_memory_usage();
+        double new_cache_capacity_adjust_weighted =
+                process_memory_usage <= cache_capacity_reduce_mem_limit
+                        ? 1
+                        : std::min<double>(
+                                  1 - (process_memory_usage - cache_capacity_reduce_mem_limit) /
+                                                  (doris::MemInfo::soft_mem_limit() -
+                                                   cache_capacity_reduce_mem_limit),
+                                  0);
+        if (new_cache_capacity_adjust_weighted !=
+            doris::GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted) {
+            doris::GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted =
+                    new_cache_capacity_adjust_weighted;
+            doris::GlobalMemoryArbitrator::notify_cache_adjust_capacity();
+            refresh_cache_capacity_sleep_time_ms = config::memory_gc_sleep_time_ms;
         }
+    }
+    refresh_cache_capacity_sleep_time_ms -= config::memory_maintenance_sleep_time_ms;
+}
+
+void je_purge_dirty_pages() {
+#ifdef USE_JEMALLOC
+    if (je_purge_dirty_pages_sleep_time_ms <= 0 &&
+        doris::MemInfo::je_dirty_pages_mem() > doris::MemInfo::je_dirty_pages_mem_limit() &&
+        GlobalMemoryArbitrator::is_exceed_soft_mem_limit()) {
+        doris::MemInfo::notify_je_purge_dirty_pages();
+        je_purge_dirty_pages_sleep_time_ms = config::memory_gc_sleep_time_ms;
+    }
+    je_purge_dirty_pages_sleep_time_ms -= config::memory_maintenance_sleep_time_ms;
+#endif
+}
+
+void Daemon::memory_maintenance_thread() {
+    while (!_stop_background_threads_latch.wait_for(
+            std::chrono::milliseconds(config::memory_maintenance_sleep_time_ms))) {
+        // step 1. Refresh process memory metrics.
+        refresh_process_memory_metrics();
+
+        // step 2. Refresh jemalloc/tcmalloc metrics.
+        refresh_common_allocator_metrics();
+
+        // step 3. Update and print memory stat when the memory changes by 256M.
+        refresh_memory_state_after_memory_change();
+
+        // step 4. Asyn Refresh cache capacity
+        // TODO adjust cache capacity based on smoothstep (smooth gradient).
+        refresh_cache_capacity();
+
+        // step 5. Cancel top memory task when process memory exceed hard limit.
+        // TODO replace memory_gc_thread.
+
+        // step 6. Refresh weighted memory ratio of workload groups.
+        doris::ExecEnv::GetInstance()->workload_group_mgr()->refresh_wg_weighted_memory_limit();
+
+        // step 7. Analyze blocking queries.
+        // TODO sort the operators that can spill, wake up the pipeline task spill
+        // or continue execution according to certain rules or cancel query.
+
+        // step 8. Flush memtable
+        doris::GlobalMemoryArbitrator::notify_memtable_memory_refresh();
+        // TODO notify flush memtable
+
+        // step 9. Jemalloc purge all arena dirty pages
+        je_purge_dirty_pages();
     }
 }
 
@@ -301,10 +369,21 @@ void Daemon::memory_gc_thread() {
 void Daemon::memtable_memory_refresh_thread() {
     // Refresh the memory statistics of the load channel tracker more frequently,
     // which helps to accurately control the memory of LoadChannelMgr.
-    while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(config::memtable_mem_tracker_refresh_interval_ms))) {
+    do {
+        std::unique_lock<std::mutex> l(doris::GlobalMemoryArbitrator::memtable_memory_refresh_lock);
+        while (_stop_background_threads_latch.count() != 0 &&
+               !doris::GlobalMemoryArbitrator::memtable_memory_refresh_notify.load(
+                       std::memory_order_relaxed)) {
+            doris::GlobalMemoryArbitrator::memtable_memory_refresh_cv.wait_for(
+                    l, std::chrono::seconds(1));
+        }
+        if (_stop_background_threads_latch.count() == 0) {
+            break;
+        }
         doris::ExecEnv::GetInstance()->memtable_memory_limiter()->refresh_mem_tracker();
-    }
+        doris::GlobalMemoryArbitrator::memtable_memory_refresh_notify.store(
+                false, std::memory_order_relaxed);
+    } while (true);
 }
 
 /*
@@ -396,6 +475,35 @@ void Daemon::je_purge_dirty_pages_thread() const {
     } while (true);
 }
 
+void Daemon::cache_adjust_capacity_thread() {
+    do {
+        std::unique_lock<std::mutex> l(doris::GlobalMemoryArbitrator::cache_adjust_capacity_lock);
+        while (_stop_background_threads_latch.count() != 0 &&
+               !doris::GlobalMemoryArbitrator::cache_adjust_capacity_notify.load(
+                       std::memory_order_relaxed)) {
+            doris::GlobalMemoryArbitrator::cache_adjust_capacity_cv.wait_for(
+                    l, std::chrono::seconds(1));
+        }
+        double adjust_weighted = GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted;
+        if (_stop_background_threads_latch.count() == 0) {
+            break;
+        }
+        if (config::disable_memory_gc) {
+            continue;
+        }
+        std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("");
+        auto freed_mem = CacheManager::instance()->for_each_cache_refresh_capacity(adjust_weighted,
+                                                                                   profile.get());
+        std::stringstream ss;
+        profile->pretty_print(&ss);
+        LOG(INFO) << fmt::format(
+                "[MemoryGC] refresh cache capacity end, free memory {}, details: {}",
+                PrettyPrinter::print(freed_mem, TUnit::BYTES), ss.str());
+        doris::GlobalMemoryArbitrator::cache_adjust_capacity_notify.store(
+                false, std::memory_order_relaxed);
+    } while (true);
+}
+
 void Daemon::cache_prune_stale_thread() {
     int32_t interval = config::cache_periodic_prune_stale_sweep_sec;
     while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval))) {
@@ -408,14 +516,6 @@ void Daemon::cache_prune_stale_thread() {
             continue;
         }
         CacheManager::instance()->for_each_cache_prune_stale();
-    }
-}
-
-void Daemon::wg_weighted_memory_ratio_refresh_thread() {
-    // Refresh weighted memory ratio of workload groups
-    while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(config::wg_weighted_memory_ratio_refresh_interval_ms))) {
-        doris::ExecEnv::GetInstance()->workload_group_mgr()->refresh_wg_weighted_memory_limit();
     }
 }
 
@@ -456,6 +556,10 @@ void Daemon::start() {
             [this]() { this->je_purge_dirty_pages_thread(); }, &_threads.emplace_back());
     CHECK(st.ok()) << st;
     st = Thread::create(
+            "Daemon", "cache_adjust_capacity_thread",
+            [this]() { this->cache_adjust_capacity_thread(); }, &_threads.emplace_back());
+    CHECK(st.ok()) << st;
+    st = Thread::create(
             "Daemon", "cache_prune_stale_thread", [this]() { this->cache_prune_stale_thread(); },
             &_threads.emplace_back());
     CHECK(st.ok()) << st;
@@ -463,11 +567,6 @@ void Daemon::start() {
             "Daemon", "query_runtime_statistics_thread",
             [this]() { this->report_runtime_query_statistics_thread(); }, &_threads.emplace_back());
     CHECK(st.ok()) << st;
-
-    st = Thread::create(
-            "Daemon", "wg_weighted_memory_ratio_refresh_thread",
-            [this]() { this->wg_weighted_memory_ratio_refresh_thread(); },
-            &_threads.emplace_back());
 
     if (config::enable_be_proc_monitor) {
         st = Thread::create(

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -43,9 +43,9 @@ private:
     void memtable_memory_refresh_thread();
     void calculate_metrics_thread();
     void je_purge_dirty_pages_thread() const;
+    void cache_adjust_capacity_thread();
     void cache_prune_stale_thread();
     void report_runtime_query_statistics_thread();
-    void wg_weighted_memory_ratio_refresh_thread();
     void be_proc_monitor_thread();
 
     CountDownLatch _stop_background_threads_latch;

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -81,6 +81,9 @@ public:
         return false;
     }
 
+    int64_t for_each_cache_refresh_capacity(double adjust_weighted,
+                                            RuntimeProfile* profile = nullptr);
+
 private:
     std::mutex _caches_lock;
     std::unordered_map<CachePolicy::CacheType, CachePolicy*> _caches;

--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -21,8 +21,12 @@
 
 namespace doris {
 
-CachePolicy::CachePolicy(CacheType type, uint32_t stale_sweep_time_s, bool enable_prune)
-        : _type(type), _stale_sweep_time_s(stale_sweep_time_s), _enable_prune(enable_prune) {
+CachePolicy::CachePolicy(CacheType type, size_t capacity, uint32_t stale_sweep_time_s,
+                         bool enable_prune)
+        : _type(type),
+          _initial_capacity(capacity),
+          _stale_sweep_time_s(stale_sweep_time_s),
+          _enable_prune(enable_prune) {
     CacheManager::instance()->register_cache(this);
     init_profile();
 }

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include "runtime/exec_env.h"
 #include "util/runtime_profile.h"
 
 namespace doris {
 
-static constexpr int32_t CACHE_MIN_FREE_SIZE = 67108864; // 64M
-static constexpr int32_t CACHE_MIN_FREE_NUMBER = 1024;
+static constexpr int32_t CACHE_MIN_PRUNE_SIZE = 67108864; // 64M
+static constexpr int32_t CACHE_MIN_PRUNE_NUMBER = 1024;
 
 // Base of all caches. register to CacheManager when cache is constructed.
 class CachePolicy {
@@ -42,12 +41,13 @@ public:
         TABLET_VERSION_CACHE = 10,
         LAST_SUCCESS_CHANNEL_CACHE = 11,
         COMMON_OBJ_LRU_CACHE = 12,
-        FOR_UT = 13,
+        FOR_UT_CACHE_SIZE = 13,
         TABLET_SCHEMA_CACHE = 14,
         CREATE_TABLET_RR_IDX_CACHE = 15,
         CLOUD_TABLET_CACHE = 16,
         CLOUD_TXN_DELETE_BITMAP_CACHE = 17,
         NONE = 18, // not be used
+        FOR_UT_CACHE_NUMBER = 19,
     };
 
     static std::string type_string(CacheType type) {
@@ -78,8 +78,8 @@ public:
             return "LastSuccessChannelCache";
         case CacheType::COMMON_OBJ_LRU_CACHE:
             return "CommonObjLRUCache";
-        case CacheType::FOR_UT:
-            return "ForUT";
+        case CacheType::FOR_UT_CACHE_SIZE:
+            return "ForUTCacheSize";
         case CacheType::TABLET_SCHEMA_CACHE:
             return "TabletSchemaCache";
         case CacheType::CREATE_TABLET_RR_IDX_CACHE:
@@ -88,6 +88,8 @@ public:
             return "CloudTabletCache";
         case CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE:
             return "CloudTxnDeleteBitmapCache";
+        case CacheType::FOR_UT_CACHE_NUMBER:
+            return "ForUTCacheNumber";
         default:
             LOG(FATAL) << "not match type of cache policy :" << static_cast<int>(type);
         }
@@ -109,11 +111,12 @@ public:
             {"MowTabletVersionCache", CacheType::TABLET_VERSION_CACHE},
             {"LastSuccessChannelCache", CacheType::LAST_SUCCESS_CHANNEL_CACHE},
             {"CommonObjLRUCache", CacheType::COMMON_OBJ_LRU_CACHE},
-            {"ForUT", CacheType::FOR_UT},
+            {"ForUTCacheSize", CacheType::FOR_UT_CACHE_SIZE},
             {"TabletSchemaCache", CacheType::TABLET_SCHEMA_CACHE},
             {"CreateTabletRRIdxCache", CacheType::CREATE_TABLET_RR_IDX_CACHE},
             {"CloudTabletCache", CacheType::CLOUD_TABLET_CACHE},
-            {"CloudTxnDeleteBitmapCache", CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE}};
+            {"CloudTxnDeleteBitmapCache", CacheType::CLOUD_TXN_DELETE_BITMAP_CACHE},
+            {"ForUTCacheNumber", CacheType::FOR_UT_CACHE_NUMBER}};
 
     static CacheType string_to_type(std::string type) {
         if (StringToType.contains(type)) {
@@ -123,13 +126,16 @@ public:
         }
     }
 
-    CachePolicy(CacheType type, uint32_t stale_sweep_time_s, bool enable_prune);
+    CachePolicy(CacheType type, size_t capacity, uint32_t stale_sweep_time_s, bool enable_prune);
     virtual ~CachePolicy();
 
     virtual void prune_stale() = 0;
     virtual void prune_all(bool force) = 0;
+    virtual int64_t adjust_capacity_weighted(double adjust_weighted) = 0;
+    virtual size_t get_capacity() = 0;
 
     CacheType type() { return _type; }
+    size_t initial_capacity() const { return _initial_capacity; }
     bool enable_prune() const { return _enable_prune; }
     RuntimeProfile* profile() { return _profile.get(); }
 
@@ -139,16 +145,20 @@ protected:
                 std::make_unique<RuntimeProfile>(fmt::format("Cache type={}", type_string(_type)));
         _prune_stale_number_counter = ADD_COUNTER(_profile, "PruneStaleNumber", TUnit::UNIT);
         _prune_all_number_counter = ADD_COUNTER(_profile, "PruneAllNumber", TUnit::UNIT);
+        _adjust_capacity_weighted_number_counter =
+                ADD_COUNTER(_profile, "SetCapacityNumber", TUnit::UNIT);
         _freed_memory_counter = ADD_COUNTER(_profile, "FreedMemory", TUnit::BYTES);
         _freed_entrys_counter = ADD_COUNTER(_profile, "FreedEntrys", TUnit::UNIT);
         _cost_timer = ADD_TIMER(_profile, "CostTime");
     }
 
     CacheType _type;
+    size_t _initial_capacity {0};
 
     std::unique_ptr<RuntimeProfile> _profile;
     RuntimeProfile::Counter* _prune_stale_number_counter = nullptr;
     RuntimeProfile::Counter* _prune_all_number_counter = nullptr;
+    RuntimeProfile::Counter* _adjust_capacity_weighted_number_counter = nullptr;
     // Reset before each gc
     RuntimeProfile::Counter* _freed_memory_counter = nullptr;
     RuntimeProfile::Counter* _freed_entrys_counter = nullptr;

--- a/be/src/runtime/memory/global_memory_arbitrator.cpp
+++ b/be/src/runtime/memory/global_memory_arbitrator.cpp
@@ -38,6 +38,13 @@ bvar::PassiveStatus<int64_t> g_sys_mem_avail(
 
 std::atomic<int64_t> GlobalMemoryArbitrator::_s_process_reserved_memory = 0;
 std::atomic<int64_t> GlobalMemoryArbitrator::refresh_interval_memory_growth = 0;
+std::mutex GlobalMemoryArbitrator::cache_adjust_capacity_lock;
+std::condition_variable GlobalMemoryArbitrator::cache_adjust_capacity_cv;
+std::atomic<bool> GlobalMemoryArbitrator::cache_adjust_capacity_notify {false};
+std::atomic<double> GlobalMemoryArbitrator::last_cache_capacity_adjust_weighted {1};
+std::mutex GlobalMemoryArbitrator::memtable_memory_refresh_lock;
+std::condition_variable GlobalMemoryArbitrator::memtable_memory_refresh_cv;
+std::atomic<bool> GlobalMemoryArbitrator::memtable_memory_refresh_notify {false};
 
 bool GlobalMemoryArbitrator::try_reserve_process_memory(int64_t bytes) {
     if (sys_mem_available() - bytes < MemInfo::sys_mem_available_warning_water_mark()) {

--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -173,6 +173,23 @@ public:
     // avoid multiple threads starting at the same time and causing OOM.
     static std::atomic<int64_t> refresh_interval_memory_growth;
 
+    static std::mutex cache_adjust_capacity_lock;
+    static std::condition_variable cache_adjust_capacity_cv;
+    static std::atomic<bool> cache_adjust_capacity_notify;
+    static std::atomic<double> last_cache_capacity_adjust_weighted;
+    static void notify_cache_adjust_capacity() {
+        cache_adjust_capacity_notify.store(true, std::memory_order_relaxed);
+        cache_adjust_capacity_cv.notify_all();
+    }
+
+    static std::mutex memtable_memory_refresh_lock;
+    static std::condition_variable memtable_memory_refresh_cv;
+    static std::atomic<bool> memtable_memory_refresh_notify;
+    static void notify_memtable_memory_refresh() {
+        memtable_memory_refresh_notify.store(true, std::memory_order_relaxed);
+        memtable_memory_refresh_cv.notify_all();
+    }
+
 private:
     static std::atomic<int64_t> _s_process_reserved_memory;
 

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -739,10 +739,10 @@ int64_t MemTrackerLimiter::free_top_overcommit_query(
         LOG(INFO) << log_prefix << "finished, no task need be canceled.";
         return 0;
     }
-    if (query_consumption.size() == 1) {
+    if (small_num == 0 && canceling_task.empty() && query_consumption.size() == 1) {
         auto iter = query_consumption.begin();
-        LOG(INFO) << log_prefix << "finished, only one task: " << iter->first
-                  << ", memory consumption: " << iter->second << ", no cancel.";
+        LOG(INFO) << log_prefix << "finished, only one overcommit task: " << iter->first
+                  << ", memory consumption: " << iter->second << ", no other tasks, so no cancel.";
         return 0;
     }
 

--- a/be/src/runtime/memory/memory_reclamation.cpp
+++ b/be/src/runtime/memory/memory_reclamation.cpp
@@ -37,7 +37,6 @@ bool MemoryReclamation::process_minor_gc(std::string mem_info) {
     std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("");
 
     Defer defer {[&]() {
-        MemInfo::notify_je_purge_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -45,11 +44,6 @@ bool MemoryReclamation::process_minor_gc(std::string mem_info) {
                 PrettyPrinter::print(freed_mem, TUnit::BYTES), watch.elapsed_time() / 1000,
                 ss.str());
     }};
-
-    freed_mem += CacheManager::instance()->for_each_cache_prune_stale(profile.get());
-    if (freed_mem > MemInfo::process_minor_gc_size()) {
-        return true;
-    }
 
     if (config::enable_workload_group_memory_gc) {
         RuntimeProfile* tg_profile = profile->create_child("WorkloadGroup", true, true);
@@ -87,7 +81,6 @@ bool MemoryReclamation::process_full_gc(std::string mem_info) {
     std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("");
 
     Defer defer {[&]() {
-        MemInfo::notify_je_purge_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -95,11 +88,6 @@ bool MemoryReclamation::process_full_gc(std::string mem_info) {
                 PrettyPrinter::print(freed_mem, TUnit::BYTES), watch.elapsed_time() / 1000,
                 ss.str());
     }};
-
-    freed_mem += CacheManager::instance()->for_each_cache_prune_all(profile.get());
-    if (freed_mem > MemInfo::process_full_gc_size()) {
-        return true;
-    }
 
     if (config::enable_workload_group_memory_gc) {
         RuntimeProfile* tg_profile = profile->create_child("WorkloadGroup", true, true);

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -234,6 +234,12 @@ void RowCache::erase(const RowCacheKey& key) {
     LRUCachePolicy::erase(encoded_key);
 }
 
+LookupConnectionCache::CacheValue::~CacheValue() {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
+            ExecEnv::GetInstance()->point_query_executor_mem_tracker());
+    item.reset();
+}
+
 PointQueryExecutor::~PointQueryExecutor() {
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
             ExecEnv::GetInstance()->point_query_executor_mem_tracker());

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -265,6 +265,7 @@ private:
 
     class CacheValue : public LRUCacheValueBase {
     public:
+        ~CacheValue() override;
         std::shared_ptr<Reusable> item;
     };
 };

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -246,8 +246,8 @@ private:
         auto* value = new CacheValue;
         value->item = item;
         LOG(INFO) << "Add item mem"
-                  << ", cache_capacity: " << get_total_capacity()
-                  << ", cache_usage: " << get_usage() << ", mem_consum: " << mem_consumption();
+                  << ", cache_capacity: " << get_capacity() << ", cache_usage: " << get_usage()
+                  << ", mem_consum: " << mem_consumption();
         auto* lru_handle = insert(key, value, 1, sizeof(Reusable), CachePriority::NORMAL);
         release(lru_handle);
     }

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -106,9 +106,6 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
             return;
         }
 
-        // no significant impact on performance is expected.
-        doris::MemInfo::notify_je_purge_dirty_pages();
-
         if (doris::thread_context()->thread_mem_tracker_mgr->is_attach_query() &&
             doris::thread_context()->thread_mem_tracker_mgr->wait_gc()) {
             int64_t wait_milliseconds = 0;


### PR DESCRIPTION
step 1. Refresh process memory metrics.
step 2. Refresh allocator memory metrics.
step 3. Update and print memory stat when the memory changes by 256M.
step 4. Asyn Refresh cache capacity
step 5. Cancel top memory task when process memory exceed hard limit.
step 6. Refresh weighted memory ratio of workload groups.
step 7. Analyze blocking queries.
step 8. Flush memtable.
step 9. Jemalloc purge all arena dirty pages.

`memory_maintenance_thread` execute once cost:
- 3ms (cluster idle)
- 20ms (cluster high concurrency, CPU full)

`memory_maintenance_thread` CPU usage:
- 10%-20% (default memory_maintenance_sleep_time_ms=20ms)
- 20%-30% (memory_maintenance_sleep_time_ms=10ms)
- 30%+ (memory_maintenance_sleep_time_ms=5ms)