### PR TITLE
[fix](regression) test_primary_key_partial_update fail due to the U.S. change from DST to standard time (#43288)

### DIFF
--- a/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
+++ b/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update.out
@@ -39,7 +39,7 @@
 1
 
 -- !select_timestamp2 --
-11
+1
 
 -- !select_date --
 1
@@ -90,7 +90,7 @@ B
 1
 
 -- !select_timestamp2 --
-11
+1
 
 -- !select_date --
 1

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -207,7 +207,7 @@ suite("test_primary_key_partial_update", "p0") {
 
             qt_select_timestamp "select count(*) from ${tableName} where `ctime` > \"1970-01-01\""
 
-            sql "set time_zone = 'America/New_York'"
+            sql "set time_zone = 'Asia/Tokyo'"
 
             Thread.sleep(5000)
 


### PR DESCRIPTION
cherry-pick #43288
