### PR TITLE
[fix](explain) fix NPE when explain verbose with partition batch mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -133,7 +133,7 @@ public abstract class FileScanNode extends ExternalScanNode {
         output.append(prefix).append("partition=").append(selectedPartitionNum).append("/").append(totalPartitionNum)
             .append("\n");
 
-        if (detailLevel == TExplainLevel.VERBOSE) {
+        if (detailLevel == TExplainLevel.VERBOSE && !isBatchMode()) {
             output.append(prefix).append("backends:").append("\n");
             Multimap<Long, TFileRangeDesc> scanRangeLocationsMap = ArrayListMultimap.create();
             // 1. group by backend id

--- a/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
@@ -91,7 +91,16 @@ suite("test_hive_partitions", "p0,external,hive,external_docker,external_docker_
 
             q01()
 
-            sql """drop catalog if exists ${catalog_name}"""
+            sql """set num_partitions_in_batch_mode=1"""
+            explain {
+                sql ("select * from partition_table")
+                verbose (true)
+
+                contains "(approximate)inputSplitNum=60"
+            }
+            sql """unset variable num_partitions_in_batch_mode"""
+
+            // sql """drop catalog if exists ${catalog_name}"""
         } finally {
         }
     }


### PR DESCRIPTION
If trigger "fetching partition in batch mode" feature, the `explain verbose` for external table may cause NPE.
Because in batch mode, the scan range is not initialized in plan phase.

```
org.apache.doris.common.NereidsException: errCode = 2, detailMessage = java.lang.NullPointerException
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:767) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:591) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:554) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:544) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:323) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:234) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:194) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:222) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:281) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = java.lang.NullPointerException
        ... 13 more
Caused by: java.lang.NullPointerException
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903) ~[guava-32.1.2-jre.jar:?]
        at com.google.common.collect.AbstractMultimap.putAll(AbstractMultimap.java:83) ~[guava-32.1.2-jre.jar:?]
        at com.google.common.collect.ArrayListMultimap.putAll(ArrayListMultimap.java:62) ~[guava-32.1.2-jre.jar:?]
        at org.apache.doris.datasource.FileScanNode.getNodeExplainString(FileScanNode.java:141) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.getExplainString(PlanNode.java:548) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanFragment.getExplainString(PlanFragment.java:369) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.Planner.getExplainString(Planner.java:93) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.getExplainString(NereidsPlanner.java:627) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ExplainCommand.run(ExplainCommand.java:96) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:736) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 12 more
```
