### PR TITLE
[Fix](inverted index) add DATEV2 and DATETIMEV2 for inverted index reader

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -407,6 +407,8 @@ public:
             M(PrimitiveType::TYPE_CHAR)
             M(PrimitiveType::TYPE_VARCHAR)
             M(PrimitiveType::TYPE_STRING)
+            M(PrimitiveType::TYPE_DATEV2)
+            M(PrimitiveType::TYPE_DATETIMEV2)
 #undef M
         default:
             return Status::NotSupported("Unsupported primitive type {} for inverted index reader",


### PR DESCRIPTION
## Proposed changes

This PR adds support for DATEV2 and DATETIMEV2 types in the inverted index reader, aligning with the types already allowed in the inverted index writer.
