### PR TITLE
[fix](regression) test_primary_key_partial_update fail due to the U.S. change from DST to standard time

### DIFF
--- a/regression-test/data/unique_with_mow_c_p0/partial_update/test_partial_update.out
+++ b/regression-test/data/unique_with_mow_c_p0/partial_update/test_partial_update.out
@@ -37,7 +37,7 @@
 1
 
 -- !select_timestamp2 --
-11
+1
 
 -- !select_date --
 1
@@ -86,7 +86,7 @@ B
 1
 
 -- !select_timestamp2 --
-11
+1
 
 -- !select_date --
 1

--- a/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
+++ b/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
@@ -39,7 +39,7 @@
 1
 
 -- !select_timestamp2 --
-11
+1
 
 -- !select_date --
 1
@@ -90,7 +90,7 @@ B
 1
 
 -- !select_timestamp2 --
-11
+1
 
 -- !select_date --
 1

--- a/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update.groovy
@@ -257,7 +257,7 @@ suite("test_primary_key_partial_update", "p0") {
 
             qt_select_timestamp "select count(*) from ${tableName} where `ctime` > \"1970-01-01\""
 
-            sql "set time_zone = 'America/New_York'"
+            sql "set time_zone = 'Asia/Tokyo'"
 
             Thread.sleep(5000)
 

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -207,7 +207,7 @@ suite("test_primary_key_partial_update", "p0") {
 
             qt_select_timestamp "select count(*) from ${tableName} where `ctime` > \"1970-01-01\""
 
-            sql "set time_zone = 'America/New_York'"
+            sql "set time_zone = 'Asia/Tokyo'"
 
             Thread.sleep(5000)
 


### PR DESCRIPTION
### What problem does this PR solve?

The case used time zone `America/New_York`, and the  result of `TIMESTAMPDIFF` will change when U.S. switch between DST(daylight saving time) and standard time, we should use a time zone not sensitive to this.

<!--
If there are related issues, please fill in the issue number.
- If you want the issue to be closed after the PR is merged, please use "close #12345". Otherwise, use "ref #12345"
-->
Issue Number: close #xxx

<!--
If this PR is followup a preivous PR, for example, fix the bug that introduced by a related PR,
link the PR here
-->
Related PR: #xxx

Problem Summary:

### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

