### PR TITLE
[fix](encrypt) wrong mode arg of encrypt and decrypt function make BE crash

### DIFF
--- a/be/src/vec/functions/function_encryption.cpp
+++ b/be/src/vec/functions/function_encryption.cpp
@@ -244,8 +244,9 @@ struct EncryptionAndDecryptTwoImpl {
         if (mode_arg.size != 0) {
             if (!aes_mode_map.contains(mode_str)) {
                 all_insert_null = true;
+            } else {
+                encryption_mode = aes_mode_map.at(mode_str);
             }
-            encryption_mode = aes_mode_map.at(mode_str);
         }
         const ColumnString::Offsets* offsets_column = &column->get_offsets();
         const ColumnString::Chars* chars_column = &column->get_chars();
@@ -371,13 +372,15 @@ struct EncryptionAndDecryptMultiImpl {
             if constexpr (is_sm_mode) {
                 if (sm4_mode_map.count(mode_str) == 0) {
                     all_insert_null = true;
+                } else {
+                    encryption_mode = sm4_mode_map.at(mode_str);
                 }
-                encryption_mode = sm4_mode_map.at(mode_str);
             } else {
                 if (aes_mode_map.count(mode_str) == 0) {
                     all_insert_null = true;
+                } else {
+                    encryption_mode = aes_mode_map.at(mode_str);
                 }
-                encryption_mode = aes_mode_map.at(mode_str);
             }
         }
 

--- a/regression-test/data/query_p0/sql_functions/encryption_digest/test_encryption_function.out
+++ b/regression-test/data/query_p0/sql_functions/encryption_digest/test_encryption_function.out
@@ -272,3 +272,6 @@ zhang
 -- !sql56 --
 zhang
 
+-- !sql57 --
+\N
+

--- a/regression-test/suites/query_p0/sql_functions/encryption_digest/test_encryption_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/encryption_digest/test_encryption_function.groovy
@@ -226,4 +226,7 @@ suite("test_encryption_function") {
     qt_sql54 """ select aes_decrypt(aes_encrypt(k,k1,k2, "AES_256_CFB"),k1,k2, "AES_256_CFB") from quantile_table2; """
     qt_sql55 """ select aes_decrypt(aes_encrypt("zhang",k1,k2, "AES_256_CFB"),k1,k2, "AES_256_CFB") from quantile_table2; """
     qt_sql56 """ select aes_decrypt(aes_encrypt("zhang",k1,k2, "AES_256_CFB"),k1,k2, "AES_256_CFB") from quantile_table2; """
+
+    //four arg (column/const) with wrong mode
+    qt_sql57 """ select sm4_decrypt(sm4_encrypt(k,"doris","abcdefghij", "SM4_128_CBC"),"doris","abcdefghij","SM4_555_CBC") from quantile_table2; """
 }


### PR DESCRIPTION
Not supported mode arg in sm4_encrypt and sm4_decrypt make BE crash.

Intro by https://github.com/apache/doris/pull/37194