### PR TITLE
[fix](nereids)reserve stats and groupId on rewriting plan node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.visitor;
 
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate;
 
@@ -56,6 +57,15 @@ public abstract class DefaultPlanRewriter<C> extends PlanVisitor<Plan, C> {
             }
             newChildren.add(newChild);
         }
-        return hasNewChildren ? (P) plan.withChildren(newChildren.build()) : plan;
+
+        if (hasNewChildren) {
+            plan = (P) plan.withChildren(newChildren.build())
+            if (plan instanceof AbstractPhysicalPlan) {
+                AbstractPhysicalPlan physicalPlan = (AbstractPhysicalPlan) plan;
+                plan = (P) ((AbstractPhysicalPlan)physicalPlan.withChildren(newChildren.build()))
+                        .copyStatsAndGroupIdFrom(physicalPlan);
+            }
+        }
+        return plan;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
@@ -59,10 +59,10 @@ public abstract class DefaultPlanRewriter<C> extends PlanVisitor<Plan, C> {
         }
 
         if (hasNewChildren) {
-            plan = (P) plan.withChildren(newChildren.build())
+            plan = (P) plan.withChildren(newChildren.build());
             if (plan instanceof AbstractPhysicalPlan) {
                 AbstractPhysicalPlan physicalPlan = (AbstractPhysicalPlan) plan;
-                plan = (P) ((AbstractPhysicalPlan)physicalPlan.withChildren(newChildren.build()))
+                plan = (P) ((AbstractPhysicalPlan) physicalPlan.withChildren(newChildren.build()))
                         .copyStatsAndGroupIdFrom(physicalPlan);
             }
         }


### PR DESCRIPTION
## Proposed changes
when node is rewriten, stats and group Id is removed
this pr try to keep them
Issue Number: close #xxx

<!--Describe your changes.-->

