### PR TITLE
[fix](log) fix group commit warn log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
@@ -393,10 +393,10 @@ public class GroupCommitManager {
     private void updateLoadDataInternal(long tableId, long receiveData) {
         if (tableToPressureMap.containsKey(tableId)) {
             tableToPressureMap.get(tableId).add(receiveData);
-            LOG.info("Update load data for table{}, receiveData {}, tablePressureMap {}", tableId, receiveData,
+            LOG.info("Update load data for table {}, receiveData {}, tablePressureMap {}", tableId, receiveData,
                     tableToPressureMap.toString());
-        } else {
-            LOG.warn("can not find backend id: {}", tableId);
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("can not find table id {}", tableId);
         }
     }
 }


### PR DESCRIPTION
if stream load in group commit mode connect to be directly, the fe does not select backend for it. the map used to record <table, be, dataSize> in fe is empty, so there are too many warn log:
```
[GroupCommitManager.updateLoadDataInternal():399] can not find backend id: 12229430
2024-10-21 08:58:28,975 WARN (thrift-server-pool-7|132)
```