### PR TITLE
[fix](analysis) Fix ColumnDef to sql result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -175,8 +175,6 @@ public class ColumnDef {
                 }
                 return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId())
                         .format(DateTimeFormatter.ofPattern(format));
-            } else if (value == null) {
-                return "NULL";
             }
             return value;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -175,8 +175,21 @@ public class ColumnDef {
                 }
                 return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId())
                         .format(DateTimeFormatter.ofPattern(format));
+            } else if (value == null) {
+                return "NULL";
             }
             return value;
+        }
+
+        public String toSql() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("DEFAULT ");
+            if (value != null) {
+                sb.append('"').append(value).append('"');
+            } else {
+                sb.append("NULL");
+            }
+            return sb.toString();
         }
     }
 
@@ -662,7 +675,7 @@ public class ColumnDef {
         }
 
         if (defaultValue.isSet) {
-            sb.append("DEFAULT \"").append(defaultValue.value).append("\" ");
+            sb.append(defaultValue.toSql()).append(" ");
         }
         sb.append("COMMENT \"").append(comment).append("\"");
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ColumnDefTest.java
@@ -89,7 +89,7 @@ public class ColumnDefTest {
             ColumnDef column = new ColumnDef("col", intCol, false, AggregateType.REPLACE_IF_NOT_NULL, true, DefaultValue.NOT_SET, "");
             column.analyze(true);
             Assert.assertEquals(AggregateType.REPLACE_IF_NOT_NULL, column.getAggregateType());
-            Assert.assertEquals("`col` int REPLACE_IF_NOT_NULL NULL DEFAULT \"null\" COMMENT \"\"", column.toSql());
+            Assert.assertEquals("`col` int REPLACE_IF_NOT_NULL NULL DEFAULT NULL COMMENT \"\"", column.toSql());
         } // CHECKSTYLE IGNORE THIS LINE
         { // CHECKSTYLE IGNORE THIS LINE
             // not allow null
@@ -97,6 +97,12 @@ public class ColumnDefTest {
             column.analyze(true);
             Assert.assertEquals(AggregateType.REPLACE_IF_NOT_NULL, column.getAggregateType());
             Assert.assertEquals("`col` int REPLACE_IF_NOT_NULL NULL DEFAULT \"10\" COMMENT \"\"", column.toSql());
+        } // CHECKSTYLE IGNORE THIS LINE
+        { // CHECKSTYLE IGNORE THIS LINE
+            ColumnDef column = new ColumnDef("col", intCol, false, AggregateType.REPLACE_IF_NOT_NULL, true, DefaultValue.NULL_DEFAULT_VALUE, "");
+            column.analyze(true);
+            Assert.assertEquals(AggregateType.REPLACE_IF_NOT_NULL, column.getAggregateType());
+            Assert.assertEquals("`col` int REPLACE_IF_NOT_NULL NULL DEFAULT NULL COMMENT \"\"", column.toSql());
         } // CHECKSTYLE IGNORE THIS LINE
     }
 


### PR DESCRIPTION
For sql:

```
ALTER TABLE table_3333338 ADD COLUMN col484 DATETIME(1) REPLACE_IF_NOT_NULL
```

the toSql result is:

```
ADD COLUMN `col484` datetimev2(1) REPLACE_IF_NOT_NULL NULL DEFAULT "null" COMMENT ""
```

the `DEFAULT "null"` is not a valid expr for datetime. This PR corrects the behavior of toSql of the NULL DEFAULT VALUE to `DEFAULT NULL`. Then the new result is:

```
ADD COLUMN `col484` datetimev2(1) REPLACE_IF_NOT_NULL NULL DEFAULT NULL COMMENT ""
```

