### PR TITLE
[fix](build) Change the return type of `get_size` in `tablet_meta` for MacOS compatibility.

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1092,9 +1092,9 @@ uint64_t DeleteBitmap::cardinality() const {
     return res;
 }
 
-size_t DeleteBitmap::get_size() const {
+uint64_t DeleteBitmap::get_size() const {
     std::shared_lock l(lock);
-    size_t charge = 0;
+    uint64_t charge = 0;
     for (auto& [k, v] : delete_bitmap) {
         charge += v.getSizeInBytes();
     }

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -455,7 +455,7 @@ public:
      * return the total size of the Delete Bitmap(after serialized)
      */
 
-    size_t get_size() const;
+    uint64_t get_size() const;
 
     /**
      * Sets the bitmap of specific segment, it's may be insertion or replacement


### PR DESCRIPTION
```
auto size = tablet->tablet_meta()->delete_bitmap().get_size();
root.AddMember("size", size, root.GetAllocator());
```

The compiler complains because there is an ambiguity in the call when passing size to the constructor of rapidjson::GenericValue. This is because the type of size (which may be size_t or unsigned long) is 64 bits on ARM64-based Macs (such as the M1 chip), and RapidJSON provides multiple possible matching constructors.

