### PR TITLE
[fix](glue) support glue on aws

### DIFF
--- a/fe/fe-core/src/main/java/com/amazonaws/glue/catalog/credentials/ConfigAWSProvider.java
+++ b/fe/fe-core/src/main/java/com/amazonaws/glue/catalog/credentials/ConfigAWSProvider.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.amazonaws.glue.catalog.credentials;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.util.Map;
+
+public class ConfigAWSProvider implements AwsCredentialsProvider {
+
+    private AwsBasicCredentials awsBasicCredentials;
+
+    private ConfigAWSProvider(AwsBasicCredentials awsBasicCredentials) {
+        this.awsBasicCredentials = awsBasicCredentials;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        return awsBasicCredentials;
+    }
+
+    public static AwsCredentialsProvider create(Map<String, String> config) {
+        String ak = config.get("glue.access_key");
+        String sk = config.get("glue.secret_key");
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(ak, sk);
+        return new ConfigAWSProvider(awsBasicCredentials);
+    }
+}

--- a/fe/fe-core/src/main/java/com/amazonaws/glue/catalog/credentials/ConfigurationAWSCredentialsProvider2x.java
+++ b/fe/fe-core/src/main/java/com/amazonaws/glue/catalog/credentials/ConfigurationAWSCredentialsProvider2x.java
@@ -23,11 +23,16 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.util.Map;
 
-public class ConfigAWSProvider implements AwsCredentialsProvider {
+/**
+ * This is credentials provider for AWS SDK 2.x, comparing to ConfigurationAWSCredentialsProvider,
+ * which is for AWS SDK 1.x.
+ * See: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html
+ */
+public class ConfigurationAWSCredentialsProvider2x implements AwsCredentialsProvider {
 
     private AwsBasicCredentials awsBasicCredentials;
 
-    private ConfigAWSProvider(AwsBasicCredentials awsBasicCredentials) {
+    private ConfigurationAWSCredentialsProvider2x(AwsBasicCredentials awsBasicCredentials) {
         this.awsBasicCredentials = awsBasicCredentials;
     }
 
@@ -40,6 +45,6 @@ public class ConfigAWSProvider implements AwsCredentialsProvider {
         String ak = config.get("glue.access_key");
         String sk = config.get("glue.secret_key");
         AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(ak, sk);
-        return new ConfigAWSProvider(awsBasicCredentials);
+        return new ConfigurationAWSCredentialsProvider2x(awsBasicCredentials);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/PropertyConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/PropertyConverter.java
@@ -520,6 +520,10 @@ public class PropertyConverter {
             // glue ak sk for iceberg
             props.putIfAbsent(GlueProperties.ACCESS_KEY, credential.getAccessKey());
             props.putIfAbsent(GlueProperties.SECRET_KEY, credential.getSecretKey());
+            props.putIfAbsent(GlueProperties.CLIENT_CREDENTIALS_PROVIDER,
+                    "com.amazonaws.glue.catalog.credentials.ConfigurationAWSCredentialsProvider2x");
+            props.putIfAbsent(GlueProperties.CLIENT_CREDENTIALS_PROVIDER_AK, credential.getAccessKey());
+            props.putIfAbsent(GlueProperties.CLIENT_CREDENTIALS_PROVIDER_SK, credential.getSecretKey());
         }
         // set glue client metadata
         if (props.containsKey(GlueProperties.ENDPOINT)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/GlueProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/GlueProperties.java
@@ -32,9 +32,14 @@ public class GlueProperties extends BaseProperties {
     public static final String SECRET_KEY = "glue.secret_key";
     public static final String SESSION_TOKEN = "glue.session_token";
 
+    public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
+    public static final String CLIENT_CREDENTIALS_PROVIDER_AK = "client.credentials-provider.glue.access_key";
+    public static final String CLIENT_CREDENTIALS_PROVIDER_SK = "client.credentials-provider.glue.secret_key";
+
     public static final List<String> META_KEYS = Arrays.asList(AWSGlueConfig.AWS_GLUE_ENDPOINT,
             AWSGlueConfig.AWS_REGION, AWSGlueConfig.AWS_GLUE_ACCESS_KEY, AWSGlueConfig.AWS_GLUE_SECRET_KEY,
-            AWSGlueConfig.AWS_GLUE_SESSION_TOKEN);
+            AWSGlueConfig.AWS_GLUE_SESSION_TOKEN, CLIENT_CREDENTIALS_PROVIDER, CLIENT_CREDENTIALS_PROVIDER_AK,
+            CLIENT_CREDENTIALS_PROVIDER_SK);
 
     public static CloudCredential getCredential(Map<String, String> props) {
         return getCloudCredential(props, ACCESS_KEY, SECRET_KEY, SESSION_TOKEN);


### PR DESCRIPTION
```
CREATE CATALOG glue2 PROPERTIES (
    "type"="iceberg",
    "iceberg.catalog.type" = "glue",
    "glue.endpoint" = "https://glue.us-east-1.amazonaws.com/",
    "client.credentials-provider" = "com.amazonaws.glue.catalog.credentials.ConfigAWSProvider",
    "client.credentials-provider.glue.access_key" = "ak",
    "client.credentials-provider.glue.secret_key" = "sk"
);
```

another example:
(this still has problem, just mark it)
```
CREATE CATALOG hive PROPERTIES (
    "type"="hms",
    "hive.metastore.type" = "glue",
    "glue.endpoint" = "https://glue.us-east-1.amazonaws.com/",
    "glue.access_key" = "ak",
    "glue.secret_key" = "sk",
    "aws.catalog.credentials.provider.factory.class" = "com.amazonaws.glue.catalog.credentials.ConfigurationAWSCredentialsProviderFactory"
);
```