### PR TITLE
[regression](case)fix mc regression test p2 case.

### DIFF
--- a/regression-test/suites/external_table_p2/maxcompute/test_external_catalog_maxcompute.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_external_catalog_maxcompute.groovy
@@ -403,7 +403,7 @@ suite("test_external_catalog_maxcompute", "p2,external,maxcompute,external_remot
                 "mc.endpoint" = "http://service.cn-beijing-vpc.maxcompute.aliyun-inc.com/api"
             );
         """
-        sql """ switch `${mc_catalog_name}_2`" ""
+        sql """ switch `${mc_catalog_name}_2` """
 
         //other db 
         sql """ use other_mc_datalake_test """

--- a/regression-test/suites/external_table_p2/maxcompute/test_external_catalog_maxcompute.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_external_catalog_maxcompute.groovy
@@ -392,6 +392,19 @@ suite("test_external_catalog_maxcompute", "p2,external,maxcompute,external_remot
         order_qt_multi_partition_q10 """ select pt, yy, mm, dd from multi_partitions where pt >= 2 and create_time > '2023-08-03 03:11:00' order by pt, yy, mm, dd; """
 
 
+
+
+        sql """
+            create catalog if not exists ${mc_catalog_name}_2 properties (
+                "type" = "max_compute",
+                "mc.default.project" = "other_mc_datalake_test",
+                "mc.access_key" = "${ak}",
+                "mc.secret_key" = "${sk}",
+                "mc.endpoint" = "http://service.cn-beijing-vpc.maxcompute.aliyun-inc.com/api"
+            );
+        """
+        sql """ switch `${mc_catalog_name}_2`" ""
+
         //other db 
         sql """ use other_mc_datalake_test """
         order_qt_other_db_show  """ show tables ; """
@@ -400,7 +413,7 @@ suite("test_external_catalog_maxcompute", "p2,external,maxcompute,external_remot
         order_qt_other_db_show_partiton """show partitions from other_db_mc_parts;"""
 
 
-
+        sql """ switch `${mc_catalog_name}`; """
         sql """ use `${mc_db}`; """
         //test null value 
         order_qt_null_1 """ select * from mc_test_null; """


### PR DESCRIPTION
## Proposed changes
In previous versions, use a db that does not exist in show databases will not cause an error, so this test can be run before. 

Since the test account does not have the list all projects permission, there is no db want to be used when show databases， which causes the case to fail.

Therefore, creat a new catalog and  specify  `mc.default.project`  to fix this case.