### PR TITLE
[Fix](Nereids) fix outer join can not eliminate outer join recursively

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -421,7 +421,6 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         ),
                         custom(RuleType.COLUMN_PRUNING, ColumnPruning::new),
                         bottomUp(RuleSet.PUSH_DOWN_FILTERS),
-                        bottomUp(new EliminateNotNull()),
                         custom(RuleType.ELIMINATE_UNNECESSARY_PROJECT, EliminateUnnecessaryProject::new)
                 ),
                 topic("adjust preagg status",
@@ -433,6 +432,7 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         // SORT_PRUNING should be applied after mergeLimit
                         custom(RuleType.ELIMINATE_SORT, EliminateSort::new),
                         bottomUp(
+                                new EliminateNotNull(),
                                 new EliminateEmptyRelation(),
                                 // after eliminate empty relation under union, we could get
                                 // limit

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -421,6 +421,7 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         ),
                         custom(RuleType.COLUMN_PRUNING, ColumnPruning::new),
                         bottomUp(RuleSet.PUSH_DOWN_FILTERS),
+                        bottomUp(new EliminateNotNull()),
                         custom(RuleType.ELIMINATE_UNNECESSARY_PROJECT, EliminateUnnecessaryProject::new)
                 ),
                 topic("adjust preagg status",

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -90,6 +90,7 @@ import org.apache.doris.nereids.rules.rewrite.ConvertOuterJoinToAntiJoin;
 import org.apache.doris.nereids.rules.rewrite.CreatePartitionTopNFromWindow;
 import org.apache.doris.nereids.rules.rewrite.EliminateFilter;
 import org.apache.doris.nereids.rules.rewrite.EliminateOuterJoin;
+import org.apache.doris.nereids.rules.rewrite.InferFilterNotNull;
 import org.apache.doris.nereids.rules.rewrite.MaxMinFilterPushDown;
 import org.apache.doris.nereids.rules.rewrite.MergeFilters;
 import org.apache.doris.nereids.rules.rewrite.MergeGenerates;
@@ -147,6 +148,7 @@ public class RuleSet {
             new PushDownFilterThroughSetOperation(),
             new PushDownFilterThroughGenerate(),
             new PushDownProjectThroughLimit(),
+            new InferFilterNotNull(),
             new EliminateOuterJoin(),
             new ConvertOuterJoinToAntiJoin(),
             new MergeProjects(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferAggNotNull.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferAggNotNull.java
@@ -73,6 +73,9 @@ public class InferAggNotNull extends OneRewriteRuleFactory {
                             }
                         }
                     }
+                    for (Expression predicate : predicates) {
+                        predicate.setInferNotNull(true);
+                    }
                     Set<Expression> needGenerateNotNulls = needGenerateNotNullsBuilder.build();
                     if (needGenerateNotNulls.isEmpty()) {
                         return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferFilterNotNull.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferFilterNotNull.java
@@ -58,6 +58,9 @@ public class InferFilterNotNull extends OneRewriteRuleFactory {
                         needGenerateNotNullsBuilder.add(((Not) isNotNull).withGeneratedIsNotNull(true));
                     }
                 }
+                for (Expression predicate : predicates) {
+                    predicate.setInferNotNull(true);
+                }
                 Set<Expression> needGenerateNotNulls = needGenerateNotNullsBuilder.build();
                 if (needGenerateNotNulls.isEmpty()) {
                     return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferJoinNotNull.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferJoinNotNull.java
@@ -68,6 +68,9 @@ public class InferJoinNotNull extends OneRewriteRuleFactory {
                             conjuncts, join.right().getOutputSet(), ctx.cascadesContext);
                     right = PlanUtils.filterOrSelf(rightNotNull, join.right());
                 }
+                for (Expression conjunct : conjuncts) {
+                    conjunct.setInferNotNull(true);
+                }
 
                 if (left.equals(join.left()) && right.equals(join.right())) {
                     return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -69,6 +69,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
     private final Supplier<Set<Slot>> inputSlots = Suppliers.memoize(
             () -> collect(e -> e instanceof Slot && !(e instanceof ArrayItemSlot)));
     private final int fastChildrenHashCode;
+    private boolean inferNotNull = false;
 
     protected Expression(Expression... children) {
         super(children);
@@ -174,6 +175,14 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         checkLimit();
         this.inferred = inferred;
         this.hasUnbound = hasUnbound || this instanceof Unbound;
+    }
+
+    public void setInferNotNull(boolean inferNotNull) {
+        this.inferNotNull = inferNotNull;
+    }
+
+    public boolean isInferNotNull() {
+        return inferNotNull;
     }
 
     private void checkLimit() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -608,7 +608,6 @@ public class ExpressionUtils {
                         new ExpressionRewriteContext(cascadesContext)
                 );
                 if (evalExpr.isNullLiteral() || BooleanLiteral.FALSE.equals(evalExpr)) {
-                    predicate.setInferNotNull(true);
                     notNullSlots.add(slot);
                 }
             }


### PR DESCRIPTION
when there is multi full outer join or outer join, filter should be able to push down and infer not null recursively
Issue Number: close #39740

