### PR TITLE
[test](p0) fix load stream leak in injection cases

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_writer_v2_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_writer_v2_fault_injection.groovy
@@ -73,8 +73,10 @@ suite("test_writer_v2_fault_injection", "nonConcurrent") {
             sql "insert into test select * from baseall where k1 <= 3"
         } catch(Exception e) {
             logger.info(e.getMessage())
-            assertTrue(e.getMessage().contains(error_msg))
+            assertTrue(e.getMessage().contains(error_msg),
+                       String.format("expected '%s', actual '%s'", error_msg, e.getMessage()))
         } finally {
+            sleep 1000 // wait some time for instance finish before disable injection
             GetDebugPoint().disableDebugPointForAllBEs(injection)
         }
     }


### PR DESCRIPTION
## Proposed changes

Some injection cases (e.g. `VTabletWriterV2._open_streams_to_backend.node_info_null`) will cause LoadStream leak.
Because the injection was disabled too early.

When some sink operators returns "failed" status to the user (regression framework), other sinks are still executing.
Causing partially opened LoadStreams (some instances are not fault-injected, and successfully open the stream).
We should wait a small amount of time to safely assume all instances are done, before disabling the injection.