### PR TITLE
[branch-2.1] Fix `is_partial_update` parameter is not set in `append_block_with_partial_content()`

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -481,7 +481,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         RowsetSharedPtr rowset;
         auto st = tablet->lookup_row_key(key, _tablet_schema.get(), have_input_seq_column,
                                          specified_rowsets, &loc, _mow_context->max_version,
-                                         segment_caches, &rowset);
+                                         segment_caches, &rowset, true, true);
         if (st.is<KEY_NOT_FOUND>()) {
             if (_opts.rowset_ctx->partial_update_info->is_strict_mode) {
                 ++num_rows_filtered;

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -427,7 +427,7 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
         RowsetSharedPtr rowset;
         auto st = tablet->lookup_row_key(key, _tablet_schema.get(), have_input_seq_column,
                                          specified_rowsets, &loc, _mow_context->max_version,
-                                         segment_caches, &rowset);
+                                         segment_caches, &rowset, true, true);
         if (st.is<KEY_NOT_FOUND>()) {
             if (_opts.rowset_ctx->partial_update_info->is_strict_mode) {
                 ++num_rows_filtered;


### PR DESCRIPTION
https://github.com/apache/doris/pull/41439 forgets to set `is_partial_update` parameter for `Tablet::lookup_row_key()` in `append_block_with_partial_content()`
