### PR TITLE
[fix](Nereids) could not parse date/datetime with blank + zone (#41394)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -220,7 +220,11 @@ public class DateLiteral extends Literal {
                     while (i < s.length() && (isPunctuation(s.charAt(i)) || s.charAt(i) == ' ' || s.charAt(i) == 'T')) {
                         i += 1;
                     }
-                    sb.append(' ');
+                    // avoid add blank before zone-id, for example 2008-08-08 +08:00
+                    // should be normalized to 2008-08-08+08:00
+                    if (i >= s.length() || Character.isDigit(s.charAt(i))) {
+                        sb.append(' ');
+                    }
                 } else if (partNumber > 3 && isPunctuation(c)) {
                     sb.append(':');
                 } else {
@@ -240,18 +244,20 @@ public class DateLiteral extends Literal {
 
         // parse MicroSecond
         // Keep up to 7 digits at most, 7th digit is use for overflow.
+        int j = i;
         if (partNumber == 6 && i < s.length() && s.charAt(i) == '.') {
             sb.append(s.charAt(i));
             i += 1;
             while (i < s.length() && Character.isDigit(s.charAt(i))) {
-                if (i - 19 <= 7) {
+                if (i - j <= 7) {
                     sb.append(s.charAt(i));
                 }
                 i += 1;
             }
         }
 
-        sb.append(s.substring(i));
+        // trim use to remove any blank before zone id or zone offset
+        sb.append(s.substring(i).trim());
 
         return sb.toString();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -47,6 +47,12 @@ class DateLiteralTest {
         Assertions.assertEquals("2021-05-01 00:00:00", s);
         s = DateLiteral.normalize("2021-5-01 0:0:0.001");
         Assertions.assertEquals("2021-05-01 00:00:00.001", s);
+        s = DateLiteral.normalize("2021-5-01 0:0:0.12345678");
+        Assertions.assertEquals("2021-05-01 00:00:00.1234567", s);
+        s = DateLiteral.normalize("2021-5-1    Asia/Shanghai");
+        Assertions.assertEquals("2021-05-01Asia/Shanghai", s);
+        s = DateLiteral.normalize("2021-5-1 0:0:0.12345678   Asia/Shanghai");
+        Assertions.assertEquals("2021-05-01 00:00:00.1234567Asia/Shanghai", s);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/DateTimeFormatterUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/DateTimeFormatterUtilsTest.java
@@ -111,4 +111,30 @@ class DateTimeFormatterUtilsTest {
         Assertions.assertThrows(DateTimeParseException.class, () -> timeFormatter.parse("01:01"));
         Assertions.assertThrows(DateTimeParseException.class, () -> timeFormatter.parse("01"));
     }
+
+    @Test
+    void testZoneDateFormatter() {
+        DateTimeFormatter formatter = DateTimeFormatterUtils.ZONE_DATE_FORMATTER;
+        TemporalAccessor date = formatter.parse("2020-02-19Asia/Shanghai");
+        assertDatePart(date);
+        date = formatter.parse("2020-02-19UTC+08:00");
+        assertDatePart(date);
+        date = formatter.parse("2020-02-19+08:00");
+        assertDatePart(date);
+        Assertions.assertThrows(DateTimeParseException.class, () -> formatter.parse("2020-02-19 Asia/Shanghai"));
+        Assertions.assertThrows(DateTimeParseException.class, () -> formatter.parse("2020-02-19++08:00"));
+    }
+
+    @Test
+    void testZoneDateTimeFormatter() {
+        DateTimeFormatter formatter = DateTimeFormatterUtils.ZONE_DATE_TIME_FORMATTER;
+        TemporalAccessor dateTime = formatter.parse("2020-02-19 00:00:00Asia/Shanghai");
+        assertDatePart(dateTime);
+        dateTime = formatter.parse("2020-02-19 00:00:00UTC+08:00");
+        assertDatePart(dateTime);
+        dateTime = formatter.parse("2020-02-19 00:00:00+08:00");
+        assertDatePart(dateTime);
+        Assertions.assertThrows(DateTimeParseException.class, () -> formatter.parse("2020-02-19 00:00:00 Asia/Shanghai"));
+        Assertions.assertThrows(DateTimeParseException.class, () -> formatter.parse("2020-02-19 00:00:00++08:00"));
+    }
 }


### PR DESCRIPTION
pick from master #41394

for example:
2008-08-08 20:08:08 +08:00 parse failed because the blank before +08:00
