### PR TITLE
[improve](multi table) allow auto resume if plan load fails

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -2103,7 +2103,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             try {
                 RoutineLoadJob routineLoadJob = Env.getCurrentEnv().getRoutineLoadManager()
                         .getRoutineLoadJobByMultiLoadTaskTxnId(request.getTxnId());
-                routineLoadJob.updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.CANNOT_RESUME_ERR,
+                routineLoadJob.updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.INTERNAL_ERR,
                             "failed to get stream load plan, " + exception.getMessage()), false);
             } catch (Throwable e) {
                 LOG.warn("catch update routine load job error.", e);


### PR DESCRIPTION
If plan fails, multi table load would not auto resume:
```
ReasonOfStateChanged: ErrorReason{code=errCode = 105, msg='failed to get stream load plan, errCode = 2, detailMessage = txn does not exist: 2998667899272192'}
```

In cloud mode, job will be unstable under deterioration of network conditions.
