### PR TITLE
[bugfix](segmentload) should remove segment from segment cache if load segment failed

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -464,7 +464,7 @@ Status Segment::load_pk_index_and_bf() {
     return Status::OK();
 }
 
-Status Segment::load_index()() {
+Status Segment::load_index() {
     return _load_index_once.call([this] {
         if (_tablet_schema->keys_type() == UNIQUE_KEYS && _pk_index_meta != nullptr) {
             _pk_index_reader = std::make_unique<PrimaryKeyIndexReader>();

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -458,14 +458,6 @@ Status Segment::_load_pk_bloom_filter() {
     });
 }
 
-void Segment::remove_from_segment_cache() const {
-    if (config::disable_segment_cache) {
-        return;
-    }
-    SegmentCache::CacheKey cache_key(_rowset_id, _segment_id);
-    SegmentLoader::instance()->erase_segment(cache_key);
-}
-
 Status Segment::load_pk_index_and_bf() {
     RETURN_IF_ERROR(load_index());
     RETURN_IF_ERROR(_load_pk_bloom_filter());
@@ -520,7 +512,8 @@ Status Segment::healthy_status() {
         if (_inverted_index_file_reader_open.has_called()) {
             RETURN_IF_ERROR(_inverted_index_file_reader_open.stored_result());
         }
-        return Status::OK();
+        // This status is set by running time, for example, if there is something wrong during read segment iterator.
+        return _healthy_status.status();
     } catch (const doris::Exception& e) {
         // If there is an exception during load_xxx, should not throw exception directly because
         // the caller may not exception safe.

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -142,6 +142,11 @@ public:
 
     Status load_pk_index_and_bf();
 
+    // The segment is loaded into SegmentCache and then will load indices, if there are something wrong
+    // during loading indices, should remove it from SegmentCache. If not, it will always report error during
+    // query. So we add a healthy status API, the caller should check the healhty status before using the segment.
+    Status healthy_status();
+
     std::string min_key() {
         DCHECK(_tablet_schema->keys_type() == UNIQUE_KEYS && _pk_index_meta != nullptr);
         return _pk_index_meta->min_key();

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -142,6 +142,7 @@ public:
 
     Status load_pk_index_and_bf();
 
+    void update_healthy_status(Status new_status) { _healthy_status.update(new_status); }
     // The segment is loaded into SegmentCache and then will load indices, if there are something wrong
     // during loading indices, should remove it from SegmentCache. If not, it will always report error during
     // query. So we add a healthy status API, the caller should check the healhty status before using the segment.
@@ -159,8 +160,6 @@ public:
     io::FileReaderSPtr file_reader() { return _file_reader; }
 
     int64_t meta_mem_usage() const { return _meta_mem_usage; }
-
-    void remove_from_segment_cache() const;
 
     // Identify the column by unique id or path info
     struct ColumnIdentifier {
@@ -237,6 +236,7 @@ private:
     io::FileReaderSPtr _file_reader;
     uint32_t _segment_id;
     uint32_t _num_rows;
+    AtomicStatus _healthy_status;
 
     // 1. Tracking memory use by segment meta data such as footer or index page.
     // 2. Tracking memory use by segment column reader

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -227,7 +227,6 @@ private:
     Status _write_error_file(size_t file_size, size_t offset, size_t bytes_read, char* data,
                              io::IOContext& io_ctx);
 
-    Status _load_index_impl();
     Status _open_inverted_index();
 
     Status _create_column_readers_once();

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -270,9 +270,7 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr sc
 
 Status SegmentIterator::init(const StorageReadOptions& opts) {
     auto status = _init_impl(opts);
-    if (!status.ok() && !config::disable_segment_cache) {
-        _segment->remove_from_segment_cache();
-    }
+    _segment->update_healthy_status(status);
     return status;
 }
 
@@ -1927,7 +1925,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
 
     // if rows read by batch is 0, will return end of file, we should not remove segment cache in this situation.
     if (!status.ok() && !status.is<END_OF_FILE>()) {
-        _segment->remove_from_segment_cache();
+        _segment->update_healthy_status(status);
     }
     return status;
 }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -270,7 +270,9 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr sc
 
 Status SegmentIterator::init(const StorageReadOptions& opts) {
     auto status = _init_impl(opts);
-    _segment->update_healthy_status(status);
+    if (!status.ok()) {
+        _segment->update_healthy_status(status);
+    }
     return status;
 }
 

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -59,8 +59,14 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     for (int64_t i = 0; i < rowset->num_segments(); i++) {
         SegmentCache::CacheKey cache_key(rowset->rowset_id(), i);
         if (_segment_cache->lookup(cache_key, cache_handle)) {
-            continue;
+            // Has to check the segment status here, because the segment in cache may has something wrong during
+            // load index or create column reader.
+            // Not merge this if logic with previous to make the logic more clear.
+            if (cache_handle->pop_unhealthy_segment() == nullptr) {
+                continue;
+            }
         }
+        // If the segment is not healthy, then will create a new segment and will replace the unhealthy one in SegmentCache.
         segment_v2::SegmentSharedPtr segment;
         RETURN_IF_ERROR(rowset->load_segment(i, &segment));
         if (need_load_pk_index_and_bf) {

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -165,10 +165,12 @@ public:
         if (segments.empty()) {
             return nullptr;
         }
-        if (segments.back()->healthy_status().ok()) {
+        auto& last_segment = segments.back();
+        if (last_segment->healthy_status().ok()) {
             return nullptr;
         }
-        return segments.pop_back();
+        segments.pop_back();
+        return last_segment;
     }
 
 private:

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -161,6 +161,16 @@ public:
         _init = true;
     }
 
+    segment_v2::SegmentSharedPtr pop_unhealthy_segment() {
+        if (segments.empty()) {
+            return nullptr;
+        }
+        if (segments.back()->healthy_status().ok()) {
+            return nullptr;
+        }
+        return segments.pop_back();
+    }
+
 private:
     std::vector<segment_v2::SegmentSharedPtr> segments;
     bool _init {false};


### PR DESCRIPTION
## Proposed changes

1. If the segment load failed, it is not recoverable, should remove it from segment cache and the query will create new segment again.
2. Could not depend on remove segment from cache during load index failed, because the call once may throw exception and the error handle logic is not reached.