### PR TITLE
[bugfix](hive)Use the connected user to initialize the owner of the hive table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -40,6 +40,7 @@ import org.apache.doris.datasource.jdbc.client.JdbcClient;
 import org.apache.doris.datasource.jdbc.client.JdbcClientConfig;
 import org.apache.doris.datasource.operations.ExternalMetadataOps;
 import org.apache.doris.datasource.property.constants.HMSProperties;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -172,6 +173,12 @@ public class HiveMetadataOps implements ExternalMetadataOps {
         }
         try {
             Map<String, String> props = stmt.getProperties();
+            // set default owner
+            if (!props.containsKey("owner")) {
+                if (ConnectContext.get() != null) {
+                    props.put("owner", ConnectContext.get().getUserIdentity().getUser());
+                }
+            }
             String fileFormat = props.getOrDefault(FILE_FORMAT_KEY, Config.hive_default_file_format);
             Map<String, String> ddlProps = new HashMap<>();
             for (Map.Entry<String, String> entry : props.entrySet()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveUtil.java
@@ -215,8 +215,6 @@ public final class HiveUtil {
         props.put("comment", hiveTable.getComment());
         if (props.containsKey("owner")) {
             table.setOwner(props.get("owner"));
-        } else {
-            table.setOwner(ConnectContext.get().getUserIdentity().getUser());
         }
         HiveProperties.setTableProperties(table, props);
         return table;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveUtil.java
@@ -215,6 +215,8 @@ public final class HiveUtil {
         props.put("comment", hiveTable.getComment());
         if (props.containsKey("owner")) {
             table.setOwner(props.get("owner"));
+        } else {
+            table.setOwner(ConnectContext.get().getUserIdentity().getUser());
         }
         HiveProperties.setTableProperties(table, props);
         return table;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource.hive;
 
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.backup.Status;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
@@ -35,6 +36,7 @@ import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.thrift.TUpdateMode;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -54,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -127,7 +130,7 @@ public class HmsCommitTest {
     }
 
     @Before
-    public void before() {
+    public void before() throws IOException {
         // create table for tbWithPartition
         List<Column> columns = new ArrayList<>();
         columns.add(new Column("c1", PrimitiveType.INT, true));
@@ -136,11 +139,15 @@ public class HmsCommitTest {
         List<String> partitionKeys = new ArrayList<>();
         partitionKeys.add("c3");
         String fileFormat = "orc";
+        Map<String, String> tblProperties = Maps.newHashMap();
+        tblProperties.put("owner", "admin");
         HiveTableMetadata tableMetadata = new HiveTableMetadata(
                 dbName, tbWithPartition, Optional.of(dbLocation + tbWithPartition + UUID.randomUUID()),
                 columns, partitionKeys,
-                new HashMap<>(), fileFormat, "");
+                tblProperties, fileFormat, "");
         hmsClient.createTable(tableMetadata, true);
+        Table tbl = hmsClient.getTable(dbName, tbWithPartition);
+        Assert.assertEquals(UserIdentity.ADMIN.getUser(), tbl.getParameters().get("owner"));
 
         // create table for tbWithoutPartition
         HiveTableMetadata tableMetadata2 = new HiveTableMetadata(

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy
@@ -273,6 +273,7 @@ suite("test_hive_ddl", "p0,external,hive,external_docker,external_docker_hive") 
             def create_tbl_res = sql """ show create table loc_tbl_${file_format}_default """
             logger.info("${create_tbl_res}")
             assertTrue(create_tbl_res.toString().containsIgnoreCase("${loc}/loc_tbl_${file_format}_default"))
+            assertTrue(create_tbl_res.toString().containsIgnoreCase("'owner'='root'"))
 
             sql """ INSERT INTO loc_tbl_${file_format}_default values(1)  """
 
@@ -303,12 +304,14 @@ suite("test_hive_ddl", "p0,external,hive,external_docker,external_docker_hive") 
                     )  ENGINE=hive 
                     PROPERTIES (
                       'file_format'='${file_format}',
-                      'location'='${tbl_loc}'
+                      'location'='${tbl_loc}',
+                      'owner' = 'doris_writer'
                     )
                  """
             def create_tbl_res2 = sql """ show create table loc_tbl_${file_format}_custom """
             logger.info("${create_tbl_res2}")
             assertTrue(create_tbl_res2.toString().containsIgnoreCase("${tbl_loc}"))
+            assertTrue(create_tbl_res2.toString().containsIgnoreCase("'owner'='doris_writer'"))
             sql """ INSERT INTO loc_tbl_${file_format}_custom values(1)  """
             def tvfRes2 = sql """ SELECT * FROM hdfs(
                                     'uri'='${tbl_loc}/*',


### PR DESCRIPTION
Use the connected user to initialize the owner of the hive table created by Doris.
If user specified `"owner"` property in create table statement, will use user specified owner.

```
mysql> create table test_table(k1 int) properties("owner" = "user2");

mysql> show create table test_table;
CREATE TABLE `test_table`(
  `k1` int COMMENT '')
COMMENT ''
ROW FORMAT SERDE
  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
WITH SERDEPROPERTIES (
)
STORED AS INPUTFORMAT
  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
LOCATION
  'hdfs://172.20.32.136:8020/user/hive/warehouse/test.db/test_table'
TBLPROPERTIES (
  'owner'='user2',
  'transient_lastDdlTime'='1729162217',
  'orc.compress'='zlib',
  'doris.version'='doris-0.0.0--de4e2eadc3')
```
