### PR TITLE
[Refactor](BE) Uniform Expr, Block, Columns size-relative interface (Part II)

### DIFF
--- a/be/src/vec/exprs/table_function/table_function.h
+++ b/be/src/vec/exprs/table_function/table_function.h
@@ -18,13 +18,15 @@
 #pragma once
 
 #include <fmt/core.h>
-#include <stddef.h>
+
+#include <cstddef>
 
 #include "common/status.h"
 #include "vec/core/block.h"
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 constexpr auto COMBINATOR_SUFFIX_OUTER = "_outer";
 
@@ -101,4 +103,6 @@ protected:
     bool _is_nullable = false;
     bool _is_const = false;
 };
+
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/table_function_factory.cpp
+++ b/be/src/vec/exprs/table_function/table_function_factory.cpp
@@ -21,7 +21,6 @@
 
 #include <memory>
 #include <string_view>
-#include <utility>
 
 #include "common/object_pool.h"
 #include "vec/exprs/table_function/table_function.h"
@@ -37,6 +36,7 @@
 #include "vec/utils/util.hpp"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 template <typename TableFunctionType>
 struct TableFunctionCreator {
@@ -91,4 +91,5 @@ Status TableFunctionFactory::get_fn(const TFunction& t_fn, ObjectPool* pool, Tab
     return Status::NotSupported("Table function {} is not support", t_fn.name.function_name);
 }
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/table_function_factory.h
+++ b/be/src/vec/exprs/table_function/table_function_factory.h
@@ -27,6 +27,8 @@
 #include "common/status.h"
 
 namespace doris {
+#include "common/compile_check_begin.h"
+
 class ObjectPool;
 
 namespace vectorized {
@@ -41,4 +43,5 @@ public:
             _function_map;
 };
 } // namespace vectorized
+#include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/vec/exprs/table_function/udf_table_function.cpp
+++ b/be/src/vec/exprs/table_function/udf_table_function.cpp
@@ -33,6 +33,8 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
 const char* EXECUTOR_CLASS = "org/apache/doris/udf/UdfExecutor";
 const char* EXECUTOR_CTOR_SIGNATURE = "([B)V";
 const char* EXECUTOR_EVALUATE_SIGNATURE = "(Ljava/util/Map;Ljava/util/Map;)J";
@@ -206,4 +208,6 @@ int UDFTableFunction::get_value(MutableColumnPtr& column, int max_step) {
     forward(max_step);
     return max_step;
 }
+
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/udf_table_function.h
+++ b/be/src/vec/exprs/table_function/udf_table_function.h
@@ -26,6 +26,7 @@
 #include "vec/functions/array/function_array_utils.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 class UDFTableFunction final : public TableFunction {
     ENABLE_FACTORY_CREATOR(UDFTableFunction);
@@ -94,4 +95,5 @@ private:
     size_t _array_offset = 0;        // start offset of array[row_idx]
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode.cpp
+++ b/be/src/vec/exprs/table_function/vexplode.cpp
@@ -20,12 +20,10 @@
 #include <glog/logging.h>
 
 #include <ostream>
-#include <vector>
 
 #include "common/status.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_object.h"
-#include "vec/common/string_ref.h"
 #include "vec/core/block.h"
 #include "vec/core/column_with_type_and_name.h"
 #include "vec/data_types/data_type.h"
@@ -33,6 +31,7 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 VExplodeTableFunction::VExplodeTableFunction() {
     _fn_name = "vexplode";
@@ -124,4 +123,6 @@ int VExplodeTableFunction::get_value(MutableColumnPtr& column, int max_step) {
     forward(max_step);
     return max_step;
 }
+
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode.h
+++ b/be/src/vec/exprs/table_function/vexplode.h
@@ -17,18 +17,18 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 
 #include "common/status.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exprs/table_function/table_function.h"
 #include "vec/functions/array/function_array_utils.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
 class Block;
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::vectorized
 
 namespace doris::vectorized {
 
@@ -52,4 +52,5 @@ private:
     size_t _array_offset; // start offset of array[row_idx]
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.cpp
@@ -21,7 +21,6 @@
 
 #include <memory>
 #include <ostream>
-#include <vector>
 
 #include "common/status.h"
 #include "util/bitmap_value.h"
@@ -36,6 +35,7 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 VExplodeBitmapTableFunction::VExplodeBitmapTableFunction() {
     _fn_name = "vexplode_bitmap";
@@ -126,7 +126,7 @@ int VExplodeBitmapTableFunction::get_value(MutableColumnPtr& column, int max_ste
         }
         auto origin_size = target->size();
         target->resize(origin_size + max_step);
-        auto target_data = target->get_data().data();
+        auto* target_data = target->get_data().data();
         for (int i = 0; i < max_step; ++i) {
             target_data[i + origin_size] = **_cur_iter;
             ++(*_cur_iter);
@@ -135,4 +135,5 @@ int VExplodeBitmapTableFunction::get_value(MutableColumnPtr& column, int max_ste
     TableFunction::forward(max_step);
     return max_step;
 }
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.h
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <memory>
 
 #include "common/status.h"
@@ -26,13 +25,10 @@
 #include "vec/data_types/data_type.h"
 #include "vec/exprs/table_function/table_function.h"
 
-namespace doris {
-namespace vectorized {
-class Block;
-} // namespace vectorized
-} // namespace doris
-
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
+class Block;
 
 class VExplodeBitmapTableFunction final : public TableFunction {
     ENABLE_FACTORY_CREATOR(VExplodeBitmapTableFunction);
@@ -60,4 +56,5 @@ private:
     ColumnPtr _value_column;
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -18,16 +18,12 @@
 #include "vec/exprs/table_function/vexplode_json_array.h"
 
 #include <glog/logging.h>
-#include <inttypes.h>
 #include <rapidjson/rapidjson.h>
-#include <stdio.h>
 
 #include <algorithm>
-#include <limits>
+#include <cstdio>
 
 #include "common/status.h"
-#include "util/jsonb_parser.h"
-#include "util/jsonb_utils.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/columns_number.h"
@@ -38,6 +34,8 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
 template <typename DataImpl>
 VExplodeJsonArrayTableFunction<DataImpl>::VExplodeJsonArrayTableFunction() : TableFunction() {
     _fn_name = "vexplode_json_array";
@@ -155,4 +153,5 @@ template class VExplodeJsonArrayTableFunction<ParsedDataDouble>;
 template class VExplodeJsonArrayTableFunction<ParsedDataString>;
 template class VExplodeJsonArrayTableFunction<ParsedDataJSON>;
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_json_object.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_object.h
@@ -17,21 +17,15 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 
 #include "common/status.h"
-#include "vec/columns/column_map.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_array.h"
-#include "vec/data_types/data_type_map.h"
 #include "vec/exprs/table_function/table_function.h"
-#include "vec/functions/array/function_array_utils.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 class Block;
-} // namespace doris::vectorized
-
-namespace doris::vectorized {
 
 // explode_json_object("{\"a\": 1, \"b\": 2}") ->
 // | key | value |
@@ -56,4 +50,5 @@ private:
     std::pair<MutableColumnPtr, MutableColumnPtr> _object_pairs; // ColumnNullable<ColumnString>
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_map.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_map.cpp
@@ -20,17 +20,16 @@
 #include <glog/logging.h>
 
 #include <ostream>
-#include <vector>
 
 #include "common/status.h"
 #include "vec/columns/column.h"
-#include "vec/common/string_ref.h"
 #include "vec/core/block.h"
 #include "vec/core/column_with_type_and_name.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 VExplodeMapTableFunction::VExplodeMapTableFunction() {
     _fn_name = "vexplode_map";
@@ -156,4 +155,6 @@ int VExplodeMapTableFunction::get_value(MutableColumnPtr& column, int max_step) 
     forward(max_step);
     return max_step;
 }
+
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_map.h
+++ b/be/src/vec/exprs/table_function/vexplode_map.h
@@ -17,21 +17,17 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 
 #include "common/status.h"
 #include "vec/columns/column_map.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_array.h"
-#include "vec/data_types/data_type_map.h"
 #include "vec/exprs/table_function/table_function.h"
-#include "vec/functions/array/function_array_utils.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
 class Block;
-} // namespace doris::vectorized
-
-namespace doris::vectorized {
 
 struct ColumnMapExecutionData {
 public:
@@ -66,4 +62,5 @@ private:
     size_t _collection_offset; // start offset of array[row_idx]
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <ostream>
-#include <vector>
 
 #include "common/status.h"
 #include "runtime/runtime_state.h"
@@ -36,6 +35,7 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 VExplodeNumbersTableFunction::VExplodeNumbersTableFunction() {
     _fn_name = "vexplode_numbers";
@@ -52,19 +52,25 @@ Status VExplodeNumbersTableFunction::process_init(Block* block, RuntimeState* st
     _value_column = block->get_by_position(value_column_idx).column;
     if (is_column_const(*_value_column)) {
         _cur_size = 0;
-        auto& column_nested = assert_cast<const ColumnConst&>(*_value_column).get_data_column_ptr();
+
+        // the argument columns -> Int32
+        const auto& column_nested =
+                assert_cast<const ColumnConst&>(*_value_column).get_data_column_ptr();
         if (column_nested->is_nullable()) {
             if (!column_nested->is_null_at(0)) {
-                _cur_size = assert_cast<const ColumnNullable*>(column_nested.get())
-                                    ->get_nested_column()
-                                    .get_int(0);
+                _cur_size = assert_cast<const ColumnInt32*>(
+                                    assert_cast<const ColumnNullable*>(column_nested.get())
+                                            ->get_nested_column_ptr()
+                                            .get())
+                                    ->get_element(0);
             }
         } else {
-            _cur_size = column_nested->get_int(0);
+            _cur_size = assert_cast<const ColumnInt32*>(column_nested.get())->get_element(0);
         }
+
         ((ColumnInt32*)_elements_column.get())->clear();
         //_cur_size may be a negative number
-        _cur_size = std::max<int64_t>(0, _cur_size);
+        _cur_size = std::max(0L, _cur_size);
         if (_cur_size &&
             _cur_size <= state->batch_size()) { // avoid elements_column too big or empty
             _is_const = true;                   // use const optimize
@@ -96,17 +102,20 @@ void VExplodeNumbersTableFunction::get_same_many_values(MutableColumnPtr& column
     if (current_empty()) {
         column->insert_many_defaults(length);
     } else {
+        // for explode numbers, the argument is int32. so cast is safe.
         if (_is_nullable) {
             assert_cast<ColumnInt32*>(
                     assert_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
-                    ->insert_many_vals(_cur_offset, length);
+                    ->insert_many_vals(static_cast<int32_t>(_cur_offset), length);
             assert_cast<ColumnUInt8*>(
                     assert_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
                     ->insert_many_defaults(length);
         } else {
-            assert_cast<ColumnInt32*>(column.get())->insert_many_vals(_cur_offset, length);
+            assert_cast<ColumnInt32*>(column.get())
+                    ->insert_many_vals(static_cast<int32_t>(_cur_offset), length);
         }
     }
 }
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_numbers.h
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <algorithm>
+#include <cstddef>
 
 #include "common/status.h"
 #include "vec/columns/column_nullable.h"
@@ -29,10 +28,9 @@
 #include "vec/exprs/table_function/table_function.h"
 
 namespace doris::vectorized {
-class Block;
-} // namespace doris::vectorized
+#include "common/compile_check_begin.h"
 
-namespace doris::vectorized {
+class Block;
 
 class VExplodeNumbersTableFunction : public TableFunction {
     ENABLE_FACTORY_CREATOR(VExplodeNumbersTableFunction);
@@ -92,4 +90,5 @@ private:
     ColumnPtr _elements_column = ColumnInt32::create();
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_split.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_split.cpp
@@ -34,6 +34,7 @@
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 VExplodeSplitTableFunction::VExplodeSplitTableFunction() {
     _fn_name = "vexplode_split";
@@ -156,4 +157,6 @@ int VExplodeSplitTableFunction::get_value(doris::vectorized::MutableColumnPtr& c
     TableFunction::forward(max_step);
     return max_step;
 }
+
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_split.h
+++ b/be/src/vec/exprs/table_function/vexplode_split.h
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string_view>
 #include <vector>
 
 #include "common/status.h"
@@ -28,6 +27,7 @@
 #include "vec/exprs/table_function/table_function.h"
 
 namespace doris::vectorized {
+#include "common/compile_check_begin.h"
 
 class Block;
 template <typename T>
@@ -58,4 +58,5 @@ private:
     StringRef _delimiter = {};
 };
 
+#include "common/compile_check_end.h"
 } // namespace doris::vectorized


### PR DESCRIPTION
part 2 of https://github.com/apache/doris/pull/42930

two modifications:
1. when parsing data of json array, cast to target type when parse int data no matter what source type is.
2. in explode_numbers, the argument column type is certain Int32. so reduce some virtual function call.