### PR TITLE
[Test](count on index) enhance count on index case retrying for statistics

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_count_on_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_count_on_index.groovy
@@ -145,9 +145,31 @@ suite("test_count_on_index_httplogs", "p0") {
         sql """set experimental_enable_nereids_planner=true;"""
         sql """set enable_fallback_to_original_planner=false;"""
         sql """analyze table ${testTable_dup} with sync""";
-        // wait BE report every partition's row count
-        sleep(10000)
         // case1: test duplicate table
+        def maxRetries = 3
+        def attempt = 0
+        def success = false
+
+        while (attempt < maxRetries && !success) {
+            try {
+                explain {
+                    sleep(10000)
+                    sql("select COUNT() from ${testTable_dup}")
+                    notContains("cardinality=0")
+                }
+                success = true
+            } catch (Exception e) {
+                attempt++
+                log.error("Attempt ${attempt} failed: ${e.message}")
+                if (attempt < maxRetries) {
+                    log.info("Retrying... (${attempt + 1}/${maxRetries})")
+                    sleep(1000)
+                } else {
+                    log.error("All ${maxRetries} attempts failed.")
+                    throw e
+                }
+            }
+        }
         explain {
             sql("select COUNT() from ${testTable_dup} where request match 'GET'")
             contains "pushAggOp=COUNT_ON_INDEX"


### PR DESCRIPTION
## Proposed changes

Fix case error as below
```
Exception in inverted_index_p0/test_count_on_index.groovy(line 151):


        sql "sync"
        sql """ set enable_common_expr_pushdown = true """
        sql """set experimental_enable_nereids_planner=true;"""
        sql """set enable_fallback_to_original_planner=false;"""
        sql """analyze table ${testTable_dup} with sync""";
        // wait BE report every partition's row count
        sleep(10000)
        // case1: test duplicate table
        explain {
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^
            sql("select COUNT() from ${testTable_dup} where request match 'GET'")
            contains "pushAggOp=COUNT_ON_INDEX"
        }
        qt_sql(" select COUNT(*) from ${testTable_dup} where request match 'images' ")
        sql " set enable_count_on_index_pushdown=false; "
        qt_sql(" select COUNT(*) from ${testTable_dup} where request match 'images' ")
        sql " set enable_count_on_index_pushdown=true; "

        // case1.1: test duplicate table with null values.
        sql " insert into ${testTable_dup} values(1683964756,null,'GET /images/hm_bg.jpg HTTP/1.0 ',null,null); "

Exception:
java.lang.IllegalStateException: Explain and check failed, expect contains 'pushAggOp=COUNT_ON_INDEX', but actual explain string is:
```

