### PR TITLE
[enhance](mtmv)Mtmv support audit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -200,7 +200,7 @@ public class MTMVTask extends AbstractTask {
                 // need get names before exec
                 Map<String, MTMVRefreshPartitionSnapshot> execPartitionSnapshots = MTMVPartitionUtil
                         .generatePartitionSnapshots(context, relation.getBaseTablesOneLevel(), execPartitionNames);
-                exec(ctx, execPartitionNames, tableWithPartKey);
+                exec(execPartitionNames, tableWithPartKey);
                 completedPartitions.addAll(execPartitionNames);
                 partitionSnapshots.putAll(execPartitionSnapshots);
             }
@@ -215,10 +215,10 @@ public class MTMVTask extends AbstractTask {
         }
     }
 
-    private void exec(ConnectContext ctx, Set<String> refreshPartitionNames,
+    private void exec(Set<String> refreshPartitionNames,
             Map<TableIf, String> tableWithPartKey)
             throws Exception {
-        Objects.requireNonNull(ctx, "ctx should not be null");
+        ConnectContext ctx = MTMVPlanUtil.createMTMVContext(mtmv);
         StatementContext statementContext = new StatementContext();
         ctx.setStatementContext(statementContext);
         TUniqueId queryId = generateQueryId();
@@ -228,7 +228,6 @@ public class MTMVTask extends AbstractTask {
                 .from(mtmv, mtmv.getMvPartitionInfo().getPartitionType() != MTMVPartitionType.SELF_MANAGE
                         ? refreshPartitionNames : Sets.newHashSet(), tableWithPartKey);
         try {
-            ctx.setStartTime();
             executor = new StmtExecutor(ctx, new LogicalPlanAdapter(command, ctx.getStatementContext()));
             ctx.setExecutor(executor);
             ctx.setQueryId(queryId);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -250,7 +250,8 @@ public class MTMVTask extends AbstractTask {
 
     private String getDummyStmt(Set<String> refreshPartitionNames) {
         return String.format(
-                "Asynchronous materialized view refresh task, taskId: %s, partitions refreshed by this insert overwrite: %s",
+                "Asynchronous materialized view refresh task, "
+                        + "taskId: %s, partitions refreshed by this insert overwrite: %s",
                 super.getTaskId(), refreshPartitionNames);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -242,10 +242,16 @@ public class MTMVTask extends AbstractTask {
             }
         } finally {
             if (executor != null) {
-                AuditLogHelper.logAuditLog(ctx, executor.getOriginStmt().originStmt,
+                AuditLogHelper.logAuditLog(ctx, getDummyStmt(refreshPartitionNames),
                         executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(), true);
             }
         }
+    }
+
+    private String getDummyStmt(Set<String> refreshPartitionNames) {
+        return String.format(
+                "Asynchronous materialized view refresh task, taskId: %s, partitions refreshed by this insert overwrite: %s",
+                super.getTaskId(), refreshPartitionNames);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -250,9 +250,9 @@ public class MTMVTask extends AbstractTask {
 
     private String getDummyStmt(Set<String> refreshPartitionNames) {
         return String.format(
-                "Asynchronous materialized view refresh task, "
+                "Asynchronous materialized view refresh task, mvName: %s,"
                         + "taskId: %s, partitions refreshed by this insert overwrite: %s",
-                super.getTaskId(), refreshPartitionNames);
+                mtmv.getName(), super.getTaskId(), refreshPartitionNames);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -228,6 +228,7 @@ public class MTMVTask extends AbstractTask {
                 .from(mtmv, mtmv.getMvPartitionInfo().getPartitionType() != MTMVPartitionType.SELF_MANAGE
                         ? refreshPartitionNames : Sets.newHashSet(), tableWithPartKey);
         try {
+            ctx.setStartTime();
             executor = new StmtExecutor(ctx, new LogicalPlanAdapter(command, ctx.getStatementContext()));
             ctx.setExecutor(executor);
             ctx.setQueryId(queryId);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
@@ -59,6 +59,7 @@ public class MTMVPlanUtil {
         if (workloadGroup.isPresent()) {
             ctx.getSessionVariable().setWorkloadGroup(workloadGroup.get());
         }
+        ctx.setStartTime();
         return ctx;
     }
 


### PR DESCRIPTION
mtmv not have real sql, fill stmt with a string containing taskId and partitionNames information

select * from __internal_schema.audit_log;
```
query_id: e0c4d330b49742c7-99dcf9903ad94b51
             time: 2024-09-30 15:19:05.216
        client_ip: 
             user: admin
          catalog: internal
               db: 
            state: OK
       error_code: 0
    error_message: 
       query_time: 119
       scan_bytes: 4542464
        scan_rows: 244
      return_rows: 244
          stmt_id: 0
        stmt_type: INSERT
         is_query: 0
      frontend_ip: 127.0.0.1
      cpu_time_ms: 4
         sql_hash: null
       sql_digest: 
peak_memory_bytes: 2829184
   workload_group: normal
             stmt: Asynchronous materialized view refresh task, taskId: 260885015586390, partitions refreshed by this insert overwrite: [mv_log]
```

