### PR TITLE
[bugfix](loadmem) load memory is too small because flush memory is not right

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -142,9 +142,12 @@ Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, in
     signal::set_signal_task_id(_rowset_writer->load_id());
     signal::tablet_id = memtable->tablet_id();
     {
-        SCOPED_CONSUME_MEM_TRACKER(memtable->flush_mem_tracker());
         std::unique_ptr<vectorized::Block> block;
+        // During to block method, it will release old memory and create new block, so that
+        // we could not scoped it.
         RETURN_IF_ERROR(memtable->to_block(&block));
+        memtable->flush_mem_tracker()->consume(block->allocated_bytes());
+        SCOPED_CONSUME_MEM_TRACKER(memtable->flush_mem_tracker());
         RETURN_IF_ERROR(_rowset_writer->flush_memtable(block.get(), segment_id, flush_size));
     }
     _memtable_stat += memtable->stat();


### PR DESCRIPTION
## Proposed changes

<img width="946" alt="image" src="https://github.com/user-attachments/assets/1a203137-57bd-4f54-8771-b1536ca5ddd3">


to block will clear input block and will release some memory, so if scoped, then the result will be small