### PR TITLE
[ubsan](PODArray)Avoid  applying non-zero offset to null pointer

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -403,7 +403,7 @@ public:
 
     template <typename U, typename... TAllocatorParams>
     void push_back(U&& x, TAllocatorParams&&... allocator_params) {
-        if (UNLIKELY(this->c_end == nullptr || this->c_end + sizeof(T) > this->c_end_of_storage)) {
+        if (UNLIKELY(this->c_end + sizeof(T) > this->c_end_of_storage)) {
             this->reserve_for_next_size(std::forward<TAllocatorParams>(allocator_params)...);
         }
 
@@ -445,8 +445,7 @@ public:
       */
     template <typename... Args>
     void emplace_back(Args&&... args) {
-        if (UNLIKELY(this->c_end == nullptr ||
-                     (this->c_end + sizeof(T) > this->c_end_of_storage))) {
+        if (UNLIKELY(this->c_end + sizeof(T) > this->c_end_of_storage)) {
             this->reserve_for_next_size();
         }
 

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -114,8 +114,7 @@ protected:
     /// pad_left is also rounded up to 16 bytes to maintain alignment of allocated memory.
     static constexpr size_t pad_left = integerRoundUp(integerRoundUp(pad_left_, ELEMENT_SIZE), 16);
     /// Empty array will point to this static memory as padding.
-    static constexpr char* null =
-            pad_left ? const_cast<char*>(empty_pod_array) + EmptyPODArraySize : nullptr;
+    static constexpr char* null = const_cast<char*>(empty_pod_array) + pad_left;
 
     static_assert(pad_left <= EmptyPODArraySize &&
                   "Left Padding exceeds EmptyPODArraySize. Is the element size too large?");


### PR DESCRIPTION
## Proposed changes
The original code would generate a null c_end when there is no padding.
before
```
    static constexpr char* null =
            pad_left ? const_cast<char*>(empty_pod_array) + EmptyPODArraySize : nullptr;
```
now
```
    static constexpr char* null = const_cast<char*>(empty_pod_array) + pad_left;
```


<!--Describe your changes.-->

