### PR TITLE
[test](p2) ignore order of load counters in etl info

### DIFF
--- a/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
@@ -338,7 +338,10 @@ suite("test_broker_load_p2", "p2") {
                     if (result[0][2].equals("FINISHED")) {
                         logger.info("Load FINISHED " + label)
                         assertTrue(result[0][6].contains(task_info[i]))
-                        assertTrue(etl_info[i] == result[0][5], "expected: " + etl_info[i] + ", actual: " + result[0][5] + ", label: $label")
+                        load_counters = etl_info[i].split('; ');
+                        for (String counter : load_counters) {
+                            assertTrue(result[0][5].contains(counter), "expected: " + counter + ", actual: " + result[0][5] + ", label: $label")
+                        }
                         break;
                     }
                     if (result[0][2].equals("CANCELLED")) {

--- a/regression-test/suites/load_p2/broker_load/test_parquet_large_metadata_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_parquet_large_metadata_load.groovy
@@ -88,7 +88,10 @@ suite("test_parquet_large_metadata_load_p2", "p2") {
                     if (result[0][2].equals("FINISHED")) {
                         logger.info("Load FINISHED " + label)
                         assertTrue(result[0][6].contains(task_info[i]))
-                        assertTrue(etl_info[i] == result[0][5], "expected: " + etl_info[i] + ", actual: " + result[0][5] + ", label: $label")
+                        load_counters = etl_info[i].split('; ');
+                        for (String counter : load_counters) {
+                            assertTrue(result[0][5].contains(counter), "expected: " + counter + ", actual: " + result[0][5] + ", label: $label")
+                        }
                         break;
                     }
                     if (result[0][2].equals("CANCELLED")) {


### PR DESCRIPTION
## Proposed changes

Fix the following error:

```
org.opentest4j.AssertionFailedError:
expected: unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000,
actual: unselected.rows=0; dpp.norm.ALL=200000; dpp.abnorm.ALL=0,
label: L0_8ae1e3500486e04e350b2530c5e24813756a
==> expected: <true> but was: <false>
```
