### PR TITLE
[fix](cache prune) Fix _stale_sweep_time_s not working when its value less than 0

### DIFF
--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -149,7 +149,7 @@ public:
         std::lock_guard<std::mutex> l(_lock);
         COUNTER_SET(_freed_entrys_counter, (int64_t)0);
         COUNTER_SET(_freed_memory_counter, (int64_t)0);
-        if (_stale_sweep_time_s <= 0 && _cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
+        if (_stale_sweep_time_s <= 0 || _cache == ExecEnv::GetInstance()->get_dummy_lru_cache()) {
             return;
         }
         if (exceed_prune_limit()) {


### PR DESCRIPTION
As title.

We have a lot of things todo with cache prune behavior.