### PR TITLE
[fix](config) enlarge batch size when insert cache hotspot table

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3010,7 +3010,7 @@ public class Config extends ConfigBase {
     // to control the max num of values inserted into cache hotspot internal table
     // insert into cache table when the size of batch values reaches this limit
     @ConfField(mutable = true)
-    public static long batch_insert_cluster_cache_hotspot_num = 50;
+    public static long batch_insert_cluster_cache_hotspot_num = 1000;
 
     /**
      * intervals between be status checks for CloudUpgradeMgr


### PR DESCRIPTION
This adjustment is based on the analysis that each entry in the params map is roughly 1KB, thus the old limit resulted in a 50KB footprint. With no concurrency issues, expanding the batch size to 1000 should enhance processing efficiency with a reasonable 1MB memory footprint.

