### PR TITLE
[Compile](fix) Fix mac complie BE error because codecvt_utf8_utf16 deprecated in C++17 and atomic_long not support in mac

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -236,7 +236,7 @@ protected:
 
     // for scaling up the running scanners
     size_t _estimated_block_size = 0;
-    std::atomic_long _block_memory_usage = 0;
+    std::atomic<int64_t> _block_memory_usage = 0;
     int64_t _last_scale_up_time = 0;
     int64_t _last_fetch_time = 0;
     int64_t _total_wait_block_time = 0;

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -22,9 +22,9 @@
 #include <algorithm>
 #include <array>
 #include <boost/iterator/iterator_facade.hpp>
+#include <boost/locale.hpp>
 #include <climits>
 #include <cmath>
-#include <codecvt>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
@@ -448,8 +448,7 @@ public:
 
 private:
     std::u16string _string_to_u16string(const std::string& str) const {
-        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-        return convert.from_bytes(str);
+        return boost::locale::conv::utf_to_utf<char16_t>(str);
     }
 
     std::string _string_to_unicode(const std::u16string& s) const {


### PR DESCRIPTION
## Proposed changes

 Fix mac complie BE error because codecvt_utf8_utf16 deprecated in C++17 and atomic_long not support in mac