### PR TITLE
[fix](statistics)Change column statistics table varchar length to 1024.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -46,6 +46,10 @@ public class ModifyColumnClause extends AlterTableClause {
         return column;
     }
 
+    public void setColumn(Column column) {
+        this.column = column;
+    }
+
     public ColumnPosition getColPos() {
         return colPos;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -35,7 +35,7 @@ public class StatisticConstants {
     public static final String PARTITION_STATISTIC_TBL_NAME = "partition_statistics";
     public static final String HISTOGRAM_TBL_NAME = "histogram_statistics";
 
-    public static final int MAX_NAME_LEN = 64;
+    public static final int MAX_NAME_LEN = 1024;
 
     public static final int ID_LEN = 4096;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/InternalSchemaInitializerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/InternalSchemaInitializerTest.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.analysis.AlterClause;
+import org.apache.doris.analysis.ModifyColumnClause;
+import org.apache.doris.datasource.hive.HMSExternalTable;
+import org.apache.doris.statistics.StatisticConstants;
+
+import com.google.common.collect.Lists;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class InternalSchemaInitializerTest {
+    @Test
+    public void testGetModifyColumn() {
+        new MockUp<HMSExternalTable>() {
+            @Mock
+            public HMSExternalTable.DLAType getDlaType() {
+                return HMSExternalTable.DLAType.HUDI;
+            }
+        };
+
+        InternalSchemaInitializer initializer = new InternalSchemaInitializer();
+        OlapTable table = new OlapTable();
+        Column key1 = new Column("key1", ScalarType.createVarcharType(100), true, null, false, null, "");
+        Column key2 = new Column("key2", ScalarType.createVarcharType(100), true, null, true, null, "");
+        Column key3 = new Column("key3", ScalarType.createVarcharType(1024), true, null, null, "");
+        Column key4 = new Column("key4", ScalarType.createVarcharType(1025), true, null, null, "");
+        Column key5 = new Column("key5", ScalarType.INT, true, null, null, "");
+        Column value1 = new Column("value1", ScalarType.INT, false, null, null, "");
+        Column value2 = new Column("value2", ScalarType.createVarcharType(100), false, null, null, "");
+        List<Column> schema = Lists.newArrayList();
+        schema.add(key1);
+        schema.add(key2);
+        schema.add(key3);
+        schema.add(key4);
+        schema.add(key5);
+        schema.add(value1);
+        schema.add(value2);
+        table.fullSchema = schema;
+        List<AlterClause> modifyColumnClauses = initializer.getModifyColumnClauses(table);
+        Assertions.assertEquals(2, modifyColumnClauses.size());
+        ModifyColumnClause clause1 = (ModifyColumnClause) modifyColumnClauses.get(0);
+        Assertions.assertEquals("key1", clause1.getColumn().getName());
+        Assertions.assertEquals(StatisticConstants.MAX_NAME_LEN, clause1.getColumn().getType().getLength());
+        Assertions.assertFalse(clause1.getColumn().isAllowNull());
+
+        ModifyColumnClause clause2 = (ModifyColumnClause) modifyColumnClauses.get(1);
+        Assertions.assertEquals("key2", clause2.getColumn().getName());
+        Assertions.assertEquals(StatisticConstants.MAX_NAME_LEN, clause2.getColumn().getType().getLength());
+        Assertions.assertTrue(clause2.getColumn().isAllowNull());
+
+    }
+
+}


### PR DESCRIPTION
Change column statistics table varchar length to 1024. Including db name, table name, column name and partition name. Because the maximum length of the names above is 256 characters. (For 256 Chinese character, we need varchar 1024 to store it)