### PR TITLE
[fix](user cancel) Make sure we can see unified cancel msg if query is killed by user.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -949,8 +949,10 @@ public class ConnectContext {
         return getMysqlChannel().getRemoteHostPortString();
     }
 
-    // kill operation with no protect.
-    public void kill(boolean killConnection) {
+    // kill operation with no protect by user.
+    // killConnection: If true, close the connection, so client need to re-connect
+    // to doris to send stmt.
+    public void killByUser(boolean killConnection) {
         LOG.warn("kill query from {}, kill mysql connection: {}", getRemoteHostPortString(), killConnection);
 
         if (killConnection) {
@@ -959,6 +961,11 @@ public class ConnectContext {
             closeChannel();
         }
         // Now, cancel running query.
+        StmtExecutor executorRef = executor;
+        if (executorRef != null) {
+            executorRef.setCancelSource(getRemoteHostPortString());
+            executorRef.setCancelledByUser();
+        }
         cancelQuery(new Status(TStatusCode.CANCELLED, "cancel query by user"));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
@@ -67,7 +67,7 @@ public class FlightSqlConnectContext extends ConnectContext {
 
     // kill operation with no protect.
     @Override
-    public void kill(boolean killConnection) {
+    public void killByUser(boolean killConnection) {
         LOG.warn("kill query from {}, kill flight sql connection: {}", getRemoteHostPortString(), killConnection);
 
         if (killConnection) {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -159,9 +159,9 @@ public class ConnectContextTest {
         Assert.assertTrue(ctx.isKilled());
 
         // Kill
-        ctx.kill(true);
+        ctx.killByUser(true);
         Assert.assertTrue(ctx.isKilled());
-        ctx.kill(false);
+        ctx.killByUser(false);
         Assert.assertTrue(ctx.isKilled());
 
         // clean up
@@ -187,7 +187,7 @@ public class ConnectContextTest {
         Assert.assertFalse(ctx.isKilled());
 
         // Kill
-        ctx.kill(true);
+        ctx.killByUser(true);
         Assert.assertTrue(ctx.isKilled());
 
         // clean up

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -389,7 +389,7 @@ public class StmtExecutorTest {
                 minTimes = 0;
                 result = "blockUser";
 
-                killCtx.kill(true);
+                killCtx.killByUser(true);
                 minTimes = 0;
 
                 killCtx.getConnectType();
@@ -450,7 +450,7 @@ public class StmtExecutorTest {
                 minTimes = 0;
                 result = "killUser";
 
-                killCtx.kill(true);
+                killCtx.killByUser(true);
                 minTimes = 0;
 
                 killCtx.getConnectType();


### PR DESCRIPTION
```
mysql [tpch]>select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= date '1998-12-01' - interval '90' day group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus;
--------------
select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= date '1998-12-01' - interval '90' day group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus
--------------

^C^C -- sending "KILL QUERY 0" to server ...
^C -- query aborted
ERROR 1105 (HY000): Cancelled by user from 127.0.0.1:52036
```