### PR TITLE
[fix](profile) Fix npe when updating profile for internal load task.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -399,7 +399,7 @@ public class StmtExecutor {
         builder.defaultCatalog(context.getCurrentCatalog().getName());
         builder.defaultDb(context.getDatabase());
         builder.workloadGroup(context.getWorkloadGroupName());
-        builder.sqlStatement(originStmt.originStmt);
+        builder.sqlStatement(originStmt == null ? "" : originStmt.originStmt);
         builder.isCached(isCached ? "Yes" : "No");
 
         Map<String, Integer> beToInstancesNum = coord == null ? Maps.newTreeMap() : coord.getBeToInstancesNum();


### PR DESCRIPTION
Fix problem 
```
2024-09-19 15:39:08,025 WARN (mtmv-task-execute-1-thread-1|131) [StmtExecutor.updateProfile():1225] failed to update profile, ignore th
is error
java.lang.NullPointerException: Cannot read field "originStmt" because "this.originStmt" is null
        at org.apache.doris.qe.StmtExecutor.getSummaryInfo(StmtExecutor.java:402) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.updateProfile(StmtExecutor.java:1219) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.AbstractInsertExecutor.executeSingleInsert(AbstractInsertExecutor.java:
193) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.runInternal(InsertIntoTableCommand.java:250) ~[d
oris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.run(InsertIntoTableCommand.java:117) ~[doris-fe.
jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.runInsertCommand(InsertOverwriteTableComman
d.java:204) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.insertInto(InsertOverwriteTableCommand.java
:267) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.run(InsertOverwriteTableCommand.java:175) ~
[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.extensions.mtmv.MTMVTask.exec(MTMVTask.java:231) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.extensions.mtmv.MTMVTask.run(MTMVTask.java:200) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.task.AbstractTask.runTask(AbstractTask.java:167) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.extensions.mtmv.MTMVTask.runTask(MTMVTask.java:306) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.job.executor.DefaultTaskExecutorHandler.onEvent(DefaultTaskExecutorHandler.java:50) ~[doris-fe.jar:1.2-SNAP
SHOT]
        at org.apache.doris.job.executor.DefaultTaskExecutorHandler.onEvent(DefaultTaskExecutorHandler.java:33) ~[doris-fe.jar:1.2-SNAP
SHOT]
        at com.lmax.disruptor.WorkProcessor.run(WorkProcessor.java:143) ~[disruptor-3.4.4.jar:?]
        at java.lang.Thread.run(Thread.java:842) ~[?:?] 
```