### PR TITLE
[enhancement](util) print if using nereids planner when be coredump #31981

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -54,6 +54,7 @@ namespace doris::signal {
 inline thread_local uint64 query_id_hi;
 inline thread_local uint64 query_id_lo;
 inline thread_local int64_t tablet_id = 0;
+inline thread_local bool is_nereids = false;
 
 namespace {
 
@@ -243,6 +244,9 @@ void DumpTimeInfo() {
     formatter.AppendUint64(query_id_hi, 16);
     formatter.AppendString("-");
     formatter.AppendUint64(query_id_lo, 16);
+    formatter.AppendString(" ***\n");
+    formatter.AppendString("*** is nereids: ");
+    formatter.AppendUint64(is_nereids, 10);
     formatter.AppendString(" ***\n");
     formatter.AppendString("*** tablet id: ");
     formatter.AppendUint64(tablet_id, 10);
@@ -434,6 +438,10 @@ inline void set_signal_task_id(PUniqueId tid) {
 inline void set_signal_task_id(TUniqueId tid) {
     query_id_hi = tid.hi;
     query_id_lo = tid.lo;
+}
+
+inline void set_signal_is_nereids(bool is_nereids_arg) {
+    is_nereids = is_nereids_arg;
 }
 
 inline void InstallFailureSignalHandler() {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -681,7 +681,7 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
         // This may be a first fragment request of the query.
         // Create the query fragments context.
         query_ctx = QueryContext::create_shared(params.fragment_num_on_host, _exec_env,
-                                                params.query_options);
+                                                params.query_options,params.is_nereids);
         query_ctx->query_id = query_id;
         RETURN_IF_ERROR(DescriptorTbl::create(&(query_ctx->obj_pool), params.desc_tbl,
                                               &(query_ctx->desc_tbl)));
@@ -812,6 +812,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
     std::shared_ptr<QueryContext> query_ctx;
     bool pipeline_engine_enabled = params.query_options.__isset.enable_pipeline_engine &&
                                    params.query_options.enable_pipeline_engine;
+
     RETURN_IF_ERROR(
             _get_query_ctx(params, params.params.query_id, pipeline_engine_enabled, query_ctx));
     {

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -51,8 +51,10 @@ class QueryContext {
     ENABLE_FACTORY_CREATOR(QueryContext);
 
 public:
-    QueryContext(int total_fragment_num, ExecEnv* exec_env, const TQueryOptions& query_options)
-            : fragment_num(total_fragment_num),
+    QueryContext(int total_fragment_num, ExecEnv* exec_env, const TQueryOptions& query_options,
+                 bool is_nereids)
+            : _is_nereids(is_nereids),
+              fragment_num(total_fragment_num),
               timeout_second(-1),
               _exec_env(exec_env),
               _runtime_filter_mgr(new RuntimeFilterMgr(TUniqueId(), this)),
@@ -222,12 +224,16 @@ public:
 public:
     TUniqueId query_id;
     DescriptorTbl* desc_tbl;
+
+    bool is_nereids() const { return _is_nereids; }
+
     bool set_rsc_info = false;
     std::string user;
     std::string group;
     TNetworkAddress coord_addr;
     TNetworkAddress current_connect_fe;
     TQueryGlobals query_globals;
+    const bool _is_nereids;
 
     /// In the current implementation, for multiple fragments executed by a query on the same BE node,
     /// we store some common components in QueryContext, and save QueryContext in FragmentMgr.

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -392,6 +392,12 @@ bool RuntimeState::enable_page_cache() const {
 }
 
 bool RuntimeState::is_nereids() const {
+#ifdef BE_TEST
+    if (_query_ctx == nullptr) {
+        return false;
+    }
+#endif
+    DCHECK(_query_ctx);
     return _query_ctx->is_nereids();
 }
 } // end namespace doris

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -34,6 +34,7 @@
 #include "runtime/load_path_mgr.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/memory/thread_mem_tracker_mgr.h"
+#include "runtime/query_context.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/thread_context.h"
 #include "util/timezone_utils.h"
@@ -390,4 +391,7 @@ bool RuntimeState::enable_page_cache() const {
            (_query_options.__isset.enable_page_cache && _query_options.enable_page_cache);
 }
 
+bool RuntimeState::is_nereids() const {
+    return _query_ctx->is_nereids();
+}
 } // end namespace doris

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -450,6 +450,9 @@ public:
                        : 0;
     }
 
+
+    bool is_nereids() const;
+
 private:
     Status create_error_log_file();
 

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -40,6 +40,7 @@ AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
 AttachTask::AttachTask(RuntimeState* runtime_state) {
     SwitchBthreadLocal::switch_to_bthread_local();
     signal::set_signal_task_id(runtime_state->query_id());
+    signal::set_signal_is_nereids(runtime_state->is_nereids());
     thread_context()->attach_task(runtime_state->query_id(), runtime_state->fragment_instance_id(),
                                   runtime_state->query_mem_tracker());
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -3203,6 +3203,7 @@ public class Coordinator implements CoordInterface {
             for (int i = 0; i < instanceExecParams.size(); ++i) {
                 final FInstanceExecParam instanceExecParam = instanceExecParams.get(i);
                 TExecPlanFragmentParams params = new TExecPlanFragmentParams();
+                params.setIsNereids(ConnectContext.get() != null ? ConnectContext.get().getState().isNereids() : false);
                 params.setProtocolVersion(PaloInternalServiceVersion.V1);
                 params.setFragment(fragment.toThrift());
                 params.setDescTbl(descTable);
@@ -3302,6 +3303,8 @@ public class Coordinator implements CoordInterface {
                     TPipelineFragmentParams params = new TPipelineFragmentParams();
 
                     // Set global param
+                    params.setIsNereids(
+                            ConnectContext.get() != null ? ConnectContext.get().getState().isNereids() : false);
                     params.setProtocolVersion(PaloInternalServiceVersion.V1);
                     params.setDescTbl(descTable);
                     params.setQueryId(queryId);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -464,6 +464,8 @@ struct TExecPlanFragmentParams {
   // scan node id -> scan range params, only for external file scan
   24: optional map<Types.TPlanNodeId, PlanNodes.TFileScanRangeParams> file_scan_params
 
+  31: optional bool is_nereids = true;
+
   32: optional Types.TNetworkAddress current_connect_fe
 }
 
@@ -680,6 +682,8 @@ struct TPipelineFragmentParams {
   // scan node id -> scan range params, only for external file scan
   29: optional map<Types.TPlanNodeId, PlanNodes.TFileScanRangeParams> file_scan_params
   43: optional Types.TNetworkAddress current_connect_fe
+
+  40: optional bool is_nereids = true;
 }
 
 struct TPipelineFragmentParamsList {


### PR DESCRIPTION
## Proposed changes

pick https://github.com/apache/doris/pull/31752
pick https://github.com/apache/doris/pull/31981


```
*** Query id: 77433c763b14535-be989f185c71e240 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1728464190 (unix time) try "date -d @1728464190" if you are using GNU date ***
*** Current BE git commitID: eaaf726019 ***
*** SIGABRT unknown detail explain (@0x47000060661) received by PID 394849 (TID 395426 OR 0x7ff4a5f36700) from PID 394849; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/yanxuecheng/branch-2.0/doris/be/src/common/signal_handler.h:421
 1# 0x00007FF6CED47B50 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6



*** Query id: 1b3633126e640e0-b1f06a5bb6c0b1cc ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1728464469 (unix time) try "date -d @1728464469" if you are using GNU date ***
*** Current BE git commitID: eaaf726019 ***
*** SIGABRT unknown detail explain (@0x4700006f5b8) received by PID 456120 (TID 456600 OR 0x7f72da8df700) from PID 456120; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/yanxuecheng/branch-2.0/doris/be/src/common/signal_handler.h:421
 1# 0x00007F745021BB50 in /lib64/libc.so.6
```


Issue Number: close #xxx

<!--Describe your changes.-->

