### PR TITLE
[chore](CI)Sonar build should use JDK 17

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,11 +41,11 @@ jobs:
               - 'fe/**'
               - 'gensrc/proto/**'
               - 'gensrc/thrift/**'
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         if: ${{ steps.filter.outputs.fe_changes == 'true' }}
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'adopt'
       - name: Cache SonarCloud packages
         if: ${{ steps.filter.outputs.fe_changes == 'true' }}


### PR DESCRIPTION
workflow log:

```
Python 3.10.12
Check JAVA_HOME version
JAVA_HOME=/opt/hostedtoolcache/Java_Adopt_jdk/11.0.24-8/x64. It does not point to JDK-17.
The 'JDK_17' environment variable is not set.
ERROR: The JAVA version is [11](https://github.com/CalvinKirs/incubator-doris/actions/runs/10828165037/job/30042908344#step:10:12), it must be JDK-17.
Error: Process completed with exit code 1.

```