### PR TITLE
[fix](tablet io error) fix tablet not increase _io_error_times in some cases.

### DIFF
--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -183,8 +183,9 @@ Status BetaRowset::load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* se
             .file_size = _rowset_meta->segment_file_size(seg_id),
     };
 
-    auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema, reader_options,
-                                       segment, _rowset_meta->inverted_index_file_info(seg_id));
+    auto s = segment_v2::Segment::open(fs, seg_path, _rowset_meta->tablet_id(), seg_id, rowset_id(),
+                                       _schema, reader_options, segment,
+                                       _rowset_meta->inverted_index_file_info(seg_id));
     if (!s.ok()) {
         LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset " << rowset_id()
                      << " : " << s.to_string();
@@ -543,8 +544,8 @@ Status BetaRowset::check_current_rowset_segment() {
                 .file_size = _rowset_meta->segment_file_size(seg_id),
         };
 
-        auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
-                                           reader_options, &segment,
+        auto s = segment_v2::Segment::open(fs, seg_path, _rowset_meta->tablet_id(), seg_id,
+                                           rowset_id(), _schema, reader_options, &segment,
                                            _rowset_meta->inverted_index_file_info(seg_id));
         if (!s.ok()) {
             LOG(WARNING) << "segment can not be opened. file=" << seg_path;

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -315,7 +315,8 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
             .is_doris_table = true,
             .cache_base_path {},
     };
-    auto s = segment_v2::Segment::open(io::global_local_filesystem(), path, segment_id, rowset_id(),
+    auto s = segment_v2::Segment::open(io::global_local_filesystem(), path,
+                                       _rowset_meta->tablet_id(), segment_id, rowset_id(),
                                        _context.tablet_schema, reader_options, &segment);
     if (!s.ok()) {
         LOG(WARNING) << "failed to open segment. " << path << ":" << s;

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -80,8 +80,8 @@ using SegmentSharedPtr = std::shared_ptr<Segment>;
 // change finished, client should disable all cached Segment for old TabletSchema.
 class Segment : public std::enable_shared_from_this<Segment>, public MetadataAdder<Segment> {
 public:
-    static Status open(io::FileSystemSPtr fs, const std::string& path, uint32_t segment_id,
-                       RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
+    static Status open(io::FileSystemSPtr fs, const std::string& path, int64_t tablet_id,
+                       uint32_t segment_id, RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
                        const io::FileReaderOptions& reader_options,
                        std::shared_ptr<Segment>* output, InvertedIndexFileInfo idx_file_info = {});
 
@@ -214,6 +214,10 @@ private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(uint32_t segment_id, RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
             InvertedIndexFileInfo idx_file_info = InvertedIndexFileInfo());
+    static Status _open(io::FileSystemSPtr fs, const std::string& path, uint32_t segment_id,
+                        RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
+                        const io::FileReaderOptions& reader_options,
+                        std::shared_ptr<Segment>* output, InvertedIndexFileInfo idx_file_info);
     // open segment file and read the minimum amount of necessary information (footer)
     Status _open();
     Status _parse_footer(SegmentFooterPB* footer);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -451,13 +451,7 @@ public:
     void gc_binlogs(int64_t version);
     Status ingest_binlog_metas(RowsetBinlogMetasPB* metas_pb);
 
-    inline void report_error(const Status& st) {
-        if (st.is<ErrorCode::IO_ERROR>()) {
-            ++_io_error_times;
-        } else if (st.is<ErrorCode::CORRUPTION>()) {
-            _io_error_times = config::max_tablet_io_errors + 1;
-        }
-    }
+    void report_error(const Status& st);
 
     inline int64_t get_io_error_times() const { return _io_error_times; }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -54,7 +54,10 @@ void ExecEnv::set_write_cooldown_meta_executors() {
 #endif // BE_TEST
 
 Result<BaseTabletSPtr> ExecEnv::get_tablet(int64_t tablet_id) {
-    return GetInstance()->storage_engine().get_tablet(tablet_id);
+    auto storage_engine = GetInstance()->_storage_engine;
+    return storage_engine
+                   ? storage_engine->get_tablet(tablet_id)
+                   : ResultError(Status::InternalError("failed to get tablet {}", tablet_id));
 }
 
 const std::string& ExecEnv::token() const {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -54,8 +54,8 @@ void ExecEnv::set_write_cooldown_meta_executors() {
 #endif // BE_TEST
 
 Result<BaseTabletSPtr> ExecEnv::get_tablet(int64_t tablet_id) {
-    auto storage_engine = GetInstance()->_storage_engine;
-    return storage_engine
+    auto storage_engine = GetInstance()->_storage_engine.get();
+    return storage_engine != nullptr
                    ? storage_engine->get_tablet(tablet_id)
                    : ResultError(Status::InternalError("failed to get tablet {}", tablet_id));
 }

--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -31,11 +31,14 @@
 #include <sstream>
 
 #include "bvar/bvar.h"
+#include "cloud/config.h"
 #include "common/signal_handler.h"
 #include "exec/tablet_info.h"
 #include "gutil/ref_counted.h"
+#include "olap/tablet.h"
 #include "olap/tablet_fwd.h"
 #include "olap/tablet_schema.h"
+#include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/load_channel.h"
 #include "runtime/load_stream_mgr.h"
@@ -149,6 +152,14 @@ Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data
         signal::set_signal_task_id(_load_id);
         g_load_stream_flush_running_threads << -1;
         auto st = _load_stream_writer->append_data(new_segid, header.offset(), buf, file_type);
+        if (!st.ok() && !config::is_cloud_mode()) {
+            auto res = ExecEnv::get_tablet(_id);
+            TabletSharedPtr tablet =
+                    res.has_value() ? std::dynamic_pointer_cast<Tablet>(res.value()) : nullptr;
+            if (tablet) {
+                tablet->report_error(st);
+            }
+        }
         if (eos && st.ok()) {
             DBUG_EXECUTE_IF("TabletStream.append_data.unknown_file_type",
                             { file_type = static_cast<FileType>(-1); });

--- a/be/test/olap/delete_bitmap_calculator_test.cpp
+++ b/be/test/olap/delete_bitmap_calculator_test.cpp
@@ -127,7 +127,8 @@ public:
         EXPECT_NE("", writer.min_encoded_key().to_string());
         EXPECT_NE("", writer.max_encoded_key().to_string());
 
-        st = segment_v2::Segment::open(fs, path, segment_id, rowset_id, query_schema,
+        int64_t tablet_id = 100;
+        st = segment_v2::Segment::open(fs, path, tablet_id, segment_id, rowset_id, query_schema,
                                        io::FileReaderOptions {}, res);
         EXPECT_TRUE(st.ok());
         EXPECT_EQ(nrows, (*res)->num_rows());

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -169,6 +169,7 @@ class SimpleCommand(Command):
         LOG.info(
             utils.render_green("{} succ, total related node num {}".format(
                 show_cmd, related_node_num)))
+        return ""
 
 
 class UpCommand(Command):
@@ -1213,6 +1214,20 @@ class GetCloudIniCommand(Command):
         return self._handle_data(header, rows)
 
 
+class AddRWPermCommand(Command):
+
+    def add_parser(self, args_parsers):
+        parser = args_parsers.add_parser(
+            "add-rw-perm",
+            help="Add read and write permissions to the cluster files")
+        parser.add_argument("NAME", help="Specify cluster name.")
+        self._add_parser_common_args(parser)
+
+    def run(self, args):
+        utils.enable_dir_with_rw_perm(CLUSTER.get_cluster_path(args.NAME))
+        return ""
+
+
 ALL_COMMANDS = [
     UpCommand("up"),
     DownCommand("down"),
@@ -1224,4 +1239,5 @@ ALL_COMMANDS = [
     GetCloudIniCommand("get-cloud-ini"),
     GenConfCommand("config"),
     ListCommand("ls"),
+    AddRWPermCommand("add-rw-perm"),
 ]

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -617,6 +617,11 @@ class SuiteCluster {
         }
     }
 
+    void addRWPermToAllFiles() {
+        def cmd = 'add-rw-perm ' + name
+        runCmd(cmd)
+    }
+
     private void waitHbChanged() {
         // heart beat interval is 5s
         Thread.sleep(7000)

--- a/regression-test/suites/control_p0/test_tablet_io_error.groovy
+++ b/regression-test/suites/control_p0/test_tablet_io_error.groovy
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+import groovy.io.FileType
+
+suite('test_tablet_io_error', 'docker') {
+    def runTest = { isRead, debugPointName, isDropTabletDir ->
+        GetDebugPoint().clearDebugPointsForAllBEs()
+        def tbl =  'tbl_test_tablet_io_error'
+        sql "create table ${tbl} (k int) distributed by hash(k) buckets 1 properties('replication_num' = '2')"
+        sql "insert into ${tbl} values (1)"
+        sql "insert into ${tbl} values (2)"
+        sql "insert into ${tbl} values (3)"
+        def tablets = sql_return_maparray "SHOW TABLETS FROM ${tbl}"
+        assertEquals(2, tablets.size())
+        def tabletId = tablets[0].TabletId.toLong()
+        def injectBe = cluster.getBeByBackendId(tablets[0].BackendId.toLong())
+        assertNotNull(injectBe)
+
+        sql 'set use_fix_replica = 0'
+
+        def tabletOnInjectBe = sql_return_maparray("SHOW TABLETS FROM ${tbl}").find { it.BackendId.toLong() == injectBe.backendId }
+        assertNotNull(tabletOnInjectBe)
+
+        if (debugPointName != null) {
+            GetDebugPoint().enableDebugPoint(injectBe.host, injectBe.httpPort, injectBe.getNodeType(),
+                    debugPointName, [ sub_path : "/${tabletId}/" ])
+        }
+
+        if (isDropTabletDir) {
+            // the docker files owner is root, need change its permission
+            cluster.addRWPermToAllFiles()
+            def dataPath = new File("${injectBe.path}/storage/1.HDD/data")
+            dataPath.eachFile(FileType.DIRECTORIES) { shardPath ->
+                shardPath.eachFile(FileType.DIRECTORIES) { tabletPath ->
+                    try {
+                        if (tabletPath.getName().toLong() == tabletId) {
+                            logger.info("delete tablet path: ${tabletPath}")
+                            tabletPath.deleteDir()
+                        }
+                    } catch (Throwable t) {
+                        logger.warn('delete tablet path exception: ', t)
+                    }
+                }
+            }
+        }
+
+        boolean hasExcept = false
+        try {
+            if (isRead) {
+                sql "select * from ${tbl}"
+            } else {
+                sql "insert into ${tbl} values (1)"
+            }
+        } catch (Throwable e) {
+            logger.info("exec exeption: ${e.getMessage()}")
+            hasExcept = true
+        }
+        assertTrue(hasExcept)
+
+        sleep 8000
+
+        // be will report tablet as bad, then fe will drop it
+        tabletOnInjectBe = sql_return_maparray("SHOW TABLETS FROM ${tbl}").find { it.BackendId.toLong() == injectBe.backendId }
+        assertNull(tabletOnInjectBe)
+        sql "insert into ${tbl} values (1)"
+        sql "select * from ${tbl}"
+
+        sql "drop table ${tbl} force"
+    }
+
+    def options = new ClusterOptions()
+    options.cloudMode = false
+    options.enableDebugPoints()
+    options.feConfigs += [
+        'disable_balance=true',
+        'tablet_checker_interval_ms=500',
+        'schedule_batch_size=1000',
+        'schedule_slot_num_per_hdd_path=1000',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'max_tablet_io_errors=1',
+        'disable_page_cache=true',
+    ]
+
+    docker(options) {
+        runTest(true, 'LocalFileReader::read_at_impl.io_error', false)
+        runTest(true, 'LocalFileSystem.create_file_impl.open_file_failed', false)
+        runTest(true, null, true)
+        runTest(false, 'LocalFileWriter::appendv.io_error', false)
+        runTest(false, 'LocalFileSystem.create_file_impl.open_file_failed', false)
+        runTest(false, null, true)
+    }
+}


### PR DESCRIPTION
When read/write a tablet,  if meet io error,  it will increase this tablet's field `_io_error_times`.  And if `_io_error_times` >= config::max_tablet_io_errors,  then be will report this tablet as bad,   then fe can drop it later.

But there are a lot of code that may met an io error!  And they may forget to increase this tablet's  _io_error_times.  
This PR only fix some,  there should be others not fixed.

What's more,   config::max_tablet_io_errors of be.conf  default value is -1.  It means always no set tablet as bad. For an online cluster, it shoud manually set this parameter > 0 in order to make it work.

