### PR TITLE
[fix](load) disable num segments check in compatibility mode

### DIFF
--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -53,6 +53,7 @@ public:
     Status append_data(const PStreamHeader& header, butil::IOBuf* data);
     Status add_segment(const PStreamHeader& header, butil::IOBuf* data);
     void add_num_segments(int64_t num_segments) { _num_segments += num_segments; }
+    void disable_num_segments_check() { _check_num_segments = false; }
     Status close();
     int64_t id() const { return _id; }
 
@@ -65,6 +66,7 @@ private:
     std::unordered_map<int64_t, std::unique_ptr<SegIdMapping>> _segids_mapping;
     std::atomic<uint32_t> _next_segid;
     int64_t _num_segments = 0;
+    bool _check_num_segments = true;
     bthread::Mutex _lock;
     Status _status;
     PUniqueId _load_id;


### PR DESCRIPTION
## Proposed changes

When using mixed version of BEs, sink v2 on old BE won't report num segments to load streams on the new BE.
This will cause false positive segment num mismatch.

This PR addressed this issue by disabling num segments check when any tablets_to_commit proto has not set num_segments field.

