### PR TITLE
[Enhancement](brpc)Added  enable_brpc_builtin_services  parameter in be.conf

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -513,6 +513,10 @@ DEFINE_Int32(brpc_heavy_work_pool_max_queue_size, "-1");
 DEFINE_Int32(brpc_light_work_pool_max_queue_size, "-1");
 DEFINE_mBool(enable_bthread_transmit_block, "true");
 
+//Enable brpc builtin services, see:
+//https://brpc.apache.org/docs/server/basics/#disable-built-in-services-completely
+DEFINE_Bool(enable_brpc_builtin_services, "true");
+
 // The maximum amount of data that can be processed by a stream load
 DEFINE_mInt64(streaming_load_max_mb, "10240");
 // Some data formats, such as JSON, cannot be streamed.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -984,6 +984,8 @@ DECLARE_mInt64(nodechannel_pending_queue_max_bytes);
 // The batch size for sending data by brpc streaming client
 DECLARE_mInt64(brpc_streaming_client_batch_bytes);
 
+DECLARE_Bool(enable_brpc_builtin_services);
+
 // Max waiting time to wait the "plan fragment start" rpc.
 // If timeout, the fragment will be cancelled.
 // This parameter is usually only used when the FE loses connection,

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -83,6 +83,8 @@ Status BRpcService::start(int port, int num_threads) {
         sslOptions->default_cert.private_key = config::ssl_private_key_path;
     }
 
+    options.has_builtin_services = config::enable_brpc_builtin_services;
+
     butil::EndPoint point;
     if (butil::str2endpoint(BackendOptions::get_service_bind_address(), port, &point) < 0) {
         return Status::InternalError("convert address failed, host={}, port={}", "[::0]", port);

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -65,7 +65,7 @@ enable_missing_rows_correctness_check=true
 trino_connector_plugin_dir=/tmp/trino_connector/connectors
 
 enable_jvm_monitor = true
-
+enable_brpc_builtin_services=false
 enable_be_proc_monitor = true
 be_proc_monitor_interval_ms = 30000
 webserver_num_workers = 128

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -65,7 +65,7 @@ enable_missing_rows_correctness_check=true
 trino_connector_plugin_dir=/tmp/trino_connector/connectors
 
 enable_jvm_monitor = true
-enable_brpc_builtin_services=false
+
 enable_be_proc_monitor = true
 be_proc_monitor_interval_ms = 30000
 webserver_num_workers = 128


### PR DESCRIPTION
## Proposed changes

Since [brpc's built-in services](https://brpc.apache.org/zh/docs/builtin-services/buildin_services/) will expose some internal server status, for security reasons, add the parameter `enable_brpc_builtin_services` in `be.conf`. When the parameter is false, this built-in service can be disabled.
