### PR TITLE
[bugfix](brpc) Should use status to generate protobuf message, because it will encoding Backend Info (#41515)

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -189,9 +189,11 @@ concept CanCancel = requires(T* response) { response->mutable_status(); };
 template <CanCancel T>
 void offer_failed(T* response, google::protobuf::Closure* done, const FifoThreadPool& pool) {
     brpc::ClosureGuard closure_guard(done);
-    response->mutable_status()->set_status_code(TStatusCode::CANCELLED);
-    response->mutable_status()->add_error_msgs("fail to offer request to the work pool, pool=" +
-                                               pool.get_info());
+    // Should use status to generate protobuf message, because it will encoding Backend Info
+    // into the error message and then we could know which backend's pool is full.
+    Status st = Status::Error<TStatusCode::CANCELLED>(
+            "fail to offer request to the work pool, pool={}", pool.get_info());
+    st.to_protobuf(response->mutable_status());
     LOG(WARNING) << "cancelled due to fail to offer request to the work pool, pool="
                  << pool.get_info();
 }


### PR DESCRIPTION

pick  #41515
Should use status to generate protobuf message, because it will encoding Backend Info

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

