### PR TITLE
[opt](hive) make supported hive table error msg clearer

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -41,6 +41,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.hive.HMSExternalTable;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.planner.AggregationNode;
 import org.apache.doris.planner.AnalyticEvalNode;
 import org.apache.doris.planner.PlanNode;
@@ -846,11 +847,14 @@ public class Analyzer {
         // Now hms table only support a bit of table kinds in the whole hive system.
         // So Add this strong checker here to avoid some undefine behaviour in doris.
         if (table.getType() == TableType.HMS_EXTERNAL_TABLE) {
-            if (!((HMSExternalTable) table).isSupportedHmsTable()) {
+            try {
+                ((HMSExternalTable) table).isSupportedHmsTable();
+            } catch (NotSupportedException e) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NONSUPPORT_HMS_TABLE,
                         table.getName(),
                         ((HMSExternalTable) table).getDbName(),
-                        tableName.getCtl());
+                        tableName.getCtl(),
+                        e.getMessage());
             }
             if (Config.enable_query_hive_views) {
                 if (((HMSExternalTable) table).isView()

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1199,7 +1199,7 @@ public enum ErrorCode {
     ERR_CATALOG_ACCESS_DENIED(5087, new byte[]{'4', '2', '0', '0', '0'},
             "Access denied for user '%s' to catalog '%s'"),
     ERR_NONSUPPORT_HMS_TABLE(5088, new byte[]{'4', '2', '0', '0', '0'},
-            "Nonsupport hive metastore table named '%s' in database '%s' with catalog '%s'."),
+            "Nonsupport hive metastore table named '%s' in database '%s' with catalog '%s'. %s"),
     ERR_TABLE_NAME_LENGTH_LIMIT(5089, new byte[]{'4', '2', '0', '0', '0'}, "Table name length exceeds limit, "
      + "the length of table name '%s' is %d which is greater than the configuration 'table_name_length_limit' (%d)."),
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -167,14 +167,11 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
         super(id, name, catalog, dbName, TableType.HMS_EXTERNAL_TABLE);
     }
 
+    // Will throw NotSupportedException if not supported hms table.
+    // Otherwise, return true.
     public boolean isSupportedHmsTable() {
-        try {
-            makeSureInitialized();
-            return true;
-        } catch (NotSupportedException e) {
-            LOG.warn("Not supported hms table, message: {}", e.getMessage());
-            return false;
-        }
+        makeSureInitialized();
+        return true;
     }
 
     protected synchronized void makeSureInitialized() {
@@ -191,6 +188,7 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
                 } else if (supportedHiveTable()) {
                     dlaType = DLAType.HIVE;
                 } else {
+                    // Should not reach here. Because `supportedHiveTable` will throw exception if not return true.
                     throw new NotSupportedException("Unsupported dlaType for table: " + getNameWithFullQualifiers());
                 }
             }


### PR DESCRIPTION
Previously, if there is unsupported table in hive catalog, user will get msg like:
```
Nonsupport hive metastore table named 'inventory' in database 'tpcds1000_orc' with catalog 'hive_krb'.
```
But don't know why.

After this PR, user will get:
```
Nonsupport hive metastore table named 'inventory' in database 'tpcds1000_orc' with catalog 'hive_krb'. Not Supported: Unsupported hive input format: org.apache.paimon.hive.mapred.PaimonInputFormat
```