### PR TITLE
[fix](arrow-flight-sql) Fix kill timeout FlightSqlConnection and FlightSqlConnectProcessor close

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
@@ -53,6 +53,8 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Process one flgiht sql connection.
+ *
+ * Must use try-with-resources.
  */
 public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoCloseable {
     private static final Logger LOG = LogManager.getLogger(FlightSqlConnectProcessor.class);
@@ -177,6 +179,7 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
     @Override
     public void close() throws Exception {
         ctx.setCommand(MysqlCommand.COM_SLEEP);
+        ctx.clear();
         // TODO support query profile
         for (StmtExecutor asynExecutor : returnResultFromRemoteExecutor) {
             asynExecutor.finalizeQuery();

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
@@ -63,6 +63,7 @@ public class FlightSqlConnectContext extends ConnectContext {
         if (flightSqlChannel != null) {
             flightSqlChannel.close();
         }
+        connectScheduler.unregisterConnection(this);
     }
 
     // kill operation with no protect.
@@ -72,8 +73,8 @@ public class FlightSqlConnectContext extends ConnectContext {
 
         if (killConnection) {
             isKilled = true;
+            // Close channel and break connection with client.
             closeChannel();
-            connectScheduler.unregisterConnection(this);
         }
         // Now, cancel running query.
         cancelQuery(new Status(TStatusCode.CANCELLED, "arrow flight query killed by user"));


### PR DESCRIPTION
1. Doris will cancel the connection that has not responded for a long time,  Mysql Conenction will exit directly, but Arrow Flight Conenction does not exit immediately, may be frequently cancel and print logs. timeout is `wait_timeout` in session veriable. 
2. FlightSqlConnectProcessor Use try-with-resources to close correctly.