### PR TITLE
[fix](ubsan) fix ubsan : runtime error: applying non-zero offset 16 to null pointer

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -403,7 +403,7 @@ public:
 
     template <typename U, typename... TAllocatorParams>
     void push_back(U&& x, TAllocatorParams&&... allocator_params) {
-        if (UNLIKELY(this->c_end + sizeof(T) > this->c_end_of_storage)) {
+        if (UNLIKELY(this->c_end == nullptr || this->c_end + sizeof(T) > this->c_end_of_storage)) {
             this->reserve_for_next_size(std::forward<TAllocatorParams>(allocator_params)...);
         }
 


### PR DESCRIPTION
## Proposed changes

```
/root/doris/be/src/vec/common/pod_array.h:406:13: runtime error: applying non-zero offset 16 to null pointer
    #0 0x55827f4bbf0c in void doris::vectorized::PODArray<__int128, 4096ul, Allocator<false, false, false, DefaultMemoryAllocator>, 0ul, 0ul>::push_back<__int128&>(__int128&) /root/doris/be/src/vec/common/pod_array.h:406:13
    #1 0x55827f4baa40 in doris::Counts<__int128>::increment(__int128) /root/doris/be/src/util/counts.h:160:36
    #2 0x55827f4baa40 in doris::vectorized::PercentileState<__int128>::add(__int128, doris::vectorized::PODArray<double, 4096ul, Allocator<false, false, false, DefaultMemoryAllocator>, 16ul, 15ul> const&, int) /root/doris/be/src/vec/aggregate_functions/aggregate_function_percentile.h:634:27
    #3 0x55827f6ca40f in doris::vectorized::AggregateFunctionNullVariadicInline<doris::vectorized::AggregateFunctionPercentileArray<__int128>, false>::add(char*, doris::vectorized::IColumn const**, long, doris::vectorized::Arena*) const /root/doris/be/src/vec/aggregate_functions/aggregate_function_null.h:324:32
    #4 0x55827f6cef0e in doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionNullVariadicInline<doris::vectorized::AggregateFunctionPercentileArray<__int128>, false> >::add_batch(unsigned long, char**, unsigned long, doris::vectorized::IColumn const**, doris::vectorized::Arena*, bool) const /root/doris/be/src/vec/aggregate_functions/aggregate_function.h:273:22
    #5 0x5582a0c41059 in doris::vectorized::AggFnEvaluator::execute_batch_add(doris::vectorized::Block*, unsigned long, char**, doris::vectorized::Arena*, bool) /root/doris/be/src/vec/exprs/vectorized_agg_fn.cpp:241:16
    #6 0x5582a0c39037 in doris::Status doris::pipeline::AggSinkLocalState::_execute_with_serialized_key_helper<false>(doris::vectorized::Block*)::'lambda'()::operator()() const /root/doris/be/src/pipeline/exec/aggregation_sink_operator.cpp:481:17
    #7 0x5582a0b51e1e in doris::Status doris::pipeline::AggSinkLocalState::_execute_with_serialized_key_helper<false>(doris::vectorized::Block*) /root/doris/be/src/pipeline/exec/aggregation_sink_operator.cpp:497:13
    #8 0x5582a0a014e1 in doris::pipeline::AggSinkLocalState::_execute_with_serialized_key(doris::vectorized::Block*) /root/doris/be/src/pipeline/exec/aggregation_sink_operator.cpp:437:16
    #9 0x5582a0c37811 in doris::pipeline::AggSinkLocalState::Executor<false, false>::execute(doris::pipeline::AggSinkLocalState*, doris::vectorized::Block*) /root/doris/be/src/pipeline/exec/aggregation_sink_operator.h:61:41
```

<!--Describe your changes.-->

