### PR TITLE
[improve](column) implement insert_many_from function for all column

### DIFF
--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -390,6 +390,7 @@ void NestedLoopJoinProbeLocalState::_process_left_child_block(
                     .get_data()
                     .resize_fill(origin_sz + max_added_rows, 0);
         } else {
+            // TODO: for cross join, maybe could insert one row, and wrap for a const column
             dst_columns[i]->insert_many_from(*src_column.column, _left_block_pos, max_added_rows);
         }
     }

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -841,6 +841,12 @@ void ColumnArray::insert_indices_from(const IColumn& src, const uint32_t* indice
     }
 }
 
+void ColumnArray::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    for (auto x = 0; x != length; ++x) {
+        ColumnArray::insert_from(src, position);
+    }
+}
+
 ColumnPtr ColumnArray::replicate(const IColumn::Offsets& replicate_offsets) const {
     if (replicate_offsets.empty()) return clone_empty();
 

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -165,6 +165,7 @@ public:
     size_t byte_size() const override;
     size_t allocated_bytes() const override;
     ColumnPtr replicate(const IColumn::Offsets& replicate_offsets) const override;
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
 
     ColumnPtr convert_to_full_column_if_const() const override;
 

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -172,6 +172,14 @@ public:
         }
     }
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override {
+        const Self& src_vec = assert_cast<const Self&>(src);
+        auto val = src_vec.get_element(position);
+        for (uint32_t i = 0; i < length; ++i) {
+            data.emplace_back(val);
+        }
+    }
+
     void pop_back(size_t n) override { data.erase(data.end() - n, data.end()); }
     // it's impossible to use ComplexType as key , so we don't have to implement them
     [[noreturn]] StringRef serialize_value_into_arena(size_t n, Arena& arena,

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -147,6 +147,10 @@ public:
         s += length;
     }
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override {
+        s += length;
+    }
+
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override {
         s += (indices_end - indices_begin);

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -301,6 +301,16 @@ void ColumnDecimal<T>::insert_many_fix_len_data(const char* data_ptr, size_t num
 }
 
 template <typename T>
+void ColumnDecimal<T>::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    auto old_size = data.size();
+    data.resize(old_size + length);
+    auto& vals = assert_cast<const Self&>(src).get_data();
+    for (auto i = 0; i < length; ++i) {
+        data[old_size + i] = vals[position];
+    }
+}
+
+template <typename T>
 void ColumnDecimal<T>::insert_range_from(const IColumn& src, size_t start, size_t length) {
     const ColumnDecimal& src_vec = assert_cast<const ColumnDecimal&>(src);
 

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -305,9 +305,7 @@ void ColumnDecimal<T>::insert_many_from(const IColumn& src, size_t position, siz
     auto old_size = data.size();
     data.resize(old_size + length);
     auto& vals = assert_cast<const Self&>(src).get_data();
-    for (auto i = 0; i < length; ++i) {
-        data[old_size + i] = vals[position];
-    }
+    std::fill(&data[old_size], &data[old_size + length], vals[position]);
 }
 
 template <typename T>

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -158,6 +158,8 @@ public:
         memset(data.data() + old_size, 0, length * sizeof(data[0]));
     }
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
+
     void pop_back(size_t n) override { data.resize_assume_reserved(data.size() - n); }
 
     StringRef serialize_value_into_arena(size_t n, Arena& arena, char const*& begin) const override;

--- a/be/src/vec/columns/column_map.cpp
+++ b/be/src/vec/columns/column_map.cpp
@@ -197,6 +197,12 @@ void ColumnMap::insert_indices_from(const IColumn& src, const uint32_t* indices_
     }
 }
 
+void ColumnMap::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    for (auto x = 0; x != length; ++x) {
+        ColumnMap::insert_from(src, position);
+    }
+}
+
 StringRef ColumnMap::serialize_value_into_arena(size_t n, Arena& arena, char const*& begin) const {
     size_t array_size = size_at(n);
     size_t offset = offset_at(n);

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -131,6 +131,8 @@ public:
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override;
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
+
     void append_data_by_selector(MutableColumnPtr& res,
                                  const IColumn::Selector& selector) const override {
         return append_data_by_selector_impl<ColumnMap>(res, selector);

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -206,6 +206,12 @@ void ColumnNullable::insert_many_strings(const StringRef* strings, size_t num) {
     }
 }
 
+void ColumnNullable::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    const auto& nullable_col = assert_cast<const ColumnNullable&>(src);
+    get_null_map_column().insert_many_from(nullable_col.get_null_map_column(), position, length);
+    get_nested_column().insert_many_from(*nullable_col.nested_column, position, length);
+}
+
 StringRef ColumnNullable::serialize_value_into_arena(size_t n, Arena& arena,
                                                      char const*& begin) const {
     const auto& arr = get_null_map_data();

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -198,6 +198,8 @@ public:
     void insert(const Field& x) override;
     void insert_from(const IColumn& src, size_t n) override;
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
+
     template <typename ColumnType>
     void insert_from_with_type(const IColumn& src, size_t n) {
         const auto& src_concrete = assert_cast<const ColumnNullable&>(src);

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -179,9 +179,11 @@ void ColumnStr<T>::insert_many_from(const IColumn& src, size_t position, size_t 
 
     auto start_pos = old_size;
     auto end_pos = old_size + length;
+    auto prev_pos = old_chars_size;
     for (; start_pos < end_pos; ++start_pos) {
-        offsets[start_pos] = offsets[start_pos - 1] + data_length;
-        memcpy(chars.data() + offsets[start_pos], data_val, data_length);
+        memcpy(&chars[prev_pos], data_val, data_length);
+        offsets[start_pos] = prev_pos + data_length;
+        prev_pos = prev_pos + data_length;
     }
 }
 

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -166,6 +166,26 @@ void ColumnStr<T>::insert_range_from(const IColumn& src, size_t start, size_t le
 }
 
 template <typename T>
+void ColumnStr<T>::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    const auto& string_column = assert_cast<const ColumnStr<T>&>(src);
+    auto [data_val, data_length] = string_column.get_data_at(position);
+
+    size_t old_chars_size = chars.size();
+    check_chars_length(old_chars_size + data_length * length, offsets.size() + length);
+    chars.resize(old_chars_size + data_length * length);
+
+    auto old_size = offsets.size();
+    offsets.resize(old_size + length);
+
+    auto start_pos = old_size;
+    auto end_pos = old_size + length;
+    for (; start_pos < end_pos; ++start_pos) {
+        offsets[start_pos] = offsets[start_pos - 1] + data_length;
+        memcpy(chars.data() + offsets[start_pos], data_val, data_length);
+    }
+}
+
+template <typename T>
 void ColumnStr<T>::insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                                        const uint32_t* indices_end) {
     auto do_insert = [&](const auto& src_str) {

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -161,6 +161,8 @@ public:
         offsets.push_back(new_size);
     }
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
+
     bool is_column_string64() const override { return sizeof(T) == sizeof(uint64_t); }
 
     void insert_from(const IColumn& src_, size_t n) override {

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -243,6 +243,13 @@ void ColumnStruct::insert_indices_from(const IColumn& src, const uint32_t* indic
     }
 }
 
+void ColumnStruct::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    const auto& src_concrete = assert_cast<const ColumnStruct&>(src);
+    for (size_t i = 0; i < columns.size(); ++i) {
+        columns[i]->insert_many_from(src_concrete.get_column(i), position, length);
+    }
+}
+
 void ColumnStruct::insert_range_from(const IColumn& src, size_t start, size_t length) {
     const size_t tuple_size = columns.size();
     for (size_t i = 0; i < tuple_size; ++i) {

--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -135,6 +135,8 @@ public:
     void insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                              const uint32_t* indices_end) override;
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
+
     void append_data_by_selector(MutableColumnPtr& res, const Selector& selector) const override {
         return append_data_by_selector_impl<ColumnStruct>(res, selector);
     }

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -432,6 +432,16 @@ size_t ColumnVector<T>::filter(const IColumn::Filter& filter) {
 }
 
 template <typename T>
+void ColumnVector<T>::insert_many_from(const IColumn& src, size_t position, size_t length) {
+    auto old_size = data.size();
+    data.resize(old_size + length);
+    auto& vals = assert_cast<const Self&>(src).get_data();
+    for (auto i = 0; i < length; ++i) {
+        data[old_size + i] = vals[position];
+    }
+}
+
+template <typename T>
 ColumnPtr ColumnVector<T>::permute(const IColumn::Permutation& perm, size_t limit) const {
     size_t size = data.size();
 

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -436,9 +436,7 @@ void ColumnVector<T>::insert_many_from(const IColumn& src, size_t position, size
     auto old_size = data.size();
     data.resize(old_size + length);
     auto& vals = assert_cast<const Self&>(src).get_data();
-    for (auto i = 0; i < length; ++i) {
-        data[old_size + i] = vals[position];
-    }
+    std::fill(&data[old_size], &data[old_size + length], vals[position]);
 }
 
 template <typename T>

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -173,6 +173,8 @@ public:
         std::fill(data.data() + old_size, data.data() + old_size + n, val);
     }
 
+    void insert_many_from(const IColumn& src, size_t position, size_t length) override;
+
     void insert_range_of_integer(T begin, T end) {
         if constexpr (std::is_integral_v<T>) {
             auto old_size = data.size();


### PR DESCRIPTION
## Proposed changes

the cross join will call insert_many_from function to combine left table column as result,
implement it's will reduce much virtual function call.
```
mysql [ssb]>select count(c_custkey) from (select customer.c_custkey from dates cross join customer)t;
+------------------+
| count(c_custkey) |
+------------------+
|       7668000000 |
+------------------+
1 row in set (5.56 sec)
```

```
mysql [ssb]>select count(c_custkey) from (select customer.c_custkey from dates cross join customer)t;
+------------------+
| count(c_custkey) |
+------------------+
|       7668000000 |
+------------------+
1 row in set (3.29 sec)
```

<!--Describe your changes.-->

