### PR TITLE
[fix](regression-test) Fix scanner profile test failed occasionally

### DIFF
--- a/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
+++ b/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
@@ -149,27 +149,22 @@ suite('adaptive_pipeline_task_serial_read_on_limit') {
         }
     }
     
-    logger.info("queryIdNoLimit1_${uuidString}: {}", queryIdNoLimit1)
     logger.info("queryIdWithLimit1_${uuidString}: {}", queryIdWithLimit1)
-    logger.info("queryIdWithLimit2_${uuidString}: {}", queryIdWithLimit2)
-    logger.info("queryIDNotEnableLimit_${uuidString}: {}", queryIDNotEnableLimit)
     logger.info("queryIdModifyTo20_${uuidString}: {}", queryIdModifyTo20)
 
-    assertTrue(queryIdNoLimit1 != "")
     assertTrue(queryIdWithLimit1 != "")
-    assertTrue(queryIdWithLimit2 != "")
-    assertTrue(queryIDNotEnableLimit != "")
     assertTrue(queryIdModifyTo20 != "")
 
-    def String profileNoLimit1 = getProfile(queryIdNoLimit1).toString()
     def String profileWithLimit1 = getProfile(queryIdWithLimit1).toString()
-    def String profileWithLimit2 = getProfile(queryIdWithLimit2).toString()
-    def String profileNotEnableLimit = getProfile(queryIDNotEnableLimit).toString()
     def String profileModifyTo20 = getProfile(queryIdModifyTo20).toString()
     
-    assertTrue(profileNoLimit1.contains("- MaxScannerThreadNum: 10"))
+    if (!profileWithLimit1.contains("- MaxScannerThreadNum: 1")) {
+        logger.info("profileWithLimit1:\n{}", profileWithLimit1)
+    }
     assertTrue(profileWithLimit1.contains("- MaxScannerThreadNum: 1"))
-    assertTrue(profileWithLimit2.contains("- MaxScannerThreadNum: 10"))
-    assertTrue(profileNotEnableLimit.contains("- MaxScannerThreadNum: 10"))
+
+    if (!difyTo20.contains("- MaxScannerThreadNum: 1")) {
+        logger.info("profileModifyTo20:\n{}", profileModifyTo20)
+    }
     assertTrue(profileModifyTo20.contains("- MaxScannerThreadNum: 1"))
 }

--- a/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
+++ b/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
@@ -165,7 +165,7 @@ suite('adaptive_pipeline_task_serial_read_on_limit') {
     }
     assertTrue(profileWithLimit1.contains("- MaxScannerThreadNum: 1"))
 
-    if (!difyTo20.contains("- MaxScannerThreadNum: 1")) {
+    if (!profileModifyTo20.contains("- MaxScannerThreadNum: 1")) {
         logger.info("profileModifyTo20:\n{}", profileModifyTo20)
     }
     assertTrue(profileModifyTo20.contains("- MaxScannerThreadNum: 1"))

--- a/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
+++ b/regression-test/suites/query_profile/adaptive_pipeline_task_serial_read_on_limit.groovy
@@ -116,6 +116,8 @@ suite('adaptive_pipeline_task_serial_read_on_limit') {
 
     sql "set enable_profile=false"
 
+    Thread.sleep(5)
+
     def wholeString = getProfileList()
     List profileData = new JsonSlurper().parseText(wholeString).data.rows
     String queryIdNoLimit1 = "";

--- a/regression-test/suites/query_profile/scanner_profile.groovy
+++ b/regression-test/suites/query_profile/scanner_profile.groovy
@@ -98,6 +98,10 @@ suite('scanner_profile') {
     logger.info("queryIdWithLimit1_${uuidString}: {}", queryIdWithLimit1)
 
     assertTrue(queryIdWithLimit1 != "")
+
+    // Sleep 5 seconds to make sure profile collection is done
+    Thread.sleep(5000)
+
     def String profileWithLimit1 = getProfile(queryIdWithLimit1).toString()
     logger.info("query profile {}", profileWithLimit1)
     assertTrue(profileWithLimit1.contains("- PeakRunningScanner: 1"))


### PR DESCRIPTION
Collection of profile is async. So wait 5 seconds before get profile.

adaptive_pipeline_task_serial_read_on_limit will fail on multi backends env, since tablets num on each be will not be 10.