### PR TITLE
[fix](Nereids) replay create function npe since connect context not exists

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SqlModeHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SqlModeHelper.java
@@ -210,12 +210,18 @@ public class SqlModeHelper {
     }
 
     public static boolean hasNoBackSlashEscapes() {
-        return ((ConnectContext.get().getSessionVariable().getSqlMode() & MODE_ALLOWED_MASK)
+        SessionVariable sessionVariable = ConnectContext.get() == null
+                ? VariableMgr.newSessionVariable()
+                : ConnectContext.get().getSessionVariable();
+        return ((sessionVariable.getSqlMode() & MODE_ALLOWED_MASK)
                 & MODE_NO_BACKSLASH_ESCAPES) != 0;
     }
 
     public static boolean hasPipeAsConcat() {
-        return ((ConnectContext.get().getSessionVariable().getSqlMode() & MODE_ALLOWED_MASK)
+        SessionVariable sessionVariable = ConnectContext.get() == null
+                ? VariableMgr.newSessionVariable()
+                : ConnectContext.get().getSessionVariable();
+        return ((sessionVariable.getSqlMode() & MODE_ALLOWED_MASK)
                 & MODE_PIPES_AS_CONCAT) != 0;
     }
 


### PR DESCRIPTION
nereids will parse function statement when replay create alias function, when do parse, need to get sql mode and other variable. because replay thread do not have connect context, NPE be thrown when parsing

- [ ] Unit Test
- [ ] Regression test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test or manual test. Explain why:
    - [ ] This is a refactor/code format and no logic has been changed.
    - [x] Previous test can cover this change.
    - [ ] No colde files have been changed.
    - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

