### PR TITLE
[fix](regression test) fix test_tvf

### DIFF
--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -252,3 +252,7 @@ lakesoulMinioAK="*******"
 lakesoulMinioSK="*******"
 lakesoulMinioEndpoint="*******"
 
+// cloud
+metaServiceToken = "greedisgood9999"
+instanceId = "default_instance_id"
+multiClusterInstance = "default_instance_id"

--- a/regression-test/suites/cloud_p0/multi_cluster/test_tvf.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/test_tvf.groovy
@@ -18,10 +18,7 @@
 import org.apache.doris.regression.suite.ClusterOptions
 import groovy.json.JsonSlurper
 
-suite('test_tvf_in_cloud', 'multi_cluster,docker') {
-    if (!isCloudMode()) {
-        return;
-    }
+suite('test_tvf', 'multi_cluster,docker') {
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',


### PR DESCRIPTION
```

        // 调用http api 将add_new_cluster 下掉
        def ms = cluster.getAllMetaservices().get(0)
        logger.info("ms addr={}, port={}", ms.host, ms.httpPort)
        drop_cluster(clusterName, cloudClusterId, ms)
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^
        Thread.sleep(5000)
        result = sql """show clusters"""
        logger.info("show cluster2 : {}", result)

        // single cluster env
        // use old clusterName, has been droped
        test {
            sql """select * from numbers("number" = "100")"""
            exception "in cloud maybe this cluster has been dropped" 
        }

Exception:
java.lang.IllegalStateException: HttpCliAction failed, uri:http://128.2.101.1:5000/MetaService/http/drop_cluster?token=null
  at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
  at org.apache.doris.regression.action.HttpCliAction.run(HttpCliAction.groovy:160)
  at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
  at org.apache.doris.regression.suite.Suite.runAction(Suite.groovy:1080)
  at sun.reflect.GeneratedMethodAccessor34.invoke(Unknown Source)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
  at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
  at groovy.lang.MetaClassImpl.doInvokeMethod(MetaClassImpl.java:1333)
  at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1088)
```