### PR TITLE
[test](inverted index) set enable_common_expr_pushdown true for variant_github_events_p2

### DIFF
--- a/regression-test/suites/variant_github_events_p2/load.groovy
+++ b/regression-test/suites/variant_github_events_p2/load.groovy
@@ -215,6 +215,7 @@ suite("regression_test_variant_github_events_p2", "nonConcurrent,p2"){
     }
 
     sql """set enable_match_without_inverted_index = false""" 
+    sql """ set enable_common_expr_pushdown = true """
     // filter by bloom filter
     qt_sql """select cast(v["payload"]["pull_request"]["additions"] as int)  from github_events where cast(v["repo"]["name"] as string) = 'xpressengine/xe-core' order by 1;"""
     qt_sql """select * from github_events where  cast(v["repo"]["name"] as string) = 'xpressengine/xe-core' order by 1 limit 10"""


### PR DESCRIPTION
## Proposed changes

fix regression case of variant_github_events_p2
```
Exception in variant_github_events_p2/load.groovy(line 236):

UNIQUE KEY(`k`)
DISTRIBUTED BY HASH(k) BUCKETS 4
properties("replication_num" = "1", "disable_auto_compaction" = "false", "bloom_filter_columns" = "v", "variant_enable_flatten_nested" = "true");
"""
sql """insert into github_events2 select * from github_events order by k"""
sql """select v['payload']['commits'] from github_events order by k ;"""
sql """select v['payload']['commits'] from github_events2 order by k ;"""

// query with inverted index
qt_sql """select cast(v["payload"]["pull_request"]["additions"] as int) from github_events where v["repo"]["name"] match 'xpressengine' order by 1;"""
^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^
qt_sql """select count() from github_events where v["repo"]["name"] match 'apache' order by 1;"""
}

Exception:
java.sql.SQLException: errCode = 2, detailMessage = (172.20.50.232)[E-6001]match_any not support execute_match
```
