### PR TITLE
[opt](profile) Add profile_manager_gc_interval_seconds on fe.conf

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -19,6 +19,8 @@ package org.apache.doris.common;
 
 import java.io.File;
 
+import org.apache.doris.common.ConfigBase.ConfField;
+
 public class Config extends ConfigBase {
 
     @ConfField(description = {"用户自定义配置文件的路径，用于存放 fe_custom.conf。该文件中的配置会覆盖 fe.conf 中的配置",
@@ -2726,6 +2728,12 @@ public class Config extends ConfigBase {
     })
     public static int profile_async_collect_expire_time_secs = 5;
 
+    @ConfField(description = {
+            "用于控制 ProfileManager 进行 Profile 垃圾回收的间隔时间，垃圾回收期间 ProfileManager 会把多余的以及过期的 profile "
+                    + "从内存和磁盘中清理掉，节省内存。",
+            "Used to control the interval time of ProfileManager for profile garbage collection."
+    })
+    public static int profile_manager_gc_interval_seconds = 1;
     // Used to check compatibility when upgrading.
     @ConfField
     public static boolean enable_check_compatibility_mode = false;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -19,8 +19,6 @@ package org.apache.doris.common;
 
 import java.io.File;
 
-import org.apache.doris.common.ConfigBase.ConfField;
-
 public class Config extends ConfigBase {
 
     @ConfField(description = {"用户自定义配置文件的路径，用于存放 fe_custom.conf。该文件中的配置会覆盖 fe.conf 中的配置",
@@ -2731,7 +2729,7 @@ public class Config extends ConfigBase {
     @ConfField(description = {
             "用于控制 ProfileManager 进行 Profile 垃圾回收的间隔时间，垃圾回收期间 ProfileManager 会把多余的以及过期的 profile "
                     + "从内存和磁盘中清理掉，节省内存。",
-            "Used to control the interval time of ProfileManager for profile garbage collection."
+            "Used to control the interval time of ProfileManager for profile garbage collection. "
     })
     public static int profile_manager_gc_interval_seconds = 1;
     // Used to check compatibility when upgrading.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -159,6 +159,7 @@ public class ProfileManager extends MasterDaemon {
 
     // The visiablity of ProfileManager() is package level, so that we can write ut for it.
     ProfileManager() {
+        super("profile-manager", Config.profile_manager_gc_interval_seconds * 1000);
         lock = new ReentrantReadWriteLock(true);
         readLock = lock.readLock();
         writeLock = lock.writeLock();


### PR DESCRIPTION
profile_manager_gc_interval_seconds will control the frequency of ProfileManager to do garbage collection. Current value is 30s, default value of new config is 1s.

Left side is before, and right side is after modification.

<img width="453" alt="image" src="https://github.com/user-attachments/assets/8fc8f76c-491f-4afb-a584-5dd38b2367f7">

<img width="445" alt="image" src="https://github.com/user-attachments/assets/d1443cc6-185d-4461-9065-8bbe3eebaa1e">

