### PR TITLE
[fix](test) fix unstable case of partitions

### DIFF
--- a/regression-test/data/query_p0/system/test_partitions_schema.out
+++ b/regression-test/data/query_p0/system/test_partitions_schema.out
@@ -9,35 +9,35 @@ test_range_table	p4	3
 test_range_table	p5	0
 
 -- !select_check_1 --
-internal	test_partitions_schema_db	duplicate_table	duplicate_table	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	listtable	p1_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("1", "Beijing"),("1", "Shanghai"))	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	listtable	p2_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("2", "Beijing"),("2", "Shanghai"))	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	listtable	p3_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("3", "Beijing"),("3", "Shanghai"))	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	randomtable	randomtable	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p0	NULL	0	0	RANGE	NULL	col_1	NULL	[('-2147483648'), ('4'))	9	636	5728	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p1	NULL	0	0	RANGE	NULL	col_1	NULL	[('4'), ('6'))	2	959	1919	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p100	NULL	0	0	RANGE	NULL	col_1	NULL	[('83647'), ('2147483647'))	4	735	2941	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p2	NULL	0	0	RANGE	NULL	col_1	NULL	[('6'), ('7'))	1	975	975	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p3	NULL	0	0	RANGE	NULL	col_1	NULL	[('7'), ('8'))	1	959	959	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p4	NULL	0	0	RANGE	NULL	col_1	NULL	[('8'), ('10'))	3	948	2846	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p5	NULL	0	0	RANGE	NULL	col_1	NULL	[('10'), ('83647'))	0	0	0	0	0	0	0			
-internal	test_partitions_schema_db	test_row_column_page_size1	test_row_column_page_size1	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	test_row_column_page_size2	test_row_column_page_size2	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
+internal	test_partitions_schema_db	duplicate_table	duplicate_table	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
+internal	test_partitions_schema_db	listtable	p1_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("1", "Beijing"),("1", "Shanghai"))
+internal	test_partitions_schema_db	listtable	p2_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("2", "Beijing"),("2", "Shanghai"))
+internal	test_partitions_schema_db	listtable	p3_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("3", "Beijing"),("3", "Shanghai"))
+internal	test_partitions_schema_db	randomtable	randomtable	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
+internal	test_partitions_schema_db	test_range_table	p0	NULL	0	0	RANGE	NULL	col_1	NULL	[('-2147483648'), ('4'))
+internal	test_partitions_schema_db	test_range_table	p1	NULL	0	0	RANGE	NULL	col_1	NULL	[('4'), ('6'))
+internal	test_partitions_schema_db	test_range_table	p100	NULL	0	0	RANGE	NULL	col_1	NULL	[('83647'), ('2147483647'))
+internal	test_partitions_schema_db	test_range_table	p2	NULL	0	0	RANGE	NULL	col_1	NULL	[('6'), ('7'))
+internal	test_partitions_schema_db	test_range_table	p3	NULL	0	0	RANGE	NULL	col_1	NULL	[('7'), ('8'))
+internal	test_partitions_schema_db	test_range_table	p4	NULL	0	0	RANGE	NULL	col_1	NULL	[('8'), ('10'))
+internal	test_partitions_schema_db	test_range_table	p5	NULL	0	0	RANGE	NULL	col_1	NULL	[('10'), ('83647'))
+internal	test_partitions_schema_db	test_row_column_page_size1	test_row_column_page_size1	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
+internal	test_partitions_schema_db	test_row_column_page_size2	test_row_column_page_size2	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
 
 -- !select_check_2 --
-internal	test_partitions_schema_db	duplicate_table	duplicate_table	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	listtable	p1_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("1", "Beijing"),("1", "Shanghai"))	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	listtable	p2_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("2", "Beijing"),("2", "Shanghai"))	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	listtable	p3_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("3", "Beijing"),("3", "Shanghai"))	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	randomtable	randomtable	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p0	NULL	0	0	RANGE	NULL	col_1	NULL	[('-2147483648'), ('4'))	9	636	5728	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p1	NULL	0	0	RANGE	NULL	col_1	NULL	[('4'), ('6'))	2	959	1919	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p100	NULL	0	0	RANGE	NULL	col_1	NULL	[('83647'), ('2147483647'))	4	735	2941	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p2	NULL	0	0	RANGE	NULL	col_1	NULL	[('6'), ('7'))	1	975	975	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p3	NULL	0	0	RANGE	NULL	col_1	NULL	[('7'), ('8'))	1	959	959	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p4	NULL	0	0	RANGE	NULL	col_1	NULL	[('8'), ('10'))	3	948	2846	0	0	0	0			
-internal	test_partitions_schema_db	test_range_table	p5	NULL	0	0	RANGE	NULL	col_1	NULL	[('10'), ('83647'))	0	0	0	0	0	0	0			
-internal	test_partitions_schema_db	test_row_column_page_size1	test_row_column_page_size1	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL	-1	0	0	0	0	0	0			
+internal	test_partitions_schema_db	duplicate_table	duplicate_table	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
+internal	test_partitions_schema_db	listtable	p1_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("1", "Beijing"),("1", "Shanghai"))
+internal	test_partitions_schema_db	listtable	p2_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("2", "Beijing"),("2", "Shanghai"))
+internal	test_partitions_schema_db	listtable	p3_city	NULL	0	0	LIST	NULL	user_id, city	NULL	(("3", "Beijing"),("3", "Shanghai"))
+internal	test_partitions_schema_db	randomtable	randomtable	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
+internal	test_partitions_schema_db	test_range_table	p0	NULL	0	0	RANGE	NULL	col_1	NULL	[('-2147483648'), ('4'))
+internal	test_partitions_schema_db	test_range_table	p1	NULL	0	0	RANGE	NULL	col_1	NULL	[('4'), ('6'))
+internal	test_partitions_schema_db	test_range_table	p100	NULL	0	0	RANGE	NULL	col_1	NULL	[('83647'), ('2147483647'))
+internal	test_partitions_schema_db	test_range_table	p2	NULL	0	0	RANGE	NULL	col_1	NULL	[('6'), ('7'))
+internal	test_partitions_schema_db	test_range_table	p3	NULL	0	0	RANGE	NULL	col_1	NULL	[('7'), ('8'))
+internal	test_partitions_schema_db	test_range_table	p4	NULL	0	0	RANGE	NULL	col_1	NULL	[('8'), ('10'))
+internal	test_partitions_schema_db	test_range_table	p5	NULL	0	0	RANGE	NULL	col_1	NULL	[('10'), ('83647'))
+internal	test_partitions_schema_db	test_row_column_page_size1	test_row_column_page_size1	NULL	0	0	UNPARTITIONED	NULL	NULL	NULL	NULL
 
 -- !select_check_3 --
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
   row count skipped in common validation
   if table report not done for the all tablet 
    row count will be -1 if done can get actual data.
So row count can cause timing issue and make testcase unstable.
 we already have a checkpoint for rowcount with waiting . in common validation we have skiped rowcount.