### PR TITLE
[Bug](runtime-filter) fix wrong check on BloomFilterFuncBase::merge

### DIFF
--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -162,8 +162,8 @@ public:
         // allocate memory again.
         if (!_inited) {
             auto* other_func = static_cast<BloomFilterFuncBase*>(bloomfilter_func);
-            if (_bloom_filter == nullptr) {
-                return Status::InternalError("_bloom_filter is nullptr");
+            if (_bloom_filter != nullptr) {
+                return Status::InternalError("_bloom_filter must is nullptr");
             }
             _bloom_filter = bloomfilter_func->_bloom_filter;
             _bloom_filter_alloced = other_func->_bloom_filter_alloced;


### PR DESCRIPTION
## Proposed changes
fix wrong check on BloomFilterFuncBase::merge
introduced by https://github.com/apache/doris/pull/41648