### PR TITLE
[improvement](mem)Dereference for executor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AutoCloseConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AutoCloseConnectContext.java
@@ -36,6 +36,7 @@ public class AutoCloseConnectContext implements AutoCloseable {
 
     @Override
     public void close() {
+        connectContext.clear();
         ConnectContext.remove();
         if (previousContext != null) {
             previousContext.setThreadLocalInfo();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -832,6 +832,11 @@ public class ConnectContext {
         return executor;
     }
 
+    public void clear() {
+        executor = null;
+        statementContext = null;
+    }
+
     public PlSqlOperation getPlSqlOperation() {
         if (plSqlOperation == null) {
             plSqlOperation = new PlSqlOperation();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -283,6 +283,8 @@ public class MysqlConnectProcessor extends ConnectProcessor {
         finalizeCommand();
 
         ctx.setCommand(MysqlCommand.COM_SLEEP);
+        ctx.clear();
+        executor = null;
     }
 
     public void loop() {


### PR DESCRIPTION
## Proposed changes

When a cmd is executed, we can cancel the reference to the `executor` to release the related resources. Otherwise, these resources can only be released when the next cmd is executed.
