### PR TITLE
[fix](routine load) reduce routine load task consume log

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -261,12 +261,13 @@ Status KafkaDataConsumer::group_consume(BlockingQueue<RdKafka::Message*>* queue,
             }
             [[fallthrough]];
         case RdKafka::ERR__PARTITION_EOF: {
-            LOG(INFO) << "consumer meet partition eof: " << _id
-                      << " partition offset: " << msg->offset();
+            VLOG_NOTICE << "consumer meet partition eof: " << _id
+                        << " partition offset: " << msg->offset();
             _consuming_partition_ids.erase(msg->partition());
             if (!queue->blocking_put(msg.get())) {
                 done = true;
             } else if (_consuming_partition_ids.size() <= 0) {
+                LOG(INFO) << "all partitions meet eof: " << _id;
                 msg.release();
                 done = true;
             } else {


### PR DESCRIPTION
There is too much routine load task log, five million logs were generated in 10 minutes.

```
grep 'consumer meet partition eof' be.INFO.log.20240930-164533 | wc -l 
5369624
```

