### PR TITLE
[Fix](metahelper)Filename regex validation only checks if the filename is valid.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -26,6 +26,7 @@ import org.apache.doris.httpv2.rest.manager.HttpUtils;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,7 +48,7 @@ public class MetaHelper {
     public static final String X_IMAGE_MD5 = "X-Image-Md5";
     private static final int BUFFER_BYTES = 8 * 1024;
     private static final int CHECKPOINT_LIMIT_BYTES = 30 * 1024 * 1024;
-    private static final String VALID_FILENAME_REGEX = "^image\\.\\d+(\\.part)?$";
+    private static final String VALID_FILENAME_REGEX = "^(?!\\.)[a-zA-Z0-9_\\-.]+$";
 
 
     public static File getMasterImageDir() {
@@ -115,13 +116,15 @@ public class MetaHelper {
         }
     }
 
-
-    private static void checkIsValidFileName(String filename) {
+    protected static void checkIsValidFileName(String filename) {
         if (!Config.meta_helper_security_mode) {
             return;
         }
+        if (StringUtils.isBlank(filename)) {
+            return;
+        }
         if (!filename.matches(VALID_FILENAME_REGEX)) {
-            throw new IllegalArgumentException("Invalid filename");
+            throw new IllegalArgumentException("Invalid filename : " + filename);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -200,9 +200,6 @@ public class MetaHelper {
             if (out != null) {
                 out.close();
             }
-            if (!md5Matched && file.exists() & Config.meta_helper_security_mode) {
-                file.delete();
-            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -159,7 +159,6 @@ public class MetaHelper {
             throws IOException {
         HttpURLConnection conn = null;
         checkFile(file);
-        boolean md5Matched = true;
         OutputStream out = new FileOutputStream(file);
         try {
             conn = HttpURLUtil.getConnectionWithNodeIdent(urlStr);
@@ -189,7 +188,6 @@ public class MetaHelper {
             if (remoteMd5 != null) {
                 String localMd5 = DigestUtils.md5Hex(new FileInputStream(file));
                 if (!remoteMd5.equals(localMd5)) {
-                    md5Matched = false;
                     throw new IOException("Unexpected image md5, expected: " + remoteMd5 + ", actual: " + localMd5);
                 }
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/master/MetaHelperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/master/MetaHelperTest.java
@@ -89,6 +89,18 @@ public class MetaHelperTest {
 
     }
 
+    @Test
+    public void testFileNameCheck() {
+        Config.meta_helper_security_mode = true;
+        MetaHelper.checkIsValidFileName("VERSION");
+        MetaHelper.checkIsValidFileName("image.1");
+        MetaHelper.checkIsValidFileName("image.1.part");
+        MetaHelper.checkIsValidFileName("image.1.part.1");
+        Assert.assertThrows(IllegalArgumentException.class, () -> MetaHelper.checkIsValidFileName("../testfile."));
+
+
+    }
+
     @AfterEach
     public void tearDown() {
         if (tempDir.exists()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/master/MetaHelperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/master/MetaHelperTest.java
@@ -70,7 +70,7 @@ public class MetaHelperTest {
     @Test
     public void testFile() throws IOException {
 
-        String errorFilename = "testfile.";
+        String errorFilename = "..testfile.";
         File errorFileWithSuffix = new File(tempDir, errorFilename);
         String rightFilename = "image.1";
         File rightFileWithSuffix = new File(tempDir, rightFilename);
@@ -80,8 +80,8 @@ public class MetaHelperTest {
         if (errorFileWithSuffix.exists()) {
             errorFileWithSuffix.delete();
         }
-        Assert.assertThrows(IllegalArgumentException.class, () -> MetaHelper.complete(errorFilename, tempDir));
-        Assert.assertThrows(IllegalArgumentException.class, () -> MetaHelper.getFile(errorFilename, tempDir));
+        Assert.assertThrows(Exception.class, () -> MetaHelper.complete(errorFilename, tempDir));
+        Assert.assertThrows(Exception.class, () -> MetaHelper.getFile(errorFilename, tempDir));
         if (rightFileWithSuffix.exists()) {
             rightFileWithSuffix.delete();
         }


### PR DESCRIPTION
## Proposed changes
The file name may also be VERSION. Considering the code maintainability, we will only check whether the file name is legal.

