### PR TITLE
[Fix](Nereids) fix fold const be return type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -176,14 +176,14 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             if (newChild != child) {
                 hasNewChildren = true;
             }
-            if (!newChild.getDataType().equals(child.getDataType())) {
-                try {
+            try {
+                if (!newChild.getDataType().equals(child.getDataType())) {
                     newChildren.add(newChild.castTo(child.getDataType()));
-                } catch (Exception e) {
-                    LOG.warn("expression of type {} cast to {} failed. ", newChild.getDataType(), child.getDataType());
+                } else {
                     newChildren.add(newChild);
                 }
-            } else {
+            } catch (Exception e) {
+                LOG.warn("expression {} cast to {} failed. ", newChild.toString(), child.toString());
                 newChildren.add(newChild);
             }
         }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -58,4 +58,29 @@ suite("fold_constant_by_be") {
         sql("verbose select substring('123456', 1, 3)")
         contains "varchar(3)"
     }
+
+    sql "drop table if exists table_200_undef_partitions2_keys3_properties4_distributed_by53"
+    sql """create table table_200_undef_partitions2_keys3_properties4_distributed_by53 (
+                    pk int,
+                    col_char_255__undef_signed char(255)  null  ,
+                    col_char_100__undef_signed char(100)  null  ,
+                    col_char_255__undef_signed_not_null char(255)  not null  ,
+                    col_char_100__undef_signed_not_null char(100)  not null  ,
+                    col_varchar_255__undef_signed varchar(255)  null  ,
+                    col_varchar_255__undef_signed_not_null varchar(255)  not null  ,
+                    col_varchar_1000__undef_signed varchar(1000)  null  ,
+                    col_varchar_1000__undef_signed_not_null varchar(1000)  not null  ,
+                    col_varchar_1001__undef_signed varchar(1001)  null  ,
+                    col_varchar_1001__undef_signed_not_null varchar(1001)  not null  
+                    ) engine=olap
+                    DUPLICATE KEY(pk, col_char_255__undef_signed, col_char_100__undef_signed)
+                    distributed by hash(pk) buckets 10
+                    properties("replication_num" = "1");"""
+    explain {
+        sql("select LAST_VALUE(col_char_255__undef_signed_not_null, false) over (partition by " +
+                "concat('GkIPbzAZSu', col_char_100__undef_signed), mask('JrqFkEDqeA') " +
+                "order by pk rows between unbounded preceding and 6 following) AS col_alias26947 " +
+                "from table_200_undef_partitions2_keys3_properties4_distributed_by53;")
+        notContains("mask")
+    }
 }


### PR DESCRIPTION
When expression of be fold const can not get datatype, it should not throw an exception directly
intro by: https://github.com/apache/doris/pull/39723

