### PR TITLE
[Fix](scanner) lazy update block mem usage when status is not ok

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -278,14 +278,14 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
                 ctx->update_peak_memory_usage(free_block->allocated_bytes());
                 ctx->update_peak_memory_usage(-free_block->allocated_bytes());
                 status = scanner->get_block_after_projects(state, free_block.get(), &eos);
-                // Projection will truncate useless columns, makes block size change.
-                auto free_block_bytes = free_block->allocated_bytes();
-                ctx->update_peak_memory_usage(free_block_bytes);
                 first_read = false;
                 if (!status.ok()) {
                     LOG(WARNING) << "Scan thread read VScanner failed: " << status.to_string();
                     break;
                 }
+                // Projection will truncate useless columns, makes block size change.
+                auto free_block_bytes = free_block->allocated_bytes();
+                ctx->update_peak_memory_usage(free_block_bytes);
                 raw_bytes_read += free_block_bytes;
                 if (!scan_task->cached_blocks.empty() &&
                     scan_task->cached_blocks.back().first->rows() + free_block->rows() <=


### PR DESCRIPTION
## Proposed changes

fix problem like this:
```
set enable_common_expr_pushdown=false;

create table t(a int, c varchar(1024)) PROPERTIES ("replication_allocation" = "tag.location.default: 1");

insert into t values(1, "a b c d e");

SELECT count() FROM t where c MATCH_PHRASE_EDGE 's';

I20240919 09:31:40.713896 2224044 internal_service.cpp:626] Cancel query 3e48a306704f4691-840d239bf31420aa, reason: [INTERNAL_ERROR]PStatus: (127.0.0.1)[INTERNAL_ERROR]Column match_phrase_edge({"c", "String"}) in block is nullptr, in method bytes. All Columns are c String match_phrase_edge({"c", "String"})                                                                                                                                                                                     
        3#  doris::vectorized::Block::allocated_bytes() const at be/src/vec/core/block.cpp:446
        4#  doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at be/src/vec/exec/scan/scanner_scheduler.cpp:243
```

