### PR TITLE
[fix](meta) fix Unknown column 'mva_SUM__CAST`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CastExpr;
 import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotRef;
@@ -211,6 +212,24 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
                     column.setDefineExpr(entry.getValue());
                     match = true;
                     break;
+                }
+            }
+
+            boolean isCastSlot =
+                    entry.getValue() instanceof CastExpr && entry.getValue().getChild(0) instanceof SlotRef;
+
+            // Compatibility code for older versions of mv
+            // old version:
+            // goods_number -> mva_SUM__CAST(`goods_number` AS BIGINT)
+            // new version:
+            // goods_number -> mva_SUM__CAST(`goods_number` AS bigint)
+            if (isCastSlot && !match) {
+                for (Column column : schema) {
+                    if (column.getName().equalsIgnoreCase(entry.getKey())) {
+                        column.setDefineExpr(entry.getValue());
+                        match = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

fix insert into select statement failed when upgrade doris, introduced by #38012
```sql
ERROR 1054 (42S22): errCode = 2, detailMessage = Unknown column 'mva_SUM__CAST(`goods_number` AS BIGINT)' in 'dm_sales_settlement_day_goods'
```
