### PR TITLE
[fix](load) fix memtable memory limiter total mem usage

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -251,7 +251,7 @@ void MemTableMemoryLimiter::_refresh_mem_tracker() {
             _writers.pop_back();
         }
     }
-    _mem_usage = _flush_mem_usage + _queue_mem_usage;
+    _mem_usage = _active_mem_usage + _queue_mem_usage + _flush_mem_usage;
     g_memtable_active_memory.set_value(_active_mem_usage);
     g_memtable_write_memory.set_value(_queue_mem_usage);
     g_memtable_flush_memory.set_value(_flush_mem_usage);


### PR DESCRIPTION
## Proposed changes

Previously, `mem_usage = write_mem + flush_mem`, because `active_mem` is included in `write_mem`.

After #40912, `write_mem` becomes `queue_mem`, which no longer includes `active_mem`.
This PR fixes this problem, by setting `mem_usage = active_mem + queue_mem + flush_mem` 
