### PR TITLE
[fix] (nereids) simplify-range-rule keeps expr states if there is no simplification

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -494,6 +494,7 @@ public class SimplifyRange implements ExpressionPatternRuleFactory {
             for (int i = 1; i < sourceValues.size(); i++) {
                 result = mergeExprOp.apply(result, sourceValues.get(i).toExpression());
             }
+            expr.transferState(result);
             return result;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/AbstractTreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/AbstractTreeNode.java
@@ -76,4 +76,8 @@ public abstract class AbstractTreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>>
     public int arity() {
         return children.size();
     }
+
+    public void transferState(AbstractTreeNode target) {
+        target.mutableState = mutableState.clone();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/MutableState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/MutableState.java
@@ -34,6 +34,7 @@ public interface MutableState {
     <T> Optional<T> get(String key);
 
     MutableState set(String key, Object value);
+
     MutableState clone();
 
     /** EmptyMutableState */
@@ -53,7 +54,7 @@ public interface MutableState {
         }
 
         @Override
-        public MutableState clone () {
+        public MutableState clone() {
             return INSTANCE;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/MutableState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/MutableState.java
@@ -34,6 +34,7 @@ public interface MutableState {
     <T> Optional<T> get(String key);
 
     MutableState set(String key, Object value);
+    MutableState clone();
 
     /** EmptyMutableState */
     class EmptyMutableState implements MutableState {
@@ -49,6 +50,11 @@ public interface MutableState {
         @Override
         public MutableState set(String key, Object value) {
             return new SingleMutableState(key, value);
+        }
+
+        @Override
+        public MutableState clone () {
+            return INSTANCE;
         }
     }
 
@@ -80,6 +86,11 @@ public interface MutableState {
             multiMutableState.set(key, value);
             return multiMutableState;
         }
+
+        @Override
+        public MutableState clone() {
+            return new SingleMutableState(key, value);
+        }
     }
 
     /** MultiMutableState */
@@ -95,6 +106,15 @@ public interface MutableState {
         public MutableState set(String key, Object value) {
             states.put(key, value);
             return this;
+        }
+
+        @Override
+        public MutableState clone() {
+            MutableState target = new MultiMutableState();
+            for (String key : states.keySet()) {
+                target = target.set(key, states.get(key));
+            }
+            return target;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes
simplifyRange rule removes expression stats even the expression is not changed. And hence OrToIn rule is repeatedly applied to the same expression.
Issue Number: close #xxx

<!--Describe your changes.-->

