### PR TITLE
[opt](profile) Move ExecutedByFrontend to execution summary profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -902,11 +902,11 @@ public class SummaryProfile {
     }
 
     public void setSystemMessage(String msg) {
-        summaryProfile.addInfoString(SYSTEM_MESSAGE, msg);
+        executionSummaryProfile.addInfoString(SYSTEM_MESSAGE, msg);
     }
 
     public void setExecutedByFrontend(boolean executedByFrontend) {
-        summaryProfile.addInfoString(EXECUTED_BY_FRONTEND, String.valueOf(executedByFrontend));
+        executionSummaryProfile.addInfoString(EXECUTED_BY_FRONTEND, String.valueOf(executedByFrontend));
     }
 
     public void write(DataOutput output) throws IOException {


### PR DESCRIPTION
To make `Executed  By  Frontend` more noticeable.
Now:
<img width="596" alt="image" src="https://github.com/user-attachments/assets/bfcf4b43-be71-4a31-968e-cdfeebaff153">

<img width="481" alt="image" src="https://github.com/user-attachments/assets/8f026934-d411-4bb1-9066-1d3c5c12ce79">

After pr:
<img width="543" alt="image" src="https://github.com/user-attachments/assets/2c958e8f-544d-480e-9610-9d1ef7878246">

<img width="838" alt="image" src="https://github.com/user-attachments/assets/93ba14c8-d788-47b1-8614-459c65d4799b">

