### PR TITLE
[Fix](fe) Avoid interrupt daemon thread and use proper polling interval

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -5840,8 +5840,9 @@ public class Env {
         ConfigBase.setMutableConfig(key, value);
         if (configtoThreads.get(key) != null) {
             try {
+                // not atomic. maybe delay to aware. but acceptable.
                 configtoThreads.get(key).get().setInterval(Config.getField(key).getLong(null) * 1000L);
-                configtoThreads.get(key).get().interrupt();
+                // shouldn't interrupt to keep possible bdbje writing safe.
                 LOG.info("set config " + key + " to " + value);
             } catch (IllegalAccessException e) {
                 LOG.warn("set config " + key + " failed: " + e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -94,6 +94,8 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
     private static final String DEFAULT_RUNTIME_VALUE = FeConstants.null_string;
 
+    private static final long SLEEP_PIECE = 5000L;
+
     private Map<Long, Map<String, String>> runtimeInfos = Maps.newConcurrentMap();
     private Set<Pair<Long, Long>> dynamicPartitionTableInfo = Sets.newConcurrentHashSet();
     private boolean initialize;
@@ -825,16 +827,16 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             try {
                 long oldInterval = intervalMs;
                 long remainingInterval = oldInterval;
-                while (remainingInterval > 5000L) {
+                while (remainingInterval > SLEEP_PIECE) {
                     // if it changed. let it know at most 10 seconds. and 5 second per wakeup is acceptable.
                     if (intervalMs != oldInterval) { // changed
                         break;
                     }
 
-                    Thread.sleep(5000L);
-                    remainingInterval -= 5000L;
+                    Thread.sleep(SLEEP_PIECE);
+                    remainingInterval -= SLEEP_PIECE;
                 }
-                if (remainingInterval <= 5000L) {
+                if (remainingInterval <= SLEEP_PIECE) {
                     Thread.sleep(remainingInterval);
                 }
             } catch (InterruptedException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Daemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Daemon.java
@@ -28,12 +28,15 @@ public class Daemon extends Thread {
     private static final Logger LOG = LogManager.getLogger(Daemon.class);
     private static final int DEFAULT_INTERVAL_SECONDS = 30; // 30 seconds
 
-    private long intervalMs;
-    private AtomicBoolean isStop;
-    private Runnable runnable;
-    private AtomicBoolean isStart = new AtomicBoolean(false);
+    protected long intervalMs;
 
-    private MetaContext metaContext = null;
+    protected AtomicBoolean isStop;
+
+    protected MetaContext metaContext = null;
+
+    private Runnable runnable;
+
+    private AtomicBoolean isStart = new AtomicBoolean(false);
 
     {
         setDaemon(true);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

use a proper sleep interval to balance both:
a. no interrupt so no bdbje writing break which leads to crash
b. the daemon threads don't need much time to know its interval change.