### PR TITLE
[fix](p2) fix assertion in test_broker_load_p2

### DIFF
--- a/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
@@ -344,7 +344,7 @@ suite("test_broker_load_p2", "p2") {
                     if (result[0][2].equals("CANCELLED")) {
                         logger.info("Load result: " + result[0])
                         assertTrue(result[0][6].contains(task_info[i]))
-                        assertTrue(result[0][7].contains(error_msg[i]), "expected: " + error_msg[i] + ", actual: " + result[0][7] + ", label: $label")
+                        assertTrue(result[0][9].contains(error_msg[i]), "expected: " + error_msg[i] + ", actual: " + result[0][7] + ", label: $label")
                         break;
                     }
                     Thread.sleep(1000)


### PR DESCRIPTION
## Proposed changes

Fix assertion failure due to comparing wrong columns.

expected: [INTERNAL_ERROR]failed to find default value expr for slot: x1
actual: type:LOAD_RUN_FAIL

```
    2024-09-22 11:13:43.771 INFO [suite-thread-3] (test_broker_load.groovy:337) - Load result: [838879, L14_5c0d84b80e121044a5091fc065ee763c8e0e, CANCELLED, 0.00% (0/4), BROKER, null, cluster:oss-cn-beijing-internal.aliyuncs.com; timeout(s):14400; max_filter_ratio:0.0; priority:NORMAL, type:LOAD_RUN_FAIL; msg:errCode = 2, detailMessage = (172.20.50.26)[INTERNAL_ERROR]cur path: s3://qa-build/regression/load/data/part0.parquet. failed to find default value expr for slot: x1, 2024-09-22 11:13:41, 2024-09-22 11:13:43, 2024-09-22 11:13:43, 2024-09-22 11:13:43, 2024-09-22 11:13:43, null, {"Unfinished backends":{"e15fe3f045a94ab2-bb62fae396495ffd":[]},"ScannedRows":0,"TaskNumber":1,"LoadBytes":0,"All backends":{"e15fe3f045a94ab2-bb62fae396495ffd":[10009]},"FileNumber":2,"FileSize":6312557}, 30085, {}, root, ]
```