### PR TITLE
[fix](nereids)Solve the problem of pruning wrong partitions in multi-column partition pruning

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -174,6 +174,7 @@ public class OneRangePartitionEvaluator
 
     @Override
     public Expression evaluate(Expression expression, Map<Slot, PartitionSlotInput> currentInputs) {
+        rangeMap.clear();
         Map<Expression, ColumnRange> defaultColumnRanges = currentInputs.values().iterator().next().columnRanges;
         rangeMap.putAll(defaultColumnRanges);
         EvaluateRangeResult result = expression.accept(this, new EvaluateRangeInput(currentInputs));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -93,7 +93,6 @@ public class OneRangePartitionEvaluator
     private final List<List<Expression>> inputs;
     private final Map<Expression, Boolean> partitionSlotContainsNull;
     private final Map<Slot, PartitionSlotType> slotToType;
-    private final Map<Expression, ColumnRange> rangeMap = new HashMap<>();
 
     /** OneRangePartitionEvaluator */
     public OneRangePartitionEvaluator(long partitionId, List<Slot> partitionSlots,
@@ -174,10 +173,9 @@ public class OneRangePartitionEvaluator
 
     @Override
     public Expression evaluate(Expression expression, Map<Slot, PartitionSlotInput> currentInputs) {
-        rangeMap.clear();
         Map<Expression, ColumnRange> defaultColumnRanges = currentInputs.values().iterator().next().columnRanges;
-        rangeMap.putAll(defaultColumnRanges);
-        EvaluateRangeResult result = expression.accept(this, new EvaluateRangeInput(currentInputs));
+        Map<Expression, ColumnRange> rangeMap = new HashMap<>(defaultColumnRanges);
+        EvaluateRangeResult result = expression.accept(this, new EvaluateRangeInput(currentInputs, rangeMap));
         return result.result;
     }
 
@@ -398,6 +396,7 @@ public class OneRangePartitionEvaluator
     public EvaluateRangeResult visitAnd(And and, EvaluateRangeInput context) {
         EvaluateRangeResult result = evaluateChildrenThenThis(and, context);
         result = mergeRanges(result.result, result.childrenResult.get(0), result.childrenResult.get(1),
+                context.rangeMap,
                 (leftRange, rightRange) -> leftRange.intersect(rightRange));
 
         result = returnFalseIfExistEmptyRange(result);
@@ -426,6 +425,7 @@ public class OneRangePartitionEvaluator
                     result.childrenResult);
         }
         result = mergeRanges(result.result, result.childrenResult.get(0), result.childrenResult.get(1),
+                context.rangeMap,
                 (leftRange, rightRange) -> leftRange.union(rightRange));
         return returnFalseIfExistEmptyRange(result);
     }
@@ -438,8 +438,8 @@ public class OneRangePartitionEvaluator
             for (Map.Entry<Expression, ColumnRange> entry : result.childrenResult.get(0).columnRanges.entrySet()) {
                 Expression expr = entry.getKey();
                 ColumnRange childRange = entry.getValue();
-                ColumnRange partitionRange = rangeMap.containsKey(expr)
-                        ? rangeMap.get(expr) : ColumnRange.all();
+                ColumnRange partitionRange = context.rangeMap.containsKey(expr)
+                        ? context.rangeMap.get(expr) : ColumnRange.all();
                 newRanges.put(expr, partitionRange.intersect(childRange.complete()));
             }
             result = new EvaluateRangeResult(result.result, newRanges, result.childrenResult);
@@ -563,6 +563,7 @@ public class OneRangePartitionEvaluator
 
     private EvaluateRangeResult mergeRanges(
             Expression originResult, EvaluateRangeResult left, EvaluateRangeResult right,
+            Map<Expression, ColumnRange> rangeMap,
             BiFunction<ColumnRange, ColumnRange, ColumnRange> mergeFunction) {
 
         Map<Expression, ColumnRange> leftRanges = left.columnRanges;
@@ -624,7 +625,7 @@ public class OneRangePartitionEvaluator
         if (partitionSlotContainsNull.containsKey(dateTruncChild)) {
             partitionSlotContainsNull.put(dateTrunc, true);
         }
-        return computeMonotonicFunctionRange(result);
+        return computeMonotonicFunctionRange(result, context.rangeMap);
     }
 
     @Override
@@ -637,7 +638,7 @@ public class OneRangePartitionEvaluator
         if (partitionSlotContainsNull.containsKey(dateChild)) {
             partitionSlotContainsNull.put(date, true);
         }
-        return computeMonotonicFunctionRange(result);
+        return computeMonotonicFunctionRange(result, context.rangeMap);
     }
 
     @Override
@@ -650,7 +651,7 @@ public class OneRangePartitionEvaluator
         if (partitionSlotContainsNull.containsKey(converTzChild)) {
             partitionSlotContainsNull.put(convertTz, true);
         }
-        return computeMonotonicFunctionRange(result);
+        return computeMonotonicFunctionRange(result, context.rangeMap);
     }
 
     private boolean isPartitionSlot(Slot slot) {
@@ -682,10 +683,12 @@ public class OneRangePartitionEvaluator
 
     /** EvaluateRangeInput */
     public static class EvaluateRangeInput {
-        private Map<Slot, PartitionSlotInput> slotToInput;
+        private final Map<Slot, PartitionSlotInput> slotToInput;
+        private final Map<Expression, ColumnRange> rangeMap;
 
-        public EvaluateRangeInput(Map<Slot, PartitionSlotInput> slotToInput) {
+        public EvaluateRangeInput(Map<Slot, PartitionSlotInput> slotToInput, Map<Expression, ColumnRange> rangeMap) {
             this.slotToInput = slotToInput;
+            this.rangeMap = rangeMap;
         }
     }
 
@@ -817,7 +820,8 @@ public class OneRangePartitionEvaluator
         return onePartitionInputs;
     }
 
-    private EvaluateRangeResult computeMonotonicFunctionRange(EvaluateRangeResult result) {
+    private EvaluateRangeResult computeMonotonicFunctionRange(EvaluateRangeResult result,
+            Map<Expression, ColumnRange> rangeMap) {
         Monotonic func = (Monotonic) result.result;
         if (rangeMap.containsKey(func)) {
             return new EvaluateRangeResult((Expression) func, ImmutableMap.of((Expression) func,

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
@@ -334,4 +334,29 @@ suite("test_date_trunc_prune") {
     ( NOT (  ( table1 . `col_int_undef_signed` != table1 . `col_int_undef_signed` ) AND table1 . `col_date_undef_signed` <= '2025-06-18' ) AND 
     table1 . `col_date_undef_signed`  IN ( '2023-12-20' ) )  GROUP BY field1  ORDER BY field1 LIMIT 1000;
     """
+
+    // test multi column partition table and predicate with date_trunc
+    sql "drop table if exists t_multi_column_partition"
+    sql """
+    create table t_multi_column_partition(a int, dt datetime, v int) partition by range(a, dt)
+    (
+    partition p0 values [(0,'2024-01-01 00:00:00'), (10,'2024-01-10 00:00:00')),
+    partition p10 values [(10,'2024-01-10 00:00:00'), (20,'2024-01-20 00:00:00')),
+    partition p20 values [(20,'2024-01-20 00:00:00'), (30,'2024-01-31 00:00:00')),
+    partition p30 values [(30,'2024-01-31 00:00:00'), (40,'2024-02-10 00:00:00')),
+    partition p40 values [(40,'2024-02-10 00:00:00'), (50,'2024-02-20 00:00:00'))
+    )
+    distributed by hash(a);
+    """
+    sql """
+    insert into t_multi_column_partition values(0,'2024-01-01 00:00:00',2),(1,'2024-01-01 00:00:00',2),(1,'2025-01-01 00:00:00',2),
+    (10,'2024-01-10 00:00:00',3),(10,'2024-01-11 00:00:00',200),(12,'2021-01-01 00:00:00',2),
+    (25,'2024-01-10 00:00:00',3),(20,'2024-01-11 00:00:00',200),(30,'2021-01-01 00:00:00',2),
+    (40,'2024-01-01 00:00:00',2),(40,'2024-01-31 00:00:00',2),(10,'2024-01-9 00:00:00',1000),(10,'2024-01-10 00:00:00',1000),(10,'2024-01-10 01:00:00',1000),
+    (2,'2023-01-10 01:00:00',1000)
+    """
+    explain {
+        sql """select * from t_multi_column_partition where a=2 and date_trunc(dt,'day') <'2024-01-1 00:00:00';"""
+        contains ("partitions=1/5 (p0)")
+    }
 }

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
@@ -346,7 +346,7 @@ suite("test_date_trunc_prune") {
     partition p30 values [(30,'2024-01-31 00:00:00'), (40,'2024-02-10 00:00:00')),
     partition p40 values [(40,'2024-02-10 00:00:00'), (50,'2024-02-20 00:00:00'))
     )
-    distributed by hash(a);
+    distributed by hash(a) properties("replication_num"="1");
     """
     sql """
     insert into t_multi_column_partition values(0,'2024-01-01 00:00:00',2),(1,'2024-01-01 00:00:00',2),(1,'2025-01-01 00:00:00',2),


### PR DESCRIPTION
### What problem does this PR solve?
<!--
You need to clearly describe your PR in this part:

1. What problem was fixed (it's best to include specific error reporting information). How it was fixed.
2. Which behaviors were modified. What was the previous behavior, what is it now, why was it modified, and what possible impacts might there be.
3. What features were added. Why this function was added.
4. Which codes were refactored and why this part of the code was refactored.
5. Which functions were optimized and what is the difference before and after the optimization.

The description of the PR needs to enable reviewers to quickly and clearly understand the logic of the code modification.
-->
For example, with a partition defined as PARTITION BY RANGE (a, dt) [(0, '2024-01-01 00:00:00'), (10, '2024-01-10 00:00:00')). With the predicate WHERE a = 0 AND date_trunc(dt, 'day') <= '2024-01-10 00:00:00', partition pruning will expand the partition ranges to:
a = 0, dt in ['2024-01-01 00:00:00', +∞)
a = 1, dt in (-∞, +∞)
a = 2, dt in (-∞, +∞)
...
a = 10, dt in (-∞, '2024-01-10 00:00:00')
Each of these eleven ranges will be evaluated against the predicate. If all evaluations return False, the partition can be pruned.
During the evaluation of the first range (a = 0, dt in ['2024-01-01 00:00:00', +∞)), the range of date_trunc(dt, 'day') is calculated as ['2024-01-01', +∞) and stored in rangeMap. However, subsequent evaluations (e.g., for a = 2, dt in (-∞, +∞)) reuse this range ['2024-01-01', +∞), which is incorrect. For a = 2, the correct range should be (-∞, +∞) for date_trunc(dt, 'day').
Due to this incorrect reuse, the range for a = 2, dt in (-∞, +∞) will incorrectly evaluate to False, causing improper pruning of the partition.
The correct approach is to place rangeMap within the context, so that a new rangeMap is constructed for each evaluation.
<!--
If there are related issues, please fill in the issue number.
- If you want the issue to be closed after the PR is merged, please use "close #12345". Otherwise, use "ref #12345"
-->
Issue Number: close #xxx

<!--
If this PR is followup a preivous PR, for example, fix the bug that introduced by a related PR,
link the PR here
-->
Related PR: introduced by #38849

Problem Summary:

### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

