### PR TITLE
[Fix](regression test) Fix schema change concurrent with txn regression case

### DIFF
--- a/regression-test/suites/schema_change/test_schema_change_concurrent_with_txn.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_concurrent_with_txn.groovy
@@ -22,6 +22,7 @@ suite('test_schema_change_concurrent_with_txn') {
     def options = new ClusterOptions()
     options.enableDebugPoints()
     options.feConfigs.add('publish_wait_time_second=-1')
+    options.feConfigs.add('enable_abort_txn_by_checking_conflict_txn=false')
     docker(options) {
         sql 'SET GLOBAL insert_visible_timeout_ms = 2000'
 


### PR DESCRIPTION
## Proposed changes

PR #37669 introduced a new config `enable_abort_txn_by_checking_conflict_txn=true`. This config will abort schema while loading txn and restart coordinator, which causes regression test failed. We set it to false to fix this test.

<!--Describe your changes.-->

