### PR TITLE
[fix](cloud-mow) Add enable config for procesing old version delete bitmap when doing cu compaction

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -351,7 +351,8 @@ Status CloudCumulativeCompaction::modify_rowsets() {
                                                     stats.num_rows(), stats.data_size());
         }
     }
-    if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+    if (config::enable_delete_old_version_delete_bitmap_on_cu_compaction &&
+        _tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write() && _input_rowsets.size() != 1) {
         process_old_version_delete_bitmap();
     }

--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -351,7 +351,7 @@ Status CloudCumulativeCompaction::modify_rowsets() {
                                                     stats.num_rows(), stats.data_size());
         }
     }
-    if (config::enable_delete_old_version_delete_bitmap_on_cu_compaction &&
+    if (config::enable_delete_bitmap_merge_on_compaction &&
         _tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write() && _input_rowsets.size() != 1) {
         process_old_version_delete_bitmap();

--- a/be/src/cloud/cloud_delete_bitmap_action.cpp
+++ b/be/src/cloud/cloud_delete_bitmap_action.cpp
@@ -95,6 +95,8 @@ Status CloudDeleteBitmapAction::_handle_show_delete_bitmap_count(HttpRequest* re
     auto count = tablet->tablet_meta()->delete_bitmap().get_delete_bitmap_count();
     auto cardinality = tablet->tablet_meta()->delete_bitmap().cardinality();
     auto size = tablet->tablet_meta()->delete_bitmap().get_size();
+    LOG(INFO) << "show_delete_bitmap_count,tablet_id=" << tablet_id << ",count=" << count
+              << ",cardinality=" << cardinality << ",size=" << size;
 
     rapidjson::Document root;
     root.SetObject();

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -1051,7 +1051,8 @@ Status CloudMetaMgr::update_delete_bitmap(const CloudTablet& tablet, int64_t loc
 
 Status CloudMetaMgr::update_delete_bitmap_without_lock(const CloudTablet& tablet,
                                                        DeleteBitmap* delete_bitmap) {
-    VLOG_DEBUG << "update_delete_bitmap_without_lock , tablet_id: " << tablet.tablet_id();
+    LOG(INFO) << "update_delete_bitmap_without_lock , tablet_id: " << tablet.tablet_id()
+              << ",delete_bitmap size:" << delete_bitmap->delete_bitmap.size();
     UpdateDeleteBitmapRequest req;
     UpdateDeleteBitmapResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1354,7 +1354,7 @@ DEFINE_mInt32(check_score_rounds_num, "1000");
 
 DEFINE_Int32(query_cache_size, "512");
 
-DEFINE_mBool(enable_delete_old_version_delete_bitmap_on_cu_compaction, "false");
+DEFINE_mBool(enable_delete_bitmap_merge_on_compaction, "false");
 
 // clang-format off
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1354,6 +1354,8 @@ DEFINE_mInt32(check_score_rounds_num, "1000");
 
 DEFINE_Int32(query_cache_size, "512");
 
+DEFINE_mBool(enable_delete_old_version_delete_bitmap_on_cu_compaction, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1442,6 +1442,8 @@ DECLARE_mInt32(check_score_rounds_num);
 // MB
 DECLARE_Int32(query_cache_size);
 
+DECLARE_mBool(enable_delete_old_version_delete_bitmap_on_cu_compaction);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1442,7 +1442,7 @@ DECLARE_mInt32(check_score_rounds_num);
 // MB
 DECLARE_Int32(query_cache_size);
 
-DECLARE_mBool(enable_delete_old_version_delete_bitmap_on_cu_compaction);
+DECLARE_mBool(enable_delete_bitmap_merge_on_compaction);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -282,8 +282,7 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
     LOG(INFO) << "[Memtable Flush] construct delete bitmap tablet: " << _context.tablet->tablet_id()
               << ", rowset_ids: " << _context.mow_context->rowset_ids.size()
               << ", cur max_version: " << _context.mow_context->max_version
-              << ", transaction_id: " << _context.mow_context->txn_id << ", delete_bitmap_count: "
-              << _context.tablet->tablet_meta()->delete_bitmap().get_delete_bitmap_count()
+              << ", transaction_id: " << _context.mow_context->txn_id
               << ", cost: " << watch.get_elapse_time_us() << "(us), total rows: " << total_rows;
     return Status::OK();
 }

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1189,7 +1189,7 @@ void DeleteBitmap::add_to_remove_queue(
 }
 
 void DeleteBitmap::remove_stale_delete_bitmap_from_queue(const std::vector<std::string>& vector) {
-    if (!config::enable_delete_old_version_delete_bitmap_on_cu_compaction) {
+    if (!config::enable_delete_bitmap_merge_on_compaction) {
         return;
     }
     std::shared_lock l(stale_delete_bitmap_lock);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1189,6 +1189,9 @@ void DeleteBitmap::add_to_remove_queue(
 }
 
 void DeleteBitmap::remove_stale_delete_bitmap_from_queue(const std::vector<std::string>& vector) {
+    if (!config::enable_delete_old_version_delete_bitmap_on_cu_compaction) {
+        return;
+    }
     std::shared_lock l(stale_delete_bitmap_lock);
     //<rowset_id, start_version, end_version>
     std::vector<std::tuple<std::string, uint64_t, uint64_t>> to_delete;


### PR DESCRIPTION
pr https://github.com/apache/doris/pull/40204 support deleting  old version delete bitmap when doing cu compaction, it a new function and better to add a config to enable it or not.

