### PR TITLE
[opt](partition) delete idToStoragePolicy from PartitionInfo.java

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4280,8 +4280,9 @@ public class Env {
                         if (dataProperty.getStorageMedium() == TStorageMedium.SSD
                                 && dataProperty.getCooldownTimeMs() < currentTimeMs) {
                             // expire. change to HDD.
-                            DataProperty hddProperty = new DataProperty(TStorageMedium.HDD);
-                            partitionInfo.setDataProperty(partition.getId(), hddProperty);
+                            DataProperty newProperty = new DataProperty(TStorageMedium.HDD);
+                            newProperty.setStoragePolicy(partitionInfo.getStoragePolicy(partitionId));
+                            partitionInfo.setDataProperty(partition.getId(), newProperty);
                             storageMediumMap.put(partitionId, TStorageMedium.HDD);
                             LOG.info("partition[{}-{}-{}] storage medium changed from SSD to HDD. "
                                             + "cooldown time: {}. current time: {}", dbId, tableId, partitionId,
@@ -4290,9 +4291,8 @@ public class Env {
 
                             // log
                             ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), olapTable.getId(),
-                                    partition.getId(), hddProperty, ReplicaAllocation.NOT_SET,
-                                    partitionInfo.getIsInMemory(partition.getId()),
-                                    partitionInfo.getStoragePolicy(partitionId), Maps.newHashMap());
+                                    partition.getId(), newProperty, ReplicaAllocation.NOT_SET,
+                                    partitionInfo.getIsInMemory(partition.getId()), Maps.newHashMap());
 
                             editLog.logModifyPartition(info);
                         }
@@ -5249,8 +5249,7 @@ public class Env {
 
         // log
         ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
-                newDataProperty, replicaAlloc, isInMemory, partitionInfo.getStoragePolicy(partition.getId()),
-                tblProperties);
+                newDataProperty, replicaAlloc, isInMemory, tblProperties);
         editLog.logModifyPartition(info);
         if (LOG.isDebugEnabled()) {
             LOG.debug("modify partition[{}-{}-{}] replica allocation to {}",

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -264,9 +264,10 @@ public class ListPartitionInfo extends PartitionInfo {
             PartitionKeyDesc partitionKeyDesc = PartitionKeyDesc.createIn(inValues);
 
             Map<String, String> properties = Maps.newHashMap();
-            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
-                if (!p.equals("")) {
-                    properties.put("STORAGE POLICY", p);
+            Optional.ofNullable(this.idToDataProperty.get(entry.getKey())).ifPresent(p -> {
+                String storagePolicy = p.getStoragePolicy();
+                if (!storagePolicy.equals("")) {
+                    properties.put("STORAGE POLICY", storagePolicy);
                 }
             });
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -70,8 +70,6 @@ public class PartitionInfo {
     // partition id -> data property
     @SerializedName("IdToDataProperty")
     protected Map<Long, DataProperty> idToDataProperty;
-    // partition id -> storage policy
-    protected Map<Long, String> idToStoragePolicy;
     // partition id -> replication allocation
     @SerializedName("IdToReplicaAllocation")
     protected Map<Long, ReplicaAllocation> idToReplicaAllocation;
@@ -100,7 +98,6 @@ public class PartitionInfo {
         this.idToReplicaAllocation = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
-        this.idToStoragePolicy = new HashMap<>();
         this.partitionExprs = new ArrayList<>();
     }
 
@@ -110,7 +107,6 @@ public class PartitionInfo {
         this.idToReplicaAllocation = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
-        this.idToStoragePolicy = new HashMap<>();
         this.partitionExprs = new ArrayList<>();
     }
 
@@ -209,7 +205,6 @@ public class PartitionInfo {
         idToDataProperty.put(partitionId, desc.getPartitionDataProperty());
         idToReplicaAllocation.put(partitionId, desc.getReplicaAlloc());
         idToInMemory.put(partitionId, desc.isInMemory());
-        idToStoragePolicy.put(partitionId, desc.getStoragePolicy());
 
         return partitionItem;
     }
@@ -225,7 +220,6 @@ public class PartitionInfo {
         idToDataProperty.put(partitionId, dataProperty);
         idToReplicaAllocation.put(partitionId, replicaAlloc);
         idToInMemory.put(partitionId, isInMemory);
-        idToStoragePolicy.put(partitionId, "");
         //TODO
         //idToMutable.put(partitionId, isMutable);
     }
@@ -299,18 +293,17 @@ public class PartitionInfo {
     }
 
     public void refreshTableStoragePolicy(String storagePolicy) {
-        idToStoragePolicy.replaceAll((k, v) -> storagePolicy);
         idToDataProperty.entrySet().forEach(entry -> {
             entry.getValue().setStoragePolicy(storagePolicy);
         });
     }
 
     public String getStoragePolicy(long partitionId) {
-        return idToStoragePolicy.getOrDefault(partitionId, "");
+        return idToDataProperty.get(partitionId).getStoragePolicy();
     }
 
     public void setStoragePolicy(long partitionId, String storagePolicy) {
-        idToStoragePolicy.put(partitionId, storagePolicy);
+        idToDataProperty.get(partitionId).setStoragePolicy(storagePolicy);
     }
 
     public Map<Long, ReplicaAllocation> getPartitionReplicaAllocations() {
@@ -421,12 +414,10 @@ public class PartitionInfo {
         Map<Long, ReplicaAllocation> origIdToReplicaAllocation = idToReplicaAllocation;
         Map<Long, PartitionItem> origIdToItem = idToItem;
         Map<Long, Boolean> origIdToInMemory = idToInMemory;
-        Map<Long, String> origIdToStoragePolicy = idToStoragePolicy;
         idToDataProperty = Maps.newHashMap();
         idToReplicaAllocation = Maps.newHashMap();
         idToItem = Maps.newHashMap();
         idToInMemory = Maps.newHashMap();
-        idToStoragePolicy = Maps.newHashMap();
 
         for (Map.Entry<Long, Long> entry : partitionIdMap.entrySet()) {
             idToDataProperty.put(entry.getKey(), origIdToDataProperty.get(entry.getValue()));
@@ -437,7 +428,6 @@ public class PartitionInfo {
                 idToItem.put(entry.getKey(), origIdToItem.get(entry.getValue()));
             }
             idToInMemory.put(entry.getKey(), origIdToInMemory.get(entry.getValue()));
-            idToStoragePolicy.put(entry.getKey(), origIdToStoragePolicy.get(entry.getValue()));
         }
     }
 
@@ -518,15 +508,15 @@ public class PartitionInfo {
         return isMultiColumnPartition == that.isMultiColumnPartition && type == that.type && Objects.equals(
                 partitionColumns, that.partitionColumns) && Objects.equals(idToItem, that.idToItem)
                 && Objects.equals(idToTempItem, that.idToTempItem) && Objects.equals(idToDataProperty,
-                that.idToDataProperty) && Objects.equals(idToStoragePolicy, that.idToStoragePolicy)
-                && Objects.equals(idToReplicaAllocation, that.idToReplicaAllocation) && Objects.equals(
-                idToInMemory, that.idToInMemory) && Objects.equals(idToTabletType, that.idToTabletType)
+                that.idToDataProperty) && Objects.equals(idToReplicaAllocation, that.idToReplicaAllocation)
+                && Objects.equals(idToInMemory, that.idToInMemory)
+                && Objects.equals(idToTabletType, that.idToTabletType)
                 && Objects.equals(partitionExprs, that.partitionExprs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, partitionColumns, idToItem, idToTempItem, idToDataProperty, idToStoragePolicy,
-                idToReplicaAllocation, isMultiColumnPartition, idToInMemory, idToTabletType, partitionExprs);
+        return Objects.hash(type, partitionColumns, idToItem, idToTempItem, idToDataProperty, idToReplicaAllocation,
+                isMultiColumnPartition, idToInMemory, idToTabletType, partitionExprs);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -330,9 +330,10 @@ public class RangePartitionInfo extends PartitionInfo {
                     PartitionInfo.toPartitionValue(range.upperEndpoint()));
 
             Map<String, String> properties = Maps.newHashMap();
-            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
-                if (!p.equals("")) {
-                    properties.put("STORAGE POLICY", p);
+            Optional.ofNullable(this.idToDataProperty.get(entry.getKey())).ifPresent(p -> {
+                String storagePolicy = p.getStoragePolicy();
+                if (!storagePolicy.equals("")) {
+                    properties.put("STORAGE POLICY", storagePolicy);
                 }
             });
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ModifyPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ModifyPartitionInfo.java
@@ -51,13 +51,11 @@ public class ModifyPartitionInfo implements Writable {
     @SerializedName(value = "replicaAlloc")
     private ReplicaAllocation replicaAlloc;
 
-    @SerializedName(value = "storagePolicy")
-    private String storagePolicy;
     @SerializedName(value = "tableProperties")
     private Map<String, String> tblProperties;
 
     public String getStoragePolicy() {
-        return storagePolicy;
+        return dataProperty.getStoragePolicy();
     }
 
     public ModifyPartitionInfo() {
@@ -65,15 +63,13 @@ public class ModifyPartitionInfo implements Writable {
     }
 
     public ModifyPartitionInfo(long dbId, long tableId, long partitionId, DataProperty dataProperty,
-            ReplicaAllocation replicaAlloc, boolean isInMemory, String storagePolicy,
-            Map<String, String> tblProperties) {
+            ReplicaAllocation replicaAlloc, boolean isInMemory, Map<String, String> tblProperties) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.dataProperty = dataProperty;
         this.replicaAlloc = replicaAlloc;
         this.isInMemory = isInMemory;
-        this.storagePolicy = storagePolicy;
         this.tblProperties = tblProperties;
         if (this.tblProperties == null) {
             this.tblProperties = Maps.newHashMap();
@@ -134,7 +130,7 @@ public class ModifyPartitionInfo implements Writable {
         ModifyPartitionInfo otherInfo = (ModifyPartitionInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId()
                 && dataProperty.equals(otherInfo.getDataProperty()) && replicaAlloc.equals(otherInfo.replicaAlloc)
-                && isInMemory == otherInfo.isInMemory() && storagePolicy.equals(otherInfo.storagePolicy);
+                && isInMemory == otherInfo.isInMemory();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/BatchModifyPartitionsInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/BatchModifyPartitionsInfoTest.java
@@ -62,7 +62,7 @@ public class BatchModifyPartitionsInfoTest {
         for (long partitionId : partitionIds) {
             modifyInfos.add(new ModifyPartitionInfo(DB_ID, TB_ID, partitionId,
                     new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM), ReplicaAllocation.DEFAULT_ALLOCATION,
-                    true, "", Maps.newHashMap()));
+                    true, Maps.newHashMap()));
         }
 
         BatchModifyPartitionsInfo batchModifyPartitionsInfo = new BatchModifyPartitionsInfo(modifyInfos);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The partitions' storage policy is saved in both  idToStoragePolicy and idToDataProperty, but idToStoragePolicy will not be written to editLog, this PR deletes the redundant info idToStoragePolicy to simplify partition info.

