### PR TITLE
[Enhancement](inverted index) return OK instead of not supported in expr evaluate_inverted_index

### DIFF
--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -120,7 +120,7 @@ public:
 
     // execute current expr with inverted index to filter block. Given a roaring bitmap of match rows
     virtual Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) {
-        return Status::NotSupported("Not supported execute_with_inverted_index");
+        return Status::OK();
     }
 
     Status _evaluate_inverted_index(VExprContext* context, const FunctionBasePtr& function,

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -195,8 +195,7 @@ public:
             const std::vector<vectorized::IndexFieldNameAndTypePair>& data_type_with_names,
             std::vector<segment_v2::InvertedIndexIterator*> iterators, uint32_t num_rows,
             segment_v2::InvertedIndexResultBitmap& bitmap_result) const {
-        return Status::NotSupported("evaluate_inverted_index is not supported in function: ",
-                                    get_name());
+        return Status::OK();
     }
 
     /// Do cleaning work when function is finished, i.e., release state variables in the


### PR DESCRIPTION
## Proposed changes

Fix annoying error stack info

