### PR TITLE
[Fix](Job)Replace BlockingWaitStrategy with LiteTimeoutBlockingWaitStrategy to avoid deadlock issues.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -50,7 +50,7 @@ public class TaskDisruptor<T> {
                          WaitStrategy waitStrategy, WorkHandler<T>[] workHandlers,
                          EventTranslatorVararg<T> eventTranslator) {
         disruptor = new Disruptor<>(eventFactory, ringBufferSize, threadFactory,
-                ProducerType.SINGLE, waitStrategy);
+                ProducerType.MULTI, waitStrategy);
         disruptor.handleEventsWithWorkerPool(workHandlers);
         this.eventTranslator = eventTranslator;
         disruptor.start();

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -77,7 +77,7 @@ public class TaskDisruptor<T> {
             ringBuffer.publishEvent(eventTranslator, args);
             return true;
         } catch (Exception e) {
-            LOG.error("Failed to publish event", e);
+            LOG.warn("Failed to publish event", e);
             // Handle the exception, e.g., retry or alert
         }
         return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -74,8 +74,7 @@ public class TaskDisruptor<T> {
     public boolean publishEvent(Object... args) {
         try {
             RingBuffer<T> ringBuffer = disruptor.getRingBuffer();
-            ringBuffer.publishEvent(eventTranslator, args);
-            return true;
+            return ringBuffer.tryPublishEvent(eventTranslator, args);
         } catch (Exception e) {
             LOG.warn("Failed to publish event", e);
             // Handle the exception, e.g., retry or alert

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -24,6 +24,8 @@ import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.WorkHandler;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ThreadFactory;
 
@@ -33,6 +35,7 @@ import java.util.concurrent.ThreadFactory;
  * @param <T> the type of the event handled by the Disruptor
  */
 public class TaskDisruptor<T> {
+    private static final Logger LOG = LogManager.getLogger(TaskDisruptor.class);
     private final Disruptor<T> disruptor;
     private final EventTranslatorVararg<T> eventTranslator;
 
@@ -68,9 +71,16 @@ public class TaskDisruptor<T> {
      *
      * @param args the arguments for the event
      */
-    public void publishEvent(Object... args) {
-        RingBuffer<T> ringBuffer = disruptor.getRingBuffer();
-        ringBuffer.publishEvent(eventTranslator, args);
+    public boolean publishEvent(Object... args) {
+        try {
+            RingBuffer<T> ringBuffer = disruptor.getRingBuffer();
+            ringBuffer.publishEvent(eventTranslator, args);
+            return true;
+        } catch (Exception e) {
+            LOG.error("Failed to publish event", e);
+            // Handle the exception, e.g., retry or alert
+        }
+        return false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/DispatchTaskHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/DispatchTaskHandler.java
@@ -66,7 +66,10 @@ public class DispatchTaskHandler<T extends AbstractJob> implements WorkHandler<T
                 }
                 JobType jobType = event.getJob().getJobType();
                 for (AbstractTask task : tasks) {
-                    disruptorMap.get(jobType).publishEvent(task, event.getJob().getJobConfig());
+                    if (!disruptorMap.get(jobType).publishEvent(task, event.getJob().getJobConfig())) {
+                        task.cancel();
+                        continue;
+                    }
                     log.info("dispatch timer job success, job id is {},  task id is {}",
                             event.getJob().getJobId(), task.getTaskId());
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/TimerJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/TimerJobSchedulerTask.java
@@ -44,7 +44,7 @@ public class TimerJobSchedulerTask<T extends AbstractJob> implements TimerTask {
                 log.info("job status is not running, job id is {}, skip dispatch", this.job.getJobId());
                 return;
             }
-            if (dispatchDisruptor.publishEvent(this.job)) {
+            if (!dispatchDisruptor.publishEvent(this.job)) {
                 log.warn("dispatch timer job failed, job id is {}, job name is {}",
                         this.job.getJobId(), this.job.getJobName());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/TimerJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/TimerJobSchedulerTask.java
@@ -44,7 +44,10 @@ public class TimerJobSchedulerTask<T extends AbstractJob> implements TimerTask {
                 log.info("job status is not running, job id is {}, skip dispatch", this.job.getJobId());
                 return;
             }
-            dispatchDisruptor.publishEvent(this.job);
+            if (dispatchDisruptor.publishEvent(this.job)) {
+                log.warn("dispatch timer job failed, job id is {}, job name is {}",
+                        this.job.getJobId(), this.job.getJobName());
+            }
         } catch (Exception e) {
             log.warn("dispatch timer job error, task id is {}", this.job.getJobId(), e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/JobScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/JobScheduler.java
@@ -155,7 +155,7 @@ public class JobScheduler<T extends AbstractJob<?, C>, C> implements Closeable {
     }
 
 
-    public void schedulerInstantJob(T job, TaskType taskType, C context) {
+    public void schedulerInstantJob(T job, TaskType taskType, C context) throws JobException {
         List<? extends AbstractTask> tasks = job.commonCreateTasks(taskType, context);
         if (CollectionUtils.isEmpty(tasks)) {
             log.info("job create task is empty, skip scheduler, job id is {}, job name is {}", job.getJobId(),
@@ -165,12 +165,15 @@ public class JobScheduler<T extends AbstractJob<?, C>, C> implements Closeable {
             }
             return;
         }
-        tasks.forEach(task -> {
-            taskDisruptorGroupManager.dispatchInstantTask(task, job.getJobType(),
-                    job.getJobConfig());
+        for (AbstractTask task : tasks) {
+            if (!taskDisruptorGroupManager.dispatchInstantTask(task, job.getJobType(),
+                    job.getJobConfig())) {
+                throw new JobException("dispatch instant task failed, job id is "
+                        + job.getJobId() + ", task id is " + task.getTaskId());
+            }
             log.info("dispatch instant job, job id is {}, job name is {}, task id is {}", job.getJobId(),
                     job.getJobName(), task.getTaskId());
-        });
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
@@ -81,7 +81,7 @@ public class TaskDisruptor implements Closeable {
     public void start() {
         ThreadFactory producerThreadFactory = DaemonThreadFactory.INSTANCE;
         disruptor = new Disruptor<>(TaskEvent.FACTORY, DEFAULT_RING_BUFFER_SIZE, producerThreadFactory,
-                ProducerType.SINGLE, new BlockingWaitStrategy());
+                ProducerType.MULTI, new BlockingWaitStrategy());
         WorkHandler<TaskEvent>[] workers = new TaskHandler[consumerThreadCount];
         for (int i = 0; i < consumerThreadCount; i++) {
             workers[i] = new TaskHandler(transientTaskManager);

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 @Log4j2
 public class TaskDisruptor implements Closeable {
 
-    private  Disruptor<TaskEvent> disruptor;
+    private Disruptor<TaskEvent> disruptor;
     private static final int DEFAULT_RING_BUFFER_SIZE = Config.async_task_queen_size;
 
     private static final int consumerThreadCount = Config.async_task_consumer_thread_num;
@@ -66,10 +66,10 @@ public class TaskDisruptor implements Closeable {
      */
     private static final EventTranslatorThreeArg<TaskEvent, Long, Long, TaskType> TRANSLATOR
             = (event, sequence, jobId, taskId, taskType) -> {
-        event.setId(jobId);
-        event.setTaskId(taskId);
-        event.setTaskType(taskType);
-    };
+                event.setId(jobId);
+                event.setTaskId(taskId);
+                event.setTaskType(taskType);
+            };
 
     public void start() {
         CustomThreadFactory exportTaskThreadFactory = new CustomThreadFactory("export-task-consumer");

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
@@ -109,7 +109,7 @@ public class TaskDisruptor implements Closeable {
         try {
             disruptor.publishEvent(TRANSLATOR, jobId, taskId, taskType);
         } catch (Exception e) {
-            log.error("tryPublish failed, jobId: {}", jobId, e);
+            log.warn("tryPublish failed, jobId: {}", jobId, e);
         }
     }
 
@@ -127,7 +127,7 @@ public class TaskDisruptor implements Closeable {
         try {
             disruptor.publishEvent(TRANSLATOR, taskId, 0L, TaskType.TRANSIENT_TASK);
         } catch (Exception e) {
-            log.error("tryPublish failed, taskId: {}", taskId, e);
+            log.warn("tryPublish failed, taskId: {}", taskId, e);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

FYI https://issues.apache.org/jira/browse/LOG4J2-1221
- BlockingWaitStrategy is a wait strategy used in the Disruptor framework that blocks the thread when the ring buffer is full or not yet available for publishing.

When threads are blocked, they are waiting for space in the ring buffer to become available, which can lead to potential deadlocks if not managed properly.
Timeout Handling:

- LiteTimeoutBlockingWaitStrategy provides a timeout for waiting threads. If the buffer is not ready within the timeout period, the thread is released, preventing it from being blocked indefinitely.
Reduced Risk of Deadlocks:

- By avoiding indefinite blocking, this strategy reduces the risk of deadlocks caused by threads waiting on each other. The timeout allows the system to handle scenarios where resources are temporarily

