### PR TITLE
[fix](mtmv) Fix duplicate column name not check when create materialized view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateMTMVInfo.java
@@ -174,8 +174,7 @@ public class CreateMTMVInfo {
         final boolean finalEnableMergeOnWrite = false;
         Set<String> keysSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         keysSet.addAll(keys);
-        columns.forEach(c -> c.validate(true, keysSet, Sets.newHashSet(), finalEnableMergeOnWrite, KeysType.DUP_KEYS));
-
+        validateColumns(this.columns, keysSet, finalEnableMergeOnWrite);
         if (distribution == null) {
             throw new AnalysisException("Create async materialized view should contain distribution desc");
         }
@@ -198,12 +197,14 @@ public class CreateMTMVInfo {
     }
 
     /**validate column name*/
-    public void validateColumns(List<ColumnDefinition> columns) throws UserException {
+    public void validateColumns(List<ColumnDefinition> columns, Set<String> keysSet,
+            boolean finalEnableMergeOnWrite) throws UserException {
         Set<String> colSets = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         for (ColumnDefinition col : columns) {
             if (!colSets.add(col.getName())) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_DUP_FIELDNAME, col.getName());
             }
+            col.validate(true, keysSet, Sets.newHashSet(), finalEnableMergeOnWrite, KeysType.DUP_KEYS);
         }
     }
 
@@ -268,7 +269,6 @@ public class CreateMTMVInfo {
                 .analyzeAndTransferToMTMVPartitionInfo(planner, ctx, logicalQuery);
         this.partitionDesc = generatePartitionDesc(ctx);
         getColumns(plan, ctx, mvPartitionInfo.getPartitionCol(), distribution);
-        validateColumns(this.columns);
         analyzeKeys();
 
     }

--- a/regression-test/suites/mtmv_p0/same_column_name_check/same_column_name_check.groovy
+++ b/regression-test/suites/mtmv_p0/same_column_name_check/same_column_name_check.groovy
@@ -1,4 +1,3 @@
-package same_column_name_check
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/regression-test/suites/mtmv_p0/same_column_name_check/same_column_name_check.groovy
+++ b/regression-test/suites/mtmv_p0/same_column_name_check/same_column_name_check.groovy
@@ -1,0 +1,102 @@
+package same_column_name_check
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("same_column_name_check") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
+    sql "set runtime_filter_mode=OFF";
+    sql "SET ignore_shape_nodes='PhysicalDistribute,PhysicalProject'"
+
+    sql """
+    drop table if exists orders
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS orders  (
+      o_orderkey       INTEGER NOT NULL,
+      o_custkey        INTEGER NOT NULL,
+      o_orderstatus    CHAR(1) NOT NULL,
+      o_totalprice     DECIMALV3(15,2) NOT NULL,
+      o_orderdate      DATE NOT NULL,
+      o_orderpriority  CHAR(15) NOT NULL,  
+      o_clerk          CHAR(15) NOT NULL, 
+      o_shippriority   INTEGER NOT NULL,
+      O_COMMENT        VARCHAR(79) NOT NULL
+    )
+    DUPLICATE KEY(o_orderkey, o_custkey)
+    PARTITION BY RANGE(o_orderdate) (
+    PARTITION `day_2` VALUES LESS THAN ('2023-12-9'),
+    PARTITION `day_3` VALUES LESS THAN ("2023-12-11"),
+    PARTITION `day_4` VALUES LESS THAN ("2023-12-30")
+    )
+    DISTRIBUTED BY HASH(o_orderkey) BUCKETS 3
+    PROPERTIES (
+      "replication_num" = "1"
+    );
+    """
+
+    sql """
+    insert into orders values
+    (1, 1, 'o', 9.5, '2023-12-08', 'a', 'b', 1, 'yy'),
+    (1, 1, 'o', 10.5, '2023-12-08', 'a', 'b', 1, 'yy'),
+    (1, 1, 'o', 10.5, '2023-12-08', 'a', 'b', 1, 'yy'),
+    (1, 1, 'o', 10.5, '2023-12-08', 'a', 'b', 1, 'yy'),
+    (2, 1, 'o', 11.5, '2023-12-09', 'a', 'b', 1, 'yy'),
+    (2, 1, 'o', 11.5, '2023-12-09', 'a', 'b', 1, 'yy'),
+    (2, 1, 'o', 11.5, '2023-12-09', 'a', 'b', 1, 'yy'),
+    (3, 1, 'o', 12.5, '2023-12-10', 'a', 'b', 1, 'yy'),
+    (3, 1, 'o', 12.5, '2023-12-10', 'a', 'b', 1, 'yy'),
+    (3, 1, 'o', 12.5, '2023-12-10', 'a', 'b', 1, 'yy'),
+    (3, 1, 'o', 33.5, '2023-12-10', 'a', 'b', 1, 'yy'),
+    (4, 2, 'o', 43.2, '2023-12-11', 'c','d',2, 'mm'),
+    (4, 2, 'o', 43.2, '2023-12-11', 'c','d',2, 'mm'),
+    (4, 2, 'o', 43.2, '2023-12-11', 'c','d',2, 'mm'),
+    (5, 2, 'o', 56.2, '2023-12-12', 'c','d',2, 'mi'),
+    (5, 2, 'o', 56.2, '2023-12-12', 'c','d',2, 'mi'),
+    (5, 2, 'o', 56.2, '2023-12-12', 'c','d',2, 'mi'),
+    (5, 2, 'o', 1.2, '2023-12-12', 'c','d',2, 'mi');  
+    """
+
+    sql """analyze table orders with sync"""
+
+    sql """DROP MATERIALIZED VIEW IF EXISTS mv_1"""
+    test {
+        sql """
+        CREATE MATERIALIZED VIEW mv_1
+        BUILD IMMEDIATE REFRESH AUTO ON MANUAL 
+        partition by(o_orderdate) 
+        DISTRIBUTED BY RANDOM BUCKETS 2 
+        PROPERTIES ('replication_num' = '1') 
+        AS  
+        select o_orderdatE, o_shippriority, o_comment, o_orderdate, 
+        sum(o_totalprice) as sum_total, 
+        max(o_totalpricE) as max_total, 
+        min(o_totalprice) as min_total, 
+        count(*) as count_all, 
+        bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (1, 3) then o_custkey else null end)) cnt_1, 
+        bitmap_union(to_bitmap(case when o_shippriority > 2 and o_orderkey IN (2) then o_custkey else null end)) as cnt_2 
+        from (select * from orders) as t1
+        group by 
+        o_orderdatE, 
+        o_shippriority, 
+        o_comment,
+        o_orderdate;
+        """
+        exception "Duplicate column name"
+    }
+}

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_self_conn.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_self_conn.groovy
@@ -533,7 +533,7 @@ suite("partition_mv_rewrite_dimension_self_conn") {
 
     // predicate compensate
     def predicate_mv_stmt_1 = """
-        select t1.l_shipdatE, t2.l_shipdate, t1.l_partkey 
+        select t1.l_shipdatE, t2.l_shipdate as l_shipdate_t2, t1.l_partkey 
         from lineitem_self_conn as t1 
         inner join lineitem_self_conn as t2  
         on t1.l_orderkey = t2.l_orderkey

--- a/regression-test/suites/nereids_rules_p0/mv/union_rewrite/usercase_union_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_rewrite/usercase_union_rewrite.groovy
@@ -121,7 +121,7 @@ suite ("usercase_union_rewrite") {
     }
 
     def mv_name = "mv_usercase"
-    def mv_stmt = """select o_orderdatE, o_shippriority, o_comment, o_orderdate, 
+    def mv_stmt = """select o_orderdatE, o_shippriority, o_comment, o_orderdate as o_orderdate_alias, 
         sum(o_totalprice) as sum_total, 
         max(o_totalpricE) as max_total, 
         min(o_totalprice) as min_total, 
@@ -139,7 +139,7 @@ suite ("usercase_union_rewrite") {
     def job_name_1 = getJobName(db, mv_name)
     waitingMTMVTaskFinished(job_name_1)
 
-    def query_stmt = """select o_orderdatE, o_shippriority, o_comment, o_orderdate, 
+    def query_stmt = """select o_orderdatE, o_shippriority, o_comment, o_orderdate as o_orderdate_alias, 
         sum(o_totalprice) as sum_total, 
         max(o_totalpricE) as max_total, 
         min(o_totalprice) as min_total, 


### PR DESCRIPTION
## Proposed changes
This is brought by https://github.com/apache/doris/pull/26146
If create materialized view as following, Should fail, because has the duplicated column name `o_orderdatE` and `o_orderdate`. But now can create materialized view successfully. the pr fix this.

```sql
        CREATE MATERIALIZED VIEW mv_1
        BUILD IMMEDIATE REFRESH AUTO ON MANUAL 
        partition by(o_orderdate) 
        DISTRIBUTED BY RANDOM BUCKETS 2 
        PROPERTIES ('replication_num' = '1') 
        AS  
        select o_orderdatE, o_shippriority, o_comment, o_orderdate, 
        sum(o_totalprice) as sum_total, 
        max(o_totalpricE) as max_total, 
        min(o_totalprice) as min_total, 
        count(*) as count_all, 
        bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (1, 3) then o_custkey else null end)) cnt_1, 
        bitmap_union(to_bitmap(case when o_shippriority > 2 and o_orderkey IN (2) then o_custkey else null end)) as cnt_2 
        from (select * from orders) as t1
        group by 
        o_orderdatE, 
        o_shippriority, 
        o_comment,
        o_orderdate;
```
