### PR TITLE
[bugfix](allocatebytes) ignore null ptr column in Block

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -439,13 +439,9 @@ size_t Block::allocated_bytes() const {
     size_t res = 0;
     for (const auto& elem : data) {
         if (!elem.column) {
-            std::stringstream ss;
-            for (const auto& e : data) {
-                ss << e.name + " ";
-            }
-            throw Exception(ErrorCode::INTERNAL_ERROR,
-                            "Column {} in block is nullptr, in method bytes. All Columns are {}",
-                            elem.name, ss.str());
+            // Sometimes if expr failed, then there will be a nullptr
+            // column left in the block.
+            continue;
         }
         res += elem.column->allocated_bytes();
     }


### PR DESCRIPTION
## Proposed changes
Sometimes if expr failed, then there will be a nullptr column left in the block.
We should ignore the nullptr column, or exception will be thrown and some profile will not computed correctly.

