### PR TITLE
[enhancement](start) ignore lowercase names in conf if it is invalid

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1953,11 +1953,11 @@ public class Env {
             }
         }
         if (Config.lower_case_table_names != GlobalVariable.lowerCaseTableNames) {
-            LOG.error("The configuration of \'lower_case_table_names\' does not support modification, "
+            LOG.warn("The configuration of \'lower_case_table_names\' does not support modification, "
                             + "the expected value is {}, but the actual value is {}",
                     GlobalVariable.lowerCaseTableNames,
                     Config.lower_case_table_names);
-            System.exit(-1);
+            Config.lower_case_table_names = GlobalVariable.lowerCaseTableNames;
         }
         LOG.info("lower_case_table_names is {}", GlobalVariable.lowerCaseTableNames);
     }


### PR DESCRIPTION
If lowercase_table_names in fe.conf and meta are not same, we can only use value in meta. So exit is helpless.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

