### PR TITLE
[fix](restore) Remove the sqlMode from the view signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
@@ -222,7 +222,14 @@ public class View extends Table implements GsonPostProcessable {
         sb.append(type);
         sb.append(Util.getSchemaSignatureString(fullSchema));
         sb.append(inlineViewDef);
-        sb.append(sqlMode);
+
+        // ATTN: sqlMode is missing when persist view, so we should not append it here.
+        //
+        // To keep compatible with the old version, without sqlMode, if the signature of views
+        // are the same, we think the should has the same sqlMode. (since the sqlMode doesn't
+        // effect the parsing of inlineViewDef, otherwise the parsing will fail),
+        //
+        // sb.append(sqlMode);
         String md5 = DigestUtils.md5Hex(sb.toString());
         if (LOG.isDebugEnabled()) {
             LOG.debug("get signature of view {}: {}. signature string: {}", name, md5, sb.toString());


### PR DESCRIPTION
To keep compatible with the old version, without sqlMode, if the signature of views are the same, we should have the same sqlMode. (since the sqlMode doesn't affect the parsing of inlineViewDef, otherwise the parsing will fail)