### PR TITLE
[Improvement](LDAP Auth)Enhance LDAP authentication with a configurable group filter

### DIFF
--- a/conf/ldap.conf
+++ b/conf/ldap.conf
@@ -30,6 +30,7 @@
 # ldap_user_basedn - Search base for users.
 # ldap_user_filter - User lookup filter, the placeholder {login} will be replaced by the user supplied login.
 # ldap_group_basedn - Search base for groups.
+# ldap_group_filter - Group lookup filter, the placeholder {login} will be replaced by the user supplied login. example : "(&(memberUid={login}))"
 ## step2: Restart fe, and use root or admin account to log in to doris.
 ## step3: Execute sql statement to set ldap admin password:
 # set ldap_admin_password = 'password';

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -67,6 +67,12 @@ public class LdapConfig extends ConfigBase {
     public static String ldap_group_basedn = "";
 
     /**
+     * Group lookup filter, the placeholder {login} will be replaced by the user supplied login.
+     */
+    @ConfigBase.ConfField
+    public static String ldap_group_filter = "";
+
+    /**
      * The user LDAP information cache time.
      * After timeout, the user information will be retrieved from the LDAP service again.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -162,12 +162,13 @@ public class LdapClient {
         List<String> groupDns;
 
         // Support Open Directory implementations
-        // If no group filter is configured, it defaults to querying groups based on the attribute 'member' for standard LDAP implementations
+        // If no group filter is configured, it defaults to querying groups based on the attribute 'member'
+        // for standard LDAP implementations
         if (!LdapConfig.ldap_group_filter.isEmpty()) {
             groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
                 .base(LdapConfig.ldap_group_basedn)
                 .filter(getGroupFilter(LdapConfig.ldap_group_filter, userName)));
-        }else{
+        } else {
             groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
                 .base(LdapConfig.ldap_group_basedn)
                 .where("member").is(userDn));

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -159,9 +159,20 @@ public class LdapClient {
         if (userDn == null) {
             return groups;
         }
-        List<String> groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
+        List<String> groupDns;
+
+        // Support Open Directory implementations
+        // If no group filter is configured, it defaults to querying groups based on the attribute 'member' for standard LDAP implementations
+        if (!LdapConfig.ldap_group_filter.isEmpty()) {
+            groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
+                .base(LdapConfig.ldap_group_basedn)
+                .filter(getGroupFilter(LdapConfig.ldap_group_filter, userName)));
+        }else{
+            groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
                 .base(LdapConfig.ldap_group_basedn)
                 .where("member").is(userDn));
+        }
+
         if (groupDns == null) {
             return groups;
         }
@@ -208,5 +219,9 @@ public class LdapClient {
 
     private String getUserFilter(String userFilter, String userName) {
         return userFilter.replaceAll("\\{login}", userName);
+    }
+
+    private String getGroupFilter(String groupFilter, String userName) {
+        return groupFilter.replaceAll("\\{login}", userName);
     }
 }


### PR DESCRIPTION
## Proposed changes
<!--Describe your changes.-->

This PR enhances LDAP authentication by adding an optional configurable filter for retrieving user groups, primarily to support Open Directory LDAP implementations. If the configurable property is left empty, the existing workflow will remain unchanged.
