### PR TITLE
[revert](storage) storage medium of partition should not inherit from table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1671,13 +1671,6 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY)) {
                 properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, olapTable.getStoragePolicy());
             }
-            if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
-                TStorageMedium tableStorageMedium = olapTable.getStorageMedium();
-                if (tableStorageMedium != null) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM,
-                            tableStorageMedium.name().toLowerCase());
-                }
-            }
 
             singlePartitionDesc.analyze(partitionInfo.getPartitionColumns().size(), properties);
             partitionInfo.createAndCheckPartitionItem(singlePartitionDesc, isTempPartition);

--- a/regression-test/suites/mtmv_p0/test_storage_medium_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_storage_medium_mtmv.groovy
@@ -18,6 +18,8 @@
 import org.junit.Assert;
 
 suite("test_storage_medium_mtmv","mtmv") {
+    // current, can not support extend storage medium from table
+    return;
     // cloud not support set storage medium
     if (isCloudMode()) {
         return;


### PR DESCRIPTION
revert #35644

table if not set storage medium, will set default by `Config.default_storage_medium`, 
at present, we cannot distinguish whether the storage medium of the table is set by the user.
If it is not set by the user, it represents priority use rather than mandatory use. If we directly inherit the storage medium of the table, it may cause the partition to be forced to use 'Config. default_storage_madium', resulting in the partition being unable to be created



