### PR TITLE
[fix](table_options) fix potential NPE when quering table_options sys table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -1089,40 +1089,45 @@ public class MetadataGenerator {
                 continue;
             }
             OlapTable olapTable = (OlapTable) table;
-            TRow trow = new TRow();
-            trow.addToColumnValue(new TCell().setStringVal(catalog.getName())); // TABLE_CATALOG
-            trow.addToColumnValue(new TCell().setStringVal(database.getFullName())); // TABLE_SCHEMA
-            trow.addToColumnValue(new TCell().setStringVal(table.getName())); // TABLE_NAME
-            trow.addToColumnValue(
-                    new TCell().setStringVal(olapTable.getKeysType().toMetadata())); // TABLE_MODEL
-            trow.addToColumnValue(
-                    new TCell().setStringVal(olapTable.getKeyColAsString())); // key columTypes
+            olapTable.readLock();
+            try {
+                TRow trow = new TRow();
+                trow.addToColumnValue(new TCell().setStringVal(catalog.getName())); // TABLE_CATALOG
+                trow.addToColumnValue(new TCell().setStringVal(database.getFullName())); // TABLE_SCHEMA
+                trow.addToColumnValue(new TCell().setStringVal(table.getName())); // TABLE_NAME
+                trow.addToColumnValue(
+                        new TCell().setStringVal(olapTable.getKeysType().toMetadata())); // TABLE_MODEL
+                trow.addToColumnValue(
+                        new TCell().setStringVal(olapTable.getKeyColAsString())); // key columTypes
 
-            DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
-            if (distributionInfo.getType() == DistributionInfoType.HASH) {
-                HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
-                List<Column> distributionColumns = hashDistributionInfo.getDistributionColumns();
-                StringBuilder distributeKey = new StringBuilder();
-                for (Column c : distributionColumns) {
-                    if (distributeKey.length() != 0) {
-                        distributeKey.append(",");
+                DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
+                if (distributionInfo.getType() == DistributionInfoType.HASH) {
+                    HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
+                    List<Column> distributionColumns = hashDistributionInfo.getDistributionColumns();
+                    StringBuilder distributeKey = new StringBuilder();
+                    for (Column c : distributionColumns) {
+                        if (distributeKey.length() != 0) {
+                            distributeKey.append(",");
+                        }
+                        distributeKey.append(c.getName());
                     }
-                    distributeKey.append(c.getName());
-                }
-                if (distributeKey.length() == 0) {
-                    trow.addToColumnValue(new TCell().setStringVal(""));
+                    if (distributeKey.length() == 0) {
+                        trow.addToColumnValue(new TCell().setStringVal(""));
+                    } else {
+                        trow.addToColumnValue(
+                                new TCell().setStringVal(distributeKey.toString()));
+                    }
+                    trow.addToColumnValue(new TCell().setStringVal("HASH")); // DISTRIBUTE_TYPE
                 } else {
-                    trow.addToColumnValue(
-                            new TCell().setStringVal(distributeKey.toString()));
+                    trow.addToColumnValue(new TCell().setStringVal("RANDOM")); // DISTRIBUTE_KEY
+                    trow.addToColumnValue(new TCell().setStringVal("RANDOM")); // DISTRIBUTE_TYPE
                 }
-                trow.addToColumnValue(new TCell().setStringVal("HASH")); // DISTRIBUTE_TYPE
-            } else {
-                trow.addToColumnValue(new TCell().setStringVal("RANDOM")); // DISTRIBUTE_KEY
-                trow.addToColumnValue(new TCell().setStringVal("RANDOM")); // DISTRIBUTE_TYPE
+                trow.addToColumnValue(new TCell().setIntVal(distributionInfo.getBucketNum())); // BUCKETS_NUM
+                trow.addToColumnValue(new TCell().setIntVal(olapTable.getPartitionNum())); // PARTITION_NUM
+                dataBatch.add(trow);
+            } finally {
+                olapTable.readUnlock();
             }
-            trow.addToColumnValue(new TCell().setIntVal(distributionInfo.getBucketNum())); // BUCKETS_NUM
-            trow.addToColumnValue(new TCell().setIntVal(olapTable.getPartitionNum())); // PARTITION_NUM
-            dataBatch.add(trow);
         }
     }
 


### PR DESCRIPTION
Fix unstable issue like:

```
2024-09-17 12:41:04,755 WARN (thrift-server-pool-4|384) [FrontendServiceImpl.fetchSchemaTableData():2292] Failed to fetchSchemaTableData
java.lang.NullPointerException: Cannot invoke "org.apache.doris.catalog.MaterializedIndexMeta.getSchema()" because the return value of "java.util.Map.get(Object)" is null
        at org.apache.doris.catalog.OlapTable.getSchemaByIndexId(OlapTable.java:954) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.OlapTable.getSchemaByIndexId(OlapTable.java:947) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.OlapTable.getBaseSchema(OlapTable.java:2097) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.OlapTable.getKeyColAsString(OlapTable.java:2167) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.tablefunction.MetadataGenerator.tableOptionsForInternalCatalog(MetadataGenerator.java:1099) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.tablefunction.MetadataGenerator.tableOptionsMetadataResult(MetadataGenerator.java:1189) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.tablefunction.MetadataGenerator.getSchemaTableData(MetadataGenerator.java:273) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.service.FrontendServiceImpl.fetchSchemaTableData(FrontendServiceImpl.java:2289) ~[doris-fe.jar:1.2-SNAPSHOT]
        at jdk.internal.reflect.GeneratedMethodAccessor50.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
        at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60) ~[doris-fe.jar:1.2-SNAPSHOT]
        at jdk.proxy2.$Proxy44.fetchSchemaTableData(Unknown Source) ~[?:?]
        at org.apache.doris.thrift.FrontendService$Processor$fetchSchemaTableData.getResult(FrontendService.java:4572) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
        at org.apache.doris.thrift.FrontendService$Processor$fetchSchemaTableData.getResult(FrontendService.java:4552) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.16.0.jar:0.16.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.16.0.jar:0.16.0]
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250) ~[libthrift-0.16.0.jar:0.16.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```