### PR TITLE
[Fix](Nereids) fix append_trailing_char_if_absent function return null (#40820)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/ExecutableFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/ExecutableFunctions.java
@@ -26,7 +26,9 @@ import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.FloatLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.LargeIntLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 
@@ -91,13 +93,19 @@ public class ExecutableFunctions {
         return new DoubleLiteral(Math.acos(literal.getValue()));
     }
 
-    @ExecFunction(name = "append_trailing_if_char_absent", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "VARCHAR")
-    public static Expression appendTrailingIfCharAbsent(VarcharLiteral literal, VarcharLiteral chr) {
-        if (literal.getValue().length() != 1) {
-            return null;
+    /**
+     * append_trailing_char_if_absent function
+     */
+    @ExecFunction(name = "append_trailing_char_if_absent", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "VARCHAR")
+    public static Expression appendTrailingIfCharAbsent(StringLikeLiteral literal, StringLikeLiteral chr) {
+        if (chr.getStringValue().length() != 1) {
+            return new NullLiteral(literal.getDataType());
         }
-        return literal.getValue().endsWith(chr.getValue()) ? literal
-                : new VarcharLiteral(literal.getValue() + chr.getValue());
+        if (literal.getStringValue().endsWith(chr.getStringValue())) {
+            return literal;
+        } else {
+            return new VarcharLiteral(literal.getStringValue() + chr.getStringValue());
+        }
     }
 
     @ExecFunction(name = "e", argTypes = {}, returnType = "DOUBLE")

--- a/regression-test/data/nereids_p0/expression/fold_constant/fold_constant_by_fe.out
+++ b/regression-test/data/nereids_p0/expression/fold_constant/fold_constant_by_fe.out
@@ -2894,3 +2894,63 @@
 -- !sql --
 0
 
+-- !select --
+hello!
+
+-- !select --
+hello!
+
+-- !select --
+hello 
+
+-- !select --
+!
+
+-- !select --
+hello?
+
+-- !select --
+hello?!
+
+-- !select --
+\N
+
+-- !select --
+\N
+
+-- !select --
+\N
+
+-- !select --
+\N
+
+-- !select --
+12345!
+
+-- !select --
+hello1
+
+-- !select --
+h!
+
+-- !select --
+こんにちは!
+
+-- !select --
+\N
+
+-- !select --
+This is a very long string.
+
+-- !select --
+hello1
+
+-- !select --
+12345!
+
+-- !select --
+Привет!
+
+-- !select --
+hello 
+

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_fe.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_fe.groovy
@@ -161,4 +161,90 @@ suite("test_fold_constant_by_fe") {
     res = sql """explain select "12" like '%123%'"""
     assertTrue(res.contains("like"))
 
+    // Normal Usage Test Cases
+
+    // Test Case 1: Append missing trailing character
+    qt_select"select append_trailing_char_if_absent('hello', '!')"
+    // Expected Output: 'hello!'
+
+    // Test Case 2: Trailing character already present
+    qt_select"select append_trailing_char_if_absent('hello!', '!')"
+    // Expected Output: 'hello!'
+
+    // Test Case 3: Append trailing space
+    qt_select"select append_trailing_char_if_absent('hello', ' ')"
+    // Expected Output: 'hello '
+
+    // Test Case 4: Empty string input
+    qt_select"select append_trailing_char_if_absent('', '!')"
+    // Expected Output: '!'
+
+    // Test Case 5: Append different character
+    qt_select"select append_trailing_char_if_absent('hello', '?')"
+    // Expected Output: 'hello?'
+
+    // Test Case 6: String ends with a different character
+    qt_select"select append_trailing_char_if_absent('hello?', '!')"
+    // Expected Output: 'hello?!'
+
+    // Edge and Unusual Usage Test Cases
+
+    // Test Case 7: Input is NULL
+    qt_select"select append_trailing_char_if_absent(NULL, '!')"
+    // Expected Output: NULL
+
+    // Test Case 8: Trailing character is NULL
+    qt_select"select append_trailing_char_if_absent('hello', NULL)"
+    // Expected Output: NULL
+
+    // Test Case 9: Empty trailing character
+    qt_select"select append_trailing_char_if_absent('hello', '')"
+    // Expected Output: Error or no change depending on implementation
+
+    // Test Case 10: Trailing character is more than 1 character long
+    qt_select"select append_trailing_char_if_absent('hello', 'ab')"
+    // Expected Output: Error
+
+    // Test Case 11: Input string is a number
+    qt_select"select append_trailing_char_if_absent(12345, '!')"
+    // Expected Output: Error or '12345!'
+
+    // Test Case 12: Trailing character is a number
+    qt_select"select append_trailing_char_if_absent('hello', '1')"
+    // Expected Output: 'hello1'
+
+    // Test Case 13: Input is a single character
+    qt_select"select append_trailing_char_if_absent('h', '!')"
+    // Expected Output: 'h!'
+
+    // Test Case 14: Unicode character as input and trailing character
+    qt_select"select append_trailing_char_if_absent('こんにちは', '!')"
+    // Expected Output: 'こんにちは!'
+
+    // Test Case 15: Multibyte character as trailing character
+    qt_select"select append_trailing_char_if_absent('hello', '😊')"
+    // Expected Output: 'hello😊'
+
+    // Test Case 16: Long string input
+    qt_select"select append_trailing_char_if_absent('This is a very long string', '.')"
+    // Expected Output: 'This is a very long string.'
+
+    // Error Handling Test Cases
+
+    // Test Case 17: Invalid trailing character data type (numeric)
+    qt_select"select append_trailing_char_if_absent('hello', 1)"
+    // Expected Output: Error
+
+    // Test Case 18: Invalid input data type (integer)
+    qt_select"select append_trailing_char_if_absent(12345, '!')"
+    // Expected Output: Error or '12345!'
+
+    // Test Case 19: Non-ASCII characters
+    qt_select"select append_trailing_char_if_absent('Привет', '!')"
+    // Expected Output: 'Привет!'
+
+    // Test Case 20: Trailing character with whitespace
+    qt_select"select append_trailing_char_if_absent('hello', ' ')"
+    // Expected Output: 'hello '
+
 }


### PR DESCRIPTION
cherry-pick： https://github.com/apache/doris/pull/40820
example: select append_trailing_char_if_absent('it','a') would return null in original design, it can not return null when folding constant on fe any time
