### PR TITLE
[fix](migrate) Fix iterator returning too early

### DIFF
--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -406,7 +406,7 @@ Status RowsetMetaManager::get_rowset_binlog_metas(OlapMeta* meta, TabletUid tabl
         binlog_meta_pb->set_data_key(binlog_data_key);
         binlog_meta_pb->set_data(binlog_data);
 
-        return false;
+        return true;
     };
 
     Status iterStatus =


### PR DESCRIPTION
introduced in #41083.

Because the iterator returns too early, only one piece of data is returned each time a binlog is obtained for a certain version range. When the system triggers compaction and generates a rowset that spans versions, the binlog files copied by the migrate task may be missed.

