### PR TITLE
[feat](nereids)estimate selected partition row count if some partition rows are not available

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -502,6 +502,10 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 }
                 checkIfUnknownStatsUsedAsKey(builder);
                 builder.setRowCount(selectedPartitionsRowCount);
+            } else {
+                // estimate table rowCount according to pruned partition num
+                tableRowCount = tableRowCount * olapScan.getSelectedPartitionIds().size()
+                        / olapScan.getTable().getPartitionNum();
             }
         }
         // 1. no partition is pruned, or

--- a/regression-test/suites/nereids_p0/stats/partitionRowCunt.groovy
+++ b/regression-test/suites/nereids_p0/stats/partitionRowCunt.groovy
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("partitionRowCount") {
+    sql """
+        drop table if exists partitionRowCountTable;
+        create table partitionRowCountTable (a int,
+        b int,
+        c int)
+        partition by range (a)
+        (partition p1 values [("1", "2"), ("10", "20")),
+        partition p2 values [("20", "100"), ("30", "200")),
+        partition p3 values [("300", "-1"), ("400", "1000")) 
+        )
+        distributed by hash(a) properties("replication_num"="1");
+        insert into partitionRowCountTable values (5, 3, 0), (22, 150, 1), (333, 1, 2);
+        insert into partitionRowCountTable values (5, 3, 10), (22, 150, 11), (333, 1, 12);
+        analyze table partitionRowCountTable with sync;
+    """
+    explain {
+        sql """physical plan
+            select * from partitionRowCountTable where a < 250;
+            """
+        contains("PhysicalOlapScan[partitionRowCountTable partitions(2/3)]@0 ( stats=4 )")
+    }
+
+}

--- a/regression-test/suites/nereids_p0/stats/partition_key_minmax.groovy
+++ b/regression-test/suites/nereids_p0/stats/partition_key_minmax.groovy
@@ -37,7 +37,7 @@ suite("partition_key_minmax") {
             select * from rangetable where a < 250;
             """
         containsAny("a#0 -> ndv=3.0000, min=1.000000(1), max=30.000000(30), count=3.0000")
-        containsAny("a#0 -> ndv=4.0000, min=5.000000(5), max=333.000000(333), count=4.0000")
+        containsAny("a#0 -> ndv=2.6667, min=5.000000(5), max=333.000000(333), count=2.6667")
     }
 
     sql """
@@ -61,7 +61,7 @@ suite("partition_key_minmax") {
          memo plan select * from listtable where id >=3;
         """
         containsAny("id#0 -> ndv=1.0000, min=3.000000(3), max=3.000000(3), count=1.0000,")
-        containsAny("id#0 -> ndv=3.0000, min=1.000000(1), max=3.000000(3), count=3.0000,")
+        containsAny("id#0 -> ndv=1.0000, min=1.000000(1), max=3.000000(3), count=1.0000,")
     }
 }
 


### PR DESCRIPTION

## Proposed changes
there is a delay for BE to report partition row count.
when the partition row count is not available, the selected partition row count is estimated by:
tableRowCount * selectPartitionNum /  totalPartitionNum

Issue Number: close #xxx

<!--Describe your changes.-->

