### PR TITLE
[fix](cloud-mow) Fix clear GetDeleteBitmapResponse problem when geting delete bitmap fail and retry

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -699,6 +699,13 @@ Status CloudMetaMgr::sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_
     const auto& segment_ids = res.segment_ids();
     const auto& vers = res.versions();
     const auto& delete_bitmaps = res.segment_delete_bitmaps();
+    if (rowset_ids.size() != segment_ids.size() || rowset_ids.size() != vers.size() ||
+        rowset_ids.size() != delete_bitmaps.size()) {
+        return Status::Error<ErrorCode::INTERNAL_ERROR, false>(
+                "get delete bitmap data wrong,"
+                "rowset_ids.size={},segment_ids.size={},vers.size={},delete_bitmaps.size={}",
+                rowset_ids.size(), segment_ids.size(), vers.size(), delete_bitmaps.size());
+    }
     for (size_t i = 0; i < rowset_ids.size(); i++) {
         RowsetId rst_id;
         rst_id.init(rowset_ids[i]);

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1942,6 +1942,11 @@ void MetaServiceImpl::get_delete_bitmap(google::protobuf::RpcController* control
                     last_ver = ver;
                     last_seg_id = seg_id;
                 } else {
+                    TEST_SYNC_POINT_CALLBACK("get_delete_bitmap_code", &code);
+                    if (code != MetaServiceCode::OK) {
+                        msg = "test get get_delete_bitmap fail,code=" + MetaServiceCode_Name(code);
+                        return;
+                    }
                     response->mutable_segment_delete_bitmaps()->rbegin()->append(v);
                 }
             }

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -96,7 +96,7 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
             res->clear_rowset_ids();
             res->clear_segment_ids();
             res->clear_versions();
-            res->segment_delete_bitmaps();
+            res->clear_segment_delete_bitmaps();
         }
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
                   << " status=" << res->status().ShortDebugString()


### PR DESCRIPTION
pr https://github.com/apache/doris/pull/43261 doesn't clear GetDeleteBitmapResponse correctly, this pr fix this problem
pick pr https://github.com/apache/doris/pull/43358