### PR TITLE
[Fix](expr) fix wrong debug string of cast expr and remove useless variable

### DIFF
--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -57,14 +57,11 @@ doris::Status VCastExpr::prepare(doris::RuntimeState* state, const doris::RowDes
     // Using typeindex to indicate the datatype, not using type name because
     // type name is not stable, but type index is stable and immutable
     _cast_param_data_type = _target_data_type;
-    // Has to cast to int16_t or there will be compile error because there is no
-    // TypeIndexField
-    _cast_param = _cast_param_data_type->create_column_const_with_default_value(1);
 
     ColumnsWithTypeAndName argument_template;
     argument_template.reserve(2);
     argument_template.emplace_back(nullptr, child->data_type(), child_name);
-    argument_template.emplace_back(_cast_param, _cast_param_data_type, _target_data_type_name);
+    argument_template.emplace_back(nullptr, _cast_param_data_type, _target_data_type_name);
     _function = SimpleFunctionFactory::instance().get_function(
             function_name, argument_template, _data_type,
             {.enable_decimal256 = state->enable_decimal256()});
@@ -133,7 +130,7 @@ const std::string& VCastExpr::expr_name() const {
 
 std::string VCastExpr::debug_string() const {
     std::stringstream out;
-    out << "CastExpr(CAST " << _cast_param_data_type->get_name() << " to "
+    out << "CastExpr(CAST " << get_child(0)->data_type()->get_name() << " to "
         << _target_data_type->get_name() << "){";
     bool first = true;
     for (auto& input_expr : children()) {

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -61,7 +61,6 @@ private:
     std::string _target_data_type_name;
 
     DataTypePtr _cast_param_data_type;
-    ColumnPtr _cast_param;
 
     static const constexpr char* function_name = "CAST";
 };


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before we print target type as the argument type.

and for target type, we only need type itself. don't need dummy column.
