### PR TITLE
[fix](test-case) fix unstable test case about table_options sys table

### DIFF
--- a/regression-test/data/query_p0/system/test_table_properties.out
+++ b/regression-test/data/query_p0/system/test_table_properties.out
@@ -12,7 +12,6 @@ internal	test_table_properties_db	duplicate_table	compaction_policy	size_based
 internal	test_table_properties_db	duplicate_table	compression	LZ4F
 internal	test_table_properties_db	duplicate_table	data_sort.col_num	3
 internal	test_table_properties_db	duplicate_table	data_sort.sort_type	LEXICAL
-internal	test_table_properties_db	duplicate_table	default.replication_allocation	tag.location.default: 1
 internal	test_table_properties_db	duplicate_table	disable_auto_compaction	false
 internal	test_table_properties_db	duplicate_table	enable_mow_light_delete	false
 internal	test_table_properties_db	duplicate_table	enable_single_replica_compaction	false
@@ -45,7 +44,6 @@ internal	test_table_properties_db	listtable	compaction_policy	size_based
 internal	test_table_properties_db	listtable	compression	LZ4F
 internal	test_table_properties_db	listtable	data_sort.col_num	6
 internal	test_table_properties_db	listtable	data_sort.sort_type	LEXICAL
-internal	test_table_properties_db	listtable	default.replication_allocation	tag.location.default: 1
 internal	test_table_properties_db	listtable	disable_auto_compaction	false
 internal	test_table_properties_db	listtable	enable_mow_light_delete	false
 internal	test_table_properties_db	listtable	enable_single_replica_compaction	false
@@ -78,7 +76,6 @@ internal	test_table_properties_db	unique_table	compaction_policy	size_based
 internal	test_table_properties_db	unique_table	compression	LZ4F
 internal	test_table_properties_db	unique_table	data_sort.col_num	2
 internal	test_table_properties_db	unique_table	data_sort.sort_type	LEXICAL
-internal	test_table_properties_db	unique_table	default.replication_allocation	tag.location.default: 1
 internal	test_table_properties_db	unique_table	disable_auto_compaction	false
 internal	test_table_properties_db	unique_table	enable_mow_light_delete	false
 internal	test_table_properties_db	unique_table	enable_single_replica_compaction	false
@@ -113,7 +110,6 @@ internal	test_table_properties_db	duplicate_table	compaction_policy	size_based
 internal	test_table_properties_db	duplicate_table	compression	LZ4F
 internal	test_table_properties_db	duplicate_table	data_sort.col_num	3
 internal	test_table_properties_db	duplicate_table	data_sort.sort_type	LEXICAL
-internal	test_table_properties_db	duplicate_table	default.replication_allocation	tag.location.default: 1
 internal	test_table_properties_db	duplicate_table	disable_auto_compaction	false
 internal	test_table_properties_db	duplicate_table	enable_mow_light_delete	false
 internal	test_table_properties_db	duplicate_table	enable_single_replica_compaction	false
@@ -146,7 +142,6 @@ internal	test_table_properties_db	unique_table	compaction_policy	size_based
 internal	test_table_properties_db	unique_table	compression	LZ4F
 internal	test_table_properties_db	unique_table	data_sort.col_num	2
 internal	test_table_properties_db	unique_table	data_sort.sort_type	LEXICAL
-internal	test_table_properties_db	unique_table	default.replication_allocation	tag.location.default: 1
 internal	test_table_properties_db	unique_table	disable_auto_compaction	false
 internal	test_table_properties_db	unique_table	enable_mow_light_delete	false
 internal	test_table_properties_db	unique_table	enable_single_replica_compaction	false
@@ -183,7 +178,6 @@ internal	test_table_properties_db	duplicate_table	compaction_policy	size_based
 internal	test_table_properties_db	duplicate_table	compression	LZ4F
 internal	test_table_properties_db	duplicate_table	data_sort.col_num	3
 internal	test_table_properties_db	duplicate_table	data_sort.sort_type	LEXICAL
-internal	test_table_properties_db	duplicate_table	default.replication_allocation	tag.location.default: 1
 internal	test_table_properties_db	duplicate_table	disable_auto_compaction	false
 internal	test_table_properties_db	duplicate_table	enable_mow_light_delete	false
 internal	test_table_properties_db	duplicate_table	enable_single_replica_compaction	false

--- a/regression-test/suites/query_p0/system/test_table_properties.groovy
+++ b/regression-test/suites/query_p0/system/test_table_properties.groovy
@@ -84,11 +84,11 @@ suite("test_table_properties") {
     """
 
     qt_select_check_1 """select count(*) from information_schema.table_properties where table_schema=\"${dbName}\"; """
-    qt_select_check_2 """select * from information_schema.table_properties where table_schema=\"${dbName}\" where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
+    qt_select_check_2 """select * from information_schema.table_properties where table_schema=\"${dbName}\" and PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
     sql """
         drop table listtable;
     """    
-    qt_select_check_3 """select * from information_schema.table_properties where table_schema=\"${dbName}\" where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
+    qt_select_check_3 """select * from information_schema.table_properties where table_schema=\"${dbName}\" and PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
 
     def user = "table_properties_user"
     sql "DROP USER IF EXISTS ${user}"

--- a/regression-test/suites/query_p0/system/test_table_properties.groovy
+++ b/regression-test/suites/query_p0/system/test_table_properties.groovy
@@ -84,11 +84,11 @@ suite("test_table_properties") {
     """
 
     qt_select_check_1 """select count(*) from information_schema.table_properties where table_schema=\"${dbName}\"; """
-    qt_select_check_2 """select * from information_schema.table_properties where table_schema=\"${dbName}\" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation" """
+    qt_select_check_2 """select * from information_schema.table_properties where table_schema=\"${dbName}\" where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
     sql """
         drop table listtable;
     """    
-    qt_select_check_3 """select * from information_schema.table_properties where table_schema=\"${dbName}\" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation" """
+    qt_select_check_3 """select * from information_schema.table_properties where table_schema=\"${dbName}\" where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
 
     def user = "table_properties_user"
     sql "DROP USER IF EXISTS ${user}"
@@ -106,17 +106,17 @@ suite("test_table_properties") {
     def url=tokens[0] + "//" + tokens[2] + "/" + "information_schema" + "?"
 
     connect(user=user, password='123abc!@#', url=url) {
-       qt_select_check_4 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation"; """
+       qt_select_check_4 """select * from information_schema.table_properties where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
     }
 
     sql "GRANT SELECT_PRIV ON ${dbName}.duplicate_table  TO ${user}"
     connect(user=user, password='123abc!@#', url=url) {
-       qt_select_check_5 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation"; """
+       qt_select_check_5 """select * from information_schema.table_properties where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
     }
  
     sql "REVOKE SELECT_PRIV ON ${dbName}.duplicate_table  FROM ${user}"
     connect(user=user, password='123abc!@#', url=url) {
-       qt_select_check_6 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation"; """       
+       qt_select_check_6 """select * from information_schema.table_properties where PROPERTY_NAME != "default.replication_allocation" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE"""
     }
 
 

--- a/regression-test/suites/query_p0/system/test_table_properties.groovy
+++ b/regression-test/suites/query_p0/system/test_table_properties.groovy
@@ -84,11 +84,11 @@ suite("test_table_properties") {
     """
 
     qt_select_check_1 """select count(*) from information_schema.table_properties where table_schema=\"${dbName}\"; """
-    qt_select_check_2 """select * from information_schema.table_properties where table_schema=\"${dbName}\" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE; """
+    qt_select_check_2 """select * from information_schema.table_properties where table_schema=\"${dbName}\" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation" """
     sql """
         drop table listtable;
     """    
-    qt_select_check_3 """select * from information_schema.table_properties where table_schema=\"${dbName}\" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE; """       
+    qt_select_check_3 """select * from information_schema.table_properties where table_schema=\"${dbName}\" ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation" """
 
     def user = "table_properties_user"
     sql "DROP USER IF EXISTS ${user}"
@@ -106,17 +106,17 @@ suite("test_table_properties") {
     def url=tokens[0] + "//" + tokens[2] + "/" + "information_schema" + "?"
 
     connect(user=user, password='123abc!@#', url=url) {
-       qt_select_check_4 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE; """       
+       qt_select_check_4 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation"; """
     }
 
     sql "GRANT SELECT_PRIV ON ${dbName}.duplicate_table  TO ${user}"
     connect(user=user, password='123abc!@#', url=url) {
-       qt_select_check_5 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE; """       
+       qt_select_check_5 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation"; """
     }
  
     sql "REVOKE SELECT_PRIV ON ${dbName}.duplicate_table  FROM ${user}"
     connect(user=user, password='123abc!@#', url=url) {
-       qt_select_check_6 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE; """       
+       qt_select_check_6 """select * from information_schema.table_properties  ORDER BY TABLE_CATALOG,TABLE_SCHEMA,TABLE_NAME,PROPERTY_NAME,PROPERTY_VALUE where PROPERTY_NAME != "default.replication_allocation"; """       
     }
 
 


### PR DESCRIPTION
Some regression test env use 3 replicas, some use 1 replicas.
So do not query "default.replication_allocation", because the result is uncertain