### PR TITLE
[Bug](rpad) should check_chars_length avoid exceed max_string_size in pad function

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -1638,7 +1638,7 @@ public:
                 const size_t pad_times = (len - str_char_size) / pad_char_size;
                 const size_t pad_remainder_len = pad_index[(len - str_char_size) % pad_char_size];
                 const size_t new_capacity = str_len + size_t(pad_times + 1) * pad_len;
-                ColumnString::check_chars_length(new_capacity, 0);
+                ColumnString::check_chars_length(buffer_len + new_capacity, i);
                 buffer.reserve(buffer_len + new_capacity);
                 if constexpr (!Impl::is_lpad) {
                     memcpy(buffer.data() + buffer_len, str_data, str_len);


### PR DESCRIPTION
## Proposed changes
 this pr https://github.com/apache/doris/pull/40162 introduced,
 and have test case in P1,  regression-test/suites/query_p1/test_big_pad.groovy 
 

<!--Describe your changes.-->

