### PR TITLE
[fix](move-memtable) detect repeated stream open due to retry

### DIFF
--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -126,6 +126,8 @@ public:
         }
     }
 
+    void increase_use_count() { _total_streams++; }
+
     void close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
                std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
 

--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -126,7 +126,7 @@ public:
         }
     }
 
-    void increase_use_count() { _total_streams++; }
+    void increase_total_streams() { _total_streams++; }
 
     void close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
                std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);

--- a/be/src/runtime/load_stream_mgr.cpp
+++ b/be/src/runtime/load_stream_mgr.cpp
@@ -65,7 +65,7 @@ Status LoadStreamMgr::open_load_stream(const POpenLoadStreamRequest* request,
         load_stream->add_source(request->src_id());
         if (_known_connections.contains(conn_id)) {
             // detected retry open, increase total streams
-            load_stream->increase_use_count();
+            load_stream->increase_total_streams();
         } else {
             _known_connections.insert(conn_id);
         }

--- a/be/src/runtime/load_stream_mgr.h
+++ b/be/src/runtime/load_stream_mgr.h
@@ -68,6 +68,7 @@ public:
 private:
     std::mutex _lock;
     std::unordered_map<UniqueId, LoadStreamPtr> _load_streams_map;
+    std::unordered_set<UniqueId> _known_connections;
     std::unique_ptr<ThreadPool> _file_writer_thread_pool;
 
     uint32_t _num_threads = 0;

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -166,6 +166,14 @@ inline TUniqueId generate_uuid() {
     return uid;
 }
 
+inline PUniqueId generate_uuid_p() {
+    auto uuid = boost::uuids::basic_random_generator<boost::mt19937>()();
+    PUniqueId uid;
+    uid.set_hi(reinterpret_cast<int64_t*>(uuid.data)[0]);
+    uid.set_lo(reinterpret_cast<int64_t*>(uuid.data)[1]);
+    return uid;
+}
+
 std::ostream& operator<<(std::ostream& os, const UniqueId& uid);
 
 std::string print_id(const TUniqueId& id);

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -166,6 +166,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     cntl.set_timeout_ms(config::open_load_stream_timeout_ms);
     POpenLoadStreamRequest request;
     *request.mutable_load_id() = _load_id;
+    *request.mutable_connection_id() = _connection_id;
     request.set_src_id(_src_id);
     request.set_txn_id(txn_id);
     request.set_enable_profile(enable_profile);

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -62,6 +62,7 @@
 #include "util/debug_points.h"
 #include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
+#include "util/uid_util.h"
 #include "vec/columns/column.h"
 #include "vec/common/allocator.h"
 #include "vec/core/block.h"
@@ -235,6 +236,7 @@ protected:
     std::atomic<bool> _is_cancelled;
     std::atomic<bool> _is_eos;
 
+    PUniqueId _connection_id = generate_uuid_p();
     PUniqueId _load_id;
     brpc::StreamId _stream_id;
     int64_t _src_id = -1; // source backend_id

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -874,6 +874,7 @@ message POpenLoadStreamRequest {
     optional bool enable_profile = 6 [default = false];
     optional int64 total_streams = 7;
     optional int64 idle_timeout_ms = 8;
+    optional PUniqueId connection_id = 9;
 }
 
 message PTabletSchemaWithIndex {


### PR DESCRIPTION
## Proposed changes

There may be retries when `LoadStreamStub::open` fails, causing the expected total streams count less than the actual open count.
