### PR TITLE
[fix](Nerieds) column prune should retain at least one column for union all 

### DIFF
--- a/regression-test/suites/nereids_rules_p0/column_pruning/union_const_expr_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/union_const_expr_column_pruning.groovy
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("const_expr_column_pruning") {
+    sql """SET ignore_shape_nodes='PhysicalDistribute,PhysicalProject'"""
+    // should only keep one column in union
+    sql "select count(1) from(select 3, 6 union all select 1, 3) t"
+    sql "select count(a) from(select 3 a, 6 union all select 1, 3) t"
+}


### PR DESCRIPTION
introduce by #31811 and #39450
```sql
select count(1) from(select 3, 6 union all select 1, 3) t
```
wrong LogicalUnion plan:
```sql
LogicalUnion( qualifier=ALL, outputs=[3#6], regularChildrenOutputs=[], constantExprsList=[[], []], hasPushedFilter=false
```
this sql will report error in explain, because the logical union outputs has a slot, but the logical union has no child and has a empty constantExprList, which is wrong set in column prune.
this pr fixes it by consider when require columns is empty and keep the min slot and min slot corresponding const expressions.
