### PR TITLE
[fix](Export) fix issue that `Export` can not specify the columns which have capital letters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -241,7 +241,7 @@ public class ExportStmt extends StatementBase implements NotFallbackInParser {
 
         if (columns != null) {
             Splitter split = Splitter.on(',').trimResults().omitEmptyStrings();
-            exportJob.setExportColumns(split.splitToList(this.columns.toLowerCase()));
+            exportJob.setExportColumns(split.splitToList(this.columns));
         }
 
         // set broker desc

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -50,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 // EXPORT statement, export data to dirs by broker.
 //
@@ -241,7 +239,7 @@ public class ExportStmt extends StatementBase implements NotFallbackInParser {
 
         if (columns != null) {
             Splitter split = Splitter.on(',').trimResults().omitEmptyStrings();
-            exportJob.setExportColumns(split.splitToList(this.columns));
+            exportJob.setExportColumns(split.splitToList(this.columns.toLowerCase()));
         }
 
         // set broker desc
@@ -327,11 +325,6 @@ public class ExportStmt extends StatementBase implements NotFallbackInParser {
         // "" means user specified zero columns
         this.columns = properties.getOrDefault(LoadStmt.KEY_IN_PARAM_COLUMNS, null);
 
-        // check columns are exits
-        if (columns != null) {
-            checkColumns();
-        }
-
         // format
         this.format = properties.getOrDefault(LoadStmt.KEY_IN_PARAM_FORMAT_TYPE, "csv").toLowerCase();
 
@@ -383,24 +376,6 @@ public class ExportStmt extends StatementBase implements NotFallbackInParser {
 
         // compress_type
         this.compressionType = properties.getOrDefault(COMPRESS_TYPE, "");
-    }
-
-    private void checkColumns() throws DdlException {
-        if (this.columns.isEmpty()) {
-            throw new DdlException("columns can not be empty");
-        }
-        Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(this.tblName.getDb());
-        Table table = db.getTableOrDdlException(this.tblName.getTbl());
-        List<String> tableColumns = table.getBaseSchema().stream().map(column -> column.getName())
-                .collect(Collectors.toList());
-        Splitter split = Splitter.on(',').trimResults().omitEmptyStrings();
-
-        List<String> columnsSpecified = split.splitToList(this.columns.toLowerCase());
-        for (String columnName : columnsSpecified) {
-            if (!tableColumns.contains(columnName)) {
-                throw new DdlException("unknown column [" + columnName + "] in table [" + this.tblName.getTbl() + "]");
-            }
-        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -425,8 +425,8 @@ public class ExportJob implements Writable {
             list.addItem(SelectListItem.createStarItem(this.tableName));
         } else {
             for (Column column : exportTable.getBaseSchema()) {
-                String colName = column.getName().toLowerCase();
-                if (exportColumns.contains(colName)) {
+                String colName = column.getName();
+                if (exportColumns.contains(colName.toLowerCase())) {
                     SlotRef slotRef = new SlotRef(this.tableName, colName);
                     SelectListItem selectListItem = new SelectListItem(slotRef, null);
                     list.addItem(selectListItem);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * EXPORT statement, export data to dirs by broker.
@@ -354,38 +353,9 @@ public class ExportCommand extends Command implements ForwardWithSync {
 
     private void checkFileProperties(ConnectContext ctx, Map<String, String> fileProperties, TableName tblName)
             throws UserException {
-        // check user specified columns
-        if (fileProperties.containsKey(LoadStmt.KEY_IN_PARAM_COLUMNS)) {
-            checkColumns(ctx, fileProperties.get(LoadStmt.KEY_IN_PARAM_COLUMNS), tblName);
-        }
-
         // check user specified label
         if (fileProperties.containsKey(LABEL)) {
             FeNameFormat.checkLabel(fileProperties.get(LABEL));
-        }
-    }
-
-    private void checkColumns(ConnectContext ctx, String columns, TableName tblName)
-            throws AnalysisException, UserException {
-        if (columns.isEmpty()) {
-            throw new AnalysisException("columns can not be empty");
-        }
-
-        CatalogIf catalog = ctx.getEnv().getCatalogMgr().getCatalogOrAnalysisException(tblName.getCtl());
-        DatabaseIf db = catalog.getDbOrAnalysisException(tblName.getDb());
-        TableIf table = db.getTableOrAnalysisException(tblName.getTbl());
-
-        // As for external table
-        // their base schemas are equals to full schemas
-        List<String> tableColumns = table.getBaseSchema().stream().map(column -> column.getName())
-                .collect(Collectors.toList());
-        Splitter split = Splitter.on(',').trimResults().omitEmptyStrings();
-
-        List<String> columnsSpecified = split.splitToList(columns);
-        for (String columnName : columnsSpecified) {
-            if (!tableColumns.contains(columnName)) {
-                throw new AnalysisException("unknown column [" + columnName + "] in table [" + tblName.getTbl() + "]");
-            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -381,7 +381,7 @@ public class ExportCommand extends Command implements ForwardWithSync {
                 .collect(Collectors.toList());
         Splitter split = Splitter.on(',').trimResults().omitEmptyStrings();
 
-        List<String> columnsSpecified = split.splitToList(columns.toLowerCase());
+        List<String> columnsSpecified = split.splitToList(columns);
         for (String columnName : columnsSpecified) {
             if (!tableColumns.contains(columnName)) {
                 throw new AnalysisException("unknown column [" + columnName + "] in table [" + tblName.getTbl() + "]");

--- a/regression-test/suites/export_p0/test_export_basic.groovy
+++ b/regression-test/suites/export_p0/test_export_basic.groovy
@@ -66,7 +66,7 @@ suite("test_export_basic", "p0") {
     sql """
     CREATE TABLE IF NOT EXISTS ${table_export_name} (
         `id` int(11) NULL,
-        `name` string NULL,
+        `Name` string NULL,
         `age` int(11) NULL
         )
         PARTITION BY RANGE(id)
@@ -163,7 +163,7 @@ suite("test_export_basic", "p0") {
         sql """
         CREATE TABLE IF NOT EXISTS ${table_load_name} (
             `id` int(11) NULL,
-            `name` string NULL,
+            `Name` string NULL,
             `age` int(11) NULL
             )
             DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
@@ -175,7 +175,7 @@ suite("test_export_basic", "p0") {
             table "${table_load_name}"
 
             set 'column_separator', ','
-            set 'columns', 'id, name, age'
+            set 'columns', 'id, Name, age'
             set 'strict_mode', 'true'
 
             file "${file_path}"
@@ -229,7 +229,7 @@ suite("test_export_basic", "p0") {
         sql """
         CREATE TABLE IF NOT EXISTS ${table_load_name} (
             `id` int(11) NULL,
-            `name` string NULL,
+            `Name` string NULL,
             `age` int(11) NULL
             )
             DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
@@ -241,7 +241,7 @@ suite("test_export_basic", "p0") {
             table "${table_load_name}"
 
             set 'column_separator', ','
-            set 'columns', 'id, name, age'
+            set 'columns', 'id, Name, age'
             set 'strict_mode', 'true'
 
             file "${file_path}"
@@ -295,7 +295,7 @@ suite("test_export_basic", "p0") {
         sql """
         CREATE TABLE IF NOT EXISTS ${table_load_name} (
             `id` int(11) NULL,
-            `name` string NULL,
+            `Name` string NULL,
             `age` int(11) NULL
             )
             DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
@@ -307,7 +307,7 @@ suite("test_export_basic", "p0") {
             table "${table_load_name}"
 
             set 'column_separator', ','
-            set 'columns', 'id, name, age'
+            set 'columns', 'id, Name, age'
             set 'strict_mode', 'true'
 
             file "${file_path}"
@@ -361,7 +361,7 @@ suite("test_export_basic", "p0") {
         sql """
         CREATE TABLE IF NOT EXISTS ${table_load_name} (
             `id` int(11) NULL,
-            `name` string NULL,
+            `Name` string NULL,
             `age` int(11) NULL
             )
             DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
@@ -373,7 +373,7 @@ suite("test_export_basic", "p0") {
             table "${table_load_name}"
 
             set 'column_separator', ','
-            set 'columns', 'id, name, age'
+            set 'columns', 'id, Name, age'
             set 'strict_mode', 'true'
 
             file "${file_path}"
@@ -460,7 +460,7 @@ suite("test_export_basic", "p0") {
                 "label" = "${label}",
                 "format" = "csv",
                 "column_separator"=",",
-                "columns" = "id, name",
+                "columns" = "id, Name",
                 "data_consistency" = "none"
             );
         """
@@ -474,7 +474,7 @@ suite("test_export_basic", "p0") {
         sql """
         CREATE TABLE IF NOT EXISTS ${table_load_name} (
             `id` int(11) NULL,
-            `name` string NULL
+            `Name` string NULL
             )
             DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
         """
@@ -485,7 +485,7 @@ suite("test_export_basic", "p0") {
             table "${table_load_name}"
 
             set 'column_separator', ','
-            set 'columns', 'id, name'
+            set 'columns', 'id, Name'
             set 'strict_mode', 'true'
 
             file "${file_path}"


### PR DESCRIPTION
If `Export` sql specifies the columns which contain captical letters, it will occur a error:
![image](https://github.com/user-attachments/assets/1678e2f8-af82-47fa-a772-37198cc5ed57)
 
We remove the check of column name in `Export`. So the name of columns will be checked in `SELECT..INTO OUTFILE`.

