### PR TITLE
[fix](nereids)do not add delta row count to BE reported row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -396,7 +396,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             rowCount = olapTable.getRowCountForIndex(olapScan.getSelectedIndexId(), true);
             if (rowCount == -1) {
                 if (tableMeta != null) {
-                    rowCount = tableMeta.getRowCount(olapScan.getSelectedIndexId());
+                    rowCount = tableMeta.getRowCount(olapScan.getSelectedIndexId()) + computeDeltaRowCount(olapScan);
                 }
             }
         }
@@ -489,7 +489,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                     builder.putColumnStatistics(slot, colStatsBuilder.build());
                 }
                 checkIfUnknownStatsUsedAsKey(builder);
-                builder.setRowCount(selectedPartitionsRowCount + deltaRowCount);
+                builder.setRowCount(selectedPartitionsRowCount);
             }
         }
         // 1. no partition is pruned, or
@@ -503,7 +503,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 builder.putColumnStatistics(slot, colStatsBuilder.build());
             }
             checkIfUnknownStatsUsedAsKey(builder);
-            builder.setRowCount(tableRowCount + deltaRowCount);
+            builder.setRowCount(tableRowCount);
         }
         return builder.build();
     }


### PR DESCRIPTION
## Proposed changes
the table row count is in 3 cases:
1. injected row count
2. analyzed row count + delta row count
3. BE reported row count.

in previous pr #40529, we added delta row count in all 3 cases
Issue Number: close #xxx

<!--Describe your changes.-->

