### PR TITLE
[Opt](scanner-scheduler) Opt scanner scheduler starvation issue.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -284,6 +284,8 @@ DEFINE_mInt32(doris_scan_range_max_mb, "1024");
 DEFINE_mInt32(doris_scanner_row_num, "16384");
 // single read execute fragment row bytes
 DEFINE_mInt32(doris_scanner_row_bytes, "10485760");
+// single read execute fragment max run time millseconds
+DEFINE_mInt32(doris_scanner_max_run_time_ms, "1000");
 // (Advanced) Maximum size of per-query receive-side buffer
 DEFINE_mInt32(exchg_node_buffer_size_bytes, "20485760");
 DEFINE_mInt32(exchg_buffer_queue_capacity_factor, "64");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -332,6 +332,8 @@ DECLARE_mInt32(doris_scan_range_max_mb);
 DECLARE_mInt32(doris_scanner_row_num);
 // single read execute fragment row bytes
 DECLARE_mInt32(doris_scanner_row_bytes);
+// single read execute fragment max run time millseconds
+DECLARE_mInt32(doris_scanner_max_run_time_ms);
 // (Advanced) Maximum size of per-query receive-side buffer
 DECLARE_mInt32(exchg_node_buffer_size_bytes);
 DECLARE_mInt32(exchg_buffer_queue_capacity_factor);

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -236,6 +236,8 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
         Thread::set_thread_nice_value();
     }
 #endif
+    MonotonicStopWatch max_run_time_watch;
+    max_run_time_watch.start();
     scanner->update_wait_worker_timer();
     scanner->start_scan_cpu_timer();
     Status status = Status::OK();
@@ -268,6 +270,10 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
             while (!eos && raw_bytes_read < raw_bytes_threshold) {
                 if (UNLIKELY(ctx->done())) {
                     eos = true;
+                    break;
+                }
+                if (max_run_time_watch.elapsed_time() >
+                    config::doris_scanner_max_run_time_ms * 1e6) {
                     break;
                 }
                 BlockUPtr free_block = ctx->get_free_block(first_read);

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -333,8 +333,8 @@ Status VFileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool*
                 // or not found in the file column schema.
                 RETURN_IF_ERROR(_truncate_char_or_varchar_columns(block));
             }
-            break;
         }
+        break;
     } while (true);
 
     // Update filtered rows and unselected rows for load, reset counter.


### PR DESCRIPTION
## Proposed changes

### Issue
When a scanner scheduler is stuck in executing a scan task, other scan tasks will starve and have no chance to execute, which will affect other queries. Currently, the scan task hopes to scan as much data as possible to reduce the overhead of scheduling switching. Currently, it hopes to obtain up to 10MB of data in `doris_scanner_row_bytes`. However, if a query scans a table with many rows of data, but the filtering rate is very high, the filter will eventually filter out a lot of data and will never get 10MB of data. It will keep getting and executing expression filtering, which will cause other scan tasks to starve.

### Solution
The current solution is to check `max_run_time_ms` by `MonotonicStopWatch`. After executing for a maximum of 1s,  it will yield self's task for other tasks. When the scan task executes some time-consuming tasks, it needs to slice to do it. 

