### PR TITLE
[branch-3.0][chore](dependencies)upgrade fe dependencies (#41142)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SerializationUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SerializationUtils.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * A utility class for serializing and deep cloning Serializable objects.
+ * <p>
+ * This class provides a method to clone an object by serializing it to a byte array
+ * and then deserializing it back to an object. This approach ensures that a deep copy
+ * is created, meaning that all objects referenced by the original object are also cloned.
+ * <p>
+ * Note: The object to be cloned must implement the {@link Serializable} interface.
+ */
+public class SerializationUtils {
+
+    /**
+     * Clones a Serializable object by serializing and deserializing it.
+     *
+     * @param object the object to be cloned. Must be Serializable.
+     * @param <T>    the type of the object to clone. Must extend Serializable.
+     * @return a deep copy of the provided object, or null if the input object is null.
+     * @throws RuntimeException if cloning fails due to I/O or class not found exceptions.
+     */
+    public static <T> T clone(final T object) {
+        // Check if the object is null; if true, return null
+        if (object == null) {
+            return null; // Return null for null input
+        }
+
+        try {
+            // Serialize the object to a byte array
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); // Output stream to hold the serialized data
+                    ObjectOutputStream oos = new ObjectOutputStream(baos)) { // ObjectOutputStream for serialization
+                oos.writeObject(object); // Write the object to the output stream
+                oos.flush(); // Ensure all data is written
+
+                // Deserialize the byte array back to an object
+                // Input stream from byte array
+                try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+                        ObjectInputStream ois = new ObjectInputStream(bais)) { // ObjectInputStream for deserialization
+                    return (T) ois.readObject(); // Read and return the cloned object
+                }
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            // Wrap any exceptions thrown during serialization/deserialization
+            throw new RuntimeException("Cloning failed", e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -31,6 +31,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.VariableAnnotation;
+import org.apache.doris.common.util.SerializationUtils;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.persist.GlobalVarPersistInfo;
 
@@ -40,7 +41,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.JaroWinklerDistance;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/SerializationUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/SerializationUtilsTest.java
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Objects;
+
+public class SerializationUtilsTest {
+
+
+    private final HashMap<String, Object> sampleMap = new HashMap<>();
+    private final String sampleString = "sampleString";
+    private final Integer sampleInteger = 456;
+
+    public SerializationUtilsTest() {
+        sampleMap.put("KEY_ONE", sampleString);
+        sampleMap.put("KEY_TWO", sampleInteger);
+    }
+
+    @Test
+    public void testClone() {
+        final Object clonedObject = SerializationUtils.clone(sampleMap);
+        Assertions.assertNotNull(clonedObject);
+        Assertions.assertTrue(clonedObject instanceof HashMap<?, ?>);
+        Assertions.assertNotSame(clonedObject, sampleMap);
+
+        final HashMap<?, ?> clonedMap = (HashMap<?, ?>) clonedObject;
+        Assertions.assertEquals(sampleString, clonedMap.get("KEY_ONE"));
+        Assertions.assertNotSame(sampleString, clonedMap.get("KEY_ONE"));
+        Assertions.assertEquals(sampleInteger, clonedMap.get("KEY_TWO"));
+        Assertions.assertNotSame(sampleInteger, clonedMap.get("KEY_TWO"));
+        Assertions.assertEquals(sampleMap, clonedMap);
+    }
+
+    @Test
+    public void testCloneNull() {
+        final Object clonedObject = SerializationUtils.clone(null);
+        Assertions.assertNull(clonedObject);
+    }
+
+    @Test
+    public void testCloneWithWriteReplace() {
+        Child childObject = new Child(true);
+        Parent clonedParent = SerializationUtils.clone(childObject);
+
+        Assertions.assertNotSame(childObject, clonedParent);
+        Assertions.assertEquals(new Parent(true), clonedParent);
+    }
+
+    static class Parent implements Serializable {
+        private static final long serialVersionUID = 1L;
+        protected boolean status;
+
+        Parent(boolean status) {
+            this.status = status;
+        }
+
+        protected Parent(Parent parent) {
+            this.status = parent.status;
+        }
+
+        protected Object writeReplace() {
+            return new Parent(this);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(status);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Parent other = (Parent) obj;
+            return status == other.status;
+        }
+    }
+
+    static class Child extends Parent {
+        private static final long serialVersionUID = 2L;
+
+        Child(boolean status) {
+            super(status);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergTransactionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergTransactionTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.datasource.iceberg;
 
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.info.SimpleTableInfo;
+import org.apache.doris.common.util.SerializationUtils;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.nereids.trees.plans.commands.insert.IcebergInsertCommandContext;
 import org.apache.doris.thrift.TFileContent;
@@ -27,7 +28,6 @@ import org.apache.doris.thrift.TIcebergCommitData;
 import com.google.common.collect.Maps;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.commons.lang3.SerializationUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileScanTask;

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -239,9 +239,10 @@ under the License.
         <cglib.version>2.2</cglib.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-filerupload.version>1.5</commons-filerupload.version>
+        <commons-configuration2.version>2.11.0</commons-configuration2.version>
         <commons-codec.version>1.13</commons-codec.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-lang3.version>3.9</commons-lang3.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
         <commons-pool2.version>2.2</commons-pool2.version>
         <commons-pool.version>1.5.1</commons-pool.version>
         <commons-text.version>1.10.0</commons-text.version>
@@ -287,7 +288,7 @@ under the License.
         <automaton.version>1.11-8</automaton.version>
         <generex.version>1.0.1</generex.version>
         <fabric8.kubernetes.version>6.7.2</fabric8.kubernetes.version>
-        <logging-interceptor.version>4.7.2</logging-interceptor.version>
+        <logging-interceptor.version>4.12.0</logging-interceptor.version>
         <okhttp.version>4.9.3</okhttp.version>
         <okio.version>3.4.0</okio.version>
         <snakeyaml.version>2.0</snakeyaml.version>
@@ -324,7 +325,7 @@ under the License.
 
         <parquet.version>1.13.1</parquet.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-compress.version>1.22</commons-compress.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
         <scala.version>2.12.10</scala.version>
         <kryo.version>4.0.2</kryo.version>
         <lombok.version>1.18.24</lombok.version>
@@ -352,7 +353,7 @@ under the License.
         <woodstox.version>6.5.1</woodstox.version>
         <kerby.version>2.0.3</kerby.version>
         <jettison.version>1.5.4</jettison.version>
-        <jetty.version>9.4.55.v20240627</jetty.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
         <immutables.version>2.9.3</immutables.version>
         <ivy.version>2.5.2</ivy.version>
         <icu4j.version>75.1</icu4j.version>
@@ -371,7 +372,7 @@ under the License.
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <asm.version>9.4</asm.version>
         <airlift.version>202</airlift.version>
-        <azure.sdk.version>1.2.24</azure.sdk.version>
+        <azure.sdk.version>1.2.27</azure.sdk.version>
         <azure.sdk.batch.version>12.22.0</azure.sdk.batch.version>
         <semver4j.version>5.3.0</semver4j.version>
         <aliyun-sdk-oss.version>3.15.0</aliyun-sdk-oss.version>
@@ -745,6 +746,11 @@ under the License.
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>${commons-filerupload.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons-configuration2.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->


### PR DESCRIPTION
## Proposed changes
upgrade commons-configuration2 to 2.11.0
upgrade logging-interceptor to 4.12.0
upgrade commons-compress to 1.27.1
upgrade jetty-bom to 9.4.56.v20240826
upgrade azure-sdk to 1.2.27

Iceberg depends on configuration2, and configuration2 relies on a newer version of commons-lang3. However, there were significant breaking changes in commons-lang3, which made it
incompatible.https://issues.apache.org/jira/browse/LANG-1705 As a result, I rewrote the clone method.

(cherry picked from commit 945edf8dbffaa25c987bcefad59b6cde52772d4f)

## Proposed changes

Issue Number: close #41142

