### PR TITLE
[enhancement](cloud) expose file cache capacity for each disk

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -54,6 +54,8 @@ BlockFileCache::BlockFileCache(const std::string& cache_base_path,
           _max_query_cache_size(cache_settings.max_query_cache_size) {
     _cur_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(_cache_base_path.c_str(),
                                                                      "file_cache_cache_size", 0);
+    _cache_capacity_metrics = std::make_shared<bvar::Status<size_t>>(
+            _cache_base_path.c_str(), "file_cache_capacity", _capacity);
     _cur_ttl_cache_size_metrics = std::make_shared<bvar::Status<size_t>>(
             _cache_base_path.c_str(), "file_cache_ttl_cache_size", 0);
     _cur_normal_queue_element_count_metrics = std::make_shared<bvar::Status<size_t>>(
@@ -1527,6 +1529,7 @@ std::string BlockFileCache::reset_capacity(size_t new_capacity) {
         }
         old_capacity = _capacity;
         _capacity = new_capacity;
+        _cache_capacity_metrics->set_value(_capacity);
     }
     auto use_time = duration_cast<milliseconds>(steady_clock::time_point() - start_time);
     LOG(INFO) << "Finish tag deleted block. path=" << _cache_base_path

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -447,6 +447,7 @@ private:
     LRUQueue _ttl_queue;
 
     // metrics
+    std::shared_ptr<bvar::Status<size_t>> _cache_capacity_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_cache_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_size_metrics;
     std::shared_ptr<bvar::Status<size_t>> _cur_ttl_cache_lru_queue_cache_size_metrics;


### PR DESCRIPTION
expose file cache capacity for better monitoring and easier to calculate file cache space usage using prometheus.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

