### PR TITLE
[fix](jdbc catalog) fix be crash when create jdbc catalog without driver jar

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -195,6 +195,9 @@ Status JdbcConnector::test_connection() {
 }
 
 Status JdbcConnector::clean_datasource() {
+    if (!_is_open) {
+        return Status::OK();
+    }
     JNIEnv* env = nullptr;
     RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
     env->CallNonvirtualVoidMethod(_executor_obj, _executor_clazz, _executor_clean_datasource_id);


### PR DESCRIPTION
When creating a JDBC Catalog, a connection test is performed. However, if the JDBC Driver path does not exist, we should report an error that the file cannot be opened and not clean up the resources, because the resources have not been created. Cleaning up non-existent resources will cause the program to crash. This PR is changed to clean up only when the resources are created.