### PR TITLE
[fix](crash) fix be crash because of int overflow

### DIFF
--- a/be/src/pipeline/task_queue.h
+++ b/be/src/pipeline/task_queue.h
@@ -147,7 +147,7 @@ private:
             int core_id, std::vector<std::unique_ptr<PriorityTaskQueue>>& prio_task_queue_list);
 
     std::shared_ptr<std::vector<std::unique_ptr<PriorityTaskQueue>>> _prio_task_queue_list;
-    std::atomic<int> _next_core = 0;
+    std::atomic<uint32_t> _next_core = 0;
     std::atomic<bool> _closed;
 };
 


### PR DESCRIPTION
come from: https://github.com/apache/doris/pull/38514

After long run, MultiCoreTaskQueue::_next_core overflow, make `core_id = _next_core.fetch_add(1) % _core_size;` got negative value

The crash stack:
```
#0  doris::pipeline::PriorityTaskQueue::push (this=0x0, task=task@entry=0x7f6a4cb4d800) at /root/be/src/pipeline/task_queue.cpp:115
#1  0x0000564e19c729fd in doris::pipeline::MultiCoreTaskQueue::push_back (this=0x7f6b59551990, task=0x7f6a4cb4d800, core_id=-31)
    at /root/be/src/pipeline/task_queue.cpp:216
#2  0x0000564e19c72934 in doris::pipeline::MultiCoreTaskQueue::push_back (this=0x0, task=0x0) at /root/be/src/pipeline/task_queue.cpp:208
#3  0x0000564e19c763f3 in doris::pipeline::TaskScheduler::schedule_task (this=<optimized out>, task=0x7f6a4cb4d800)
    at /root/be/src/pipeline/task_scheduler.cpp:224
#4  0x0000564e19c4cc24 in doris::pipeline::PipelineXFragmentContext::submit (this=0x7f6a4da5bc10)
    at /root/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp:1418
#5  0x0000564e0ff86683 in doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, doris::QuerySource, std::function<void (doris::RuntimeState*, doris::Status*)> const&) (this=this@entry=0x7f6e94a67000, params=..., query_source=<optimized out>, cb=...)
    at /root/be/src/runtime/fragment_mgr.cpp:1013
#6  0x0000564e0ff84e80 in doris::FragmentMgr::exec_plan_fragment (this=0x7f6e94a67000, params=..., query_source=3680166656)
    at /root/be/src/runtime/fragment_mgr.cpp:685
#7  0x0000564e1014b4d5 in doris::PInternalServiceImpl::_exec_plan_fragment_impl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::PFragmentRequestVersion, bool, std::function<void (doris::RuntimeState*, doris::Status*)> const&) (this=this@entry=0x7f6f01d21300, 
    ser_request=..., version=<optimized out>, compact=<optimized out>, cb=...) at /root/be/src/service/internal_service.cpp:582
#8  0x0000564e1014ae02 in doris::PInternalServiceImpl::_exec_plan_fragment_in_pthread (this=0x7f6f01d21300, controller=<optimized out>, request=
    0x7f6a9f1bb020, response=0x7f689e352d00, done=0x7f689e352d40) at /root/be/src/service/internal_service.cpp:328
#9  0x0000564e10171b9b in std::function<void ()>::operator()() const (this=<optimized out>)
    at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#10 doris::WorkThreadPool<false>::work_thread (this=0x7f6f01d214b8, thread_id=<optimized out>) at /root/be/src/util/work_thread_pool.hpp:158
#11 0x0000564e1c7b0d60 in std::execute_native_thread_routine (__p=0x7f6f00ef6970) at ../../../../../libstdc++-v3/src/c++11/thread.cc:82
#12 0x00007f6f03d77ea5 in start_thread () from /lib64/libpthread.so.0
#13 0x00007f6f047a69fd in clone () from /lib64/libc.so.6
```