### PR TITLE
[feature](stream-load) support stream load endpoint redirect policy

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3100,9 +3100,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int audit_event_log_queue_size = 250000;
 
-    @ConfField(description = {"存算分离模式下streamload导入使用的转发策略, 可选值为public-private或者空",
-            "streamload route policy in cloud mode, availale options are public-private and empty string"})
+    @ConfField(mutable = true, description = {"streamload导入使用的转发策略, 可选值为public-private/public/private/random_be/空",
+            "streamload route policy, availale options are public-private/public/private/random_be and empty string"})
     public static String streamload_redirect_policy = "";
+
+    @ConfField(mutable = true, description = {"be的公网endpoint", "be public endpoint"})
+    public static String be_public_endpoint = "";
+
+    @ConfField(mutable = true, description = {"be的私网endpoint", "be private endpoint"})
+    public static String be_private_endpoint = "";
 
     @ConfField(description = {"存算分离模式下建表是否检查残留recycler key, 默认true",
         "create table in cloud mode, check recycler key remained, default true"})

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -79,6 +79,7 @@ public class LoadAction extends RestBaseController {
 
     public static final String REDIRECT_POLICY_PUBLIC_PRIVATE = "public-private";
     public static final String REDIRECT_POLICY_RANDOM_BE = "random-be";
+    public static final String REDIRECT_POLICY_DIRECT = "direct";
     public static final String REDIRECT_POLICY_PUBLIC = "public";
     public static final String REDIRECT_POLICY_PRIVATE = "private";
 
@@ -467,7 +468,7 @@ public class LoadAction extends RestBaseController {
     /**
      * Selects the endpoint address based on the redirect policy specified in the request header.
      * The available redirect policies are:
-     * - RANDOM_BE: Redirects to the host of the backend.
+     * - DIRECT: Redirects to the backend's host.
      * - PUBLIC: Redirects to the public endpoint of the backend.
      * - PRIVATE: Redirects to the private endpoint of the backend.
      * - PUBLIC_PRIVATE: Redirects based on the host IP or domain. If the  host is a site-local
@@ -524,7 +525,8 @@ public class LoadAction extends RestBaseController {
         }
 
         // User specified redirect policy
-        if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_RANDOM_BE)) {
+        if (redirectPolicy != null && (redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_DIRECT)
+                || redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_RANDOM_BE))) {
             return new TNetworkAddress(backend.getHost(), backend.getHttpPort());
         } else if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_PUBLIC)) {
             if (publicHostPort != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -79,6 +79,8 @@ public class LoadAction extends RestBaseController {
 
     public static final String REDIRECT_POLICY_PUBLIC_PRIVATE = "public-private";
     public static final String REDIRECT_POLICY_RANDOM_BE = "random-be";
+    public static final String REDIRECT_POLICY_PUBLIC = "public";
+    public static final String REDIRECT_POLICY_PRIVATE = "private";
 
     private ExecuteEnv execEnv = ExecuteEnv.getInstance();
 
@@ -447,7 +449,7 @@ public class LoadAction extends RestBaseController {
         if (backend == null) {
             throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy);
         }
-        return new TNetworkAddress(backend.getHost(), backend.getHttpPort());
+        return selectEndpointByRedirectPolicy(request, backend);
     }
 
     private TNetworkAddress selectCloudRedirectBackend(String clusterName, HttpServletRequest req, boolean groupCommit,
@@ -459,32 +461,49 @@ public class LoadAction extends RestBaseController {
         } else {
             backend = StreamLoadHandler.selectBackend(clusterName);
         }
+        return selectEndpointByRedirectPolicy(req, backend);
+    }
 
-        String redirectPolicy = req.getHeader(LoadAction.HEADER_REDIRECT_POLICY);
-        // User specified redirect policy
-        if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_RANDOM_BE)) {
-            return new TNetworkAddress(backend.getHost(), backend.getHttpPort());
-        }
-        redirectPolicy = redirectPolicy == null || redirectPolicy.isEmpty()
-                ? Config.streamload_redirect_policy : redirectPolicy;
-
+    /**
+     * Selects the endpoint address based on the redirect policy specified in the request header.
+     * The available redirect policies are:
+     * - RANDOM_BE: Redirects to the host of the backend.
+     * - PUBLIC: Redirects to the public endpoint of the backend.
+     * - PRIVATE: Redirects to the private endpoint of the backend.
+     * - PUBLIC_PRIVATE: Redirects based on the host IP or domain. If the  host is a site-local
+     *     address, redirects to the private endpoint. Otherwise, redirects to the public endpoint.
+     * - DEFAULT: If request host equals to backend's public endpoint, redirects to the public endpoint.
+     *     If private endpoint of backend is set, redirects to the private endpoint. Otherwise, redirects
+     *     to the backend's host.
+     *
+     * @param req The HTTP request object.
+     * @param backend The backend to redirect to.
+     * @return The selected endpoint address.
+     * @throws LoadException If there is an error in the redirect policy or endpoint selection.
+     */
+    private TNetworkAddress selectEndpointByRedirectPolicy(HttpServletRequest req, Backend backend)
+            throws LoadException {
         Pair<String, Integer> publicHostPort = null;
         Pair<String, Integer> privateHostPort = null;
         try {
-            if (!Strings.isNullOrEmpty(backend.getCloudPublicEndpoint())) {
-                publicHostPort = splitHostAndPort(backend.getCloudPublicEndpoint());
+            if (!Strings.isNullOrEmpty(backend.getPublicEndpoint())) {
+                publicHostPort = splitHostAndPort(backend.getPublicEndpoint());
             }
         } catch (AnalysisException e) {
             throw new LoadException(e.getMessage());
         }
 
         try {
-            if (!Strings.isNullOrEmpty(backend.getCloudPrivateEndpoint())) {
-                privateHostPort = splitHostAndPort(backend.getCloudPrivateEndpoint());
+            if (!Strings.isNullOrEmpty(backend.getPrivateEndpoint())) {
+                privateHostPort = splitHostAndPort(backend.getPrivateEndpoint());
             }
         } catch (AnalysisException e) {
             throw new LoadException(e.getMessage());
         }
+
+        String redirectPolicy = req.getHeader(LoadAction.HEADER_REDIRECT_POLICY);
+        redirectPolicy = redirectPolicy == null || redirectPolicy.isEmpty()
+                ? Config.streamload_redirect_policy : redirectPolicy;
 
         String reqHostStr = req.getHeader(HttpHeaderNames.HOST.toString());
         reqHostStr = reqHostStr.replaceAll("\\s+", "");
@@ -504,7 +523,20 @@ public class LoadAction extends RestBaseController {
             throw new LoadException("Invalid header host: " + reqHost);
         }
 
-        if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_PUBLIC_PRIVATE)) {
+        // User specified redirect policy
+        if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_RANDOM_BE)) {
+            return new TNetworkAddress(backend.getHost(), backend.getHttpPort());
+        } else if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_PUBLIC)) {
+            if (publicHostPort != null) {
+                return new TNetworkAddress(publicHostPort.first, publicHostPort.second);
+            }
+            throw new LoadException("public endpoint is null, please check be public endpoint config");
+        } else if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_PRIVATE)) {
+            if (privateHostPort != null) {
+                return new TNetworkAddress(privateHostPort.first, privateHostPort.second);
+            }
+            throw new LoadException("private endpoint is null, please check be private endpoint config");
+        } else if (redirectPolicy != null && redirectPolicy.equalsIgnoreCase(REDIRECT_POLICY_PUBLIC_PRIVATE)) {
             // redirect with ip
             if (InetAddressValidator.getInstance().isValid(reqHost)) {
                 InetAddress addr;
@@ -540,7 +572,7 @@ public class LoadAction extends RestBaseController {
                     && publicHostPort != null && reqHost == publicHostPort.first) {
                 return new TNetworkAddress(publicHostPort.first, publicHostPort.second);
             } else if (privateHostPort != null) {
-                return new TNetworkAddress(reqHost, privateHostPort.second);
+                return new TNetworkAddress(privateHostPort.first, privateHostPort.second);
             } else {
                 return new TNetworkAddress(backend.getHost(), backend.getHttpPort());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -69,9 +69,12 @@ public class Tag implements Writable {
     public static final String CLOUD_CLUSTER_NAME = "cloud_cluster_name";
     public static final String CLOUD_CLUSTER_ID = "cloud_cluster_id";
     public static final String CLOUD_UNIQUE_ID = "cloud_unique_id";
-    public static final String CLOUD_CLUSTER_PUBLIC_ENDPOINT = "cloud_cluster_public_endpoint";
-    public static final String CLOUD_CLUSTER_PRIVATE_ENDPOINT = "cloud_cluster_private_endpoint";
     public static final String CLOUD_CLUSTER_STATUS = "cloud_cluster_status";
+
+    public static final String COMPUTE_GROUP_PUBLIC_ENDPOINT = "compute_group_public_endpoint";
+    public static final String COMPUTE_GROUP_PRIVATE_ENDPOINT = "compute_group_private_endpoint";
+    public static final String PUBLIC_ENDPOINT = "public_endpoint";
+    public static final String PRIVATE_ENDPOINT = "private_endpoint";
 
     public static final String COMPUTE_GROUP_NAME = "compute_group_name";
 
@@ -86,6 +89,7 @@ public class Tag implements Writable {
             VALUE_MIX, VALUE_DEFAULT_CLUSTER);
     private static final String TAG_TYPE_REGEX = "^[a-z][a-z0-9_]{0,32}$";
     private static final String TAG_VALUE_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,32}$";
+    private static final String ENDPOINT_REGEX = "^[a-zA-Z0-9.-]+(:[0-9]+)?$";
 
 
     public static final Tag DEFAULT_BACKEND_TAG;
@@ -112,7 +116,7 @@ public class Tag implements Writable {
         if (!type.matches(TAG_TYPE_REGEX)) {
             throw new AnalysisException("Invalid tag type format: " + type);
         }
-        if (!value.matches(TAG_VALUE_REGEX)) {
+        if (!value.matches(TAG_VALUE_REGEX) && !value.matches(ENDPOINT_REGEX)) {
             throw new AnalysisException("Invalid tag value format: " + value);
         }
         return new Tag(type, value);

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -116,7 +116,16 @@ public class Tag implements Writable {
         if (!type.matches(TAG_TYPE_REGEX)) {
             throw new AnalysisException("Invalid tag type format: " + type);
         }
-        if (!value.matches(TAG_VALUE_REGEX) && !value.matches(ENDPOINT_REGEX)) {
+
+        // if type is an endpoint type, value must be a valid endpoint
+        if ((type.equalsIgnoreCase(PUBLIC_ENDPOINT) || type.equalsIgnoreCase(PRIVATE_ENDPOINT)
+                || type.equalsIgnoreCase(COMPUTE_GROUP_PUBLIC_ENDPOINT)
+                || type.equalsIgnoreCase(COMPUTE_GROUP_PRIVATE_ENDPOINT))
+                && !value.matches(ENDPOINT_REGEX)) {
+            throw new AnalysisException("Invalid " + type + " value format: " + value);
+        }
+
+        if (!value.matches(TAG_VALUE_REGEX)) {
             throw new AnalysisException("Invalid tag value format: " + value);
         }
         return new Tag(type, value);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -211,12 +211,12 @@ public class Backend implements Writable {
         return tagMap.getOrDefault(Tag.CLOUD_UNIQUE_ID, "");
     }
 
-    public String getCloudPublicEndpoint() {
-        return tagMap.getOrDefault(Tag.CLOUD_CLUSTER_PUBLIC_ENDPOINT, "");
+    public String getPublicEndpoint() {
+        return StringUtils.defaultIfEmpty(tagMap.getOrDefault(Tag.PUBLIC_ENDPOINT, ""), Config.be_public_endpoint);
     }
 
-    public String getCloudPrivateEndpoint() {
-        return tagMap.getOrDefault(Tag.CLOUD_CLUSTER_PRIVATE_ENDPOINT, "");
+    public String getPrivateEndpoint() {
+        return StringUtils.defaultIfEmpty(tagMap.getOrDefault(Tag.PRIVATE_ENDPOINT, ""), Config.be_private_endpoint);
     }
 
     public long getId() {
@@ -995,12 +995,6 @@ public class Backend implements Writable {
         Map<String, String> displayTagMap = Maps.newHashMap();
         displayTagMap.putAll(tagMap);
 
-        if (displayTagMap.containsKey("cloud_cluster_public_endpoint")) {
-            displayTagMap.put("public_endpoint", displayTagMap.remove("cloud_cluster_public_endpoint"));
-        }
-        if (displayTagMap.containsKey("cloud_cluster_private_endpoint")) {
-            displayTagMap.put("private_endpoint", displayTagMap.remove("cloud_cluster_private_endpoint"));
-        }
         if (displayTagMap.containsKey("cloud_cluster_status")) {
             displayTagMap.put("compute_group_status", displayTagMap.remove("cloud_cluster_status"));
         }

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -160,6 +160,8 @@ message NodeInfoPB {
     optional bool is_smooth_upgrade = 12;
     // fqdn
     optional string host = 13;
+    optional string public_endpoint = 14;
+    optional string private_endpoint = 15;
 }
 
 enum NodeStatusPB {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -214,6 +214,10 @@ class Backend extends ServerNode {
         return path + '/conf/be.conf'
     }
 
+    String getHeartbeatPort() {
+        return heartbeatPort;
+    }
+
 }
 
 class MetaService extends ServerNode {

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_endpoint.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_endpoint.groovy
@@ -68,8 +68,8 @@ suite('test_stream_load_endpoint', 'docker') {
         log.info("private location: ${location}")
         assertTrue(location.contains("1.2.3.5:8012"))
 
-        location = getRedirectLocation(feIp, fePort, "random-be")
-        log.info("random-be location: ${location}")
+        location = getRedirectLocation(feIp, fePort, "direct")
+        log.info("direct location: ${location}")
         assertTrue(location.contains("${beIp}:${beHttpPort}"))
 
         location = getRedirectLocation(feIp, fePort, "")
@@ -95,8 +95,8 @@ suite('test_stream_load_endpoint', 'docker') {
         log.info("private location: ${location}")
         assertTrue(location.contains("10.10.10.9:8020"))
 
-        location = getRedirectLocation(feIp, fePort, "random-be")
-        log.info("random-be location: ${location}")
+        location = getRedirectLocation(feIp, fePort, "direct")
+        log.info("direct location: ${location}")
         assertTrue(location.contains("${beIp}:${beHttpPort}"))
 
         location = getRedirectLocation(feIp, fePort, "")
@@ -133,8 +133,8 @@ suite('test_stream_load_endpoint', 'docker') {
         log.info("private location: ${location}")
         assertTrue(location.contains("1.2.3.5:8012"))
 
-        location = getRedirectLocation(feIp, fePort, "random-be")
-        log.info("random-be location: ${location}")
+        location = getRedirectLocation(feIp, fePort, "direct")
+        log.info("direct location: ${location}")
         assertTrue(location.contains("${beIp}:${beHttpPort}"))
 
         location = getRedirectLocation(feIp, fePort, "")
@@ -168,8 +168,8 @@ suite('test_stream_load_endpoint', 'docker') {
         log.info("private location: ${location}")
         assertTrue(location.contains("1.2.3.5:8012"))
 
-        location = getRedirectLocation(feIp, fePort, "random-be")
-        log.info("random-be location: ${location}")
+        location = getRedirectLocation(feIp, fePort, "direct")
+        log.info("direct location: ${location}")
         assertTrue(location.contains("${beIp}:${beHttpPort}"))
 
         location = getRedirectLocation(feIp, fePort, "")

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_endpoint.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_endpoint.groovy
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+
+suite('test_stream_load_endpoint', 'docker') {
+    def getRedirectLocation = { feIp, fePort, redirectPolicy ->
+        def command = """ curl -v --max-redirs 0 --location-trusted -u root:  
+                -H redirect-policy:$redirectPolicy  
+                 -T ${context.config.dataPath}/load_p0/stream_load/test_stream_load1.csv 
+                http://${feIp}:${fePort}/api/test/tbl/_stream_load """
+        log.info("redirect command: ${command}")
+
+        def code = -1
+        def location = ""
+        try {
+            def process = command.execute()
+            code = process.waitFor()
+            // Parse Location from stderr since curl -v outputs headers to stderr
+            def errorOutput = process.err.text
+            def locationLine = errorOutput.readLines().find { it.trim().startsWith('< Location: ') }
+            if (locationLine) {
+                location = locationLine.trim().substring('< Location: '.length())
+            }
+            log.info("curl output: ${process.text}")
+            log.info("curl error: ${errorOutput}")
+        } catch (Exception e) {
+            log.info("exception: ${e}".toString())
+        }
+        return location
+    }
+    // local mode
+    def options = new ClusterOptions()
+    options.feNum = 1
+    options.beNum = 1
+    options.cloudMode = false
+    docker(options) {
+        // get fe ip
+        def feIp = cluster.getMasterFe().getHttpAddress()[0]
+        def fePort = cluster.getMasterFe().getHttpAddress()[1]
+        def beIp = cluster.getBackends().get(0).getHttpAddress()[0]
+        def beHttpPort = cluster.getBackends().get(0).getHttpAddress()[1]
+        def beHeartbeatPort = cluster.getBackends().get(0).getHeartbeatPort()
+        
+        // set public endpoint and private endpoint in fe config
+        sql """ADMIN SET FRONTEND CONFIG ('be_public_endpoint' = '1.2.3.4:8011')"""
+        sql """ADMIN SET FRONTEND CONFIG ('be_private_endpoint' = '1.2.3.5:8012')"""
+        def location = getRedirectLocation(feIp, fePort, "public")
+        log.info("public location: ${location}")
+        assertTrue(location.contains("1.2.3.4:8011"))
+
+        location = getRedirectLocation(feIp, fePort, "private")
+        log.info("private location: ${location}")
+        assertTrue(location.contains("1.2.3.5:8012"))
+
+        location = getRedirectLocation(feIp, fePort, "random-be")
+        log.info("random-be location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("1.2.3.5:8012"))
+
+        sql """ADMIN SET FRONTEND CONFIG ('be_private_endpoint' = '')"""
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+
+        // set public endpoint and private endpoint to backend
+        sql """show backends"""
+        sql """ALTER SYSTEM DROPP BACKEND '${beIp}:${beHeartbeatPort}'"""
+        sql """ALTER SYSTEM ADD BACKEND '${beIp}:${beHeartbeatPort}' properties('tag.public_endpoint' = '11.10.10.10:8010', 'tag.private_endpoint' = '10.10.10.9:8020')"""
+        sleep(10000)
+        location = getRedirectLocation(feIp, fePort, "public")
+        log.info("public location: ${location}")
+        assertTrue(location.contains("11.10.10.10:8010"))
+
+        location = getRedirectLocation(feIp, fePort, "private")
+        log.info("private location: ${location}")
+        assertTrue(location.contains("10.10.10.9:8020"))
+
+        location = getRedirectLocation(feIp, fePort, "random-be")
+        log.info("random-be location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("10.10.10.9:8020"))
+
+        sql """ALTER SYSTEM MODIFY BACKEND '${beIp}:${beHeartbeatPort}' set ('tag.location' = 'default', 'tag.public_endpoint' = '11.10.10.10:8010')"""
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+    }
+
+    // cloud mode
+    def options2 = new ClusterOptions()
+    options2.feNum = 1
+    options2.beNum = 1
+    options2.cloudMode = true
+    docker(options2) {
+        // get fe ip
+        def feIp = cluster.getMasterFe().getHttpAddress()[0]
+        def fePort = cluster.getMasterFe().getHttpAddress()[1]
+        def beIp = cluster.getBackends().get(0).getHttpAddress()[0]
+        def beHttpPort = cluster.getBackends().get(0).getHttpAddress()[1]
+        def beHeartbeatPort = cluster.getBackends().get(0).getHeartbeatPort()
+        
+        // set public endpoint and private endpoint in fe config
+        sql """ADMIN SET FRONTEND CONFIG ('be_public_endpoint' = '1.2.3.4:8011')"""
+        sql """ADMIN SET FRONTEND CONFIG ('be_private_endpoint' = '1.2.3.5:8012')"""
+        def location = getRedirectLocation(feIp, fePort, "public")
+        log.info("public location: ${location}")
+        assertTrue(location.contains("1.2.3.4:8011"))
+
+        location = getRedirectLocation(feIp, fePort, "private")
+        log.info("private location: ${location}")
+        assertTrue(location.contains("1.2.3.5:8012"))
+
+        location = getRedirectLocation(feIp, fePort, "random-be")
+        log.info("random-be location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("1.2.3.5:8012"))
+
+        sql """ADMIN SET FRONTEND CONFIG ('be_private_endpoint' = '')"""
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+        def clusters = sql """show clusters"""
+        logger.info("show clusters : {}", clusters)
+        def backends = sql """show backends"""
+        logger.info("show backends : {}", backends)
+        def computeGroupName = clusters[0][0]
+        // set public endpoint and private endpoint to compute group
+        sql """ALTER SYSTEM ADD BACKEND '' properties('tag.compute_group_name' = '${computeGroupName}',
+              'tag.compute_group_public_endpoint' = '1.2.3.4:8011', 'tag.compute_group_private_endpoint' = '1.2.3.5:8012')"""
+        sleep(30000)
+        clusters = sql """show clusters"""
+        logger.info("show clusters : {}", clusters)
+        backends = sql """show backends"""
+        logger.info("show backends : {}", backends)
+
+        location = getRedirectLocation(feIp, fePort, "public")
+        log.info("public location: ${location}")
+        assertTrue(location.contains("1.2.3.4:8011"))
+
+        location = getRedirectLocation(feIp, fePort, "private")
+        log.info("private location: ${location}")
+        assertTrue(location.contains("1.2.3.5:8012"))
+
+        location = getRedirectLocation(feIp, fePort, "random-be")
+        log.info("random-be location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("1.2.3.5:8012"))
+
+        // set public endpoint and private endpoint to backend
+        sql """ALTER SYSTEM DROPP BACKEND '${beIp}:${beHeartbeatPort}'"""
+        sql """ALTER SYSTEM ADD BACKEND '${beIp}:${beHeartbeatPort}' properties('tag.compute_group_name' = '${computeGroupName}',
+              'tag.compute_group_public_endpoint' = '11.10.10.10:8010', 'tag.compute_group_private_endpoint' = '10.10.10.9:8020')"""
+        sleep(30000)
+
+        backends = sql """show backends"""
+        logger.info("show backends : {}", backends)
+        location = getRedirectLocation(feIp, fePort, "public")
+        log.info("public location: ${location}")
+        assertTrue(location.contains("11.10.10.10:8010"))
+
+        location = getRedirectLocation(feIp, fePort, "private")
+        log.info("private location: ${location}")
+        assertTrue(location.contains("10.10.10.9:8020"))
+
+        location = getRedirectLocation(feIp, fePort, "random-be")
+        log.info("random-be location: ${location}")
+        assertTrue(location.contains("${beIp}:${beHttpPort}"))
+
+        location = getRedirectLocation(feIp, fePort, "")
+        log.info("default location: ${location}")
+        assertTrue(location.contains("10.10.10.9:8020"))
+    }
+}


### PR DESCRIPTION
## Overview
Supports flexible endpoint configuration for Stream Load operations, allowing you to control how load requests are redirected. This is particularly useful in cloud environments or when working with different network segments.


## Redirect Policies
When sending Stream Load requests, you can specify a redirect policy using the `redirect-policy` header. Available policies are:

- `public`: Redirects to public endpoint
- `private`: Redirects to private endpoint
- `direct`: Redirects to a random backend's host
- `""` (empty/default): Uses private endpoint if configured, falls back to random BE

## Deployment Scenarios

### 1. Single IP Scenario
- BE node has only one IP
- All communications use this IP
- Configuration: No special configuration needed

### 2. VIP Scenario
- BE node keeps its original internal IP for cluster internal communication
- Provides Stream Load service through VIPs:
  - Public VIP: for external access
  - Private VIP: for internal access

### 3. Multi-NIC Scenario
- BE node configured with multiple network cards:
  - Internal NIC: for cluster internal communication and internal access
  - External NIC: for external access


## Configuration Methods

### 1. FE-level Configuration
Set global endpoint configurations through FE configs:

```sql
-- Set public endpoint for all BEs
ADMIN SET FRONTEND CONFIG ('be_public_endpoint' = '1.2.3.4:8011');

-- Set private endpoint for all BEs
ADMIN SET FRONTEND CONFIG ('be_private_endpoint' = '1.2.3.5:8012');
```

### 2. Backend-specific Configuration
Configure endpoints for specific backend nodes:

```sql
-- Add/Modify BE with custom endpoints
ALTER SYSTEM ADD BACKEND 'be_host:heartbeat_port' properties(
    'tag.public_endpoint' = '11.10.10.10:8010',
    'tag.private_endpoint' = '10.10.10.9:8020'
);
```

### 3. Compute Group Configuration
In cloud mode, you can configure endpoints at the compute group level:

```sql
-- Configure compute group endpoints
ALTER SYSTEM ADD BACKEND '' properties(
    'tag.compute_group_name' = 'group_name',
    'tag.compute_group_public_endpoint' = '1.2.3.4:8011',
    'tag.compute_group_private_endpoint' = '1.2.3.5:8012'
);
```

## Usage Example
Here's how to use the redirect policy when sending a Stream Load request:

```bash
curl --location-trusted -u username:password \
    -H "redirect-policy:public" \
    -T data.csv \
    http://fe_host:fe_port/api/db_name/table_name/_stream_load
```

## Priority Order
The endpoint selection follows this priority:
1. Backend-specific configuration
2. Compute group configuration (in cloud mode)
3. FE-level configuration
4. Default BE Host

