### PR TITLE
[Enhancement](ExternalTable)Optimize the performance of getCachedRowCount when reading ExternalTable (#41659)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -202,14 +202,15 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
 
     @Override
     public long getCachedRowCount() {
-        // Return -1 if makeSureInitialized throw exception.
-        // For example, init hive table may throw NotSupportedException.
-        try {
-            makeSureInitialized();
-        } catch (Exception e) {
-            LOG.warn("Failed to initialize table {}.{}.{}", catalog.getName(), dbName, name, e);
+        // Return -1 if uninitialized.
+        // Before this, for uninitialized tables, we would call makeSureInitialized(), just like the implementation of
+        // ExternalTable.getRowCount(), but this is not very meaningful and time-consuming.
+        // The getCachedRowCount() function is only used when `show table` and querying `information_schema.tables`.
+        if (!isObjectCreated()) {
             return -1;
         }
+        // getExtMetaCacheMgr().getRowCountCache().getCachedRowCount() is an asynchronous non-blocking operation.
+        // For tables that are not in the cache, it will load asynchronously and return -1.
         return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache().getCachedRowCount(catalog.getId(), dbId, id);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -34,6 +34,7 @@ import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.SessionContext;
+import org.apache.doris.datasource.iceberg.IcebergUtils;
 import org.apache.doris.datasource.jdbc.client.JdbcClientConfig;
 import org.apache.doris.datasource.operations.ExternalMetadataOperations;
 import org.apache.doris.datasource.property.PropertyConverter;
@@ -53,6 +54,7 @@ import com.google.common.collect.Maps;
 import lombok.Getter;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -85,6 +87,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
     private int hmsEventsBatchSizePerRpc = -1;
     private boolean enableHmsEventsIncrementalSync = false;
 
+    //for "type" = "hms" , but is iceberg table.
+    private HiveCatalog icebergHiveCatalog;
 
     @VisibleForTesting
     public HMSExternalCatalog() {
@@ -195,6 +199,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
         transactionManager = TransactionManagerFactory.createHiveTransactionManager(hiveOps, fileSystemProvider,
                 fileSystemExecutor);
         metadataOps = hiveOps;
+
+        icebergHiveCatalog = IcebergUtils.createIcebergHiveCatalog(this, getName());
     }
 
     @Override
@@ -329,6 +335,10 @@ public class HMSExternalCatalog extends ExternalCatalog {
 
     public boolean isEnableHmsEventsIncrementalSync() {
         return enableHmsEventsIncrementalSync;
+    }
+
+    public HiveCatalog getIcebergHiveCatalog() {
+        return icebergHiveCatalog;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
@@ -19,10 +19,6 @@ package org.apache.doris.datasource.iceberg;
 
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.property.PropertyConverter;
-import org.apache.doris.datasource.property.constants.HMSProperties;
-
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.hive.HiveCatalog;
 
 import java.util.Map;
 
@@ -38,14 +34,7 @@ public class IcebergHMSExternalCatalog extends IcebergExternalCatalog {
     @Override
     protected void initCatalog() {
         icebergCatalogType = ICEBERG_HMS;
-        HiveCatalog hiveCatalog = new org.apache.iceberg.hive.HiveCatalog();
-        hiveCatalog.setConf(getConfiguration());
-        // initialize hive catalog
-        Map<String, String> catalogProperties = catalogProperty.getProperties();
-        String metastoreUris = catalogProperty.getOrDefault(HMSProperties.HIVE_METASTORE_URIS, "");
-        catalogProperties.put(CatalogProperties.URI, metastoreUris);
-        hiveCatalog.initialize(getName(), catalogProperties);
-        catalog = hiveCatalog;
+        catalog = IcebergUtils.createIcebergHiveCatalog(this, getName());
     }
 }
 

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_stats.groovy
@@ -40,6 +40,7 @@ suite("test_iceberg_table_stats", "p0,external,doris,external_docker,external_do
                 def retry = 0
                 def act = ""
                 while (retry < 10) {
+                    sql """ select * from ${table_name} """
                     def result = sql """ show table stats ${table_name} """
                     act = result[0][2]
                     if (act != "-1") {


### PR DESCRIPTION
bp #41659 

## Proposed changes
Because ExternalTable will initialize the previously uninitialized table when `getCachedRowCount()`, which is unnecessary. So for the uninitialized table, we directly return -1.
This will increase the speed of our query `information_schema.tables`.


