### PR TITLE
[fix](block_rule)Fix SQL block rule not working after FE restart

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3092,4 +3092,8 @@ public class Config extends ConfigBase {
     @ConfField(description = {"检查资源就绪的周期，单位秒",
             "Interval checking if resource is ready"})
     public static long resource_not_ready_sleep_seconds = 5;
+
+    @ConfField(mutable = true, description = {
+            "设置为 true，如果查询无法选择到健康副本时，会打印出该tablet所有副本的详细信息，"})
+    public static boolean sql_block_rule_ignore_admin = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.CreateSqlBlockRuleStmt;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.SqlBlockUtil;
+import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.collect.Lists;
@@ -37,7 +38,7 @@ import java.util.regex.Pattern;
 /**
  * Use for block some sql by rule.
  **/
-public class SqlBlockRule implements Writable {
+public class SqlBlockRule implements Writable, GsonPostProcessable {
 
     public static final String NAME_TYPE = "SQL BLOCK RULE NAME";
 
@@ -191,11 +192,14 @@ public class SqlBlockRule implements Writable {
      **/
     public static SqlBlockRule read(DataInput in) throws IOException {
         String json = Text.readString(in);
-        SqlBlockRule sqlBlockRule = GsonUtils.GSON.fromJson(json, SqlBlockRule.class);
-        if (StringUtils.isNotEmpty(sqlBlockRule.getSql()) && !SqlBlockUtil.STRING_DEFAULT.equals(
-                sqlBlockRule.getSql())) {
-            sqlBlockRule.setSqlPattern(Pattern.compile(sqlBlockRule.getSql()));
+        return GsonUtils.GSON.fromJson(json, SqlBlockRule.class);
+    }
+
+    @Override
+    public void gsonPostProcess() {
+        if (StringUtils.isNotEmpty(this.getSql()) && !SqlBlockUtil.STRING_DEFAULT.equals(
+                this.getSql())) {
+            this.setSqlPattern(Pattern.compile(this.getSql()));
         }
-        return sqlBlockRule;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -23,12 +23,14 @@ import org.apache.doris.analysis.DropSqlBlockRuleStmt;
 import org.apache.doris.analysis.ShowSqlBlockRuleStmt;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.SqlBlockUtil;
 import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 
@@ -225,6 +227,9 @@ public class SqlBlockRuleMgr implements Writable {
      * Match SQL according to rules.
      **/
     public void matchSql(String originSql, String sqlHash, String user) throws AnalysisException {
+        if (Config.sql_block_rule_ignore_admin && (Auth.ROOT_USER.equals(user) || Auth.ADMIN_USER.equals(user))) {
+            return;
+        }
         if (ConnectContext.get() != null
                 && ConnectContext.get().getSessionVariable().internalSession) {
             return;


### PR DESCRIPTION
- Fix SQL block rule not working after FE restart
- Add fe configuration 'sql-block_rule_ignore_ admin' to control root and admin to bypass SQL block rules, avoiding any commands being unable to execute due to user set regularization

