### PR TITLE
[fix](FoldConst)The length function returns incorrect results under FoldConst.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -113,7 +113,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "length")
     public static Expression lengthVarchar(StringLikeLiteral first) {
-        return new IntegerLiteral(first.getValue().length());
+        return new IntegerLiteral(first.getValue().getBytes(StandardCharsets.UTF_8).length);
     }
 
     /**

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -50,6 +50,7 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("SELECT  Concat_Ws('-', '2024', '09', '02')")
     testFoldConst("SELECT  Char(65)")
     testFoldConst("SELECT  Character_Length('Hello World')")
+    testFoldConst("SELECT  Length('你')")
     testFoldConst("SELECT  Initcap('hello world')")
     testFoldConst("SELECT  Md5('Hello World')")
     testFoldConst("SELECT  Md5Sum('Hello World')")


### PR DESCRIPTION
## Proposed changes

```
mysql [(none)]>set debug_skip_fold_constant = false;
Query OK, 0 rows affected (0.00 sec)

mysql [(none)]>select length('你');
+---------------+
| length('你')  |
+---------------+
|             1 |
+---------------+
1 row in set (0.01 sec)

mysql [(none)]>set debug_skip_fold_constant = true;
Query OK, 0 rows affected (0.00 sec)

mysql [(none)]>select length('你');
+---------------+
| length('你')  |
+---------------+
|             3 |
+---------------+
```

<!--Describe your changes.-->

