### PR TITLE
[improvement](stream load) display the time of receiving network data

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -107,6 +107,8 @@ std::string StreamLoadContext::to_json() const {
     writer.Int64(read_data_cost_nanos / 1000000);
     writer.Key("WriteDataTimeMs");
     writer.Int(write_data_cost_nanos / 1000000);
+    writer.Key("ReceiveDataTimeMs");
+    writer.Int((receive_and_read_data_cost_nanos - read_data_cost_nanos) / 1000000);
     if (!group_commit) {
         writer.Key("CommitAndPublishTimeMs");
         writer.Int64(commit_and_publish_txn_cost_nanos / 1000000);


### PR DESCRIPTION
Display the time of receiving network data.

For example:
```
Stream load result: {
    "TxnId": 19,
    "Label": "c10ee032-c19c-484f-80b2-16f6c1d0c209",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Success",
    "Message": "OK",
    "NumberTotalRows": 6,
    "NumberLoadedRows": 6,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 60,
    "LoadTimeMs": 32,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 4,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 4,
    "ReceiveDataTimeMs": 6,
    "CommitAndPublishTimeMs": 22
}
```

