### PR TITLE
[Bug](auto-partition) should check the expr of auto range partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
@@ -129,9 +129,9 @@ public class PartitionDesc {
                                     + expr.toSql());
                 }
             } else if (expr instanceof SlotRef) {
-                if (isAutoPartition && !colNames.isEmpty() && !isListPartition) {
+                if (isAutoPartition && !isListPartition) {
                     throw new AnalysisException(
-                            "auto create partition only support one slotRef in expr of RANGE partition. "
+                            "auto create partition only support date_trunc function of RANGE partition. "
                                     + expr.toSql());
                 }
                 colNames.add(((SlotRef) expr).getColumnName());

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -314,4 +314,35 @@ suite("test_auto_partition_behavior") {
     sql "insert into test_change select * from empty_range"
     sql "create table if not exists empty_list like long_value"
     sql "insert into long_value select * from empty_list"
+
+
+    // test not auto partition have expr.
+    test {
+        sql """
+            CREATE TABLE if not exists dup_dynamic_t_logs (
+                `timestamp` datetime NOT NULL,
+                `source` text NULL,
+                `node` text NULL,
+                `level` text NULL,
+                `component` text NULL,
+                `clientRequestId` varchar(50) NULL,
+                `message` text NULL,
+                `properties` variant NULL,
+            INDEX idx_source (`source`) USING INVERTED COMMENT '',
+            INDEX idx_node (`node`) USING INVERTED COMMENT '',
+            INDEX idx_level (`level`) USING INVERTED COMMENT '',
+            INDEX idx_component (`component`) USING INVERTED COMMENT '',
+            INDEX idx_clientRequestId (`clientRequestId`) USING INVERTED COMMENT '',
+            INDEX idx_message (`message`) USING INVERTED PROPERTIES("parser"="english") COMMENT '',
+            -- INDEX idx_properties (`properties`) USING INVERTED COMMENT '',
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`timestamp`)
+            AUTO PARTITION BY RANGE (`timestamp`)()
+            DISTRIBUTED BY RANDOM BUCKETS 100
+            PROPERTIES (
+            "file_cache_ttl_seconds" = "600"
+            );
+        """
+        exception "auto create partition only support date_trunc function of RANGE partition"
+    }
 }

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_range_partition.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_range_partition.groovy
@@ -184,7 +184,7 @@ suite("test_auto_range_partition") {
                 "replication_num" = "1"
             );
         """
-        exception "Auto Range Partition need FunctionCallExpr"
+        exception "auto create partition only support date_trunc function of RANGE partition"
     }
     test {
         sql """


### PR DESCRIPTION
## Proposed changes


```

AUTO PARTITION BY RANGE (FUNC_CALL_EXPR)
(
)

FUNC_CALL_EXPR ::= date_trunc ( <partition_column>, '<interval>' )

should check the expr, now auto range partition only support date_trunc

```

<!--Describe your changes.-->

