### PR TITLE
[Improvement](sort) adjust HEAP_SORT usage threshold

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -357,7 +357,7 @@ public class SortNode extends PlanNode {
             } else if (hasRuntimePredicate || useTwoPhaseReadOpt) {
                 algorithm = TSortAlgorithm.HEAP_SORT;
             } else {
-                if (limit + offset < 5000000) {
+                if (limit + offset < 50000) {
                     algorithm = TSortAlgorithm.HEAP_SORT;
                 } else if (limit + offset < 20000000) {
                     algorithm = TSortAlgorithm.FULL_SORT;


### PR DESCRIPTION
## Proposed changes
adjust HEAP_SORT usage threshold

```sql
before
mysql [test]>SELECT/*+SET_VAR(parallel_pipeline_task_num=1)*/ COUNT() FROM (   SELECT URL   FROM hits_1m   ORDER BY FlashMajor   LIMIT 1000000   OFFSET 50000 ) t;
+----------+
| count(*) |
+----------+
|   950000 |
+----------+
1 row in set (0.82 sec)

after
mysql [test]>SELECT/*+SET_VAR(parallel_pipeline_task_num=1)*/ COUNT() FROM (   SELECT URL   FROM hits_1m   ORDER BY FlashMajor   LIMIT 1000000   OFFSET 50000 ) t;
+----------+
| count(*) |
+----------+
|   950000 |
+----------+
1 row in set (0.22 sec)
```