### PR TITLE
[fix](scan) Avoid memory allocated by buffered_reader from being traced

### DIFF
--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -168,12 +168,7 @@ public:
         }
     }
 
-    ~MergeRangeFileReader() override {
-        delete[] _read_slice;
-        for (char* box : _boxes) {
-            delete[] box;
-        }
-    }
+    ~MergeRangeFileReader() override = default;
 
     Status close() override {
         if (!_closed) {
@@ -244,8 +239,8 @@ private:
     bool _closed = false;
     size_t _remaining;
 
-    char* _read_slice = nullptr;
-    std::vector<char*> _boxes;
+    std::unique_ptr<OwnedSlice> _read_slice;
+    std::vector<OwnedSlice> _boxes;
     int16 _last_box_ref = -1;
     uint32 _last_box_usage = 0;
     std::vector<int16> _box_ref;

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -344,6 +344,10 @@ class OwnedSlice : private Allocator<false, false, false, DefaultMemoryAllocator
 public:
     OwnedSlice() : _slice((uint8_t*)nullptr, 0) {}
 
+    OwnedSlice(size_t length)
+            : _slice(reinterpret_cast<char*>(Allocator::alloc(length)), length),
+              _capacity(length) {}
+
     OwnedSlice(OwnedSlice&& src) : _slice(src._slice), _capacity(src._capacity) {
         src._slice.data = nullptr;
         src._slice.size = 0;
@@ -368,6 +372,8 @@ public:
             Allocator::free(_slice.data, _capacity);
         }
     }
+
+    char* data() const { return _slice.data; }
 
     const Slice& slice() const { return _slice; }
 


### PR DESCRIPTION
Use OwnedSlice to replace `char*` in BufferedReader

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

