### PR TITLE
[feat](Authorization-plugin)Authorization framework modularization

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2313,6 +2313,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static long ranger_cache_size = 10000;
 
+    @ConfField(description = {
+            "鉴权插件配置文件路径，需在 DORIS_HOME 下，默认为 conf/authorization.conf",
+            "Authorization plugin configuration file path, need to be in DORIS_HOME,"
+                    + "default is conf/authorization.conf"})
+    public static String authorization_config_file_path = "conf/authorization.conf";
+
     /**
      * This configuration is used to enable the statistics of query information, which will record
      * the access status of databases, tables, and columns, and can be used to guide the

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -35,7 +35,6 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.CatalogIf;
-import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
@@ -1556,16 +1555,6 @@ public class PropertyAnalyzer {
         // "access_controller.properties.prop2" = "yyy",
         // )
         // 1. get access controller class
-        String acClass = properties.getOrDefault(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "");
-        if (!Strings.isNullOrEmpty(acClass)) {
-            // 2. check if class exists
-            try {
-                Class.forName(acClass);
-            } catch (ClassNotFoundException e) {
-                throw new AnalysisException("failed to find class " + acClass, e);
-            }
-        }
-
         if (isAlter) {
             // The 'use_meta_cache' property can not be modified
             if (properties.containsKey(ExternalCatalog.USE_META_CACHE)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerFactory.java
@@ -20,6 +20,14 @@ package org.apache.doris.mysql.privilege;
 import java.util.Map;
 
 public interface AccessControllerFactory {
+    /**
+     * Returns the identifier for the factory, such as "range-doris".
+     *
+     * @return the factory identifier
+     */
+    default String factoryIdentifier() {
+        return this.getClass().getSimpleName();
+    }
 
     CatalogAccessController createAccessController(Map<String, String> prop);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
@@ -82,13 +82,13 @@ public class AccessControllerManager {
             try {
                 prop = PropertiesUtils.loadAccessControllerPropertiesOrNull();
             } catch (IOException e) {
-                throw new RuntimeException("Failed to load authorization properties,"
-                        + "please check the configuration file, authorization name is " + accessControllerName, e);
+                throw new RuntimeException("Failed to load authorization properties."
+                        + "Please check the configuration file, authorization name is " + accessControllerName, e);
             }
             return accessControllerFactoriesCache.get(accessControllerName).createAccessController(prop);
         }
         throw new RuntimeException("No authorization plugin factory found for " + accessControllerName
-                + "Please confirm that your plugin is placed in the correct location.");
+                + ". Please confirm that your plugin is placed in the correct location.");
     }
 
     private void loadAccessControllerPlugins() {
@@ -135,7 +135,7 @@ public class AccessControllerManager {
                 .createAccessController(prop);
         if (!isDryRun) {
             ctlToCtlAccessController.put(ctl, accessController);
-            LOG.info("create access controller {} for catalog {}", ctl, acFactoryClassName);
+            LOG.info("create access controller {} for catalog {}", acFactoryClassName, ctl);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RangerDorisAccessControllerFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RangerDorisAccessControllerFactory.java
@@ -15,22 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.catalog.authorizer.ranger.hive;
+package org.apache.doris.mysql.privilege;
 
-import org.apache.doris.mysql.privilege.AccessControllerFactory;
-import org.apache.doris.mysql.privilege.CatalogAccessController;
+import org.apache.doris.catalog.authorizer.ranger.doris.RangerCacheDorisAccessController;
 
 import java.util.Map;
 
-public class RangerHiveAccessControllerFactory implements AccessControllerFactory {
-
+public class RangerDorisAccessControllerFactory implements AccessControllerFactory {
     @Override
     public String factoryIdentifier() {
-        return "ranger-hive";
+        return "ranger-doris";
     }
 
     @Override
-    public CatalogAccessController createAccessController(Map<String, String> prop) {
-        return new RangerCacheHiveAccessController(prop);
+    public RangerCacheDorisAccessController createAccessController(Map<String, String> prop) {
+        return new RangerCacheDorisAccessController("doris");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/PropertiesUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/PropertiesUtils.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.plugin;
+
+import org.apache.doris.common.EnvUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class PropertiesUtils {
+    public static final String ACCESS_PROPERTIES_FILE_DIR = "/conf/access.conf";
+
+    public static Map<String, String> loadAccessControllerPropertiesOrNull() throws IOException {
+        String configFilePath = EnvUtils.getDorisHome() + ACCESS_PROPERTIES_FILE_DIR;
+        if (new File(configFilePath).exists()) {
+            Properties properties = new Properties();
+            properties.load(Files.newInputStream(Paths.get(configFilePath)));
+            return propertiesToMap(properties);
+        }
+        return null;
+    }
+
+    public static Map<String, String> propertiesToMap(Properties properties) {
+        Map<String, String> map = new HashMap<>();
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            String value = String.valueOf(entry.getValue());
+            map.put(key, value);
+        }
+        return map;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/PropertiesUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/PropertiesUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.plugin;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.EnvUtils;
 
 import java.io.File;
@@ -28,7 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class PropertiesUtils {
-    public static final String ACCESS_PROPERTIES_FILE_DIR = "/conf/access.conf";
+    public static final String ACCESS_PROPERTIES_FILE_DIR = Config.authorization_config_file_path;
 
     public static Map<String, String> loadAccessControllerPropertiesOrNull() throws IOException {
         String configFilePath = EnvUtils.getDorisHome() + ACCESS_PROPERTIES_FILE_DIR;

--- a/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
+++ b/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
@@ -1,0 +1,2 @@
+org.apache.doris.mysql.privilege.RangerDorisAccessControllerFactory
+org.apache.doris.catalog.authorizer.ranger.hive.RangerHiveAccessControllerFactory

--- a/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
+++ b/fe/fe-core/src/main/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
@@ -1,2 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.mysql.privilege.RangerDorisAccessControllerFactory
 org.apache.doris.catalog.authorizer.ranger.hive.RangerHiveAccessControllerFactory

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/CustomAccessControllerFactory.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/CustomAccessControllerFactory.java
@@ -15,22 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.catalog.authorizer.ranger.hive;
+package org.apache.doris.nereids.privileges;
 
 import org.apache.doris.mysql.privilege.AccessControllerFactory;
 import org.apache.doris.mysql.privilege.CatalogAccessController;
 
 import java.util.Map;
 
-public class RangerHiveAccessControllerFactory implements AccessControllerFactory {
-
+public class CustomAccessControllerFactory implements AccessControllerFactory {
     @Override
     public String factoryIdentifier() {
-        return "ranger-hive";
+        return "CustomAccess";
     }
 
     @Override
     public CatalogAccessController createAccessController(Map<String, String> prop) {
-        return new RangerCacheHiveAccessController(prop);
+        return new TestCheckPrivileges.SimpleCatalogAccessController();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/TestCheckPrivileges.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/TestCheckPrivileges.java
@@ -26,7 +26,6 @@ import org.apache.doris.common.AuthorizationException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.test.TestExternalCatalog.TestCatalogProvider;
-import org.apache.doris.mysql.privilege.AccessControllerFactory;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.CatalogAccessController;
 import org.apache.doris.mysql.privilege.DataMaskPolicy;
@@ -92,7 +91,7 @@ public class TestCheckPrivileges extends TestWithFeService implements GeneratedM
         String catalogProvider
                 = "org.apache.doris.nereids.privileges.TestCheckPrivileges$CustomCatalogProvider";
         String accessControllerFactory
-                = "org.apache.doris.nereids.privileges.TestCheckPrivileges$CustomAccessControllerFactory";
+                = "org.apache.doris.nereids.privileges.CustomAccessControllerFactory";
 
         String catalog = "custom_catalog";
         String db = "test_db";
@@ -311,13 +310,6 @@ public class TestCheckPrivileges extends TestWithFeService implements GeneratedM
         @Override
         public Map<String, Map<String, List<Column>>> getMetadata() {
             return CATALOG_META;
-        }
-    }
-
-    public static class CustomAccessControllerFactory implements AccessControllerFactory {
-        @Override
-        public CatalogAccessController createAccessController(Map<String, String> prop) {
-            return new SimpleCatalogAccessController();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/TestCheckPrivileges.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/TestCheckPrivileges.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AuthorizationException;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.test.TestExternalCatalog.TestCatalogProvider;
@@ -92,9 +93,19 @@ public class TestCheckPrivileges extends TestWithFeService implements GeneratedM
                 = "org.apache.doris.nereids.privileges.TestCheckPrivileges$CustomCatalogProvider";
         String accessControllerFactory
                 = "org.apache.doris.nereids.privileges.CustomAccessControllerFactory";
-
         String catalog = "custom_catalog";
         String db = "test_db";
+        String failedAccessControllerFactory
+                = "org.apache.doris.nereids.privileges.FailedAccessControllerFactory";
+        //try to create catalog with failed access controller
+        Assertions.assertThrows(DdlException.class, () -> {
+            createCatalog("create catalog " + catalog + " properties("
+                    + " \"type\"=\"test\","
+                    + " \"catalog_provider.class\"=\"" + catalogProvider + "\","
+                    + " \"" + CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP + "\"=\"" + failedAccessControllerFactory + "\""
+                    + ")");
+        }, "Failed to init access controller");
+
         createCatalog("create catalog " + catalog + " properties("
                 + " \"type\"=\"test\","
                 + " \"catalog_provider.class\"=\"" + catalogProvider + "\","

--- a/fe/fe-core/src/test/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
+++ b/fe/fe-core/src/test/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.nereids.privileges.CustomAccessControllerFactory

--- a/fe/fe-core/src/test/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
+++ b/fe/fe-core/src/test/resources/META-INF/services/org.apache.doris.mysql.privilege.AccessControllerFactory
@@ -1,0 +1,1 @@
+org.apache.doris.nereids.privileges.CustomAccessControllerFactory


### PR DESCRIPTION
# AccessControllerFactory Interface

## Overview

The `AccessControllerFactory` interface is responsible for creating and managing `CatalogAccessController` instances. The interface includes the following methods:

- **`default String factoryIdentifier()`**: Returns the identifier for the factory, defaulting to the simple name of the implementing class. To maintain compatibility with user-defined plugins from older versions, the `factoryIdentifier` method provides a default implementation that returns the simple name of the current implementation class, ensuring that each factory has a unique identifier.

- **`CatalogAccessController createAccessController(Map<String, String> prop)`**: Creates a new instance of `CatalogAccessController` and initializes it with the provided properties.

## Factory Identifier

Each class implementing `AccessControllerFactory` will automatically use its class name as the factory identifier. This helps in identifying different factory instances during plugin loading and selection.

## Instance Creation

The `createAccessController` method allows you to create and initialize `CatalogAccessController` instances. The `prop` parameter provides the configuration properties needed for initialization.

## Compatibility

- If you are using the previously built-in `range-dorir` authentication plugin, no configuration changes are required; it will continue to function as before.
- For custom plugins, configuration information should be defined in `conf/access.conf`. Then, in `fe.conf`, specify the `access_controller_type` as the identifier for the custom plugin.

## How to Extend

- Add the `fe-core` dependency to your Maven `pom.xml` file.

```xml
        <dependency>
            <groupId>org.apache.doris</groupId>
            <artifactId>fe-core</artifactId>
            <version>1.2-SNAPSHOT</version>
            <scope>provided</scope>
        </dependency>
```
Then, implement the AccessControllerFactory interface to create your own plugin factory class as follows:
```java

public class SimpleAccessControllerFactory implements AccessControllerFactory {
    @Override
    public String factoryIdentifier() {
        return "local-simple";
    }

    @Override
    public CatalogAccessController createAccessController(Map<String, String> map) {
        return new SimpleAccessController(map);
    }
}

package org.example.access;

import org.apache.doris.analysis.ResourceTypeEnum;
import org.apache.doris.analysis.UserIdentity;
import org.apache.doris.common.AuthorizationException;
import org.apache.doris.mysql.privilege.CatalogAccessController;
import org.apache.doris.mysql.privilege.DataMaskPolicy;
import org.apache.doris.mysql.privilege.PrivPredicate;
import org.apache.doris.mysql.privilege.RowFilterPolicy;

import java.util.Collections;
import java.util.HashMap;
import java.util.List;
import java.util.Map;
import java.util.Optional;
import java.util.Set;

public class SimpleAccessController implements CatalogAccessController {

    private HashMap<String, Boolean> databasePrivs = new HashMap<>();
    // just for test
    public SimpleAccessController(Map<String, String> prop) {
        prop.forEach((k, v) -> {
            databasePrivs.put(k, Boolean.parseBoolean(v));
        });
    }

    @Override
    public boolean checkGlobalPriv(UserIdentity userIdentity, PrivPredicate privPredicate) {
        return false;
    }

    @Override
    public boolean checkCtlPriv(UserIdentity userIdentity, String s, PrivPredicate privPredicate) {
        return true;
    }
    ...

```
Add a new folder named **META-INF/services** under the resources directory, Create a new file named **org.apache.doris.mysql.privilege.AccessControllerFactory.** with a file containing **org.apache.doris.mysql.privilege.AccessControllerFactory.**

## How to Use
- In `fe.conf`, specify the **access_controller_type=local-simple**
- Put the jar file containing the custom plugin in the **fe/custom_lib** directory.



