### PR TITLE
[Fix]Fix thread num not reset 0 when fetch failed

### DIFF
--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -332,7 +332,7 @@ void DorisMetrics::_update_process_thread_num() {
     std::filesystem::directory_iterator dict_iter("/proc/self/task/", ec);
     if (ec) {
         LOG(WARNING) << "failed to count thread num: " << ec.message();
-        process_fd_num_used->set_value(0);
+        process_thread_num->set_value(0);
         return;
     }
     int64_t count =


### PR DESCRIPTION
## Proposed changes

Fix thread num not reset 0 when fetch failed
