### PR TITLE
[fix](statistics)Fix clear stale mv row count bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatsMeta.java
@@ -154,10 +154,6 @@ public class TableStatsMeta implements Writable, GsonPostProcessable {
         colToColStatsMeta.remove(Pair.of(indexName, colName));
     }
 
-    public void removeAllColumn() {
-        colToColStatsMeta.clear();
-    }
-
     public Set<Pair<String, String>> analyzeColumns() {
         return colToColStatsMeta.keySet();
     }
@@ -230,19 +226,20 @@ public class TableStatsMeta implements Writable, GsonPostProcessable {
         return indexesRowCount.getOrDefault(indexId, -1L);
     }
 
-    public void clearIndexesRowCount() {
-        indexesRowCount.clear();
-    }
-
-    private void clearStaleIndexRowCount(OlapTable table) {
+    protected void clearStaleIndexRowCount(OlapTable table) {
         Iterator<Long> iterator = indexesRowCount.keySet().iterator();
-        List<Long> indexIds = table.getIndexIds();
+        List<Long> indexIds = table.getIndexIdList();
         while (iterator.hasNext()) {
             long key = iterator.next();
-            if (indexIds.contains(key)) {
+            if (!indexIds.contains(key)) {
                 iterator.remove();
             }
         }
+    }
+
+    // For unit test only.
+    protected void addIndexRowForTest(long indexId, long rowCount) {
+        indexesRowCount.put(indexId, rowCount);
     }
 
     public long getBaseIndexDeltaRowCount(OlapTable table) {

--- a/regression-test/suites/statistics/test_analyze_mv.groovy
+++ b/regression-test/suites/statistics/test_analyze_mv.groovy
@@ -387,6 +387,30 @@ suite("test_analyze_mv") {
     assertEquals("5001", result_sample[0][8])
     assertEquals("FULL", result_sample[0][9])
 
+    // Test drop mv and other indexes' row still exist.
+    sql """DROP MATERIALIZED VIEW mv1 ON mvTestAgg;"""
+    sql """analyze table mvTestAgg with sync;"""
+    result_row = sql """show index stats mvTestAgg mvTestAgg"""
+    assertEquals(1, result_row.size())
+    assertEquals("mvTestAgg", result_row[0][0])
+    assertEquals("mvTestAgg", result_row[0][1])
+    assertEquals("5", result_row[0][2])
+    result_row = sql """show index stats mvTestAgg mv3"""
+    assertEquals(1, result_row.size())
+    assertEquals("mvTestAgg", result_row[0][0])
+    assertEquals("mv3", result_row[0][1])
+    assertEquals("5", result_row[0][2])
+    result_row = sql """show index stats mvTestAgg mv6"""
+    assertEquals(1, result_row.size())
+    assertEquals("mvTestAgg", result_row[0][0])
+    assertEquals("mv6", result_row[0][1])
+    assertEquals("4", result_row[0][2])
+    result_row = sql """show index stats mvTestAgg rollup1"""
+    assertEquals(1, result_row.size())
+    assertEquals("mvTestAgg", result_row[0][0])
+    assertEquals("rollup1", result_row[0][1])
+    assertEquals("4", result_row[0][2])
+
 
     sql """
         CREATE TABLE mvTestUni (


### PR DESCRIPTION
When drop an mv, the row count for that mv should be removed in memory as well. Before we use OlapTable.getIndexIds to get all index ids, but this function always returns null. This pr is to fix this bug, use getIndexIdList instead.