### PR TITLE
[chore](status) Static member accessed through instance

### DIFF
--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -294,7 +294,7 @@ Status PartitionedHashJoinSinkLocalState::revoke_memory(RuntimeState* state) {
                         return Status::OK();
                     }();
 
-                    if (!status.OK()) {
+                    if (!status.ok()) {
                         std::unique_lock<std::mutex> lock(_spill_lock);
                         _dependency->set_ready();
                         _spill_status_ok = false;

--- a/be/test/olap/compaction_score_test.cpp
+++ b/be/test/olap/compaction_score_test.cpp
@@ -90,12 +90,12 @@ TEST_F(CompactionScoreTest, TestCompactionScore) {
                       .set_min_threads(2)
                       .set_max_threads(2)
                       .build(&_storage_engine->_base_compaction_thread_pool);
-    EXPECT_TRUE(st.OK());
+    EXPECT_TRUE(st.ok());
     st = ThreadPoolBuilder("CumuCompactionTaskThreadPool")
                  .set_min_threads(2)
                  .set_max_threads(2)
                  .build(&_storage_engine->_cumu_compaction_thread_pool);
-    EXPECT_TRUE(st.OK());
+    EXPECT_TRUE(st.ok());
     */
 
     /*
@@ -115,12 +115,12 @@ TEST_F(CompactionScoreTest, TestCompactionScore) {
     TabletSharedPtr tablet(new Tablet(*(_storage_engine.get()), tablet_meta, _data_dir.get(),
                                       CUMULATIVE_SIZE_BASED_POLICY));
     Status st = tablet->init();
-    EXPECT_TRUE(st.OK());
+    EXPECT_TRUE(st.ok());
 
     for (int i = 2; i < 10; ++i) {
         RowsetSharedPtr rs = create_rowset({i, i}, 1, false, 102400);
         st = tablet->add_inc_rowset(rs);
-        EXPECT_TRUE(st.OK());
+        EXPECT_TRUE(st.ok());
     }
     EXPECT_EQ(tablet->get_compaction_score(), -1);
     EXPECT_EQ(tablet->calc_compaction_score(), 8);
@@ -129,7 +129,7 @@ TEST_F(CompactionScoreTest, TestCompactionScore) {
     for (int i = 10; i < 30; ++i) {
         RowsetSharedPtr rs = create_rowset({i, i}, 1, false, 102400);
         st = tablet->add_inc_rowset(rs);
-        EXPECT_TRUE(st.OK());
+        EXPECT_TRUE(st.ok());
     }
     EXPECT_EQ(tablet->get_compaction_score(), 28);
     EXPECT_EQ(tablet->calc_compaction_score(), 28);
@@ -148,7 +148,7 @@ TEST_F(CompactionScoreTest, TestCompactionScore) {
     std::vector<RowsetSharedPtr> output_rowsets;
     output_rowsets.push_back(rs);
     st = tablet->modify_rowsets(output_rowsets, input_rowsets, true);
-    EXPECT_TRUE(st.OK());
+    EXPECT_TRUE(st.ok());
 
     EXPECT_EQ(tablet->get_compaction_score(), 9);
     EXPECT_EQ(tablet->calc_compaction_score(), 9);

--- a/be/test/olap/compaction_task_test.cpp
+++ b/be/test/olap/compaction_task_test.cpp
@@ -88,12 +88,12 @@ TEST_F(CompactionTaskTest, TestSubmitCompactionTask) {
                       .set_min_threads(2)
                       .set_max_threads(2)
                       .build(&_storage_engine->_base_compaction_thread_pool);
-    EXPECT_TRUE(st.OK());
+    EXPECT_TRUE(st.ok());
     st = ThreadPoolBuilder("CumuCompactionTaskThreadPool")
                  .set_min_threads(2)
                  .set_max_threads(2)
                  .build(&_storage_engine->_cumu_compaction_thread_pool);
-    EXPECT_TRUE(st.OK());
+    EXPECT_TRUE(st.ok());
 
     auto* sp = SyncPoint::get_instance();
     sp->enable_processing();
@@ -111,7 +111,7 @@ TEST_F(CompactionTaskTest, TestSubmitCompactionTask) {
         TabletSharedPtr tablet(new Tablet(*(_storage_engine.get()), tablet_meta, _data_dir.get(),
                                           CUMULATIVE_SIZE_BASED_POLICY));
         st = tablet->init();
-        EXPECT_TRUE(st.OK());
+        EXPECT_TRUE(st.ok());
 
         for (int i = 2; i < 30; ++i) {
             RowsetSharedPtr rs = create_rowset({i, i}, 1, false, 1024);
@@ -121,7 +121,7 @@ TEST_F(CompactionTaskTest, TestSubmitCompactionTask) {
 
         st = _storage_engine->_submit_compaction_task(tablet, CompactionType::CUMULATIVE_COMPACTION,
                                                       false);
-        EXPECT_TRUE(st.OK());
+        EXPECT_TRUE(st.ok());
     }
 
     int executing_task_num =

--- a/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
@@ -110,7 +110,7 @@ public:
         paths.emplace_back(kTestDir, 1024);
         auto tmp_file_dirs = std::make_unique<segment_v2::TmpFileDirs>(paths);
         st = tmp_file_dirs->init();
-        if (!st.OK()) {
+        if (!st.ok()) {
             std::cout << "init tmp file dirs error:" << st.to_string() << std::endl;
             return;
         }


### PR DESCRIPTION
## Proposed changes

The capitalized OK in status constructs an "ok" status. 
Since we allow status to be converted to bool, these checks are redundant.


<!--Describe your changes.-->

