### PR TITLE
[fix](jdbc catalog) Fixed FE memory leak by enabling weak references in HikariCP

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -98,6 +98,7 @@ public abstract class JdbcClient {
     }
 
     protected JdbcClient(JdbcClientConfig jdbcClientConfig) {
+        System.setProperty("com.zaxxer.hikari.useWeakReferences", "true");
         this.catalogName = jdbcClientConfig.getCatalog();
         this.jdbcUser = jdbcClientConfig.getUser();
         this.isOnlySpecifiedDatabase = Boolean.parseBoolean(jdbcClientConfig.getOnlySpecifiedDatabase());


### PR DESCRIPTION
When FE collects statistics, its ThreadLocal will hold the ThreadLocal of HikariCP in JdbcClient, making it difficult for HikariCP to be gc, so this problem can be alleviated by enabling weak references of HikariCP.
Introduced from #38889
