### PR TITLE
[opt][file cache] Do not return error if file cache can not be created if ignore_broken_disk is set

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -441,8 +441,11 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
     }
     for (const auto& status : cache_status) {
         if (!status.ok()) {
-            LOG(FATAL) << "failed to init file cache, err: " << status;
-            exit(-1);
+            if (!doris::config::ignore_broken_disk) {
+                LOG(FATAL) << "failed to init file cache, err: " << status;
+                exit(-1);
+            }
+            LOG(WARNING) << "failed to init file cache, err: " << status;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
If `ignore_broken_disk` is set, do not return error if file cache can not be created
