### PR TITLE
[fix](mtmv)Fix the old version of the materialized view error 'Current database is not set'`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -114,6 +114,7 @@ public class MTMV extends OlapTable {
         this.mvPartitionInfo = params.mvPartitionInfo;
         this.relation = params.relation;
         this.refreshSnapshot = new MTMVRefreshSnapshot();
+        this.envInfo = new EnvInfo(-1L, -1L);
         mvRwLock = new ReentrantReadWriteLock(true);
     }
 
@@ -506,7 +507,11 @@ public class MTMV extends OlapTable {
         refreshInfo = materializedView.refreshInfo;
         querySql = materializedView.querySql;
         status = materializedView.status;
-        envInfo = materializedView.envInfo;
+        if (materializedView.envInfo != null) {
+            envInfo = materializedView.envInfo;
+        } else {
+            envInfo = new EnvInfo(-1L, -1L);
+        }
         jobInfo = materializedView.jobInfo;
         mvProperties = materializedView.mvProperties;
         relation = materializedView.relation;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.job.common.TaskStatus;
 import org.apache.doris.job.extensions.mtmv.MTMVTask;
+import org.apache.doris.mtmv.EnvInfo;
 import org.apache.doris.mtmv.MTMVCache;
 import org.apache.doris.mtmv.MTMVJobInfo;
 import org.apache.doris.mtmv.MTMVJobManager;
@@ -73,6 +74,9 @@ public class MTMV extends OlapTable {
     private String querySql;
     @SerializedName("s")
     private MTMVStatus status;
+    @Deprecated
+    @SerializedName("ei")
+    private EnvInfo envInfo;
     @SerializedName("ji")
     private MTMVJobInfo jobInfo;
     @SerializedName("mp")
@@ -138,6 +142,10 @@ public class MTMV extends OlapTable {
         } finally {
             readMvUnlock();
         }
+    }
+
+    public EnvInfo getEnvInfo() {
+        return envInfo;
     }
 
     public MTMVJobInfo getJobInfo() {
@@ -498,6 +506,7 @@ public class MTMV extends OlapTable {
         refreshInfo = materializedView.refreshInfo;
         querySql = materializedView.querySql;
         status = materializedView.status;
+        envInfo = materializedView.envInfo;
         jobInfo = materializedView.jobInfo;
         mvProperties = materializedView.mvProperties;
         relation = materializedView.relation;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/EnvInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/EnvInfo.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mtmv;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * EnvInfo
+ */
+@Deprecated
+public class EnvInfo {
+    @SerializedName("ci")
+    private long ctlId;
+    @SerializedName("di")
+    private long dbId;
+
+    public EnvInfo(long ctlId, long dbId) {
+        this.ctlId = ctlId;
+        this.dbId = dbId;
+    }
+
+    public long getCtlId() {
+        return ctlId;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    @Override
+    public String toString() {
+        return "EnvInfo{"
+                + "ctlId='" + ctlId + '\''
+                + ", dbId='" + dbId + '\''
+                + '}';
+    }
+}


### PR DESCRIPTION
cause by: https://github.com/apache/doris/pull/36543


after 36543,not need set db&catalog in `ConnectContext`, because query sql Because the query statement was rewritten to the full path (ctl.db. table. col) during creation,

but query sql of old materialized view not was rewritten, so need set db&catalog in `ConnectContext`
