### PR TITLE
[Fix](jdbc-scanner) Fix jdbc scanner memory leak because it didn't close `outputTable`. 

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -99,6 +99,9 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
     }
 
     public void close() throws Exception {
+        if (outputTable != null) {
+            outputTable.close();
+        }
         try {
             if (stmt != null && !stmt.isClosed()) {
                 try {
@@ -111,8 +114,8 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
             if (conn != null && resultSet != null) {
                 abortReadConnection(conn, resultSet);
             }
-            closeResources(resultSet, stmt, conn);
         } finally {
+            closeResources(resultSet, stmt, conn);
             if (config.getConnectionPoolMinSize() == 0 && hikariDataSource != null) {
                 hikariDataSource.close();
                 JdbcDataSource.getDataSource().getSourcesMap().remove(config.createCacheKey());


### PR DESCRIPTION
## Proposed changes

Backport #41041.

