### PR TITLE
[improve](load) show 99.99% instead of 100.00% in progess when load is not finished

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -440,7 +440,8 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
             }
 
             // progress
-            String progress = Env.getCurrentProgressManager().getProgressInfo(String.valueOf(getJobId()));
+            String progress = Env.getCurrentProgressManager()
+                    .getProgressInfo(String.valueOf(getJobId()), getJobStatus() == JobStatus.FINISHED);
             switch (getJobStatus()) {
                 case RUNNING:
                     if (isPending()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -757,7 +757,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
 
         // progress
         // check null
-        String progress = Env.getCurrentProgressManager().getProgressInfo(String.valueOf(id));
+        String progress = Env.getCurrentProgressManager()
+                .getProgressInfo(String.valueOf(id), state == JobState.FINISHED);
         switch (state) {
             case PENDING:
                 jobInfo.add("0%");

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/ProgressManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/ProgressManager.java
@@ -67,13 +67,13 @@ public class ProgressManager {
         }
     }
 
-    public String getProgressInfo(String id) {
+    public String getProgressInfo(String id, boolean finished) {
         String progressInfo = "Unknown id: " + id;
         Progress progress = idToProgress.get(id);
         if (progress != null) {
             int finish = progress.getFinishedScanNums();
             int total = progress.getTotalScanNums();
-            String currentProgress = String.format("%.2f", progress.getProgress());
+            String currentProgress = String.format("%.2f", progress.getProgress(finished));
             progressInfo = currentProgress + "% (" + finish + "/" + total + ")";
         }
         return progressInfo;
@@ -107,12 +107,13 @@ public class ProgressManager {
             return result;
         }
 
-        public double getProgress() {
+        public double getProgress(boolean finished) {
             // if no scan range found, the progress should be finished(100%)
-            if (totalScanNums == 0) {
-                return 100.0;
+            int finishedScanNums = getFinishedScanNums();
+            if (totalScanNums == 0 || finishedScanNums == totalScanNums) {
+                return finished ? 100.0 : 99.99;
             }
-            return getFinishedScanNums() * 100 / (double) totalScanNums;
+            return finishedScanNums * 100.0 / totalScanNums;
         }
 
         public Progress(int totalScanNums) {
@@ -127,7 +128,7 @@ public class ProgressManager {
             sb.append("/");
             sb.append(totalScanNums);
             sb.append(" => ");
-            sb.append(getProgress());
+            sb.append(getProgress(true));
             sb.append("%");
             return sb.toString();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Currently when all instances finished, but the load is not finished,
the progress will display `100.00%`, which is misleading to users.

This PR detected changes it to `99.99%`.

### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

