### PR TITLE
[fix](cloud)Compatibility with the initial default compute group usage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -214,7 +214,7 @@ public class CloudReplica extends Replica {
                     ((CloudEnv) Env.getCurrentEnv()).checkCloudClusterPriv(cluster);
                 } catch (Exception e) {
                     LOG.warn("get compute group by session context exception");
-                    throw new ComputeGroupException(String.format("default compute group %s check auth failed",
+                    throw new ComputeGroupException(String.format("session context compute group %s check auth failed",
                             cluster),
                         ComputeGroupException.FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_DEFAULT_COMPUTE_GROUP);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/qe/ComputeGroupException.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/qe/ComputeGroupException.java
@@ -34,6 +34,7 @@ public class ComputeGroupException extends UserException {
         CONNECT_CONTEXT_NOT_SET_COMPUTE_GROUP,
         CURRENT_USER_NO_AUTH_TO_USE_ANY_COMPUTE_GROUP,
         CURRENT_USER_NO_AUTH_TO_USE_DEFAULT_COMPUTE_GROUP,
+        CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP,
         CURRENT_COMPUTE_GROUP_NO_BE,
         COMPUTE_GROUPS_NO_ALIVE_BE,
         CURRENT_COMPUTE_GROUP_NOT_EXIST,
@@ -59,6 +60,8 @@ public class ComputeGroupException extends UserException {
         helpInfos.put(FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_ANY_COMPUTE_GROUP, " contact the system administrator "
                 + "and request that they grant you the appropriate compute group permissions, "
                 + "use SQL `GRANT USAGE_PRIV ON COMPUTE GROUP {compute_group_name} TO {user}`");
+        helpInfos.put(FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP,
+                "use SQL `GRANT USAGE_PRIV ON COMPUTE GROUP {compute_group_name} TO {user}`");
         helpInfos.put(FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_DEFAULT_COMPUTE_GROUP,
                 " contact the system administrator "
                 + "and request that they grant you the default compute group permissions, "

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -393,10 +393,11 @@ public class UserProperty implements Writable {
     private String checkCloudDefaultCluster(String[] keyArr, String value, String defaultComputeGroup)
             throws ComputeGroupException, DdlException {
         // check cluster auth
-        if (!Env.getCurrentEnv().getAuth().checkCloudPriv(UserIdentity.fromString(qualifiedUser),
-                value, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
+        if (!Strings.isNullOrEmpty(value) && !Env.getCurrentEnv().getAuth().checkCloudPriv(
+            new UserIdentity(qualifiedUser, "%"), value, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
             throw new ComputeGroupException(String.format("set default compute group failed, "
-                + "user {} must first have auth to use this compute group ", value),
+                + "user %s has no permission to use compute group '%s', please grant use privilege first ",
+                qualifiedUser, value),
                 ComputeGroupException.FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP);
         }
         // set property "DEFAULT_CLOUD_CLUSTER" = "cluster1"

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -17,8 +17,11 @@
 
 package org.apache.doris.mysql.privilege;
 
+import org.apache.doris.analysis.ResourceTypeEnum;
 import org.apache.doris.analysis.SetUserPropertyVar;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -257,23 +260,9 @@ public class UserProperty implements Writable {
 
                 newDefaultLoadCluster = value;
             }  else if (keyArr[0].equalsIgnoreCase(DEFAULT_CLOUD_CLUSTER)) {
-                // set property "DEFAULT_CLOUD_CLUSTER" = "cluster1"
-                if (keyArr.length != 1) {
-                    throw new DdlException(DEFAULT_CLOUD_CLUSTER + " format error");
-                }
-                if (value == null) {
-                    value = "";
-                }
-                newDefaultCloudCluster = value;
+                newDefaultCloudCluster = checkCloudDefaultCluster(keyArr, value, DEFAULT_CLOUD_CLUSTER);
             } else if (keyArr[0].equalsIgnoreCase(DEFAULT_COMPUTE_GROUP)) {
-                // set property "DEFAULT_CLOUD_CLUSTER" = "cluster1"
-                if (keyArr.length != 1) {
-                    throw new DdlException(DEFAULT_COMPUTE_GROUP + " format error");
-                }
-                if (value == null) {
-                    value = "";
-                }
-                newDefaultCloudCluster = value;
+                newDefaultCloudCluster = checkCloudDefaultCluster(keyArr, value, DEFAULT_COMPUTE_GROUP);
             } else if (keyArr[0].equalsIgnoreCase(PROP_MAX_QUERY_INSTANCES)) {
                 // set property "max_query_instances" = "1000"
                 if (keyArr.length != 1) {
@@ -399,6 +388,25 @@ public class UserProperty implements Writable {
         }
         clusterToDppConfig = newDppConfigs;
         defaultCloudCluster = newDefaultCloudCluster;
+    }
+
+    private String checkCloudDefaultCluster(String[] keyArr, String value, String defaultComputeGroup)
+            throws ComputeGroupException, DdlException {
+        // check cluster auth
+        if (!Env.getCurrentEnv().getAuth().checkCloudPriv(UserIdentity.fromString(qualifiedUser),
+                value, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
+            throw new ComputeGroupException(String.format("set default compute group failed, "
+                + "user {} must first have auth to use this compute group ", value),
+                ComputeGroupException.FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP);
+        }
+        // set property "DEFAULT_CLOUD_CLUSTER" = "cluster1"
+        if (keyArr.length != 1) {
+            throw new DdlException(defaultComputeGroup + " format error");
+        }
+        if (value == null) {
+            value = "";
+        }
+        return value;
     }
 
     private long getLongProperty(String key, String value, String[] keyArr, String propName) throws DdlException {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1272,11 +1272,6 @@ public class ConnectContext {
         if (!Strings.isNullOrEmpty(defaultCluster)) {
             cluster = defaultCluster;
             choseWay = "default compute group";
-            if (!Env.getCurrentEnv().getAuth().checkCloudPriv(getCurrentUserIdentity(),
-                    cluster, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
-                throw new ComputeGroupException(String.format("default compute group %s check auth failed", cluster),
-                    ComputeGroupException.FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_DEFAULT_COMPUTE_GROUP);
-            }
         } else {
             CloudClusterResult cloudClusterTypeAndName = getCloudClusterByPolicy();
             if (cloudClusterTypeAndName != null && !Strings.isNullOrEmpty(cloudClusterTypeAndName.clusterName)) {

--- a/regression-test/suites/cloud_p0/auth/test_set_default_cluster.groovy
+++ b/regression-test/suites/cloud_p0/auth/test_set_default_cluster.groovy
@@ -88,6 +88,9 @@ suite("test_default_cluster", "docker") {
         connectInDocker(user = user2, password = 'Cloud123456') {
             // user set himself
             setAndCheckDefaultCluster validCluster
+            sql """set property 'DEFAULT_CLOUD_CLUSTER' = '' """
+            def ret = getProperty("default_cloud_cluster")
+            assertEquals(ret.Value as String, "")
         }
     }
 }

--- a/regression-test/suites/cloud_p0/auth/test_set_default_cluster.groovy
+++ b/regression-test/suites/cloud_p0/auth/test_set_default_cluster.groovy
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import org.apache.doris.regression.suite.ClusterOptions
+import org.junit.Assert
+
+suite("test_default_cluster", "docker") {
+    def options = new ClusterOptions()
+    options.cloudMode = true
+
+    def getProperty = { property ->
+        def result = null
+        result = sql_return_maparray """SHOW PROPERTY""" 
+        result.find {
+            it.Key == property as String
+        }
+    }
+
+    def setAndCheckDefaultCluster = { validCluster ->
+        sql """set property 'DEFAULT_CLOUD_CLUSTER' = '$validCluster'"""
+        def ret1 = getProperty("default_cloud_cluster")
+        def ret2 = getProperty("default_compute_group")
+        assertEquals(ret1.Value as String, validCluster)
+        assertEquals(ret1.Value as String, ret2.Value as String)
+    }
+
+    docker(options) {
+        // not admin
+        def user1 = "default_user1"
+        // admin role
+        def user2 = "default_user2"
+
+        sql """CREATE USER $user1 IDENTIFIED BY 'Cloud123456' DEFAULT ROLE 'admin'"""
+        sql """CREATE USER $user2 IDENTIFIED BY 'Cloud123456'"""
+        sql """GRANT SELECT_PRIV on *.*.* to ${user2}"""
+
+        def clusters = sql " SHOW CLUSTERS "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+
+        // admin set himself
+        setAndCheckDefaultCluster validCluster
+
+        // user1
+        connectInDocker(user = user1, password = 'Cloud123456') {
+            setAndCheckDefaultCluster validCluster
+            def ret = sql """show grants"""
+            log.info("ret = {}", ret)
+        }
+
+        connectInDocker(user = user2, password = 'Cloud123456') {
+            //java.sql.SQLException: errCode = 2, detailMessage = set default compute group failed, user default_user2 has no permission to use compute group 'compute_cluster', please
+            //grant use privilege first , ComputeGroupException: CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP, you canuse SQL `GRANT USAGE_PRIV ON COMPUTE GROUP {compute_group_name} TO
+            //{user}`
+            try {
+                sql """set property 'DEFAULT_CLOUD_CLUSTER' = '$validCluster'"""
+            } catch (Exception e) {
+                log.info(e.getMessage())
+                assertTrue(e.getMessage().contains("CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP"))
+            }
+        }
+
+        try {
+            // admin set user2, failed not give user2 cluster auth
+            sql """set property for $user2 'DEFAULT_CLOUD_CLUSTER' = '$validCluster'"""
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP"))
+        }
+        sql """GRANT USAGE_PRIV ON COMPUTE GROUP $validCluster TO $user2""" 
+        // succ
+        setAndCheckDefaultCluster validCluster
+        // admin clean
+        sql """set property for $user2 'DEFAULT_CLOUD_CLUSTER' = '' """
+
+        connectInDocker(user = user2, password = 'Cloud123456') {
+            // user set himself
+            setAndCheckDefaultCluster validCluster
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Bug:
In the previous implementation, the default compute group did not check if the user had usage permissions. 

This issue has now been fixed. 
When using the default compute group, a prerequisite for successfully setting it for userA is that userA already has usage permissions for the compute group. 
For example:
```
1. GRANT USAGE_PRIV ON COMPUTE GROUP {cluster} TO userA
2. SET PROPERTY FOR userA 'DEFAULT_CLOUD_CLUSTER' = '{cluster}'
```
