### PR TITLE
[feature](doris compose) enable fe jvm debug port

### DIFF
--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import configparser
 import filelock
 import getpass
 import hashlib
@@ -39,6 +40,7 @@ FE_HTTP_PORT = 8030
 FE_RPC_PORT = 9020
 FE_QUERY_PORT = 9030
 FE_EDITLOG_PORT = 9010
+FE_JAVA_DBG_PORT = 5005
 
 BE_PORT = 9060
 BE_WEBSVR_PORT = 8040
@@ -250,8 +252,6 @@ class Node(object):
         path = self.get_path()
         os.makedirs(path, exist_ok=True)
 
-        config = self.get_add_init_config()
-
         # copy config to local
         conf_dir = os.path.join(path, "conf")
         if not os.path.exists(conf_dir) or utils.is_dir_empty(conf_dir):
@@ -259,12 +259,15 @@ class Node(object):
             assert not utils.is_dir_empty(conf_dir), "conf directory {} is empty, " \
                     "check doris path in image is correct".format(conf_dir)
             utils.enable_dir_with_rw_perm(conf_dir)
+            config = self.get_add_init_config()
             if config:
                 with open(os.path.join(conf_dir, self.conf_file_name()),
                           "a") as f:
                     f.write("\n")
+                    f.write("#### start doris-compose add config ####\n\n")
                     for item in config:
                         f.write(item + "\n")
+                    f.write("\n#### end doris-compose add config ####\n")
         for sub_dir in self.expose_sub_dirs():
             os.makedirs(os.path.join(path, sub_dir), exist_ok=True)
 
@@ -453,6 +456,18 @@ class FE(Node):
                 cfg += [
                     "cloud_unique_id = " + self.cloud_unique_id(),
                 ]
+
+        with open("{}/conf/{}".format(self.get_path(), self.conf_file_name()),
+                  "r") as f:
+            parser = configparser.ConfigParser()
+            parser.read_string('[dummy_section]\n' + f.read())
+            for key in ("JAVA_OPTS", "JAVA_OPTS_FOR_JDK_17"):
+                value = parser["dummy_section"].get(key)
+                if value:
+                    cfg.append(
+                        f"{key} = \"{value} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:{FE_JAVA_DBG_PORT}\""
+                    )
+
         return cfg
 
     def init_is_follower(self):
@@ -478,7 +493,10 @@ class FE(Node):
         return ["bash", os.path.join(DOCKER_RESOURCE_PATH, "init_fe.sh")]
 
     def docker_ports(self):
-        return [FE_HTTP_PORT, FE_EDITLOG_PORT, FE_RPC_PORT, FE_QUERY_PORT]
+        return [
+            FE_HTTP_PORT, FE_EDITLOG_PORT, FE_RPC_PORT, FE_QUERY_PORT,
+            FE_JAVA_DBG_PORT
+        ]
 
     def docker_home_dir(self):
         return os.path.join(DOCKER_DORIS_PATH, "fe")

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -182,6 +182,18 @@ class Command(object):
     def _support_boolean_action(self):
         return sys.version_info.major == 3 and sys.version_info.minor >= 9
 
+    def _print_table(self, header, datas):
+        if utils.is_enable_log():
+            table = prettytable.PrettyTable(
+                [utils.render_green(field) for field in header])
+            for row in datas:
+                table.add_row(row)
+            print(table)
+            return ""
+        else:
+            datas.insert(0, header)
+            return datas
+
 
 class SimpleCommand(Command):
 
@@ -1022,18 +1034,6 @@ class ListCommand(Command):
                             action=self._get_parser_bool_action(True),
                             help="Print more detail fields.")
 
-    def _handle_data(self, header, datas):
-        if utils.is_enable_log():
-            table = prettytable.PrettyTable(
-                [utils.render_green(field) for field in header])
-            for row in datas:
-                table.add_row(row)
-            print(table)
-            return ""
-        else:
-            datas.insert(0, header)
-            return datas
-
     def run(self, args):
         COMPOSE_MISSING = "(missing)"
         COMPOSE_BAD = "(bad)"
@@ -1125,7 +1125,7 @@ class ListCommand(Command):
                              CLUSTER.get_master_fe_endpoint(name), is_cloud,
                              "{}{}".format(compose_file,
                                            cluster_info["status"])))
-            return self._handle_data(header, rows)
+            return self._print_table(header, rows)
 
         header = [
             "CLUSTER", "NAME", "IP", "STATUS", "CONTAINER ID", "IMAGE",
@@ -1212,48 +1212,42 @@ class ListCommand(Command):
             for node in sorted(nodes, key=get_node_seq):
                 rows.append(node.info(args.detail))
 
-        return self._handle_data(header, rows)
+        return self._print_table(header, rows)
 
 
-class GetCloudIniCommand(Command):
+class InfoCommand(Command):
 
     def add_parser(self, args_parsers):
-        parser = args_parsers.add_parser("get-cloud-ini",
-                                         help="Get cloud.init")
-        parser.add_argument(
-            "NAME",
-            nargs="*",
-            help=
-            "Specify multiple clusters, if specific, show all their containers."
-        )
+        parser = args_parsers.add_parser(
+            "info", help="Show info like cloud.ini, port, path, etc")
         self._add_parser_common_args(parser)
-
-    def _handle_data(self, header, datas):
-        if utils.is_enable_log():
-            table = prettytable.PrettyTable(
-                [utils.render_green(field) for field in header])
-            for row in datas:
-                table.add_row(row)
-            print(table)
-            return ""
-        else:
-            datas.insert(0, header)
-            return datas
 
     def run(self, args):
 
-        header = ["key", "value"]
-
-        rows = []
+        header = ["key", "value", "scope"]
+        cloud_cfg_file_env = os.getenv("DORIS_CLOUD_CFG_FILE")
+        cloud_cfg_file = cloud_cfg_file_env if cloud_cfg_file_env else "${LOCAL_DORIS_PATH}/cloud.ini"
+        rows = [
+            ("LOCAL_DORIS_PATH", CLUSTER.LOCAL_DORIS_PATH, "env variable"),
+            ("DORIS_CLOUD_CFG_FILE", cloud_cfg_file, "env variable"),
+            ("FE_QUERY_PORT", CLUSTER.FE_QUERY_PORT, "constant"),
+            ("FE_HTTP_PORT", CLUSTER.FE_HTTP_PORT, "constant"),
+            ("FE_EDITLOG_PORT", CLUSTER.FE_EDITLOG_PORT, "constant"),
+            ("FE_JAVA_DBG_PORT", CLUSTER.FE_JAVA_DBG_PORT, "constant"),
+            ("BE_HEARTBEAT_PORT", CLUSTER.BE_HEARTBEAT_PORT, "constant"),
+            ("BE_WEBSVR_PORT", CLUSTER.BE_WEBSVR_PORT, "constant"),
+            ("MS_PORT", CLUSTER.MS_PORT, "constant"),
+            ("RECYCLER_PORT", CLUSTER.MS_PORT, "constant"),
+        ]
 
         with open(CLUSTER.CLOUD_CFG_FILE, "r") as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith('#'):
                     key, value = line.split('=', 1)
-                    rows.append([key.strip(), value.strip()])
+                    rows.append((key.strip(), value.strip(), "cloud.ini"))
 
-        return self._handle_data(header, rows)
+        return self._print_table(header, rows)
 
 
 class AddRWPermCommand(Command):
@@ -1278,8 +1272,8 @@ ALL_COMMANDS = [
     NeedStartCommand("restart", "Restart the doris containers. "),
     SimpleCommand("pause", "Pause the doris containers. "),
     SimpleCommand("unpause", "Unpause the doris containers. "),
-    GetCloudIniCommand("get-cloud-ini"),
     GenConfCommand("config"),
+    InfoCommand("info"),
     ListCommand("ls"),
     AddRWPermCommand("add-rw-perm"),
 ]


### PR DESCRIPTION
1.  fe use 5005 as jvm debug port,  user can run `docker ps | grep  <fe-node-name>` to find out the port on host machine;
2.  extends get-cloud-ini command to print more info

