### PR TITLE
[Refactor] (inverted index) list inverted index files 

### DIFF
--- a/be/src/http/action/download_binlog_action.cpp
+++ b/be/src/http/action/download_binlog_action.cpp
@@ -48,6 +48,7 @@ const std::string kBinlogVersionParameter = "binlog_version";
 const std::string kRowsetIdParameter = "rowset_id";
 const std::string kSegmentIndexParameter = "segment_index";
 const std::string kSegmentIndexIdParameter = "segment_index_id";
+const std::string kSegmentIndexSuffixIdParameter = "segment_index_suffix";
 const std::string kAcquireMD5Parameter = "acquire_md5";
 
 // get http param, if no value throw exception
@@ -147,8 +148,9 @@ void handle_get_segment_index_file(StorageEngine& engine, HttpRequest* req,
         const auto& rowset_id = get_http_param(req, kRowsetIdParameter);
         const auto& segment_index = get_http_param(req, kSegmentIndexParameter);
         const auto& segment_index_id = req->param(kSegmentIndexIdParameter);
-        segment_index_file_path =
-                tablet->get_segment_index_filepath(rowset_id, segment_index, segment_index_id);
+        const auto& segment_index_suffix = req->param(kSegmentIndexSuffixIdParameter);
+        segment_index_file_path = tablet->get_segment_index_filepath(
+                rowset_id, segment_index, segment_index_id, segment_index_suffix);
         is_acquire_md5 = !req->param(kAcquireMD5Parameter).empty();
     } catch (const std::exception& e) {
         HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, e.what());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -640,7 +640,7 @@ Status Compaction::do_inverted_index_compaction() {
     Status status = Status::OK();
     for (auto&& column_uniq_id : ctx.columns_to_do_index_compaction) {
         auto col = _cur_tablet_schema->column_by_uid(column_uniq_id);
-        const auto* index_meta = _cur_tablet_schema->get_inverted_index(col);
+        const auto* index_meta = _cur_tablet_schema->inverted_index(col);
 
         std::vector<lucene::store::Directory*> dest_index_dirs(dest_segment_num);
         try {
@@ -737,7 +737,7 @@ void Compaction::construct_index_compaction_columns(RowsetWriterContext& ctx) {
                 return false;
             }
 
-            const auto* index_meta = rowset->tablet_schema()->get_inverted_index(col_unique_id, "");
+            const auto* index_meta = rowset->tablet_schema()->inverted_index(col_unique_id);
             if (index_meta == nullptr) {
                 LOG(WARNING) << "tablet[" << _tablet->tablet_id() << "] column_unique_id["
                              << col_unique_id << "] index meta is null, will skip index compaction";

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -701,8 +701,7 @@ void Compaction::construct_index_compaction_columns(RowsetWriterContext& ctx) {
         bool is_continue = false;
         std::optional<std::map<std::string, std::string>> first_properties;
         for (const auto& rowset : _input_rowsets) {
-            const auto* tablet_index =
-                    rowset->tablet_schema()->get_inverted_index(col_unique_id, "");
+            const auto* tablet_index = rowset->tablet_schema()->inverted_index(col_unique_id);
             // no inverted index or index id is different from current index id
             if (tablet_index == nullptr || tablet_index->index_id() != index.index_id()) {
                 is_continue = true;

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "io/fs/file_system.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_reader.h"
@@ -38,6 +39,7 @@ class BetaRowset;
 
 namespace io {
 class RemoteFileSystem;
+struct FileInfo;
 } // namespace io
 struct RowsetId;
 
@@ -88,6 +90,8 @@ public:
 
     Status show_nested_index_file(rapidjson::Value* rowset_value,
                                   rapidjson::Document::AllocatorType& allocator);
+
+    Result<std::vector<io::FileInfo>> list_inverted_index_files() override;
 
 protected:
     BetaRowset(const TabletSchemaSPtr& schema, const RowsetMetaSharedPtr& rowset_meta,

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -517,6 +517,7 @@ Status BetaRowsetWriter::_rename_compacted_segment_plain(uint64_t seg_id) {
     return Status::OK();
 }
 
+// Variant columns don't participate in segment compaction; here, we can construct the file names.
 Status BetaRowsetWriter::_rename_compacted_indices(int64_t begin, int64_t end, uint64_t seg_id) {
     int ret;
 
@@ -548,7 +549,7 @@ Status BetaRowsetWriter::_rename_compacted_indices(int64_t begin, int64_t end, u
     // rename remaining inverted index files
     for (auto column : _context.tablet_schema->columns()) {
         if (_context.tablet_schema->has_inverted_index(*column)) {
-            const auto* index_info = _context.tablet_schema->get_inverted_index(*column);
+            const auto* index_info = _context.tablet_schema->inverted_index(*column);
             auto index_id = index_info->index_id();
             if (_context.tablet_schema->get_inverted_index_storage_format() ==
                 InvertedIndexStorageFormatPB::V1) {

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -140,6 +140,17 @@ Result<std::string> Rowset::segment_path(int64_t seg_id) {
     });
 }
 
+Result<std::string> Rowset::rowset_dir() {
+    if (is_local()) {
+        return _tablet_path;
+    }
+
+    return _rowset_meta->remote_storage_resource().transform([=, this](auto&& storage_resource) {
+        return storage_resource->remote_rowset_path(_rowset_meta->tablet_id(),
+                                                    _rowset_meta->rowset_id().to_string());
+    });
+}
+
 Status check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets) {
     if (rowsets.size() < 2) {
         return Status::OK();

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -310,6 +310,10 @@ public:
 
     Result<std::string> segment_path(int64_t seg_id);
 
+    Result<std::string> rowset_dir();
+
+    virtual Result<std::vector<io::FileInfo>> list_inverted_index_files() = 0;
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -154,6 +154,7 @@ Status SegcompactionWorker::_delete_original_segments(uint32_t begin, uint32_t e
         // message when we encounter an error.
         RETURN_NOT_OK_STATUS_WITH_WARN(fs->delete_file(seg_path),
                                        strings::Substitute("Failed to delete file=$0", seg_path));
+        // Variant columns don't participate in segment compaction; here, we can construct the file names.
         if (schema->has_inverted_index() &&
             schema->get_inverted_index_storage_format() >= InvertedIndexStorageFormatPB::V2) {
             auto idx_path = InvertedIndexDescriptor::get_index_file_path_v2(
@@ -166,7 +167,7 @@ Status SegcompactionWorker::_delete_original_segments(uint32_t begin, uint32_t e
         // Delete inverted index files
         for (auto&& column : schema->columns()) {
             if (schema->has_inverted_index(*column)) {
-                const auto* index_info = schema->get_inverted_index(*column);
+                const auto* index_info = schema->inverted_index(*column);
                 auto index_id = index_info->index_id();
                 if (schema->get_inverted_index_storage_format() ==
                     InvertedIndexStorageFormatPB::V1) {

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -63,7 +63,7 @@ struct ColumnWriterOptions {
     bool need_inverted_index = false;
     uint8_t gram_size;
     uint16_t gram_bf_size;
-    std::vector<const TabletIndex*> indexes;
+    std::vector<const TabletIndex*> indexes; // unused
     const TabletIndex* inverted_index = nullptr;
     InvertedIndexFileWriter* inverted_index_file_writer;
     std::string to_string() const {

--- a/be/src/olap/rowset/segment_v2/inverted_index_desc.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_desc.h
@@ -23,8 +23,15 @@
 
 namespace doris {
 struct RowsetId;
+class Status;
 
 namespace segment_v2 {
+
+struct IndexFileNameFragment {
+    std::string_view rowset_id;
+    int32_t seg_id = -1;
+    std::string_view index_suffix; // "such as _10078@path.idx or .idx"
+};
 
 class InvertedIndexDescriptor {
 public:
@@ -45,6 +52,18 @@ public:
     static std::string get_index_file_cache_key(std::string_view index_path_prefix,
                                                 int64_t index_id,
                                                 std::string_view index_path_suffix);
+
+    // local index file path:
+    //   {storage_dir}/data/{shard_id}/{tablet_id}/{schema_hash}/{rowset_id}_{seg_id}{index_suffix}
+    // InvertedIndexStorageFormatV1: index_suffix = _{index_id}@{suffix}.idx
+    // InvertedIndexStorageFormatV1: index_suffix = .idx
+    // if index file name is valid, seg_id = -1
+    static IndexFileNameFragment decompose_local_index_file_name(
+            const std::string& index_file_name);
+
+    // param: {file_name}.idx
+    // return: {file_name}.binlog-index
+    static std::string snapshot_index_file_name(const std::string& index_file_name);
 
     static const char* get_temporary_null_bitmap_file_name() { return "null_bitmap"; }
     static const char* get_temporary_bkd_index_data_file_name() { return "bkd"; }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1057,16 +1057,18 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         return Status::OK();
     }
     for (auto cid : _schema->column_ids()) {
+        // Use segment’s own index_meta, for compatibility with future indexing needs to default to lowercase.
         if (_inverted_index_iterators[cid] == nullptr) {
-            // Not check type valid, since we need to get inverted index for related variant type when reading the segment.
-            // If check type valid, we can not get inverted index for variant type, and result nullptr.The result for calling
-            // get_inverted_index with variant suffix should return corresponding inverted index meta.
-            bool check_inverted_index_by_type = false;
-            // Use segment’s own index_meta, for compatibility with future indexing needs to default to lowercase.
+            // In the _opts.tablet_schema, the sub-column type information for the variant is FieldType::OLAP_FIELD_TYPE_VARIANT.
+            // This is because the sub-column is created in create_materialized_variant_column.
+            // We use this column to locate the metadata for the inverted index, which requires a unique_id and path.
+            const auto& column = _opts.tablet_schema->column(cid);
+            int32_t col_unique_id =
+                    column.is_extracted_column() ? column.parent_unique_id() : column.unique_id();
+            const std::string& suffix_path =
+                    column.has_path_info() ? column.path_info_ptr()->get_path() : "";
             RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
-                    _opts.tablet_schema->column(cid),
-                    _segment->_tablet_schema->get_inverted_index(_opts.tablet_schema->column(cid),
-                                                                 check_inverted_index_by_type),
+                    column, _segment->_tablet_schema->inverted_index(col_unique_id, suffix_path),
                     _opts, &_inverted_index_iterators[cid]));
         }
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -214,7 +214,7 @@ Status SegmentWriter::_create_column_writer(uint32_t cid, const TabletColumn& co
         opts.inverted_index = inverted_index;
         opts.need_inverted_index = true;
         DCHECK(_inverted_index_file_writer != nullptr);
-        opts.inverted_index_file_writer = _inverted_index_file_writer.get();
+        opts.inverted_index_file_writer = _inverted_index_file_writer;
     }
 #define CHECK_FIELD_TYPE(TYPE, type_name)                                                      \
     if (column.type() == FieldType::OLAP_FIELD_TYPE_##TYPE) {                                  \

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -186,20 +186,22 @@ Status SegmentWriter::_create_column_writer(uint32_t cid, const TabletColumn& co
 
     // now we create zone map for key columns in AGG_KEYS or all column in UNIQUE_KEYS or DUP_KEYS
     // except for columns whose type don't support zone map.
-    opts.need_zone_map = column.is_key() || schema->keys_type() != KeysType::AGG_KEYS;
-    opts.need_bloom_filter = column.is_bf_column();
-    auto* tablet_index = schema->get_ngram_bf_index(column.unique_id());
-    if (tablet_index) {
+    opts.need_zone_map = (column.is_key() || schema->keys_type() != KeysType::AGG_KEYS) &&
+                         !column.is_variant_type();
+    opts.need_bloom_filter = column.is_bf_column() && !column.is_variant_type();
+    auto* ngram_bf_index = schema->ngram_bf_index(column);
+    if (ngram_bf_index) {
         opts.need_bloom_filter = true;
         opts.is_ngram_bf_index = true;
-        opts.gram_size = tablet_index->get_gram_size();
-        opts.gram_bf_size = tablet_index->get_gram_bf_size();
+        opts.gram_size = ngram_bf_index->get_gram_size();
+        opts.gram_bf_size = ngram_bf_index->get_gram_bf_size();
     }
 
     opts.need_bitmap_index = column.has_bitmap_index();
     bool skip_inverted_index = false;
     if (_opts.rowset_ctx != nullptr) {
         // skip write inverted index for index compaction column
+        // index compaction will skip variant column and its subcolumn
         skip_inverted_index =
                 _opts.rowset_ctx->columns_to_do_index_compaction.count(column.unique_id()) > 0;
     }
@@ -207,22 +209,12 @@ Status SegmentWriter::_create_column_writer(uint32_t cid, const TabletColumn& co
     if (_opts.write_type == DataWriteType::TYPE_DIRECT && schema->skip_write_index_on_load()) {
         skip_inverted_index = true;
     }
-    // indexes for this column
-    opts.indexes = schema->get_indexes_for_column(column);
-    if (!InvertedIndexColumnWriter::check_support_inverted_index(column)) {
-        opts.need_zone_map = false;
-        opts.need_bloom_filter = false;
-        opts.need_bitmap_index = false;
-    }
-    opts.inverted_index_file_writer = _inverted_index_file_writer;
-    for (const auto* index : opts.indexes) {
-        if (!skip_inverted_index && index->index_type() == IndexType::INVERTED) {
-            opts.inverted_index = index;
-            opts.need_inverted_index = true;
-            DCHECK(_inverted_index_file_writer != nullptr);
-            // TODO support multiple inverted index
-            break;
-        }
+    if (const auto& inverted_index = schema->inverted_index(column);
+        inverted_index && !skip_inverted_index) {
+        opts.inverted_index = inverted_index;
+        opts.need_inverted_index = true;
+        DCHECK(_inverted_index_file_writer != nullptr);
+        opts.inverted_index_file_writer = _inverted_index_file_writer.get();
     }
 #define CHECK_FIELD_TYPE(TYPE, type_name)                                                      \
     if (column.type() == FieldType::OLAP_FIELD_TYPE_##TYPE) {                                  \

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -208,7 +208,7 @@ Status VerticalSegmentWriter::_create_column_writer(uint32_t cid, const TabletCo
         opts.inverted_index = inverted_index;
         opts.need_inverted_index = true;
         DCHECK(_inverted_index_file_writer != nullptr);
-        opts.inverted_index_file_writer = _inverted_index_file_writer.get();
+        opts.inverted_index_file_writer = _inverted_index_file_writer;
     }
 
 #define CHECK_FIELD_TYPE(TYPE, type_name)                                                      \

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1372,8 +1372,8 @@ Status SchemaChangeJob::parse_request(const SchemaChangeParams& sc_params,
             // index changed
             if (column_new.is_bf_column() != column_old.is_bf_column() ||
                 column_new.has_bitmap_index() != column_old.has_bitmap_index() ||
-                new_tablet_schema->has_inverted_index(column_new) !=
-                        base_tablet_schema->has_inverted_index(column_old)) {
+                new_tablet_schema->inverted_index(column_new.unique_id()) !=
+                        base_tablet_schema->inverted_index(column_new.unique_id())) {
                 *sc_directly = true;
                 return Status::OK();
             }

--- a/be/src/olap/storage_policy.cpp
+++ b/be/src/olap/storage_policy.cpp
@@ -191,43 +191,39 @@ std::string StorageResource::remote_segment_path(const RowsetMeta& rowset, int64
     }
 }
 
-std::string StorageResource::remote_idx_v1_path(const RowsetMeta& rowset, int64_t seg_id,
-                                                int64_t index_id,
-                                                std::string_view index_path_suffix) const {
-    std::string suffix =
-            index_path_suffix.empty() ? "" : std::string {"@"} + index_path_suffix.data();
-    switch (path_version) {
-    case 0:
-        return fmt::format("{}/{}/{}_{}_{}{}.idx", DATA_PREFIX, rowset.tablet_id(),
-                           rowset.rowset_id().to_string(), seg_id, index_id, suffix);
-    case 1:
-        return fmt::format("{}/{}/{}/{}/{}_{}{}.idx", DATA_PREFIX, shard_fn(rowset.tablet_id()),
-                           rowset.tablet_id(), rowset.rowset_id().to_string(), seg_id, index_id,
-                           suffix);
-    default:
-        exit_at_unknown_path_version(fs->id(), path_version);
-    }
-}
-
-std::string StorageResource::remote_idx_v2_path(const RowsetMeta& rowset, int64_t seg_id) const {
-    switch (path_version) {
-    case 0:
-        return fmt::format("{}/{}/{}_{}.idx", DATA_PREFIX, rowset.tablet_id(),
-                           rowset.rowset_id().to_string(), seg_id);
-    case 1:
-        return fmt::format("{}/{}/{}/{}/{}.idx", DATA_PREFIX, shard_fn(rowset.tablet_id()),
-                           rowset.tablet_id(), rowset.rowset_id().to_string(), seg_id);
-    default:
-        exit_at_unknown_path_version(fs->id(), path_version);
-    }
-}
-
 std::string StorageResource::remote_tablet_path(int64_t tablet_id) const {
     switch (path_version) {
     case 0:
         return fmt::format("{}/{}", DATA_PREFIX, tablet_id);
     case 1:
         return fmt::format("{}/{}/{}", DATA_PREFIX, shard_fn(tablet_id), tablet_id);
+    default:
+        exit_at_unknown_path_version(fs->id(), path_version);
+    }
+}
+
+std::string StorageResource::remote_rowset_path(int64_t tablet_id,
+                                                std::string_view rowset_id) const {
+    switch (path_version) {
+    case 0:
+        return fmt::format("{}/{}", DATA_PREFIX, tablet_id);
+    case 1:
+        return fmt::format("{}/{}/{}/{}", DATA_PREFIX, shard_fn(tablet_id), tablet_id, rowset_id);
+    default:
+        exit_at_unknown_path_version(fs->id(), path_version);
+    }
+}
+
+std::string StorageResource::remote_inverted_index_path(
+        int64_t tablet_id, const std::string_view& rowset_id, int64_t seg_id,
+        const std::string_view& index_suffix) const {
+    switch (path_version) {
+    case 0:
+        return fmt::format("{}/{}/{}_{}{}", DATA_PREFIX, tablet_id, rowset_id, seg_id,
+                           index_suffix);
+    case 1:
+        return fmt::format("{}/{}/{}/{}/{}{}", DATA_PREFIX, shard_fn(tablet_id), tablet_id,
+                           rowset_id, seg_id, index_suffix);
     default:
         exit_at_unknown_path_version(fs->id(), path_version);
     }

--- a/be/src/olap/storage_policy.h
+++ b/be/src/olap/storage_policy.h
@@ -77,10 +77,11 @@ struct StorageResource {
                                     int64_t seg_id) const;
     std::string remote_segment_path(const RowsetMeta& rowset, int64_t seg_id) const;
     std::string remote_tablet_path(int64_t tablet_id) const;
+    std::string remote_rowset_path(int64_t tablet_id, std::string_view rowset_id) const;
 
-    std::string remote_idx_v1_path(const RowsetMeta& rowset, int64_t seg_id, int64_t index_id,
-                                   std::string_view index_suffix) const;
-    std::string remote_idx_v2_path(const RowsetMeta& rowset, int64_t seg_id) const;
+    std::string remote_inverted_index_path(int64_t tablet_id, const std::string_view& rowset_id,
+                                           int64_t seg_id,
+                                           const std::string_view& index_suffix) const;
 
     std::string cooldown_tablet_meta_path(int64_t tablet_id, int64_t replica_id,
                                           int64_t cooldown_term) const;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -444,9 +444,11 @@ public:
     std::string get_segment_filepath(std::string_view rowset_id, int64_t segment_index) const;
     std::string get_segment_index_filepath(std::string_view rowset_id,
                                            std::string_view segment_index,
-                                           std::string_view index_id) const;
+                                           std::string_view index_id,
+                                           const std::string_view& index_id_suffix) const;
     std::string get_segment_index_filepath(std::string_view rowset_id, int64_t segment_index,
-                                           int64_t index_id) const;
+                                           int64_t index_id,
+                                           const std::string_view& index_id_suffix) const;
     bool can_add_binlog(uint64_t total_binlog_size) const;
     void gc_binlogs(int64_t version);
     Status ingest_binlog_metas(RowsetBinlogMetasPB* metas_pb);

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -536,7 +536,7 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
         auto* pred = predicates.back();
 
         const auto& col = _tablet_schema->column(pred->column_id());
-        const auto* tablet_index = _tablet_schema->get_ngram_bf_index(col.unique_id());
+        const auto* tablet_index = _tablet_schema->ngram_bf_index(col);
         if (is_like_predicate(pred) && tablet_index && config::enable_query_like_bloom_filter) {
             std::unique_ptr<segment_v2::BloomFilter> ng_bf;
             std::string pattern = pred->get_search_str();

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -894,18 +894,21 @@ void TabletColumn::append_sparse_column(TabletColumn column) {
     _num_sparse_columns++;
 }
 
-void TabletSchema::append_index(TabletIndex index) {
+void TabletSchema::append_index(TabletIndex&& index) {
     _indexes.push_back(std::move(index));
 }
 
-void TabletSchema::update_index(const TabletColumn& col, TabletIndex index) {
-    int32_t col_unique_id = col.unique_id();
+void TabletSchema::update_index(const TabletColumn& col, const IndexType& index_type,
+                                TabletIndex&& index) {
+    int32_t col_unique_id = col.is_extracted_column() ? col.parent_unique_id() : col.unique_id();
     const std::string& suffix_path =
             col.has_path_info() ? escape_for_path_name(col.path_info_ptr()->get_path()) : "";
     for (size_t i = 0; i < _indexes.size(); i++) {
         for (int32_t id : _indexes[i].col_unique_ids()) {
-            if (id == col_unique_id && _indexes[i].get_index_suffix() == suffix_path) {
-                _indexes[i] = index;
+            if (_indexes[i].index_type() == index_type && id == col_unique_id &&
+                _indexes[i].get_index_suffix() == suffix_path) {
+                _indexes[i] = std::move(index);
+                break;
             }
         }
     }
@@ -1329,28 +1332,6 @@ Result<const TabletColumn*> TabletSchema::column(const std::string& field_name) 
     return _cols[it->second].get();
 }
 
-std::vector<const TabletIndex*> TabletSchema::get_indexes_for_column(
-        const TabletColumn& col) const {
-    std::vector<const TabletIndex*> indexes_for_column;
-    // Some columns (Float, Double, JSONB ...) from the variant do not support index, but they are listed in TabltetIndex.
-    if (!segment_v2::InvertedIndexColumnWriter::check_support_inverted_index(col)) {
-        return indexes_for_column;
-    }
-    int32_t col_unique_id = col.is_extracted_column() ? col.parent_unique_id() : col.unique_id();
-    const std::string& suffix_path =
-            col.has_path_info() ? escape_for_path_name(col.path_info_ptr()->get_path()) : "";
-    // TODO use more efficient impl
-    for (size_t i = 0; i < _indexes.size(); i++) {
-        for (int32_t id : _indexes[i].col_unique_ids()) {
-            if (id == col_unique_id && _indexes[i].get_index_suffix() == suffix_path) {
-                indexes_for_column.push_back(&(_indexes[i]));
-            }
-        }
-    }
-
-    return indexes_for_column;
-}
-
 void TabletSchema::update_tablet_columns(const TabletSchema& tablet_schema,
                                          const std::vector<TColumn>& t_columns) {
     copy_from(tablet_schema);
@@ -1362,49 +1343,24 @@ void TabletSchema::update_tablet_columns(const TabletSchema& tablet_schema,
     }
 }
 
-bool TabletSchema::has_inverted_index(const TabletColumn& col) const {
-    // TODO use more efficient impl
-    int32_t col_unique_id = col.is_extracted_column() ? col.parent_unique_id() : col.unique_id();
-    const std::string& suffix_path =
-            col.has_path_info() ? escape_for_path_name(col.path_info_ptr()->get_path()) : "";
+bool TabletSchema::has_inverted_index(int64_t index_id) const {
     for (size_t i = 0; i < _indexes.size(); i++) {
-        if (_indexes[i].index_type() == IndexType::INVERTED) {
-            for (int32_t id : _indexes[i].col_unique_ids()) {
-                if (id == col_unique_id && _indexes[i].get_index_suffix() == suffix_path) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    return false;
-}
-
-bool TabletSchema::has_inverted_index_with_index_id(int64_t index_id,
-                                                    const std::string& suffix_name) const {
-    for (size_t i = 0; i < _indexes.size(); i++) {
-        if (_indexes[i].index_type() == IndexType::INVERTED &&
-            _indexes[i].get_index_suffix() == suffix_name && _indexes[i].index_id() == index_id) {
+        if (_indexes[i].index_type() == IndexType::INVERTED && index_id == _indexes[i].index_id()) {
             return true;
         }
     }
     return false;
 }
 
-const TabletIndex* TabletSchema::get_inverted_index_with_index_id(
-        int64_t index_id, const std::string& suffix_name) const {
-    for (size_t i = 0; i < _indexes.size(); i++) {
-        if (_indexes[i].index_type() == IndexType::INVERTED &&
-            _indexes[i].get_index_suffix() == suffix_name && _indexes[i].index_id() == index_id) {
-            return &(_indexes[i]);
-        }
-    }
-
-    return nullptr;
+bool TabletSchema::has_inverted_index(const TabletColumn& col) const {
+    int32_t col_unique_id = col.is_extracted_column() ? col.parent_unique_id() : col.unique_id();
+    const std::string& suffix_path =
+            col.has_path_info() ? escape_for_path_name(col.path_info_ptr()->get_path()) : "";
+    return inverted_index(col_unique_id, suffix_path);
 }
 
-const TabletIndex* TabletSchema::get_inverted_index(int32_t col_unique_id,
-                                                    const std::string& suffix_path) const {
+const TabletIndex* TabletSchema::inverted_index(int32_t col_unique_id,
+                                                const std::string& suffix_path) const {
     for (size_t i = 0; i < _indexes.size(); i++) {
         if (_indexes[i].index_type() == IndexType::INVERTED) {
             for (int32_t id : _indexes[i].col_unique_ids()) {
@@ -1418,11 +1374,9 @@ const TabletIndex* TabletSchema::get_inverted_index(int32_t col_unique_id,
     return nullptr;
 }
 
-const TabletIndex* TabletSchema::get_inverted_index(const TabletColumn& col,
-                                                    bool check_valid) const {
-    // With check_valid set to true by default
+const TabletIndex* TabletSchema::inverted_index(const TabletColumn& col) const {
     // Some columns(Float, Double, JSONB ...) from the variant do not support inverted index
-    if (check_valid && !segment_v2::InvertedIndexColumnWriter::check_support_inverted_index(col)) {
+    if (!segment_v2::InvertedIndexColumnWriter::check_support_inverted_index(col)) {
         return nullptr;
     }
     // TODO use more efficient impl
@@ -1430,28 +1384,27 @@ const TabletIndex* TabletSchema::get_inverted_index(const TabletColumn& col,
     int32_t col_unique_id = col.is_extracted_column() ? col.parent_unique_id() : col.unique_id();
     const std::string& suffix_path =
             col.has_path_info() ? escape_for_path_name(col.path_info_ptr()->get_path()) : "";
-    return get_inverted_index(col_unique_id, suffix_path);
+    return inverted_index(col_unique_id, suffix_path);
 }
 
-bool TabletSchema::has_ngram_bf_index(int32_t col_unique_id) const {
-    // TODO use more efficient impl
-    for (size_t i = 0; i < _indexes.size(); i++) {
-        if (_indexes[i].index_type() == IndexType::NGRAM_BF) {
-            for (int32_t id : _indexes[i].col_unique_ids()) {
-                if (id == col_unique_id) {
-                    return true;
-                }
-            }
-        }
+const TabletIndex* TabletSchema::ngram_bf_index(const TabletColumn& col) const {
+    // Some columns(Float, Double, JSONB ...) from the variant do not support ngram bf
+    if (!field_is_slice_type(col.type())) {
+        return nullptr;
     }
+    int32_t col_unique_id = col.is_extracted_column() ? col.parent_unique_id() : col.unique_id();
+    const std::string& suffix_path =
+            col.has_path_info() ? escape_for_path_name(col.path_info_ptr()->get_path()) : "";
 
-    return false;
+    return ngram_bf_index(col_unique_id, suffix_path);
 }
 
-const TabletIndex* TabletSchema::get_ngram_bf_index(int32_t col_unique_id) const {
+const TabletIndex* TabletSchema::ngram_bf_index(int32_t col_unique_id,
+                                                const std::string& suffix_path) const {
     // TODO use more efficient impl
     for (size_t i = 0; i < _indexes.size(); i++) {
-        if (_indexes[i].index_type() == IndexType::NGRAM_BF) {
+        if (_indexes[i].index_type() == IndexType::NGRAM_BF &&
+            _indexes[i].get_index_suffix() == escape_for_path_name(suffix_path)) {
             for (int32_t id : _indexes[i].col_unique_ids()) {
                 if (id == col_unique_id) {
                     return &(_indexes[i]);
@@ -1459,7 +1412,6 @@ const TabletIndex* TabletSchema::get_ngram_bf_index(int32_t col_unique_id) const
             }
         }
     }
-
     return nullptr;
 }
 

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -304,8 +304,8 @@ public:
     static std::string deterministic_string_serialize(const TabletSchemaPB& schema_pb);
     void to_schema_pb(TabletSchemaPB* tablet_meta_pb) const;
     void append_column(TabletColumn column, ColumnType col_type = ColumnType::NORMAL);
-    void append_index(TabletIndex index);
-    void update_index(const TabletColumn& column, TabletIndex index);
+    void append_index(TabletIndex&& index);
+    void update_index(const TabletColumn& column, const IndexType& index_type, TabletIndex&& index);
     void remove_index(int64_t index_id);
     void clear_index();
     // Must make sure the row column is always the last column
@@ -385,19 +385,21 @@ public:
         }
         return false;
     }
-    std::vector<const TabletIndex*> get_indexes_for_column(const TabletColumn& col) const;
+    bool has_inverted_index(int64_t index_id) const;
     bool has_inverted_index(const TabletColumn& col) const;
-    bool has_inverted_index_with_index_id(int64_t index_id, const std::string& suffix_path) const;
-    const TabletIndex* get_inverted_index_with_index_id(int64_t index_id,
-                                                        const std::string& suffix_name) const;
-    // check_valid: check if this column supports inverted index
-    // Some columns (Float, Double, JSONB ...) from the variant do not support index, but they are listed in TabletIndex.
-    // If returned, the index file will not be found.
-    const TabletIndex* get_inverted_index(const TabletColumn& col, bool check_valid = true) const;
-    const TabletIndex* get_inverted_index(int32_t col_unique_id,
-                                          const std::string& suffix_path) const;
-    bool has_ngram_bf_index(int32_t col_unique_id) const;
-    const TabletIndex* get_ngram_bf_index(int32_t col_unique_id) const;
+    // Check whether the column supports inverted index.
+    const TabletIndex* inverted_index(const TabletColumn& col) const;
+    // Regardless of whether this column supports inverted index
+    // TabletIndex information will be returned as long as it exists.
+    const TabletIndex* inverted_index(int32_t col_unique_id,
+                                      const std::string& suffix_path = "") const;
+
+    // Check whether the column supports ngram bf index.
+    const TabletIndex* ngram_bf_index(const TabletColumn& col) const;
+    // Regardless of whether this column supports ngram bf
+    // TabletIndex information will be returned as long as it exists.
+    const TabletIndex* ngram_bf_index(int32_t col_unique_id,
+                                      const std::string& suffix_path = "") const;
     void update_indexes_from_thrift(const std::vector<doris::TOlapTableIndex>& indexes);
     // If schema version is not set, it should be -1
     int32_t schema_version() const { return _schema_version; }

--- a/be/src/vec/common/schema_util.h
+++ b/be/src/vec/common/schema_util.h
@@ -109,6 +109,8 @@ void update_least_sparse_column(const std::vector<TabletSchemaSPtr>& schemas,
 // inherit attributes like index/agg info from it's parent column
 void inherit_column_attributes(TabletSchemaSPtr& schema);
 
+// source: variant column
+// target: extracted column from variant column
 void inherit_column_attributes(const TabletColumn& source, TabletColumn& target,
                                TabletSchemaSPtr& target_schema);
 

--- a/be/test/common/schema_util_test.cpp
+++ b/be/test/common/schema_util_test.cpp
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/common/schema_util.h"
+
+#include <gtest/gtest.h>
+
+namespace doris {
+
+class SchemaUtilTest : public testing::Test {};
+
+void construct_column(ColumnPB* column_pb, TabletIndexPB* tablet_index, int64_t index_id,
+                      const std::string& index_name, int32_t col_unique_id,
+                      const std::string& column_type, const std::string& column_name,
+                      const IndexType& index_type) {
+    column_pb->set_unique_id(col_unique_id);
+    column_pb->set_name(column_name);
+    column_pb->set_type(column_type);
+    column_pb->set_is_nullable(true);
+    column_pb->set_is_bf_column(true);
+    tablet_index->set_index_id(index_id);
+    tablet_index->set_index_name(index_name);
+    tablet_index->set_index_type(index_type);
+    tablet_index->add_col_unique_id(col_unique_id);
+    if (index_type == IndexType::NGRAM_BF) {
+        auto* properties = tablet_index->mutable_properties();
+        (*properties)["gram_size"] = "5";
+        (*properties)["bf_size"] = "1024";
+    }
+}
+
+void construct_subcolumn(TabletSchemaSPtr schema, const FieldType& type, int32_t col_unique_id,
+                         std::string_view path, std::vector<TabletColumn>* subcolumns) {
+    TabletColumn subcol;
+    subcol.set_type(type);
+    subcol.set_is_nullable(true);
+    subcol.set_unique_id(-1);
+    subcol.set_parent_unique_id(col_unique_id);
+    vectorized::PathInData col_path(path);
+    subcol.set_path_info(col_path);
+    subcol.set_name(col_path.get_path());
+    schema->append_column(subcol);
+    subcolumns->emplace_back(std::move(subcol));
+}
+
+TEST_F(SchemaUtilTest, inherit_column_attributes) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    schema_pb.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::V2);
+
+    construct_column(schema_pb.add_column(), schema_pb.add_index(), 10000, "key_index", 0, "INT",
+                     "key", IndexType::INVERTED);
+    construct_column(schema_pb.add_column(), schema_pb.add_index(), 10001, "v1_index", 1, "VARIANT",
+                     "v1", IndexType::INVERTED);
+    construct_column(schema_pb.add_column(), schema_pb.add_index(), 10002, "v2_index", 2, "VARIANT",
+                     "v2", IndexType::NGRAM_BF);
+    construct_column(schema_pb.add_column(), schema_pb.add_index(), 10003, "v3_index", 3, "VARIANT",
+                     "v3", IndexType::INVERTED);
+    construct_column(schema_pb.add_column(), schema_pb.add_index(), 10004, "v4_index", 4, "VARIANT",
+                     "v4", IndexType::NGRAM_BF);
+
+    TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(schema_pb);
+    std::vector<TabletColumn> subcolumns;
+
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_STRING, 1, "v1.b", &subcolumns);
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_INT, 1, "v1.c", &subcolumns);
+
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_STRING, 2, "v2.b", &subcolumns);
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_VARCHAR, 2, "v2.c", &subcolumns);
+
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_ARRAY, 3, "v3.d", &subcolumns);
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_FLOAT, 3, "v3.a", &subcolumns);
+
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_ARRAY, 4, "v4.d", &subcolumns);
+    construct_subcolumn(tablet_schema, FieldType::OLAP_FIELD_TYPE_FLOAT, 4, "v4.a", &subcolumns);
+    vectorized::schema_util::inherit_column_attributes(tablet_schema);
+    for (const auto& col : subcolumns) {
+        switch (col._parent_col_unique_id) {
+        case 1:
+            EXPECT_TRUE(tablet_schema->inverted_index(col) != nullptr);
+            break;
+        case 2:
+            EXPECT_TRUE(tablet_schema->ngram_bf_index(col) != nullptr);
+            break;
+        case 3:
+            EXPECT_TRUE(tablet_schema->inverted_index(col) == nullptr);
+            break;
+        case 4:
+            EXPECT_TRUE(tablet_schema->ngram_bf_index(col) == nullptr);
+            break;
+        default:
+            EXPECT_TRUE(false);
+        }
+    }
+    EXPECT_EQ(tablet_schema->indexes().size(), 13);
+
+    for (const auto& col : tablet_schema->_cols) {
+        if (!col->is_extracted_column()) {
+            continue;
+        }
+        switch (col->_parent_col_unique_id) {
+        case 1:
+            EXPECT_TRUE(col->is_bf_column());
+            break;
+        case 2:
+            EXPECT_TRUE(col->is_bf_column());
+            break;
+        case 3:
+            EXPECT_TRUE(!col->is_bf_column());
+            break;
+        case 4:
+            EXPECT_TRUE(!col->is_bf_column());
+            break;
+        default:
+            EXPECT_TRUE(false);
+        }
+    }
+}
+
+} // namespace doris

--- a/be/test/olap/rowset/segment_v2/inverted_index/compaction/index_compaction_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/compaction/index_compaction_test.cpp
@@ -406,7 +406,7 @@ TEST_F(IndexCompactionTest, write_index_test) {
 
         // read col key
         const auto& key = _tablet_schema->column_by_uid(0);
-        const auto* key_index = _tablet_schema->get_inverted_index(key);
+        const auto* key_index = _tablet_schema->inverted_index(key);
         EXPECT_TRUE(key_index != nullptr);
         std::vector<int> query_data {99, 66, 56, 87, 85, 96, 20000};
         std::vector<int> query_result {21, 25, 22, 18, 14, 18, 0};
@@ -414,7 +414,7 @@ TEST_F(IndexCompactionTest, write_index_test) {
 
         // read col v3
         const auto& v3_column = _tablet_schema->column_by_uid(3);
-        const auto* v3_index = _tablet_schema->get_inverted_index(v3_column);
+        const auto* v3_index = _tablet_schema->inverted_index(v3_column);
         EXPECT_TRUE(v3_index != nullptr);
         std::vector<int> query_data3 {99, 66, 56, 87, 85, 96, 10000};
         std::vector<int> query_result3 {12, 20, 25, 23, 16, 24, 0};
@@ -422,7 +422,7 @@ TEST_F(IndexCompactionTest, write_index_test) {
 
         // read col v1
         const auto& v1_column = _tablet_schema->column_by_uid(1);
-        const auto* v1_index = _tablet_schema->get_inverted_index(v1_column);
+        const auto* v1_index = _tablet_schema->inverted_index(v1_column);
         EXPECT_TRUE(v1_index != nullptr);
         std::vector<std::string> query_data1 {"good", "maybe", "great", "null"};
         std::vector<int> query_result1 {197, 191, 194, 0};
@@ -431,7 +431,7 @@ TEST_F(IndexCompactionTest, write_index_test) {
 
         // read col v2
         const auto& v2_column = _tablet_schema->column_by_uid(2);
-        const auto* v2_index = _tablet_schema->get_inverted_index(v2_column);
+        const auto* v2_index = _tablet_schema->inverted_index(v2_column);
         EXPECT_TRUE(v2_index != nullptr);
         std::vector<std::string> query_data2 {"musicstream.com", "http", "https", "null"};
         std::vector<int> query_result2 {191, 799, 1201, 0};

--- a/be/test/olap/rowset/segment_v2/inverted_index/inverted_index_desc_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/inverted_index_desc_test.cpp
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
+
+#include <gtest/gtest.h>
+
+namespace doris::segment_v2 {
+
+class InvertedIndexDescTest : public testing::Test {
+public:
+    InvertedIndexDescTest() = default;
+    ~InvertedIndexDescTest() override = default;
+};
+
+TEST_F(InvertedIndexDescTest, test_decompose_local_index_file_name) {
+    std::string local_file_name_v1 = "rowsetid_0_indexid@suffix.idx";
+    std::string local_file_name_v2 = "rowsetid_0.idx";
+
+    const auto& local_fragment_v1 =
+            InvertedIndexDescriptor::decompose_local_index_file_name(local_file_name_v1);
+    EXPECT_EQ(local_fragment_v1.rowset_id, "rowsetid");
+    EXPECT_EQ(local_fragment_v1.seg_id, 0);
+    EXPECT_EQ(local_fragment_v1.index_suffix, "_indexid@suffix.idx");
+
+    const auto& local_fragment_v2 =
+            InvertedIndexDescriptor::decompose_local_index_file_name(local_file_name_v2);
+    EXPECT_EQ(local_fragment_v2.rowset_id, "rowsetid");
+    EXPECT_EQ(local_fragment_v2.seg_id, 0);
+    EXPECT_EQ(local_fragment_v2.index_suffix, ".idx");
+
+    const auto& unvalid_name =
+            InvertedIndexDescriptor::decompose_local_index_file_name("local_file_name_v2.idx");
+    EXPECT_EQ(unvalid_name.rowset_id, "");
+    EXPECT_EQ(unvalid_name.seg_id, -1);
+    EXPECT_EQ(unvalid_name.index_suffix, "");
+}
+
+TEST_F(InvertedIndexDescTest, test_snapshot_index_file_name) {
+    std::string local_file_name_v1 = "rowsetid_0_indexid@suffix.idx";
+    std::string local_file_name_v2 = "rowsetid_0.idx";
+
+    std::string remote_v0_file_name_v1 = "rowsetid_1_indexid@suffix.idx";
+    std::string remote_v0_file_name_v2 = "rowsetid_1.idx";
+
+    std::string remote_v1_file_name_v1 = "2_indexid@suffix.idx";
+    std::string remote_v1_file_name_v2 = "2.idx";
+
+    const auto& snapshot_name_1 =
+            InvertedIndexDescriptor::snapshot_index_file_name(local_file_name_v1);
+    EXPECT_EQ(snapshot_name_1, "rowsetid_0_indexid@suffix.binlog-index");
+
+    const auto& snapshot_name_2 =
+            InvertedIndexDescriptor::snapshot_index_file_name(local_file_name_v2);
+    EXPECT_EQ(snapshot_name_2, "rowsetid_0.binlog-index");
+
+    const auto& snapshot_name_3 =
+            InvertedIndexDescriptor::snapshot_index_file_name(remote_v0_file_name_v1);
+    EXPECT_EQ(snapshot_name_3, "rowsetid_1_indexid@suffix.binlog-index");
+
+    const auto& snapshot_name_4 =
+            InvertedIndexDescriptor::snapshot_index_file_name(remote_v0_file_name_v2);
+    EXPECT_EQ(snapshot_name_4, "rowsetid_1.binlog-index");
+
+    const auto& snapshot_name_5 =
+            InvertedIndexDescriptor::snapshot_index_file_name(remote_v1_file_name_v1);
+    EXPECT_EQ(snapshot_name_5, "2_indexid@suffix.binlog-index");
+
+    const auto& snapshot_name_6 =
+            InvertedIndexDescriptor::snapshot_index_file_name(remote_v1_file_name_v2);
+    EXPECT_EQ(snapshot_name_6, "2.binlog-index");
+
+    std::string file_name = "123456.idx";
+    const auto& snapshot_name_7 = InvertedIndexDescriptor::snapshot_index_file_name(file_name);
+    EXPECT_EQ(snapshot_name_7, "123456.binlog-index");
+}
+
+} // namespace doris::segment_v2

--- a/be/test/testutil/mock_rowset.h
+++ b/be/test/testutil/mock_rowset.h
@@ -67,6 +67,8 @@ class MockRowset : public Rowset {
         return Status::OK();
     }
 
+    Result<std::vector<io::FileInfo>> list_inverted_index_files() override { return {}; }
+
 protected:
     MockRowset(TabletSchemaSPtr schema, RowsetMetaSharedPtr rowset_meta)
             : Rowset(schema, rowset_meta, "") {}

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -664,10 +664,14 @@ message PResetRPCChannelResponse {
 message PEmptyRequest {};
 
 message PTabletWriteSlaveRequest {
+    // IndexSize is used to represent information about the inverted index file,
+    // and the suffix path will be deprecated. 
+    // We now use the index file name to identify a file, and the indexId will always be set to -1.    
     message IndexSize {
         required int64 indexId = 1;
         required int64 size = 2;
-        optional string suffix_path = 3;
+        optional string suffix_path = 3; // deprecated
+        optional string index_file_name = 4;
     };
 
     message IndexSizeMap{
@@ -682,7 +686,10 @@ message PTabletWriteSlaveRequest {
     optional int32 brpc_port = 6;
     optional string token = 7;
     optional int32 node_id = 8;
-    map<int64, IndexSizeMap> inverted_indices_size = 9;
+    map<int64, IndexSizeMap> inverted_indices_size = 9; // deprecated
+
+    // all inverted index files in the current rowset
+    repeated IndexSize indeices_size = 10;
 };
 
 message PTabletWriteSlaveResult {

--- a/regression-test/suites/inverted_index_p0/index_format_v2/test_drop_column_with_format_v2.groovy
+++ b/regression-test/suites/inverted_index_p0/index_format_v2/test_drop_column_with_format_v2.groovy
@@ -86,7 +86,7 @@ suite("test_drop_column_with_format_v2", "inverted_index_format_v2"){
             "replication_allocation" = "tag.location.default: 1",
             "inverted_index_storage_format" = "V2",
             "disable_auto_compaction" = "true",
-            "light_schema_change" = "false"
+            "light_schema_change" = "true"
         );
     """
     sql """ INSERT INTO ${tableName} VALUES (1, "andy", 100); """

--- a/regression-test/suites/inverted_index_p0/index_format_v2/test_drop_index_with_format_v2.groovy
+++ b/regression-test/suites/inverted_index_p0/index_format_v2/test_drop_index_with_format_v2.groovy
@@ -38,8 +38,9 @@ suite("test_drop_index_with_format_v2", "inverted_index_format_v2"){
         for(int t = delta_time; t <= OpTimeout; t += delta_time){
             alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
             alter_res = alter_res.toString()
+            // "FINISHED does not indicate that the drop index operation is finished."
             if(alter_res.contains("FINISHED")) {
-                sleep(3000) // wait change table state to normal
+                sleep(10000) // wait change table state to normal
                 logger.info(table_name + " latest alter job finished, detail: " + alter_res)
                 break
             }


### PR DESCRIPTION
## Proposed changes

1. Retrieve the index meta for the inverted index. Currently, there are two types: one is `inverted_index(TabletColumn)`, which checks the column type (e.g., if the column type is float, it does not support indexing and will be filtered out); the other is `inverted_index(unique_id, index_suffix)`, which retrieves the index meta for the current column without checking the column type.

2. Variant sub-columns inherit the index metadata from the parent column, including both inverted index and ngram index. During the writing, the `inverted_index(TabletColumn)` interface is used to determine if the current column requires indexing, similar to ngram.

3. The index file name, which was previously constructed based on the index meta to retrieve the index file, has been modified to use a "list file" approach to obtain the index files for the current rowset.

<!--Describe your changes.-->

