### PR TITLE
[opt](in expr) Optimize the IN expression by skipping constant column…

### DIFF
--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -93,8 +93,22 @@ Status VInPredicate::open(RuntimeState* state, VExprContext* context,
     if (scope == FunctionContext::FRAGMENT_LOCAL) {
         RETURN_IF_ERROR(VExpr::get_const_col(context, nullptr));
     }
+
+    _is_args_all_constant = std::all_of(_children.begin() + 1, _children.end(),
+                                        [](const VExprSPtr& expr) { return expr->is_constant(); });
     _open_finished = true;
     return Status::OK();
+}
+
+size_t VInPredicate::skip_constant_args_size() const {
+    if (_is_args_all_constant && !_can_fast_execute) {
+        // This is an optimization. For expressions like colA IN (1, 2, 3, 4),
+        // where all values inside the IN clause are constants,
+        // a hash set is created during open, and it will not be accessed again during execute
+        //  Here, _children[0] is colA
+        return 1;
+    }
+    return _children.size();
 }
 
 void VInPredicate::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
@@ -115,9 +129,8 @@ Status VInPredicate::execute(VExprContext* context, Block* block, int* result_co
         return Status::OK();
     }
     DCHECK(_open_finished || _getting_const_col);
-    // TODO: not execute const expr again, but use the const column in function context
-    doris::vectorized::ColumnNumbers arguments(_children.size());
-    for (int i = 0; i < _children.size(); ++i) {
+    doris::vectorized::ColumnNumbers arguments(skip_constant_args_size());
+    for (int i = 0; i < skip_constant_args_size(); ++i) {
         int column_id = -1;
         RETURN_IF_ERROR(_children[i]->execute(context, block, &column_id));
         arguments[i] = column_id;

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -51,6 +51,8 @@ public:
 
     std::string debug_string() const override;
 
+    size_t skip_constant_args_size() const;
+
     const FunctionBasePtr function() { return _function; }
 
     bool is_not_in() const { return _is_not_in; };
@@ -62,5 +64,6 @@ private:
 
     const bool _is_not_in;
     static const constexpr char* function_name = "in";
+    bool _is_args_all_constant = false;
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
…s. (#39912)
https://github.com/apache/doris/pull/39912

Optimize the IN expression by skipping constant columns

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

