### PR TITLE
[fix](index compaction) fix fd leak and mem leak while index compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -746,19 +746,18 @@ Status Compaction::do_inverted_index_compaction() {
         }
 
         std::vector<lucene::store::Directory*> dest_index_dirs(dest_segment_num);
-        std::vector<lucene::store::Directory*> src_index_dirs(src_segment_num);
         try {
+            std::vector<std::unique_ptr<DorisCompoundReader>> src_idx_dirs(src_segment_num);
             for (int src_segment_id = 0; src_segment_id < src_segment_num; src_segment_id++) {
-                auto src_dir =
+                src_idx_dirs[src_segment_id] =
                         DORIS_TRY(inverted_index_file_readers[src_segment_id]->open(index_meta));
-                src_index_dirs[src_segment_id] = src_dir.release();
             }
             for (int dest_segment_id = 0; dest_segment_id < dest_segment_num; dest_segment_id++) {
                 auto* dest_dir =
                         DORIS_TRY(inverted_index_file_writers[dest_segment_id]->open(index_meta));
                 dest_index_dirs[dest_segment_id] = dest_dir;
             }
-            auto st = compact_column(index_meta->index_id(), src_index_dirs, dest_index_dirs,
+            auto st = compact_column(index_meta->index_id(), src_idx_dirs, dest_index_dirs,
                                      index_tmp_path.native(), trans_vec, dest_segment_num_rows);
             if (!st.ok()) {
                 error_handler(index_meta->index_id(), column_uniq_id);

--- a/be/src/olap/rowset/segment_v2/inverted_index_compaction.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compaction.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "inverted_index_compound_reader.h"
 
 namespace doris {
 class TabletIndex;
@@ -30,7 +31,8 @@ namespace segment_v2 {
 class InvertedIndexFileWriter;
 class InvertedIndexFileReader;
 
-Status compact_column(int64_t index_id, std::vector<lucene::store::Directory*>& src_index_dirs,
+Status compact_column(int64_t index_id,
+                      std::vector<std::unique_ptr<DorisCompoundReader>>& src_index_dirs,
                       std::vector<lucene::store::Directory*>& dest_index_dirs,
                       std::string_view tmp_path,
                       const std::vector<std::vector<std::pair<uint32_t, uint32_t>>>& trans_vec,


### PR DESCRIPTION
if `DORIS_TRY(inverted_index_file_readers[src_segment_id]->open(index_meta))` failed and return,
then `lucene::store::Directory*` stay in `src_index_dirs` will got fd leak and memory leak.