### PR TITLE
[test](inverted index) enhace test_build_index case for quickly finished jobs

### DIFF
--- a/regression-test/suites/inverted_index_p0/index_change/test_build_index.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_build_index.groovy
@@ -97,7 +97,7 @@ suite("test_build_index", "inverted_index"){
             }
             if (alter_res.size() > 0) {
                 def last_job_state = alter_res[alter_res.size()-1][7];
-                if (last_job_state == "RUNNING") {
+                if (last_job_state == "RUNNING" || last_job_state == "FINISHED") {
                     logger.info(table_name + " last index job running, state: " + last_job_state + ", detail: " + alter_res)
                     return last_job_state;
                 }
@@ -181,7 +181,7 @@ suite("test_build_index", "inverted_index"){
     // BUILD INDEX and expect state is RUNNING
     sql """ BUILD INDEX idx_comment ON ${tableName} """
     def state = wait_for_last_build_index_on_table_running(tableName, timeout)
-    if (state != "SKIPPED") {
+    if (state == "RUNNING") {
         def result = sql """ SHOW BUILD INDEX WHERE TableName = "${tableName}" ORDER BY JobId """
         assertEquals(result[result.size()-1][1], tableName)
         assertTrue(result[result.size()-1][3].contains("ADD INDEX"))


### PR DESCRIPTION
## Proposed changes

Fix case failure like below
```
Exception in inverted_index_p0/test_build_index.groovy(line 185):

    wait_for_latest_op_on_table_finish(tableName, timeout)

    // BUILD INDEX and expect state is RUNNING
    sql """ BUILD INDEX idx_comment ON ${tableName} """
    def state = wait_for_last_build_index_on_table_running(tableName, timeout)
    if (state != "SKIPPED") {
        def result = sql """ SHOW BUILD INDEX WHERE TableName = "${tableName}" ORDER BY JobId """
        assertEquals(result[result.size()-1][1], tableName)
        assertTrue(result[result.size()-1][3].contains("ADD INDEX"))
        assertEquals(result[result.size()-1][7], "RUNNING")
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^

        // CANCEL BUILD INDEX and expect state is CANCELED
        sql """ CANCEL BUILD INDEX ON ${tableName} (${result[result.size()-1][0]}) """
        result = sql """ SHOW BUILD INDEX WHERE TableName = "${tableName}" ORDER BY JobId """
        assertEquals(result[result.size()-1][1], tableName)
        assertTrue(result[result.size()-1][3].contains("ADD INDEX"))
        assertEquals(result[result.size()-1][7], "CANCELLED")
        assertEquals(result[result.size()-1][8], "user cancelled")

        // BUILD INDEX and expect state is FINISHED

Exception:
org.opentest4j.AssertionFailedError: expected: <FINISHED> but was: <RUNNING>
```

