### PR TITLE
[fix](remote scan) Fix remote scan paralism

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1040,7 +1040,7 @@ Status ScanLocalState<Derived>::_start_scanners(
     auto& p = _parent->cast<typename Derived::Parent>();
     _scanner_ctx = PipXScannerContext::create_shared(
             state(), this, p._output_tuple_desc, p.output_row_descriptor(), scanners, p.limit(),
-            _scan_dependency, p.ignore_data_distribution());
+            _scan_dependency, p.ignore_data_distribution(), p.is_file_scan_operator());
     return Status::OK();
 }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -43,7 +43,8 @@ using namespace std::chrono_literals;
 ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* output_tuple_desc,
                                const RowDescriptor* output_row_descriptor,
                                const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
-                               int64_t limit_, bool ignore_data_distribution, bool is_file_scan_operator,
+                               int64_t limit_, bool ignore_data_distribution,
+                               bool is_file_scan_operator,
                                pipeline::ScanLocalStateBase* local_state)
         : HasTaskExecutionCtx(state),
           _state(state),

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -79,9 +79,10 @@ ScannerContext::ScannerContext(doris::RuntimeState* state, doris::vectorized::VS
                                const RowDescriptor* output_row_descriptor,
                                const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
                                int64_t limit_, bool ignore_data_distribution,
+                               bool is_file_scan_operator,
                                pipeline::ScanLocalStateBase* local_state)
         : ScannerContext(state, output_tuple_desc, output_row_descriptor, scanners, limit_,
-                         ignore_data_distribution, local_state) {
+                         ignore_data_distribution, is_file_scan_operator, local_state) {
     _parent = parent;
 
     // No need to increase scanner_ctx_cnt here. Since other constructor has already done it.

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* output_tuple_desc,
                                const RowDescriptor* output_row_descriptor,
                                const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
-                               int64_t limit_, bool ignore_data_distribution,
+                               int64_t limit_, bool ignore_data_distribution, bool is_file_scan_operator,
                                pipeline::ScanLocalStateBase* local_state)
         : HasTaskExecutionCtx(state),
           _state(state),
@@ -56,7 +56,8 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
           limit(limit_),
           _scanner_scheduler_global(state->exec_env()->scanner_scheduler()),
           _all_scanners(scanners.begin(), scanners.end()),
-          _ignore_data_distribution(ignore_data_distribution) {
+          _ignore_data_distribution(ignore_data_distribution),
+          _is_file_scan_operator(is_file_scan_operator) {
     DCHECK(_output_row_descriptor == nullptr ||
            _output_row_descriptor->tuple_descriptors().size() == 1);
     _query_id = _state->get_query_ctx()->query_id();
@@ -160,7 +161,8 @@ Status ScannerContext::init() {
     }
 
     // _scannner_scheduler will be used to submit scan task.
-    if (_scanner_scheduler->get_queue_size() * 2 > config::doris_scanner_thread_pool_queue_size) {
+    if (_scanner_scheduler->get_queue_size() * 2 > config::doris_scanner_thread_pool_queue_size ||
+        _is_file_scan_operator) {
         submit_many_scan_tasks_for_potential_performance_issue = false;
     }
 
@@ -183,8 +185,10 @@ Status ScannerContext::init() {
         if (submit_many_scan_tasks_for_potential_performance_issue || _ignore_data_distribution) {
             _max_thread_num = config::doris_scanner_thread_pool_thread_num / 1;
         } else {
-            _max_thread_num =
-                    4 * (config::doris_scanner_thread_pool_thread_num / num_parallel_instances);
+            const int scale_arg = _is_file_scan_operator ? 1 : 4;
+            _max_thread_num = scale_arg * (config::doris_scanner_thread_pool_thread_num /
+                                           num_parallel_instances);
+
             // In some rare cases, user may set num_parallel_instances to 1 handly to make many query could be executed
             // in parallel. We need to make sure the _max_thread_num is smaller than previous value.
             _max_thread_num =

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -107,7 +107,7 @@ public:
     ScannerContext(RuntimeState* state, VScanNode* parent, const TupleDescriptor* output_tuple_desc,
                    const RowDescriptor* output_row_descriptor,
                    const std::list<std::shared_ptr<ScannerDelegate>>& scanners, int64_t limit_,
-                   bool ignore_data_distribution,
+                   bool ignore_data_distribution, bool is_file_scan_operator,
                    pipeline::ScanLocalStateBase* local_state = nullptr);
 
     ~ScannerContext() override {
@@ -234,6 +234,7 @@ protected:
     RuntimeProfile::Counter* _scale_up_scanners_counter = nullptr;
     QueryThreadContext _query_thread_context;
     bool _ignore_data_distribution = false;
+    bool _is_file_scan_operator;
 
     // for scaling up the running scanners
     size_t _estimated_block_size = 0;

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -183,7 +183,8 @@ protected:
     ScannerContext(RuntimeState* state_, const TupleDescriptor* output_tuple_desc,
                    const RowDescriptor* output_row_descriptor,
                    const std::list<std::shared_ptr<ScannerDelegate>>& scanners_, int64_t limit_,
-                   bool ignore_data_distribution, pipeline::ScanLocalStateBase* local_state);
+                   bool ignore_data_distribution, bool is_file_scan_operator,
+                   pipeline::ScanLocalStateBase* local_state);
 
     /// Four criteria to determine whether to increase the parallelism of the scanners
     /// 1. It ran for at least `SCALE_UP_DURATION` ms after last scale up

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -321,7 +321,7 @@ void VScanNode::_start_scanners(const std::list<std::shared_ptr<ScannerDelegate>
     } else {
         _scanner_ctx = ScannerContext::create_shared(_state, this, _output_tuple_desc,
                                                      _output_row_descriptor.get(), scanners,
-                                                     limit(), false);
+                                                     limit(), false, true);
     }
 }
 


### PR DESCRIPTION
Introduced by https://github.com/apache/doris/pull/41273.

The modification of _max_scan_thread_num is a long story. So, the modification i will describe only contains three timestamp. 1. Before https://github.com/apache/doris/pull/41273; 2. After https://github.com/apache/doris/pull/41273; 3. After this pr.

We have two dimension, so i will use a table. The value of the table is the _max_scan_thread_num when queries running **serially**.

C refers to num of cpu cores.

1. Before 41273

|Engine|OLAPScanOperator|FileScanOperator|
|---|---|---|
|PipelineX|min(2C, num_of_scanner)|4|
|Old-Pipeline|4|4|
|Non-Pipeline|4|4|

2. After 41273

|Engine|OLAPScanOperator|FileScanOperator|
|---|---|---|
|PipelineX|min(2C, num_of_scanner)|min(2C, num_of_scanner)|
|Old-Pipeline|4|4|
|Non-Pipeline|4|4|

3. After this pr

|Engine|OLAPScanOperator|FileScanOperator|
|---|---|---|
|PipelineX|min(2C, num_of_scanner)|4|
|Old-Pipeline|4|4|
|Non-Pipeline|4|4|


