### PR TITLE
[fix](mtmv)Fix the problem where the job does not exist, which prevents the deletion of MTMV

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -130,7 +130,7 @@ public class MTMVJobManager implements MTMVHookService {
     public void dropMTMV(MTMV mtmv) throws DdlException {
         try {
             Env.getCurrentEnv().getJobManager()
-                    .unregisterJob(mtmv.getJobInfo().getJobName(), false);
+                    .unregisterJob(mtmv.getJobInfo().getJobName(), true);
         } catch (JobException e) {
             LOG.warn("drop mtmv job failed, mtmvName: {}", mtmv.getName(), e);
             throw new DdlException(e.getMessage());


### PR DESCRIPTION
Fix the problem where the job does not exist, which prevents the deletion of MTMV

The fundamental reason is that deleting materialized views is not guaranteed by an independent editlog. Here, let's first ensure that materialized views can be deleted normally

