### PR TITLE
[chore](log) Adjust log level for replaying a batch editlog cost time(#41392)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2988,8 +2988,8 @@ public class Env {
             }
         }
         long cost = System.currentTimeMillis() - startTime;
-        if (cost >= 1000) {
-            LOG.warn("replay journal cost too much time: {} replayedJournalId: {}", cost, replayedJournalId);
+        if (LOG.isDebugEnabled() && cost >= 1000) {
+            LOG.debug("replay journal cost too much time: {} replayedJournalId: {}", cost, replayedJournalId);
         }
 
         return hasLog;


### PR DESCRIPTION
* `replay journal cost too much time` is a counter for replaying a batch editlog it is normal that cost too much time, the warning level can make confused

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

