### PR TITLE
[opt](merge-on-write) avoid to check delete bitmap while lookup rowkey in some situation to reduce CPU cost

### DIFF
--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -441,7 +441,8 @@ Status BaseTablet::lookup_row_key(const Slice& encoded_key, TabletSchema* latest
                                   const std::vector<RowsetSharedPtr>& specified_rowsets,
                                   RowLocation* row_location, uint32_t version,
                                   std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-                                  RowsetSharedPtr* rowset, bool with_rowid) {
+                                  RowsetSharedPtr* rowset, bool with_rowid,
+                                  bool is_partial_update) {
     SCOPED_BVAR_LATENCY(g_tablet_lookup_rowkey_latency);
     size_t seq_col_length = 0;
     // use the latest tablet schema to decide if the tablet has sequence column currently
@@ -457,6 +458,8 @@ Status BaseTablet::lookup_row_key(const Slice& encoded_key, TabletSchema* latest
     Slice key_without_seq =
             Slice(encoded_key.get_data(), encoded_key.get_size() - seq_col_length - rowid_length);
     RowLocation loc;
+
+    bool need_to_check_delete_bitmap = is_partial_update || with_seq_col;
 
     for (size_t i = 0; i < specified_rowsets.size(); i++) {
         auto& rs = specified_rowsets[i];
@@ -496,16 +499,21 @@ Status BaseTablet::lookup_row_key(const Slice& encoded_key, TabletSchema* latest
             if (!s.ok() && !s.is<KEY_ALREADY_EXISTS>()) {
                 return s;
             }
-            if (s.ok() && _tablet_meta->delete_bitmap().contains_agg_without_cache(
-                                  {loc.rowset_id, loc.segment_id, version}, loc.row_id)) {
-                // if has sequence col, we continue to compare the sequence_id of
-                // all rowsets, util we find an existing key.
-                if (schema->has_sequence_col()) {
-                    continue;
+            if (s.ok() && need_to_check_delete_bitmap) {
+                // check if the key is already mark deleted
+                if (_tablet_meta->delete_bitmap().contains_agg_without_cache(
+                            {loc.rowset_id, loc.segment_id, version}, loc.row_id)) {
+                    // if has sequence col, we continue to compare the sequence_id of
+                    // all rowsets, util we find an existing key.
+                    if (with_seq_col) {
+                        continue;
+                    }
+                    // The key is deleted, we need to break the loop and return
+                    // KEY_NOT_FOUND.
+                    break;
                 }
-                // The key is deleted, we don't need to search for it any more.
-                break;
             }
+
             // `st` is either OK or KEY_ALREADY_EXISTS now.
             // for partial update, even if the key is already exists, we still need to
             // read it's original values to keep all columns align.
@@ -661,7 +669,8 @@ Status BaseTablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
 
             RowsetSharedPtr rowset_find;
             auto st = lookup_row_key(key, rowset_schema.get(), true, specified_rowsets, &loc,
-                                     dummy_version.first - 1, segment_caches, &rowset_find);
+                                     dummy_version.first - 1, segment_caches, &rowset_find, false,
+                                     is_partial_update);
             bool expected_st = st.ok() || st.is<KEY_NOT_FOUND>() || st.is<KEY_ALREADY_EXISTS>();
             // It's a defensive DCHECK, we need to exclude some common errors to avoid core-dump
             // while stress test

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -153,7 +153,8 @@ public:
                           const std::vector<RowsetSharedPtr>& specified_rowsets,
                           RowLocation* row_location, uint32_t version,
                           std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-                          RowsetSharedPtr* rowset = nullptr, bool with_rowid = true);
+                          RowsetSharedPtr* rowset = nullptr, bool with_rowid = true,
+                          bool is_partial_update = false);
 
     // calc delete bitmap when flush memtable, use a fake version to calc
     // For example, cur max version is 5, and we use version 6 to calc but


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

MoW performs a lookup on the primary key index for each key during the data loading process, and when a key is hit in the index, it continues to check if the key has been marked for deletion. Generally this check is not very costly.
However, in some scenarios, users perform high-frequency real-time update operations on a larger table, and most of the writes are updating existing data. In this scenario, the version of the table grows very fast, and the delete bitmap is also dense because duplicate keys are continuously being written.
In this scenario, this check is very costly
1. because it means calling the contains method of the roaring bitmap for almost every version of the rowset hit by an imported key to check if it has been marked for deletion
2. due to the high frequency of imports, there are typically thousands of versions that are not merged to base compaction.
3. because of the high duplication rate, every key is basically hit in the index
4. so this means that for almost every imported key, a loop needs to be called up to thousands of times to check if it has been marked for deletion
5. This overhead becomes very exaggerated when we are doing load jobs of about 100,000+ rows per second for a table

Here's a flame diagram for this scenario
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/0dad0705-577d-4fad-945c-6e5b2983d3e3">

For tables that don't use seq columns, and for non-column update imports, this check can be skipped. Even if a key is already marked for deletion, it's not a problem to mark it for deletion again as if it existed.

