### PR TITLE
[Fix](Nereids) ignore match expression logging warning message (#41546)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -192,7 +192,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
 
     private static void collectConst(Expression expr, Map<String, Expression> constMap,
             Map<String, TExpr> tExprMap, IdGenerator<ExprId> idGenerator) {
-        if (expr.isConstant() && !shouldSkipFold(expr)) {
+        if (expr.isConstant() && !expr.isLiteral() && !expr.anyMatch(e -> shouldSkipFold((Expression) e))) {
             String id = idGenerator.getNextId().toString();
             constMap.put(id, expr);
             Expr staleExpr;
@@ -218,11 +218,6 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
 
     // Some expressions should not do constant folding
     private static boolean shouldSkipFold(Expression expr) {
-        // Skip literal expr
-        if (expr.isLiteral()) {
-            return true;
-        }
-
         // Frontend can not represent those types
         if (expr.getDataType().isAggStateType() || expr.getDataType().isObjectType()
                 || expr.getDataType().isVariantType() || expr.getDataType().isTimeLikeType()

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/ExpressionTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/ExpressionTranslatorTest.java
@@ -23,9 +23,12 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.catalog.Function.NullableMode;
 import org.apache.doris.catalog.Type;
-import org.apache.doris.common.AnalysisException;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.BitNot;
+import org.apache.doris.nereids.trees.expressions.MatchAny;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,12 +36,19 @@ import org.junit.jupiter.api.Test;
 public class ExpressionTranslatorTest {
 
     @Test
-    public void testUnaryArithmetic() throws AnalysisException {
+    public void testUnaryArithmetic() throws Exception {
         BitNot bitNot = new BitNot(new IntegerLiteral(1));
         ExpressionTranslator translator = ExpressionTranslator.INSTANCE;
         Expr actual = translator.visitUnaryArithmetic(bitNot, null);
         Expr expected = new ArithmeticExpr(Operator.BITNOT,
                 new IntLiteral(1, Type.INT), null, Type.INT, NullableMode.DEPEND_ON_ARGUMENT);
         Assertions.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testMatch() {
+        MatchAny matchAny = new MatchAny(new VarcharLiteral("collections"), new NullLiteral());
+        ExpressionTranslator translator = ExpressionTranslator.INSTANCE;
+        Assertions.assertThrows(AnalysisException.class, () -> translator.visitMatch(matchAny, null));
     }
 }


### PR DESCRIPTION
pick: #41546
when match do not contains slot reference it would throw an exception when translate to original planner expr.
this kind of message is not need to be recorded

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

