### PR TITLE
[fix](cluster key) Cluster key skip non vertical compact

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -186,7 +186,7 @@ Status Compaction::merge_input_rowsets() {
     Status res;
     {
         SCOPED_TIMER(_merge_rowsets_latency_timer);
-        if (_is_vertical) {
+        if (_is_vertical || !_tablet->tablet_schema()->cluster_key_idxes().empty()) {
             res = Merger::vertical_merge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
                                                  input_rs_readers, _output_rs_writer.get(),
                                                  get_avg_segment_rows(), way_num, &_stats);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -186,11 +186,15 @@ Status Compaction::merge_input_rowsets() {
     Status res;
     {
         SCOPED_TIMER(_merge_rowsets_latency_timer);
-        if (_is_vertical || !_tablet->tablet_schema()->cluster_key_idxes().empty()) {
+        if (_is_vertical) {
             res = Merger::vertical_merge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
                                                  input_rs_readers, _output_rs_writer.get(),
                                                  get_avg_segment_rows(), way_num, &_stats);
         } else {
+            if (!_tablet->tablet_schema()->cluster_key_idxes().empty()) {
+                return Status::InternalError(
+                        "mow table with cluster keys does not support non vertical compaction");
+            }
             res = Merger::vmerge_rowsets(_tablet, compaction_type(), *_cur_tablet_schema,
                                          input_rs_readers, _output_rs_writer.get(), &_stats);
         }


### PR DESCRIPTION
now the cluster key does not support non vertical compaction.
https://github.com/apache/doris/pull/41208 try to implement it, but there are some problems, so we skip non vertical compaction for cluster key