### PR TITLE
[fix](restore) Ignore base tablet if it is migrated

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -94,16 +94,13 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
     if (request.__isset.ref_tablet_id) {
         int64_t ref_tablet_id = request.ref_tablet_id;
         TabletSharedPtr base_tablet = _engine.tablet_manager()->get_tablet(ref_tablet_id);
-        if (base_tablet == nullptr) {
-            return Status::Error<TABLE_NOT_FOUND>("failed to get ref tablet. tablet={}",
-                                                  ref_tablet_id);
-        }
 
         // Some tasks, like medium migration, cause the target tablet and base tablet to stay on
         // different disks. In this case, we fall through to the normal restore path.
         //
         // Otherwise, we can directly link the rowset files from the base tablet to the target tablet.
-        if (base_tablet->data_dir()->path() == target_tablet->data_dir()->path()) {
+        if (base_tablet != nullptr &&
+            base_tablet->data_dir()->path() == target_tablet->data_dir()->path()) {
             ref_tablet = std::move(base_tablet);
         }
     }

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -91,7 +91,6 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
     }
 
     TabletSharedPtr ref_tablet = target_tablet;
-    std::shared_lock<std::shared_timed_mutex> migration_rlock;
     if (request.__isset.ref_tablet_id) {
         int64_t ref_tablet_id = request.ref_tablet_id;
         TabletSharedPtr base_tablet = _engine.tablet_manager()->get_tablet(ref_tablet_id);
@@ -100,14 +99,12 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
                                                   ref_tablet_id);
         }
 
-        auto rlock = std::shared_lock<std::shared_timed_mutex>(base_tablet->get_migration_lock());
         // Some tasks, like medium migration, cause the target tablet and base tablet to stay on
         // different disks. In this case, we fall through to the normal restore path.
         //
         // Otherwise, we can directly link the rowset files from the base tablet to the target tablet.
         if (base_tablet->data_dir()->path() == target_tablet->data_dir()->path()) {
             ref_tablet = std::move(base_tablet);
-            std::swap(migration_rlock, rlock);
         }
     }
 


### PR DESCRIPTION
In atomic restore, if the base tablet exists, the base tablet is directly linked to the rowset files. Sometimes the base tablet is migrated to other disks and direct linking fails. In this case, the base tablet data is ignored and downloaded directly from the upstream.

