### PR TITLE
[Test](bloom filter) add retry and retry timeout for bloom filter test case

### DIFF
--- a/regression-test/suites/bloom_filter_p0/test_bloom_filter_hit_with_renamed_column.groovy
+++ b/regression-test/suites/bloom_filter_p0/test_bloom_filter_hit_with_renamed_column.groovy
@@ -123,7 +123,7 @@ suite("test_bloom_filter_hit_with_renamed_column") {
 
         while (attempt < maxRetries) {
             profiles = httpGet(profileUrl)
-            log.debug("profiles attempt ${attempt + 1}: {}", profiles)
+            log.info("profiles attempt ${attempt + 1}: {}", profiles)
             if (profiles == null) {
                 log.warn("Failed to fetch profiles on attempt ${attempt + 1}")
             } else {
@@ -156,7 +156,7 @@ suite("test_bloom_filter_hit_with_renamed_column") {
     }
 
     def query = """select C_COMMENT_NEW from ${tableName} where C_COMMENT_NEW='OK'"""
-    def profileId = getProfileIdWithRetry(query, 3, 1)
+    def profileId = getProfileIdWithRetry(query, 3, 30)
     log.info("profileId:{}", profileId)
     def profileDetail = httpGet("/rest/v1/query_profile/" + profileId)
     log.info("profileDetail:{}", profileDetail)


### PR DESCRIPTION
## Proposed changes
fix case error as below
```
Exception in bloom_filter_p0/test_bloom_filter_hit_with_renamed_column.groovy(line 154):

            } else {
                attempt++
                if (attempt < maxRetries) {
                    log.info("profileId is null, retrying after ${waitSeconds} second(s)... (Attempt ${attempt + 1}/${maxRetries})")
                    sleep(waitSeconds * 1000)
                }
            }
        }

        assertTrue(profileId != null, "Failed to retrieve profileId after ${maxRetries} attempts")
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^
        return profileId
    }

    def query = """select C_COMMENT_NEW from ${tableName} where C_COMMENT_NEW='OK'"""
    def profileId = getProfileIdWithRetry(query, 3, 1)
    log.info("profileId:{}", profileId)
    def profileDetail = httpGet("/rest/v1/query_profile/" + profileId)
    log.info("profileDetail:{}", profileDetail)
    assertTrue(profileDetail.contains("BloomFilterFiltered:&nbsp;&nbsp;15.0K&nbsp;&nbsp;(15000)"))


Exception:
org.opentest4j.AssertionFailedError: Failed to retrieve profileId after 3 attempts ==> expected: <true> but was: <false>
```

