### PR TITLE
[fix](catalog) fix filtered database when use_meta_cache=true

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -53,6 +53,7 @@ import org.apache.doris.datasource.metacache.MetaCache;
 import org.apache.doris.datasource.operations.ExternalMetadataOps;
 import org.apache.doris.datasource.paimon.PaimonExternalDatabase;
 import org.apache.doris.datasource.property.PropertyConverter;
+import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalDatabase;
 import org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalDatabase;
 import org.apache.doris.fs.remote.dfs.DFSFileSystem;
@@ -678,11 +679,11 @@ public abstract class ExternalCatalog
             InitCatalogLog.Type logType, boolean checkExists) {
         // When running ut, disable this check to make ut pass.
         // Because in ut, the database is not created in remote system.
-        if (checkExists && !FeConstants.runningUnitTest) {
+        if (checkExists && (!FeConstants.runningUnitTest || this instanceof TestExternalCatalog)) {
             try {
                 List<String> dbNames = getDbNames();
                 if (!dbNames.contains(dbName)) {
-                    dbNames = listDatabaseNames();
+                    dbNames = getFilteredDatabaseNames();
                     if (!dbNames.contains(dbName)) {
                         return null;
                     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -17,16 +17,106 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.analysis.CreateCatalogStmt;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.mysql.privilege.Auth;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ExternalCatalogTest extends TestWithFeService {
+    private static Auth auth;
+    private static Env env;
+    private CatalogMgr mgr;
+    private ConnectContext rootCtx;
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        FeConstants.runningUnitTest = true;
+        mgr = Env.getCurrentEnv().getCatalogMgr();
+        rootCtx = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        auth = env.getAuth();
+        // 1. create test catalog
+        CreateCatalogStmt testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test1 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.RefreshCatalogTest$RefreshCatalogProvider\",\n"
+                        + "    \"include_database_list\" = \"db1\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+
+        testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test2 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.RefreshCatalogTest$RefreshCatalogProvider\",\n"
+                        + "    \"exclude_database_list\" = \"db1\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+
+        testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test3 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.RefreshCatalogTest$RefreshCatalogProvider\",\n"
+                        + "    \"include_database_list\" = \"db1\",\n"
+                        + "    \"exclude_database_list\" = \"db1\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+
+        // use_meta_cache=false
+        testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test4 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"use_meta_cache\" = \"false\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.RefreshCatalogTest$RefreshCatalogProvider\",\n"
+                        + "    \"include_database_list\" = \"db1\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+
+        testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test5 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"use_meta_cache\" = \"false\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.RefreshCatalogTest$RefreshCatalogProvider\",\n"
+                        + "    \"exclude_database_list\" = \"db1\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+
+        testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test6 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"use_meta_cache\" = \"false\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.RefreshCatalogTest$RefreshCatalogProvider\",\n"
+                        + "    \"include_database_list\" = \"db1\",\n"
+                        + "    \"exclude_database_list\" = \"db1\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog);
+    }
 
     @Test
     public void testExternalCatalogAutoAnalyze() throws Exception {
@@ -47,5 +137,79 @@ public class ExternalCatalogTest extends TestWithFeService {
         prop.put(ExternalCatalog.ENABLE_AUTO_ANALYZE, "TRUE");
         catalog.modifyCatalogProps(prop);
         Assertions.assertTrue(catalog.enableAutoAnalyze());
+    }
+
+    @Test
+    public void testExternalCatalogFilteredDatabase() throws Exception {
+        // use_meta_cache=true
+        TestExternalCatalog ctl = (TestExternalCatalog) mgr.getCatalog("test1");
+        List<String> dbNames = ctl.getDbNames();
+        System.out.println(dbNames);
+        Assertions.assertEquals(3, dbNames.size());
+        Assertions.assertTrue(!dbNames.contains("db2"));
+
+        ctl = (TestExternalCatalog) mgr.getCatalog("test2");
+        dbNames = ctl.getDbNames();
+        System.out.println(dbNames);
+        Assertions.assertEquals(3, dbNames.size());
+        Assertions.assertTrue(!dbNames.contains("db1"));
+
+        ctl = (TestExternalCatalog) mgr.getCatalog("test3");
+        dbNames = ctl.getDbNames();
+        System.out.println(dbNames);
+        Assertions.assertEquals(2, dbNames.size());
+        Assertions.assertTrue(!dbNames.contains("db1"));
+        Assertions.assertTrue(!dbNames.contains("db2"));
+
+        // use_meta_cache=false
+        ctl = (TestExternalCatalog) mgr.getCatalog("test4");
+        dbNames = ctl.getDbNames();
+        System.out.println(dbNames);
+        Assertions.assertEquals(3, dbNames.size());
+        Assertions.assertTrue(!dbNames.contains("db2"));
+
+        ctl = (TestExternalCatalog) mgr.getCatalog("test5");
+        dbNames = ctl.getDbNames();
+        System.out.println(dbNames);
+        Assertions.assertEquals(3, dbNames.size());
+        Assertions.assertTrue(!dbNames.contains("db1"));
+
+        ctl = (TestExternalCatalog) mgr.getCatalog("test6");
+        dbNames = ctl.getDbNames();
+        System.out.println(dbNames);
+        Assertions.assertEquals(2, dbNames.size());
+        Assertions.assertTrue(!dbNames.contains("db1"));
+        Assertions.assertTrue(!dbNames.contains("db2"));
+    }
+
+    public static class RefreshCatalogProvider implements TestExternalCatalog.TestCatalogProvider {
+        public static final Map<String, Map<String, List<Column>>> MOCKED_META;
+
+        static {
+            MOCKED_META = Maps.newHashMap();
+            Map<String, List<Column>> tblSchemaMap1 = Maps.newHashMap();
+            // db1
+            tblSchemaMap1.put("tbl11", Lists.newArrayList(
+                    new Column("a11", PrimitiveType.BIGINT),
+                    new Column("a12", PrimitiveType.STRING),
+                    new Column("a13", PrimitiveType.FLOAT)));
+            tblSchemaMap1.put("tbl12", Lists.newArrayList(
+                    new Column("b21", PrimitiveType.BIGINT),
+                    new Column("b22", PrimitiveType.STRING),
+                    new Column("b23", PrimitiveType.FLOAT)));
+            MOCKED_META.put("db1", tblSchemaMap1);
+            // db2
+            Map<String, List<Column>> tblSchemaMap2 = Maps.newHashMap();
+            tblSchemaMap2.put("tbl21", Lists.newArrayList(
+                    new Column("c11", PrimitiveType.BIGINT),
+                    new Column("c12", PrimitiveType.STRING),
+                    new Column("c13", PrimitiveType.FLOAT)));
+            MOCKED_META.put("db2", tblSchemaMap2);
+        }
+
+        @Override
+        public Map<String, Map<String, List<Column>>> getMetadata() {
+            return MOCKED_META;
+        }
     }
 }


### PR DESCRIPTION
Followup #38244
When setting `use_meta_cache=true`, the `include_database_list` and `exclude_database_list`
will have no effect. This PR fix it.

Also fix a bug, related to #40479.
if `include_database_list` and `exclude_database_list` is set, and `use` a database which is excluded,
Doris should return "database not found" error