### PR TITLE
[fix](multi-catalog) Disable string dictionary filtering when predicate express is not slot

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -2018,7 +2018,7 @@ bool OrcReader::_can_filter_by_dict(int slot_id) {
         //  the implementation of NULL values because the dictionary itself does not contain
         //  NULL value encoding. As a result, many NULL-related functions or expressions
         //  cannot work properly, such as is null, is not null, coalesce, etc.
-        //  Here we first disable dictionary filtering when predicate contains functions.
+        //  Here we first disable dictionary filtering when predicate expr is not slot.
         //  Implementation of NULL value dictionary filtering will be carried out later.
         if (expr->node_type() != TExprNodeType::SLOT_REF) {
             return false;

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -2020,7 +2020,7 @@ bool OrcReader::_can_filter_by_dict(int slot_id) {
         //  cannot work properly, such as is null, is not null, coalesce, etc.
         //  Here we first disable dictionary filtering when predicate contains functions.
         //  Implementation of NULL value dictionary filtering will be carried out later.
-        if (expr->node_type() == TExprNodeType::FUNCTION_CALL) {
+        if (expr->node_type() != TExprNodeType::SLOT_REF) {
             return false;
         }
         for (auto& child : expr->children()) {

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -214,7 +214,7 @@ bool RowGroupReader::_can_filter_by_dict(int slot_id,
         //  cannot work properly, such as is null, is not null, coalesce, etc.
         //  Here we first disable dictionary filtering when predicate contains functions.
         //  Implementation of NULL value dictionary filtering will be carried out later.
-        if (expr->node_type() == TExprNodeType::FUNCTION_CALL) {
+        if (expr->node_type() != TExprNodeType::SLOT_REF) {
             return false;
         }
         for (auto& child : expr->children()) {

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -212,7 +212,7 @@ bool RowGroupReader::_can_filter_by_dict(int slot_id,
         //  the implementation of NULL values because the dictionary itself does not contain
         //  NULL value encoding. As a result, many NULL-related functions or expressions
         //  cannot work properly, such as is null, is not null, coalesce, etc.
-        //  Here we first disable dictionary filtering when predicate contains functions.
+        //  Here we first disable dictionary filtering when predicate is not slot.
         //  Implementation of NULL value dictionary filtering will be carried out later.
         if (expr->node_type() != TExprNodeType::SLOT_REF) {
             return false;

--- a/regression-test/data/external_table_p0/hive/test_string_dict_filter.out
+++ b/regression-test/data/external_table_p0/hive/test_string_dict_filter.out
@@ -56,61 +56,7 @@ null
 -- !q14 --
 null
 
--- !q01 --
-3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
-5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
-
--- !q02 --
-1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
-2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
-4	136777	O	32151.78	1995-10-11	\N	Clerk#000000124	0	sits. slyly regular warthogs cajole. regular, regular theodolites acro
-
--- !q03 --
-1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
-2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
-3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
-4	136777	O	32151.78	1995-10-11	\N	Clerk#000000124	0	sits. slyly regular warthogs cajole. regular, regular theodolites acro
-5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
-
--- !q04 --
-4	136777	O	32151.78	1995-10-11	\N	Clerk#000000124	0	sits. slyly regular warthogs cajole. regular, regular theodolites acro
-
--- !q05 --
-1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
-2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
-3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
-5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
-
--- !q06 --
-1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
-3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
-5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
-
--- !q07 --
-1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
-3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
-5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
-
--- !q08 --
-
--- !q09 --
-2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
-3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
-5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
-
--- !q10 --
-null
-
--- !q11 --
-null
-
--- !q12 --
-null
-
--- !q13 --
-null
-
--- !q14 --
+-- !q15 --
 null
 
 -- !q01 --
@@ -170,6 +116,9 @@ null
 -- !q14 --
 null
 
+-- !q15 --
+null
+
 -- !q01 --
 3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
 5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
@@ -225,5 +174,68 @@ null
 null
 
 -- !q14 --
+null
+
+-- !q15 --
+null
+
+-- !q01 --
+3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
+5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
+
+-- !q02 --
+1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
+2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
+4	136777	O	32151.78	1995-10-11	\N	Clerk#000000124	0	sits. slyly regular warthogs cajole. regular, regular theodolites acro
+
+-- !q03 --
+1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
+2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
+3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
+4	136777	O	32151.78	1995-10-11	\N	Clerk#000000124	0	sits. slyly regular warthogs cajole. regular, regular theodolites acro
+5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
+
+-- !q04 --
+4	136777	O	32151.78	1995-10-11	\N	Clerk#000000124	0	sits. slyly regular warthogs cajole. regular, regular theodolites acro
+
+-- !q05 --
+1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
+2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
+3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
+5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
+
+-- !q06 --
+1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
+3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
+5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
+
+-- !q07 --
+1	36901	O	173665.47	1996-01-02	5-LOW	Clerk#000000951	0	nstructions sleep furiously among
+3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
+5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
+
+-- !q08 --
+
+-- !q09 --
+2	78002	O	46929.18	1996-12-01	1-URGENT	Clerk#000000880	0	foxes. pending accounts at the pending, silent asymptot
+3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
+5	44485	F	144659.20	1994-07-30	5-LOW	Clerk#000000925	0	quickly. bold deposits sleep slyly. packages use slyly
+
+-- !q10 --
+null
+
+-- !q11 --
+null
+
+-- !q12 --
+null
+
+-- !q13 --
+null
+
+-- !q14 --
+null
+
+-- !q15 --
 null
 

--- a/regression-test/data/external_table_p0/hive/test_string_dict_filter.out
+++ b/regression-test/data/external_table_p0/hive/test_string_dict_filter.out
@@ -57,7 +57,7 @@ null
 null
 
 -- !q15 --
-null
+5
 
 -- !q01 --
 3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
@@ -117,7 +117,7 @@ null
 null
 
 -- !q15 --
-null
+5
 
 -- !q01 --
 3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
@@ -177,7 +177,7 @@ null
 null
 
 -- !q15 --
-null
+5
 
 -- !q01 --
 3	123314	F	193846.25	1993-10-14	5-LOW	Clerk#000000955	0	sly final accounts boost. carefully regular ideas cajole carefully. depos
@@ -237,5 +237,5 @@ null
 null
 
 -- !q15 --
-null
+5
 

--- a/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
@@ -60,7 +60,7 @@ suite("test_string_dict_filter", "p0,external,hive,external_docker,external_dock
         select * from ( select COALESCE(o_orderpriority, 'null') AS o_orderpriority from test_string_dict_filter_parquet ) as A where o_orderpriority = 'null';
         """
         qt_q15 """
-        select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' else '0' end) as o_orderpriority from test_string_dict_filter_parquet ) as A where o_orderpriority = '0';
+        select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' when o_orderpriority = 'y' then '2' else '0' end) as o_orderpriority from test_string_dict_filter_parquet ) as A where o_orderpriority = '0';
         """
     }
     def q_orc = {
@@ -107,7 +107,7 @@ suite("test_string_dict_filter", "p0,external,hive,external_docker,external_dock
         select * from ( select COALESCE(o_orderpriority, 'null') AS o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = 'null';
         """
         qt_q15 """
-        select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' else '0' end) as o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = '0';
+        select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' when o_orderpriority = 'y' then '2' else '0' end) as o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = '0';
         """
     }
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
@@ -60,7 +60,7 @@ suite("test_string_dict_filter", "p0,external,hive,external_docker,external_dock
         select * from ( select COALESCE(o_orderpriority, 'null') AS o_orderpriority from test_string_dict_filter_parquet ) as A where o_orderpriority = 'null';
         """
         qt_q15 """
-        select * from ( select (case when o_orderpriority is null then 'null' else o_orderpriority end) case_col from test_string_dict_filter_parquet ) x where case_col = 'null';
+        select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' else '0' end) as o_orderpriority from test_string_dict_filter_parquet ) as A where o_orderpriority = '0';
         """
     }
     def q_orc = {
@@ -107,7 +107,7 @@ suite("test_string_dict_filter", "p0,external,hive,external_docker,external_dock
         select * from ( select COALESCE(o_orderpriority, 'null') AS o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = 'null';
         """
         qt_q15 """
-        select * from ( select (case when o_orderpriority is null then 'null' else o_orderpriority end) case_col from test_string_dict_filter_orc ) x where case_col = 'null';
+        select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' else '0' end) as o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = '0';
         """
     }
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
@@ -59,6 +59,9 @@ suite("test_string_dict_filter", "p0,external,hive,external_docker,external_dock
         qt_q14 """
         select * from ( select COALESCE(o_orderpriority, 'null') AS o_orderpriority from test_string_dict_filter_parquet ) as A where o_orderpriority = 'null';
         """
+        qt_q15 """
+        select * from ( select (case when o_orderpriority is null then 'null' else o_orderpriority end) case_col from test_string_dict_filter_parquet ) x where case_col = 'null';
+        """
     }
     def q_orc = {
         qt_q01 """
@@ -102,6 +105,9 @@ suite("test_string_dict_filter", "p0,external,hive,external_docker,external_dock
         """
         qt_q14 """
         select * from ( select COALESCE(o_orderpriority, 'null') AS o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = 'null';
+        """
+        qt_q15 """
+        select * from ( select (case when o_orderpriority is null then 'null' else o_orderpriority end) case_col from test_string_dict_filter_orc ) x where case_col = 'null';
         """
     }
     String enabled = context.config.otherConfigs.get("enableHiveTest")


### PR DESCRIPTION
## Proposed changes
follow up https://github.com/apache/doris/pull/35335/
When the `"case when ... then ... when ... then ... else"` occurs, function_expr may not exist in the pushed down predicate, but the handling of null values ​​is still problematic.

table data:
```text
mysql> select o_orderpriority from test_string_dict_filter_orc;
+-----------------+
| o_orderpriority |
+-----------------+
| 5-LOW           |
| 1-URGENT        |
| 5-LOW           |
| NULL            |
| 5-LOW           |
+-----------------+
```

before:
```text
mysql> select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' when o_orderpriority = 'y' then '2' else '0' end) as o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = '0';
+------------------------+
| count(o_orderpriority) |
+------------------------+
|                      4 |
+------------------------+
```

after:
```text
mysql> select count(o_orderpriority) from ( select (case when o_orderpriority = 'x' then '1' when o_orderpriority = 'y' then '2' else '0' end) as o_orderpriority from test_string_dict_filter_orc ) as A where o_orderpriority = '0';
+------------------------+
| count(o_orderpriority) |
+------------------------+
|                      5 |
+------------------------+
```

