### PR TITLE
Revert "[Improvement](sort) do not sort partitial when spill disabled(#40528)"

### DIFF
--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -177,8 +177,8 @@ public:
 
 private:
     bool _reach_limit() {
-        return _enable_spill && (_state->unsorted_block_->rows() > buffered_block_size_ ||
-                                 _state->unsorted_block_->bytes() > buffered_block_bytes_);
+        return _state->unsorted_block_->rows() > buffered_block_size_ ||
+               _state->unsorted_block_->bytes() > buffered_block_bytes_;
     }
 
     Status _do_sort();


### PR DESCRIPTION
Cause mem overflow and use more

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

