### PR TITLE
[refine](rf) Adjust the calculation logic for rf's always_true.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -898,7 +898,7 @@ DEFINE_mInt32(orc_natural_read_size_mb, "8");
 DEFINE_mInt64(big_column_size_buffer, "65535");
 DEFINE_mInt64(small_column_size_buffer, "100");
 
-// rf will decide whether the next sampling_frequency blocks need to be filtered based on the filtering rate of the current block.
+// Perform the always_true check at intervals determined by runtime_filter_sampling_frequency
 DEFINE_mInt32(runtime_filter_sampling_frequency, "64");
 
 // cooldown task configs

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1214,7 +1214,7 @@ Status IRuntimeFilter::get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr
     // The runtime filter is pushed down, adding filtering information.
     auto* expr_filtered_rows_counter = ADD_COUNTER(_profile, "expr_filtered_rows", TUnit::UNIT);
     auto* expr_input_rows_counter = ADD_COUNTER(_profile, "expr_input_rows", TUnit::UNIT);
-    auto* always_true_counter = ADD_COUNTER(_profile, "always_true", TUnit::UNIT);
+    auto* always_true_counter = ADD_COUNTER(_profile, "always_true_pass_rows", TUnit::UNIT);
     for (auto i = origin_size; i < push_exprs.size(); i++) {
         push_exprs[i]->attach_profile_counter(expr_filtered_rows_counter, expr_input_rows_counter,
                                               always_true_counter);

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -165,6 +165,7 @@ public:
     explicit ColumnPredicate(uint32_t column_id, bool opposite = false)
             : _column_id(column_id), _opposite(opposite) {
         _predicate_params = std::make_shared<PredicateParams>();
+        reset_judge_selectivity();
     }
 
     virtual ~ColumnPredicate() = default;
@@ -188,16 +189,15 @@ public:
     // evaluate predicate on IColumn
     // a short circuit eval way
     uint16_t evaluate(const vectorized::IColumn& column, uint16_t* sel, uint16_t size) const {
-        if (always_true(true)) {
+        if (always_true()) {
             return size;
         }
 
         uint16_t new_size = _evaluate_inner(column, sel, size);
         _evaluated_rows += size;
         _passed_rows += new_size;
-        if (_can_ignore() && !_judge_counter) {
-            vectorized::VRuntimeFilterWrapper::judge_selectivity(
-                    get_ignore_threshold(), size - new_size, size, _always_true, _judge_counter);
+        if (_can_ignore()) {
+            do_judge_selectivity(size - new_size, size);
         }
         return new_size;
     }
@@ -302,15 +302,7 @@ public:
         }
     }
 
-    bool always_true(bool update) const {
-        if (update) {
-            _judge_counter--;
-            if (!_judge_counter) {
-                _always_true = false;
-            }
-        }
-        return _always_true;
-    }
+    bool always_true() const { return _always_true; }
 
 protected:
     virtual std::string _debug_string() const = 0;
@@ -326,13 +318,42 @@ protected:
         throw Exception(INTERNAL_ERROR, "Not Implemented _evaluate_inner");
     }
 
+    void reset_judge_selectivity() const {
+        _always_true = false;
+        _judge_counter = config::runtime_filter_sampling_frequency;
+        _judge_input_rows = 0;
+        _judge_filter_rows = 0;
+    }
+
+    void do_judge_selectivity(int64_t filter_rows, int64_t input_rows) const {
+        if ((_judge_counter--) == 0) {
+            reset_judge_selectivity();
+        }
+        if (!_always_true) {
+            _judge_filter_rows += filter_rows;
+            _judge_input_rows += input_rows;
+            vectorized::VRuntimeFilterWrapper::judge_selectivity(
+                    get_ignore_threshold(), _judge_filter_rows, _judge_input_rows, _always_true);
+        }
+    }
+
     uint32_t _column_id;
     // TODO: the value is only in delete condition, better be template value
     bool _opposite;
     std::shared_ptr<PredicateParams> _predicate_params;
     mutable uint64_t _evaluated_rows = 1;
     mutable uint64_t _passed_rows = 0;
+    // VRuntimeFilterWrapper and ColumnPredicate share the same logic,
+    // but it's challenging to unify them, so the code is duplicated.
+    // _judge_counter, _judge_input_rows, _judge_filter_rows, and _always_true
+    // are variables used to implement the _always_true logic, calculated periodically
+    // based on runtime_filter_sampling_frequency. During each period, if _always_true
+    // is evaluated as true, the logic for always_true is applied for the rest of that period
+    // without recalculating. At the beginning of the next period,
+    // reset_judge_selectivity is used to reset these variables.
     mutable int _judge_counter = 0;
+    mutable int _judge_input_rows = 0;
+    mutable int _judge_filter_rows = 0;
     mutable bool _always_true = false;
 };
 

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -339,14 +339,13 @@ public:
             }
         }
 
-        if (_can_ignore() && !_judge_counter) {
+        if (_can_ignore()) {
             for (uint16_t i = 0; i < size; i++) {
                 current_passed_rows += flags[i];
             }
             _passed_rows += current_passed_rows;
-            vectorized::VRuntimeFilterWrapper::judge_selectivity(
-                    get_ignore_threshold(), current_evaluated_rows - current_passed_rows,
-                    current_evaluated_rows, _always_true, _judge_counter);
+            do_judge_selectivity(current_evaluated_rows - current_passed_rows,
+                                 current_evaluated_rows);
         }
     }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1761,14 +1761,14 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     SCOPED_RAW_TIMER(&_opts.stats->vec_cond_ns);
     bool all_pred_always_true = true;
     for (const auto& pred : _pre_eval_block_predicate) {
-        if (!pred->always_true(false)) {
+        if (!pred->always_true()) {
             all_pred_always_true = false;
             break;
         }
     }
     if (all_pred_always_true) {
         for (const auto& pred : _pre_eval_block_predicate) {
-            pred->always_true(true);
+            pred->always_true();
         }
     }
 
@@ -1785,7 +1785,7 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     DCHECK(!_pre_eval_block_predicate.empty());
     bool is_first = true;
     for (auto& pred : _pre_eval_block_predicate) {
-        if (pred->always_true(true)) {
+        if (pred->always_true()) {
             continue;
         }
         auto column_id = pred->column_id();

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -155,9 +155,9 @@ public:
     VExprSPtr get_child(int i) const { return _children[i]; }
     int get_num_children() const { return _children.size(); }
 
-    virtual bool need_judge_selectivity() {
+    virtual bool is_rf_wrapper() const {
         return std::ranges::any_of(_children.begin(), _children.end(),
-                                   [](VExprSPtr child) { return child->need_judge_selectivity(); });
+                                   [](VExprSPtr child) { return child->is_rf_wrapper(); });
     }
 
     virtual void do_judge_selectivity(int64_t filter_rows, int64_t input_rows) {

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -63,7 +63,9 @@ namespace doris::vectorized {
 
 VRuntimeFilterWrapper::VRuntimeFilterWrapper(const TExprNode& node, const VExprSPtr& impl,
                                              double ignore_thredhold, bool null_aware)
-        : VExpr(node), _impl(impl), _ignore_thredhold(ignore_thredhold), _null_aware(null_aware) {}
+        : VExpr(node), _impl(impl), _ignore_thredhold(ignore_thredhold), _null_aware(null_aware) {
+    reset_judge_selectivity();
+}
 
 Status VRuntimeFilterWrapper::prepare(RuntimeState* state, const RowDescriptor& desc,
                                       VExprContext* context) {
@@ -88,7 +90,6 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
 
 Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* result_column_id) {
     DCHECK(_open_finished || _getting_const_col);
-    _judge_counter--;
     if (_always_true) {
         size_t size = block->rows();
         block->insert({create_always_true_column(size, _data_type->is_nullable()), _data_type,

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -92,6 +92,9 @@ Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* 
     DCHECK(_open_finished || _getting_const_col);
     DCHECK(_expr_filtered_rows_counter && _expr_input_rows_counter && _always_true_counter)
             << "rf counter must be initialized";
+    if (_judge_counter.fetch_sub(1) == 0) {
+        reset_judge_selectivity();
+    }
     if (_always_true) {
         size_t size = block->rows();
         block->insert({create_always_true_column(size, _data_type->is_nullable()), _data_type,

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -90,6 +90,8 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
 
 Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* result_column_id) {
     DCHECK(_open_finished || _getting_const_col);
+    DCHECK(_expr_filtered_rows_counter && _expr_input_rows_counter && _always_true_counter)
+            << "rf counter must be initialized";
     if (_always_true) {
         size_t size = block->rows();
         block->insert({create_always_true_column(size, _data_type->is_nullable()), _data_type,

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -88,10 +88,6 @@ public:
     void do_judge_selectivity(int64_t filter_rows, int64_t input_rows) override {
         update_counters(filter_rows, input_rows);
 
-        if (_judge_counter.fetch_sub(1) == 0) {
-            reset_judge_selectivity();
-        }
-
         if (!_always_true) {
             _judge_filter_rows += filter_rows;
             _judge_input_rows += input_rows;

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -72,23 +72,7 @@ public:
         _always_true_counter = always_true_counter;
     }
 
-    template <typename T, typename TT>
-    static void judge_selectivity(double ignore_threshold, int64_t filter_rows, int64_t input_rows,
-                                  T& always_true, TT& judge_counter) {
-        always_true = filter_rows / (input_rows * 1.0) < ignore_threshold;
-        judge_counter = config::runtime_filter_sampling_frequency;
-    }
-
-    bool need_judge_selectivity() override {
-        if (_judge_counter <= 0) {
-            _always_true = false;
-            return true;
-        }
-        return false;
-    }
-
-    void do_judge_selectivity(int64_t filter_rows, int64_t input_rows) override {
-        judge_selectivity(_ignore_thredhold, filter_rows, input_rows, _always_true, _judge_counter);
+    void update_counters(int64_t filter_rows, int64_t input_rows) {
         if (_expr_filtered_rows_counter) {
             COUNTER_UPDATE(_expr_filtered_rows_counter, filter_rows);
         }
@@ -97,9 +81,49 @@ public:
         }
     }
 
+    template <typename T>
+    static void judge_selectivity(double ignore_threshold, int64_t filter_rows, int64_t input_rows,
+                                  T& always_true) {
+        always_true = filter_rows / (input_rows * 1.0) < ignore_threshold;
+    }
+
+    bool is_rf_wrapper() const override { return true; }
+
+    void do_judge_selectivity(int64_t filter_rows, int64_t input_rows) override {
+        update_counters(filter_rows, input_rows);
+
+        if (_judge_counter.fetch_sub(1) == 0) {
+            reset_judge_selectivity();
+        }
+
+        if (!_always_true) {
+            _judge_filter_rows += filter_rows;
+            _judge_input_rows += input_rows;
+            judge_selectivity(_ignore_thredhold, _judge_filter_rows, _judge_input_rows,
+                              _always_true);
+        }
+    }
+
 private:
+    void reset_judge_selectivity() {
+        _always_true = false;
+        _judge_counter = config::runtime_filter_sampling_frequency;
+        _judge_input_rows = 0;
+        _judge_filter_rows = 0;
+    }
+
     VExprSPtr _impl;
+    // VRuntimeFilterWrapper and ColumnPredicate share the same logic,
+    // but it's challenging to unify them, so the code is duplicated.
+    // _judge_counter, _judge_input_rows, _judge_filter_rows, and _always_true
+    // are variables used to implement the _always_true logic, calculated periodically
+    // based on runtime_filter_sampling_frequency. During each period, if _always_true
+    // is evaluated as true, the logic for always_true is applied for the rest of that period
+    // without recalculating. At the beginning of the next period,
+    // reset_judge_selectivity is used to reset these variables.
     std::atomic_int _judge_counter = 0;
+    std::atomic_int _judge_input_rows = 0;
+    std::atomic_int _judge_filter_rows = 0;
     std::atomic_int _always_true = false;
 
     RuntimeProfile::Counter* _expr_filtered_rows_counter = nullptr;

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -73,12 +73,8 @@ public:
     }
 
     void update_counters(int64_t filter_rows, int64_t input_rows) {
-        if (_expr_filtered_rows_counter) {
-            COUNTER_UPDATE(_expr_filtered_rows_counter, filter_rows);
-        }
-        if (_expr_input_rows_counter) {
-            COUNTER_UPDATE(_expr_input_rows_counter, input_rows);
-        }
+        COUNTER_UPDATE(_expr_filtered_rows_counter, filter_rows);
+        COUNTER_UPDATE(_expr_input_rows_counter, input_rows);
     }
 
     template <typename T>


### PR DESCRIPTION
## Proposed changes

Adjust the calculation logic for rf's always_true.
The previous approach was to sample one block and determine whether the always_true logic 
would be applied for the subsequent 64 blocks.
The new approach divides the execution into independent periods of 64 blocks each.
At the beginning of each period, the filter rate is accumulated. If always_true is determined, 
the remaining blocks in that period will follow the always_true logic.

Total hot run time: 12269 ms ---> Total hot run time: 11779 ms
<!--Describe your changes.-->

