### PR TITLE
[Enhancement](test) Support test DecimalV3 types in be-ut

### DIFF
--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -36,13 +36,19 @@ void DumpStackTraceToString(std::string* stacktrace);
 namespace doris {
 
 std::string get_stack_trace(int start_pointers_index, std::string dwarf_location_info_mode) {
+#ifndef BE_TEST
     if (!config::enable_stacktrace) {
         return "no enable stacktrace";
     }
+#endif
     if (dwarf_location_info_mode.empty()) {
         dwarf_location_info_mode = config::dwarf_location_info_mode;
     }
+#ifdef BE_TEST
+    auto tool = std::string {"libunwind"};
+#else
     auto tool = config::get_stack_trace_tool;
+#endif
     if (tool == "glog") {
         return get_stack_trace_by_glog();
     } else if (tool == "boost") {

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -23,8 +23,6 @@
 #include <fmt/format.h>
 
 #include <limits>
-#include <ostream>
-#include <string>
 
 #include "olap/decimal12.h"
 #include "runtime/decimalv2_value.h"

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -403,7 +403,7 @@ std::string decimal_to_string(const T& value, UInt32 scale) {
     }
     if constexpr (std::is_same_v<T, wide::Int256>) {
         std::string num_str {wide::to_string(whole_part)};
-        auto end = fmt::format_to(str.data() + pos, "{}", num_str);
+        auto* end = fmt::format_to(str.data() + pos, "{}", num_str);
         pos = end - str.data();
     } else {
         auto end = fmt::format_to(str.data() + pos, "{}", whole_part);
@@ -555,6 +555,15 @@ struct Decimal {
     }
 
     static Decimal from_int_frac(T integer, T fraction, int scale) {
+        if constexpr (std::is_same_v<T, Int32>) {
+            return Decimal(integer * common::exp10_i32(scale) + fraction);
+        } else if constexpr (std::is_same_v<T, Int64>) {
+            return Decimal(integer * common::exp10_i64(scale) + fraction);
+        } else if constexpr (std::is_same_v<T, Int128>) {
+            return Decimal(integer * common::exp10_i128(scale) + fraction);
+        } else if constexpr (std::is_same_v<T, wide::Int256>) {
+            return Decimal(integer * common::exp10_i256(scale) + fraction);
+        }
         return Decimal(integer * int_exp10(scale) + fraction);
     }
 
@@ -830,6 +839,7 @@ struct NativeType<Decimal256> {
     using Type = wide::Int256;
 };
 
+// NOLINTBEGIN(readability-function-size)
 inline const char* getTypeName(TypeIndex idx) {
     switch (idx) {
     case TypeIndex::Nothing:
@@ -935,6 +945,7 @@ inline const char* getTypeName(TypeIndex idx) {
     LOG(FATAL) << "__builtin_unreachable";
     __builtin_unreachable();
 }
+// NOLINTEND(readability-function-size)
 } // namespace vectorized
 } // namespace doris
 

--- a/be/test/vec/function/function_array_element_test.cpp
+++ b/be/test/vec/function/function_array_element_test.cpp
@@ -15,20 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <iomanip>
 #include <string>
-#include <vector>
 
-#include "common/status.h"
 #include "function_test_util.h"
-#include "gtest/gtest_pred_impl.h"
-#include "testutil/any_type.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_decimal.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
@@ -137,10 +131,10 @@ TEST(function_array_element_test, element_at) {
         Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
                      ut_type::DECIMALFIELD(0.0)};
         DataSet data_set = {{{vec, Int64(0)}, Null()},
-                            {{vec, Int64(1)}, ut_type::DECIMAL(17014116.67)},
+                            {{vec, Int64(1)}, ut_type::DECIMALV2(17014116.67)},
                             {{vec, Int64(4)}, Null()},
-                            {{vec, Int64(-1)}, ut_type::DECIMAL(0.0)},
-                            {{vec, Int64(-2)}, ut_type::DECIMAL(-17014116.67)},
+                            {{vec, Int64(-1)}, ut_type::DECIMALV2(0.0)},
+                            {{vec, Int64(-2)}, ut_type::DECIMALV2(-17014116.67)},
                             {{vec, Int64(-4)}, Null()},
                             {{Null(), Int64(1)}, Null()},
                             {{empty_arr, Int64(0)}, Null()},

--- a/be/test/vec/function/function_array_index_test.cpp
+++ b/be/test/vec/function/function_array_index_test.cpp
@@ -16,14 +16,10 @@
 // under the License.
 
 #include <string>
-#include <vector>
 
-#include "common/status.h"
 #include "function_test_util.h"
-#include "testutil/any_type.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
@@ -144,10 +140,10 @@ TEST(function_array_index_test, array_contains) {
 
         Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
                      ut_type::DECIMALFIELD(0.0)};
-        DataSet data_set = {{{vec, ut_type::DECIMAL(-17014116.67)}, UInt8(1)},
-                            {{vec, ut_type::DECIMAL(0)}, UInt8(1)},
-                            {{Null(), ut_type::DECIMAL(0)}, Null()},
-                            {{empty_arr, ut_type::DECIMAL(0)}, UInt8(0)}};
+        DataSet data_set = {{{vec, ut_type::DECIMALV2(-17014116.67)}, UInt8(1)},
+                            {{vec, ut_type::DECIMALV2(0)}, UInt8(1)},
+                            {{Null(), ut_type::DECIMALV2(0)}, Null()},
+                            {{empty_arr, ut_type::DECIMALV2(0)}, UInt8(0)}};
 
         static_cast<void>(check_function<DataTypeUInt8, true>(func_name, input_types, data_set));
     }
@@ -244,10 +240,10 @@ TEST(function_array_index_test, array_position) {
 
         Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
                      ut_type::DECIMALFIELD(0)};
-        DataSet data_set = {{{vec, ut_type::DECIMAL(-17014116.67)}, Int64(2)},
-                            {{vec, ut_type::DECIMAL(0)}, Int64(3)},
-                            {{Null(), ut_type::DECIMAL(0)}, Null()},
-                            {{empty_arr, ut_type::DECIMAL(0)}, Int64(0)}};
+        DataSet data_set = {{{vec, ut_type::DECIMALV2(-17014116.67)}, Int64(2)},
+                            {{vec, ut_type::DECIMALV2(0)}, Int64(3)},
+                            {{Null(), ut_type::DECIMALV2(0)}, Null()},
+                            {{empty_arr, ut_type::DECIMALV2(0)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -15,21 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <limits.h>
-#include <stdint.h>
-
-#include <cmath>
-#include <iomanip>
+#include <climits>
+#include <cstdint>
 #include <limits>
 #include <string>
-#include <vector>
 
-#include "common/status.h"
 #include "function_test_util.h"
-#include "gtest/gtest_pred_impl.h"
-#include "testutil/any_type.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
@@ -291,7 +283,7 @@ TEST(MathFunctionTest, abs_test) {
                             {{INT(0)}, BIGINT(0)},
                             {{INT(-60)}, BIGINT(60)},
                             {{INT(INT_MAX)}, BIGINT(INT_MAX)},
-                            {{INT(INT_MIN)}, BIGINT(-1ll * INT_MIN)}};
+                            {{INT(INT_MIN)}, BIGINT(-1LL * INT_MIN)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
@@ -498,7 +490,6 @@ TEST(MathFunctionTest, money_format_test) {
 
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
     }
-
     {
         InputTypeSet input_types = {TypeIndex::Int128};
         DataSet data_set = {{{Null()}, Null()},
@@ -519,10 +510,18 @@ TEST(MathFunctionTest, money_format_test) {
     {
         InputTypeSet input_types = {TypeIndex::Decimal128V2};
         DataSet data_set = {{{Null()}, Null()},
-                            {{DECIMAL(17014116.67)}, VARCHAR("17,014,116.67")},
-                            {{DECIMAL(-17014116.67)}, VARCHAR("-17,014,116.67")}};
+                            {{DECIMALV2(17014116.67)}, VARCHAR("17,014,116.67")},
+                            {{DECIMALV2(-17014116.67)}, VARCHAR("-17,014,116.67")}};
 
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+    }
+    {
+        BaseInputTypeSet input_types = {TypeIndex::Decimal64};
+        DataSet data_set = {{{Null()}, Null()},
+                            {{DECIMAL64(17014116, 670000000)}, VARCHAR("17,014,116.67")},
+                            {{DECIMAL64(-17014116, -670000000)}, VARCHAR("-17,014,116.67")}};
+
+        check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
 

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -17,21 +17,15 @@
 
 #include <cstdint>
 #include <cstring>
-#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "common/status.h"
 #include "function_test_util.h"
-#include "gtest/gtest_pred_impl.h"
 #include "gutil/integral_types.h"
-#include "testutil/any_type.h"
 #include "util/encryption_util.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_date_time.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
@@ -2977,8 +2971,7 @@ TEST(function_string_test, function_uuid_test) {
                             {{std::string("ffffffff-ffff-ffff-ffff-ffffffffffff")}, (__int128)-1},
                             {{std::string("00000000-0000-0000-0000-000000000000")}, (__int128)0},
                             {{std::string("123")}, Null()}};
-        static_cast<void>(check_function_all_arg_comb<DataTypeInt128, true>(func_name, input_types,
-                                                                            data_set));
+        check_function_all_arg_comb<DataTypeInt128, true>(func_name, input_types, data_set);
     }
     {
         std::string func_name = "int_to_uuid";
@@ -3091,68 +3084,6 @@ TEST(function_string_test, function_overlay_test) {
         }
     }
 }
-
-//bug TEST(function_string_test, function_strcmp_test) {
-//     std::string func_name = "strcmp";
-//     {
-//         BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
-
-//         DataSet data_set = {
-//                 {{std::string("A"), std::string("A")}, std::int8_t(0)},
-//                 {{std::string("A"), std::string(",")}, std::int8_t(1)},
-//                 {{std::string("A"), std::string("")}, std::int8_t(1)},
-//                 {{std::string("A"), Null()}, Null()},
-//                 {{std::string("A"), std::string(",ABC,")}, std::int8_t(1)},
-//                 {{std::string("A"), std::string("123ABC!@# _")}, std::int8_t(1)},
-//                 {{std::string("A"), std::string("10@()*()$*!@")}, std::int8_t(1)},
-//                 {{std::string(","), std::string("A")}, std::int8_t(-1)},
-//                 {{std::string(","), std::string(",")}, std::int8_t(0)},
-//                 {{std::string(","), std::string("")}, std::int8_t(1)},
-//                 {{std::string(","), Null()}, Null()},
-//                 {{std::string(","), std::string(",ABC,")}, std::int8_t(-1)},
-//                 {{std::string(","), std::string("123ABC!@# _")}, std::int8_t(-1)},
-//                 {{std::string(","), std::string("10@()*()$*!@")}, std::int8_t(-1)},
-//                 {{std::string(""), std::string("A")}, std::int8_t(-1)},
-//                 {{std::string(""), std::string(",")}, std::int8_t(-1)},
-//                 {{std::string(""), std::string("")}, std::int8_t(0)},
-//                 {{std::string(""), Null()}, Null()},
-//                 {{std::string(""), std::string(",ABC,")}, std::int8_t(-1)},
-//                 {{std::string(""), std::string("123ABC!@# _")}, std::int8_t(-1)},
-//                 {{std::string(""), std::string("10@()*()$*!@")}, std::int8_t(-1)},
-//                 {{Null(), std::string("A")}, Null()},
-//                 {{Null(), std::string(",")}, Null()},
-//                 {{Null(), std::string("")}, Null()},
-//                 {{Null(), Null()}, Null()},
-//                 {{Null(), std::string(",ABC,")}, Null()},
-//                 {{Null(), std::string("123ABC!@# _")}, Null()},
-//                 {{Null(), std::string("10@()*()$*!@")}, Null()},
-//                 {{std::string(",ABC,"), std::string("A")}, std::int8_t(-1)},
-//                 {{std::string(",ABC,"), std::string(",")}, std::int8_t(1)},
-//                 {{std::string(",ABC,"), std::string("")}, std::int8_t(1)},
-//                 {{std::string(",ABC,"), Null()}, Null()},
-//                 {{std::string(",ABC,"), std::string(",ABC,")}, std::int8_t(0)},
-//                 {{std::string(",ABC,"), std::string("123ABC!@# _")}, std::int8_t(-1)},
-//                 {{std::string(",ABC,"), std::string("10@()*()$*!@")}, std::int8_t(-1)},
-//                 {{std::string("123ABC!@# _"), std::string("A")}, std::int8_t(-1)},
-//                 {{std::string("123ABC!@# _"), std::string(",")}, std::int8_t(1)},
-//                 {{std::string("123ABC!@# _"), std::string("")}, std::int8_t(1)},
-//                 {{std::string("123ABC!@# _"), Null()}, Null()},
-//                 {{std::string("123ABC!@# _"), std::string(",ABC,")}, std::int8_t(1)},
-//                 {{std::string("123ABC!@# _"), std::string("123ABC!@# _")}, std::int8_t(0)},
-//                 {{std::string("123ABC!@# _"), std::string("10@()*()$*!@")}, std::int8_t(1)},
-//                 {{std::string("10@()*()$*!@"), std::string("A")}, std::int8_t(-1)},
-//                 {{std::string("10@()*()$*!@"), std::string(",")}, std::int8_t(1)},
-//                 {{std::string("10@()*()$*!@"), std::string("")}, std::int8_t(1)},
-//                 {{std::string("10@()*()$*!@"), Null()}, Null()},
-//                 {{std::string("10@()*()$*!@"), std::string(",ABC,")}, std::int8_t(1)},
-//                 {{std::string("10@()*()$*!@"), std::string("123ABC!@# _")}, std::int8_t(-1)},
-//                 {{std::string("10@()*()$*!@"), std::string("10@()*()$*!@")}, std::int8_t(0)},
-//         };
-//         static_cast<void>(
-//                 check_function_all_arg_comb<DataTypeInt8, true>(func_name, input_types, data_set));
-//     }
-// }
-//
 
 TEST(function_string_test, function_initcap) {
     std::string func_name {"initcap"};

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -19,22 +19,17 @@
 #include <gtest/gtest-test-part.h>
 #include <mysql/mysql.h>
 
-#include <algorithm>
-#include <concepts>
 #include <cstdint>
 #include <ctime>
 #include <memory>
-#include <span>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "common/status.h"
-#include "gtest/gtest_pred_impl.h"
 #include "olap/olap_common.h"
 #include "runtime/define_primitive_type.h"
-#include "runtime/exec_env.h"
 #include "runtime/types.h"
 #include "testutil/any_type.h"
 #include "testutil/function_utils.h"
@@ -52,12 +47,14 @@
 #include "vec/core/column_with_type_and_name.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
+#include "vec/core/wide_integer.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/functions/simple_function_factory.h"
+
 namespace doris::vectorized {
 
 class DataTypeJsonb;
@@ -107,7 +104,17 @@ using FLOAT = float;
 using IPV4 = uint32_t;
 using IPV6 = uint128_t;
 
-inline auto DECIMAL = Decimal128V2::double_to_decimal;
+// cell constructors. could also use from_int_frac if you'd like
+inline auto DECIMALV2 = Decimal128V2::double_to_decimal;
+inline auto DECIMAL32 = [](int32_t x, int32_t y) { return Decimal32::from_int_frac(x, y, 5); };
+inline auto DECIMAL64 = [](int64_t x, int64_t y) { return Decimal64::from_int_frac(x, y, 9); };
+inline auto DECIMAL128V3 = [](int128_t x, int128_t y) {
+    return Decimal128V3::from_int_frac(x, y, 20);
+};
+inline auto DECIMAL256 = [](wide::Int256 x, wide::Int256 y) {
+    return Decimal256::from_int_frac(x, y, 40);
+};
+
 inline auto DECIMALFIELD = [](double v) {
     return DecimalField<Decimal128V2>(Decimal128V2::double_to_decimal(v), 9);
 };
@@ -280,6 +287,8 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
         fn_ctx_return.type = doris::PrimitiveType::TYPE_DECIMAL64;
     } else if (std::is_same_v<ReturnType, Decimal128V3>) {
         fn_ctx_return.type = doris::PrimitiveType::TYPE_DECIMAL128I;
+    } else if (std::is_same_v<ReturnType, Decimal256>) {
+        fn_ctx_return.type = doris::PrimitiveType::TYPE_DECIMAL256;
     } else {
         fn_ctx_return.type = doris::PrimitiveType::INVALID_TYPE;
     }

--- a/be/test/vec/function/table_function_test.cpp
+++ b/be/test/vec/function/table_function_test.cpp
@@ -20,14 +20,12 @@
 #include <gmock/gmock-spec-builders.h>
 #include <gtest/gtest-matchers.h>
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "common/status.h"
 #include "exprs/mock_vexpr.h"
-#include "gtest/gtest_pred_impl.h"
 #include "testutil/any_type.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
@@ -46,8 +44,8 @@ using ::testing::SetArgPointee;
 
 class TableFunctionTest : public testing::Test {
 protected:
-    virtual void SetUp() {}
-    virtual void TearDown() {}
+    void SetUp() override {}
+    void TearDown() override {}
 
     void clear() {
         _ctx = nullptr;
@@ -118,8 +116,8 @@ TEST_F(TableFunctionTest, vexplode_outer) {
         InputTypeSet output_types = {TypeIndex::Decimal128V2};
         InputDataSet output_set = {{Null()},
                                    {Null()},
-                                   {ut_type::DECIMAL(17014116.67)},
-                                   {ut_type::DECIMAL(-17014116.67)}};
+                                   {ut_type::DECIMALV2(17014116.67)},
+                                   {ut_type::DECIMALV2(-17014116.67)}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

for convince, we set default scales for them because we mainly test the correctness for all scale values in regression. in ut for testing mainly about const/nullable deal that's enough