### PR TITLE
[fix](restore) Persist the sqlMode field of the View

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
@@ -76,6 +76,7 @@ public class View extends Table implements GsonPostProcessable {
     private String inlineViewDef;
 
     // for persist
+    @SerializedName("sm")
     private long sqlMode = 0L;
 
     // View definition created by parsing inlineViewDef_ into a QueryStmt.

--- a/regression-test/suites/backup_restore/test_backup_restore_with_view.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_with_view.groovy
@@ -92,6 +92,22 @@ suite("test_backup_restore_with_view", "backup_restore") {
     assertTrue(show_view.contains("${dbName1}"))
     assertTrue(show_view.contains("${tableName}"))
 
+    // restore to db, test the view signature.
+    sql """
+        RESTORE SNAPSHOT ${dbName}.${snapshotName}
+        FROM `${repoName}`
+        PROPERTIES
+        (
+            "backup_timestamp" = "${snapshot}",
+            "reserve_replica" = "true"
+        )
+    """
+
+    syncer.waitAllRestoreFinish(dbName)
+    def restore_result = sql_return_maparray """ SHOW RESTORE FROM ${dbName} WHERE Label ="${snapshotName}" """
+    restore_result.last()
+    logger.info("show restore result: ${restore_result}")
+    assertTrue(restore_result.last().State == "FINISHED")
 
     sql "DROP TABLE ${dbName}.${tableName} FORCE"
     sql "DROP VIEW ${dbName}.${viewName}"


### PR DESCRIPTION
During initialization, the View will parse inlineViewRef again according to the sqlMode value. Therefore, sqlMode must be persisted.