### PR TITLE
[env](compile) Replace the shorten-64-to-32 check with a conversion check.

### DIFF
--- a/be/src/common/compile_check_begin.h
+++ b/be/src/common/compile_check_begin.h
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
 #ifdef __clang__
 #pragma clang diagnostic push
-#pragma clang diagnostic error "-Wshorten-64-to-32"
+#pragma clang diagnostic error "-Wconversion"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wfloat-conversion"
 #endif
 //#include "common/compile_check_begin.h"

--- a/be/src/common/compile_check_end.h
+++ b/be/src/common/compile_check_end.h
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
## Proposed changes
The shorten-64-to-32 check cannot detect conversions such as 64-bit to 16-bit.

```C++
#pragma clang diagnostic push
#pragma clang diagnostic error "-Wconversion"
#pragma clang diagnostic ignored "-Wsign-conversion"
#pragma clang diagnostic ignored "-Wfloat-conversion"
    {
        int64_t x = 1000000;
        int y = x;//Implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int'
    }
    {
        int64_t x = 1000000;
        int16_t y = x;//Implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int16_t' (aka 'short')
    }
    {
        int64_t x;
        uint64_t y = x;
    }
#pragma clang diagnostic pop

#pragma clang diagnostic push
#pragma clang diagnostic error "-Wshorten-64-to-32"
    {
        int64_t x = 1000000;
        int y = x;//Implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int'
    }
    {
        int64_t x = 1000000;
        int16_t y = x;
    }
    {
        int64_t x;
        uint64_t y = x;
    }
#pragma clang diagnostic pop
```
Issue Number: close #xxx

<!--Describe your changes.-->

