### PR TITLE
[bugfix](hive)Remove redundant split operations

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -126,6 +126,7 @@ public abstract class FileScanNode extends ExternalScanNode {
         output.append(prefix);
         if (isBatchMode()) {
             output.append("(approximate)");
+            splitAssignment.stop();
         }
         output.append("inputSplitNum=").append(selectedSplitNum).append(", totalFileSize=")
             .append(totalFileSize).append(", scanRanges=").append(scanRangeLocations.size()).append("\n");


### PR DESCRIPTION
## Proposed changes

1. In explain, we don't need to get all the splits.
2. All scans in Hive share the same scheduleExecutor. If a table with a large amount of data is specified during explain, the background will continue to scan after the explain is completed. If the user queries another small Hive table at this time, the operation will be stuck.

