### PR TITLE
[fix](cloud-mow) Should clear GetDeleteBitmapResponse when geting delete bitmap fail and retry

### DIFF
--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -92,6 +92,12 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
         VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
                    << " response=" << res->ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetDeleteBitmapResponse>) {
+        if (res->status().code() != MetaServiceCode::OK) {
+            res->clear_rowset_ids();
+            res->clear_segment_ids();
+            res->clear_versions();
+            res->segment_delete_bitmaps();
+        }
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
                   << " status=" << res->status().ShortDebugString()
                   << " delete_bitmap_size=" << res->segment_delete_bitmaps_size();


### PR DESCRIPTION
When geting  delete bitmap fail, it will retry, howerve the GetDeleteBitmapResponse doesn't clear now, which will lead to the delete bitmap data  of last request residual in GetDeleteBitmapResponse and return to be, it a wrong delete bitmap data and may cause be core.