### PR TITLE
[fix] stats npe bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessor.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanRewriter;
 
 /**
@@ -27,6 +28,7 @@ import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanRewriter;
 public class PlanPostProcessor extends DefaultPlanRewriter<CascadesContext> {
 
     public Plan processRoot(Plan plan, CascadesContext ctx) {
-        return plan.accept(this, ctx);
+        AbstractPhysicalPlan newPlan = (AbstractPhysicalPlan) super.visit(plan, ctx);
+        return newPlan == plan ? plan : newPlan.copyStatsAndGroupIdFrom((AbstractPhysicalPlan) plan);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
@@ -284,6 +284,9 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
         }
         Slot leftSlot = leftSlots.iterator().next();
         Slot rightSlot = rightSlots.iterator().next();
+        if (leftStats == null || rightStats == null) {
+            return false;
+        }
         ColumnStatistic probeColumnStat = leftStats.findColumnStatistics(leftSlot);
         ColumnStatistic buildColumnStat = rightStats.findColumnStatistics(rightSlot);
         //TODO remove these code when we ensure left child if from probe side

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.visitor;
 
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate;
 
@@ -56,6 +57,14 @@ public abstract class DefaultPlanRewriter<C> extends PlanVisitor<Plan, C> {
             }
             newChildren.add(newChild);
         }
-        return hasNewChildren ? (P) plan.withChildren(newChildren.build()) : plan;
+        if (hasNewChildren) {
+            plan = (P) plan.withChildren(newChildren.build());
+            if (plan instanceof AbstractPhysicalPlan) {
+                AbstractPhysicalPlan physicalPlan = (AbstractPhysicalPlan) plan;
+                plan = (P) ((AbstractPhysicalPlan) physicalPlan.withChildren(newChildren.build()))
+                        .copyStatsAndGroupIdFrom(physicalPlan);
+            }
+        }
+        return plan;
     }
 }


### PR DESCRIPTION
## Proposed changes

Some processors have erased the stats information of the nodes, causing the runtime_filter_pruner to encounter a NullPointerException.

Issue Number: close #xxx

<!--Describe your changes.-->

