### PR TITLE
[fix](fe) Fix `PluginMgr.getActivePluginList` npt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginMgr.java
@@ -293,6 +293,10 @@ public class PluginMgr implements Writable {
 
         m.values().forEach(d -> {
             if (d.getStatus() == PluginStatus.INSTALLED) {
+                if (d.getPlugin() == null) {
+                    LOG.warn("PluginLoader({}) status is INSTALLED, but plugin is null", d);
+                    return;
+                }
                 l.add(d.getPlugin());
             }
         });


### PR DESCRIPTION
```
Exception in thread "AuditEventProcessor" java.lang.NullPointerException: at index 2
    at com.google.common.collect.ObjectArrays.checkElementNotNull(ObjectArrays.java:232)
    at com.google.common.collect.ObjectArrays.checkElementsNotNull(ObjectArrays.java:222)
    at com.google.common.collect.ObjectArrays.checkElementsNotNull(ObjectArrays.java:216)
    at com.google.common.collect.ImmutableList.construct(ImmutableList.java:353)
    at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:265)
    at org.apache.doris.plugin.PluginMgr.getActivePluginList(PluginMgr.java:300)
    at org.apache.doris.qe.AuditEventProcessor$Worker.run(AuditEventProcessor.java:120)
    at java.base/java.lang.Thread.run(Thread.java:833)
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

