### PR TITLE
[improvement](statistics)Improve statisitcs insert into audit log.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisJob.java
@@ -154,7 +154,7 @@ public class AnalysisJob {
                                 + queryState.getErrorMessage());
             }
         } finally {
-            AuditLogHelper.logAuditLog(stmtExecutor.getContext(), stmtExecutor.getOriginStmt().toString(),
+            AuditLogHelper.logAuditLog(stmtExecutor.getContext(), stmtExecutor.getOriginStmt().originStmt,
                     stmtExecutor.getParsedStmt(), stmtExecutor.getQueryStatisticsForAuditLog(),
                     true);
         }


### PR DESCRIPTION
The audit log for statistics insert sql was like:
Stmt=OriginStatement{originStmt='INSERT INTO internal.__internal_schema.column_statistics VALUES...}

Remove the "OriginStatement{originStmt" part, and change it to:
Stmt=INSERT INTO internal.__internal_schema.column_statistics VALUES..