### PR TITLE
[fix](orc) fix predicate filter failed when use hive 1.x version

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -734,6 +734,11 @@ bool OrcReader::_init_search_argument(
     if (predicates.empty()) {
         return false;
     }
+
+    if (_is_hive1_orc_or_use_idx) {
+        for (OrcPredicate& it : predicates) it.col_name = _col_name_to_file_col_name[it.col_name];
+    }
+
     std::unique_ptr<orc::SearchArgumentBuilder> builder = orc::SearchArgumentFactory::newBuilder();
     if (build_search_argument(predicates, 0, builder)) {
         std::unique_ptr<orc::SearchArgument> sargs = builder->build();


### PR DESCRIPTION
Proposed changes
 1. original issue:
     we found presto scan byte much more bigger then Doris, such as query:
     select l_orderkey from dev.lineitem_orc_100g_backup1 where l_orderkey = 7192579;
    this query just have 1 rows result, scan bytes presto vs Doris:
    presto:
![image](https://github.com/user-attachments/assets/754778ba-9031-4139-a5a3-68a7f45923eb)
    Doris:
![image](https://github.com/user-attachments/assets/8055a128-19ee-441a-8ddd-a051ab6e0af2)
![image](https://github.com/user-attachments/assets/b0e3fa88-b6bb-4041-94d1-b04d4f1a4283)
  2. root cause:
     we use hive 1.x version,query predicate column name not match orc column name, in this case: 
     schame is l_orderkey name, in orc field name is _col1。
3. how to fix:
    in _init_search_argument change l_orderkey -> _col1。
4. profile after fix:
    query latency:
![image](https://github.com/user-attachments/assets/7044f0fd-28b6-41a0-901a-01845a585e41)
    scan bytes:
![image](https://github.com/user-attachments/assets/e661e379-6ef1-44c1-94bb-14592020210b)

    

