### PR TITLE
[fix](build index)Fix build index empty index file on renamed column

### DIFF
--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -94,10 +94,16 @@ Status IndexBuilder::update_inverted_index_info() {
                 auto column_name = t_inverted_index.columns[0];
                 auto column_idx = output_rs_tablet_schema->field_index(column_name);
                 if (column_idx < 0) {
-                    LOG(WARNING) << "referenced column was missing. "
-                                 << "[column=" << column_name << " referenced_column=" << column_idx
-                                 << "]";
-                    continue;
+                    if (!t_inverted_index.column_unique_ids.empty()) {
+                        auto column_unique_id = t_inverted_index.column_unique_ids[0];
+                        column_idx = output_rs_tablet_schema->field_index(column_unique_id);
+                    }
+                    if (column_idx < 0) {
+                        LOG(WARNING) << "referenced column was missing. "
+                                     << "[column=" << column_name
+                                     << " referenced_column=" << column_idx << "]";
+                        continue;
+                    }
                 }
                 auto column = output_rs_tablet_schema->column(column_idx);
                 const auto* index_meta = output_rs_tablet_schema->inverted_index(column);
@@ -511,9 +517,16 @@ Status IndexBuilder::_write_inverted_index_data(TabletSchemaSPtr tablet_schema, 
         auto column_name = inverted_index.columns[0];
         auto column_idx = tablet_schema->field_index(column_name);
         if (column_idx < 0) {
-            LOG(WARNING) << "referenced column was missing. "
-                         << "[column=" << column_name << " referenced_column=" << column_idx << "]";
-            continue;
+            if (!inverted_index.column_unique_ids.empty()) {
+                auto column_unique_id = inverted_index.column_unique_ids[0];
+                column_idx = tablet_schema->field_index(column_unique_id);
+            }
+            if (column_idx < 0) {
+                LOG(WARNING) << "referenced column was missing. "
+                             << "[column=" << column_name << " referenced_column=" << column_idx
+                             << "]";
+                continue;
+            }
         }
         auto column = tablet_schema->column(column_idx);
         auto writer_sign = std::make_pair(segment_idx, index_id);

--- a/regression-test/suites/fault_injection_p0/test_match_without_index_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_match_without_index_fault_injection.groovy
@@ -16,9 +16,9 @@
 // under the License.
 
 
-suite("test_match_without_index", "p0") {
+suite("test_match_without_index_fault_injection", "nonConcurrent") {
 
-    def testTable = "test_match_without_index"
+    def testTable = "test_match_without_index_fault_injection"
     sql "DROP TABLE IF EXISTS ${testTable}"
     sql """
         CREATE TABLE ${testTable} (

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -104,7 +104,7 @@ suite("test_index_change_on_renamed_column") {
 
     qt_select2 """ SELECT * FROM ${tableName} order by id; """
     // disable match without inverted index
-    qt_select3 """ SELECT /*+ SET_VAR(enable_match_without_inverted_index = false) */ * FROM ${tableName} where s1 match 'welcome'; """
+    qt_select3 """ SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_inverted_index_query = true) */ * FROM ${tableName} where s1 match 'welcome'; """
 
     def tablets = sql_return_maparray """ show tablets from ${tableName}; """
     String tablet_id = tablets[0].TabletId

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -104,7 +104,7 @@ suite("test_index_change_on_renamed_column") {
 
     qt_select2 """ SELECT * FROM ${tableName} order by id; """
     // disable match without inverted index
-    qt_select3 """ SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_inverted_index_query = true) */ * FROM ${tableName} where s1 match 'welcome'; """
+    qt_select3 """ SELECT /*+ SET_VAR(enable_inverted_index_query = true) */ * FROM ${tableName} where s1 match 'welcome'; """
 
     def tablets = sql_return_maparray """ show tablets from ${tableName}; """
     String tablet_id = tablets[0].TabletId

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -103,7 +103,8 @@ suite("test_index_change_on_renamed_column") {
     assertEquals(show_result[0][2], "idx_s")
 
     qt_select2 """ SELECT * FROM ${tableName} order by id; """
-    qt_select3 """ SELECT * FROM ${tableName} where s1 match 'welcome'; """
+    // disable match without inverted index
+    qt_select3 """ SELECT /*+ SET_VAR(enable_match_without_inverted_index = false) */ * FROM ${tableName} where s1 match 'welcome'; """
 
     def tablets = sql_return_maparray """ show tablets from ${tableName}; """
     String tablet_id = tablets[0].TabletId

--- a/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_index_change_on_renamed_column.groovy
@@ -103,7 +103,6 @@ suite("test_index_change_on_renamed_column") {
     assertEquals(show_result[0][2], "idx_s")
 
     qt_select2 """ SELECT * FROM ${tableName} order by id; """
-    // disable match without inverted index
     qt_select3 """ SELECT /*+ SET_VAR(enable_inverted_index_query = true) */ * FROM ${tableName} where s1 match 'welcome'; """
 
     def tablets = sql_return_maparray """ show tablets from ${tableName}; """


### PR DESCRIPTION
### What problem does this PR solve?

This PR is a followup repair on the basis of #42882.
Building index on renamed column will produce an empty index file, when `column_idx` is not found. 
The query is successful because match without inverted index.
Move test_match_without_index to fault_injection folder and make it non-concurrent to avoid concurrency issues.


### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    Fix build index empty index file on renamed column

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

