### PR TITLE
[feature](meta-service) Support querying and adjusting rpc qps limit on meta service

### DIFF
--- a/cloud/src/rate-limiter/rate_limiter.cpp
+++ b/cloud/src/rate-limiter/rate_limiter.cpp
@@ -20,8 +20,10 @@
 #include <butil/strings/string_split.h>
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 
 #include "common/bvars.h"
 #include "common/config.h"
@@ -29,10 +31,10 @@
 
 namespace doris::cloud {
 
-void RateLimiter::init(google::protobuf::Service* service) {
-    std::map<std::string, int64_t> rpc_name_to_max_qps_limit;
+std::unordered_map<std::string, int64_t> parse_specific_qps_limit(const std::string& list_str) {
+    std::unordered_map<std::string, int64_t> rpc_name_to_max_qps_limit;
     std::vector<std::string> max_qps_limit_list;
-    butil::SplitString(config::specific_max_qps_limit, ';', &max_qps_limit_list);
+    butil::SplitString(list_str, ';', &max_qps_limit_list);
     for (const auto& v : max_qps_limit_list) {
         auto p = v.find(':');
         if (p != std::string::npos && p != (v.size() - 1)) {
@@ -41,34 +43,94 @@ void RateLimiter::init(google::protobuf::Service* service) {
                 int64_t max_qps_limit = std::stoll(v.substr(p + 1));
                 if (max_qps_limit > 0) {
                     rpc_name_to_max_qps_limit[rpc_name] = max_qps_limit;
-                    LOG(INFO) << "set rpc: " << rpc_name << " max_qps_limit: " << max_qps_limit;
                 }
             } catch (...) {
-                LOG(WARNING) << "failed to set max_qps_limit to rpc: " << rpc_name
+                LOG(WARNING) << "failed to parse max_qps_limit to rpc: " << rpc_name
                              << " config: " << v;
             }
         }
     }
+    return rpc_name_to_max_qps_limit;
+}
+
+template <typename Callable>
+void for_each_rpc_name(google::protobuf::Service* service, Callable cb) {
     auto method_size = service->GetDescriptor()->method_count();
     for (auto i = 0; i < method_size; ++i) {
         std::string rpc_name = service->GetDescriptor()->method(i)->name();
-        int64_t max_qps_limit = config::default_max_qps_limit;
+        cb(rpc_name);
+    }
+}
 
-        auto it = rpc_name_to_max_qps_limit.find(rpc_name);
-        if (it != rpc_name_to_max_qps_limit.end()) {
+void RateLimiter::init(google::protobuf::Service* service) {
+    auto rpc_name_to_specific_limit = parse_specific_qps_limit(config::specific_max_qps_limit);
+    std::unique_lock write_lock(shared_mtx_);
+    for_each_rpc_name(service, [&](const std::string& rpc_name) {
+        auto it = rpc_name_to_specific_limit.find(rpc_name);
+        int64_t max_qps_limit = config::default_max_qps_limit;
+        if (it != rpc_name_to_specific_limit.end()) {
             max_qps_limit = it->second;
         }
         limiters_[rpc_name] = std::make_shared<RpcRateLimiter>(rpc_name, max_qps_limit);
+    });
+    for (const auto& [k, _] : rpc_name_to_specific_limit) {
+        rpc_with_specific_limit_.insert(k);
     }
 }
 
 std::shared_ptr<RpcRateLimiter> RateLimiter::get_rpc_rate_limiter(const std::string& rpc_name) {
-    // no need to be locked, because it is only modified during initialization
+    std::shared_lock read_lock(shared_mtx_);
     auto it = limiters_.find(rpc_name);
     if (it == limiters_.end()) {
         return nullptr;
     }
     return it->second;
+}
+
+void RateLimiter::reset_rate_limit(google::protobuf::Service* service, int64_t default_qps_limit,
+                                   const std::string& specific_max_qps_limit) {
+    // TODO: merge specific_max_qps_limit
+    auto specific_limits = parse_specific_qps_limit(specific_max_qps_limit);
+
+    auto reset_specific_limit = [&](const std::string& rpc_name) -> bool {
+        if (auto it = specific_limits.find(rpc_name); it != specific_limits.end()) {
+            limiters_[rpc_name]->reset_max_qps_limit(it->second);
+            return true;
+        }
+        return false;
+    };
+    auto reset_default_limit = [&](const std::string& rpc_name) {
+        if (rpc_with_specific_limit_.contains(rpc_name)) {
+            return;
+        }
+        limiters_[rpc_name]->reset_max_qps_limit(default_qps_limit);
+    };
+
+    std::unique_lock write_lock(shared_mtx_);
+    for (const auto& [k, _] : specific_limits) {
+        rpc_with_specific_limit_.insert(k);
+    }
+    if (default_qps_limit < 0) {
+        for_each_rpc_name(service, std::move(reset_specific_limit));
+        return;
+    }
+    if (specific_limits.empty()) {
+        for_each_rpc_name(service, std::move(reset_default_limit));
+        return;
+    }
+    for_each_rpc_name(service, [&](const std::string& rpc_name) {
+        if (reset_specific_limit(rpc_name)) {
+            return;
+        }
+        reset_default_limit(rpc_name);
+    });
+}
+
+void RateLimiter::for_each_rpc_limiter(
+        std::function<void(std::string_view, std::shared_ptr<RpcRateLimiter>)> cb) {
+    for (const auto& [rpc_name, rpc_limiter] : limiters_) {
+        cb(rpc_name, rpc_limiter);
+    }
 }
 
 bool RpcRateLimiter::get_qps_token(const std::string& instance_id,
@@ -93,6 +155,14 @@ bool RpcRateLimiter::get_qps_token(const std::string& instance_id,
     return qps_token->get_token(get_bvar_qps);
 }
 
+void RpcRateLimiter::reset_max_qps_limit(int64_t max_qps_limit) {
+    std::lock_guard<bthread::Mutex> l(mutex_);
+    max_qps_limit_ = max_qps_limit;
+    for (auto& [_, v] : qps_limiter_) {
+        v->reset_max_qps_limit(max_qps_limit);
+    }
+}
+
 bool RpcRateLimiter::QpsToken::get_token(std::function<int()>& get_bvar_qps) {
     using namespace std::chrono;
     auto now = steady_clock::now();
@@ -108,6 +178,11 @@ bool RpcRateLimiter::QpsToken::get_token(std::function<int()>& get_bvar_qps) {
         current_qps_ = get_bvar_qps();
     }
     return current_qps_ < max_qps_limit_;
+}
+
+void RpcRateLimiter::QpsToken::reset_max_qps_limit(int64_t max_qps_limit) {
+    std::lock_guard<bthread::Mutex> l(mutex_);
+    max_qps_limit_ = max_qps_limit;
 }
 
 } // namespace doris::cloud

--- a/cloud/src/rate-limiter/rate_limiter.h
+++ b/cloud/src/rate-limiter/rate_limiter.h
@@ -19,10 +19,13 @@
 
 #include <brpc/server.h>
 #include <bthread/mutex.h>
+#include <google/protobuf/service.h>
 
 #include <cstdint>
 #include <memory>
+#include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "common/config.h"
@@ -35,12 +38,22 @@ class RateLimiter {
 public:
     RateLimiter() = default;
     ~RateLimiter() = default;
+
     void init(google::protobuf::Service* service);
+
     std::shared_ptr<RpcRateLimiter> get_rpc_rate_limiter(const std::string& rpc_name);
+
+    void reset_rate_limit(google::protobuf::Service* service, int64_t default_qps_limit,
+                          const std::string& specific_max_qps_limit);
+
+    void for_each_rpc_limiter(
+            std::function<void(std::string_view, std::shared_ptr<RpcRateLimiter>)> cb);
 
 private:
     // rpc_name -> RpcRateLimiter
     std::unordered_map<std::string, std::shared_ptr<RpcRateLimiter>> limiters_;
+    std::unordered_set<std::string> rpc_with_specific_limit_;
+    std::shared_mutex shared_mtx_;
 };
 
 class RpcRateLimiter {
@@ -58,6 +71,12 @@ public:
      */
     bool get_qps_token(const std::string& instance_id, std::function<int()>& get_bvar_qps);
 
+    std::string_view rpc_name() const { return rpc_name_; }
+
+    int64_t max_qps_limit() const { return max_qps_limit_; }
+
+    void reset_max_qps_limit(int64_t max_qps_limit);
+
     // Todo: Recycle outdated instance_id
 
 private:
@@ -67,6 +86,8 @@ private:
 
         bool get_token(std::function<int()>& get_bvar_qps);
 
+        void reset_max_qps_limit(int64_t max_qps_limit);
+
     private:
         bthread::Mutex mutex_;
         std::chrono::steady_clock::time_point last_update_time_;
@@ -75,7 +96,6 @@ private:
         int64_t max_qps_limit_;
     };
 
-private:
     bthread::Mutex mutex_;
     // instance_id -> QpsToken
     std::unordered_map<std::string, std::shared_ptr<QpsToken>> qps_limiter_;

--- a/cloud/src/rate-limiter/rate_limiter.h
+++ b/cloud/src/rate-limiter/rate_limiter.h
@@ -43,25 +43,47 @@ public:
 
     std::shared_ptr<RpcRateLimiter> get_rpc_rate_limiter(const std::string& rpc_name);
 
+    /**
+     * @brief for each rpc limiter, apply callback
+     *
+     * @param cb callback function with params rpc name and rate limiter
+     */
     void for_each_rpc_limiter(
             std::function<void(std::string_view, std::shared_ptr<RpcRateLimiter>)> cb);
 
-    // set global default rate limit, will not infulence rpc and instance specific qps limit setting
+    /** 
+     * @brief set global default rate limit, will not infulence rpc and instance specific qps limit setting
+     *
+     * @return true if set sucessfully
+     */
     bool set_rate_limit(int64_t qps_limit);
 
-    // set rpc level rate limit, will not infulence instance specific qps limit setting
+    /** 
+     * @brief set rpc level rate limit, will not infulence instance specific qps limit setting 
+     *
+     * @return true if set sucessfully
+     */
     bool set_rate_limit(int64_t qps_limit, const std::string& rpc_name);
 
-    // set instance level rate limit for specific rpc
+    /** 
+     * @brief set instance level rate limit for specific rpc
+     *
+     * @return true if set sucessfully
+     */
     bool set_rate_limit(int64_t qps_limit, const std::string& rpc_name,
                         const std::string& instance_id);
 
-    // set instance level rate limit globally, will influence settings for the same instance of specific rpc
+    /** 
+     * @brief set instance level rate limit globally, will influence settings for the same instance of specific rpc 
+     * 
+     * @return true if set sucessfully
+     */
     bool set_instance_rate_limit(int64_t qps_limit, const std::string& instance_id);
 
 private:
     // rpc_name -> RpcRateLimiter
     std::unordered_map<std::string, std::shared_ptr<RpcRateLimiter>> limiters_;
+    // rpc names which specific limit have been set
     std::unordered_set<std::string> rpc_with_specific_limit_;
     bthread::Mutex mutex_;
 };
@@ -85,8 +107,18 @@ public:
 
     int64_t max_qps_limit() const { return max_qps_limit_; }
 
+    /**
+     * @brief set max qps limit for this limiter
+     * 
+     * @return true if set sucessfully
+     */
     void set_max_qps_limit(int64_t max_qps_limit);
 
+    /**
+     * @brief set max qps limit for specific instance within this limiter
+     *
+     * @return true if set sucessfully
+     */
     bool set_max_qps_limit(int64_t max_qps_limit, const std::string& instance);
 
     class QpsToken {
@@ -115,6 +147,7 @@ private:
     bthread::Mutex mutex_;
     // instance_id -> QpsToken
     std::unordered_map<std::string, std::shared_ptr<QpsToken>> qps_limiter_;
+    // instance ids which specific limit have been set
     std::unordered_set<std::string> instance_with_specific_limit_;
     std::string rpc_name_;
     int64_t max_qps_limit_;

--- a/cloud/test/meta_service_http_test.cpp
+++ b/cloud/test/meta_service_http_test.cpp
@@ -1538,63 +1538,81 @@ TEST(MetaServiceHttpTest, get_obj_store_info_response_sk) {
 TEST(MetaServiceHttpTest, AdjustRateLimit) {
     HttpContext ctx;
     {
-        auto [status_code, content] = ctx.query<std::string>(
-                "adjust_rate_limit",
-                "default_qps_limit=10000&specific_max_qps_limit=get_cluster:10000");
+        auto [status_code, content] =
+                ctx.query<std::string>("adjust_rate_limit", "qps_limit=10000");
         ASSERT_EQ(status_code, 200);
     }
     {
         auto [status_code, content] =
-                ctx.query<std::string>("adjust_rate_limit", "default_qps_limit=10000");
+                ctx.query<std::string>("adjust_rate_limit", "qps_limit=10000&rpc_name=get_cluster");
         ASSERT_EQ(status_code, 200);
     }
     {
         auto [status_code, content] = ctx.query<std::string>(
-                "adjust_rate_limit", "specific_max_qps_limit=get_cluster:10000");
+                "adjust_rate_limit",
+                "qps_limit=10000&rpc_name=get_cluster&instance_id=test_instance");
         ASSERT_EQ(status_code, 200);
+    }
+    {
+        auto [status_code, content] = ctx.query<std::string>(
+                "adjust_rate_limit", "qps_limit=10000&instance_id=test_instance");
+        ASSERT_EQ(status_code, 200);
+    }
+    {
+        auto [status_code, content] =
+                ctx.query<std::string>("adjust_rate_limit", "qps_limit=invalid");
+        ASSERT_EQ(status_code, 400);
+        std::string msg = "param `qps_limit` is not a legal int64 type:";
+        ASSERT_NE(content.find(msg), std::string::npos);
+    }
+    {
+        auto [status_code, content] = ctx.query<std::string>("adjust_rate_limit", "qps_limit=-1");
+        ASSERT_EQ(status_code, 400);
+        std::string msg = "qps_limit` should not be less than 0";
+        ASSERT_NE(content.find(msg), std::string::npos);
+    }
+    {
+        auto [status_code, content] =
+                ctx.query<std::string>("adjust_rate_limit", "rpc_name=get_cluster");
+        ASSERT_EQ(status_code, 400);
+        std::string msg = "invalid argument:";
+        ASSERT_NE(content.find(msg), std::string::npos);
+    }
+    {
+        auto [status_code, content] =
+                ctx.query<std::string>("adjust_rate_limit", "instance_id=test_instance");
+        ASSERT_EQ(status_code, 400);
+        std::string msg = "invalid argument:";
+        ASSERT_NE(content.find(msg), std::string::npos);
+    }
+    {
+        auto [status_code, content] = ctx.query<std::string>(
+                "adjust_rate_limit", "rpc_name=get_cluster&instance_id=test_instance");
+        ASSERT_EQ(status_code, 400);
+        std::string msg = "invalid argument:";
+        ASSERT_NE(content.find(msg), std::string::npos);
     }
     {
         auto [status_code, content] = ctx.query<std::string>("adjust_rate_limit", "");
         ASSERT_EQ(status_code, 400);
-        std::string msg =
-                "default_qps_limit(int64) or specific_max_qps_limit(list of[rpcname:qps(int64);]) "
-                "is required as query param";
-        ASSERT_TRUE(content.find(msg) != std::string::npos);
-    }
-    {
-        auto [status_code, content] = ctx.query<std::string>("adjust_rate_limit", "key=abc");
-        ASSERT_EQ(status_code, 400);
-        std::string msg =
-                "default_qps_limit(int64) or specific_max_qps_limit(list of[rpcname:qps(int64);]) "
-                "is required as query param";
-        ASSERT_TRUE(content.find(msg) != std::string::npos);
+        std::string msg = "invalid argument:";
+        ASSERT_NE(content.find(msg), std::string::npos);
     }
     {
         auto [status_code, content] =
-                ctx.query<std::string>("adjust_rate_limit", "default_qps_limit=invalid");
+                ctx.query<std::string>("adjust_rate_limit", "qps_limit=1000&rpc_name=invalid");
         ASSERT_EQ(status_code, 400);
-        std::string msg = "param `qps_limit` is not a legal int64 type:";
-        ASSERT_TRUE(content.find(msg) != std::string::npos);
+        std::string msg = "failed to adjust rate limit for qps_limit";
+        ASSERT_NE(content.find(msg), std::string::npos);
     }
     {
-        auto [status_code, content] = ctx.query<std::string>(
-                "adjust_rate_limit",
-                "specific_max_qps_limit=get_cluster:10000&default_qps_limit=invalid");
-        ASSERT_EQ(status_code, 400);
-        std::string msg = "param `qps_limit` is not a legal int64 type:";
-        ASSERT_TRUE(content.find(msg) != std::string::npos);
-    }
-    {
-        auto [status_code, content] = ctx.query<std::string>(
-                "adjust_rate_limit",
-                "specific_max_qps_limit=get_cluster:invalid&default_qps_limit=10000");
-        // note: invalid so will not take effect, but return ok, by design
+        auto [status_code, content] =
+                ctx.query<std::string>("adjust_rate_limit", "qps_limit=1000&instance_id=invalid");
         ASSERT_EQ(status_code, 200);
     }
     {
         auto [status_code, content] = ctx.query<std::string>(
-                "adjust_rate_limit", "specific_max_qps_limit=xxx:10000&default_qps_limit=10000");
-        // note: invalid so will not take effect, but return ok, by design
+                "adjust_rate_limit", "qps_limit=1000&rpc_name=get_cluster&instance_id=invalid");
         ASSERT_EQ(status_code, 200);
     }
 }
@@ -1602,19 +1620,8 @@ TEST(MetaServiceHttpTest, AdjustRateLimit) {
 TEST(MetaServiceHttpTest, QueryRateLimit) {
     HttpContext ctx;
     {
-        auto [status_code, content] = ctx.query<std::string>("query_rate_limit", "");
+        auto [status_code, content] = ctx.query<std::string>("list_rate_limit", "");
         ASSERT_EQ(status_code, 200);
-    }
-    {
-        auto [status_code, content] =
-                ctx.query<std::string>("query_rate_limit", "rpc_name=get_cluster");
-        ASSERT_EQ(status_code, 200);
-    }
-    {
-        auto [status_code, content] = ctx.query<std::string>("query_rate_limit", "rpc_name=xxx");
-        ASSERT_EQ(status_code, 400);
-        std::string msg = "rpc_name=xxx is not exists";
-        ASSERT_TRUE(content.find(msg) != std::string::npos);
     }
 }
 

--- a/cloud/test/rate_limiter_test.cpp
+++ b/cloud/test/rate_limiter_test.cpp
@@ -17,7 +17,10 @@
 
 #include "rate-limiter/rate_limiter.h"
 
+#include <gen_cpp/cloud.pb.h>
 #include <gtest/gtest.h>
+
+#include <cstddef>
 
 #include "common/config.h"
 #include "common/util.h"
@@ -44,8 +47,7 @@ std::unique_ptr<MetaServiceProxy> get_meta_service() {
     return std::make_unique<MetaServiceProxy>(std::move(meta_service));
 }
 
-TEST(RateLimiterTest, RateLimitGetClusterTest) {
-    auto meta_service = get_meta_service();
+void mock_add_cluster(MetaServiceProxy& meta_service) {
     // add cluster first
     InstanceKeyInfo key_info {mock_instance};
     std::string key;
@@ -63,50 +65,131 @@ TEST(RateLimiterTest, RateLimitGetClusterTest) {
 
     std::unique_ptr<Transaction> txn;
     std::string get_val;
-    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    ASSERT_EQ(meta_service.txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
     txn->put(key, val);
     ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+}
 
-    auto get_cluster = [&](MetaServiceCode code) {
-        GetClusterRequest req;
-        req.set_cloud_unique_id("test_cloud_unique_id");
-        req.set_cluster_id(mock_cluster_id);
-        req.set_cluster_name(mock_cluster_name);
-        brpc::Controller cntl;
-        GetClusterResponse res;
-        meta_service->get_cluster(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
-                                  &res, nullptr);
+void mock_get_cluster(MetaServiceProxy& meta_service, MetaServiceCode code) {
+    GetClusterRequest req;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    req.set_cluster_id(mock_cluster_id);
+    req.set_cluster_name(mock_cluster_name);
+    brpc::Controller cntl;
+    GetClusterResponse res;
+    meta_service.get_cluster(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
+                             &res, nullptr);
 
-        ASSERT_EQ(res.status().code(), code);
-    };
+    ASSERT_EQ(res.status().code(), code);
+}
+
+template <typename Rpc>
+void mock_parallel_rpc(Rpc rpc, MetaServiceProxy* meta_service, MetaServiceCode expected,
+                       size_t times) {
     std::vector<std::thread> threads;
-    for (int i = 0; i < 20; ++i) {
-        threads.emplace_back(get_cluster, MetaServiceCode::OK);
+    for (size_t i = 0; i < times; ++i) {
+        threads.emplace_back([&]() { rpc(*meta_service, expected); });
     }
     for (auto& t : threads) {
         t.join();
     }
-    threads.clear();
+}
+
+TEST(RateLimiterTest, RateLimitGetClusterTest) {
+    auto meta_service = get_meta_service();
+    mock_add_cluster(*meta_service);
+
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     meta_service->rate_limiter()
             ->get_rpc_rate_limiter("get_cluster")
             ->qps_limiter_[mock_instance]
             ->max_qps_limit_ = 1;
-    threads.emplace_back(get_cluster, MetaServiceCode::MAX_QPS_LIMIT);
-    for (auto& t : threads) {
-        t.join();
-    }
-    threads.clear();
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::MAX_QPS_LIMIT, 1);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     meta_service->rate_limiter()
             ->get_rpc_rate_limiter("get_cluster")
             ->qps_limiter_[mock_instance]
             ->max_qps_limit_ = 10000;
-    threads.emplace_back(get_cluster, MetaServiceCode::OK);
-    for (auto& t : threads) {
-        t.join();
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 1);
+}
+
+TEST(RateLimiterTest, AdjustSpecificLimitTest) {
+    auto meta_service = get_meta_service();
+    mock_add_cluster(*meta_service);
+
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1, "get_cluster:10000");
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 10000);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-    threads.clear();
+
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1, "get_cluster:1");
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::MAX_QPS_LIMIT, 1);
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 10000,
+                                                       "get_cluster:10000");
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 10000);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 10000, "get_cluster:1");
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::MAX_QPS_LIMIT, 1);
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
+TEST(RateLimiterTest, AdjustDefaultLimitTest) {
+    auto meta_service = get_meta_service();
+    mock_add_cluster(*meta_service);
+
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1, "");
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+        limit = meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 5000000);
+    }
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1000,
+                                                       "get_cluster:5000");
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
+        ASSERT_EQ(limit, 1000);
+        limit = meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 5000);
+    }
+    {
+        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1000, "commit_txn:5000");
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
+        ASSERT_EQ(limit, 5000);
+        limit = meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 5000);
+    }
 }

--- a/cloud/test/rate_limiter_test.cpp
+++ b/cloud/test/rate_limiter_test.cpp
@@ -29,6 +29,7 @@
 #include "meta-service/meta_service.h"
 #include "meta-service/txn_kv_error.h"
 #include "mock_resource_manager.h"
+#include "resource-manager/resource_manager.h"
 
 int main(int argc, char** argv) {
     doris::cloud::config::init(nullptr, true);
@@ -38,24 +39,50 @@ int main(int argc, char** argv) {
 
 using namespace doris::cloud;
 
+const std::string mock_instance_0 = "mock_instance_0";
+const std::string mock_instance_1 = "mock_instance_1";
+const std::string mock_cluster_0 = "mock_cluster_0";
+const std::string mock_cluster_1 = "mock_cluster_1";
+const std::string mock_cluster_id_0 = "mock_cluster_id_0";
+const std::string mock_cluster_id_1 = "mock_cluster_id_1";
+const std::string mock_cloud_unique_id_0 = "mock_cloud_unique_id_0";
+const std::string mock_cloud_unique_id_1 = "mock_cloud_unique_id_1";
+
+class MockMultiInstanceRsMgr : public MockResourceManager {
+public:
+    using MockResourceManager::MockResourceManager;
+
+    std::string get_node(const std::string& cloud_unique_id,
+                         std::vector<NodeInfo>* nodes) override {
+        if (cloud_unique_id == mock_cloud_unique_id_0) {
+            nodes->emplace_back(Role::COMPUTE_NODE, mock_instance_0, mock_cluster_0,
+                                mock_cluster_id_0);
+        } else if (cloud_unique_id == mock_cloud_unique_id_1) {
+            nodes->emplace_back(Role::COMPUTE_NODE, mock_instance_1, mock_cluster_1,
+                                mock_cluster_id_1);
+        }
+        return {};
+    };
+};
+
 std::unique_ptr<MetaServiceProxy> get_meta_service() {
     auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
     [&] { ASSERT_NE(txn_kv.get(), nullptr); }();
-    auto rs = std::make_shared<MockResourceManager>(txn_kv);
+    auto rs = std::make_shared<MockMultiInstanceRsMgr>(txn_kv);
     auto rl = std::make_shared<RateLimiter>();
     auto meta_service = std::make_unique<MetaServiceImpl>(txn_kv, rs, rl);
     return std::make_unique<MetaServiceProxy>(std::move(meta_service));
 }
 
-void mock_add_cluster(MetaServiceProxy& meta_service) {
+void mock_add_cluster(MetaServiceProxy& meta_service, std::string instance_id) {
     // add cluster first
-    InstanceKeyInfo key_info {mock_instance};
+    InstanceKeyInfo key_info {instance_id};
     std::string key;
     std::string val;
     instance_key(key_info, &key);
 
     InstanceInfoPB instance;
-    instance.set_instance_id(mock_instance);
+    instance.set_instance_id(instance_id);
     ClusterPB c1;
     c1.set_cluster_name(mock_cluster_name);
     c1.set_cluster_id(mock_cluster_id);
@@ -70,9 +97,10 @@ void mock_add_cluster(MetaServiceProxy& meta_service) {
     ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
 }
 
-void mock_get_cluster(MetaServiceProxy& meta_service, MetaServiceCode code) {
+void mock_get_cluster(MetaServiceProxy& meta_service, const std::string& cloud_uid,
+                      MetaServiceCode code) {
     GetClusterRequest req;
-    req.set_cloud_unique_id("test_cloud_unique_id");
+    req.set_cloud_unique_id(cloud_uid);
     req.set_cluster_id(mock_cluster_id);
     req.set_cluster_name(mock_cluster_name);
     brpc::Controller cntl;
@@ -84,11 +112,11 @@ void mock_get_cluster(MetaServiceProxy& meta_service, MetaServiceCode code) {
 }
 
 template <typename Rpc>
-void mock_parallel_rpc(Rpc rpc, MetaServiceProxy* meta_service, MetaServiceCode expected,
-                       size_t times) {
+void mock_parallel_rpc(Rpc rpc, MetaServiceProxy* meta_service, const std::string& cloud_uid,
+                       MetaServiceCode expected, size_t times) {
     std::vector<std::thread> threads;
     for (size_t i = 0; i < times; ++i) {
-        threads.emplace_back([&]() { rpc(*meta_service, expected); });
+        threads.emplace_back([&]() { rpc(*meta_service, cloud_uid, expected); });
     }
     for (auto& t : threads) {
         t.join();
@@ -97,78 +125,54 @@ void mock_parallel_rpc(Rpc rpc, MetaServiceProxy* meta_service, MetaServiceCode 
 
 TEST(RateLimiterTest, RateLimitGetClusterTest) {
     auto meta_service = get_meta_service();
-    mock_add_cluster(*meta_service);
+    mock_add_cluster(*meta_service, mock_instance_0);
 
-    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                      MetaServiceCode::OK, 20);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     meta_service->rate_limiter()
             ->get_rpc_rate_limiter("get_cluster")
-            ->qps_limiter_[mock_instance]
+            ->qps_limiter_[mock_instance_0]
             ->max_qps_limit_ = 1;
-    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::MAX_QPS_LIMIT, 1);
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                      MetaServiceCode::MAX_QPS_LIMIT, 1);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     meta_service->rate_limiter()
             ->get_rpc_rate_limiter("get_cluster")
-            ->qps_limiter_[mock_instance]
+            ->qps_limiter_[mock_instance_0]
             ->max_qps_limit_ = 10000;
-    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 1);
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                      MetaServiceCode::OK, 1);
 }
 
-TEST(RateLimiterTest, AdjustSpecificLimitTest) {
+TEST(RateLimiterTest, AdjustLimitInfluenceTest) {
     auto meta_service = get_meta_service();
-    mock_add_cluster(*meta_service);
+    mock_add_cluster(*meta_service, mock_instance_0);
+    mock_add_cluster(*meta_service, mock_instance_1);
 
-    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1, "get_cluster:10000");
-        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
-        auto limit =
-                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
-        ASSERT_EQ(limit, 10000);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-
-    {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1, "get_cluster:1");
-        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::MAX_QPS_LIMIT, 1);
-        auto limit =
-                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
-        ASSERT_EQ(limit, 1);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-
-    {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 10000,
-                                                       "get_cluster:10000");
-        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 20);
-        auto limit =
-                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
-        ASSERT_EQ(limit, 10000);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-
-    {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 10000, "get_cluster:1");
-        mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::MAX_QPS_LIMIT, 1);
-        auto limit =
-                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
-        ASSERT_EQ(limit, 1);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-}
-
-TEST(RateLimiterTest, AdjustDefaultLimitTest) {
-    auto meta_service = get_meta_service();
-    mock_add_cluster(*meta_service);
-
-    mock_parallel_rpc(mock_get_cluster, meta_service.get(), MetaServiceCode::OK, 1);
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                      MetaServiceCode::OK, 1);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1, "");
+        ASSERT_TRUE(meta_service->rate_limiter()->set_instance_rate_limit(1, mock_instance_1));
+        ASSERT_TRUE(
+                meta_service->rate_limiter()->set_rate_limit(100, "get_cluster", mock_instance_0));
+
+        auto limit = meta_service->rate_limiter()
+                             ->get_rpc_rate_limiter("get_cluster")
+                             ->qps_limiter_.at(mock_instance_0)
+                             ->max_qps_limit();
+        ASSERT_EQ(limit, 100);
+        limit = meta_service->rate_limiter()
+                        ->get_rpc_rate_limiter("get_cluster")
+                        ->qps_limiter_.at(mock_instance_1)
+                        ->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+    }
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(1));
         auto limit =
                 meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
         ASSERT_EQ(limit, 1);
@@ -176,20 +180,117 @@ TEST(RateLimiterTest, AdjustDefaultLimitTest) {
         ASSERT_EQ(limit, 5000000);
     }
     {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1000,
-                                                       "get_cluster:5000");
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(5000, "get_cluster"));
         auto limit =
                 meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(1000));
+        limit = meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 5000);
+        limit = meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
         ASSERT_EQ(limit, 1000);
+    }
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(3000, "commit_txn"));
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
+        ASSERT_EQ(limit, 3000);
         limit = meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
         ASSERT_EQ(limit, 5000);
     }
     {
-        meta_service->rate_limiter()->reset_rate_limit(meta_service.get(), 1000, "commit_txn:5000");
+        auto limit = meta_service->rate_limiter()
+                             ->get_rpc_rate_limiter("get_cluster")
+                             ->qps_limiter_.at(mock_instance_0)
+                             ->max_qps_limit();
+        ASSERT_EQ(limit, 100);
+        limit = meta_service->rate_limiter()
+                        ->get_rpc_rate_limiter("get_cluster")
+                        ->qps_limiter_.at(mock_instance_1)
+                        ->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+    }
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_instance_rate_limit(200, mock_instance_1));
+        auto limit = meta_service->rate_limiter()
+                             ->get_rpc_rate_limiter("get_cluster")
+                             ->qps_limiter_.at(mock_instance_0)
+                             ->max_qps_limit();
+        ASSERT_EQ(limit, 100);
+        limit = meta_service->rate_limiter()
+                        ->get_rpc_rate_limiter("get_cluster")
+                        ->qps_limiter_.at(mock_instance_1)
+                        ->max_qps_limit();
+        ASSERT_EQ(limit, 200);
+    }
+}
+
+TEST(RateLimiterTest, AdjustLimitMockRPCTest) {
+    auto meta_service = get_meta_service();
+    mock_add_cluster(*meta_service, mock_instance_0);
+    mock_add_cluster(*meta_service, mock_instance_1);
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                      MetaServiceCode::OK, 20);
+    mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_1,
+                      MetaServiceCode::OK, 20);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(10000, "get_cluster"));
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(1));
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                          MetaServiceCode::OK, 20);
         auto limit =
-                meta_service->rate_limiter()->get_rpc_rate_limiter("commit_txn")->max_qps_limit();
-        ASSERT_EQ(limit, 5000);
-        limit = meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
-        ASSERT_EQ(limit, 5000);
+                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 10000);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(1, "get_cluster"));
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(1));
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                          MetaServiceCode::MAX_QPS_LIMIT, 1);
+        auto limit =
+                meta_service->rate_limiter()->get_rpc_rate_limiter("get_cluster")->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(10000, "get_cluster",
+                                                                 mock_instance_0));
+        ASSERT_TRUE(meta_service->rate_limiter()->set_rate_limit(10000, "get_cluster",
+                                                                 mock_instance_1));
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                          MetaServiceCode::OK, 20);
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_1,
+                          MetaServiceCode::OK, 20);
+        auto limit = meta_service->rate_limiter()
+                             ->get_rpc_rate_limiter("get_cluster")
+                             ->qps_limiter_.at(mock_instance_0)
+                             ->max_qps_limit();
+        ASSERT_EQ(limit, 10000);
+        limit = meta_service->rate_limiter()
+                        ->get_rpc_rate_limiter("get_cluster")
+                        ->qps_limiter_.at(mock_instance_1)
+                        ->max_qps_limit();
+        ASSERT_EQ(limit, 10000);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    {
+        ASSERT_TRUE(meta_service->rate_limiter()->set_instance_rate_limit(1, mock_instance_0));
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_0,
+                          MetaServiceCode::MAX_QPS_LIMIT, 1);
+        mock_parallel_rpc(mock_get_cluster, meta_service.get(), mock_cloud_unique_id_1,
+                          MetaServiceCode::OK, 20);
+        auto limit = meta_service->rate_limiter()
+                             ->get_rpc_rate_limiter("get_cluster")
+                             ->qps_limiter_.at(mock_instance_0)
+                             ->max_qps_limit();
+        ASSERT_EQ(limit, 1);
+        limit = meta_service->rate_limiter()
+                        ->get_rpc_rate_limiter("get_cluster")
+                        ->qps_limiter_.at(mock_instance_1)
+                        ->max_qps_limit();
+        ASSERT_EQ(limit, 10000);
     }
 }


### PR DESCRIPTION
## Proposed changes

Usage
1. adjust limit
```
curl http://ms_ip:ms_port/MetaService/http/v1/adjust_rate_limit?${params}
```
| Entry      | Description |
| ----------- | ----------- |
| param         | uint64 qps_limit  |
|behavior   | set qps_limit global default value |
|example|```curl http://ms_ip:ms_port/MetaService/http/v1/adjust_rate_limit?qps_limit=5000000```|

| Entry      | Description |
| ----------- | ----------- |
| param         | uint64 qps_limit, string rpc_name  |
|behavior   | set RPC specific qps_limit  |
|example|curl http://ms_ip:ms_port/MetaService/http/v1/adjust_rate_limit?qps_limit=5000000&rpc_name=get_cluster|

| Entry      | Description |
| ----------- | ----------- |
| param         | uint64 qps_limit, string rpc_name, string instance_id  |
|behavior   | set instance qps_limit for specific RPC  |
|example|```ccurl http://ms_ip:ms_port/MetaService/http/v1/adjust_rate_limit?qps_limit=5000000&rpc_name=get_cluster&instance_id="doris-0"```|

| Entry      | Description |
| ----------- | ----------- |
| param         | uint64 qps_limit, string instance_id  |
|behavior   | set global qps_limit for specific instance  |
|example|```curl http://ms_ip:ms_port/MetaService/http/v1/adjust_rate_limit?qps_limit=5000000&instance_id="doris-0"```|

2. query limit

| Entry      | Description |
| ----------- | ----------- |
| param         | none  |
|behavior   | query qps limit for all RPC interface |
|example|```curl http://ms_ip:ms_port/MetaService/http/v1/list_rate_limit```|
