### PR TITLE
[fix](compile)fix mac compile : std no member numbers error.

### DIFF
--- a/be/src/vec/functions/math.cpp
+++ b/be/src/vec/functions/math.cpp
@@ -413,7 +413,12 @@ public:
 
     static bool check_argument(double sd) { return sd > 0; }
     static double calculate_cell(double mean, double sd, double v) {
+#ifdef __APPLE__
+        const double sqrt2 = std::sqrt(2);
+#else
         constexpr double sqrt2 = std::numbers::sqrt2;
+#endif
+
         return 0.5 * (std::erf((v - mean) / (sd * sqrt2)) + 1);
     }
 };


### PR DESCRIPTION
before pr : #40695 
## Proposed changes

Fix the bug that be will have this error when compiling on mac.
```
be/src/vec/functions/math.cpp:416:39: error: no member named 'numbers' in namespace 'std'
        constexpr double sqrt2 = std::numbers::sqrt2;
                                 ~~~~~^
1 error generated.
```