### PR TITLE
[fix](scanner) Fix incorrect _max_thread_num in scanner context #40569

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1279,15 +1279,7 @@ Status ScanLocalState<Derived>::_start_scanners(
     auto& p = _parent->cast<typename Derived::Parent>();
     _scanner_ctx = PipXScannerContext::create_shared(
             state(), this, p._output_tuple_desc, p.output_row_descriptor(), scanners, p.limit(),
-            state()->scan_queue_mem_limit(), _scan_dependency,
-            // NOTE: This will logic makes _max_thread_num of ScannerContext to be C(num of cores) * 2
-            // For a query with C/2 instance and M scan node, scan task of this query will be C/2 * M * C*2
-            // and will be C*C*N at most.
-            // 1. If data distribution is ignored , we use 1 instance to scan.
-            // 2. Else, file scanner will consume much memory so we use config::doris_scanner_thread_pool_thread_num / query_parallel_instance_num scanners to scan.
-            p.ignore_data_distribution() && !p.is_file_scan_operator()
-                    ? 1
-                    : state()->query_parallel_instance_num());
+            _scan_dependency, p.ignore_data_distribution());
     return Status::OK();
 }
 

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -31,11 +31,9 @@ public:
                       const TupleDescriptor* output_tuple_desc,
                       const RowDescriptor* output_row_descriptor,
                       const std::list<std::shared_ptr<vectorized::ScannerDelegate>>& scanners,
-                      int64_t limit_, int64_t max_bytes_in_blocks_queue,
-                      const int num_parallel_instances)
+                      int64_t limit_, bool ignore_data_distribution)
             : vectorized::ScannerContext(state, parent, output_tuple_desc, output_row_descriptor,
-                                         scanners, limit_, max_bytes_in_blocks_queue,
-                                         num_parallel_instances) {}
+                                         scanners, limit_, ignore_data_distribution) {}
 };
 
 class PipXScannerContext final : public vectorized::ScannerContext {
@@ -46,12 +44,10 @@ public:
                        const TupleDescriptor* output_tuple_desc,
                        const RowDescriptor* output_row_descriptor,
                        const std::list<std::shared_ptr<vectorized::ScannerDelegate>>& scanners,
-                       int64_t limit_, int64_t max_bytes_in_blocks_queue,
-                       std::shared_ptr<pipeline::Dependency> dependency,
-                       const int num_parallel_instances)
+                       int64_t limit_, std::shared_ptr<pipeline::Dependency> dependency,
+                       bool ignore_data_distribution)
             : vectorized::ScannerContext(state, output_tuple_desc, output_row_descriptor, scanners,
-                                         limit_, max_bytes_in_blocks_queue, num_parallel_instances,
-                                         local_state) {
+                                         limit_, ignore_data_distribution, local_state) {
         _dependency = dependency;
     }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -41,8 +41,7 @@ using namespace std::chrono_literals;
 ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* output_tuple_desc,
                                const RowDescriptor* output_row_descriptor,
                                const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
-                               int64_t limit_, int64_t max_bytes_in_blocks_queue,
-                               const int num_parallel_instances,
+                               int64_t limit_, bool ignore_data_distribution,
                                pipeline::ScanLocalStateBase* local_state)
         : HasTaskExecutionCtx(state),
           _state(state),
@@ -53,77 +52,18 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
           _output_row_descriptor(output_row_descriptor),
           _batch_size(state->batch_size()),
           limit(limit_),
-          _max_bytes_in_queue(std::max(max_bytes_in_blocks_queue, (int64_t)1024) *
-                              num_parallel_instances),
           _scanner_scheduler(state->exec_env()->scanner_scheduler()),
           _all_scanners(scanners.begin(), scanners.end()),
-          _num_parallel_instances(num_parallel_instances) {
+          _ignore_data_distribution(ignore_data_distribution) {
     DCHECK(_output_row_descriptor == nullptr ||
            _output_row_descriptor->tuple_descriptors().size() == 1);
     _query_id = _state->get_query_ctx()->query_id();
     ctx_id = UniqueId::gen_uid().to_string();
-    // Provide more memory for wide tables, increase proportionally by multiples of 300
-    _max_bytes_in_queue *= _output_tuple_desc->slots().size() / 300 + 1;
-    if (scanners.empty()) {
-        _is_finished = true;
-        _set_scanner_done();
-    }
     _scanners.enqueue_bulk(scanners.begin(), scanners.size());
     if (limit < 0) {
         limit = -1;
     }
     MAX_SCALE_UP_RATIO = _state->scanner_scale_up_ratio();
-    // _max_thread_num controls how many scanners of this ScanOperator can be submitted to scheduler at a time.
-    // The overall target of our system is to make full utilization of the resources.
-    // At the same time, we dont want too many tasks are queued by scheduler, that makes the query
-    // waiting too long, and existing task can not be scheduled in time.
-    // First of all, we try to make sure _max_thread_num of a ScanNode of a query on a single backend is less than
-    // config::doris_scanner_thread_pool_thread_num.
-    // For example, on a 64-core machine, the default value of config::doris_scanner_thread_pool_thread_num will be 64*2 =128.
-    // and the num_parallel_instances of this scan operator will be 64/2=32.
-    // For a query who has two scan nodes, the _max_thread_num of each scan node instance will be 128 / 32 = 4.
-    // We have 32 instances of this scan operator, so for the ScanNode, we have 4 * 32 = 128 scanner tasks can be submitted at a time.
-    // Remember that we have to ScanNode in this query, so the total number of scanner tasks can be submitted at a time is 128 * 2 = 256.
-    _max_thread_num = _state->num_scanner_threads() > 0
-                              ? _state->num_scanner_threads()
-                              : config::doris_scanner_thread_pool_thread_num /
-                                        (_local_state ? num_parallel_instances
-                                                      : state->query_parallel_instance_num());
-    _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
-    // In some situation, there are not too many big tablets involed, so we can reduce the thread number.
-    _max_thread_num = std::min(_max_thread_num, (int32_t)scanners.size());
-    // 1. Calculate max concurrency
-    // For select * from table limit 10; should just use one thread.
-    if (_local_state && _local_state->should_run_serial()) {
-        _max_thread_num = 1;
-    }
-    // when user not specify scan_thread_num, so we can try downgrade _max_thread_num.
-    // becaue we found in a table with 5k columns, column reader may ocuppy too much memory.
-    // you can refer https://github.com/apache/doris/issues/35340 for details.
-    int32_t max_column_reader_num = state->query_options().max_column_reader_num;
-    if (_max_thread_num != 1 && max_column_reader_num > 0) {
-        int32_t scan_column_num = _output_tuple_desc->slots().size();
-        int32_t current_column_num = scan_column_num * _max_thread_num;
-        if (current_column_num > max_column_reader_num) {
-            int32_t new_max_thread_num = max_column_reader_num / scan_column_num;
-            new_max_thread_num = new_max_thread_num <= 0 ? 1 : new_max_thread_num;
-            if (new_max_thread_num < _max_thread_num) {
-                int32_t origin_max_thread_num = _max_thread_num;
-                _max_thread_num = new_max_thread_num;
-                LOG(INFO) << "downgrade query:" << print_id(state->query_id())
-                          << " scan's max_thread_num from " << origin_max_thread_num << " to "
-                          << _max_thread_num << ",column num: " << scan_column_num
-                          << ", max_column_reader_num: " << max_column_reader_num;
-            }
-        }
-    }
-
-    // 1. Calculate max concurrency
-    // For select * from table limit 10; should just use one thread.
-    if ((_parent && _parent->should_run_serial()) ||
-        (_local_state && _local_state->should_run_serial())) {
-        _max_thread_num = 1;
-    }
     _query_thread_context = {_query_id, _state->query_mem_tracker(),
                              _state->get_query_ctx()->workload_group()};
 }
@@ -132,11 +72,10 @@ ScannerContext::ScannerContext(doris::RuntimeState* state, doris::vectorized::VS
                                const doris::TupleDescriptor* output_tuple_desc,
                                const RowDescriptor* output_row_descriptor,
                                const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
-                               int64_t limit_, int64_t max_bytes_in_blocks_queue,
-                               const int num_parallel_instances,
+                               int64_t limit_, bool ignore_data_distribution,
                                pipeline::ScanLocalStateBase* local_state)
         : ScannerContext(state, output_tuple_desc, output_row_descriptor, scanners, limit_,
-                         max_bytes_in_blocks_queue, num_parallel_instances, local_state) {
+                         ignore_data_distribution, local_state) {
     _parent = parent;
 }
 
@@ -169,6 +108,79 @@ Status ScannerContext::init() {
         _remote_scan_task_scheduler = _state->get_query_ctx()->get_remote_scan_scheduler();
     }
 #endif
+
+    int num_parallel_instances = _state->query_parallel_instance_num();
+
+    // NOTE: When ignore_data_distribution is true, the parallelism
+    // of the scan operator is regarded as 1 (actually maybe not).
+    // That will make the number of scan task can be submitted to the scheduler
+    // in a vary large value. This logicl is kept from the older implementation.
+    // https://github.com/apache/doris/pull/28266
+    if (_ignore_data_distribution) {
+        num_parallel_instances = 1;
+    }
+
+    // _max_bytes_in_queue controls the maximum memory that can be used by a single scan instance.
+    // scan_queue_mem_limit on FE is 100MB by default, on backend we will make sure its actual value
+    // is larger than 10MB.
+    _max_bytes_in_queue = std::max(_state->scan_queue_mem_limit(), (int64_t)1024 * 1024 * 10);
+
+    // Provide more memory for wide tables, increase proportionally by multiples of 300
+    _max_bytes_in_queue *= _output_tuple_desc->slots().size() / 300 + 1;
+
+    // TODO: Where is the proper position to place this code?
+    if (_all_scanners.empty()) {
+        _is_finished = true;
+        _set_scanner_done();
+    }
+
+    // _max_thread_num controls how many scanners of this ScanOperator can be submitted to scheduler at a time.
+    // The overall target of our system is to make full utilization of the resources.
+    // At the same time, we dont want too many tasks are queued by scheduler, that is not necessary.
+    // So, first of all, we try to make sure _max_thread_num of a ScanNode of a query on a single backend is less than
+    // 2 * config::doris_scanner_thread_pool_thread_num, so that we can make all io threads busy.
+    // For example, on a 64-core machine, the default value of config::doris_scanner_thread_pool_thread_num will be 64*2 =128.
+    // and the num_parallel_instances of this scan operator will be 64/2=32.
+    // For a query who has one scan nodes, the _max_thread_num of each scan node instance will be 2 * 128 / 32 = 8.
+    // We have 32 instances of this scan operator, so for the ScanNode, we have 8 * 32 = 256 scanner tasks can be submitted at a time.
+    // The thread pool of scanner is 128, that means we will have 128 tasks running in parallel and another 128 tasks are waiting in the queue.
+    // When first 128 tasks are finished, the next 128 tasks will be extricated from the queue and be executed,
+    // and another 128 tasks will be submitted to the queue if there are remaining.
+    _max_thread_num =
+            _state->num_scanner_threads() > 0
+                    ? _state->num_scanner_threads()
+                    : 2 * (config::doris_scanner_thread_pool_thread_num / num_parallel_instances);
+    _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
+    // In some situation, there are not too many big tablets involed, so we can reduce the thread number.
+    // NOTE: when _all_scanners.size is zero, the _max_thread_num will be 0.
+    _max_thread_num = std::min(_max_thread_num, (int32_t)_all_scanners.size());
+
+    // 1. Calculate max concurrency
+    // For select * from table limit 10; should just use one thread.
+    if (_local_state && _local_state->should_run_serial()) {
+        _max_thread_num = 1;
+    }
+
+    // when user not specify scan_thread_num, so we can try downgrade _max_thread_num.
+    // becaue we found in a table with 5k columns, column reader may ocuppy too much memory.
+    // you can refer https://github.com/apache/doris/issues/35340 for details.
+    int32_t max_column_reader_num = _state->query_options().max_column_reader_num;
+    if (_max_thread_num != 1 && max_column_reader_num > 0) {
+        int32_t scan_column_num = _output_tuple_desc->slots().size();
+        int32_t current_column_num = scan_column_num * _max_thread_num;
+        if (current_column_num > max_column_reader_num) {
+            int32_t new_max_thread_num = max_column_reader_num / scan_column_num;
+            new_max_thread_num = new_max_thread_num <= 0 ? 1 : new_max_thread_num;
+            if (new_max_thread_num < _max_thread_num) {
+                int32_t origin_max_thread_num = _max_thread_num;
+                _max_thread_num = new_max_thread_num;
+                LOG(INFO) << "downgrade query:" << print_id(_state->query_id())
+                          << " scan's max_thread_num from " << origin_max_thread_num << " to "
+                          << _max_thread_num << ",column num: " << scan_column_num
+                          << ", max_column_reader_num: " << max_column_reader_num;
+            }
+        }
+    }
 
     if (_parent) {
         COUNTER_SET(_parent->_max_scanner_thread_num, (int64_t)_max_thread_num);

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -115,7 +115,7 @@ Status ScannerContext::init() {
     // of the scan operator is regarded as 1 (actually maybe not).
     // That will make the number of scan task can be submitted to the scheduler
     // in a vary large value. This logicl is kept from the older implementation.
-    // https://github.com/apache/doris/pull/28266
+    // https://github.com/apache/doris/pull/33037
     if (_ignore_data_distribution) {
         num_parallel_instances = 1;
     }
@@ -149,7 +149,10 @@ Status ScannerContext::init() {
     _max_thread_num =
             _state->num_scanner_threads() > 0
                     ? _state->num_scanner_threads()
-                    : 2 * (config::doris_scanner_thread_pool_thread_num / num_parallel_instances);
+                    : (_local_state == nullptr ? 2 * (config::doris_scanner_thread_pool_thread_num /
+                                                      num_parallel_instances)
+                                               : config::doris_scanner_thread_pool_thread_num /
+                                                         _state->query_parallel_instance_num());
     _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;
     // In some situation, there are not too many big tablets involed, so we can reduce the thread number.
     // NOTE: when _all_scanners.size is zero, the _max_thread_num will be 0.

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -105,7 +105,7 @@ public:
     ScannerContext(RuntimeState* state, VScanNode* parent, const TupleDescriptor* output_tuple_desc,
                    const RowDescriptor* output_row_descriptor,
                    const std::list<std::shared_ptr<ScannerDelegate>>& scanners, int64_t limit_,
-                   int64_t max_bytes_in_blocks_queue, const int num_parallel_instances = 1,
+                   bool ignore_data_distribution,
                    pipeline::ScanLocalStateBase* local_state = nullptr);
 
     ~ScannerContext() override {
@@ -183,8 +183,7 @@ protected:
     ScannerContext(RuntimeState* state_, const TupleDescriptor* output_tuple_desc,
                    const RowDescriptor* output_row_descriptor,
                    const std::list<std::shared_ptr<ScannerDelegate>>& scanners_, int64_t limit_,
-                   int64_t max_bytes_in_blocks_queue_, const int num_parallel_instances,
-                   pipeline::ScanLocalStateBase* local_state);
+                   bool ignore_data_distribution, pipeline::ScanLocalStateBase* local_state);
 
     /// Four criteria to determine whether to increase the parallelism of the scanners
     /// 1. It ran for at least `SCALE_UP_DURATION` ms after last scale up
@@ -218,7 +217,7 @@ protected:
     int64_t limit;
 
     int32_t _max_thread_num = 0;
-    int64_t _max_bytes_in_queue;
+    int64_t _max_bytes_in_queue = 0;
     doris::vectorized::ScannerScheduler* _scanner_scheduler;
     SimplifiedScanScheduler* _simple_scan_scheduler = nullptr;
     SimplifiedScanScheduler* _remote_scan_task_scheduler = nullptr;
@@ -228,7 +227,6 @@ protected:
     int32_t _num_running_scanners = 0;
     // weak pointer for _scanners, used in stop function
     std::vector<std::weak_ptr<ScannerDelegate>> _all_scanners;
-    const int _num_parallel_instances;
     std::shared_ptr<RuntimeProfile> _scanner_profile;
     RuntimeProfile::Counter* _scanner_sched_counter = nullptr;
     RuntimeProfile::Counter* _newly_create_free_blocks_num = nullptr;
@@ -236,6 +234,7 @@ protected:
     RuntimeProfile::Counter* _scanner_ctx_sched_time = nullptr;
     RuntimeProfile::Counter* _scale_up_scanners_counter = nullptr;
     QueryThreadContext _query_thread_context;
+    bool _ignore_data_distribution = false;
 
     // for scaling up the running scanners
     size_t _estimated_block_size = 0;

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -306,7 +306,12 @@ Status VScanNode::_init_profile() {
 void VScanNode::_start_scanners(const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
                                 const int query_parallel_instance_num) {
     if (_is_pipeline_scan) {
-        int max_queue_size = _shared_scan_opt ? std::max(query_parallel_instance_num, 1) : 1;
+        // int max_queue_size = _shared_scan_opt ? std::max(query_parallel_instance_num, 1) : 1;
+        // In the previous (maybe version 2.1.6), above code is used to set max_queue_size.
+        // Actually, this value is not working for the pipeline,
+        // https://github.com/apache/doris/blob/967801ca666f84a60010bef1f6ca5ca777d5b901/be/src/vec/exec/scan/scanner_context.cpp#L91
+        // The actual working value comes from state->query_parallel_instance_num()
+        // so remove above code changes nothing for pipeline.
         _scanner_ctx = pipeline::PipScannerContext::create_shared(_state, this, _output_tuple_desc,
                                                                   _output_row_descriptor.get(),
                                                                   scanners, limit(), false);

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -307,13 +307,13 @@ void VScanNode::_start_scanners(const std::list<std::shared_ptr<ScannerDelegate>
                                 const int query_parallel_instance_num) {
     if (_is_pipeline_scan) {
         int max_queue_size = _shared_scan_opt ? std::max(query_parallel_instance_num, 1) : 1;
-        _scanner_ctx = pipeline::PipScannerContext::create_shared(
-                _state, this, _output_tuple_desc, _output_row_descriptor.get(), scanners, limit(),
-                _state->scan_queue_mem_limit(), max_queue_size);
+        _scanner_ctx = pipeline::PipScannerContext::create_shared(_state, this, _output_tuple_desc,
+                                                                  _output_row_descriptor.get(),
+                                                                  scanners, limit(), false);
     } else {
         _scanner_ctx = ScannerContext::create_shared(_state, this, _output_tuple_desc,
                                                      _output_row_descriptor.get(), scanners,
-                                                     limit(), _state->scan_queue_mem_limit());
+                                                     limit(), false);
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -659,7 +659,10 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
     public long maxExecMemByte = 2147483648L;
 
-    @VariableMgr.VarAttr(name = SCAN_QUEUE_MEM_LIMIT)
+    @VariableMgr.VarAttr(name = SCAN_QUEUE_MEM_LIMIT,
+            description = {"每个 Scan Instance 的 block queue 能够保存多少字节的 block",
+                    "How many bytes of block can be saved in the block queue of each Scan Instance"})
+    // 100MB
     public long maxScanQueueMemByte = 2147483648L / 20;
 
     @VariableMgr.VarAttr(name = NUM_SCANNER_THREADS, needForward = true, description = {


### PR DESCRIPTION
cherry pick from #40569 and do modification on branch-2.1

1. Since constructor changed, so modified code of non-pipeline and old pipeline
2. The _max_thread_num calculation of old pipeline is not changed.