### PR TITLE
[opt](merge-on-write) optimize delete bitmap contains cost while lookup rowkey

### DIFF
--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -153,6 +153,7 @@ public:
     Status lookup_row_key(const Slice& encoded_key, TabletSchema* latest_schema, bool with_seq_col,
                           const std::vector<RowsetSharedPtr>& specified_rowsets,
                           RowLocation* row_location, uint32_t version,
+                          DeleteBitmapPtr cur_version_delete_bitmap,
                           std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
                           RowsetSharedPtr* rowset = nullptr, bool with_rowid = true,
                           std::string* encoded_seq_value = nullptr,

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -657,8 +657,9 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         };
         RETURN_IF_ERROR(probe_key_for_mow(std::move(key), segment_pos, have_input_seq_column,
                                           have_delete_sign, specified_rowsets, segment_caches,
-                                          has_default_or_nullable, use_default_or_null_flag,
-                                          update_read_plan, not_found_cb, stats));
+                                          cur_version_delete_bitmap, has_default_or_nullable,
+                                          use_default_or_null_flag, update_read_plan, not_found_cb,
+                                          stats));
     }
     CHECK_EQ(use_default_or_null_flag.size(), num_rows);
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -100,7 +100,7 @@ public:
                              bool have_delete_sign,
                              const std::vector<RowsetSharedPtr>& specified_rowsets,
                              std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-                             bool& has_default_or_nullable,
+                             DeleteBitmapPtr cur_version_bitmap, bool& has_default_or_nullable,
                              std::vector<bool>& use_default_or_null_flag,
                              const std::function<void(const RowLocation& loc)>& found_cb,
                              const std::function<Status()>& not_found_cb,

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -519,8 +519,9 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
         };
         RETURN_IF_ERROR(_probe_key_for_mow(std::move(key), segment_pos, have_input_seq_column,
                                            have_delete_sign, specified_rowsets, segment_caches,
-                                           has_default_or_nullable, use_default_or_null_flag,
-                                           update_read_plan, not_found_cb, stats));
+                                           cur_version_delete_bitmap, has_default_or_nullable,
+                                           use_default_or_null_flag, update_read_plan, not_found_cb,
+                                           stats));
     }
     CHECK_EQ(use_default_or_null_flag.size(), data.num_rows);
 
@@ -705,7 +706,8 @@ Status VerticalSegmentWriter::_append_block_with_flexible_partial_content(
     RETURN_IF_ERROR(_generate_flexible_read_plan(
             read_plan, data, segment_start_pos, schema_has_sequence_col, seq_map_col_unique_id,
             skip_bitmaps, key_columns, seq_column, delete_sign_column_data, specified_rowsets,
-            segment_caches, has_default_or_nullable, use_default_or_null_flag, stats));
+            segment_caches, cur_version_delete_bitmap, has_default_or_nullable,
+            use_default_or_null_flag, stats));
     CHECK_EQ(use_default_or_null_flag.size(), data.num_rows);
 
     if (config::enable_merge_on_write_correctness_check) {

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
@@ -170,7 +170,7 @@ private:
                               bool have_delete_sign,
                               const std::vector<RowsetSharedPtr>& specified_rowsets,
                               std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-                              bool& has_default_or_nullable,
+                              DeleteBitmapPtr cur_version_bitmap, bool& has_default_or_nullable,
                               std::vector<bool>& use_default_or_null_flag,
                               const std::function<void(const RowLocation& loc)>& found_cb,
                               const std::function<Status()>& not_found_cb,
@@ -190,14 +190,15 @@ private:
             const signed char* delete_sign_column_data,
             const std::vector<RowsetSharedPtr>& specified_rowsets,
             std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-            bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
-            PartialUpdateStats& stats);
+            DeleteBitmapPtr cur_version_delete_bitmap, bool& has_default_or_nullable,
+            std::vector<bool>& use_default_or_null_flag, PartialUpdateStats& stats);
     Status _merge_rows_for_sequence_column(
             RowsInBlock& data, std::vector<BitmapValue>* skip_bitmaps,
             const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns,
             vectorized::IOlapColumnDataAccessor* seq_column,
             const std::vector<RowsetSharedPtr>& specified_rowsets,
-            std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches);
+            std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
+            DeleteBitmapPtr cur_version_delete_bitmap);
     Status _append_block_with_variant_subcolumns(RowsInBlock& data);
     Status _generate_key_index(
             RowsInBlock& data, std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns,

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1270,7 +1270,8 @@ std::shared_ptr<roaring::Roaring> DeleteBitmap::get_agg(const BitmapKey& bmk) co
         // usually the previous version aggregated result can be found in the agg_cache
         // we can leverage the cached result to reduce union cost
         BitmapKey bmk_pre_version {std::get<0>(bmk), std::get<1>(bmk), std::get<2>(bmk) - 1};
-        CacheKey key_pre_version(agg_cache_key(_tablet_id, bmk_pre_version));
+        std::string tmp_key = agg_cache_key(_tablet_id, bmk_pre_version);
+        CacheKey key_pre_version(tmp_key);
         Cache::Handle* handle_pre_version = _agg_cache->repr()->lookup(key_pre_version);
         val = new AggCache::Value();
         // leverage the cached result

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -423,7 +423,7 @@ Status PointQueryExecutor::_lookup_row_key() {
         auto rowset_ptr = std::make_unique<RowsetSharedPtr>();
         st = (_tablet->lookup_row_key(_row_read_ctxs[i]._primary_key, nullptr, false,
                                       specified_rowsets, &location, INT32_MAX /*rethink?*/,
-                                      segment_caches, rowset_ptr.get(), false, nullptr,
+                                      nullptr, segment_caches, rowset_ptr.get(), false, nullptr,
                                       &_profile_metrics.read_stats));
         if (st.is<ErrorCode::KEY_NOT_FOUND>()) {
             continue;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -422,8 +422,8 @@ Status PointQueryExecutor::_lookup_row_key() {
         // Get rowlocation and rowset, ctx._rowset_ptr will acquire wrap this ptr
         auto rowset_ptr = std::make_unique<RowsetSharedPtr>();
         st = (_tablet->lookup_row_key(_row_read_ctxs[i]._primary_key, nullptr, false,
-                                      specified_rowsets, &location, INT32_MAX /*rethink?*/,
-                                      nullptr, segment_caches, rowset_ptr.get(), false, nullptr,
+                                      specified_rowsets, &location, INT32_MAX /*rethink?*/, nullptr,
+                                      segment_caches, rowset_ptr.get(), false, nullptr,
                                       &_profile_metrics.read_stats));
         if (st.is<ErrorCode::KEY_NOT_FOUND>()) {
             continue;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

#20762 change `contains_agg` to `contains_agg_without_cache` to avoid AggCache's lock conflict, which would cost lots of CPU on loading large amount of data.

But `contains_agg_without_cache` would cost lost of cpu when base compaction is not so instantly and there accumulates lots of versions delete bitmap, this PR reintroduces the use of `get_agg` to reduce the cost of calls to RoaringBitmap.contains.

Note that in the flame graph quoted in the PR description of #20762, the CPU is mainly consumed in CacheHandle requests and releases, and since the LRUCache needs to count the reference counts of the CacheHandle, write locks are used for each `lookup` and `release` request to the cache, so when loading hundreds of millions of pieces of data, hundreds of millions of `lookup_row_key` and corresponding `lookup` and `release` accesses to `AggCache` will be generated in a short period of time, in which case the lock of `AggCache` will become a bottleneck.

By reducing the frequency of accessing `AggCache`, the issue #20762 can be resolved. This PR avoids accessing the cache every time a rowkey is looked up by calling `get_agg` in advance.

This not only addresses the high `RoaringBitmap::contains` CPU cost caused by traversing all versions of the delete bitmap when many versions accumulate, but also prevents the `AggCache` lock from becoming a bottleneck during large data loading.

