### PR TITLE
[fix](mow) delete bitmap permanently retained when using light delete

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2762,7 +2762,7 @@ public class Config extends ConfigBase {
     })
     public static String inverted_index_storage_format = "V2";
 
-    @ConfField(mutable = true, masterOnly = true, description = {
+    @ConfField(mutable = false, masterOnly = true, description = {
             "是否在unique表mow上开启delete语句写delete predicate。若开启，会提升delete语句的性能，"
                     + "但delete后进行部分列更新可能会出现部分数据错误的情况。若关闭，会降低delete语句的性能来保证正确性。",
             "Enable the 'delete predicate' for DELETE statements. If enabled, it will enhance the performance of "


### PR DESCRIPTION
## Proposed changes
When exec delete where stmt, if the predicate is value predicate and enabling light delete, the delete bitmap maybe permanently retained.
For example:
create a mow table and enabe enable_mow_light_delete.
```
CREATE TABLE `test_tt` (
  `shop_id` int NOT NULL,
  `proxy_status` smallint NULL 
) ENGINE=OLAP
UNIQUE KEY(`shop_id`)
COMMENT ''
DISTRIBUTED BY HASH(`shop_id`) BUCKETS 1
PROPERTIES (
"enable_mow_light_delete" = "true"
);
```
Insert some value:
```insert into test_tt(shop_id, proxy_status) values ('1', 2); delete from test_tt where proxy_status is null;```
Run compation by api.
The structure of tablet is like follows:
```
rs [0-3] 1, 2
delete bitmap {}
```
Insert some value and execute delete:
```insert into test_tt(shop_id, proxy_status) values ('1', null);delete from test_tt where proxy_status is null;```
The structure of tablet is like follows:
```
rs [0-3] 1, 2
rs [4-4] 1, null
rs [5-5] delete_predicate proxy_status IS NULL
delete bitmap {
rs: [0-3] seg: 0 row: 0 version: 4
}
```
Run compation by api.
Because rs [5-5] will affect rs [4-4], the `(1, null)` in rs[4-4] will not appears in merger. So the `(1,2)` in rs[1-3] will appears in the merger and the result structure of tablet will be like follows:
```
rs [0-5] 1,2
delete bitmap {
rs: [0-5] seg: 0 row: 0 version: 4
}
```
So, we can read data with delete bitmap to filter (1,2) in rs[0-3] out.


Issue Number: close #41447

<!--Describe your changes.-->

