### PR TITLE
[fix](nereids) Fix not check column name when create or alter view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AlterViewInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AlterViewInfo.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.commands.info;
 import org.apache.doris.analysis.AlterViewStmt;
 import org.apache.doris.analysis.ColWithComment;
 import org.apache.doris.analysis.TableName;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
@@ -31,19 +30,13 @@ import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
-import org.apache.doris.nereids.NereidsPlanner;
-import org.apache.doris.nereids.analyzer.UnboundResultSink;
-import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
-import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.util.PlanUtils;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import java.util.List;
-import java.util.Set;
 
 /** AlterViewInfo */
 public class AlterViewInfo extends BaseViewInfo {
@@ -81,18 +74,6 @@ public class AlterViewInfo extends BaseViewInfo {
         analyzedPlan.accept(PlanUtils.OutermostPlanFinder.INSTANCE, outermostPlanFinderContext);
         List<Slot> outputs = outermostPlanFinderContext.outermostPlan.getOutput();
         createFinalCols(outputs);
-    }
-
-    /**validate*/
-    public void validate(ConnectContext ctx) throws UserException {
-        NereidsPlanner planner = new NereidsPlanner(ctx.getStatementContext());
-        planner.planWithLock(new UnboundResultSink<>(logicalQuery), PhysicalProperties.ANY, ExplainLevel.NONE);
-        Set<String> colSets = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        for (Column col : finalCols) {
-            if (!colSets.add(col.getName())) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_DUP_FIELDNAME, col.getName());
-            }
-        }
     }
 
     /**translateToLegacyStmt*/

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateViewInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateViewInfo.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.commands.info;
 import org.apache.doris.analysis.ColWithComment;
 import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.TableName;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -28,19 +27,13 @@ import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
-import org.apache.doris.nereids.NereidsPlanner;
-import org.apache.doris.nereids.analyzer.UnboundResultSink;
-import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
-import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.util.PlanUtils;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * CreateViewInfo
@@ -76,18 +69,6 @@ public class CreateViewInfo extends BaseViewInfo {
         analyzedPlan.accept(PlanUtils.OutermostPlanFinder.INSTANCE, outermostPlanFinderContext);
         List<Slot> outputs = outermostPlanFinderContext.outermostPlan.getOutput();
         createFinalCols(outputs);
-    }
-
-    /**validate*/
-    public void validate(ConnectContext ctx) throws UserException {
-        NereidsPlanner planner = new NereidsPlanner(ctx.getStatementContext());
-        planner.planWithLock(new UnboundResultSink<>(logicalQuery), PhysicalProperties.ANY, ExplainLevel.NONE);
-        Set<String> colSets = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        for (Column col : finalCols) {
-            if (!colSets.add(col.getName())) {
-                ErrorReport.reportAnalysisException(ErrorCode.ERR_DUP_FIELDNAME, col.getName());
-            }
-        }
     }
 
     /**translateToLegacyStmt*/

--- a/regression-test/data/ddl_p0/test_create_view_nereids.out
+++ b/regression-test/data/ddl_p0/test_create_view_nereids.out
@@ -202,7 +202,7 @@ test_view_from_view	CREATE VIEW `test_view_from_view` AS select `internal`.`regr
 7	1
 
 -- !test_backquote_in_view_define_sql --
-test_backquote_in_view_define	CREATE VIEW `test_backquote_in_view_define` AS select `internal`.`regression_test_ddl_p0`.`mal_test_view`.`a` AS `ab``c`, `internal`.`regression_test_ddl_p0`.`mal_test_view`.`b` AS `c2` from `internal`.`regression_test_ddl_p0`.`mal_test_view`;	utf8mb4	utf8mb4_0900_bin
+test_backquote_in_view_define	CREATE VIEW `test_backquote_in_view_define` AS select `internal`.`regression_test_ddl_p0`.`mal_test_view`.`a` AS `abc`, `internal`.`regression_test_ddl_p0`.`mal_test_view`.`b` AS `c2` from `internal`.`regression_test_ddl_p0`.`mal_test_view`;	utf8mb4	utf8mb4_0900_bin
 
 -- !test_backquote_in_table_alias --
 \N	6
@@ -225,6 +225,28 @@ test_backquote_in_view_define	CREATE VIEW `test_backquote_in_view_define` AS sel
 
 -- !test_backquote_in_table_alias_sql --
 test_backquote_in_table_alias	CREATE VIEW `test_backquote_in_table_alias` AS select `internal`.`regression_test_ddl_p0`.`ab``c`.`a` AS `c1`, `internal`.`regression_test_ddl_p0`.`ab``c`.`b` AS `c2` from (select `internal`.`regression_test_ddl_p0`.`mal_test_view`.`a`,`internal`.`regression_test_ddl_p0`.`mal_test_view`.`b` from `internal`.`regression_test_ddl_p0`.`mal_test_view`) `ab``c`;	utf8mb4	utf8mb4_0900_bin
+
+-- !test_invalid_column_name_in_table --
+\N	6
+1	2
+1	3
+1	4
+1	4
+1	7
+2	8
+3	5
+3	6
+3	9
+4	2
+5	\N
+5	6
+5	6
+5	6
+5	8
+7	1
+
+-- !test_invalid_column_name_in_table_define_sql --
+test_invalid_column_name_in_table	CREATE VIEW `test_invalid_column_name_in_table` AS select `internal`.`regression_test_ddl_p0`.`mal_test_view`.`a` ,`internal`.`regression_test_ddl_p0`.`mal_test_view`.`b` from `internal`.`regression_test_ddl_p0`.`mal_test_view`;	utf8mb4	utf8mb4_0900_bin
 
 -- !test_generate --
 1	10	A	30


### PR DESCRIPTION
## Proposed changes
This is brought by https://github.com/apache/doris/pull/32743

set enable_unicode_name_support = true;
If run create view sql should fail beausel_shipdate column name  contains invalid char '(' and ')', but now success
this pr fix this and throw exception
`ERROR 1105 (HY000): errCode = 2, detailMessage = Incorrect column name '(日期)'. Column regex is '^[_a-zA-Z@0-9\s/][.a-zA-Z0-9_+-/?@#$%^&*"\s,:]{0,255}$'`

```sql
CREATE VIEW view1
AS
SELECT "零售公司", l_shipdate as '(日期)', l_receiptdate as k2
FROM lineitem;
```
and if run create view sql as following, should success:
```sql
CREATE VIEW view2
AS
SELECT "零售公司", l_shipdate as '日期', l_receiptdate as k2
FROM lineitem;
```

and the schema of view2 should be
```sql
mysql> desc view2;
+-------------+-------------+------+-------+---------+-------+
| Field       | Type        | Null | Key   | Default | Extra |
+-------------+-------------+------+-------+---------+-------+
| __literal_0 | varchar(16) | No   | false | NULL    |       |
| 日期        | date        | No   | false | NULL    |       |
| k2          | date        | No   | false | NULL    |       |
+-------------+-------------+------+-------+---------+-------+
3 rows in set (0.01 sec)
```


