### PR TITLE
[fix](docker compose) Fix Object of type 'Cluster' is not JSON serializable

### DIFF
--- a/docker/runtime/doris-compose/utils.py
+++ b/docker/runtime/doris-compose/utils.py
@@ -17,7 +17,7 @@
 
 import contextlib
 import docker
-import json
+import jsonpickle
 import logging
 import os
 import pwd
@@ -321,7 +321,7 @@ def write_compose_file(file, compose):
 
 
 def pretty_json(json_data):
-    return json.dumps(json_data, indent=4, sort_keys=True)
+    return jsonpickle.dumps(json_data, indent=4)
 
 
 def is_true(val):


### PR DESCRIPTION
…izable

due to https://github.com/apache/doris/pull/42266
Fix 
```
python -W ignore /mnt/disk2/dengxin/apache_doris/docker/runtime/doris-compose/doris-compose.py stop test_clean_tablet_when_rebalance --be-id 1 --outpu
t-json
{
    "code": 1,
    "err": "Traceback (most recent call last):\n  File \"/mnt/disk2/dengxin/apache_doris/docker/runtime/doris-compose/doris-compose.py\", line 59, in <module>\n    print(utils.pretty_json({\"code\": 0, \"data\": data}), flush=True)\n  F
ile \"/mnt/disk2/dengxin/apache_doris/docker/runtime/doris-compose/utils.py\", line 324, in pretty_json\n    return json.dumps(json_data, indent=4, sort_keys=True)\n  File \"/usr/lib64/python3.6/json/__init__.py\", line 238, in dumps\n
   **kw).encode(obj)\n  File \"/usr/lib64/python3.6/json/encoder.py\", line 201, in encode\n    chunks = list(chunks)\n  File \"/usr/lib64/python3.6/json/encoder.py\", line 430, in _iterencode\n    yield from _iterencode_dict(o, _curren
t_indent_level)\n  File \"/usr/lib64/python3.6/json/encoder.py\", line 404, in _iterencode_dict\n    yield from chunks\n  File \"/usr/lib64/python3.6/json/encoder.py\", line 325, in _iterencode_list\n    yield from chunks\n  File \"/usr
/lib64/python3.6/json/encoder.py\", line 437, in _iterencode\n    o = _default(o)\n  File \"/usr/lib64/python3.6/json/encoder.py\", line 180, in default\n    o.__class__.__name__)\nTypeError: Object of type 'Cluster' is not JSON seriali
zable\n"
}
```
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

