### PR TITLE
[chore](plugin)It's allowed for the plugin directory to be empty when loading plugins

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ClassLoaderUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ClassLoaderUtils.java
@@ -22,6 +22,8 @@ import org.apache.doris.mysql.authenticate.AuthenticatorFactory;
 import org.apache.doris.mysql.privilege.AccessControllerFactory;
 
 import org.apache.commons.collections.map.HashedMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,6 +59,7 @@ import java.util.ServiceLoader;
  * @see ChildFirstClassLoader
  */
 public class ClassLoaderUtils {
+    private static final Logger LOG = LogManager.getLogger(ClassLoaderUtils.class);
     // A mapping of service class simple names to their respective plugin directories.
     private static final Map<String, String> pluginDirMapping = new HashedMap();
 
@@ -99,7 +102,8 @@ public class ClassLoaderUtils {
 
         File[] jarFiles = jarDir.listFiles((dir, name) -> name.endsWith(".jar"));
         if (jarFiles == null || jarFiles.length == 0) {
-            throw new IOException("No JAR files found in the specified directory: " + pluginDir);
+            LOG.info("No JAR files found in the plugin directory: {}", pluginDir);
+            return new ArrayList<>();
         }
 
         List<T> services = new ArrayList<>();


### PR DESCRIPTION

## Proposed changes
 in #41100 An exception will be thrown if the user creates the plugin directory but it is empty.
When loading plugins, it's acceptable for the plugin directory to be empty. Users might create the directory without placing any plugins inside, but since some plugins are still located on the classpath, this doesn’t cause any issues. If users specify a particular plugin but don’t place it in the directory, the business logic should handle that situation. The general-purpose class shouldn’t be concerned with this.

