### PR TITLE
[fix](cloud) fix read cache block file return stat NOT_FOUND

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1035,8 +1035,6 @@ DEFINE_mInt64(file_cache_ttl_valid_check_interval_second, "0"); // zero for not 
 // If true, evict the ttl cache using LRU when full.
 // Otherwise, only expiration can evict ttl and new data won't add to cache when full.
 DEFINE_Bool(enable_ttl_cache_evict_using_lru, "true");
-// rename ttl filename to new format during read, with some performance cost
-DEFINE_mBool(translate_to_new_ttl_format_during_read, "false");
 DEFINE_mBool(enbale_dump_error_file, "true");
 // limit the max size of error log on disk
 DEFINE_mInt64(file_cache_error_log_limit_bytes, "209715200"); // 200MB

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1078,8 +1078,6 @@ DECLARE_mInt64(file_cache_ttl_valid_check_interval_second);
 // If true, evict the ttl cache using LRU when full.
 // Otherwise, only expiration can evict ttl and new data won't add to cache when full.
 DECLARE_Bool(enable_ttl_cache_evict_using_lru);
-// rename ttl filename to new format during read, with some performance cost
-DECLARE_Bool(translate_to_new_ttl_format_during_read);
 DECLARE_mBool(enbale_dump_error_file);
 // limit the max size of error log on disk
 DECLARE_mInt64(file_cache_error_log_limit_bytes);

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -292,6 +292,8 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
                                  file_offset);
             }
             if (!st || block_state != FileBlock::State::DOWNLOADED) {
+                LOG(WARNING) << "Read data failed from file cache downloaded by others. err="
+                             << st.msg() << ", block state=" << block_state;
                 size_t bytes_read {0};
                 stats.hit_cache = false;
                 s3_read_counter << 1;

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -160,30 +160,36 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
                 get_path_in_local_cache(get_path_in_local_cache(key.hash, key.meta.expiration_time),
                                         key.offset, key.meta.type);
         Status s = fs->open_file(file, &file_reader);
-        if (!s.ok()) {
-            if (!s.is<ErrorCode::NOT_FOUND>() || key.meta.type != FileCacheType::TTL) {
+
+        // handle the case that the file is not found but actually exists in other type format
+        // TODO(zhengyu): nasty! better eliminate the type encoding in file name in the future
+        if (!s.ok() && !s.is<ErrorCode::NOT_FOUND>()) {
+            LOG(WARNING) << "open file failed, file=" << file << ", error=" << s.to_string();
+            return s;                                         // return other error directly
+        } else if (!s.ok() && s.is<ErrorCode::NOT_FOUND>()) { // but handle NOT_FOUND error
+            auto candidates = get_path_in_local_cache_all_candidates(
+                    get_path_in_local_cache(key.hash, key.meta.expiration_time), key.offset);
+            for (auto& candidate : candidates) {
+                s = fs->open_file(candidate, &file_reader);
+                if (s.ok()) {
+                    break; // success with one of there candidates
+                }
+            }
+            if (!s.ok()) { // still not found, return error
+                LOG(WARNING) << "open file failed, file=" << file << ", error=" << s.to_string();
                 return s;
             }
-            std::string file_old_format = get_path_in_local_cache_old_ttl_format(
-                    get_path_in_local_cache(key.hash, key.meta.expiration_time), key.offset,
-                    key.meta.type);
-            if (config::translate_to_new_ttl_format_during_read) {
-                // try to rename the file with old ttl format to new and retry
-                VLOG(7) << "try to rename the file with old ttl format to new and retry"
-                        << " oldformat=" << file_old_format << " original=" << file;
-                RETURN_IF_ERROR(fs->rename(file_old_format, file));
-                RETURN_IF_ERROR(fs->open_file(file, &file_reader));
-            } else {
-                // try to open the file with old ttl format
-                VLOG(7) << "try to open the file with old ttl format"
-                        << " oldformat=" << file_old_format << " original=" << file;
-                RETURN_IF_ERROR(fs->open_file(file_old_format, &file_reader));
-            }
-        }
+        } // else, s.ok() means open file success
+
         FDCache::instance()->insert_file_reader(fd_key, file_reader);
     }
     size_t bytes_read = 0;
-    RETURN_IF_ERROR(file_reader->read_at(value_offset, buffer, &bytes_read));
+    auto s = file_reader->read_at(value_offset, buffer, &bytes_read);
+    if (!s.ok()) {
+        LOG(WARNING) << "read file failed, file=" << file_reader->path()
+                     << ", error=" << s.to_string();
+        return s;
+    }
     DCHECK(bytes_read == buffer.get_size());
     return Status::OK();
 }
@@ -268,6 +274,18 @@ std::string FSFileCacheStorage::get_path_in_local_cache_old_ttl_format(const std
                                                                        bool is_tmp) {
     DCHECK(type == FileCacheType::TTL);
     return Path(dir) / (std::to_string(offset) + BlockFileCache::cache_type_to_string(type));
+}
+
+std::vector<std::string> FSFileCacheStorage::get_path_in_local_cache_all_candidates(
+        const std::string& dir, size_t offset) {
+    std::vector<std::string> candidates;
+    std::string base = get_path_in_local_cache(dir, offset, FileCacheType::NORMAL);
+    candidates.push_back(base);
+    candidates.push_back(base + "_idx");
+    candidates.push_back(base + "_ttl");
+    candidates.push_back(base + "_disposable");
+    candidates.push_back(base + "_tmp");
+    return candidates;
 }
 
 std::string FSFileCacheStorage::get_path_in_local_cache(const UInt128Wrapper& value,

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -75,6 +75,9 @@ public:
                                                              FileCacheType type,
                                                              bool is_tmp = false);
 
+    [[nodiscard]] std::vector<std::string> get_path_in_local_cache_all_candidates(
+            const std::string& dir, size_t offset);
+
     [[nodiscard]] static std::string get_path_in_local_cache_old_ttl_format(const std::string& dir,
                                                                             size_t offset,
                                                                             FileCacheType type,


### PR DESCRIPTION
Previously, cache blocks could be downloaded as different types than the target type we intended to read, leading to false cache misses. E.g., a block might be downloaded as an 'idx' type when the current context expected a 'ttl' type.

The root cause of this problem is the original design encoding meta info such as type and expiration time into cache block file path and readers of this cache block file have inconsistent view of the type so they use different name to locate file and run into NOT_FOUND error in the end.

This commit tries other type if the initial type failed to locate the file. Be ware that this is only a nasty quick fix. We will elimite the metadate encoded in the file path in the near future to get rid of all the path related problems.

### What problem does this PR solve?
<!--
You need to clearly describe your PR in this part:

1. What problem was fixed (it's best to include specific error reporting information). How it was fixed.
2. Which behaviors were modified. What was the previous behavior, what is it now, why was it modified, and what possible impacts might there be.
3. What features were added. Why this function was added.
4. Which codes were refactored and why this part of the code was refactored.
5. Which functions were optimized and what is the difference before and after the optimization.

The description of the PR needs to enable reviewers to quickly and clearly understand the logic of the code modification.
-->

<!--
If there are related issues, please fill in the issue number.
- If you want the issue to be closed after the PR is merged, please use "close #12345". Otherwise, use "ref #12345"
-->
Issue Number: close #xxx

<!--
If this PR is followup a preivous PR, for example, fix the bug that introduced by a related PR,
link the PR here
-->
Related PR: #xxx

Problem Summary:

### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

