### PR TITLE
[imporve][load] support set stream-load data size limit by http header

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -272,6 +272,17 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
     ctx->body_bytes = 0;
     size_t csv_max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
     size_t json_max_body_bytes = config::streaming_load_json_max_mb * 1024 * 1024;
+    if (!http_req->header(HTTP_DATA_SIZE_LIMIT).empty()) {
+        try {
+            size_t session_max_data_size = std::stoull(http_req->header(HTTP_DATA_SIZE_LIMIT));
+            csv_max_body_bytes = 
+                    std::max(session_max_data_size, session_max_data_size * 1024 * 1024);
+            json_max_body_bytes = csv_max_body_bytes;
+        } catch (const std::invalid_argument& e) {
+            return Status::InvalidArgument("Invalid data size limit format={}: {}",
+                                          http_req->header(HTTP_DATA_SIZE_LIMIT), e.what());
+        }
+    }
     bool read_json_by_line = false;
     if (!http_req->header(HTTP_READ_JSON_BY_LINE).empty()) {
         if (iequal(http_req->header(HTTP_READ_JSON_BY_LINE), "true")) {

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -275,12 +275,12 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
     if (!http_req->header(HTTP_DATA_SIZE_LIMIT).empty()) {
         try {
             size_t session_max_data_size = std::stoull(http_req->header(HTTP_DATA_SIZE_LIMIT));
-            csv_max_body_bytes = 
+            csv_max_body_bytes =
                     std::max(session_max_data_size, session_max_data_size * 1024 * 1024);
             json_max_body_bytes = csv_max_body_bytes;
         } catch (const std::invalid_argument& e) {
             return Status::InvalidArgument("Invalid data size limit format={}: {}",
-                                          http_req->header(HTTP_DATA_SIZE_LIMIT), e.what());
+                                           http_req->header(HTTP_DATA_SIZE_LIMIT), e.what());
         }
     }
     bool read_json_by_line = false;

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -40,6 +40,7 @@ static const std::string HTTP_STRICT_MODE = "strict_mode";
 static const std::string HTTP_TIMEZONE = "timezone";
 static const std::string HTTP_TIME_ZONE = "time_zone";
 static const std::string HTTP_EXEC_MEM_LIMIT = "exec_mem_limit";
+static const std::string HTTP_DATA_SIZE_LIMIT = "data_size_limit";
 static const std::string HTTP_JSONPATHS = "jsonpaths";
 static const std::string HTTP_JSONROOT = "json_root";
 static const std::string HTTP_STRIP_OUTER_ARRAY = "strip_outer_array";


### PR DESCRIPTION
## Proposed changes

Doris's stream load limits the amount of data that can be imported at one time. If the amount of data exceeds the limit, it will fail. If you want to increase the limit, you need to manually adjust the BE parameters(streaming_load_max_mb).

This adjustment adds a check rule for the amount of data during import. If the amount of imported data is set in the HTTP header, the size limit specified in HTTP can be dynamically loaded, avoiding the need to uniformly adjust the limit of the BE layer.

just like:
```
curl --location-trusted -u <doris_user>:<doris_password> \
    -H "data_size_limit:10240"
    -H "column_separator:," \
    -H "columns:user_id,name,age" \
    -T streamload_example.csv \
    -XPUT http://<fe_ip>:<fe_http_port>/api/testdb/test_streamload/_stream_load
```

<!--Describe your changes.-->

