### PR TITLE
[fix](build) add macro guard for hdfs.h to fix build error on Mac

### DIFF
--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -27,7 +27,9 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#ifdef USE_HADOOP_HDFS
 #include "hadoop_hdfs/hdfs.h"
+#endif
 #include "io/fs/hdfs.h"
 #include "util/string_util.h"
 


### PR DESCRIPTION
from #42475