### PR TITLE
[fix](nullable) Fix correctness problem caused by nullable judgement

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -132,9 +132,8 @@ public:
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             return {ExchangeType::NOOP};
         } else if (_is_broadcast_join) {
-            return _child->ignore_data_distribution()
-                           ? DataDistribution(ExchangeType::PASS_TO_ONE)
-                           : DataDistribution(ExchangeType::NOOP);
+            return _child->ignore_data_distribution() ? DataDistribution(ExchangeType::PASS_TO_ONE)
+                                                      : DataDistribution(ExchangeType::NOOP);
         }
         return _join_distribution == TJoinDistributionType::BUCKET_SHUFFLE ||
                                _join_distribution == TJoinDistributionType::COLOCATE

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -601,6 +601,12 @@ void ColumnNullable::_update_has_null() {
     _need_update_has_null = false;
 }
 
+bool ColumnNullable::has_null() const {
+    // TODO: Need to cache the '_has_null' value
+    const UInt8* null_pos = get_null_map_data().data();
+    return simd::contain_byte(null_pos, get_null_map_data().size(), 1);
+}
+
 bool ColumnNullable::has_null(size_t size) const {
     if (!_has_null && !_need_update_has_null) {
         return false;

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -339,12 +339,7 @@ public:
     /// Check that size of null map equals to size of nested column.
     void check_consistency() const;
 
-    bool has_null() const override {
-        if (UNLIKELY(_need_update_has_null)) {
-            const_cast<ColumnNullable*>(this)->_update_has_null();
-        }
-        return _has_null;
-    }
+    bool has_null() const override;
 
     bool has_null(size_t size) const override;
 


### PR DESCRIPTION
## Proposed changes

In PR #13289, `has_null` is cached in NullableColumn so we get a better performance if we need to use the nullable property.

But recently we find a serious correctness problem due to this. Now I m still not clear why this will cause this problem and I just revert this part to ensure we get a correct result. 

After this PR, we need to continue to find the root cause.

<!--Describe your changes.-->

