### PR TITLE
[improve](udaf)support class cache for java-udaf

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ScannerLoader.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ScannerLoader.java
@@ -17,9 +17,9 @@
 
 package org.apache.doris.common.classloader;
 
+import org.apache.doris.common.jni.utils.ClassCacheBase;
 import org.apache.doris.common.jni.utils.ExpiringMap;
 import org.apache.doris.common.jni.utils.Log4jOutputStream;
-import org.apache.doris.common.jni.utils.UdfClassCache;
 
 import com.google.common.collect.Streams;
 import org.apache.log4j.Level;
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 public class ScannerLoader {
     public static final Logger LOG = Logger.getLogger(ScannerLoader.class);
     private static final Map<String, Class<?>> loadedClasses = new HashMap<>();
-    private static final ExpiringMap<String, UdfClassCache> udfLoadedClasses = new ExpiringMap<>();
+    private static final ExpiringMap<String, ClassCacheBase> udfLoadedClasses = new ExpiringMap<>();
     private static final String CLASS_SUFFIX = ".class";
     private static final String LOAD_PACKAGE = "org.apache.doris";
 
@@ -80,11 +80,11 @@ public class ScannerLoader {
         System.setErr(errorPrintStream);
     }
 
-    public static UdfClassCache getUdfClassLoader(String functionSignature) {
+    public static ClassCacheBase getUdfClassLoader(String functionSignature) {
         return udfLoadedClasses.get(functionSignature);
     }
 
-    public static synchronized void cacheClassLoader(String functionSignature, UdfClassCache classCache,
+    public static synchronized void cacheClassLoader(String functionSignature, ClassCacheBase classCache,
             long expirationTime) {
         LOG.info("Cache UDF for: " + functionSignature);
         udfLoadedClasses.put(functionSignature, classCache, expirationTime * 60 * 1000L);

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/ClassCacheBase.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/ClassCacheBase.java
@@ -17,15 +17,18 @@
 
 package org.apache.doris.common.jni.utils;
 
-import java.lang.reflect.Method;
+import com.esotericsoftware.reflectasm.MethodAccess;
 
 /**
- * This class is used for caching the class of UDF.
+ * This class is used for caching the class of UDF/UDAF.
  */
-public class UdfClassCache extends ClassCacheBase {
-    public int evaluateIndex;
-    // the method of evaluate() in udf
-    public Method method;
-    // the method of prepare() in udf
-    public Method prepareMethod;
+public class ClassCacheBase {
+    public Class<?> udfClass;
+    // the index of evaluate() method in the class
+    public MethodAccess methodAccess;
+    // the argument and return's JavaUdfDataType of evaluate() method.
+    public JavaUdfDataType[] argTypes;
+    public JavaUdfDataType retType;
+    // the class type of the arguments in evaluate() method
+    public Class[] argClass;
 }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/UdafClassCache.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/UdafClassCache.java
@@ -18,14 +18,13 @@
 package org.apache.doris.common.jni.utils;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
 
 /**
- * This class is used for caching the class of UDF.
+ * This class is used for caching the class of UDAF.
  */
-public class UdfClassCache extends ClassCacheBase {
-    public int evaluateIndex;
-    // the method of evaluate() in udf
-    public Method method;
-    // the method of prepare() in udf
-    public Method prepareMethod;
+public class UdafClassCache extends ClassCacheBase {
+    public HashMap<String, Method> allMethods;
+    public int addIndex;
+    public Class retClass;
 }

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
@@ -140,13 +140,14 @@ public abstract class BaseExecutor {
     protected abstract void init(TJavaUdfExecutorCtorParams request, String jarPath,
             Type funcRetType, Type... parameterTypes) throws UdfRuntimeException;
 
-    protected abstract ClassCacheBase getClassCache(String className, String jarPath, String signature, long expirationTime,
-            Type funcRetType, Type... parameterTypes)
+    protected abstract ClassCacheBase getClassCache(String className, String jarPath, String signature,
+            long expirationTime, Type funcRetType, Type... parameterTypes)
             throws MalformedURLException, FileNotFoundException, ClassNotFoundException, InternalException,
             UdfRuntimeException;
 
-    protected abstract void checkAndCacheUdfClass(String className, ClassCacheBase cache, Type funcRetType, Type... parameterTypes)
-            throws InternalException, UdfRuntimeException, FileNotFoundException;
+    protected abstract void checkAndCacheUdfClass(String className, ClassCacheBase cache, Type funcRetType,
+            Type... parameterTypes) throws InternalException, UdfRuntimeException, FileNotFoundException;
+
     /**
      * Close the class loader we may have created.
      */

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.exception.InternalException;
 import org.apache.doris.common.exception.UdfRuntimeException;
+import org.apache.doris.common.jni.utils.ClassCacheBase;
 import org.apache.doris.common.jni.utils.JavaUdfDataType;
 import org.apache.doris.common.jni.vec.ColumnValueConverter;
 import org.apache.doris.thrift.TFunction;
@@ -33,7 +34,9 @@ import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URLClassLoader;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -70,6 +73,7 @@ public abstract class BaseExecutor {
     protected Class[] argClass;
     protected MethodAccess methodAccess;
     protected TFunction fn;
+    protected boolean isStaticLoad = false;
 
     /**
      * Create a UdfExecutor, using parameters from a serialized thrift object. Used
@@ -136,6 +140,13 @@ public abstract class BaseExecutor {
     protected abstract void init(TJavaUdfExecutorCtorParams request, String jarPath,
             Type funcRetType, Type... parameterTypes) throws UdfRuntimeException;
 
+    protected abstract ClassCacheBase getClassCache(String className, String jarPath, String signature, long expirationTime,
+            Type funcRetType, Type... parameterTypes)
+            throws MalformedURLException, FileNotFoundException, ClassNotFoundException, InternalException,
+            UdfRuntimeException;
+
+    protected abstract void checkAndCacheUdfClass(String className, ClassCacheBase cache, Type funcRetType, Type... parameterTypes)
+            throws InternalException, UdfRuntimeException, FileNotFoundException;
     /**
      * Close the class loader we may have created.
      */

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
@@ -319,12 +319,10 @@ public class UdafExecutor extends BaseExecutor {
     }
 
     @Override
-    protected void checkAndCacheUdfClass(String className, ClassCacheBase cacheBase, Type funcRetType, Type... parameterTypes)
-            throws UdfRuntimeException, InternalException, FileNotFoundException {
+    protected void checkAndCacheUdfClass(String className, ClassCacheBase cacheBase, Type funcRetType,
+            Type... parameterTypes) throws UdfRuntimeException, InternalException, FileNotFoundException {
         ArrayList<String> signatures = Lists.newArrayList();
-        // if (cacheBase instanceof UdafClassCache) {
-            UdafClassCache cache = (UdafClassCache) cacheBase;
-        // }
+        UdafClassCache cache = (UdafClassCache) cacheBase;
         Class<?> c = cache.udfClass;
         Method[] methods = c.getMethods();
         int idx = 0;
@@ -366,7 +364,7 @@ public class UdafExecutor extends BaseExecutor {
                     }
                     if (!(parameterTypes.length == 0)) {
                         Pair<Boolean, JavaUdfDataType[]> inputType = UdfUtils.setArgTypes(parameterTypes,
-                            cache.argClass, true);
+                                cache.argClass, true);
                         if (!inputType.first) {
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("add function set arg parameterTypes has error");
@@ -419,22 +417,6 @@ public class UdafExecutor extends BaseExecutor {
             allMethods = cache.allMethods;
             addIndex = cache.addIndex;
             retClass = cache.retClass;
-            // ClassLoader loader;
-            // if (jarPath != null) {
-            //     ClassLoader parent = getClass().getClassLoader();
-            //     classLoader = UdfUtils.getClassLoader(jarPath, parent);
-            //     loader = classLoader;
-            // } else {
-            //     // for test
-            //     loader = ClassLoader.getSystemClassLoader();
-            // }
-            // Class<?> c = Class.forName(className, true, loader);
-            // methodAccess = MethodAccess.get(c);
-            // Constructor<?> ctor = c.getConstructor();
-            // udf = ctor.newInstance();
-            // Method[] methods = c.getDeclaredMethods();
-
-
         } catch (MalformedURLException e) {
             throw new UdfRuntimeException("Unable to load jar.", e);
         } catch (SecurityException e) {

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdfExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdfExecutor.java
@@ -175,8 +175,8 @@ public class UdfExecutor extends BaseExecutor {
     }
 
     @Override
-    protected void checkAndCacheUdfClass(String className, ClassCacheBase cacheBase, Type funcRetType, Type... parameterTypes)
-            throws InternalException, UdfRuntimeException {
+    protected void checkAndCacheUdfClass(String className, ClassCacheBase cacheBase, Type funcRetType,
+            Type... parameterTypes) throws InternalException, UdfRuntimeException {
         UdfClassCache cache = (UdfClassCache) cacheBase;
         ArrayList<String> signatures = Lists.newArrayList();
         Class<?> c = cache.udfClass;


### PR DESCRIPTION
## Proposed changes
in some user case, 

- the udf-jars package have some resource file, it's maybe about hundreds MBs,
   so if every instances load the jar, it's easy to cause the BE JVM OOM.

- or in some udf-jars  have some init operator cause many times, so wants all instance could only init it's once.


follow up https://github.com/apache/doris/pull/40404
support class cache for java-udaf

<!--Describe your changes.-->

