### PR TITLE
[fix](ES Catalog)Only like on keyword can be applied to wildcard query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -119,6 +119,9 @@ public class EsTable extends Table implements GsonPostProcessable {
     // Periodically pull es metadata
     private EsMetaStateTracker esMetaStateTracker;
 
+    // column name -> elasticsearch field data type
+    private Map<String, String> column2typeMap = new HashMap<>();
+
     public EsTable() {
         super(TableType.ELASTICSEARCH);
     }
@@ -366,6 +369,6 @@ public class EsTable extends Table implements GsonPostProcessable {
     }
 
     public List<Column> genColumnsFromEs() {
-        return EsUtil.genColumnsFromEs(client, indexName, mappingType, false);
+        return EsUtil.genColumnsFromEs(client, indexName, mappingType, false, column2typeMap);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsExternalTable.java
@@ -25,7 +25,9 @@ import org.apache.doris.thrift.TEsTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -73,13 +75,20 @@ public class EsExternalTable extends ExternalTable {
     @Override
     public Optional<SchemaCacheValue> initSchema() {
         EsRestClient restClient = ((EsExternalCatalog) catalog).getEsRestClient();
-        return Optional.of(new SchemaCacheValue(
-                EsUtil.genColumnsFromEs(restClient, name, null,
-                        ((EsExternalCatalog) catalog).enableMappingEsId())));
+        Map<String, String> column2typeMap = new HashMap<>();
+        List<Column> columns = EsUtil.genColumnsFromEs(restClient, name, null,
+                ((EsExternalCatalog) catalog).enableMappingEsId(), column2typeMap);
+        return Optional.of(new EsSchemaCacheValue(columns, column2typeMap));
+    }
+
+    public Map<String, String> getColumn2type() {
+        Optional<SchemaCacheValue> schemaCacheValue = getSchemaCacheValue();
+        return schemaCacheValue.map(value -> ((EsSchemaCacheValue) value).getColumn2typeMap()).orElse(null);
     }
 
     private EsTable toEsTable() {
         List<Column> schema = getFullSchema();
+        Map<String, String> column2typeMap = getColumn2type();
         EsExternalCatalog esCatalog = (EsExternalCatalog) catalog;
         EsTable esTable = new EsTable(this.id, this.name, schema, TableType.ES_EXTERNAL_TABLE);
         esTable.setIndexName(name);
@@ -95,6 +104,7 @@ public class EsExternalTable extends ExternalTable {
         esTable.setHosts(String.join(",", esCatalog.getNodes()));
         esTable.syncTableMetaData();
         esTable.setIncludeHiddenIndex(esCatalog.enableIncludeHiddenIndex());
+        esTable.setColumn2typeMap(column2typeMap);
         return esTable;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsSchemaCacheValue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsSchemaCacheValue.java
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.es;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.datasource.SchemaCacheValue;
+
+import java.util.List;
+import java.util.Map;
+
+public class EsSchemaCacheValue extends SchemaCacheValue {
+    public Map<String, String> column2typeMap;
+
+    public EsSchemaCacheValue(List<Column> columns, Map<String, String> column2typeMap) {
+        super(columns);
+        this.column2typeMap = column2typeMap;
+    }
+
+    public Map<String, String> getColumn2typeMap() {
+        return column2typeMap;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
@@ -301,16 +301,17 @@ public class EsUtil {
                     type = ScalarType.createStringType();
                     break;
                 case "nested":
-                case "object":
                     type = Type.JSONB;
                     break;
                 default:
                     type = Type.UNSUPPORTED;
             }
         } else {
-            type = ScalarType.createStringType();
-            column.setComment("Elasticsearch no type");
-            column2typeMap.put(fieldName, "no_type");
+            // When there is no explicit type in mapping, it indicates this type is an `object` in Elasticsearch.
+            // reference: https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html
+            type = Type.JSONB;
+            column.setComment("Elasticsearch type is object");
+            column2typeMap.put(fieldName, "object");
         }
         if (arrayFields.contains(fieldName)) {
             column.setType(ArrayType.create(type, true));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
@@ -189,18 +189,18 @@ public class EsUtil {
      * Add mappingEsId config in es external catalog.
      **/
     public static List<Column> genColumnsFromEs(EsRestClient client, String indexName, String mappingType,
-            boolean mappingEsId) {
+            boolean mappingEsId, Map<String, String> column2typeMap) {
         String mapping = client.getMapping(indexName);
         ObjectNode mappings = getMapping(mapping);
         // Get array_fields while removing _meta property.
         List<String> arrayFields = new ArrayList<>();
         ObjectNode rootSchema = getRootSchema(mappings, mappingType, arrayFields);
-        return genColumnsFromEs(indexName, mappingType, rootSchema, mappingEsId, arrayFields);
+        return genColumnsFromEs(indexName, mappingType, rootSchema, mappingEsId, arrayFields, column2typeMap);
     }
 
     @VisibleForTesting
     public static List<Column> genColumnsFromEs(String indexName, String mappingType, ObjectNode rootSchema,
-            boolean mappingEsId, List<String> arrayFields) {
+            boolean mappingEsId, List<String> arrayFields, Map<String, String> column2typeMap) {
         List<Column> columns = new ArrayList<>();
         if (mappingEsId) {
             Column column = new Column();
@@ -220,7 +220,8 @@ public class EsUtil {
         while (iterator.hasNext()) {
             String fieldName = iterator.next();
             ObjectNode fieldValue = (ObjectNode) mappingProps.get(fieldName);
-            Column column = parseEsField(fieldName, replaceFieldAlias(mappingProps, fieldValue), arrayFields);
+            Column column = parseEsField(fieldName, replaceFieldAlias(mappingProps, fieldValue), arrayFields,
+                    column2typeMap);
             columns.add(column);
         }
         return columns;
@@ -245,7 +246,8 @@ public class EsUtil {
         return fieldValue;
     }
 
-    private static Column parseEsField(String fieldName, ObjectNode fieldValue, List<String> arrayFields) {
+    private static Column parseEsField(String fieldName, ObjectNode fieldValue, List<String> arrayFields,
+            Map<String, String> column2typeMap) {
         Column column = new Column();
         column.setName(fieldName);
         column.setIsKey(true);
@@ -256,6 +258,7 @@ public class EsUtil {
         if (fieldValue.has("type")) {
             String typeStr = fieldValue.get("type").asText();
             column.setComment("Elasticsearch type is " + typeStr);
+            column2typeMap.put(fieldName, typeStr);
             // reference https://www.elastic.co/guide/en/elasticsearch/reference/8.3/sql-data-types.html
             switch (typeStr) {
                 case "null":
@@ -307,6 +310,7 @@ public class EsUtil {
         } else {
             type = Type.JSONB;
             column.setComment("Elasticsearch no type");
+            column2typeMap.put(fieldName, "no_type");
         }
         if (arrayFields.contains(fieldName)) {
             column.setType(ArrayType.create(type, true));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
@@ -308,7 +308,7 @@ public class EsUtil {
                     type = Type.UNSUPPORTED;
             }
         } else {
-            type = Type.JSONB;
+            type = ScalarType.createStringType();
             column.setComment("Elasticsearch no type");
             column2typeMap.put(fieldName, "no_type");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/source/EsScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/source/EsScanNode.java
@@ -365,10 +365,14 @@ public class EsScanNode extends ExternalScanNode {
             boolean hasFilter = false;
             BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
             List<Expr> notPushDownList = new ArrayList<>();
+            if (table.getColumn2typeMap() == null) {
+                table.genColumnsFromEs();
+            }
             for (Expr expr : conjuncts) {
                 QueryBuilder queryBuilder = QueryBuilders.toEsDsl(expr, notPushDownList, fieldsContext,
                         BuilderOptions.builder().likePushDown(table.isLikePushDown())
-                                .needCompatDateFields(table.needCompatDateFields()).build());
+                                .needCompatDateFields(table.needCompatDateFields()).build(),
+                        table.getColumn2typeMap());
                 if (queryBuilder != null) {
                     hasFilter = true;
                     boolQueryBuilder.must(queryBuilder);

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
@@ -39,6 +39,7 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -226,7 +227,7 @@ public class EsUtilTest extends EsTestCase {
     public void testDateType() throws IOException, URISyntaxException {
         ObjectNode testDateFormat = EsUtil.getRootSchema(
                 EsUtil.getMapping(loadJsonFromFile("data/es/test_date_format.json")), null, new ArrayList<>());
-        List<Column> parseColumns = EsUtil.genColumnsFromEs("test_date_format", null, testDateFormat, false, new ArrayList<>());
+        List<Column> parseColumns = EsUtil.genColumnsFromEs("test_date_format", null, testDateFormat, false, new ArrayList<>(), new HashMap<>());
         Assertions.assertEquals(8, parseColumns.size());
         for (Column column : parseColumns) {
             String name = column.getName();
@@ -259,7 +260,7 @@ public class EsUtilTest extends EsTestCase {
     public void testFieldAlias() throws IOException, URISyntaxException {
         ObjectNode testFieldAlias = EsUtil.getRootSchema(
                 EsUtil.getMapping(loadJsonFromFile("data/es/test_field_alias.json")), null, new ArrayList<>());
-        List<Column> parseColumns = EsUtil.genColumnsFromEs("test_field_alias", null, testFieldAlias, true, new ArrayList<>());
+        List<Column> parseColumns = EsUtil.genColumnsFromEs("test_field_alias", null, testFieldAlias, true, new ArrayList<>(), new HashMap<>());
         Assertions.assertEquals("datetimev2(0)", parseColumns.get(2).getType().toSql());
         Assertions.assertEquals("text", parseColumns.get(4).getType().toSql());
     }
@@ -269,7 +270,7 @@ public class EsUtilTest extends EsTestCase {
         ObjectNode testFieldAlias = EsUtil.getRootSchema(
                 EsUtil.getMapping(loadJsonFromFile("data/es/es6_dynamic_complex_type.json")), null, new ArrayList<>());
         List<Column> columns = EsUtil.genColumnsFromEs("test_complex_type", "complex_type", testFieldAlias, true,
-                new ArrayList<>());
+                new ArrayList<>(), new HashMap<>());
         Assertions.assertEquals(3, columns.size());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/QueryBuildersTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/QueryBuildersTest.java
@@ -71,30 +71,32 @@ public class QueryBuildersTest {
         Expr ltExpr = new BinaryPredicate(Operator.LT, k1, intLiteral);
         Expr gtExpr = new BinaryPredicate(Operator.GT, k1, intLiteral);
         Expr efnExpr = new BinaryPredicate(Operator.EQ_FOR_NULL, new SlotRef(null, "k1"), new IntLiteral(3));
-        Assertions.assertEquals("{\"term\":{\"k1\":3}}", QueryBuilders.toEsDsl(eqExpr).toJson());
+        Map<String, String> column2typeMap = new HashMap<>();
+        Assertions.assertEquals("{\"term\":{\"k1\":3}}", QueryBuilders.toEsDsl(eqExpr, column2typeMap).toJson());
         Assertions.assertEquals("{\"bool\":{\"must_not\":{\"term\":{\"k1\":3}}}}",
-                QueryBuilders.toEsDsl(neExpr).toJson());
-        Assertions.assertEquals("{\"range\":{\"k1\":{\"lte\":3}}}", QueryBuilders.toEsDsl(leExpr).toJson());
-        Assertions.assertEquals("{\"range\":{\"k1\":{\"gte\":3}}}", QueryBuilders.toEsDsl(geExpr).toJson());
-        Assertions.assertEquals("{\"range\":{\"k1\":{\"lt\":3}}}", QueryBuilders.toEsDsl(ltExpr).toJson());
-        Assertions.assertEquals("{\"range\":{\"k1\":{\"gt\":3}}}", QueryBuilders.toEsDsl(gtExpr).toJson());
-        Assertions.assertEquals("{\"term\":{\"k1\":3}}", QueryBuilders.toEsDsl(efnExpr).toJson());
+                QueryBuilders.toEsDsl(neExpr, column2typeMap).toJson());
+        Assertions.assertEquals("{\"range\":{\"k1\":{\"lte\":3}}}", QueryBuilders.toEsDsl(leExpr, column2typeMap).toJson());
+        Assertions.assertEquals("{\"range\":{\"k1\":{\"gte\":3}}}", QueryBuilders.toEsDsl(geExpr, column2typeMap).toJson());
+        Assertions.assertEquals("{\"range\":{\"k1\":{\"lt\":3}}}", QueryBuilders.toEsDsl(ltExpr, column2typeMap).toJson());
+        Assertions.assertEquals("{\"range\":{\"k1\":{\"gt\":3}}}", QueryBuilders.toEsDsl(gtExpr, column2typeMap).toJson());
+        Assertions.assertEquals("{\"term\":{\"k1\":3}}", QueryBuilders.toEsDsl(efnExpr, column2typeMap).toJson());
 
         SlotRef k2 = new SlotRef(null, "k2");
         Expr dateTimeLiteral = new StringLiteral("2023-02-19 22:00:00");
         Expr dateTimeEqExpr = new BinaryPredicate(Operator.EQ, k2, dateTimeLiteral);
         Assertions.assertEquals("{\"term\":{\"k2\":\"2023-02-19T22:00:00.000+08:00\"}}",
                 QueryBuilders.toEsDsl(dateTimeEqExpr, new ArrayList<>(), new HashMap<>(),
-                        BuilderOptions.builder().needCompatDateFields(Lists.newArrayList("k2")).build()).toJson());
+                        BuilderOptions.builder().needCompatDateFields(Lists.newArrayList("k2")).build(),
+                        new HashMap<>()).toJson());
         SlotRef k3 = new SlotRef(null, "k3");
         Expr stringLiteral = new StringLiteral("");
         Expr stringNeExpr = new BinaryPredicate(Operator.NE, k3, stringLiteral);
         Assertions.assertEquals("{\"bool\":{\"must\":{\"exists\":{\"field\":\"k3\"}},\"must_not\":{\"term\":{\"k3\":\"\"}}}}",
-                QueryBuilders.toEsDsl(stringNeExpr).toJson());
+                QueryBuilders.toEsDsl(stringNeExpr, column2typeMap).toJson());
         stringLiteral = new StringLiteral("message");
         stringNeExpr = new BinaryPredicate(Operator.NE, k3, stringLiteral);
         Assertions.assertEquals("{\"bool\":{\"must_not\":{\"term\":{\"k3\":\"message\"}}}}",
-                QueryBuilders.toEsDsl(stringNeExpr).toJson());
+                QueryBuilders.toEsDsl(stringNeExpr, column2typeMap).toJson());
     }
 
     @Test
@@ -103,6 +105,7 @@ public class QueryBuildersTest {
         IntLiteral intLiteral1 = new IntLiteral(3);
         SlotRef k2 = new SlotRef(null, "k2");
         IntLiteral intLiteral2 = new IntLiteral(5);
+        Map<String, String> column2typeMap = new HashMap<>();
         BinaryPredicate binaryPredicate1 = new BinaryPredicate(Operator.EQ, k1, intLiteral1);
         BinaryPredicate binaryPredicate2 = new BinaryPredicate(Operator.GT, k2, intLiteral2);
         CompoundPredicate andPredicate = new CompoundPredicate(CompoundPredicate.Operator.AND, binaryPredicate1,
@@ -111,21 +114,22 @@ public class QueryBuildersTest {
                 binaryPredicate2);
         CompoundPredicate notPredicate = new CompoundPredicate(CompoundPredicate.Operator.NOT, binaryPredicate1, null);
         Assertions.assertEquals("{\"bool\":{\"must\":[{\"term\":{\"k1\":3}},{\"range\":{\"k2\":{\"gt\":5}}}]}}",
-                QueryBuilders.toEsDsl(andPredicate).toJson());
+                QueryBuilders.toEsDsl(andPredicate, column2typeMap).toJson());
         Assertions.assertEquals("{\"bool\":{\"should\":[{\"term\":{\"k1\":3}},{\"range\":{\"k2\":{\"gt\":5}}}]}}",
-                QueryBuilders.toEsDsl(orPredicate).toJson());
+                QueryBuilders.toEsDsl(orPredicate, column2typeMap).toJson());
         Assertions.assertEquals("{\"bool\":{\"must_not\":{\"term\":{\"k1\":3}}}}",
-                QueryBuilders.toEsDsl(notPredicate).toJson());
+                QueryBuilders.toEsDsl(notPredicate, column2typeMap).toJson());
     }
 
     @Test
     public void testIsNullPredicateConvertEsDsl() {
         SlotRef k1 = new SlotRef(null, "k1");
+        Map<String, String> column2typeMap = new HashMap<>();
         IsNullPredicate isNullPredicate = new IsNullPredicate(k1, false);
         IsNullPredicate isNotNullPredicate = new IsNullPredicate(k1, true);
         Assertions.assertEquals("{\"bool\":{\"must_not\":{\"exists\":{\"field\":\"k1\"}}}}",
-                QueryBuilders.toEsDsl(isNullPredicate).toJson());
-        Assertions.assertEquals("{\"exists\":{\"field\":\"k1\"}}", QueryBuilders.toEsDsl(isNotNullPredicate).toJson());
+                QueryBuilders.toEsDsl(isNullPredicate, column2typeMap).toJson());
+        Assertions.assertEquals("{\"exists\":{\"field\":\"k1\"}}", QueryBuilders.toEsDsl(isNotNullPredicate, column2typeMap).toJson());
     }
 
     @Test
@@ -137,13 +141,28 @@ public class QueryBuildersTest {
         LikePredicate likePredicate1 = new LikePredicate(LikePredicate.Operator.LIKE, k1, stringLiteral1);
         LikePredicate regexPredicate = new LikePredicate(LikePredicate.Operator.REGEXP, k1, stringLiteral2);
         LikePredicate likePredicate2 = new LikePredicate(LikePredicate.Operator.LIKE, k1, stringLiteral3);
-        Assertions.assertEquals("{\"wildcard\":{\"k1\":\"*1*\"}}", QueryBuilders.toEsDsl(likePredicate1).toJson());
-        Assertions.assertEquals("{\"wildcard\":{\"k1\":\"*1*\"}}", QueryBuilders.toEsDsl(regexPredicate).toJson());
-        Assertions.assertEquals("{\"wildcard\":{\"k1\":\"1?2\"}}", QueryBuilders.toEsDsl(likePredicate2).toJson());
+        Map<String, String> column2typeMap = new HashMap<>();
+        column2typeMap.put("k1", "keyword");
+        Assertions.assertEquals("{\"wildcard\":{\"k1\":\"*1*\"}}", QueryBuilders.toEsDsl(likePredicate1, column2typeMap).toJson());
+        Assertions.assertEquals("{\"wildcard\":{\"k1\":\"*1*\"}}", QueryBuilders.toEsDsl(regexPredicate, column2typeMap).toJson());
+        Assertions.assertEquals("{\"wildcard\":{\"k1\":\"1?2\"}}", QueryBuilders.toEsDsl(likePredicate2, column2typeMap).toJson());
         List<Expr> notPushDownList = new ArrayList<>();
         Assertions.assertNull(QueryBuilders.toEsDsl(likePredicate2, notPushDownList, new HashMap<>(),
-                BuilderOptions.builder().likePushDown(false).build()));
+                BuilderOptions.builder().likePushDown(false).build(), column2typeMap));
         Assertions.assertFalse(notPushDownList.isEmpty());
+
+        // like can not push down
+        column2typeMap.clear();
+        notPushDownList.clear();
+        column2typeMap.put("k1", "text");
+        Assertions.assertNull(QueryBuilders.toEsDsl(likePredicate1, notPushDownList, new HashMap<>(),
+                BuilderOptions.builder().likePushDown(true).build(), column2typeMap));
+        Assertions.assertNull(QueryBuilders.toEsDsl(likePredicate2, notPushDownList, new HashMap<>(),
+                BuilderOptions.builder().likePushDown(true).build(), column2typeMap));
+        Assertions.assertNull(QueryBuilders.toEsDsl(regexPredicate, notPushDownList, new HashMap<>(),
+                BuilderOptions.builder().likePushDown(true).build(), column2typeMap));
+
+        Assertions.assertEquals(3, notPushDownList.size());
     }
 
     @Test
@@ -156,9 +175,10 @@ public class QueryBuildersTest {
         intLiterals.add(intLiteral2);
         InPredicate isInPredicate = new InPredicate(k1, intLiterals, false);
         InPredicate isNotInPredicate = new InPredicate(k1, intLiterals, true);
-        Assertions.assertEquals("{\"terms\":{\"k1\":[3,5]}}", QueryBuilders.toEsDsl(isInPredicate).toJson());
+        Map<String, String> column2typeMap = new HashMap<>();
+        Assertions.assertEquals("{\"terms\":{\"k1\":[3,5]}}", QueryBuilders.toEsDsl(isInPredicate, column2typeMap).toJson());
         Assertions.assertEquals("{\"bool\":{\"must_not\":{\"terms\":{\"k1\":[3,5]}}}}",
-                QueryBuilders.toEsDsl(isNotInPredicate).toJson());
+                QueryBuilders.toEsDsl(isNotInPredicate, column2typeMap).toJson());
     }
 
     @Test
@@ -166,11 +186,12 @@ public class QueryBuildersTest {
         SlotRef k1 = new SlotRef(null, "k1");
         String str = "{\"bool\":{\"must_not\":{\"terms\":{\"k1\":[3,5]}}}}";
         StringLiteral stringLiteral = new StringLiteral(str);
+        Map<String, String> column2typeMap = new HashMap<>();
         List<Expr> exprs = new ArrayList<>();
         exprs.add(k1);
         exprs.add(stringLiteral);
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("esquery", exprs);
-        Assertions.assertEquals(str, QueryBuilders.toEsDsl(functionCallExpr).toJson());
+        Assertions.assertEquals(str, QueryBuilders.toEsDsl(functionCallExpr, column2typeMap).toJson());
 
         SlotRef k2 = new SlotRef(null, "k2");
         IntLiteral intLiteral = new IntLiteral(5);
@@ -179,7 +200,7 @@ public class QueryBuildersTest {
                 functionCallExpr);
         Assertions.assertEquals(
                 "{\"bool\":{\"must\":[{\"term\":{\"k2\":5}},{\"bool\":{\"must_not\":{\"terms\":{\"k1\":[3,5]}}}}]}}",
-                QueryBuilders.toEsDsl(compoundPredicate).toJson());
+                QueryBuilders.toEsDsl(compoundPredicate, column2typeMap).toJson());
     }
 
     @Test
@@ -189,8 +210,10 @@ public class QueryBuildersTest {
         BinaryPredicate castPredicate = new BinaryPredicate(Operator.EQ, castExpr, new IntLiteral(3));
         List<Expr> notPushDownList = new ArrayList<>();
         Map<String, String> fieldsContext = new HashMap<>();
+        Map<String, String> col2typeMap = new HashMap<>();
         BuilderOptions builderOptions = BuilderOptions.builder().likePushDown(true).build();
-        Assertions.assertNull(QueryBuilders.toEsDsl(castPredicate, notPushDownList, fieldsContext, builderOptions));
+        Assertions.assertNull(QueryBuilders.toEsDsl(castPredicate, notPushDownList, fieldsContext, builderOptions,
+                col2typeMap));
         Assertions.assertEquals(1, notPushDownList.size());
 
         SlotRef k2 = new SlotRef(null, "k2");
@@ -199,7 +222,7 @@ public class QueryBuildersTest {
         CompoundPredicate compoundPredicate = new CompoundPredicate(CompoundPredicate.Operator.OR, castPredicate,
                 eqPredicate);
 
-        QueryBuilders.toEsDsl(compoundPredicate, notPushDownList, fieldsContext, builderOptions);
+        QueryBuilders.toEsDsl(compoundPredicate, notPushDownList, fieldsContext, builderOptions, col2typeMap);
         Assertions.assertEquals(3, notPushDownList.size());
 
         SlotRef k3 = new SlotRef(null, "k3");
@@ -207,7 +230,7 @@ public class QueryBuildersTest {
         CastExpr castDoubleExpr = new CastExpr(Type.DOUBLE, k3);
         BinaryPredicate castDoublePredicate = new BinaryPredicate(Operator.GE, castDoubleExpr,
                 new FloatLiteral(3.0, Type.DOUBLE));
-        QueryBuilders.toEsDsl(castDoublePredicate, notPushDownList, fieldsContext, builderOptions);
+        QueryBuilders.toEsDsl(castDoublePredicate, notPushDownList, fieldsContext, builderOptions, col2typeMap);
         Assertions.assertEquals(3, notPushDownList.size());
 
         SlotRef k4 = new SlotRef(null, "k4");
@@ -215,25 +238,29 @@ public class QueryBuildersTest {
         CastExpr castFloatExpr = new CastExpr(Type.FLOAT, k4);
         BinaryPredicate castFloatPredicate = new BinaryPredicate(Operator.GE, new FloatLiteral(3.0, Type.FLOAT),
                 castFloatExpr);
-        QueryBuilders.QueryBuilder queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions);
+        QueryBuilders.QueryBuilder queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList,
+                fieldsContext, builderOptions, col2typeMap);
         Assertions.assertEquals("{\"range\":{\"k4\":{\"lte\":3.0}}}", queryBuilder.toJson());
         Assertions.assertEquals(3, notPushDownList.size());
 
         castFloatPredicate = new BinaryPredicate(Operator.LE, new FloatLiteral(3.0, Type.FLOAT),
             castFloatExpr);
-        queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions);
+        queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions,
+            col2typeMap);
         Assertions.assertEquals("{\"range\":{\"k4\":{\"gte\":3.0}}}", queryBuilder.toJson());
         Assertions.assertEquals(3, notPushDownList.size());
 
         castFloatPredicate = new BinaryPredicate(Operator.LT, new FloatLiteral(3.0, Type.FLOAT),
             castFloatExpr);
-        queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions);
+        queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions,
+            col2typeMap);
         Assertions.assertEquals("{\"range\":{\"k4\":{\"gt\":3.0}}}", queryBuilder.toJson());
         Assertions.assertEquals(3, notPushDownList.size());
 
         castFloatPredicate = new BinaryPredicate(Operator.GT, new FloatLiteral(3.0, Type.FLOAT),
             castFloatExpr);
-        queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions);
+        queryBuilder = QueryBuilders.toEsDsl(castFloatPredicate, notPushDownList, fieldsContext, builderOptions,
+            col2typeMap);
         Assertions.assertEquals("{\"range\":{\"k4\":{\"lt\":3.0}}}", queryBuilder.toJson());
         Assertions.assertEquals(3, notPushDownList.size());
     }

--- a/regression-test/data/external_table_p0/es/test_es_query.out
+++ b/regression-test/data/external_table_p0/es/test_es_query.out
@@ -220,6 +220,17 @@ Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
 -- !sql_5_28 --
 value1	value2
 
+-- !sql_5_29 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+
+-- !sql_5_30 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string_ignore_above_10	text_ignore_above_10
+
 -- !sql_6_02 --
 [1, 0, 1, 1]	[1, -2, -3, 4]	["2020-01-01", "2020-01-02"]	["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	[32768, 32769, -32769, -32770]	["192.168.0.1", "127.0.0.1"]	["a", "b", "c"]	[-1, 0, 1, 2]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	[1, 2, 3, 4]	[128, 129, -129, -130]	["d", "e", "f"]	[0, 1, 2, 3]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]	\N	string1	text#1	3.14	2022-08-08T00:00	12345	2022-08-08T20:10:10
 
@@ -348,6 +359,17 @@ Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
 
 -- !sql_6_28 --
 value1	value2
+
+-- !sql_6_29 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+
+-- !sql_6_30 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string_ignore_above_10	text_ignore_above_10
 
 -- !sql_7_02 --
 [1, 0, 1, 1]	[1, -2, -3, 4]	["2020-01-01", "2020-01-02"]	["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	[32768, 32769, -32769, -32770]	["192.168.0.1", "127.0.0.1"]	["a", "b", "c"]	[-1, 0, 1, 2]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	[1, 2, 3, 4]	[128, 129, -129, -130]	["d", "e", "f"]	[0, 1, 2, 3]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]	debug	\N	This string can be quite lengthy	string1	2022-08-08T20:10:10	text#1	3.14	2022-08-08T00:00	2022-08-08T12:10:10	1659931810000	2022-08-08T12:10:10	2022-08-08T20:10:10	12345
@@ -517,6 +539,19 @@ Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
 Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
 Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
 
+-- !sql_7_35 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+
+-- !sql_7_36 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+string_ignore_above_10	text_ignore_above_10
+
 -- !sql_7_50 --
 value1	value2
 
@@ -684,6 +719,19 @@ Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
 Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
 Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
 Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+
+-- !sql_8_33 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+
+-- !sql_8_34 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+string_ignore_above_10	text_ignore_above_10
 
 -- !sql01 --
 ["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[-1, 0, 1, 2]	[0, 1, 2, 3]	["d", "e", "f"]	[128, 129, -129, -130]	["192.168.0.1", "127.0.0.1"]	string1	[1, 2, 3, 4]	2022-08-08	2022-08-08T12:10:10	text#1	["2020-01-01", "2020-01-02"]	3.14	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	["a", "b", "c"]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	2022-08-08T12:10:10	2022-08-08T12:10:10	2022-08-08T20:10:10	[1, -2, -3, 4]	[1, 0, 1, 1]	[32768, 32769, -32769, -32770]	\N	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]
@@ -906,6 +954,17 @@ Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
 -- !sql_5_28 --
 value1	value2
 
+-- !sql_5_29 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+
+-- !sql_5_30 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string_ignore_above_10	text_ignore_above_10
+
 -- !sql_6_02 --
 [1, 0, 1, 1]	[1, -2, -3, 4]	["2020-01-01", "2020-01-02"]	["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	[32768, 32769, -32769, -32770]	["192.168.0.1", "127.0.0.1"]	["a", "b", "c"]	[-1, 0, 1, 2]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	[1, 2, 3, 4]	[128, 129, -129, -130]	["d", "e", "f"]	[0, 1, 2, 3]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]	\N	string1	text#1	3.14	2022-08-08T00:00	12345	2022-08-08T20:10:10
 
@@ -1034,6 +1093,17 @@ Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
 
 -- !sql_6_28 --
 value1	value2
+
+-- !sql_6_29 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+
+-- !sql_6_30 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string_ignore_above_10	text_ignore_above_10
 
 -- !sql_7_02 --
 [1, 0, 1, 1]	[1, -2, -3, 4]	["2020-01-01", "2020-01-02"]	["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	[32768, 32769, -32769, -32770]	["192.168.0.1", "127.0.0.1"]	["a", "b", "c"]	[-1, 0, 1, 2]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	[1, 2, 3, 4]	[128, 129, -129, -130]	["d", "e", "f"]	[0, 1, 2, 3]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]	debug	\N	This string can be quite lengthy	string1	2022-08-08T20:10:10	text#1	3.14	2022-08-08T00:00	2022-08-08T12:10:10	1659931810000	2022-08-08T12:10:10	2022-08-08T20:10:10	12345
@@ -1203,6 +1273,19 @@ Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
 Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
 Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
 
+-- !sql_7_35 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+
+-- !sql_7_36 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+string_ignore_above_10	text_ignore_above_10
+
 -- !sql_7_50 --
 value1	value2
 
@@ -1370,4 +1453,17 @@ Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
 Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
 Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
 Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+
+-- !sql_8_33 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+
+-- !sql_8_34 --
+string1	text#1
+string2	text2
+string3	text3_4*5
+string4	text3_4*5
+string_ignore_above_10	text_ignore_above_10
 

--- a/regression-test/suites/external_table_p0/es/test_es_query.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_query.groovy
@@ -214,6 +214,8 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             order_qt_sql_5_26 """select test6 from test2;"""
             order_qt_sql_5_27 """select * from composite_type_array order by name;"""
             order_qt_sql_5_28 """select * from test3_20231005;"""
+            order_qt_sql_5_29 """select test1, test2 from test1 where test1 like 'string%';"""
+            order_qt_sql_5_30 """select test1, test2 from test1 where test2 like 'text%';"""
 
             sql """switch test_es_query_es6"""
             // order_qt_sql_6_01 """show tables"""
@@ -244,6 +246,8 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             order_qt_sql_6_26 """select test6 from test2;"""
             order_qt_sql_6_27 """select * from composite_type_array order by name;"""
             order_qt_sql_6_28 """select * from test3_20231005;"""
+            order_qt_sql_6_29 """select test1, test2 from test1 where test1 like 'string%';"""
+            order_qt_sql_6_30 """select test1, test2 from test1 where test2 like 'text%';"""
 
             List<List<String>> tables6N = sql """show tables"""
             boolean notContainHide = true
@@ -299,6 +303,8 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             order_qt_sql_7_32 """select test6 from test1;"""
             order_qt_sql_7_33 """select test6 from test2;"""
             order_qt_sql_7_34 """select * from composite_type_array order by name;"""
+            order_qt_sql_7_35 """select test1, test2 from test1 where test1 like 'string%';"""
+            order_qt_sql_7_36 """select test1, test2 from test1 where test2 like 'text%';"""
 
             List<List<String>> tables7N = sql """show tables"""
             boolean notContainHide7 = true
@@ -354,7 +360,9 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             order_qt_sql_8_30 """select test6 from test1;"""
             order_qt_sql_8_31 """select test6 from test2;"""
             order_qt_sql_8_32 """select * from composite_type_array order by name;"""
-        
+            order_qt_sql_8_33 """select test1, test2 from test1 where test1 like 'string%';"""
+            order_qt_sql_8_34 """select test1, test2 from test1 where test2 like 'text%';"""
+
         }
 
         sql """set enable_es_parallel_scroll=true"""


### PR DESCRIPTION
## Proposed changes

We map `text` and `keyword` both to `string` type in Doris. When enable `like_push_down`, we translate like to wildcard query in ES, which will lead unexpected result in `text` field. We should stick to `keyword` with wildcard query.
1. Add `column2typeMap` in `EsTable` to save the mapping of column_name to ES field data type.
2. Add new class `EsSchemaCacheValue` to get schema and column to type map
3. Init `column2typeMap` when cache init and build query process of ES external table
4. Support LIKE functionCallExpr for Nereids planner.
5. Add end to end like predicate test cases and UTs


