### PR TITLE
[opt](max-compute) avoid repeated location path creation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -81,8 +81,10 @@ import java.util.stream.Collectors;
 public class MaxComputeScanNode extends FileQueryScanNode {
 
     private final MaxComputeExternalTable table;
-    TableBatchReadSession tableBatchReadSession;
+    private TableBatchReadSession tableBatchReadSession;
     private Predicate filterPredicate;
+    private static final LocationPath ROW_OFFSET_PATH = new LocationPath("/row_offset", Maps.newHashMap());
+    private static final LocationPath BYTE_SIZE_PATH = new LocationPath("/byte_size", Maps.newHashMap());
 
     public MaxComputeScanNode(PlanNodeId id, TupleDescriptor desc, boolean needCheckColumnPriv) {
         this(id, desc, "MCScanNode", StatisticalType.MAX_COMPUTE_SCAN_NODE, needCheckColumnPriv);
@@ -441,7 +443,7 @@ public class MaxComputeScanNode extends FileQueryScanNode {
 
                 for (com.aliyun.odps.table.read.split.InputSplit split : assigner.getAllSplits()) {
                     MaxComputeSplit maxComputeSplit =
-                            new MaxComputeSplit(new LocationPath("/byte_size", Maps.newHashMap()),
+                            new MaxComputeSplit(BYTE_SIZE_PATH,
                                     ((IndexedInputSplit) split).getSplitIndex(), -1,
                                     mcCatalog.getSplitByteSize(),
                                     modificationTime, null,
@@ -464,7 +466,7 @@ public class MaxComputeScanNode extends FileQueryScanNode {
                             assigner.getSplitByRowOffset(offset, recordsPerSplit);
 
                     MaxComputeSplit maxComputeSplit =
-                            new MaxComputeSplit(new LocationPath("/row_offset", Maps.newHashMap()),
+                            new MaxComputeSplit(ROW_OFFSET_PATH,
                             offset, recordsPerSplit, totalRowCount, modificationTime, null,
                             Collections.emptyList());
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #41803

Problem Summary:
Cherry pick part of code from #41803, some of location path for max compute is constant
and do not need to create every time.
This optimization is already merged in branch-3.0

### Check List (For Committer)

- Test <!-- At least one of them must be included. -->

    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No colde files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:

    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?

    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

- Release note

    <!-- bugfix, feat, behavior changed need a release note -->
    <!-- Add one line release note for this PR. -->
    None

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

