### PR TITLE
[fix](parser) should not use selectHint in any place (#41260)

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -386,7 +386,7 @@ columnAliases
     ;
 
 selectClause
-    : SELECT selectHint? (DISTINCT|ALL)? selectColumnClause
+    : SELECT (DISTINCT|ALL)? selectColumnClause
     ;
 
 selectColumnClause


### PR DESCRIPTION
pick from master #41260

because all comment has been redirect to channel 2, we should not use hint in any place. selectHint only use to parse hint.

