### PR TITLE
[fix](hashjoin) check cancel status in building hash table loop to improve cancel efficiency

### DIFF
--- a/be/src/pipeline/common/agg_utils.h
+++ b/be/src/pipeline/common/agg_utils.h
@@ -135,46 +135,49 @@ struct AggregatedDataVariants
     AggregatedDataWithoutKey without_key = nullptr;
 
     template <bool nullable>
-    void init(Type type) {
+    void init(RuntimeState* state, Type type) {
         _type = type;
         switch (_type) {
         case Type::without_key:
             break;
         case Type::serialized:
-            method_variant.emplace<vectorized::MethodSerialized<AggregatedDataWithStringKey>>();
+            method_variant.emplace<vectorized::MethodSerialized<AggregatedDataWithStringKey>>(
+                    state);
             break;
         case Type::int8_key:
-            emplace_single<vectorized::UInt8, AggregatedDataWithUInt8Key, nullable>();
+            emplace_single<vectorized::UInt8, AggregatedDataWithUInt8Key, nullable>(state);
             break;
         case Type::int16_key:
-            emplace_single<vectorized::UInt16, AggregatedDataWithUInt16Key, nullable>();
+            emplace_single<vectorized::UInt16, AggregatedDataWithUInt16Key, nullable>(state);
             break;
         case Type::int32_key:
-            emplace_single<vectorized::UInt32, AggregatedDataWithUInt32Key, nullable>();
+            emplace_single<vectorized::UInt32, AggregatedDataWithUInt32Key, nullable>(state);
             break;
         case Type::int32_key_phase2:
-            emplace_single<vectorized::UInt32, AggregatedDataWithUInt32KeyPhase2, nullable>();
+            emplace_single<vectorized::UInt32, AggregatedDataWithUInt32KeyPhase2, nullable>(state);
             break;
         case Type::int64_key:
-            emplace_single<vectorized::UInt64, AggregatedDataWithUInt64Key, nullable>();
+            emplace_single<vectorized::UInt64, AggregatedDataWithUInt64Key, nullable>(state);
             break;
         case Type::int64_key_phase2:
-            emplace_single<vectorized::UInt64, AggregatedDataWithUInt64KeyPhase2, nullable>();
+            emplace_single<vectorized::UInt64, AggregatedDataWithUInt64KeyPhase2, nullable>(state);
             break;
         case Type::int128_key:
-            emplace_single<vectorized::UInt128, AggregatedDataWithUInt128Key, nullable>();
+            emplace_single<vectorized::UInt128, AggregatedDataWithUInt128Key, nullable>(state);
             break;
         case Type::int128_key_phase2:
-            emplace_single<vectorized::UInt128, AggregatedDataWithUInt128KeyPhase2, nullable>();
+            emplace_single<vectorized::UInt128, AggregatedDataWithUInt128KeyPhase2, nullable>(
+                    state);
             break;
         case Type::string_key:
             if (nullable) {
-                method_variant.emplace<
-                        vectorized::MethodSingleNullableColumn<vectorized::MethodStringNoCache<
-                                AggregatedDataWithNullableShortStringKey>>>();
+                method_variant.emplace<vectorized::MethodSingleNullableColumn<
+                        vectorized::MethodStringNoCache<AggregatedDataWithNullableShortStringKey>>>(
+                        state);
             } else {
-                method_variant.emplace<
-                        vectorized::MethodStringNoCache<AggregatedDataWithShortStringKey>>();
+                method_variant
+                        .emplace<vectorized::MethodStringNoCache<AggregatedDataWithShortStringKey>>(
+                                state);
             }
             break;
         default:
@@ -182,11 +185,11 @@ struct AggregatedDataVariants
         }
     }
 
-    void init(Type type, bool is_nullable = false) {
+    void init(RuntimeState* state, Type type, bool is_nullable = false) {
         if (is_nullable) {
-            init<true>(type);
+            init<true>(state, type);
         } else {
-            init<false>(type);
+            init<false>(state, type);
         }
     }
 };

--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -703,7 +703,7 @@ void AggSinkLocalState::_find_in_hash_table(vectorized::AggregateDataPtr* places
 
 Status AggSinkLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
     RETURN_IF_ERROR(
-            init_agg_hash_method(_agg_data, probe_exprs,
+            init_agg_hash_method(_state, _agg_data, probe_exprs,
                                  Base::_parent->template cast<AggSinkOperatorX>()._is_first_phase));
     return Status::OK();
 }

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
@@ -172,7 +172,7 @@ bool DistinctStreamingAggLocalState::_should_expand_preagg_hash_tables() {
 Status DistinctStreamingAggLocalState::_init_hash_method(
         const vectorized::VExprContextSPtrs& probe_exprs) {
     RETURN_IF_ERROR(init_agg_hash_method(
-            _agg_data.get(), probe_exprs,
+            _state, _agg_data.get(), probe_exprs,
             Base::_parent->template cast<DistinctStreamingAggOperatorX>()._is_first_phase));
     return Status::OK();
 }

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -336,22 +336,22 @@ void HashJoinBuildSinkLocalState::_hash_table_init(RuntimeState* state) {
                     switch (_build_expr_ctxs[0]->root()->result_type()) {
                     case TYPE_BOOLEAN:
                     case TYPE_TINYINT:
-                        _shared_state->hash_table_variants->emplace<I8HashTableContext>();
+                        _shared_state->hash_table_variants->emplace<I8HashTableContext>(state);
                         break;
                     case TYPE_SMALLINT:
-                        _shared_state->hash_table_variants->emplace<I16HashTableContext>();
+                        _shared_state->hash_table_variants->emplace<I16HashTableContext>(state);
                         break;
                     case TYPE_INT:
                     case TYPE_FLOAT:
                     case TYPE_DATEV2:
-                        _shared_state->hash_table_variants->emplace<I32HashTableContext>();
+                        _shared_state->hash_table_variants->emplace<I32HashTableContext>(state);
                         break;
                     case TYPE_BIGINT:
                     case TYPE_DOUBLE:
                     case TYPE_DATETIME:
                     case TYPE_DATE:
                     case TYPE_DATETIMEV2:
-                        _shared_state->hash_table_variants->emplace<I64HashTableContext>();
+                        _shared_state->hash_table_variants->emplace<I64HashTableContext>(state);
                         break;
                     case TYPE_LARGEINT:
                     case TYPE_DECIMALV2:
@@ -369,23 +369,24 @@ void HashJoinBuildSinkLocalState::_hash_table_init(RuntimeState* state) {
                                         : type_ptr->get_type_id();
                         vectorized::WhichDataType which(idx);
                         if (which.is_decimal32()) {
-                            _shared_state->hash_table_variants->emplace<I32HashTableContext>();
+                            _shared_state->hash_table_variants->emplace<I32HashTableContext>(state);
                         } else if (which.is_decimal64()) {
-                            _shared_state->hash_table_variants->emplace<I64HashTableContext>();
+                            _shared_state->hash_table_variants->emplace<I64HashTableContext>(state);
                         } else {
-                            _shared_state->hash_table_variants->emplace<I128HashTableContext>();
+                            _shared_state->hash_table_variants->emplace<I128HashTableContext>(
+                                    state);
                         }
                         break;
                     }
                     case TYPE_CHAR:
                     case TYPE_VARCHAR:
                     case TYPE_STRING: {
-                        _shared_state->hash_table_variants->emplace<MethodOneString>();
+                        _shared_state->hash_table_variants->emplace<MethodOneString>(state);
                         break;
                     }
                     default:
                         _shared_state->hash_table_variants
-                                ->emplace<vectorized::SerializedHashTableContext>();
+                                ->emplace<vectorized::SerializedHashTableContext>(state);
                     }
                     return;
                 }
@@ -404,9 +405,9 @@ void HashJoinBuildSinkLocalState::_hash_table_init(RuntimeState* state) {
                 }
 
                 if (!try_get_hash_map_context_fixed<JoinHashMap, HashCRC32>(
-                            *_shared_state->hash_table_variants, data_types)) {
+                            state, *_shared_state->hash_table_variants, data_types)) {
                     _shared_state->hash_table_variants
-                            ->emplace<vectorized::SerializedHashTableContext>();
+                            ->emplace<vectorized::SerializedHashTableContext>(state);
                 }
             },
             _shared_state->join_op_variants,

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -209,7 +209,7 @@ struct ProcessHashTableBuild {
                                             null_map ? null_map->data() : nullptr, true, true,
                                             hash_table_ctx.hash_table->get_bucket_size());
         hash_table_ctx.hash_table->template build<JoinOpType, with_other_conjuncts>(
-                hash_table_ctx.keys, hash_table_ctx.bucket_nums.data(), _rows);
+                _state, hash_table_ctx.keys, hash_table_ctx.bucket_nums.data(), _rows);
         hash_table_ctx.bucket_nums.resize(_batch_size);
         hash_table_ctx.bucket_nums.shrink_to_fit();
 

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -298,8 +298,8 @@ constexpr auto init_partition_hash_method =
         init_hash_method<PartitionedHashMapVariants, PartitionDataPtr>;
 
 Status PartitionSortSinkLocalState::_init_hash_method() {
-    RETURN_IF_ERROR(
-            init_partition_hash_method(_partitioned_data.get(), _partition_expr_ctxs, true));
+    RETURN_IF_ERROR(init_partition_hash_method(_state, _partitioned_data.get(),
+                                               _partition_expr_ctxs, true));
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/partition_sort_sink_operator.h
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.h
@@ -162,41 +162,43 @@ struct PartitionedHashMapVariants
                   PartitionedMethodVariants, vectorized::MethodSingleNullableColumn,
                   vectorized::MethodOneNumber, MethodKeysFixed, vectorized::DataWithNullKey> {
     template <bool nullable>
-    void init(vectorized::HashKeyType type) {
+    void init(RuntimeState* state, vectorized::HashKeyType type) {
         _type = type;
         switch (_type) {
         case vectorized::HashKeyType::serialized: {
-            method_variant.emplace<vectorized::MethodSerialized<PartitionDataWithStringKey>>();
+            method_variant.emplace<vectorized::MethodSerialized<PartitionDataWithStringKey>>(state);
             break;
         }
         case vectorized::HashKeyType::int8_key: {
-            emplace_single<vectorized::UInt8, PartitionDataWithUInt8Key, nullable>();
+            emplace_single<vectorized::UInt8, PartitionDataWithUInt8Key, nullable>(state);
             break;
         }
         case vectorized::HashKeyType::int16_key: {
-            emplace_single<vectorized::UInt16, PartitionDataWithUInt16Key, nullable>();
+            emplace_single<vectorized::UInt16, PartitionDataWithUInt16Key, nullable>(state);
             break;
         }
         case vectorized::HashKeyType::int32_key: {
-            emplace_single<vectorized::UInt32, PartitionDataWithUInt32Key, nullable>();
+            emplace_single<vectorized::UInt32, PartitionDataWithUInt32Key, nullable>(state);
             break;
         }
         case vectorized::HashKeyType::int64_key: {
-            emplace_single<UInt64, PartitionDataWithUInt64Key, nullable>();
+            emplace_single<UInt64, PartitionDataWithUInt64Key, nullable>(state);
             break;
         }
         case vectorized::HashKeyType::int128_key: {
-            emplace_single<UInt128, PartitionDataWithUInt128Key, nullable>();
+            emplace_single<UInt128, PartitionDataWithUInt128Key, nullable>(state);
             break;
         }
         case vectorized::HashKeyType::string_key: {
             if (nullable) {
                 method_variant.emplace<
                         vectorized::MethodSingleNullableColumn<vectorized::MethodStringNoCache<
-                                vectorized::DataWithNullKey<PartitionDataWithShortStringKey>>>>();
+                                vectorized::DataWithNullKey<PartitionDataWithShortStringKey>>>>(
+                        state);
             } else {
-                method_variant.emplace<
-                        vectorized::MethodStringNoCache<PartitionDataWithShortStringKey>>();
+                method_variant
+                        .emplace<vectorized::MethodStringNoCache<PartitionDataWithShortStringKey>>(
+                                state);
             }
             break;
         }
@@ -204,11 +206,11 @@ struct PartitionedHashMapVariants
             throw Exception(ErrorCode::INTERNAL_ERROR, "meet invalid key type, type={}", type);
         }
     }
-    void init(vectorized::HashKeyType type, bool is_nullable = false) {
+    void init(RuntimeState* state, vectorized::HashKeyType type, bool is_nullable = false) {
         if (is_nullable) {
-            init<true>(type);
+            init<true>(state, type);
         } else {
-            init<false>(type);
+            init<false>(state, type);
         }
     }
 };

--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -182,7 +182,7 @@ Status SetSinkLocalState<is_intersect>::open(RuntimeState* state) {
     auto& parent = _parent->cast<Parent>();
     DCHECK(parent._cur_child_id == 0);
     _shared_state->hash_table_variants = std::make_unique<SetHashTableVariants>();
-    _shared_state->hash_table_init();
+    _shared_state->hash_table_init(state);
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -503,7 +503,7 @@ Status StreamingAggLocalState::_merge_with_serialized_key(vectorized::Block* blo
 
 Status StreamingAggLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
     RETURN_IF_ERROR(init_agg_hash_method(
-            _agg_data.get(), probe_exprs,
+            _state, _agg_data.get(), probe_exprs,
             Base::_parent->template cast<StreamingAggOperatorX>()._is_first_phase));
     return Status::OK();
 }

--- a/be/src/vec/common/hash_table/hash_map_util.h
+++ b/be/src/vec/common/hash_table/hash_map_util.h
@@ -63,11 +63,12 @@ struct DataVariants {
     Type _type = Type::EMPTY;
 
     template <typename T, typename TT, bool nullable>
-    void emplace_single() {
+    void emplace_single(RuntimeState* state) {
         if (nullable) {
-            method_variant.template emplace<MethodNullable<MethodOneNumber<T, DataNullable<TT>>>>();
+            method_variant.template emplace<MethodNullable<MethodOneNumber<T, DataNullable<TT>>>>(
+                    state);
         } else {
-            method_variant.template emplace<MethodOneNumber<T, TT>>();
+            method_variant.template emplace<MethodOneNumber<T, TT>>(state);
         }
     }
 };


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

The query cancel status was not checked during the hash table build loop, and it will result in the query not canceled in time.

