### PR TITLE
[improvement](statistics)Remove analyze retry logic.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -91,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -905,7 +906,7 @@ public class AnalysisManager implements Writable {
     public List<AnalysisInfo> findTasksByTaskIds(long jobId) {
         AnalysisInfo jobInfo = analysisJobInfoMap.get(jobId);
         if (jobInfo != null && jobInfo.taskIds != null) {
-            return jobInfo.taskIds.stream().map(analysisTaskInfoMap::get).filter(i -> i != null)
+            return jobInfo.taskIds.stream().map(analysisTaskInfoMap::get).filter(Objects::nonNull)
                     .collect(Collectors.toList());
         }
         return null;
@@ -922,7 +923,7 @@ public class AnalysisManager implements Writable {
     public void dropAnalyzeJob(DropAnalyzeJobStmt analyzeJobStmt) throws DdlException {
         AnalysisInfo jobInfo = analysisJobInfoMap.get(analyzeJobStmt.getJobId());
         if (jobInfo == null) {
-            throw new DdlException(String.format("Analyze job [%d] not exists", jobInfo.jobId));
+            throw new DdlException(String.format("Analyze job [%d] not exists", analyzeJobStmt.getJobId()));
         }
         checkPriv(jobInfo);
         long jobId = analyzeJobStmt.getJobId();
@@ -962,15 +963,12 @@ public class AnalysisManager implements Writable {
         if (analysisInfo == null) {
             return true;
         }
-        if (analysisInfo.scheduleType == null || analysisInfo.scheduleType == null || analysisInfo.jobType == null) {
+        if (analysisInfo.scheduleType == null || analysisInfo.jobType == null) {
             return true;
         }
-        if ((AnalysisState.PENDING.equals(analysisInfo.state) || AnalysisState.RUNNING.equals(analysisInfo.state))
+        return (AnalysisState.PENDING.equals(analysisInfo.state) || AnalysisState.RUNNING.equals(analysisInfo.state))
                 && ScheduleType.ONCE.equals(analysisInfo.scheduleType)
-                && JobType.MANUAL.equals(analysisInfo.jobType)) {
-            return true;
-        }
-        return false;
+                && JobType.MANUAL.equals(analysisInfo.jobType);
     }
 
     private static void readIdToTblStats(DataInput in, Map<Long, TableStatsMeta> map) throws IOException {
@@ -1140,17 +1138,14 @@ public class AnalysisManager implements Writable {
 
     /**
      * Only OlapTable and Hive HMSExternalTable can sample for now.
-     * @param table
+     * @param table Table to check
      * @return Return true if the given table can do sample analyze. False otherwise.
      */
     public boolean canSample(TableIf table) {
         if (table instanceof OlapTable) {
             return true;
         }
-        if (table instanceof HMSExternalTable
-                && ((HMSExternalTable) table).getDlaType().equals(HMSExternalTable.DLAType.HIVE)) {
-            return true;
-        }
-        return false;
+        return table instanceof HMSExternalTable
+                && ((HMSExternalTable) table).getDlaType().equals(HMSExternalTable.DLAType.HIVE);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.text.MessageFormat;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 public abstract class BaseAnalysisTask {
 
@@ -195,37 +194,14 @@ public abstract class BaseAnalysisTask {
         }
     }
 
-    public void execute() {
+    public void execute() throws Exception {
         prepareExecution();
-        executeWithRetry();
+        doExecute();
         afterExecution();
     }
 
     protected void prepareExecution() {
         setTaskStateToRunning();
-    }
-
-    protected void executeWithRetry() {
-        int retriedTimes = 0;
-        while (retriedTimes < StatisticConstants.ANALYZE_TASK_RETRY_TIMES) {
-            if (killed) {
-                throw new RuntimeException("Task is Killed or Timeout");
-            }
-            try {
-                doExecute();
-                break;
-            } catch (Throwable t) {
-                if (killed) {
-                    throw new RuntimeException(t);
-                }
-                LOG.warn("Failed to execute analysis task, retried times: {}", retriedTimes++, t);
-                if (retriedTimes >= StatisticConstants.ANALYZE_TASK_RETRY_TIMES) {
-                    job.taskFailed(this, t.getMessage());
-                    throw new RuntimeException(t);
-                }
-                StatisticsUtil.sleep(TimeUnit.SECONDS.toMillis(2 ^ retriedTimes) * 10);
-            }
-        }
     }
 
     public abstract void doExecute() throws Exception;
@@ -285,9 +261,8 @@ public abstract class BaseAnalysisTask {
         // (https://github.com/postgres/postgres/blob/master/src/backend/commands/analyze.c)
         // (http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.93.8637&rep=rep1&type=pdf)
         // sample_row * count_distinct / ( sample_row - once_count + once_count * sample_row / total_row)
-        String fn = MessageFormat.format("{0} * {1} / ({0} - {2} + {2} * {0} / {3})", sampleRows,
+        return MessageFormat.format("{0} * {1} / ({0} - {2} + {2} * {0} / {3})", sampleRows,
                 countDistinct, onceCount, totalRows);
-        return fn;
     }
 
     // Max value is not accurate while sample, so set it to NULL to avoid optimizer generate bad plan.
@@ -345,6 +320,9 @@ public abstract class BaseAnalysisTask {
             Env.getCurrentEnv().getStatisticsCache().syncColStats(colStatsData);
             queryId = DebugUtil.printId(stmtExecutor.getContext().queryId());
             job.appendBuf(this, Collections.singletonList(colStatsData));
+        } catch (Exception e) {
+            LOG.warn("Failed to execute sql {}", sql);
+            throw e;
         } finally {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("End cost time in millisec: " + (System.currentTimeMillis() - startTime)

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -79,11 +79,6 @@ public class HistogramTask extends BaseAnalysisTask {
                 tbl.getDatabase().getCatalog().getId(), tbl.getDatabase().getId(), tbl.getId(), -1, col.getName());
     }
 
-    @Override
-    protected void afterExecution() {
-        // DO NOTHING
-    }
-
     private String getSampleRateFunction() {
         if (info.analysisMethod == AnalysisMethod.FULL) {
             return "0";

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -64,8 +64,6 @@ public class StatisticConstants {
 
     public static List<String> SYSTEM_DBS = new ArrayList<>();
 
-    public static int ANALYZE_TASK_RETRY_TIMES = 5;
-
     public static final String DB_NAME = FeConstants.INTERNAL_DB_NAME;
 
     public static final String FULL_QUALIFIED_STATS_TBL_NAME = InternalCatalog.INTERNAL_CATALOG_NAME


### PR DESCRIPTION
Remove analyze retry logic when task failed. Because usually retry would fail again and retry would bring a long time of sleep, which cause the analyze job running too slow.
Master pr: https://github.com/apache/doris/pull/33703