### PR TITLE
[branch-2.1] do not fallback to origin planner for call stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CallCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CallCommand.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 /**
  * call func()
  */
-public class CallCommand extends Command implements ForwardWithSync {
+public class CallCommand extends Command implements ForwardWithSync, NotAllowFallback {
     public static final Logger LOG = LogManager.getLogger(CallCommand.class);
 
     private final UnboundFunction unboundFunction;

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_call.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_call.groovy
@@ -102,6 +102,13 @@ suite("test_jdbc_call", "p0,external,doris,external_docker,external_docker_doris
     order_qt_sql6 """select * from ${catalog_name}.${internal_db_name}.${internal_tbl_name2}"""
     order_qt_sql7 """select * from internal.${internal_db_name}.${internal_tbl_name2}"""
 
+    // test not fallback
+    // if fallback, the error msg will be: Syntax error: xxx
+    test {
+        sql """call execute_stmt("${catalog_name}", "insert into ${internal_db_name}.${internal_tbl_name2} value (5, 6), (7, 8)")"""
+        exception """Failed to execute stmt"""
+    }
+
     // test priv
     // only user with load priv can execute call
     String user1 = "normal_jdbc_user";


### PR DESCRIPTION
`CALL xxx` statement is not supported by old planner.
And if fallback, the error message will be confused.

Only for 2.1, master does not have this issue