### PR TITLE
[chore](log) log stream load put request in debug level

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadHandler.java
@@ -108,7 +108,9 @@ public class StreamLoadHandler {
             return;
         }
 
-        LOG.info("stream load put request: {}", request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("stream load put request: {}", request);
+        }
         // create connect context
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(Env.getCurrentEnv());


### PR DESCRIPTION
The TStreamLoadPutRequest contains user passwords, printing it in the log poses a security risk. This is not a particularly critical log, so it has been adjusted to the debug level.