### PR TITLE
[Fix](load) Restrict the import of VARCHAR(0) data to avoid coredump

### DIFF
--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -211,7 +211,7 @@ Status OlapTableBlockConvertor::_internal_validate_column(
     auto string_column_checker = [&](const ColumnString* column_string) {
         size_t limit = config::string_type_length_soft_limit_bytes;
         // when type.len is negative, std::min will return overflow value, so we need to check it
-        if (type.len > 0) {
+        if (type.len >= 0) {
             limit = std::min(config::string_type_length_soft_limit_bytes, type.len);
         }
 


### PR DESCRIPTION
The VARCHAR(0) created has an actual length of 0, and BE didn't restrict it, leading to a BE core dump. #[38427](https://github.com/apache/doris/pull/38427) changed VARCHAR(0) to have a length of 65533. This PR restricts data import when the length is 0 to avoid a core dump.

