### PR TITLE
[chore](query err) fix cutting err msg incorrectly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1191,15 +1191,6 @@ public class Coordinator implements CoordInterface {
             } else {
                 String errMsg = copyStatus.getErrorMsg();
                 LOG.warn("query failed: {}", errMsg);
-
-                // hide host info exclude localhost
-                if (errMsg.contains("localhost")) {
-                    throw new UserException(errMsg);
-                }
-                int hostIndex = errMsg.indexOf("host");
-                if (hostIndex != -1) {
-                    errMsg = errMsg.substring(0, hostIndex);
-                }
                 throw new UserException(errMsg);
             }
         }


### PR DESCRIPTION
full err msg:

```
Backend Backend [id=93591, host=172.20.50.36, heartbeatPort=9050, alive=true, lastStartTi  me=2024-09-12 13:39:46, process epoch=1726119586394, tags: {location=default}] not exists or dead, query 4f199e94e2de4469-a2a0bb9aabfdbc07 should be cancelled
```

was cutted incorrectly:

```
Backend Backend [id=93591,
```

