### PR TITLE
[fix](ce) Wshorten-64-to-32-error in incr_created_tasks

### DIFF
--- a/be/src/pipeline/pipeline.h
+++ b/be/src/pipeline/pipeline.h
@@ -105,7 +105,7 @@ public:
     void set_children(std::shared_ptr<Pipeline> child) { _children.push_back(child); }
     void set_children(std::vector<std::shared_ptr<Pipeline>> children) { _children = children; }
 
-    void incr_created_tasks(int i, PipelineTask* task) {
+    void incr_created_tasks(size_t i, PipelineTask* task) {
         _num_tasks_created++;
         _num_tasks_running++;
         DCHECK_LT(i, _tasks.size());


### PR DESCRIPTION
## Proposed changes
```
 error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
  475 |                 pipeline->incr_created_tasks(i, task.get());
```
Issue Number: close #xxx

<!--Describe your changes.-->

