### PR TITLE
[env](compile) add check of compile_check_begin.h and compile_check_end.h

### DIFF
--- a/be/src/common/compile_check_begin.h
+++ b/be/src/common/compile_check_begin.h
@@ -15,10 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#ifdef COMPILE_CHECK
+#error The handling of compile_check_begin.h and compile_check_end.h is not done correctly.
+#endif
+
+#define COMPILE_CHECK
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic error "-Wconversion"
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #pragma clang diagnostic ignored "-Wfloat-conversion"
 #endif
+
 //#include "common/compile_check_begin.h"

--- a/be/src/common/compile_check_end.h
+++ b/be/src/common/compile_check_end.h
@@ -18,4 +18,6 @@
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
+#undef COMPILE_CHECK
+
 // #include "common/compile_check_end.h"


### PR DESCRIPTION
### What problem does this PR solve?

if compile_check_begin.h and compile_check_end.h are not correctly included, 
the following code between them will cause compilation errors.

Problem Summary:

### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

