### PR TITLE
[fix](Nereids) fix fold constant by be return type mismatched (#39723)(#41164)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -109,7 +109,16 @@ public class FoldConstantRuleOnBE extends AbstractExpressionRewriteRule {
             if (newChild != child) {
                 hasNewChildren = true;
             }
-            newChildren.add(newChild);
+            if (!newChild.getDataType().equals(child.getDataType())) {
+                try {
+                    newChildren.add(newChild.castTo(child.getDataType()));
+                } catch (Exception e) {
+                    LOG.warn("expression of type {} cast to {} failed. ", newChild.getDataType(), child.getDataType());
+                    newChildren.add(newChild);
+                }
+            } else {
+                newChildren.add(newChild);
+            }
         }
         return hasNewChildren ? root.withChildren(newChildren) : root;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WindowExpression.java
@@ -66,7 +66,6 @@ public class WindowExpression extends Expression {
                 .add(function)
                 .addAll(partitionKeys)
                 .addAll(orderKeys)
-                .add(windowFrame)
                 .build());
         this.function = function;
         this.partitionKeys = ImmutableList.copyOf(partitionKeys);
@@ -146,6 +145,9 @@ public class WindowExpression extends Expression {
 
         if (index < children.size()) {
             return new WindowExpression(func, partitionKeys, orderKeys, (WindowFrame) children.get(index));
+        }
+        if (windowFrame.isPresent()) {
+            return new WindowExpression(func, partitionKeys, orderKeys, windowFrame.get());
         }
         return new WindowExpression(func, partitionKeys, orderKeys);
     }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -40,4 +40,9 @@ suite("fold_constant_by_be") {
     sql """ INSERT INTO str_tb VALUES (2, repeat("test1111", 10000)); """
 
     qt_sql_1 """ select length(v1) from str_tb; """
+    
+    explain {
+        sql("verbose select substring('123456', 1, 3)")
+        contains "varchar(3)"
+    }
 }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -45,4 +45,29 @@ suite("fold_constant_by_be") {
         sql("verbose select substring('123456', 1, 3)")
         contains "varchar(3)"
     }
+
+    sql "drop table if exists table_200_undef_partitions2_keys3_properties4_distributed_by53"
+    sql """create table table_200_undef_partitions2_keys3_properties4_distributed_by53 (
+                    pk int,
+                    col_char_255__undef_signed char(255)  null  ,
+                    col_char_100__undef_signed char(100)  null  ,
+                    col_char_255__undef_signed_not_null char(255)  not null  ,
+                    col_char_100__undef_signed_not_null char(100)  not null  ,
+                    col_varchar_255__undef_signed varchar(255)  null  ,
+                    col_varchar_255__undef_signed_not_null varchar(255)  not null  ,
+                    col_varchar_1000__undef_signed varchar(1000)  null  ,
+                    col_varchar_1000__undef_signed_not_null varchar(1000)  not null  ,
+                    col_varchar_1001__undef_signed varchar(1001)  null  ,
+                    col_varchar_1001__undef_signed_not_null varchar(1001)  not null  
+                    ) engine=olap
+                    DUPLICATE KEY(pk, col_char_255__undef_signed, col_char_100__undef_signed)
+                    distributed by hash(pk) buckets 10
+                    properties("replication_num" = "1");"""
+    explain {
+        sql("select LAST_VALUE(col_char_255__undef_signed_not_null, false) over (partition by " +
+                "concat('GkIPbzAZSu', col_char_100__undef_signed), mask('JrqFkEDqeA') " +
+                "order by pk rows between unbounded preceding and 6 following) AS col_alias26947 " +
+                "from table_200_undef_partitions2_keys3_properties4_distributed_by53;")
+        notContains("mask")
+    }
 }


### PR DESCRIPTION
cherry-pick: #39723 #41164 because later problem is intro by prev one, so put them together
 when using fold constant by be, the return type of substring('123456',1, 3) would changed to be text, which we want it to be 3
remove windowframe in window expression to avoid folding constant on be
    

