### PR TITLE
[fix](test) fix `test_export_big_data` test

### DIFF
--- a/regression-test/suites/export_p2/test_export_big_data.groovy
+++ b/regression-test/suites/export_p2/test_export_big_data.groovy
@@ -139,6 +139,5 @@ suite("test_export_big_data", "p2") {
         }
     } finally {
         try_sql("DROP TABLE IF EXISTS ${table_export_name}")
-        delete_files.call("${outFilePath}")
     }
 }


### PR DESCRIPTION
It will delete all files in the `/tmp`.
But there are some configuration files in `/tmp` direction, so we can not delete these files
