### PR TITLE
[branch-2.0](schema change) use data copy to support cooldown data linked schema change

### DIFF
--- a/be/src/io/fs/broker_file_system.cpp
+++ b/be/src/io/fs/broker_file_system.cpp
@@ -546,4 +546,8 @@ std::string BrokerFileSystem::error_msg(const std::string& err) const {
     return fmt::format("({}:{}), {}", _broker_addr.hostname, _broker_addr.port, err);
 }
 
+Status BrokerFileSystem::copy_path_impl(const Path& src, const Path& dest) {
+    return Status::NotSupported("BrokerFileSystem not support this method!");
+}
+
 } // namespace doris::io

--- a/be/src/io/fs/broker_file_system.h
+++ b/be/src/io/fs/broker_file_system.h
@@ -74,6 +74,7 @@ protected:
                                      const std::string& checksum) override;
     Status download_impl(const Path& remote_file, const Path& local_file) override;
     Status direct_download_impl(const Path& remote_file, std::string* content) override;
+    Status copy_path_impl(const Path& src, const Path& dest) override;
 
 private:
     BrokerFileSystem(const TNetworkAddress& broker_addr,

--- a/be/src/io/fs/file_system.cpp
+++ b/be/src/io/fs/file_system.cpp
@@ -85,5 +85,11 @@ Status FileSystem::rename_dir(const Path& orig_name, const Path& new_name) {
     FILESYSTEM_M(rename_dir_impl(orig_path, new_path));
 }
 
+Status FileSystem::copy_path(const Path& src, const Path& dest) {
+    auto src_path = absolute_path(src);
+    auto dest_path = absolute_path(dest);
+    FILESYSTEM_M(copy_path_impl(src_path, dest_path));
+}
+
 } // namespace io
 } // namespace doris

--- a/be/src/io/fs/file_system.h
+++ b/be/src/io/fs/file_system.h
@@ -97,6 +97,8 @@ public:
     Status list(const Path& dir, bool only_file, std::vector<FileInfo>* files, bool* exists);
     Status rename(const Path& orig_name, const Path& new_name);
     Status rename_dir(const Path& orig_name, const Path& new_name);
+    // Copy src path to dest path. If `src` is a directory, this method will call recursively for each directory entry.
+    Status copy_path(const Path& src, const Path& dest);
 
     std::shared_ptr<FileSystem> getSPtr() { return shared_from_this(); }
 
@@ -165,6 +167,8 @@ protected:
 
     /// rename dir from orig_name to new_name
     virtual Status rename_dir_impl(const Path& orig_name, const Path& new_name) = 0;
+
+    virtual Status copy_path_impl(const Path& src, const Path& dest) = 0;
 
     virtual Path absolute_path(const Path& path) const {
         if (path.is_absolute()) {

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -425,6 +425,19 @@ Status HdfsFileSystem::direct_download_impl(const Path& remote_file, std::string
     return Status::OK();
 }
 
+Status HdfsFileSystem::copy_path_impl(const Path& src, const Path& dest) {
+    Path src_path = convert_path(src, _fs_name);
+    Path dest_path = convert_path(dest, _fs_name);
+    CHECK_HDFS_HANDLE(_fs_handle);
+    int ret = hdfsCopy(_fs_handle->hdfs_fs, src_path.c_str(), _fs_handle->hdfs_fs, dest_path.c_str());
+    if (ret != 0) {
+        return Status::IOError("fail to copy path from {} to {}: {}", src_path.native(),
+                               dest_path.native(), hdfs_error());
+    }
+    LOG(INFO) << "succeed to copy path from " << src_path.native() << " to " << dest_path.native();
+    return Status::OK();
+}
+
 HdfsFileSystemHandle* HdfsFileSystem::get_handle() {
     return _fs_handle;
 }

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -139,6 +139,7 @@ protected:
                                      const std::string& checksum) override;
     Status download_impl(const Path& remote_file, const Path& local_file) override;
     Status direct_download_impl(const Path& remote_file, std::string* content) override;
+    Status copy_path_impl(const Path& src, const Path& dest) override;
 
 private:
     Status delete_internal(const Path& path, int is_recursive);

--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -361,12 +361,6 @@ Status LocalFileSystem::get_space_info_impl(const Path& path, size_t* capacity, 
     return Status::OK();
 }
 
-Status LocalFileSystem::copy_path(const Path& src, const Path& dest) {
-    auto src_path = absolute_path(src);
-    auto dest_path = absolute_path(dest);
-    FILESYSTEM_M(copy_path_impl(src_path, dest_path));
-}
-
 Status LocalFileSystem::copy_path_impl(const Path& src, const Path& dest) {
     std::error_code ec;
     std::filesystem::copy(src, dest, std::filesystem::copy_options::recursive, ec);

--- a/be/src/io/fs/local_file_system.h
+++ b/be/src/io/fs/local_file_system.h
@@ -62,8 +62,6 @@ public:
     Status delete_and_create_directory(const Path& dir);
     // return disk available space where the given path is.
     Status get_space_info(const Path& path, size_t* capacity, size_t* available);
-    // Copy src path to dest path. If `src` is a directory, this method will call recursively for each directory entry.
-    Status copy_path(const Path& src, const Path& dest);
     // return true if parent path contain sub path
     static bool contain_path(const Path& parent, const Path& sub);
     // delete dir or file
@@ -100,6 +98,8 @@ protected:
                      bool* exists) override;
     Status rename_impl(const Path& orig_name, const Path& new_name) override;
     Status rename_dir_impl(const Path& orig_name, const Path& new_name) override;
+    Status copy_path_impl(const Path& src, const Path& dest) override;
+
     Status link_file_impl(const Path& src, const Path& dest);
     Status md5sum_impl(const Path& file, std::string* md5sum);
     Status iterate_directory_impl(const std::string& dir,
@@ -107,7 +107,6 @@ protected:
     Status mtime_impl(const Path& file, time_t* m_time);
     Status delete_and_create_directory_impl(const Path& dir);
     Status get_space_info_impl(const Path& path, size_t* capacity, size_t* available);
-    Status copy_path_impl(const Path& src, const Path& dest);
     Status delete_directory_or_file_impl(const Path& path);
     Status permission_impl(const Path& file, std::filesystem::perms prms);
 

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -520,11 +520,16 @@ Status S3FileSystem::copy(const Path& src, const Path& dst) {
             .WithBucket(_s3_conf.bucket);
     Aws::S3::Model::CopyObjectOutcome response = _client->CopyObject(request);
     if (response.IsSuccess()) {
+        LOG(INFO) << "succeed to copy from " << src.native() << " to " << dst.native();
         return Status::OK();
     } else {
         return Status::IOError("failed to copy from {} to {}: {}", src.native(), dst.native(),
                                error_msg(src_key, response));
     }
+}
+
+Status S3FileSystem::copy_path_impl(const Path& src, const Path& dst) {
+    return copy(src, dst);
 }
 
 Status S3FileSystem::copy_dir(const Path& src, const Path& dst) {

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -107,6 +107,8 @@ protected:
         }
     }
 
+    Status copy_path_impl(const Path& src, const Path& dest) override;
+
 private:
     S3FileSystem(S3Conf&& s3_conf, std::string&& id, RuntimeProfile* profile);
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -33,6 +33,7 @@
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/config.h"
 #include "common/logging.h"
+#include "common/status.h"
 #include "gutil/integral_types.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_reader_options.h"
@@ -49,6 +50,7 @@
 #include "olap/rowset/segment_v2/segment_writer.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
+#include "olap/tablet_manager.h"
 #include "olap/tablet_schema.h"
 #include "runtime/thread_context.h"
 #include "segcompaction.h"
@@ -448,7 +450,20 @@ Status BetaRowsetWriter::_add_block(const vectorized::Block* block,
 
 Status BetaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
     assert(rowset->rowset_meta()->rowset_type() == BETA_ROWSET);
-    RETURN_IF_ERROR(rowset->link_files_to(_context.rowset_dir, _context.rowset_id));
+    if (rowset->is_local()) {
+        RETURN_IF_ERROR(rowset->link_files_to(_context.rowset_dir, _context.rowset_id));
+    } else {
+        // use old rowset id for remote rowset
+        _rowset_meta->set_rowset_id(rowset->rowset_meta()->rowset_id());
+        _context.rowset_id = rowset->rowset_meta()->rowset_id();
+        TabletSharedPtr tablet =
+                StorageEngine::instance()->tablet_manager()->get_tablet(rowset->rowset_meta()->tablet_id());
+        if (tablet->cooldown_conf().first == tablet->replica_id()) {
+            RETURN_IF_ERROR(rowset->copy_files_to(_context.rowset_dir, _context.rowset_id));
+        } else {
+            LOG(INFO) << "tablet is not cooldown replica, skip copy remote file. tablet: " << _context.tablet_id;
+        }
+    }
     _num_rows_written += rowset->num_rows();
     _total_data_size += rowset->rowset_meta()->data_disk_size();
     _total_index_size += rowset->rowset_meta()->index_disk_size();

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -283,7 +283,7 @@ private:
                                          const TAlterTabletReqV2& request);
 
     static Status _convert_historical_rowsets(const SchemaChangeParams& sc_params,
-                                              int64_t* real_alter_version);
+                                              int64_t* real_alter_version, bool* is_linked_sc);
 
     static Status _parse_request(const SchemaChangeParams& sc_params, BlockChanger* changer,
                                  bool* sc_sorting, bool* sc_directly);

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -224,6 +224,10 @@ protected:
         return Status::OK();
     }
 
+    Status copy_path_impl(const Path& src, const Path& dest) override {
+        return Status::OK();
+    }
+
 private:
     std::shared_ptr<io::LocalFileSystem> _local_fs;
 };

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
@@ -261,10 +261,10 @@ public class S3Properties extends BaseProperties {
         s3Info.setMaxConn(Integer.parseInt(maxConnections == null
                 ? S3Properties.Env.DEFAULT_MAX_CONNECTIONS : maxConnections));
         String requestTimeoutMs = properties.get(S3Properties.REQUEST_TIMEOUT_MS);
-        s3Info.setMaxConn(Integer.parseInt(requestTimeoutMs == null
+        s3Info.setRequestTimeoutMs(Integer.parseInt(requestTimeoutMs == null
                 ? S3Properties.Env.DEFAULT_REQUEST_TIMEOUT_MS : requestTimeoutMs));
         String connTimeoutMs = properties.get(S3Properties.CONNECTION_TIMEOUT_MS);
-        s3Info.setMaxConn(Integer.parseInt(connTimeoutMs == null
+        s3Info.setConnTimeoutMs(Integer.parseInt(connTimeoutMs == null
                 ? S3Properties.Env.DEFAULT_CONNECTION_TIMEOUT_MS : connTimeoutMs));
         String usePathStyle = properties.getOrDefault(PropertyConverter.USE_PATH_STYLE, "false");
         s3Info.setUsePathStyle(Boolean.parseBoolean(usePathStyle));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
Currently, link schema change is not supported for cooldown data, it will rollback to directly schema change. So Doris will read from base tablets and write to new tablets. It's time-consuming for reading and writing remote storage data, but Doris didn't make any changes to the data, so use data copy to optimize remote data linked schema change.

