### PR TITLE
[enhance](mtmv)Optimize the logic of mtmv lock

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -1004,8 +1004,6 @@ public class Alter {
         try {
             Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(tbl.getDb());
             mtmv = (MTMV) db.getTableOrMetaException(tbl.getTbl(), TableType.MATERIALIZED_VIEW);
-
-            mtmv.writeMvLock();
             switch (alterMTMV.getOpType()) {
                 case ALTER_REFRESH_INFO:
                     mtmv.alterRefreshInfo(alterMTMV.getRefreshInfo());
@@ -1018,8 +1016,6 @@ public class Alter {
                     break;
                 case ADD_TASK:
                     mtmv.addTaskResult(alterMTMV.getTask(), alterMTMV.getRelation(), alterMTMV.getPartitionSnapshots());
-                    Env.getCurrentEnv().getMtmvService()
-                            .refreshComplete(mtmv, alterMTMV.getRelation(), alterMTMV.getTask());
                     break;
                 default:
                     throw new RuntimeException("Unknown type value: " + alterMTMV.getOpType());
@@ -1032,10 +1028,6 @@ public class Alter {
         } catch (UserException e) {
             // if MTMV has been dropped, ignore this exception
             LOG.warn(e);
-        } finally {
-            if (mtmv != null) {
-                mtmv.writeMvUnlock();
-            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -204,6 +204,8 @@ public class MTMV extends OlapTable {
             }
             this.jobInfo.addHistoryTask(task);
             this.refreshSnapshot.updateSnapshots(partitionSnapshots, getPartitionNames());
+            Env.getCurrentEnv().getMtmvService()
+                    .refreshComplete(this, relation, task);
         } finally {
             writeMvUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -48,6 +48,8 @@ import org.apache.doris.qe.ConnectContext;
 import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -55,6 +57,8 @@ import java.util.List;
  * when do some operation, do something about job
  */
 public class MTMVJobManager implements MTMVHookService {
+    private static final Logger LOG = LogManager.getLogger(MTMVJobManager.class);
+
     public static final String MTMV_JOB_PREFIX = "inner_mtmv_";
 
     /**
@@ -124,16 +128,12 @@ public class MTMVJobManager implements MTMVHookService {
      */
     @Override
     public void dropMTMV(MTMV mtmv) throws DdlException {
-        List<MTMVJob> jobs = Env.getCurrentEnv().getJobManager()
-                .queryJobs(JobType.MV, mtmv.getJobInfo().getJobName());
-        if (!CollectionUtils.isEmpty(jobs)) {
-            try {
-                Env.getCurrentEnv().getJobManager()
-                        .unregisterJob(jobs.get(0).getJobId());
-            } catch (JobException e) {
-                e.printStackTrace();
-                throw new DdlException(e.getMessage());
-            }
+        try {
+            Env.getCurrentEnv().getJobManager()
+                    .unregisterJob(mtmv.getJobInfo().getJobName(), false);
+        } catch (JobException e) {
+            LOG.warn("drop mtmv job failed, mtmvName: {}", mtmv.getName(), e);
+            throw new DdlException(e.getMessage());
         }
     }
 


### PR DESCRIPTION
- When deleting a job, do not query and delete it first. Instead, call the method to delete the job directly. If the job does not exist(When the materialized view only creates the table and the job is not yet created, the materialized view is concurrently deleted), throw an exception
- When changing mtmv, narrow down the scope of the lock and place it in each sub method

