### PR TITLE
[Fix](Nereids) fix append_trailing_char_if_absent function return null (#40820)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/ExecutableFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/ExecutableFunctions.java
@@ -107,11 +107,14 @@ public class ExecutableFunctions {
 
     @ExecFunction(name = "append_trailing_char_if_absent", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "VARCHAR")
     public static Expression appendTrailingIfCharAbsent(StringLikeLiteral literal, StringLikeLiteral chr) {
-        if (literal.getValue().length() != 1) {
-            return null;
+        if (chr.getValue().length() != 1) {
+            return new NullLiteral(literal.getDataType());
         }
-        return literal.getValue().endsWith(chr.getValue()) ? literal
-                : new VarcharLiteral(literal.getValue() + chr.getValue());
+        if (literal.getValue().endsWith(chr.getValue())) {
+            return literal;
+        } else {
+            return new VarcharLiteral( literal.getValue() + chr.getValue());
+        }
     }
 
     @ExecFunction(name = "e", argTypes = {}, returnType = "DOUBLE")

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1379,6 +1379,20 @@ class Suite implements GroovyInterceptable {
         Assert.assertEquals("FINISHED", result)
     }
 
+    void testFoldConst(String foldSql) {
+        String openFoldConstant = "set debug_skip_fold_constant=false";
+        sql(openFoldConstant)
+        logger.info(foldSql)
+        List<List<Object>> resultByFoldConstant = sql(foldSql)
+        logger.info("result by fold constant: " + resultByFoldConstant.toString())
+        String closeFoldConstant = "set debug_skip_fold_constant=true";
+        sql(closeFoldConstant)
+        logger.info(foldSql)
+        List<List<Object>> resultExpected = sql(foldSql)
+        logger.info("result expected: " + resultExpected.toString())
+        Assert.assertEquals(resultExpected, resultByFoldConstant)
+    }
+
     String getJobName(String dbName, String mtmvName) {
         String showMTMV = "select JobName from mv_infos('database'='${dbName}') where Name = '${mtmvName}'";
 	    logger.info(showMTMV)

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_fe.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_fe.groovy
@@ -163,4 +163,90 @@ suite("test_fold_constant_by_fe") {
     res = sql """explain select "12" like '%123%'"""
     assertTrue(res.contains("like"))
 
+    // Normal Usage Test Cases
+
+    // Test Case 1: Append missing trailing character
+    testFoldConst("select append_trailing_char_if_absent('hello', '!')")
+    // Expected Output: 'hello!'
+
+    // Test Case 2: Trailing character already present
+    testFoldConst("select append_trailing_char_if_absent('hello!', '!')")
+    // Expected Output: 'hello!'
+
+    // Test Case 3: Append trailing space
+    testFoldConst("select append_trailing_char_if_absent('hello', ' ')")
+    // Expected Output: 'hello '
+
+    // Test Case 4: Empty string input
+    testFoldConst("select append_trailing_char_if_absent('', '!')")
+    // Expected Output: '!'
+
+    // Test Case 5: Append different character
+    testFoldConst("select append_trailing_char_if_absent('hello', '?')")
+    // Expected Output: 'hello?'
+
+    // Test Case 6: String ends with a different character
+    testFoldConst("select append_trailing_char_if_absent('hello?', '!')")
+    // Expected Output: 'hello?!'
+
+    // Edge and Unusual Usage Test Cases
+
+    // Test Case 7: Input is NULL
+    testFoldConst("select append_trailing_char_if_absent(NULL, '!')")
+    // Expected Output: NULL
+
+    // Test Case 8: Trailing character is NULL
+    testFoldConst("select append_trailing_char_if_absent('hello', NULL)")
+    // Expected Output: NULL
+
+    // Test Case 9: Empty trailing character
+    testFoldConst("select append_trailing_char_if_absent('hello', '')")
+    // Expected Output: Error or no change depending on implementation
+
+    // Test Case 10: Trailing character is more than 1 character long
+    testFoldConst("select append_trailing_char_if_absent('hello', 'ab')")
+    // Expected Output: Error
+
+    // Test Case 11: Input string is a number
+    testFoldConst("select append_trailing_char_if_absent(12345, '!')")
+    // Expected Output: Error or '12345!'
+
+    // Test Case 12: Trailing character is a number
+    testFoldConst("select append_trailing_char_if_absent('hello', '1')")
+    // Expected Output: 'hello1'
+
+    // Test Case 13: Input is a single character
+    testFoldConst("select append_trailing_char_if_absent('h', '!')")
+    // Expected Output: 'h!'
+
+    // Test Case 14: Unicode character as input and trailing character
+    testFoldConst("select append_trailing_char_if_absent('こんにちは', '!')")
+    // Expected Output: 'こんにちは!'
+
+    // Test Case 15: Multibyte character as trailing character
+    testFoldConst("select append_trailing_char_if_absent('hello', '😊')")
+    // Expected Output: 'hello😊'
+
+    // Test Case 16: Long string input
+    testFoldConst("select append_trailing_char_if_absent('This is a very long string', '.')")
+    // Expected Output: 'This is a very long string.'
+
+    // Error Handling Test Cases
+
+    // Test Case 17: Invalid trailing character data type (numeric)
+    testFoldConst("select append_trailing_char_if_absent('hello', 1)")
+    // Expected Output: Error
+
+    // Test Case 18: Invalid input data type (integer)
+    testFoldConst("select append_trailing_char_if_absent(12345, '!')")
+    // Expected Output: Error or '12345!'
+
+    // Test Case 19: Non-ASCII characters
+    testFoldConst("select append_trailing_char_if_absent('Привет', '!')")
+    // Expected Output: 'Привет!'
+
+    // Test Case 20: Trailing character with whitespace
+    testFoldConst("select append_trailing_char_if_absent('hello', ' ')")
+    // Expected Output: 'hello '
+
 }


### PR DESCRIPTION
cherry-pick： #40820
example: select append_trailing_char_if_absent('it','a') would return null in original design, it can not return null when folding constant on fe any time

