### PR TITLE
[opt](function) optimize from_unixtime/date_format by specially format str

### DIFF
--- a/be/src/vec/functions/date_format_type.h
+++ b/be/src/vec/functions/date_format_type.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <variant>
+
 #include "vec/common/string_ref.h"
 namespace doris::vectorized {
 
@@ -154,6 +156,27 @@ struct yyyyImpl {
         return i;
     }
 };
+
+using FormatImplVariant = std::variant<NoneImpl, yyyyMMddImpl, yyyy_MM_ddImpl,
+                                       yyyy_MM_dd_HH_mm_ssImpl, yyyy_MMImpl, yyyyMMImpl, yyyyImpl>;
+
+inline FormatImplVariant string_to_impl(const std::string& format) {
+    if (format == "yyyyMMdd") {
+        return yyyyMMddImpl {};
+    } else if (format == "yyyy-MM-dd") {
+        return yyyy_MM_ddImpl {};
+    } else if (format == "yyyy-MM-dd HH:mm:ss") {
+        return yyyy_MM_dd_HH_mm_ssImpl {};
+    } else if (format == "yyyy-MM") {
+        return yyyy_MMImpl {};
+    } else if (format == "yyyyMM") {
+        return yyyyMMImpl {};
+    } else if (format == "yyyy") {
+        return yyyyImpl {};
+    } else {
+        return NoneImpl {};
+    }
+}
 
 } // namespace time_format_type
 

--- a/be/src/vec/functions/date_time_transforms.h
+++ b/be/src/vec/functions/date_time_transforms.h
@@ -213,7 +213,7 @@ struct DateFormatImpl {
 
             // No buffer is needed here because these specially optimized formats have fixed lengths,
             // and sufficient memory has already been reserved.
-            auto len = Impl::apply(dt, (char*)res_data.data() + offset);
+            auto len = Impl::date_to_str(dt, (char*)res_data.data() + offset);
             offset += len;
 
             return false;
@@ -268,7 +268,7 @@ struct FromUnixTimeImpl {
 
             // No buffer is needed here because these specially optimized formats have fixed lengths,
             // and sufficient memory has already been reserved.
-            auto len = Impl::apply(dt, (char*)res_data.data() + offset);
+            auto len = Impl::date_to_str(dt, (char*)res_data.data() + offset);
             offset += len;
 
             return false;

--- a/be/src/vec/functions/date_time_transforms.h
+++ b/be/src/vec/functions/date_time_transforms.h
@@ -191,9 +191,6 @@ struct DateFormatImpl {
         if constexpr (std::is_same_v<Impl, time_format_type::NoneImpl>) {
             // Handle non-special formats.
             const auto& dt = (DateType&)t;
-            if (format.size > 128) {
-                return true;
-            }
             char buf[100 + SAFE_FORMAT_STRING_MARGIN];
             if (!dt.to_format_string_conservative(format.data, format.size, buf,
                                                   100 + SAFE_FORMAT_STRING_MARGIN)) {
@@ -239,7 +236,7 @@ struct FromUnixTimeImpl {
                                size_t& offset, const cctz::time_zone& time_zone) {
         if constexpr (std::is_same_v<Impl, time_format_type::NoneImpl>) {
             DateType dt;
-            if (format.size > 128 || val < 0 || val > TIMESTAMP_VALID_MAX) {
+            if (val < 0 || val > TIMESTAMP_VALID_MAX) {
                 return true;
             }
             dt.from_unixtime(val, time_zone);

--- a/be/src/vec/functions/function_datetime_string_to_string.h
+++ b/be/src/vec/functions/function_datetime_string_to_string.h
@@ -29,6 +29,7 @@
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/block.h"
 #include "vec/core/column_numbers.h"
@@ -38,6 +39,7 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_string.h"
+#include "vec/functions/date_format_type.h"
 #include "vec/functions/date_time_transforms.h"
 #include "vec/functions/function.h"
 #include "vec/runtime/vdatetime_value.h"
@@ -66,6 +68,50 @@ public:
         return {};
     }
 
+    struct FormatState {
+        std::string format_str;
+        // Check if the format string is null or exceeds the length limit.
+        bool is_valid = true;
+        time_format_type::TimeFormatType format_type = time_format_type::TimeFormatType::None;
+    };
+
+    Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
+        if (scope == FunctionContext::THREAD_LOCAL) {
+            return Status::OK();
+        }
+        std::shared_ptr<FormatState> state = std::make_shared<FormatState>();
+        DCHECK((context->get_num_args() == 1) || (context->get_num_args() == 2));
+        context->set_function_state(scope, state);
+        if (context->get_num_args() == 1) {
+            // default argument
+            state->format_str = "yyyy-MM-dd HH:mm:ss";
+            state->format_type = time_format_type::TimeFormatType::yyyy_MM_dd_HH_mm_ss;
+            return IFunction::open(context, scope);
+        }
+
+        const auto* column_string = context->get_constant_col(1);
+        if (column_string == nullptr) {
+            // func(col , null);
+            state->is_valid = false;
+            return IFunction::open(context, scope);
+        }
+
+        auto string_vale = column_string->column_ptr->get_data_at(0).trim();
+        auto format_str =
+                time_format_type::rewrite_specific_format(string_vale.data, string_vale.size);
+        if (format_str.size > 128) {
+            //  exceeds the length limit.
+            state->is_valid = false;
+            return IFunction::open(context, scope);
+        }
+
+        // Preprocess special format strings.
+        state->format_str = format_str;
+        state->format_type = time_format_type::string_to_type(state->format_str);
+
+        return IFunction::open(context, scope);
+    }
+
     DataTypePtr get_return_type_impl(const ColumnsWithTypeAndName& arguments) const override {
         return make_nullable(std::make_shared<DataTypeString>());
     }
@@ -78,41 +124,96 @@ public:
         const ColumnPtr source_col = block.get_by_position(arguments[0]).column;
 
         const auto* nullable_column = check_and_get_column<ColumnNullable>(source_col.get());
-        const auto* sources = check_and_get_column<ColumnVector<typename Transform::FromType>>(
+        const auto* sources = assert_cast<const ColumnVector<typename Transform::FromType>*>(
                 nullable_column ? nullable_column->get_nested_column_ptr().get()
                                 : source_col.get());
 
-        if (sources) {
-            auto col_res = ColumnString::create();
-            ColumnUInt8::MutablePtr col_null_map_to;
-            col_null_map_to = ColumnUInt8::create();
-            auto& vec_null_map_to = col_null_map_to->get_data();
+        auto col_res = ColumnString::create();
+        ColumnUInt8::MutablePtr col_null_map_to;
+        col_null_map_to = ColumnUInt8::create();
+        auto& vec_null_map_to = col_null_map_to->get_data();
 
-            if (arguments.size() == 2) {
-                const IColumn& source_col1 = *block.get_by_position(arguments[1]).column;
-                StringRef formatter =
-                        source_col1.get_data_at(0); // for both ColumnString or ColumnConst.
-                TransformerToStringTwoArgument<Transform>::vector_constant(
-                        context, sources->get_data(), formatter, col_res->get_chars(),
-                        col_res->get_offsets(), vec_null_map_to);
-            } else { //default argument
-                TransformerToStringTwoArgument<Transform>::vector_constant(
-                        context, sources->get_data(), StringRef("%Y-%m-%d %H:%i:%s"),
-                        col_res->get_chars(), col_res->get_offsets(), vec_null_map_to);
-            }
+        RETURN_IF_ERROR(vector_constant(context, sources->get_data(), col_res->get_chars(),
+                                        col_res->get_offsets(), vec_null_map_to));
 
-            if (nullable_column) {
-                const auto& origin_null_map = nullable_column->get_null_map_column().get_data();
-                for (int i = 0; i < origin_null_map.size(); ++i) {
-                    vec_null_map_to[i] |= origin_null_map[i];
-                }
+        if (nullable_column) {
+            const auto& origin_null_map = nullable_column->get_null_map_column().get_data();
+            for (int i = 0; i < origin_null_map.size(); ++i) {
+                vec_null_map_to[i] |= origin_null_map[i];
             }
-            block.get_by_position(result).column =
-                    ColumnNullable::create(std::move(col_res), std::move(col_null_map_to));
-        } else {
-            return Status::InternalError("Illegal column {} of first argument of function {}",
-                                         block.get_by_position(arguments[0]).column->get_name(),
-                                         name);
+        }
+
+        block.get_by_position(result).column =
+                ColumnNullable::create(std::move(col_res), std::move(col_null_map_to));
+
+        return Status::OK();
+    }
+
+    Status vector_constant(FunctionContext* context,
+                           const PaddedPODArray<typename Transform::FromType>& ts,
+                           ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                           PaddedPODArray<UInt8>& null_map) const {
+        auto* format_state = reinterpret_cast<FormatState*>(
+                context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+        if (!format_state) {
+            return Status::RuntimeError("funciton context for function '{}' must have FormatState;",
+                                        get_name());
+        }
+
+        StringRef format(format_state->format_str);
+
+        auto len = ts.size();
+        res_offsets.resize(len);
+        res_data.reserve(len * format.size + len);
+        null_map.resize_fill(len, false);
+
+        if (!format_state->is_valid) {
+            return Status::OK();
+        }
+
+        auto execute_for_format_type = [&]<typename Impl>() {
+            size_t offset = 0;
+            for (int i = 0; i < len; ++i) {
+                const auto& t = ts[i];
+                size_t new_offset;
+                bool is_null;
+                std::tie(new_offset, is_null) = Transform::template execute<Impl>(
+                        t, format, res_data, offset, context->state()->timezone_obj());
+                res_offsets[i] = new_offset;
+                null_map[i] = is_null;
+            }
+        };
+
+        switch (format_state->format_type) {
+        case time_format_type::TimeFormatType::None: {
+            execute_for_format_type.template operator()<time_format_type::NoneImpl>();
+            break;
+        }
+        case time_format_type::TimeFormatType::yyyyMMdd: {
+            execute_for_format_type.template operator()<time_format_type::yyyyMMddImpl>();
+            break;
+        }
+        case time_format_type::TimeFormatType::yyyy_MM_dd: {
+            execute_for_format_type.template operator()<time_format_type::yyyy_MM_ddImpl>();
+            break;
+        }
+        case time_format_type::TimeFormatType::yyyy_MM_dd_HH_mm_ss: {
+            execute_for_format_type
+                    .template operator()<time_format_type::yyyy_MM_dd_HH_mm_ssImpl>();
+            break;
+        }
+        case time_format_type::TimeFormatType::yyyy_MM: {
+            execute_for_format_type.template operator()<time_format_type::yyyy_MMImpl>();
+            break;
+        }
+        case time_format_type::TimeFormatType::yyyyMM: {
+            execute_for_format_type.template operator()<time_format_type::yyyyMMImpl>();
+            break;
+        }
+        case time_format_type::TimeFormatType::yyyy: {
+            execute_for_format_type.template operator()<time_format_type::yyyyImpl>();
+            break;
+        }
         }
         return Status::OK();
     }

--- a/be/src/vec/functions/function_datetime_string_to_string.h
+++ b/be/src/vec/functions/function_datetime_string_to_string.h
@@ -85,8 +85,8 @@ public:
         context->set_function_state(scope, state);
         if (context->get_num_args() == 1) {
             // default argument
-            state->format_str = "yyyy-MM-dd HH:mm:ss";
-            state->format_type = time_format_type::yyyy_MM_dd_HH_mm_ssImpl {};
+            state->format_str = time_format_type::default_format;
+            state->format_type = time_format_type::default_impl;
             return IFunction::open(context, scope);
         }
 
@@ -97,9 +97,7 @@ public:
             return IFunction::open(context, scope);
         }
 
-        auto string_vale = column_string->column_ptr->get_data_at(0).trim();
-        auto format_str =
-                time_format_type::rewrite_specific_format(string_vale.data, string_vale.size);
+        auto format_str = column_string->column_ptr->get_data_at(0).trim();
         if (format_str.size > 128) {
             //  exceeds the length limit.
             state->is_valid = false;

--- a/be/src/vec/functions/function_datetime_string_to_string.h
+++ b/be/src/vec/functions/function_datetime_string_to_string.h
@@ -174,14 +174,11 @@ public:
         auto execute_for_format_type = [&]<typename Impl>() {
             size_t offset = 0;
             for (int i = 0; i < len; ++i) {
-                const auto& t = ts[i];
-                size_t new_offset;
-                bool is_null;
-                std::tie(new_offset, is_null) = Transform::template execute<Impl>(
-                        t, format, res_data, offset, context->state()->timezone_obj());
-                res_offsets[i] = new_offset;
-                null_map[i] = is_null;
+                null_map[i] = Transform::template execute<Impl>(ts[i], format, res_data, offset,
+                                                                context->state()->timezone_obj());
+                res_offsets[i] = offset;
             }
+            res_data.resize(offset);
         };
 
         switch (format_state->format_type) {

--- a/regression-test/data/nereids_p0/sql_functions/datetime_functions/test_date_function.out
+++ b/regression-test/data/nereids_p0/sql_functions/datetime_functions/test_date_function.out
@@ -147,6 +147,12 @@
 -- !sql --
 2009-10-04
 
+-- !sql_date_format_long --
+\N
+
+-- !sql_date_format_long --
+\N
+
 -- !sql --
 2008-11-30T23:59:59
 
@@ -477,6 +483,12 @@ February
 1	2022-08-01 17:00:31
 
 -- !sql --
+1	\N
+
+-- !sql --
+1	\N
+
+-- !sql --
 true
 
 -- !sql --
@@ -490,6 +502,9 @@ true
 
 -- !sql --
 2022 31 4
+
+-- !sql_date_format_long --
+\N
 
 -- !sql_date_format_long --
 \N

--- a/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -248,6 +248,9 @@ suite("test_date_function") {
     sql """ truncate table ${tableName} """
     sql """ insert into ${tableName} values ("2009-10-04 22:23:00") """
     qt_sql """ select date_format(test_datetime, 'yyyy-MM-dd') from ${tableName}; """
+    qt_sql_date_format_long """ select date_format(test_datetime, '%f %V %f %l %V %I %S %p %w %r %j %f %l %I %D %w %j %D %e %s %V %f %D %M %s %X %U %v %c %u %x %r %j %a %h %s %m %a %v %u %b') from ${tableName};"""
+    qt_sql_date_format_long """ select date_format(non_nullable(test_datetime), '%f %V %f %l %V %I %S %p %w %r %j %f %l %I %D %w %j %D %e %s %V %f %D %M %s %X %U %v %c %u %x %r %j %a %h %s %m %a %v %u %b') from ${tableName};"""
+  
     sql """ truncate table ${tableName} """
 
     sql """ insert into ${tableName} values ("2010-11-30 23:59:59") """
@@ -465,7 +468,9 @@ suite("test_date_function") {
     qt_sql """ SELECT id,FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") FROM ${tableName} WHERE FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") <= '2022-08-01 00:00:00' ORDER BY id; """
     qt_sql """ SELECT id,FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") FROM ${tableName} WHERE FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") LIKE '2022-08-01 00:00:00' ORDER BY id; """
     qt_sql """ SELECT id,FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") FROM ${tableName} WHERE FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") = '2022-08-01 17:00:31' ORDER BY id; """
-
+    qt_sql """ SELECT id,FROM_UNIXTIME(update_time,null) FROM ${tableName} WHERE FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") = '2022-08-01 17:00:31' ORDER BY id; """
+    qt_sql """ SELECT id,FROM_UNIXTIME(update_time,'%f %V %f %l %V %I %S %p %w %r %j %f %l %I %D %w %j %D %e %s %V %f %D %M %s %X %U %v %c %u %x %r %j %a %h %s %m %a %v %u %b') FROM ${tableName} WHERE FROM_UNIXTIME(update_time,"%Y-%m-%d %H:%i:%s") = '2022-08-01 17:00:31' ORDER BY id; """
+    
     qt_sql """SELECT CURDATE() = CURRENT_DATE();"""
     qt_sql """SELECT unix_timestamp(CURDATE()) = unix_timestamp(CURRENT_DATE());"""
 
@@ -475,6 +480,8 @@ suite("test_date_function") {
     qt_sql """ select date_format('2025-01-01', '%X %V'); """
     qt_sql """ select date_format('2022-08-04', '%X %V %w'); """
     qt_sql_date_format_long """ select date_format(cast('2011-06-24' as DATETIMEV2(0)), '%f %V %f %l %V %I %S %p %w %r %j %f %l %I %D %w %j %D %e %s %V %f %D %M %s %X %U %v %c %u %x %r %j %a %h %s %m %a %v %u %b') """
+    qt_sql_date_format_long """ select date_format(null, '%f %V %f %l %V %I %S %p %w %r %j %f %l %I %D %w %j %D %e %s %V %f %D %M %s %X %U %v %c %u %x %r %j %a %h %s %m %a %v %u %b') """
+    
     qt_sql """ select STR_TO_DATE('Tue Jul 12 20:00:45 CST 2022', '%a %b %e %H:%i:%s %Y'); """
     qt_sql """ select STR_TO_DATE('Tue Jul 12 20:00:45 CST 2022', '%a %b %e %T CST %Y'); """
     qt_sql """ select STR_TO_DATE('2018-4-2 15:3:28','%Y-%m-%d %H:%i:%s'); """


### PR DESCRIPTION
## Proposed changes

```
 mysql [test]>select count(date_format(a, 'yyyyMMdd')) from date_format_tmp;
+-----------------------------------+
| count(date_format(a, 'yyyyMMdd')) |
+-----------------------------------+
|                          16000000 |
+-----------------------------------+
1 row in set (0.53 sec)


mysql [test]>select count(date_format(a, 'yyyyMMdd')) from date_format_tmp;
+-----------------------------------+
| count(date_format(a, 'yyyyMMdd')) |
+-----------------------------------+
|                          16000000 |
+-----------------------------------+
1 row in set (0.28 sec)
```

<!--Describe your changes.-->

