### PR TITLE
[fix](load) fix priority queue order in memtable memory limiter

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -160,7 +160,7 @@ void MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
     }
 
     using WriterMem = std::pair<std::weak_ptr<MemTableWriter>, int64_t>;
-    auto cmp = [](WriterMem left, WriterMem right) { return left.second > right.second; };
+    auto cmp = [](WriterMem left, WriterMem right) { return left.second < right.second; };
     std::priority_queue<WriterMem, std::vector<WriterMem>, decltype(cmp)> heap(cmp);
 
     for (auto writer : _active_writers) {


### PR DESCRIPTION
## Proposed changes

#41018 used priority queue when selecting memtables to flush.
But the compare function is wrong and causing the order to be the opposite.

> Note that the Compare parameter is defined such that it returns true if its first argument comes before its second argument in a weak ordering. But because the priority queue outputs largest elements first, the elements that "come before" are actually output last. That is, the front of the queue contains the "last" element according to the weak ordering imposed by Compare.

This PR fixes the compare function to make larger memtables come front.

