### PR TITLE
[improve](cloud) add error msg when abort stream load transaction to meta service

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -880,6 +880,7 @@ Status CloudMetaMgr::abort_txn(const StreamLoadContext& ctx) {
     AbortTxnRequest req;
     AbortTxnResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);
+    req.set_reason(std::string(ctx.status.msg().substr(0, 1024)));
     if (ctx.db_id > 0 && !ctx.label.empty()) {
         req.set_db_id(ctx.db_id);
         req.set_label(ctx.label);


### PR DESCRIPTION
If use **explicit transactions**, error messages may display inaccurately:
```
mysql> begin;
Query OK, 0 rows affected (0.00 sec)
{'label':'txn_insert_df15d2c71f594be9-a7cbb425b53316b4', 'status':'PREPARE', 'txnId':''}

mysql> insert into test_begin_insert_mow1 values (13, false, 621, 723115.801, "c5","2024-10-15","2024-10-15", "c8", 1.1234, "c10");
Query OK, 1 rows affected (0.04 sec)
{'label':'txn_insert_df15d2c71f594be9-a7cbb425b53316b4', 'status':'PREPARE', 'txnId':'XXX'}

mysql> commit;
ERROR 1105 (HY000): errCode = 2, detailMessage = User Abort
```

But actually, it is **DATA_QUALITY_ERROR**. The reason is:
**explicit transactions reuses the logic of stream load, but when stream load aborts transactions, it will not submit error messages to meta service.**

Fix result:
```
mysql> begin;
Query OK, 0 rows affected (0.00 sec)
{'label':'txn_insert_bebe57d15b7b4462-93bc160c3580d47f', 'status':'PREPARE', 'txnId':''}

mysql> insert into test_begin_insert_mow1 values (13, false, 621, 723115.801, "c5","2024-10-15","2024-10-15", "c8", 1.1234, "c10");
Query OK, 1 rows affected (0.04 sec)
{'label':'txn_insert_bebe57d15b7b4462-93bc160c3580d47f', 'status':'PREPARE', 'txnId':'XXX'}

mysql> commit;
ERROR 1105 (HY000): errCode = 2, detailMessage = [DATA_QUALITY_ERROR]too many filtered rows
```


