### PR TITLE
[fix](arrow-flight-sql) Arrow flight server supports data forwarding when BE uses public vip

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -64,6 +64,7 @@ DEFINE_Int32(brpc_port, "8060");
 DEFINE_Int32(arrow_flight_sql_port, "-1");
 
 DEFINE_mString(public_access_ip, "");
+DEFINE_Int32(public_access_port, "-1");
 
 // the number of bthreads for brpc, the default value is set to -1,
 // which means the number of bthreads is #cpu-cores
@@ -520,6 +521,8 @@ DEFINE_Int32(brpc_light_work_pool_threads, "-1");
 DEFINE_Int32(brpc_heavy_work_pool_max_queue_size, "-1");
 DEFINE_Int32(brpc_light_work_pool_max_queue_size, "-1");
 DEFINE_mBool(enable_bthread_transmit_block, "true");
+DEFINE_Int32(brpc_arrow_flight_work_pool_threads, "-1");
+DEFINE_Int32(brpc_arrow_flight_work_pool_max_queue_size, "-1");
 
 //Enable brpc builtin services, see:
 //https://brpc.apache.org/docs/server/basics/#disable-built-in-services-completely

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -628,7 +628,11 @@ DEFINE_Int32(load_process_safe_mem_permit_percent, "5");
 // result buffer cancelled time (unit: second)
 DEFINE_mInt32(result_buffer_cancelled_interval_time, "300");
 
+// arrow flight result sink buffer rows size, default 4096 * 8
 DEFINE_mInt32(arrow_flight_result_sink_buffer_size_rows, "32768");
+// The timeout for ADBC Client to wait for data using arrow flight reader.
+// If the query is very complex and no result is generated after this time, consider increasing this timeout.
+DEFINE_mInt32(arrow_flight_reader_brpc_controller_timeout_ms, "300000");
 
 // the increased frequency of priority for remaining tasks in BlockingPriorityQueue
 DEFINE_mInt32(priority_queue_remaining_tasks_increased_frequency, "512");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -104,6 +104,7 @@ DECLARE_Int32(arrow_flight_sql_port);
 // For ADBC client fetch result, default is empty, the ADBC client uses the backend ip to fetch the result.
 // If ADBC client cannot access the backend ip, can set public_access_ip to modify the fetch result ip.
 DECLARE_mString(public_access_ip);
+DECLARE_Int32(public_access_port);
 
 // the number of bthreads for brpc, the default value is set to -1,
 // which means the number of bthreads is #cpu-cores
@@ -571,6 +572,8 @@ DECLARE_Int32(brpc_light_work_pool_threads);
 DECLARE_Int32(brpc_heavy_work_pool_max_queue_size);
 DECLARE_Int32(brpc_light_work_pool_max_queue_size);
 DECLARE_mBool(enable_bthread_transmit_block);
+DECLARE_Int32(brpc_arrow_flight_work_pool_threads);
+DECLARE_Int32(brpc_arrow_flight_work_pool_max_queue_size);
 
 // The maximum amount of data that can be processed by a stream load
 DECLARE_mInt64(streaming_load_max_mb);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -680,6 +680,9 @@ DECLARE_mInt32(result_buffer_cancelled_interval_time);
 
 // arrow flight result sink buffer rows size, default 4096 * 8
 DECLARE_mInt32(arrow_flight_result_sink_buffer_size_rows);
+// The timeout for ADBC Client to wait for data using arrow flight reader.
+// If the query is very complex and no result is generated after this time, consider increasing this timeout.
+DECLARE_mInt32(arrow_flight_reader_brpc_controller_timeout_ms);
 
 // the increased frequency of priority for remaining tasks in BlockingPriorityQueue
 DECLARE_mInt32(priority_queue_remaining_tasks_increased_frequency);

--- a/be/src/pipeline/exec/memory_scratch_sink_operator.cpp
+++ b/be/src/pipeline/exec/memory_scratch_sink_operator.cpp
@@ -104,7 +104,7 @@ Status MemoryScratchSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
     {
         SCOPED_TIMER(local_state._get_arrow_schema_timer);
         // After expr executed, use recaculated schema as final schema
-        RETURN_IF_ERROR(get_arrow_schema(block, &block_arrow_schema, state->timezone()));
+        RETURN_IF_ERROR(get_arrow_schema_from_block(block, &block_arrow_schema, state->timezone()));
     }
     {
         SCOPED_TIMER(local_state._convert_block_to_arrow_batch_timer);

--- a/be/src/pipeline/exec/result_file_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_file_sink_operator.cpp
@@ -72,9 +72,8 @@ Status ResultFileSinkOperatorX::open(RuntimeState* state) {
     RETURN_IF_ERROR(DataSinkOperatorX<ResultFileSinkLocalState>::open(state));
     RETURN_IF_ERROR(vectorized::VExpr::prepare(_output_vexpr_ctxs, state, _row_desc));
     if (state->query_options().enable_parallel_outfile) {
-        RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
-                state->query_id(), _buf_size, &_sender, state->execution_timeout(),
-                state->batch_size()));
+        RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->query_id(), _buf_size,
+                                                                       &_sender, state));
     }
     return vectorized::VExpr::open(_output_vexpr_ctxs, state);
 }
@@ -92,8 +91,7 @@ Status ResultFileSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& i
         _sender = _parent->cast<ResultFileSinkOperatorX>()._sender;
     } else {
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
-                state->fragment_instance_id(), p._buf_size, &_sender, state->execution_timeout(),
-                state->batch_size()));
+                state->fragment_instance_id(), p._buf_size, &_sender, state));
     }
     _sender->set_dependency(state->fragment_instance_id(), _dependency->shared_from_this());
 

--- a/be/src/pipeline/exec/result_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_sink_operator.cpp
@@ -51,8 +51,7 @@ Status ResultSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info)
     } else {
         auto& p = _parent->cast<ResultSinkOperatorX>();
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
-                fragment_instance_id, p._result_sink_buffer_size_rows, &_sender,
-                state->execution_timeout(), state->batch_size()));
+                fragment_instance_id, p._result_sink_buffer_size_rows, &_sender, state));
     }
     _sender->set_dependency(fragment_instance_id, _dependency->shared_from_this());
     return Status::OK();
@@ -81,16 +80,11 @@ Status ResultSinkLocalState::open(RuntimeState* state) {
     }
     case TResultSinkType::ARROW_FLIGHT_PROTOCAL: {
         std::shared_ptr<arrow::Schema> arrow_schema;
-        RETURN_IF_ERROR(convert_expr_ctxs_arrow_schema(_output_vexpr_ctxs, &arrow_schema,
-                                                       state->timezone()));
-        if (state->query_options().enable_parallel_result_sink) {
-            state->exec_env()->result_mgr()->register_arrow_schema(state->query_id(), arrow_schema);
-        } else {
-            state->exec_env()->result_mgr()->register_arrow_schema(state->fragment_instance_id(),
-                                                                   arrow_schema);
-        }
+        RETURN_IF_ERROR(get_arrow_schema_from_expr_ctxs(_output_vexpr_ctxs, &arrow_schema,
+                                                        state->timezone()));
+        _sender->register_arrow_schema(arrow_schema);
         _writer.reset(new (std::nothrow) vectorized::VArrowFlightResultWriter(
-                _sender.get(), _output_vexpr_ctxs, _profile, arrow_schema));
+                _sender.get(), _output_vexpr_ctxs, _profile));
         break;
     }
     default:
@@ -135,8 +129,7 @@ Status ResultSinkOperatorX::open(RuntimeState* state) {
 
     if (state->query_options().enable_parallel_result_sink) {
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
-                state->query_id(), _result_sink_buffer_size_rows, &_sender,
-                state->execution_timeout(), state->batch_size()));
+                state->query_id(), _result_sink_buffer_size_rows, &_sender, state));
     }
     return vectorized::VExpr::open(_output_vexpr_ctxs, state);
 }

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -33,9 +33,11 @@
 #include "arrow/record_batch.h"
 #include "arrow/type_fwd.h"
 #include "pipeline/dependency.h"
-#include "runtime/exec_env.h"
 #include "runtime/thread_context.h"
+#include "util/runtime_profile.h"
+#include "util/string_util.h"
 #include "util/thrift_util.h"
+#include "vec/core/block.h"
 
 namespace doris {
 
@@ -93,14 +95,81 @@ void GetResultBatchCtx::on_data(const std::unique_ptr<TFetchDataResult>& t_resul
     delete this;
 }
 
-BufferControlBlock::BufferControlBlock(const TUniqueId& id, int buffer_size, int batch_size)
+void GetArrowResultBatchCtx::on_failure(const Status& status) {
+    DCHECK(!status.ok()) << "status is ok, errmsg=" << status;
+    status.to_protobuf(result->mutable_status());
+    delete this;
+}
+
+void GetArrowResultBatchCtx::on_close(int64_t packet_seq) {
+    Status status;
+    status.to_protobuf(result->mutable_status());
+    result->set_packet_seq(packet_seq);
+    result->set_eos(true);
+    delete this;
+}
+
+void GetArrowResultBatchCtx::on_data(
+        const std::shared_ptr<vectorized::Block>& block, int64_t packet_seq, int be_exec_version,
+        segment_v2::CompressionTypePB fragement_transmission_compression_type, std::string timezone,
+        std::string arrow_schema_field_names, RuntimeProfile::Counter* serialize_batch_ns_timer,
+        RuntimeProfile::Counter* uncompressed_bytes_counter,
+        RuntimeProfile::Counter* compressed_bytes_counter) {
+    Status st = Status::OK();
+    if (result != nullptr) {
+        size_t uncompressed_bytes = 0, compressed_bytes = 0;
+        SCOPED_TIMER(serialize_batch_ns_timer);
+        st = block->serialize(be_exec_version, result->mutable_block(), &uncompressed_bytes,
+                              &compressed_bytes, fragement_transmission_compression_type, false);
+        COUNTER_UPDATE(uncompressed_bytes_counter, uncompressed_bytes);
+        COUNTER_UPDATE(compressed_bytes_counter, compressed_bytes);
+        if (st.ok()) {
+            result->set_packet_seq(packet_seq);
+            result->set_eos(false);
+            if (packet_seq == 0) {
+                result->set_timezone(timezone);
+                result->set_fields_labels(arrow_schema_field_names);
+            }
+        } else {
+            result->clear_block();
+            result->set_packet_seq(packet_seq);
+            LOG(WARNING) << "TFetchDataResult serialize failed, errmsg=" << st;
+        }
+    } else {
+        result->set_empty_batch(true);
+        result->set_packet_seq(packet_seq);
+        result->set_eos(false);
+    }
+
+    /// The size limit of proto buffer message is 2G
+    if (result->ByteSizeLong() > std::numeric_limits<int32_t>::max()) {
+        st = Status::InternalError("Message size exceeds 2GB: {}", result->ByteSizeLong());
+        result->clear_block();
+    }
+    st.to_protobuf(result->mutable_status());
+    delete this;
+}
+
+BufferControlBlock::BufferControlBlock(const TUniqueId& id, int buffer_size, RuntimeState* state)
         : _fragment_id(id),
           _is_close(false),
           _is_cancelled(false),
           _buffer_limit(buffer_size),
           _packet_num(0),
-          _batch_size(batch_size) {
+          _batch_size(state->batch_size()),
+          _timezone(state->timezone()),
+          _timezone_obj(state->timezone_obj()),
+          _be_exec_version(state->be_exec_version()),
+          _fragement_transmission_compression_type(
+                  state->fragement_transmission_compression_type()),
+          _profile("BufferControlBlock " + print_id(_fragment_id)) {
     _query_statistics = std::make_unique<QueryStatistics>();
+    _serialize_batch_ns_timer = ADD_TIMER(&_profile, "SerializeBatchNsTime");
+    _uncompressed_bytes_counter = ADD_COUNTER(&_profile, "UncompressedBytes", TUnit::BYTES);
+    _compressed_bytes_counter = ADD_COUNTER(&_profile, "CompressedBytes", TUnit::BYTES);
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::QUERY,
+            fmt::format("BufferControlBlock#FragmentInstanceId={}", print_id(_fragment_id)));
 }
 
 BufferControlBlock::~BufferControlBlock() {
@@ -148,36 +217,45 @@ Status BufferControlBlock::add_batch(RuntimeState* state,
 }
 
 Status BufferControlBlock::add_arrow_batch(RuntimeState* state,
-                                           std::shared_ptr<arrow::RecordBatch>& result) {
+                                           std::shared_ptr<vectorized::Block>& result) {
     std::unique_lock<std::mutex> l(_lock);
 
     if (_is_cancelled) {
         return Status::Cancelled("Cancelled");
     }
 
-    int num_rows = result->num_rows();
+    if (_waiting_arrow_result_batch_rpc.empty()) {
+        // TODO: Merge result into block to reduce rpc times
+        int num_rows = result->rows();
+        _arrow_flight_result_batch_queue.push_back(std::move(result));
+        _instance_rows_in_queue.emplace_back();
+        _instance_rows[state->fragment_instance_id()] += num_rows;
+        _instance_rows_in_queue.back()[state->fragment_instance_id()] += num_rows;
+        _arrow_data_arrival
+                .notify_one(); // Only valid for get_arrow_batch(std::shared_ptr<vectorized::Block>,)
+    } else {
+        auto* ctx = _waiting_arrow_result_batch_rpc.front();
+        _waiting_arrow_result_batch_rpc.pop_front();
+        ctx->on_data(result, _packet_num, _be_exec_version,
+                     _fragement_transmission_compression_type, _timezone, _arrow_schema_field_names,
+                     _serialize_batch_ns_timer, _uncompressed_bytes_counter,
+                     _compressed_bytes_counter);
+        _packet_num++;
+    }
 
-    // TODO: merge RocordBatch, ToStructArray -> Make again
-
-    _arrow_flight_batch_queue.push_back(std::move(result));
-    _instance_rows_in_queue.emplace_back();
-    _instance_rows[state->fragment_instance_id()] += num_rows;
-    _instance_rows_in_queue.back()[state->fragment_instance_id()] += num_rows;
-    _arrow_data_arrival.notify_one();
     _update_dependency();
     return Status::OK();
 }
 
 void BufferControlBlock::get_batch(GetResultBatchCtx* ctx) {
     std::lock_guard<std::mutex> l(_lock);
+    Defer defer {[&]() { _update_dependency(); }};
     if (!_status.ok()) {
         ctx->on_failure(_status);
-        _update_dependency();
         return;
     }
     if (_is_cancelled) {
         ctx->on_failure(Status::Cancelled("Cancelled"));
-        _update_dependency();
         return;
     }
     if (!_fe_result_batch_queue.empty()) {
@@ -191,21 +269,20 @@ void BufferControlBlock::get_batch(GetResultBatchCtx* ctx) {
 
         ctx->on_data(result, _packet_num);
         _packet_num++;
-        _update_dependency();
         return;
     }
     if (_is_close) {
         ctx->on_close(_packet_num, _query_statistics.get());
-        _update_dependency();
         return;
     }
     // no ready data, push ctx to waiting list
     _waiting_rpc.push_back(ctx);
-    _update_dependency();
 }
 
-Status BufferControlBlock::get_arrow_batch(std::shared_ptr<arrow::RecordBatch>* result) {
+Status BufferControlBlock::get_arrow_batch(std::shared_ptr<vectorized::Block>* result,
+                                           cctz::time_zone& timezone_obj) {
     std::unique_lock<std::mutex> l(_lock);
+    Defer defer {[&]() { _update_dependency(); }};
     if (!_status.ok()) {
         return _status;
     }
@@ -213,32 +290,88 @@ Status BufferControlBlock::get_arrow_batch(std::shared_ptr<arrow::RecordBatch>* 
         return Status::Cancelled("Cancelled");
     }
 
-    while (_arrow_flight_batch_queue.empty() && !_is_cancelled && !_is_close) {
-        _arrow_data_arrival.wait_for(l, std::chrono::seconds(1));
+    while (_arrow_flight_result_batch_queue.empty() && !_is_cancelled && !_is_close) {
+        _arrow_data_arrival.wait_for(l, std::chrono::milliseconds(20));
     }
 
     if (_is_cancelled) {
         return Status::Cancelled("Cancelled");
     }
 
-    if (!_arrow_flight_batch_queue.empty()) {
-        *result = std::move(_arrow_flight_batch_queue.front());
-        _arrow_flight_batch_queue.pop_front();
+    if (!_arrow_flight_result_batch_queue.empty()) {
+        *result = std::move(_arrow_flight_result_batch_queue.front());
+        _arrow_flight_result_batch_queue.pop_front();
+        timezone_obj = _timezone_obj;
+
         for (auto it : _instance_rows_in_queue.front()) {
             _instance_rows[it.first] -= it.second;
         }
         _instance_rows_in_queue.pop_front();
         _packet_num++;
-        _update_dependency();
         return Status::OK();
     }
 
     // normal path end
     if (_is_close) {
-        _update_dependency();
+        std::stringstream ss;
+        _profile.pretty_print(&ss);
+        VLOG_NOTICE << fmt::format(
+                "BufferControlBlock finished, fragment_id={}, is_close={}, is_cancelled={}, "
+                "packet_num={}, peak_memory_usage={}, profile={}",
+                print_id(_fragment_id), _is_close, _is_cancelled, _packet_num,
+                _mem_tracker->peak_consumption(), ss.str());
         return Status::OK();
     }
     return Status::InternalError("Get Arrow Batch Abnormal Ending");
+}
+
+void BufferControlBlock::get_arrow_batch(GetArrowResultBatchCtx* ctx) {
+    std::unique_lock<std::mutex> l(_lock);
+    SCOPED_ATTACH_TASK(_mem_tracker);
+    Defer defer {[&]() { _update_dependency(); }};
+    if (!_status.ok()) {
+        ctx->on_failure(_status);
+        return;
+    }
+    if (_is_cancelled) {
+        ctx->on_failure(Status::Cancelled("Cancelled"));
+        return;
+    }
+
+    if (!_arrow_flight_result_batch_queue.empty()) {
+        auto block = _arrow_flight_result_batch_queue.front();
+        _arrow_flight_result_batch_queue.pop_front();
+        for (auto it : _instance_rows_in_queue.front()) {
+            _instance_rows[it.first] -= it.second;
+        }
+        _instance_rows_in_queue.pop_front();
+
+        ctx->on_data(block, _packet_num, _be_exec_version, _fragement_transmission_compression_type,
+                     _timezone, _arrow_schema_field_names, _serialize_batch_ns_timer,
+                     _uncompressed_bytes_counter, _compressed_bytes_counter);
+        _packet_num++;
+        return;
+    }
+
+    // normal path end
+    if (_is_close) {
+        ctx->on_close(_packet_num);
+        std::stringstream ss;
+        _profile.pretty_print(&ss);
+        VLOG_NOTICE << fmt::format(
+                "BufferControlBlock finished, fragment_id={}, is_close={}, is_cancelled={}, "
+                "packet_num={}, peak_memory_usage={}, profile={}",
+                print_id(_fragment_id), _is_close, _is_cancelled, _packet_num,
+                _mem_tracker->peak_consumption(), ss.str());
+        return;
+    }
+    // no ready data, push ctx to waiting list
+    _waiting_arrow_result_batch_rpc.push_back(ctx);
+}
+
+void BufferControlBlock::register_arrow_schema(const std::shared_ptr<arrow::Schema>& arrow_schema) {
+    _arrow_schema = arrow_schema;
+    _arrow_schema_field_names = join(_arrow_schema->field_names(), ",");
 }
 
 Status BufferControlBlock::close(const TUniqueId& id, Status exec_status) {

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -90,8 +90,7 @@ struct GetArrowResultBatchCtx {
     void on_data(const std::shared_ptr<vectorized::Block>& block, int64_t packet_seq,
                  int be_exec_version,
                  segment_v2::CompressionTypePB fragement_transmission_compression_type,
-                 std::string timezone, std::string arrow_schema_field_names,
-                 RuntimeProfile::Counter* serialize_batch_ns_timer,
+                 std::string timezone, RuntimeProfile::Counter* serialize_batch_ns_timer,
                  RuntimeProfile::Counter* uncompressed_bytes_counter,
                  RuntimeProfile::Counter* compressed_bytes_counter);
 };
@@ -114,7 +113,7 @@ public:
     void get_arrow_batch(GetArrowResultBatchCtx* ctx);
 
     void register_arrow_schema(const std::shared_ptr<arrow::Schema>& arrow_schema);
-    std::shared_ptr<arrow::Schema> find_arrow_schema() { return _arrow_schema; }
+    Status find_arrow_schema(std::shared_ptr<arrow::Schema>* arrow_schema);
 
     // close buffer block, set _status to exec_status and set _is_close to true;
     // called because data has been read or error happened.
@@ -156,7 +155,6 @@ protected:
     ArrowFlightResultQueue _arrow_flight_result_batch_queue;
     // for arrow flight
     std::shared_ptr<arrow::Schema> _arrow_schema;
-    std::string _arrow_schema_field_names;
 
     // protects all subsequent data in this block
     std::mutex _lock;

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <arrow/type.h>
+#include <cctz/time_zone.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/Types_types.h>
 #include <stdint.h>
@@ -52,7 +54,12 @@ namespace pipeline {
 class Dependency;
 } // namespace pipeline
 
+namespace vectorized {
+class Block;
+} // namespace vectorized
+
 class PFetchDataResult;
+class PFetchArrowDataResult;
 
 struct GetResultBatchCtx {
     brpc::Controller* cntl = nullptr;
@@ -69,18 +76,45 @@ struct GetResultBatchCtx {
                  bool eos = false);
 };
 
+struct GetArrowResultBatchCtx {
+    brpc::Controller* cntl = nullptr;
+    PFetchArrowDataResult* result = nullptr;
+    google::protobuf::Closure* done = nullptr;
+
+    GetArrowResultBatchCtx(brpc::Controller* cntl_, PFetchArrowDataResult* result_,
+                           google::protobuf::Closure* done_)
+            : cntl(cntl_), result(result_), done(done_) {}
+
+    void on_failure(const Status& status);
+    void on_close(int64_t packet_seq);
+    void on_data(const std::shared_ptr<vectorized::Block>& block, int64_t packet_seq,
+                 int be_exec_version,
+                 segment_v2::CompressionTypePB fragement_transmission_compression_type,
+                 std::string timezone, std::string arrow_schema_field_names,
+                 RuntimeProfile::Counter* serialize_batch_ns_timer,
+                 RuntimeProfile::Counter* uncompressed_bytes_counter,
+                 RuntimeProfile::Counter* compressed_bytes_counter);
+};
+
 // buffer used for result customer and producer
 class BufferControlBlock {
 public:
-    BufferControlBlock(const TUniqueId& id, int buffer_size, int batch_size);
+    BufferControlBlock(const TUniqueId& id, int buffer_size, RuntimeState* state);
     ~BufferControlBlock();
 
     Status init();
     Status add_batch(RuntimeState* state, std::unique_ptr<TFetchDataResult>& result);
-    Status add_arrow_batch(RuntimeState* state, std::shared_ptr<arrow::RecordBatch>& result);
+    Status add_arrow_batch(RuntimeState* state, std::shared_ptr<vectorized::Block>& result);
 
     void get_batch(GetResultBatchCtx* ctx);
-    Status get_arrow_batch(std::shared_ptr<arrow::RecordBatch>* result);
+    // for ArrowFlightBatchLocalReader
+    Status get_arrow_batch(std::shared_ptr<vectorized::Block>* result,
+                           cctz::time_zone& timezone_obj);
+    // for ArrowFlightBatchRemoteReader
+    void get_arrow_batch(GetArrowResultBatchCtx* ctx);
+
+    void register_arrow_schema(const std::shared_ptr<arrow::Schema>& arrow_schema);
+    std::shared_ptr<arrow::Schema> find_arrow_schema() { return _arrow_schema; }
 
     // close buffer block, set _status to exec_status and set _is_close to true;
     // called because data has been read or error happened.
@@ -89,6 +123,7 @@ public:
     void cancel(const Status& reason);
 
     [[nodiscard]] const TUniqueId& fragment_id() const { return _fragment_id; }
+    [[nodiscard]] std::shared_ptr<MemTrackerLimiter> mem_tracker() { return _mem_tracker; }
 
     void update_return_rows(int64_t num_rows) {
         // _query_statistics may be null when the result sink init failed
@@ -106,7 +141,7 @@ protected:
     void _update_dependency();
 
     using FeResultQueue = std::list<std::unique_ptr<TFetchDataResult>>;
-    using ArrowFlightResultQueue = std::list<std::shared_ptr<arrow::RecordBatch>>;
+    using ArrowFlightResultQueue = std::list<std::shared_ptr<vectorized::Block>>;
 
     // result's query id
     TUniqueId _fragment_id;
@@ -118,7 +153,10 @@ protected:
 
     // blocking queue for batch
     FeResultQueue _fe_result_batch_queue;
-    ArrowFlightResultQueue _arrow_flight_batch_queue;
+    ArrowFlightResultQueue _arrow_flight_result_batch_queue;
+    // for arrow flight
+    std::shared_ptr<arrow::Schema> _arrow_schema;
+    std::string _arrow_schema_field_names;
 
     // protects all subsequent data in this block
     std::mutex _lock;
@@ -128,6 +166,7 @@ protected:
     std::condition_variable _arrow_data_arrival;
 
     std::deque<GetResultBatchCtx*> _waiting_rpc;
+    std::deque<GetArrowResultBatchCtx*> _waiting_arrow_result_batch_rpc;
 
     // only used for FE using return rows to check limit
     std::unique_ptr<QueryStatistics> _query_statistics;
@@ -137,6 +176,17 @@ protected:
     std::list<std::unordered_map<TUniqueId, size_t>> _instance_rows_in_queue;
 
     int _batch_size;
+    std::string _timezone;
+    cctz::time_zone _timezone_obj;
+    int _be_exec_version;
+    segment_v2::CompressionTypePB _fragement_transmission_compression_type;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
+
+    // only used for ArrowFlightBatchRemoteReader
+    RuntimeProfile _profile;
+    RuntimeProfile::Counter* _serialize_batch_ns_timer = nullptr;
+    RuntimeProfile::Counter* _uncompressed_bytes_counter = nullptr;
+    RuntimeProfile::Counter* _compressed_bytes_counter = nullptr;
 };
 
 } // namespace doris

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -114,8 +114,7 @@ Status ResultBufferMgr::find_arrow_schema(const TUniqueId& finst_id,
                 "no arrow schema for this query, maybe query has been canceled, finst_id={}",
                 print_id(finst_id));
     }
-    *schema = cb->find_arrow_schema();
-    return Status::OK();
+    return cb->find_arrow_schema(schema);
 }
 
 void ResultBufferMgr::fetch_data(const PUniqueId& finst_id, GetResultBatchCtx* ctx) {

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -68,8 +68,8 @@ Status ResultBufferMgr::init() {
 }
 
 Status ResultBufferMgr::create_sender(const TUniqueId& query_id, int buffer_size,
-                                      std::shared_ptr<BufferControlBlock>* sender, int exec_timout,
-                                      int batch_size) {
+                                      std::shared_ptr<BufferControlBlock>* sender,
+                                      RuntimeState* state) {
     *sender = find_control_block(query_id);
     if (*sender != nullptr) {
         LOG(WARNING) << "already have buffer control block for this instance " << query_id;
@@ -78,7 +78,7 @@ Status ResultBufferMgr::create_sender(const TUniqueId& query_id, int buffer_size
 
     std::shared_ptr<BufferControlBlock> control_block = nullptr;
 
-    control_block = std::make_shared<BufferControlBlock>(query_id, buffer_size, batch_size);
+    control_block = std::make_shared<BufferControlBlock>(query_id, buffer_size, state);
 
     {
         std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
@@ -88,7 +88,7 @@ Status ResultBufferMgr::create_sender(const TUniqueId& query_id, int buffer_size
         // otherwise in some case may block all fragment handle threads
         // details see issue https://github.com/apache/doris/issues/16203
         // add extra 5s for avoid corner case
-        int64_t max_timeout = time(nullptr) + exec_timout + 5;
+        int64_t max_timeout = time(nullptr) + state->execution_timeout() + 5;
         cancel_at_time(max_timeout, query_id);
     }
     *sender = control_block;
@@ -106,27 +106,20 @@ std::shared_ptr<BufferControlBlock> ResultBufferMgr::find_control_block(const TU
     return {};
 }
 
-void ResultBufferMgr::register_arrow_schema(const TUniqueId& query_id,
-                                            const std::shared_ptr<arrow::Schema>& arrow_schema) {
-    std::unique_lock<std::shared_mutex> wlock(_arrow_schema_map_lock);
-    _arrow_schema_map.insert(std::make_pair(query_id, arrow_schema));
-}
-
-std::shared_ptr<arrow::Schema> ResultBufferMgr::find_arrow_schema(const TUniqueId& query_id) {
-    std::shared_lock<std::shared_mutex> rlock(_arrow_schema_map_lock);
-    auto iter = _arrow_schema_map.find(query_id);
-
-    if (_arrow_schema_map.end() != iter) {
-        return iter->second;
+Status ResultBufferMgr::find_arrow_schema(const TUniqueId& finst_id,
+                                          std::shared_ptr<arrow::Schema>* schema) {
+    std::shared_ptr<BufferControlBlock> cb = find_control_block(finst_id);
+    if (cb == nullptr) {
+        return Status::InternalError(
+                "no arrow schema for this query, maybe query has been canceled, finst_id={}",
+                print_id(finst_id));
     }
-
-    return nullptr;
+    *schema = cb->find_arrow_schema();
+    return Status::OK();
 }
 
 void ResultBufferMgr::fetch_data(const PUniqueId& finst_id, GetResultBatchCtx* ctx) {
-    TUniqueId tid;
-    tid.__set_hi(finst_id.hi());
-    tid.__set_lo(finst_id.lo());
+    TUniqueId tid = UniqueId(finst_id).to_thrift();
     std::shared_ptr<BufferControlBlock> cb = find_control_block(tid);
     if (cb == nullptr) {
         ctx->on_failure(Status::InternalError("no result for this query, tid={}", print_id(tid)));
@@ -135,14 +128,41 @@ void ResultBufferMgr::fetch_data(const PUniqueId& finst_id, GetResultBatchCtx* c
     cb->get_batch(ctx);
 }
 
-Status ResultBufferMgr::fetch_arrow_data(const TUniqueId& finst_id,
-                                         std::shared_ptr<arrow::RecordBatch>* result) {
+Status ResultBufferMgr::find_mem_tracker(const TUniqueId& finst_id,
+                                         std::shared_ptr<MemTrackerLimiter>* mem_tracker) {
     std::shared_ptr<BufferControlBlock> cb = find_control_block(finst_id);
     if (cb == nullptr) {
-        return Status::InternalError("no result for this query, finst_id={}", print_id(finst_id));
+        return Status::InternalError(
+                "no result for this query, maybe query has been canceled, finst_id={}",
+                print_id(finst_id));
     }
-    RETURN_IF_ERROR(cb->get_arrow_batch(result));
+    *mem_tracker = cb->mem_tracker();
     return Status::OK();
+}
+
+Status ResultBufferMgr::fetch_arrow_data(const TUniqueId& finst_id,
+                                         std::shared_ptr<vectorized::Block>* result,
+                                         cctz::time_zone& timezone_obj) {
+    std::shared_ptr<BufferControlBlock> cb = find_control_block(finst_id);
+    if (cb == nullptr) {
+        return Status::InternalError(
+                "no result for this query, maybe query has been canceled, finst_id={}",
+                print_id(finst_id));
+    }
+    RETURN_IF_ERROR(cb->get_arrow_batch(result, timezone_obj));
+    return Status::OK();
+}
+
+void ResultBufferMgr::fetch_arrow_data(const PUniqueId& finst_id, GetArrowResultBatchCtx* ctx) {
+    TUniqueId tid = UniqueId(finst_id).to_thrift();
+    std::shared_ptr<BufferControlBlock> cb = find_control_block(tid);
+    if (cb == nullptr) {
+        ctx->on_failure(Status::InternalError(
+                "no result for this query, maybe query has been canceled, finst_id={}",
+                print_id(tid)));
+        return;
+    }
+    cb->get_arrow_batch(ctx);
 }
 
 void ResultBufferMgr::cancel(const TUniqueId& query_id, const Status& reason) {
@@ -153,15 +173,6 @@ void ResultBufferMgr::cancel(const TUniqueId& query_id, const Status& reason) {
         if (_buffer_map.end() != iter) {
             iter->second->cancel(reason);
             _buffer_map.erase(iter);
-        }
-    }
-
-    {
-        std::unique_lock<std::shared_mutex> wlock(_arrow_schema_map_lock);
-        auto arrow_schema_iter = _arrow_schema_map.find(query_id);
-
-        if (_arrow_schema_map.end() != arrow_schema_iter) {
-            _arrow_schema_map.erase(arrow_schema_iter);
         }
     }
 }

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <cctz/time_zone.h>
 #include <gen_cpp/Types_types.h>
+#include <gen_cpp/segment_v2.pb.h>
 
 #include <ctime>
 #include <map>
@@ -41,8 +43,14 @@ namespace doris {
 
 class BufferControlBlock;
 struct GetResultBatchCtx;
+struct GetArrowResultBatchCtx;
 class PUniqueId;
+class RuntimeState;
+class MemTrackerLimiter;
 class Thread;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 // manage all result buffer control block in one backend
 class ResultBufferMgr {
@@ -58,17 +66,18 @@ public:
     // the returned sender do not need release
     // sender is not used when call cancel or unregister
     Status create_sender(const TUniqueId& query_id, int buffer_size,
-                         std::shared_ptr<BufferControlBlock>* sender, int exec_timeout,
-                         int batch_size);
+                         std::shared_ptr<BufferControlBlock>* sender, RuntimeState* state);
 
     // fetch data result to FE
     void fetch_data(const PUniqueId& finst_id, GetResultBatchCtx* ctx);
-    // fetch data result to Arrow Flight Server
-    Status fetch_arrow_data(const TUniqueId& finst_id, std::shared_ptr<arrow::RecordBatch>* result);
-
-    void register_arrow_schema(const TUniqueId& query_id,
-                               const std::shared_ptr<arrow::Schema>& arrow_schema);
-    std::shared_ptr<arrow::Schema> find_arrow_schema(const TUniqueId& query_id);
+    // fetch data result to Arrow Flight Client
+    Status fetch_arrow_data(const TUniqueId& finst_id, std::shared_ptr<vectorized::Block>* result,
+                            cctz::time_zone& timezone_obj);
+    // fetch data result to Other BE forwards to Client
+    void fetch_arrow_data(const PUniqueId& finst_id, GetArrowResultBatchCtx* ctx);
+    Status find_mem_tracker(const TUniqueId& finst_id,
+                            std::shared_ptr<MemTrackerLimiter>* mem_tracker);
+    Status find_arrow_schema(const TUniqueId& query_id, std::shared_ptr<arrow::Schema>* schema);
 
     // cancel
     void cancel(const TUniqueId& query_id, const Status& reason);
@@ -79,7 +88,6 @@ public:
 private:
     using BufferMap = std::unordered_map<TUniqueId, std::shared_ptr<BufferControlBlock>>;
     using TimeoutMap = std::map<time_t, std::vector<TUniqueId>>;
-    using ArrowSchemaMap = std::unordered_map<TUniqueId, std::shared_ptr<arrow::Schema>>;
 
     std::shared_ptr<BufferControlBlock> find_control_block(const TUniqueId& query_id);
 
@@ -91,10 +99,6 @@ private:
     std::shared_mutex _buffer_map_lock;
     // buffer block map
     BufferMap _buffer_map;
-    // lock for arrow schema map
-    std::shared_mutex _arrow_schema_map_lock;
-    // for arrow flight
-    ArrowSchemaMap _arrow_schema_map;
 
     // lock for timeout map
     std::mutex _timeout_lock;

--- a/be/src/service/arrow_flight/arrow_flight_batch_reader.cpp
+++ b/be/src/service/arrow_flight/arrow_flight_batch_reader.cpp
@@ -18,52 +18,276 @@
 #include "service/arrow_flight/arrow_flight_batch_reader.h"
 
 #include <arrow/status.h>
+#include <arrow/type.h>
+#include <gen_cpp/internal_service.pb.h>
 
-#include "arrow/builder.h"
+#include <utility>
+
 #include "runtime/exec_env.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/result_buffer_mgr.h"
+#include "runtime/thread_context.h"
+#include "service/backend_options.h"
+#include "util/arrow/block_convertor.h"
 #include "util/arrow/row_batch.h"
 #include "util/arrow/utils.h"
+#include "util/brpc_client_cache.h"
+#include "util/ref_count_closure.h"
+#include "util/string_util.h"
+#include "vec/core/block.h"
 
-namespace doris {
-namespace flight {
+namespace doris::flight {
 
-std::shared_ptr<arrow::Schema> ArrowFlightBatchReader::schema() const {
-    return schema_;
+constexpr size_t BRPC_CONTROLLER_TIMEOUT_MS = 60 * 1000;
+
+ArrowFlightBatchReaderBase::ArrowFlightBatchReaderBase(
+        const std::shared_ptr<QueryStatement>& statement)
+        : _statement(statement) {}
+
+std::shared_ptr<arrow::Schema> ArrowFlightBatchReaderBase::schema() const {
+    return _schema;
 }
 
-ArrowFlightBatchReader::ArrowFlightBatchReader(std::shared_ptr<QueryStatement> statement,
-                                               std::shared_ptr<arrow::Schema> schema)
-        : statement_(std::move(statement)), schema_(std::move(schema)) {}
+arrow::Status ArrowFlightBatchReaderBase::_return_invalid_status(const std::string& msg) {
+    std::string status_msg =
+            fmt::format("ArrowFlightBatchReader {}, packet_seq={}, result={}:{}, finistId={}", msg,
+                        _packet_seq, _statement->result_addr.hostname, _statement->result_addr.port,
+                        print_id(_statement->query_id));
+    LOG(WARNING) << status_msg;
+    return arrow::Status::Invalid(status_msg);
+}
 
-arrow::Result<std::shared_ptr<ArrowFlightBatchReader>> ArrowFlightBatchReader::Create(
-        const std::shared_ptr<QueryStatement>& statement_) {
+ArrowFlightBatchReaderBase::~ArrowFlightBatchReaderBase() {
+    VLOG_NOTICE << fmt::format(
+            "ArrowFlightBatchReader finished, packet_seq={}, result_addr={}:{}, finistId={}, "
+            "convert_arrow_batch_timer={}, deserialize_block_timer={}, peak_memory_usage={}",
+            _packet_seq, _statement->result_addr.hostname, _statement->result_addr.port,
+            print_id(_statement->query_id), _convert_arrow_batch_timer, _deserialize_block_timer,
+            _mem_tracker->peak_consumption());
+}
+
+ArrowFlightBatchLocalReader::ArrowFlightBatchLocalReader(
+        const std::shared_ptr<QueryStatement>& statement,
+        const std::shared_ptr<arrow::Schema>& schema,
+        const std::shared_ptr<MemTrackerLimiter>& mem_tracker)
+        : ArrowFlightBatchReaderBase(statement) {
+    _schema = schema;
+    _mem_tracker = mem_tracker;
+}
+
+arrow::Result<std::shared_ptr<ArrowFlightBatchLocalReader>> ArrowFlightBatchLocalReader::Create(
+        const std::shared_ptr<QueryStatement>& statement) {
+    DCHECK(statement->result_addr.hostname == BackendOptions::get_localhost());
     // Make sure that FE send the fragment to BE and creates the BufferControlBlock before returning ticket
     // to the ADBC client, so that the schema and control block can be found.
-    auto schema = ExecEnv::GetInstance()->result_mgr()->find_arrow_schema(statement_->query_id);
-    if (schema == nullptr) {
-        ARROW_RETURN_NOT_OK(arrow::Status::Invalid(fmt::format(
-                "Client not found arrow flight schema, maybe query has been canceled, queryid: {}",
-                print_id(statement_->query_id))));
-    }
-    std::shared_ptr<ArrowFlightBatchReader> result(new ArrowFlightBatchReader(statement_, schema));
+    std::shared_ptr<arrow::Schema> schema;
+    RETURN_ARROW_STATUS_IF_ERROR(
+            ExecEnv::GetInstance()->result_mgr()->find_arrow_schema(statement->query_id, &schema));
+    std::shared_ptr<MemTrackerLimiter> mem_tracker;
+    RETURN_ARROW_STATUS_IF_ERROR(ExecEnv::GetInstance()->result_mgr()->find_mem_tracker(
+            statement->query_id, &mem_tracker));
+
+    std::shared_ptr<ArrowFlightBatchLocalReader> result(
+            new ArrowFlightBatchLocalReader(statement, schema, mem_tracker));
     return result;
 }
 
-arrow::Status ArrowFlightBatchReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
-    // *out not nullptr
+arrow::Status ArrowFlightBatchLocalReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
+    // parameter *out not nullptr
     *out = nullptr;
-    auto st = ExecEnv::GetInstance()->result_mgr()->fetch_arrow_data(statement_->query_id, out);
-    if (UNLIKELY(!st.ok())) {
-        LOG(WARNING) << "ArrowFlightBatchReader fetch arrow data failed: " + st.to_string();
+    SCOPED_ATTACH_TASK(_mem_tracker);
+    std::shared_ptr<vectorized::Block> result;
+    auto st = ExecEnv::GetInstance()->result_mgr()->fetch_arrow_data(_statement->query_id, &result,
+                                                                     _timezone_obj);
+    st.prepend("ArrowFlightBatchLocalReader fetch arrow data failed");
+    ARROW_RETURN_NOT_OK(to_arrow_status(st));
+    if (result == nullptr) {
+        // eof, normal path end
+        return arrow::Status::OK();
+    }
+
+    {
+        // convert one batch
+        SCOPED_ATOMIC_TIMER(&_convert_arrow_batch_timer);
+        st = convert_to_arrow_batch(*result, _schema, arrow::default_memory_pool(), out,
+                                    _timezone_obj);
+        st.prepend("ArrowFlightBatchLocalReader convert block to arrow batch failed");
         ARROW_RETURN_NOT_OK(to_arrow_status(st));
     }
+
+    _packet_seq++;
     if (*out != nullptr) {
-        VLOG_NOTICE << "ArrowFlightBatchReader read next: " << (*out)->num_rows() << ", "
-                    << (*out)->num_columns();
+        VLOG_NOTICE << "ArrowFlightBatchLocalReader read next: " << (*out)->num_rows() << ", "
+                    << (*out)->num_columns() << ", packet_seq: " << _packet_seq;
     }
     return arrow::Status::OK();
 }
 
-} // namespace flight
-} // namespace doris
+ArrowFlightBatchRemoteReader::ArrowFlightBatchRemoteReader(
+        const std::shared_ptr<QueryStatement>& statement,
+        const std::shared_ptr<PBackendService_Stub>& stub)
+        : ArrowFlightBatchReaderBase(statement), _brpc_stub(stub), _block(nullptr) {
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::QUERY,
+            fmt::format("ArrowFlightBatchRemoteReader#QueryId={}", print_id(_statement->query_id)));
+}
+
+arrow::Result<std::shared_ptr<ArrowFlightBatchRemoteReader>> ArrowFlightBatchRemoteReader::Create(
+        const std::shared_ptr<QueryStatement>& statement) {
+    std::shared_ptr<PBackendService_Stub> stub =
+            ExecEnv::GetInstance()->brpc_internal_client_cache()->get_client(
+                    statement->result_addr);
+    if (!stub) {
+        std::string msg = fmt::format(
+                "ArrowFlightBatchRemoteReader get rpc stub failed, result_addr={}:{}, finistId={}",
+                statement->result_addr.hostname, statement->result_addr.port,
+                print_id(statement->query_id));
+        LOG(WARNING) << msg;
+        return arrow::Status::Invalid(msg);
+    }
+
+    std::shared_ptr<ArrowFlightBatchRemoteReader> result(
+            new ArrowFlightBatchRemoteReader(statement, stub));
+    ARROW_RETURN_NOT_OK(result->init_schema());
+    return result;
+}
+
+arrow::Status ArrowFlightBatchRemoteReader::_fetch_data(bool first_fetch_for_init) {
+    DCHECK(_block == nullptr);
+    while (true) {
+        // if `continue` occurs, data is invalid, continue fetch, block is nullptr.
+        // if `break` occurs, fetch data successfully (block is not nullptr) or fetch eos.
+        Status st;
+        auto request = std::make_shared<PFetchArrowDataRequest>();
+        auto* pfinst_id = request->mutable_finst_id();
+        pfinst_id->set_hi(_statement->query_id.hi);
+        pfinst_id->set_lo(_statement->query_id.lo);
+        auto callback = DummyBrpcCallback<PFetchArrowDataResult>::create_shared();
+        auto closure = AutoReleaseClosure<
+                PFetchArrowDataRequest,
+                DummyBrpcCallback<PFetchArrowDataResult>>::create_unique(request, callback);
+        callback->cntl_->set_timeout_ms(BRPC_CONTROLLER_TIMEOUT_MS);
+        callback->cntl_->ignore_eovercrowded();
+
+        _brpc_stub->fetch_arrow_data(closure->cntl_.get(), closure->request_.get(),
+                                     closure->response_.get(), closure.get());
+        closure.release();
+        callback->join();
+
+        if (callback->cntl_->Failed()) {
+            if (!ExecEnv::GetInstance()->brpc_internal_client_cache()->available(
+                        _brpc_stub, _statement->result_addr.hostname,
+                        _statement->result_addr.port)) {
+                ExecEnv::GetInstance()->brpc_internal_client_cache()->erase(
+                        callback->cntl_->remote_side());
+            }
+            auto error_code = callback->cntl_->ErrorCode();
+            auto error_text = callback->cntl_->ErrorText();
+            return _return_invalid_status(
+                    fmt::format("error={}, error_text={}", berror(error_code), error_text));
+        }
+        st = Status::create(callback->response_->status());
+        ARROW_RETURN_NOT_OK(to_arrow_status(st));
+
+        DCHECK(callback->response_->has_packet_seq());
+        if (_packet_seq != callback->response_->packet_seq()) {
+            return _return_invalid_status(
+                    fmt::format("receive packet failed, expect={}, receive={}", _packet_seq,
+                                callback->response_->packet_seq()));
+        }
+        _packet_seq++;
+
+        if (callback->response_->has_eos() && callback->response_->eos()) {
+            if (!first_fetch_for_init) {
+                break;
+            } else {
+                return _return_invalid_status(fmt::format("received unexpected eos, packet_seq={}",
+                                                          callback->response_->packet_seq()));
+            }
+        }
+
+        if (callback->response_->has_empty_batch() && callback->response_->empty_batch()) {
+            continue;
+        }
+
+        DCHECK(callback->response_->has_block());
+        if (callback->response_->block().ByteSizeLong() == 0) {
+            continue;
+        }
+
+        if (first_fetch_for_init) {
+            DCHECK(callback->response_->has_timezone());
+            DCHECK(callback->response_->has_fields_labels());
+            _timezone = callback->response_->timezone();
+            TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj);
+            _arrow_schema_field_names = callback->response_->fields_labels();
+        }
+
+        {
+            SCOPED_ATOMIC_TIMER(&_deserialize_block_timer);
+            _block = vectorized::Block::create_shared();
+            st = _block->deserialize(callback->response_->block());
+            ARROW_RETURN_NOT_OK(to_arrow_status(st));
+            break;
+        }
+
+        if (!first_fetch_for_init) {
+            const auto rows = _block->rows();
+            if (rows == 0) {
+                _block = nullptr;
+                continue;
+            }
+        }
+    }
+    return arrow::Status::OK();
+}
+
+arrow::Status ArrowFlightBatchRemoteReader::init_schema() {
+    SCOPED_ATTACH_TASK(_mem_tracker);
+    ARROW_RETURN_NOT_OK(_fetch_data(true));
+    if (_block == nullptr) {
+        return _return_invalid_status("failed to fetch data for schema");
+    }
+    RETURN_ARROW_STATUS_IF_ERROR(get_arrow_schema_from_block(*_block, &_schema, _timezone));
+
+    // Block does not contain the real column name (label), for example: select avg(k) from tbl
+    //  - Block.name: type=decimal(38, 9)
+    //  - Real column name (label): avg(k)
+    // so, the first fetch data Block will return the actual column name, and then modify the schema.
+    std::vector<std::string> arrow_schema_field_names = split(_arrow_schema_field_names, ",");
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (int i = 0; i < arrow_schema_field_names.size(); i++) {
+        fields.push_back(_schema->fields()[i]->WithName(arrow_schema_field_names[i]));
+    }
+    _schema = arrow::schema(std::move(fields));
+    return arrow::Status::OK();
+}
+
+arrow::Status ArrowFlightBatchRemoteReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
+    // parameter *out not nullptr
+    *out = nullptr;
+    if (_block == nullptr) {
+        // eof, normal path end
+        // last ReadNext -> _fetch_data return block is nullptr
+        return arrow::Status::OK();
+    }
+    SCOPED_ATTACH_TASK(_mem_tracker);
+    {
+        // convert one batch
+        SCOPED_ATOMIC_TIMER(&_convert_arrow_batch_timer);
+        auto st = convert_to_arrow_batch(*_block, _schema, arrow::default_memory_pool(), out,
+                                         _timezone_obj);
+        st.prepend("ArrowFlightBatchRemoteReader convert block to arrow batch failed");
+        ARROW_RETURN_NOT_OK(to_arrow_status(st));
+    }
+    _block = nullptr;
+    ARROW_RETURN_NOT_OK(_fetch_data(false));
+
+    if (*out != nullptr) {
+        VLOG_NOTICE << "ArrowFlightBatchRemoteReader read next: " << (*out)->num_rows() << ", "
+                    << (*out)->num_columns() << ", packet_seq: " << _packet_seq;
+    }
+    return arrow::Status::OK();
+}
+
+} // namespace doris::flight

--- a/be/src/service/arrow_flight/arrow_flight_batch_reader.h
+++ b/be/src/service/arrow_flight/arrow_flight_batch_reader.h
@@ -17,40 +17,93 @@
 
 #pragma once
 
+#include <cctz/time_zone.h>
 #include <gen_cpp/Types_types.h>
 
 #include <memory>
+#include <utility>
 
 #include "arrow/record_batch.h"
+#include "runtime/exec_env.h"
 
 namespace doris {
+
+namespace vectorized {
+class Block;
+} // namespace vectorized
+
 namespace flight {
 
 struct QueryStatement {
 public:
     TUniqueId query_id;
+    TNetworkAddress result_addr; // BE brpc ip & port
     std::string sql;
 
-    QueryStatement(const TUniqueId& query_id_, const std::string& sql_)
-            : query_id(query_id_), sql(sql_) {}
+    QueryStatement(TUniqueId query_id_, TNetworkAddress result_addr_, std::string sql_)
+            : query_id(std::move(query_id_)),
+              result_addr(std::move(result_addr_)),
+              sql(std::move(sql_)) {}
 };
 
-class ArrowFlightBatchReader : public arrow::RecordBatchReader {
+class ArrowFlightBatchReaderBase : public arrow::RecordBatchReader {
 public:
-    static arrow::Result<std::shared_ptr<ArrowFlightBatchReader>> Create(
-            const std::shared_ptr<QueryStatement>& statement);
-
+    // RecordBatchReader force override
     [[nodiscard]] std::shared_ptr<arrow::Schema> schema() const override;
+
+protected:
+    ArrowFlightBatchReaderBase(const std::shared_ptr<QueryStatement>& statement);
+    ~ArrowFlightBatchReaderBase() override;
+    arrow::Status _return_invalid_status(const std::string& msg);
+
+    std::shared_ptr<QueryStatement> _statement;
+    std::shared_ptr<arrow::Schema> _schema;
+    cctz::time_zone _timezone_obj;
+    std::atomic<int64_t> _packet_seq = 0;
+
+    std::atomic<int64_t> _convert_arrow_batch_timer = 0;
+    std::atomic<int64_t> _deserialize_block_timer = 0;
+    std::shared_ptr<MemTrackerLimiter> _mem_tracker;
+};
+
+class ArrowFlightBatchLocalReader : public ArrowFlightBatchReaderBase {
+public:
+    static arrow::Result<std::shared_ptr<ArrowFlightBatchLocalReader>> Create(
+            const std::shared_ptr<QueryStatement>& statement);
 
     arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override;
 
 private:
-    std::shared_ptr<QueryStatement> statement_;
-    std::shared_ptr<arrow::Schema> schema_;
+    ArrowFlightBatchLocalReader(const std::shared_ptr<QueryStatement>& statement,
+                                const std::shared_ptr<arrow::Schema>& schema,
+                                const std::shared_ptr<MemTrackerLimiter>& mem_tracker);
+};
 
-    ArrowFlightBatchReader(std::shared_ptr<QueryStatement> statement,
-                           std::shared_ptr<arrow::Schema> schema);
+class ArrowFlightBatchRemoteReader : public ArrowFlightBatchReaderBase {
+public:
+    static arrow::Result<std::shared_ptr<ArrowFlightBatchRemoteReader>> Create(
+            const std::shared_ptr<QueryStatement>& statement);
+
+    // create arrow RecordBatchReader must initialize the schema.
+    // so when creating arrow RecordBatchReader, fetch result data once,
+    // which will return Block and some necessary information, and extract arrow schema from Block.
+    arrow::Status init_schema();
+    arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override;
+
+private:
+    ArrowFlightBatchRemoteReader(const std::shared_ptr<QueryStatement>& statement,
+                                 const std::shared_ptr<PBackendService_Stub>& stub);
+    // If first_fetch_for_init is true, some additional information will be returned
+    // to initialize the schema. in this case, the fetched block is allowed to be empty,
+    // but eos is not expected to be returned.
+    arrow::Status _fetch_data(bool first_fetch_for_init);
+
+    std::shared_ptr<PBackendService_Stub> _brpc_stub = nullptr;
+    std::string _timezone;
+    std::shared_ptr<vectorized::Block> _block;
+    std::string _arrow_schema_field_names;
 };
 
 } // namespace flight
+
 } // namespace doris

--- a/be/src/service/arrow_flight/arrow_flight_batch_reader.h
+++ b/be/src/service/arrow_flight/arrow_flight_batch_reader.h
@@ -93,15 +93,13 @@ public:
 private:
     ArrowFlightBatchRemoteReader(const std::shared_ptr<QueryStatement>& statement,
                                  const std::shared_ptr<PBackendService_Stub>& stub);
-    // If first_fetch_for_init is true, some additional information will be returned
-    // to initialize the schema. in this case, the fetched block is allowed to be empty,
-    // but eos is not expected to be returned.
-    arrow::Status _fetch_data(bool first_fetch_for_init);
+
+    arrow::Status _fetch_schema();
+    arrow::Status _fetch_data();
 
     std::shared_ptr<PBackendService_Stub> _brpc_stub = nullptr;
-    std::string _timezone;
+    std::once_flag _timezone_once_flag;
     std::shared_ptr<vectorized::Block> _block;
-    std::string _arrow_schema_field_names;
 };
 
 } // namespace flight

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -157,6 +157,11 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_pool_max_queue_size, MetricUnit::N
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_max_threads, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_max_threads, MetricUnit::NOUNIT);
 
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(arrow_flight_work_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(arrow_flight_work_active_threads, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(arrow_flight_work_pool_max_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(arrow_flight_work_max_threads, MetricUnit::NOUNIT);
+
 bthread_key_t btls_key;
 
 static void thread_context_deleter(void* d) {
@@ -200,7 +205,14 @@ PInternalService::PInternalService(ExecEnv* exec_env)
                            config::brpc_light_work_pool_max_queue_size != -1
                                    ? config::brpc_light_work_pool_max_queue_size
                                    : std::max(10240, CpuInfo::num_cores() * 320),
-                           "brpc_light") {
+                           "brpc_light"),
+          _arrow_flight_work_pool(config::brpc_arrow_flight_work_pool_threads != -1
+                                          ? config::brpc_arrow_flight_work_pool_threads
+                                          : std::max(512, CpuInfo::num_cores() * 16),
+                                  config::brpc_arrow_flight_work_pool_max_queue_size != -1
+                                          ? config::brpc_arrow_flight_work_pool_max_queue_size
+                                          : std::max(20480, CpuInfo::num_cores() * 640),
+                                  "brpc_arrow_flight") {
     REGISTER_HOOK_METRIC(heavy_work_pool_queue_size,
                          [this]() { return _heavy_work_pool.get_queue_size(); });
     REGISTER_HOOK_METRIC(light_work_pool_queue_size,
@@ -218,6 +230,15 @@ PInternalService::PInternalService(ExecEnv* exec_env)
                          []() { return config::brpc_heavy_work_pool_threads; });
     REGISTER_HOOK_METRIC(light_work_max_threads,
                          []() { return config::brpc_light_work_pool_threads; });
+
+    REGISTER_HOOK_METRIC(arrow_flight_work_pool_queue_size,
+                         [this]() { return _arrow_flight_work_pool.get_queue_size(); });
+    REGISTER_HOOK_METRIC(arrow_flight_work_active_threads,
+                         [this]() { return _arrow_flight_work_pool.get_active_threads(); });
+    REGISTER_HOOK_METRIC(arrow_flight_work_pool_max_queue_size,
+                         []() { return config::brpc_arrow_flight_work_pool_max_queue_size; });
+    REGISTER_HOOK_METRIC(arrow_flight_work_max_threads,
+                         []() { return config::brpc_arrow_flight_work_pool_threads; });
 
     _exec_env->load_stream_mgr()->set_heavy_work_pool(&_heavy_work_pool);
     _exec_env->load_stream_mgr()->set_light_work_pool(&_light_work_pool);
@@ -241,6 +262,11 @@ PInternalService::~PInternalService() {
     DEREGISTER_HOOK_METRIC(light_work_pool_max_queue_size);
     DEREGISTER_HOOK_METRIC(heavy_work_max_threads);
     DEREGISTER_HOOK_METRIC(light_work_max_threads);
+
+    DEREGISTER_HOOK_METRIC(arrow_flight_work_pool_queue_size);
+    DEREGISTER_HOOK_METRIC(arrow_flight_work_active_threads);
+    DEREGISTER_HOOK_METRIC(arrow_flight_work_pool_max_queue_size);
+    DEREGISTER_HOOK_METRIC(arrow_flight_work_max_threads);
 
     CHECK_EQ(0, bthread_key_delete(btls_key));
     CHECK_EQ(0, bthread_key_delete(AsyncIO::btls_io_ctx_key));
@@ -650,6 +676,22 @@ void PInternalService::fetch_data(google::protobuf::RpcController* controller,
     }
 }
 
+void PInternalService::fetch_arrow_data(google::protobuf::RpcController* controller,
+                                        const PFetchArrowDataRequest* request,
+                                        PFetchArrowDataResult* result,
+                                        google::protobuf::Closure* done) {
+    bool ret = _arrow_flight_work_pool.try_offer([this, controller, request, result, done]() {
+        brpc::ClosureGuard closure_guard(done);
+        auto* cntl = static_cast<brpc::Controller*>(controller);
+        auto* ctx = new GetArrowResultBatchCtx(cntl, result, done);
+        _exec_env->result_mgr()->fetch_arrow_data(request->finst_id(), ctx);
+    });
+    if (!ret) {
+        offer_failed(result, done, _arrow_flight_work_pool);
+        return;
+    }
+}
+
 void PInternalService::outfile_write_success(google::protobuf::RpcController* controller,
                                              const POutfileWriteSuccessRequest* request,
                                              POutfileWriteSuccessResult* result,
@@ -857,23 +899,21 @@ void PInternalService::fetch_arrow_flight_schema(google::protobuf::RpcController
                                                  google::protobuf::Closure* done) {
     bool ret = _light_work_pool.try_offer([request, result, done]() {
         brpc::ClosureGuard closure_guard(done);
-        std::shared_ptr<arrow::Schema> schema =
-                ExecEnv::GetInstance()->result_mgr()->find_arrow_schema(
-                        UniqueId(request->finst_id()).to_thrift());
-        if (schema == nullptr) {
-            LOG(INFO) << "FE not found arrow flight schema, maybe query has been canceled";
-            auto st = Status::NotFound(
-                    "FE not found arrow flight schema, maybe query has been canceled");
+        std::shared_ptr<arrow::Schema> schema;
+        auto st = ExecEnv::GetInstance()->result_mgr()->find_arrow_schema(
+                UniqueId(request->finst_id()).to_thrift(), &schema);
+        if (!st.ok()) {
             st.to_protobuf(result->mutable_status());
             return;
         }
 
         std::string schema_str;
-        auto st = serialize_arrow_schema(&schema, &schema_str);
+        st = serialize_arrow_schema(&schema, &schema_str);
         if (st.ok()) {
             result->set_schema(std::move(schema_str));
-            if (config::public_access_ip != "") {
+            if (!config::public_access_ip.empty() && config::public_access_port != -1) {
                 result->set_be_arrow_flight_ip(config::public_access_ip);
+                result->set_be_arrow_flight_port(config::public_access_port);
             }
         }
         st.to_protobuf(result->mutable_status());

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -97,6 +97,10 @@ public:
     void fetch_data(google::protobuf::RpcController* controller, const PFetchDataRequest* request,
                     PFetchDataResult* result, google::protobuf::Closure* done) override;
 
+    void fetch_arrow_data(google::protobuf::RpcController* controller,
+                          const PFetchArrowDataRequest* request, PFetchArrowDataResult* result,
+                          google::protobuf::Closure* done) override;
+
     void outfile_write_success(google::protobuf::RpcController* controller,
                                const POutfileWriteSuccessRequest* request,
                                POutfileWriteSuccessResult* result,
@@ -271,6 +275,7 @@ protected:
     // otherwise as light interface
     FifoThreadPool _heavy_work_pool;
     FifoThreadPool _light_work_pool;
+    FifoThreadPool _arrow_flight_work_pool;
 };
 
 // `StorageEngine` mixin for `PInternalService`

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -157,8 +157,9 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     return Status::OK();
 }
 
-Status get_arrow_schema(const vectorized::Block& block, std::shared_ptr<arrow::Schema>* result,
-                        const std::string& timezone) {
+Status get_arrow_schema_from_block(const vectorized::Block& block,
+                                   std::shared_ptr<arrow::Schema>* result,
+                                   const std::string& timezone) {
     std::vector<std::shared_ptr<arrow::Field>> fields;
     for (const auto& type_and_name : block) {
         std::shared_ptr<arrow::DataType> arrow_type;
@@ -171,9 +172,9 @@ Status get_arrow_schema(const vectorized::Block& block, std::shared_ptr<arrow::S
     return Status::OK();
 }
 
-Status convert_expr_ctxs_arrow_schema(const vectorized::VExprContextSPtrs& output_vexpr_ctxs,
-                                      std::shared_ptr<arrow::Schema>* result,
-                                      const std::string& timezone) {
+Status get_arrow_schema_from_expr_ctxs(const vectorized::VExprContextSPtrs& output_vexpr_ctxs,
+                                       std::shared_ptr<arrow::Schema>* result,
+                                       const std::string& timezone) {
     std::vector<std::shared_ptr<arrow::Field>> fields;
     for (int i = 0; i < output_vexpr_ctxs.size(); i++) {
         std::shared_ptr<arrow::DataType> arrow_type;

--- a/be/src/util/arrow/row_batch.h
+++ b/be/src/util/arrow/row_batch.h
@@ -44,13 +44,13 @@ class RowDescriptor;
 Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::DataType>* result,
                              const std::string& timezone);
 
-// Convert Doris RowDescriptor to Arrow Schema.
-Status get_arrow_schema(const vectorized::Block& block, std::shared_ptr<arrow::Schema>* result,
-                        const std::string& timezone);
+Status get_arrow_schema_from_block(const vectorized::Block& block,
+                                   std::shared_ptr<arrow::Schema>* result,
+                                   const std::string& timezone);
 
-Status convert_expr_ctxs_arrow_schema(const vectorized::VExprContextSPtrs& output_vexpr_ctxs,
-                                      std::shared_ptr<arrow::Schema>* result,
-                                      const std::string& timezone);
+Status get_arrow_schema_from_expr_ctxs(const vectorized::VExprContextSPtrs& output_vexpr_ctxs,
+                                       std::shared_ptr<arrow::Schema>* result,
+                                       const std::string& timezone);
 
 Status serialize_record_batch(const arrow::RecordBatch& record_batch, std::string* result);
 

--- a/be/src/util/arrow/utils.cpp
+++ b/be/src/util/arrow/utils.cpp
@@ -33,9 +33,10 @@ Status to_doris_status(const arrow::Status& status) {
 }
 
 arrow::Status to_arrow_status(const Status& status) {
-    if (status.ok()) {
+    if (LIKELY(status.ok())) {
         return arrow::Status::OK();
     } else {
+        LOG(WARNING) << status.to_string();
         // The length of exception msg returned to the ADBC Client cannot larger than 8192,
         // otherwise ADBC Client will receive:
         // `INTERNAL: http2 exception Header size exceeded max allowed size (8192)`.

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -218,6 +218,11 @@ public:
     UIntGauge* heavy_work_max_threads = nullptr;
     UIntGauge* light_work_max_threads = nullptr;
 
+    UIntGauge* arrow_flight_work_pool_queue_size = nullptr;
+    UIntGauge* arrow_flight_work_active_threads = nullptr;
+    UIntGauge* arrow_flight_work_pool_max_queue_size = nullptr;
+    UIntGauge* arrow_flight_work_max_threads = nullptr;
+
     UIntGauge* flush_thread_pool_queue_size = nullptr;
     UIntGauge* flush_thread_pool_thread_num = nullptr;
 

--- a/be/src/vec/sink/varrow_flight_result_writer.cpp
+++ b/be/src/vec/sink/varrow_flight_result_writer.cpp
@@ -19,22 +19,17 @@
 
 #include "runtime/buffer_control_block.h"
 #include "runtime/runtime_state.h"
-#include "util/arrow/block_convertor.h"
-#include "util/arrow/row_batch.h"
+#include "runtime/thread_context.h"
 #include "vec/core/block.h"
 #include "vec/exprs/vexpr_context.h"
 
-namespace doris {
+namespace doris::vectorized {
 #include "common/compile_check_begin.h"
-namespace vectorized {
 
-VArrowFlightResultWriter::VArrowFlightResultWriter(
-        BufferControlBlock* sinker, const VExprContextSPtrs& output_vexpr_ctxs,
-        RuntimeProfile* parent_profile, const std::shared_ptr<arrow::Schema>& arrow_schema)
-        : _sinker(sinker),
-          _output_vexpr_ctxs(output_vexpr_ctxs),
-          _parent_profile(parent_profile),
-          _arrow_schema(arrow_schema) {}
+VArrowFlightResultWriter::VArrowFlightResultWriter(BufferControlBlock* sinker,
+                                                   const VExprContextSPtrs& output_vexpr_ctxs,
+                                                   RuntimeProfile* parent_profile)
+        : _sinker(sinker), _output_vexpr_ctxs(output_vexpr_ctxs), _parent_profile(parent_profile) {}
 
 Status VArrowFlightResultWriter::init(RuntimeState* state) {
     _init_profile();
@@ -42,13 +37,11 @@ Status VArrowFlightResultWriter::init(RuntimeState* state) {
         return Status::InternalError("sinker is NULL pointer.");
     }
     _is_dry_run = state->query_options().dry_run_query;
-    _timezone_obj = state->timezone_obj();
     return Status::OK();
 }
 
 void VArrowFlightResultWriter::_init_profile() {
     _append_row_batch_timer = ADD_TIMER(_parent_profile, "AppendBatchTime");
-    _convert_tuple_timer = ADD_CHILD_TIMER(_parent_profile, "TupleConvertTime", "AppendBatchTime");
     _result_send_timer = ADD_CHILD_TIMER(_parent_profile, "ResultSendTime", "AppendBatchTime");
     _sent_rows_counter = ADD_COUNTER(_parent_profile, "NumSentRows", TUnit::UNIT);
     _bytes_sent_counter = ADD_COUNTER(_parent_profile, "BytesSent", TUnit::BYTES);
@@ -67,29 +60,31 @@ Status VArrowFlightResultWriter::write(RuntimeState* state, Block& input_block) 
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_output_vexpr_ctxs,
                                                                        input_block, &block));
 
-    // convert one batch
-    std::shared_ptr<arrow::RecordBatch> result;
-    auto num_rows = block.rows();
-    // arrow::RecordBatch without `nbytes()` in C++
-    uint64_t bytes_sent = block.bytes();
     {
-        SCOPED_TIMER(_convert_tuple_timer);
-        RETURN_IF_ERROR(convert_to_arrow_batch(block, _arrow_schema, arrow::default_memory_pool(),
-                                               &result, _timezone_obj));
-    }
-    {
-        SCOPED_TIMER(_result_send_timer);
-        // If this is a dry run task, no need to send data block
-        if (!_is_dry_run) {
-            status = _sinker->add_arrow_batch(state, result);
-        }
-        if (status.ok()) {
-            _written_rows += num_rows;
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_sinker->mem_tracker());
+        std::unique_ptr<vectorized::MutableBlock> mutable_block =
+                vectorized::MutableBlock::create_unique(block.clone_empty());
+        RETURN_IF_ERROR(mutable_block->merge_ignore_overflow(std::move(block)));
+        std::shared_ptr<vectorized::Block> output_block = vectorized::Block::create_shared();
+        output_block->swap(mutable_block->to_block());
+
+        auto num_rows = output_block->rows();
+        // arrow::RecordBatch without `nbytes()` in C++
+        uint64_t bytes_sent = output_block->bytes();
+        {
+            SCOPED_TIMER(_result_send_timer);
+            // If this is a dry run task, no need to send data block
             if (!_is_dry_run) {
-                _bytes_sent += bytes_sent;
+                status = _sinker->add_arrow_batch(state, output_block);
             }
-        } else {
-            LOG(WARNING) << "append result batch to sink failed.";
+            if (status.ok()) {
+                _written_rows += num_rows;
+                if (!_is_dry_run) {
+                    _bytes_sent += bytes_sent;
+                }
+            } else {
+                LOG(WARNING) << "append result batch to sink failed.";
+            }
         }
     }
     return status;
@@ -101,5 +96,4 @@ Status VArrowFlightResultWriter::close(Status st) {
     return Status::OK();
 }
 
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::vectorized

--- a/be/src/vec/sink/varrow_flight_result_writer.h
+++ b/be/src/vec/sink/varrow_flight_result_writer.h
@@ -17,13 +17,6 @@
 
 #pragma once
 
-#include <arrow/type.h>
-#include <cctz/time_zone.h>
-#include <stddef.h>
-
-#include <memory>
-#include <vector>
-
 #include "common/status.h"
 #include "runtime/result_writer.h"
 #include "util/runtime_profile.h"
@@ -40,8 +33,7 @@ class Block;
 class VArrowFlightResultWriter final : public ResultWriter {
 public:
     VArrowFlightResultWriter(BufferControlBlock* sinker, const VExprContextSPtrs& output_vexpr_ctxs,
-                             RuntimeProfile* parent_profile,
-                             const std::shared_ptr<arrow::Schema>& arrow_schema);
+                             RuntimeProfile* parent_profile);
 
     Status init(RuntimeState* state) override;
 
@@ -59,8 +51,6 @@ private:
     RuntimeProfile* _parent_profile = nullptr; // parent profile from result sink. not owned
     // total time cost on append batch operation
     RuntimeProfile::Counter* _append_row_batch_timer = nullptr;
-    // tuple convert timer, child timer of _append_row_batch_timer
-    RuntimeProfile::Counter* _convert_tuple_timer = nullptr;
     // file write timer, child timer of _append_row_batch_timer
     RuntimeProfile::Counter* _result_send_timer = nullptr;
     // number of sent rows
@@ -71,10 +61,6 @@ private:
     bool _is_dry_run = false;
 
     uint64_t _bytes_sent = 0;
-
-    std::shared_ptr<arrow::Schema> _arrow_schema;
-
-    cctz::time_zone _timezone_obj;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -34,6 +34,7 @@ protected:
     virtual void SetUp() {}
 
 private:
+    RuntimeState _state;
 };
 
 TEST_F(ResultBufferMgrTest, create_normal) {
@@ -43,7 +44,7 @@ TEST_F(ResultBufferMgrTest, create_normal) {
     query_id.hi = 100;
 
     std::shared_ptr<BufferControlBlock> control_block1;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, false).ok());
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state).ok());
 }
 
 TEST_F(ResultBufferMgrTest, create_same_buffer) {
@@ -53,9 +54,9 @@ TEST_F(ResultBufferMgrTest, create_same_buffer) {
     query_id.hi = 100;
 
     std::shared_ptr<BufferControlBlock> control_block1;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, false).ok());
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state).ok());
     std::shared_ptr<BufferControlBlock> control_block2;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block2, false).ok());
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block2, &_state).ok());
 
     EXPECT_EQ(control_block1.get(), control_block1.get());
 }
@@ -67,7 +68,7 @@ TEST_F(ResultBufferMgrTest, fetch_data_normal) {
     query_id.hi = 100;
 
     std::shared_ptr<BufferControlBlock> control_block1;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, false).ok());
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state).ok());
 
     TFetchDataResult* result = new TFetchDataResult();
     result->result_batch.rows.push_back("hello test");
@@ -85,7 +86,7 @@ TEST_F(ResultBufferMgrTest, fetch_data_no_block) {
     query_id.hi = 100;
 
     std::shared_ptr<BufferControlBlock> control_block1;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, false).ok());
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state).ok());
 
     TFetchDataResult* result = new TFetchDataResult();
     query_id.lo = 11;
@@ -101,7 +102,7 @@ TEST_F(ResultBufferMgrTest, normal_cancel) {
     query_id.hi = 100;
 
     std::shared_ptr<BufferControlBlock> control_block1;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, false).ok());
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state).ok());
 
     EXPECT_TRUE(buffer_mgr.cancel(query_id).ok());
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
@@ -53,17 +53,22 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Process one flgiht sql connection.
- *
+ * <p>
  * Must use try-with-resources.
  */
 public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoCloseable {
     private static final Logger LOG = LogManager.getLogger(FlightSqlConnectProcessor.class);
+    private TNetworkAddress publicAccessAddr = new TNetworkAddress();
 
     public FlightSqlConnectProcessor(ConnectContext context) {
         super(context);
         connectType = ConnectType.ARROW_FLIGHT_SQL;
         context.setThreadLocalInfo();
         context.setReturnResultFromLocal(true);
+    }
+
+    public TNetworkAddress getPublicAccessAddr() {
+        return publicAccessAddr;
     }
 
     public void prepare(MysqlCommand command) {
@@ -130,10 +135,11 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
             Status resultStatus = new Status(pResult.getStatus());
             if (resultStatus.getErrorCode() != TStatusCode.OK) {
                 throw new RuntimeException(String.format("fetch arrow flight schema failed, queryId: %s, errmsg: %s",
-                        DebugUtil.printId(tid), resultStatus.toString()));
+                        DebugUtil.printId(tid), resultStatus));
             }
-            if (pResult.hasBeArrowFlightIp()) {
-                ctx.getResultFlightServerAddr().hostname = pResult.getBeArrowFlightIp().toStringUtf8();
+            if (pResult.hasBeArrowFlightIp() && pResult.hasBeArrowFlightPort()) {
+                publicAccessAddr.hostname = pResult.getBeArrowFlightIp().toStringUtf8();
+                publicAccessAddr.port = pResult.getBeArrowFlightPort();
             }
             if (pResult.hasSchema() && pResult.getSchema().size() > 0) {
                 RootAllocator rootAllocator = new RootAllocator(Integer.MAX_VALUE);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -283,6 +283,21 @@ message PFetchDataResult {
     optional bool empty_batch = 6;
 };
 
+message PFetchArrowDataRequest {
+    optional PUniqueId finst_id = 1;
+};
+
+message PFetchArrowDataResult {
+    optional PStatus status = 1;
+    // valid when status is ok
+    optional int64 packet_seq = 2;
+    optional bool eos = 3;
+    optional PBlock block = 4;
+    optional bool empty_batch = 5;
+    optional string timezone = 6;
+    optional string fields_labels = 7;
+};
+
 message PFetchArrowFlightSchemaRequest {
     optional PUniqueId finst_id = 1;
 };
@@ -292,6 +307,7 @@ message PFetchArrowFlightSchemaResult {
     // valid when status is ok
     optional bytes schema = 2;
     optional bytes be_arrow_flight_ip = 3;
+    optional int32 be_arrow_flight_port = 4;
 };
 
 message KeyTuple {
@@ -979,6 +995,7 @@ service PBackendService {
     rpc exec_plan_fragment_start(PExecPlanFragmentStartRequest) returns (PExecPlanFragmentResult);
     rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);
     rpc fetch_data(PFetchDataRequest) returns (PFetchDataResult);
+    rpc fetch_arrow_data(PFetchArrowDataRequest) returns (PFetchArrowDataResult);
     rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);
     rpc open_load_stream(POpenLoadStreamRequest) returns (POpenLoadStreamResponse);
     rpc tablet_writer_add_block(PTabletWriterAddBlockRequest) returns (PTabletWriterAddBlockResult);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -295,7 +295,6 @@ message PFetchArrowDataResult {
     optional PBlock block = 4;
     optional bool empty_batch = 5;
     optional string timezone = 6;
-    optional string fields_labels = 7;
 };
 
 message PFetchArrowFlightSchemaRequest {


### PR DESCRIPTION
## Motivation
If there is a Doris cluster, its FE node can be accessed by the external network, and all its BE nodes can only be accessed by the internal network.

This is fine when using Mysql client and JDBC to connect to Doris to execute queries, and the query results will be returned to the client by the Doris FE node.

However, using Arrow Flight SQL to connect to Doris cannot execute queries, because the ADBC ​​client needs to connect to the Doris BE node to pull query results, but the Doris BE node is not allowed to be accessed by the external network.

In a production environment, it is often inconvenient to expose Doris BE nodes to the external network. However, a reverse proxy (such as nginx) can be added to all Doris BE nodes, and the external client will be randomly routed to a Doris BE node when connecting to nginx.

The query results of Arrow Flight SQL will be randomly saved on a Doris BE node. If it is different from the Doris BE node randomly routed by nginx, data forwarding needs to be done inside the Doris BE node.

## Implementation

1. The Ticket returned by Doris FE Arrow Flight Server to ADBC ​​client contains the IP and Brpc Port of the Doris BE node where the query result is located.

2. Doris BE Arrow Flight Server receives a request to pull data. If the IP:BrpcPort in the Ticket is not itself, it pulls the query result Block from the Doris BE node specified by IP:BrpcPort, converts it to Arrow Batch and returns it to ADBC ​​Client; if the IP:BrpcPort in the Ticket is itself, it is the same as before.

## TODO

1. If the data is not in the current BE node, you can pull the data from other BE nodes asynchronously and cache at least one Block locally in the current BE node, which will reduce the time consumption of serialization, deserialization, and RPC.

## How to test

1. Create a Doris cluster with 1 FE and 2 BE, and modify `arrow_flight_sql_port` in `fe.conf` and `be.conf`.

2. Root executes `systemctl status nginx` to check whether Nginx is installed. If not, yum install is recommended.

3. `vim /etc/nginx/nginx.conf` adds `underscores_in_headers on;`

4. `touch /etc/nginx/conf.d/arrowflight.conf` creates a file, and `vim /etc/nginx/conf.d/arrowflight.conf` adds:

```
upstream arrowflight {
    server {BE1_ip}:{BE1_arrow_flight_sql_port};
    server {BE2_IP}:{BE2_arrow_flight_sql_port};
}

server {
    listen {nginx port} http2;
    listen [::]:{nginx port} http2;
    server_name doris.arrowflight.com;

    #ssl_certificate   /etc/nginx/cert/myCA.pem;
    #ssl_certificate_key /etc/nginx/cert/myCA.key;

    location / {
        grpc_pass grpc://arrowflight;
        grpc_set_header X-Real-IP $remote_addr;
        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        grpc_set_header X-Forwarded-Proto $scheme;

        proxy_read_timeout 60s;
        proxy_send_timeout 60s;

        #proxy_http_version 1.1;
        #proxy_set_header Connection "";
    }
}
```

Where {BE1_ip}:{BE1_arrow_flight_sql_port} is the IP of BE 1 and arrow_flight_sql_port in be.conf, and similarly {BE2_IP}:{BE2_arrow_flight_sql_port}. `{nginx port}` is any available port.

6. Add in be.conf of all BEs:

```
public_host={nginx ip}
arrow_flight_sql_proxy_port={nginx port}
```

---

## 动机
如果存在一个 Doris 集群，它的 FE 节点可以被外部网络访问，它的所有 BE 节点只可以被内网访问。

这在使用 Mysql client 和 JDBC 连接 Doris 执行查询是没问题的，查询结果将由 Doris FE 节点返回给 client。

但使用 Arrow Flight SQL 连接 Doris 无法执行查询，因为 ADBC client 需要连接 Doris BE 节点拉取查询结果，但 Doris BE 节点不允许被外网访问。

生产环境中，很多时候不方便在外网暴露 Doris BE 节点。但可以为所有 Doris BE 节点增加了一层反向代理（比如 nginx），外网的 client 连接 nginx 时会随机路由到一台 Doris BE 节点上。

Arrow Flight SQL 查询结果会随机保存在一台 Doris BE 节点上，如果和 nginx 随机路由的 Doris BE 节点不同，需要在 Doris BE 节点内部做一次数据转发。

## 实现

1. Doris FE  Arrow Flight Server 向 ADBC client 返回的 Ticket 中包含查询结果所在 Doris BE节点的 IP 和 Brpc Port。
2. Doris BE Arrow Flight Server 收到拉取数据请求。如果 Ticket 中的 IP:BrpcPort 不是自己，则从 IP:BrpcPort 指定的 Doris BE 节点拉取查询结果Block，转为 Arrow Batch 后返回 ADBC Client；如果 Ticket 中的 IP:BrpcPort 是自己，则和过去一样。

## TODO

1. 若数据不在当前 BE 节点，可以异步的从其他 BE 节点拉取数据，并在当前 BE 节点本地缓存至少一个 Block，这将减少序列化、反序列化、RPC 的耗时。

## 如何测试

1. 创建一个 1 FE 和 2 BE 的 Doris 集群，修改 `fe.conf` 和 `be.conf` 中的 `arrow_flight_sql_port`。
2. Root 执行 `systemctl status nginx` 查看是否安装 Nginx，若没有则推荐 yum install。
3. `vim /etc/nginx/nginx.conf` 增加 `underscores_in_headers on;`
4. `touch /etc/nginx/conf.d/arrowflight.conf` 创建文件，`vim  /etc/nginx/conf.d/arrowflight.conf` 增加：

```
upstream arrowflight {
    server {BE1_ip}:{BE1_arrow_flight_sql_port};
    server {BE2_IP}:{BE2_arrow_flight_sql_port};
}

server {
    listen {nginx port} http2;
    listen [::]:{nginx port} http2;
    server_name doris.arrowflight.com;

    #ssl_certificate   /etc/nginx/cert/myCA.pem;
    #ssl_certificate_key /etc/nginx/cert/myCA.key;

    location / {
        grpc_pass grpc://arrowflight;
        grpc_set_header X-Real-IP $remote_addr;
        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        grpc_set_header X-Forwarded-Proto $scheme;

        proxy_read_timeout 60s;
        proxy_send_timeout 60s;

        #proxy_http_version 1.1;
        #proxy_set_header Connection "";
    }
}
```

其中 {BE1_ip}:{BE1_arrow_flight_sql_port} 是 BE 1 的 IP 和 be.conf 中的 arrow_flight_sql_port，同理 {BE2_IP}:{BE2_arrow_flight_sql_port}。`{nginx port}` 是一个任意可用端口。

6. 在所有 BE 的 be.conf 中增加

```
public_host={nginx ip}
arrow_flight_sql_proxy_port={nginx port}
```