### PR TITLE
Add missing libsframe to linker

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -658,7 +658,7 @@ endif()
 
 if (NOT OS_MACOSX)
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
-        -lrt -l:libbfd.a -liberty -lc -lm -ldl -pthread
+        -lrt -l:libbfd.a -liberty -lc -lm -ldl -lsframe -pthread
     )
 else()
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}


### PR DESCRIPTION
## Proposed changes

Fix build on Linux, needs libsframe linked in (at least on Debian 12).

