### PR TITLE
[Fix](load) fix wrong replica number when loading to table with no partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -215,11 +215,7 @@ public class OlapTableSink extends DataSink {
 
         tSink.setTableId(dstTable.getId());
         tSink.setTupleId(tupleDescriptor.getId().asInt());
-        int numReplicas = 1;
-        for (Partition partition : dstTable.getPartitions()) {
-            numReplicas = dstTable.getPartitionInfo().getReplicaAllocation(partition.getId()).getTotalReplicaNum();
-            break;
-        }
+        int numReplicas = dstTable.getTableProperty().getReplicaAllocation().getTotalReplicaNum();
         tSink.setNumReplicas(numReplicas);
         tSink.setNeedGenRollup(dstTable.shouldLoadToNewRollup());
         tSink.setSchema(createSchema(tSink.getDbId(), dstTable, analyzer));

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -126,7 +126,6 @@ public class OlapTableSinkTest {
 
         Column partKey = new Column("k2", PrimitiveType.VARCHAR);
         Partition p1 = new Partition(1, "p1", index, distInfo);
-        Partition p2 = new Partition(2, "p2", index, distInfo);
 
         new Expectations() {
             {
@@ -140,8 +139,6 @@ public class OlapTableSinkTest {
                 result = PartitionType.RANGE;
                 partInfo.getPartitionColumns();
                 result = Lists.newArrayList(partKey);
-                dstTable.getPartitions();
-                result = Lists.newArrayList(p1, p2);
                 dstTable.getPartition(p1.getId());
                 result = p1;
             }
@@ -190,7 +187,6 @@ public class OlapTableSinkTest {
 
         Column partKey = new Column("k2", PrimitiveType.VARCHAR);
         Partition p1 = new Partition(1, "p1", index, distInfo);
-        Partition p2 = new Partition(2, "p2", index, distInfo);
 
         new Expectations() {
             {
@@ -204,8 +200,6 @@ public class OlapTableSinkTest {
                 result = PartitionType.LIST;
                 partInfo.getPartitionColumns();
                 result = Lists.newArrayList(partKey);
-                dstTable.getPartitions();
-                result = Lists.newArrayList(p1, p2);
                 dstTable.getPartition(p1.getId());
                 result = p1;
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

now in auto-partition situation it will occur. may effect the txn commit check.
