### PR TITLE
[enhancement](Optimizer) optimize delete statement can not do partition prune when column is not lower case 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionPrunerV2Base.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionPrunerV2Base.java
@@ -108,7 +108,7 @@ public abstract class PartitionPrunerV2Base implements PartitionPruner {
     public Collection<Long> prune() throws AnalysisException {
         Map<Column, FinalFilters> columnToFilters = Maps.newHashMap();
         for (Column column : partitionColumns) {
-            ColumnRange columnRange = columnNameToRange.get(column.getName());
+            ColumnRange columnRange = columnNameToRange.get(column.getName().toLowerCase());
             if (columnRange == null) {
                 columnToFilters.put(column, FinalFilters.noFilters());
             } else {


### PR DESCRIPTION
## Proposed changes

optimize delete statement can not do partition prune when column is not lower case 

for example, this sql will send finishRealtimePush rpc for all partitions, but we only want to process one partition
```sql
delete from tbl where Dt = '2024-01-01'
```

