### PR TITLE
[improve](stream load) set NumberLoadedRows to zero when stream load transaction failed (#41946)

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -99,6 +99,7 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
         } else {
             LOG(WARNING) << "fragment execute failed"
                          << ", err_msg=" << status->to_string() << ", " << ctx->brief();
+            ctx->number_loaded_rows = 0;
             // cancel body_sink, make sender known it
             if (ctx->body_sink != nullptr) {
                 ctx->body_sink->cancel(status->to_string());

--- a/regression-test/suites/insert_p0/insert_group_commit_into_max_filter_ratio.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_into_max_filter_ratio.groovy
@@ -117,7 +117,7 @@ suite("insert_group_commit_into_max_filter_ratio") {
         assertTrue(json.GroupCommit)
         // assertTrue(json.Label.startsWith("group_commit_"))
         assertEquals(total_rows, json.NumberTotalRows)
-        assertEquals(loaded_rows, json.NumberLoadedRows)
+        assertEquals(0, json.NumberLoadedRows)
         assertEquals(filtered_rows, json.NumberFilteredRows)
         assertEquals(unselected_rows, json.NumberUnselectedRows)
         if (filtered_rows > 0) {

--- a/regression-test/suites/json_p0/test_json_load_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_and_function.groovy
@@ -57,7 +57,7 @@ suite("test_json_load_and_function", "p0") {
             assertEquals("fail", json.Status.toLowerCase())
             assertTrue(json.Message.contains("too many filtered rows"))
             assertEquals(25, json.NumberTotalRows)
-            assertEquals(18, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
             assertTrue(json.LoadBytes > 0)
             log.info("url: " + json.ErrorURL)

--- a/regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
@@ -52,7 +52,7 @@ suite("test_json_unique_load_and_function", "p0") {
             assertEquals("fail", json.Status.toLowerCase())
             assertTrue(json.Message.contains("too many filtered rows"))
             assertEquals(75, json.NumberTotalRows)
-            assertEquals(54, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(21, json.NumberFilteredRows)
             assertTrue(json.LoadBytes > 0)
         }

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
@@ -57,7 +57,7 @@ suite("test_jsonb_load_and_function", "p0") {
             assertEquals("fail", json.Status.toLowerCase())
             assertTrue(json.Message.contains("too many filtered rows"))
             assertEquals(25, json.NumberTotalRows)
-            assertEquals(18, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
             assertTrue(json.LoadBytes > 0)
             log.info("url: " + json.ErrorURL)

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy
@@ -53,7 +53,7 @@ suite("test_jsonb_unique_load_and_function", "p0") {
             assertEquals("fail", json.Status.toLowerCase())
             assertTrue(json.Message.contains("too many filtered rows"))
             assertEquals(75, json.NumberTotalRows)
-            assertEquals(54, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(21, json.NumberFilteredRows)
             assertTrue(json.LoadBytes > 0)
         }

--- a/regression-test/suites/load_p0/stream_load/load_json_column_exclude_schema_without_jsonpath.groovy
+++ b/regression-test/suites/load_p0/stream_load/load_json_column_exclude_schema_without_jsonpath.groovy
@@ -73,8 +73,8 @@ suite("test_load_json_column_exclude_schema_without_jsonpath", "p0") {
                 log.info("Stream load result: ${result}".toString())
                 def json = parseJson(result)
                 assertEquals("fail", json.Status.toLowerCase())
-                assertEquals(json.NumberTotalRows, json.NumberLoadedRows + json.NumberFilteredRows)
-                assertTrue(json.NumberLoadedRows == 30);
+                assertTrue(json.NumberTotalRows == 60)
+                assertTrue(json.NumberLoadedRows == 0)
                 assertTrue(json.NumberFilteredRows == 30);
             }
         }

--- a/regression-test/suites/load_p0/stream_load/test_csv_with_none_utf8_data.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_csv_with_none_utf8_data.groovy
@@ -60,7 +60,7 @@ suite("test_csv_with_none_utf8_data", "p0") {
             assertEquals("fail", json.Status.toLowerCase())
             assertTrue(json.Message.contains("too many filtered rows"))
             assertEquals(4, json.NumberTotalRows)
-            assertEquals(2, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(2, json.NumberFilteredRows)
             assertTrue(json.LoadBytes > 0)
             log.info("url: " + json.ErrorURL)

--- a/regression-test/suites/load_p0/stream_load/test_stream_load.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load.groovy
@@ -837,7 +837,7 @@ suite("test_stream_load", "p0") {
             def json = parseJson(result)
             assertEquals("fail", json.Status.toLowerCase())
             assertEquals(5, json.NumberTotalRows)
-            assertEquals(3, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(2, json.NumberFilteredRows)
             assertEquals(0, json.NumberUnselectedRows)
         }
@@ -941,7 +941,7 @@ suite("test_stream_load", "p0") {
             def json = parseJson(result)
             assertEquals("fail", json.Status.toLowerCase())
             assertEquals(5, json.NumberTotalRows)
-            assertEquals(3, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(2, json.NumberFilteredRows)
             assertEquals(0, json.NumberUnselectedRows)
         }

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_move_memtable.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_move_memtable.groovy
@@ -712,7 +712,7 @@ suite("test_stream_load_move_memtable", "p0") {
             def json = parseJson(result)
             assertEquals("fail", json.Status.toLowerCase())
             assertEquals(5, json.NumberTotalRows)
-            assertEquals(3, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(2, json.NumberFilteredRows)
             assertEquals(0, json.NumberUnselectedRows)
         }
@@ -818,7 +818,7 @@ suite("test_stream_load_move_memtable", "p0") {
             def json = parseJson(result)
             assertEquals("fail", json.Status.toLowerCase())
             assertEquals(5, json.NumberTotalRows)
-            assertEquals(3, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(2, json.NumberFilteredRows)
             assertEquals(0, json.NumberUnselectedRows)
         }

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_properties.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_properties.groovy
@@ -284,7 +284,7 @@ suite("test_stream_load_properties", "p0,nonConcurrent") {
                     def json = parseJson(result)
                     assertEquals("fail", json.Status.toLowerCase())
                     assertEquals(20, json.NumberTotalRows)
-                    assertEquals(loadedRows[i], json.NumberLoadedRows)
+                    assertEquals(0, json.NumberLoadedRows)
                     assertEquals(filteredRows[i], json.NumberFilteredRows)
                     assertEquals(0, json.NumberUnselectedRows)
                 }

--- a/regression-test/suites/nereids_function_p0/scalar_function/J.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/J.groovy
@@ -57,7 +57,7 @@ suite("nereids_scalar_fn_J") {
             assertEquals("fail", json.Status.toLowerCase())
             assertTrue(json.Message.contains("too many filtered rows"))
             assertEquals(25, json.NumberTotalRows)
-            assertEquals(18, json.NumberLoadedRows)
+            assertEquals(0, json.NumberLoadedRows)
             assertEquals(7, json.NumberFilteredRows)
             assertTrue(json.LoadBytes > 0)
             log.info("url: " + json.ErrorURL)

--- a/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_strict_mode.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_strict_mode.groovy
@@ -117,7 +117,7 @@ suite("test_partial_update_strict_mode", "p0") {
                     assertEquals("Fail", json.Status)
                     assertTrue(json.Message.contains("[DATA_QUALITY_ERROR]too many filtered rows"))
                     assertEquals(3, json.NumberTotalRows)
-                    assertEquals(1, json.NumberLoadedRows)
+                    assertEquals(0, json.NumberLoadedRows)
                     assertEquals(2, json.NumberFilteredRows)
                 }
             }
@@ -166,7 +166,6 @@ suite("test_partial_update_strict_mode", "p0") {
                     assertEquals("Fail", json.Status)
                     assertTrue(json.Message.contains("[DATA_QUALITY_ERROR]too many filtered rows"))
                     assertEquals(3, json.NumberTotalRows)
-                    assertEquals(1, json.NumberLoadedRows)
                     assertEquals(2, json.NumberFilteredRows)
                 }
             }

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -176,7 +176,7 @@ suite("test_primary_key_partial_update", "p0") {
                     assertEquals("Fail", json.Status)
                     assertTrue(json.Message.contains("[DATA_QUALITY_ERROR]too many filtered rows"))
                     assertEquals(3, json.NumberTotalRows)
-                    assertEquals(1, json.NumberLoadedRows)
+                    assertEquals(0, json.NumberLoadedRows)
                     assertEquals(2, json.NumberFilteredRows)
                 }
             }

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.groovy
@@ -117,7 +117,7 @@ suite("test_partial_update_strict_mode", "p0") {
                     assertEquals("Fail", json.Status)
                     assertTrue(json.Message.contains("[DATA_QUALITY_ERROR]too many filtered rows"))
                     assertEquals(3, json.NumberTotalRows)
-                    assertEquals(1, json.NumberLoadedRows)
+                    assertEquals(0, json.NumberLoadedRows)
                     assertEquals(2, json.NumberFilteredRows)
                 }
             }
@@ -166,7 +166,6 @@ suite("test_partial_update_strict_mode", "p0") {
                     assertEquals("Fail", json.Status)
                     assertTrue(json.Message.contains("[DATA_QUALITY_ERROR]too many filtered rows"))
                     assertEquals(3, json.NumberTotalRows)
-                    assertEquals(1, json.NumberLoadedRows)
                     assertEquals(2, json.NumberFilteredRows)
                 }
             }


### PR DESCRIPTION
pick (#41946)

Set NumberLoadedRows to zero when stream load failed.

before:
```
stream load result: {
    "TxnId": 8589,
    "Label": "c8e7c4fe-56b2-4e3b-b4cc-4f2a94cdd003",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Fail",
    "Message": "[DATA_QUALITY_ERROR]too many filtered rows",
    "NumberTotalRows": 3,
    "NumberLoadedRows": 1,
    "NumberFilteredRows": 2,
    "NumberUnselectedRows": 0,
    "LoadBytes": 77,
    "LoadTimeMs": 78,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 4,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 72,
    "ReceiveDataTimeMs": 7,
    "CommitAndPublishTimeMs": 0,
    "ErrorURL": "XXX"
}
```

now:
```
stream load result: {
    "TxnId": 8589,
    "Label": "c8e7c4fe-56b2-4e3b-b4cc-4f2a94cdd003",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Fail",
    "Message": "[DATA_QUALITY_ERROR]too many filtered rows",
    "NumberTotalRows": 3,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 2,
    "NumberUnselectedRows": 0,
    "LoadBytes": 77,
    "LoadTimeMs": 78,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 4,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 72,
    "ReceiveDataTimeMs": 7,
    "CommitAndPublishTimeMs": 0,
    "ErrorURL": "XXX"
}
```

