### PR TITLE
[fix](cooldown) fix cooldown data schema change writes multiple replicas

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1150,12 +1150,6 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
         context.segments_overlap = rs_reader->rowset()->rowset_meta()->segments_overlap();
         context.tablet_schema = _new_tablet_schema;
         context.newest_write_timestamp = rs_reader->newest_write_timestamp();
-
-        if (!rs_reader->rowset()->is_local()) {
-            context.storage_resource =
-                    *DORIS_TRY(rs_reader->rowset()->rowset_meta()->remote_storage_resource());
-        }
-
         context.write_type = DataWriteType::TYPE_SCHEMA_CHANGE;
         auto result = _new_tablet->create_rowset_writer(context, false);
         if (!result.has_value()) {


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
Schema change will build a new tablet for base tablet, and all replicas do this separately, so the cooldown data SC writes all replicas to the remote storage, But the cooldown rowsets just need one master replica to cooldown, the other replicas follow the master. To optimize this issue, Doris can just write the new rowsets to the local storage, and the tablet will cooldown this rowsets automatically for just one mater replica.
