### PR TITLE
[Fix](test)Fixing  Kerberos Principal Not Mapping Correctly to a Local User (#40905)

### DIFF
--- a/regression-test/suites/external_table_p0/kerberos/test_single_hive_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_single_hive_kerberos.groovy
@@ -29,6 +29,10 @@ suite("test_single_hive_kerberos", "p0,external,kerberos,external_docker,externa
                 "hadoop.security.authentication" = "kerberos",
                 "hadoop.kerberos.principal"="presto-server/presto-master.docker.cluster@LABS.TERADATA.COM",
                 "hadoop.kerberos.keytab" = "/keytabs/presto-server.keytab",
+                "hadoop.security.auth_to_local" = "RULE:[2:\$1@\$0](.*@LABS.TERADATA.COM)s/@.*//
+                                   RULE:[2:\$1@\$0](.*@OTHERLABS.TERADATA.COM)s/@.*//
+                                   RULE:[2:\$1@\$0](.*@OTHERREALM.COM)s/@.*//
+                                   DEFAULT",
                 "hive.metastore.sasl.enabled " = "true",
                 "hive.metastore.kerberos.principal" = "hive/_HOST@LABS.TERADATA.COM"
             );
@@ -57,7 +61,7 @@ suite("test_single_hive_kerberos", "p0,external,kerberos,external_docker,externa
             logger.info(e.toString())
             // caused by a warning msg if enable sasl on hive but "hive.metastore.sasl.enabled" is not true:
             // "set_ugi() not successful, Likely cause: new client talking to old server. Continuing without it."
-            assertTrue(e.toString().contains("org.apache.thrift.transport.TTransportException: null"))
+            assertTrue(e.toString().contains("thrift.transport.TTransportException"))
         }
 
         try {


### PR DESCRIPTION

## Proposed changes
error log

http://43.132.222.7:8111/buildConfiguration/Doris_External_Regression/529960?buildTab=tests&status=muted&focusLine=NaN&suite=&package=external_table_p0.kerberos&class=test_single_hive_kerberos&expandedTest=build%3A%28id%3A529960%29%2Cid%3A2000000060

## Changes
- If there are multiple realms, it's best to configure hadoop.security.auth_to_local to correctly map Kerberos Principals to local users.
- Thrift exceptions should use those from hive-shade, but to avoid future changes in hive-shade, I omitted part of the package name prefix.

(cherry picked from commit 902cf1e913f1b01dccb5978e9c9d521a2e8c9350)

#40905

