### PR TITLE
[Improment]Add CustomStdAllocator

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -874,7 +874,7 @@ Status AggSinkLocalState::close(RuntimeState* state, Status exec_status) {
     vectorized::PODArray<vectorized::AggregateDataPtr> tmp_places;
     _places.swap(tmp_places);
 
-    std::vector<char> tmp_deserialize_buffer;
+    MyVector<char> tmp_deserialize_buffer;
     _deserialize_buffer.swap(tmp_deserialize_buffer);
     Base::_mem_tracker->release(Base::_shared_state->mem_usage_record.used_in_state +
                                 Base::_shared_state->mem_usage_record.used_in_arena);

--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -21,6 +21,7 @@
 
 #include "pipeline/exec/operator.h"
 #include "runtime/exec_env.h"
+#include "vec/common/custom_allocator.h"
 
 namespace doris::pipeline {
 
@@ -114,7 +115,7 @@ protected:
     bool _should_limit_output = false;
 
     vectorized::PODArray<vectorized::AggregateDataPtr> _places;
-    std::vector<char> _deserialize_buffer;
+    MyVector<char> _deserialize_buffer;
 
     vectorized::Block _preagg_block = vectorized::Block();
 

--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -665,7 +665,7 @@ Status AggLocalState::close(RuntimeState* state) {
     vectorized::PODArray<vectorized::AggregateDataPtr> tmp_places;
     _places.swap(tmp_places);
 
-    std::vector<char> tmp_deserialize_buffer;
+    MyVector<char> tmp_deserialize_buffer;
     _deserialize_buffer.swap(tmp_deserialize_buffer);
     return Base::close(state);
 }

--- a/be/src/pipeline/exec/aggregation_source_operator.h
+++ b/be/src/pipeline/exec/aggregation_source_operator.h
@@ -20,6 +20,7 @@
 
 #include "common/status.h"
 #include "operator.h"
+#include "vec/common/custom_allocator.h"
 
 namespace doris {
 class RuntimeState;
@@ -71,7 +72,7 @@ protected:
     size_t _get_hash_table_size();
 
     vectorized::PODArray<vectorized::AggregateDataPtr> _places;
-    std::vector<char> _deserialize_buffer;
+    MyVector<char> _deserialize_buffer;
 
     RuntimeProfile::Counter* _get_results_timer = nullptr;
     RuntimeProfile::Counter* _serialize_result_timer = nullptr;
@@ -117,7 +118,7 @@ private:
 
     // left / full join will change the key nullable make output/input solt
     // nullable diff. so we need make nullable of it.
-    std::vector<size_t> _make_nullable_keys;
+    MyVector<size_t> _make_nullable_keys;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
@@ -25,6 +25,7 @@
 #include "common/status.h"
 #include "pipeline/exec/operator.h"
 #include "util/runtime_profile.h"
+#include "vec/common/custom_allocator.h"
 #include "vec/core/block.h"
 
 namespace doris {
@@ -132,7 +133,7 @@ private:
     // group by k1,k2
     vectorized::VExprContextSPtrs _probe_expr_ctxs;
     std::vector<vectorized::AggFnEvaluator*> _aggregate_evaluators;
-    std::vector<size_t> _make_nullable_keys;
+    MyVector<size_t> _make_nullable_keys;
     /// The total size of the row from the aggregate functions.
     size_t _total_size_of_aggregate_states = 0;
     bool _is_streaming_preagg = false;

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -1253,7 +1253,7 @@ Status StreamingAggLocalState::close(RuntimeState* state) {
     vectorized::PODArray<vectorized::AggregateDataPtr> tmp_places;
     _places.swap(tmp_places);
 
-    std::vector<char> tmp_deserialize_buffer;
+    MyVector<char> tmp_deserialize_buffer;
     _deserialize_buffer.swap(tmp_deserialize_buffer);
     Base::_mem_tracker->release(_mem_usage_record.used_in_state + _mem_usage_record.used_in_arena);
 

--- a/be/src/pipeline/exec/streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.h
@@ -24,6 +24,7 @@
 #include "common/status.h"
 #include "pipeline/exec/operator.h"
 #include "util/runtime_profile.h"
+#include "vec/common/custom_allocator.h"
 #include "vec/core/block.h"
 
 namespace doris {
@@ -119,7 +120,7 @@ private:
     size_t _input_num_rows = 0;
 
     vectorized::PODArray<vectorized::AggregateDataPtr> _places;
-    std::vector<char> _deserialize_buffer;
+    MyVector<char> _deserialize_buffer;
 
     struct ExecutorBase {
         virtual Status execute(StreamingAggLocalState* local_state, vectorized::Block* block) = 0;
@@ -243,7 +244,7 @@ private:
     vectorized::VExprContextSPtrs _probe_expr_ctxs;
     std::vector<vectorized::AggFnEvaluator*> _aggregate_evaluators;
     bool _can_short_circuit = false;
-    std::vector<size_t> _make_nullable_keys;
+    MyVector<size_t> _make_nullable_keys;
     bool _have_conjuncts;
     RowDescriptor _agg_fn_output_row_descriptor;
 };

--- a/be/src/vec/common/custom_allocator.h
+++ b/be/src/vec/common/custom_allocator.h
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/common/allocator.h"
+#include "vec/common/allocator_fwd.h"
+
+template <class T, typename MemoryAllocator = Allocator<true>>
+class CustomStdAllocator;
+
+template <typename P>
+using MyVector = std::vector<P, CustomStdAllocator<P>>;
+
+template <class T, typename MemoryAllocator>
+class CustomStdAllocator : private MemoryAllocator {
+public:
+    using value_type = T;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    CustomStdAllocator() noexcept = default;
+
+    template <class U>
+    struct rebind {
+        typedef CustomStdAllocator<U> other;
+    };
+
+    template <class Up>
+    CustomStdAllocator(const CustomStdAllocator<Up>&) noexcept {}
+
+    T* allocate(size_t n) { return static_cast<T*>(MemoryAllocator::alloc(n * sizeof(T))); }
+
+    void deallocate(T* ptr, size_t n) noexcept { MemoryAllocator::free((void*)ptr, n * sizeof(T)); }
+
+    size_t max_size() const noexcept { return size_t(~0) / sizeof(T); }
+
+    T* allocate(size_t n, const void*) { return allocate(n); }
+
+    template <class Up, class... Args>
+    void construct(Up* p, Args&&... args) {
+        ::new ((void*)p) Up(std::forward<Args>(args)...);
+    }
+
+    void destroy(T* p) { p->~T(); }
+
+    T* address(T& t) const noexcept { return std::addressof(t); }
+
+    T* address(const T& t) const noexcept { return std::addressof(t); }
+};
+
+template <class T, class Up>
+bool operator==(const CustomStdAllocator<T>&, const CustomStdAllocator<Up>&) {
+    return true;
+}
+
+template <class T, class Up>
+bool operator!=(const CustomStdAllocator<T>&, const CustomStdAllocator<Up>&) {
+    return false;
+}


### PR DESCRIPTION
## Proposed changes
Add a custom allocator to instead of std::allocator, used for std::vector, so that we can add std::vector's memory to thread context's memory tracker.

Currently just add the CustomStdAllocator and using it in some  aggregation operator, later all block used by aggregation operator should use the CustomStdAllocator.
