### PR TITLE
[fix](default value) Avoid default precision value of 0 for default expressions during deserialization

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DefaultValueExprDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DefaultValueExprDef.java
@@ -64,7 +64,7 @@ public class DefaultValueExprDef implements Writable, GsonPostProcessable {
      */
     public FunctionCallExpr getExpr(Type type) {
         List<Expr> exprs = null;
-        if (precision != null) {
+        if (precision != null && precision != 0) {
             exprs = Lists.newArrayList();
             exprs.add(new IntLiteral(precision));
         }
@@ -101,8 +101,6 @@ public class DefaultValueExprDef implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        if (precision == null) {
-            precision = 0L;
-        }
+        // nothing to do
     }
 }


### PR DESCRIPTION
This PR fixes the issue where the precision of default value expressions was incorrectly set to `0` during deserialization. The `gsonPostProcess` method no longer assigns a default precision of `0` if the precision is not provided. Additionally, logic has been added to ensure that expressions without precision do not incorrectly apply a precision of `0`.