### PR TITLE
[opt](datatype)  avoid unnecessary copying in the push number for the date type, 

### DIFF
--- a/be/src/vec/data_types/data_type_date.cpp
+++ b/be/src/vec/data_types/data_type_date.cpp
@@ -42,14 +42,14 @@ bool DataTypeDate::equals(const IDataType& rhs) const {
 }
 
 size_t DataTypeDate::number_length() const {
-    return 10;
+    return sizeof("2024-01-01"); //11
 }
-void DataTypeDate::push_number(ColumnString::Chars& chars, const Int64& num) const {
+void DataTypeDate::push_number_reserved(ColumnString::Char* chars, const Int64& num,
+                                        size_t& offset) const {
     doris::VecDateTimeValue value = binary_cast<Int64, doris::VecDateTimeValue>(num);
-    char buf[64];
-    char* pos = value.to_string(buf);
-    // DateTime to_string the end is /0
-    chars.insert(buf, pos - 1);
+
+    const auto len = value.to_buffer((char*)chars + offset);
+    offset += len;
 }
 std::string DataTypeDate::to_string(const IColumn& column, size_t row_num) const {
     auto result = check_column_const_set_readability(column, row_num);

--- a/be/src/vec/data_types/data_type_date.h
+++ b/be/src/vec/data_types/data_type_date.h
@@ -65,7 +65,7 @@ public:
     }
 
     size_t number_length() const;
-    void push_number(ColumnString::Chars& chars, const Int64& num) const;
+    void push_number_reserved(ColumnString::Char* chars, const Int64& num, size_t& offset) const;
     std::string to_string(Int64 int_val) const {
         doris::VecDateTimeValue value = binary_cast<Int64, doris::VecDateTimeValue>(int_val);
         char buf[64];

--- a/be/src/vec/data_types/data_type_date_time.cpp
+++ b/be/src/vec/data_types/data_type_date_time.cpp
@@ -43,17 +43,14 @@ bool DataTypeDateTime::equals(const IDataType& rhs) const {
 }
 
 size_t DataTypeDateTime::number_length() const {
-    //2024-01-01 00:00:00
-    return 20;
+    return sizeof("2024-01-01 00:00:00"); //20
 }
 
-void DataTypeDateTime::push_number(ColumnString::Chars& chars, const Int64& num) const {
+void DataTypeDateTime::push_number_reserved(ColumnString::Char* chars, const Int64& num,
+                                            size_t& offset) const {
     doris::VecDateTimeValue value = binary_cast<Int64, doris::VecDateTimeValue>(num);
-
-    char buf[64];
-    char* pos = value.to_string(buf);
-    // DateTime to_string the end is /0
-    chars.insert(buf, pos - 1);
+    const auto len = value.to_buffer((char*)chars + offset);
+    offset += len;
 }
 
 std::string DataTypeDateTime::to_string(const IColumn& column, size_t row_num) const {

--- a/be/src/vec/data_types/data_type_date_time.h
+++ b/be/src/vec/data_types/data_type_date_time.h
@@ -108,7 +108,7 @@ public:
     }
 
     size_t number_length() const;
-    void push_number(ColumnString::Chars& chars, const Int64& num) const;
+    void push_number_reserved(ColumnString::Char* chars, const Int64& num, size_t& offset) const;
 
     Status from_string(ReadBuffer& rb, IColumn* column) const override;
 

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -199,7 +199,7 @@ protected:
                 static_cast<const Derived*>(this)->push_number_reserved(chars.data(), num, offset);
                 offsets[row_num] = offset;
             }
-            DCHECK_EQ(offset, static_cast<const Derived*>(this)->number_length() * size);
+            DCHECK_LE(offset, static_cast<const Derived*>(this)->number_length() * size);
             chars.resize(offset);
         } else {
             for (int row_num = 0; row_num < size; row_num++) {

--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -48,16 +48,13 @@ bool DataTypeDateV2::equals(const IDataType& rhs) const {
 }
 
 size_t DataTypeDateV2::number_length() const {
-    //2024-01-01
-    return 10;
+    return sizeof("2024-01-01"); //11
 }
-void DataTypeDateV2::push_number(ColumnString::Chars& chars, const UInt32& num) const {
+void DataTypeDateV2::push_number_reserved(ColumnString::Char* chars, const UInt32& num,
+                                          size_t& offset) const {
     DateV2Value<DateV2ValueType> val = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(num);
-
-    char buf[64];
-    char* pos = val.to_string(buf);
-    // DateTime to_string the end is /0
-    chars.insert(buf, pos - 1);
+    const auto len = val.to_buffer((char*)chars + offset);
+    offset += len;
 }
 
 std::string DataTypeDateV2::to_string(const IColumn& column, size_t row_num) const {
@@ -168,15 +165,14 @@ std::string DataTypeDateTimeV2::to_string(UInt64 int_val) const {
 }
 
 size_t DataTypeDateTimeV2::number_length() const {
-    //2024-01-01 00:00:00-000000
-    return 32;
+    return sizeof("2024-01-01 00:00:00-000000"); //27
 }
-void DataTypeDateTimeV2::push_number(ColumnString::Chars& chars, const UInt64& num) const {
+void DataTypeDateTimeV2::push_number_reserved(ColumnString::Char* chars, const UInt64& num,
+                                              size_t& offset) const {
     DateV2Value<DateTimeV2ValueType> val =
             binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(num);
-    char buf[64];
-    char* pos = val.to_string(buf, _scale);
-    chars.insert(buf, pos - 1);
+    const auto len = val.to_buffer((char*)chars + offset, _scale);
+    offset += len;
 }
 
 void DataTypeDateTimeV2::to_string(const IColumn& column, size_t row_num,

--- a/be/src/vec/data_types/data_type_time_v2.h
+++ b/be/src/vec/data_types/data_type_time_v2.h
@@ -87,7 +87,7 @@ public:
     }
 
     size_t number_length() const;
-    void push_number(ColumnString::Chars& chars, const UInt32& num) const;
+    void push_number_reserved(ColumnString::Char* chars, const UInt32& num, size_t& offset) const;
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(UInt32 int_val) const;
@@ -138,7 +138,7 @@ public:
     }
 
     size_t number_length() const;
-    void push_number(ColumnString::Chars& chars, const UInt64& num) const;
+    void push_number_reserved(ColumnString::Char* chars, const UInt64& num, size_t& offset) const;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     std::string to_string(UInt64 int_val) const;
     Status from_string(ReadBuffer& rb, IColumn* column) const override;


### PR DESCRIPTION
## Proposed changes

Before calling push_number, sufficient length has already been allocated using number_length. There's no need for an additional copy using buf here.


<!--Describe your changes.-->

