### PR TITLE
[fix](sync point) Fix sync point not reg but construct default value

### DIFF
--- a/common/cpp/sync_point.cpp
+++ b/common/cpp/sync_point.cpp
@@ -50,6 +50,7 @@ public:
   void enable_processing();
   void disable_processing();
   void clear_trace();
+  bool has_point(const std::string& point);
 private:
   bool disable_by_marker(const std::string& point, std::thread::id thread_id);
 private:
@@ -106,6 +107,9 @@ void SyncPoint::clear_trace() {
 }
 void SyncPoint::process(const std::string& point, std::vector<std::any>&& cb_arg) {
   impl_->process(point, std::move(cb_arg));
+}
+bool SyncPoint::has_point(const std::string& point) {
+  return impl_->has_point(point);
 }
 
 // =============================================================================
@@ -235,6 +239,12 @@ void SyncPoint::Data::enable_processing() {
 
 void SyncPoint::Data::disable_processing() {
   enabled_ = false;
+}
+
+bool SyncPoint::Data::has_point(const std::string& point) {
+  std::unique_lock lock(mutex_);
+  auto marked_point_iter = marked_thread_id_.find(point);
+  return marked_point_iter != marked_thread_id_.end();
 }
 
 } // namespace doris

--- a/common/cpp/sync_point.cpp
+++ b/common/cpp/sync_point.cpp
@@ -51,6 +51,7 @@ public:
   void disable_processing();
   void clear_trace();
   bool has_point(const std::string& point);
+  bool get_enable();
 private:
   bool disable_by_marker(const std::string& point, std::thread::id thread_id);
 private:
@@ -110,6 +111,10 @@ void SyncPoint::process(const std::string& point, std::vector<std::any>&& cb_arg
 }
 bool SyncPoint::has_point(const std::string& point) {
   return impl_->has_point(point);
+}
+
+bool SyncPoint::get_enable() {
+  return impl_->get_enable();
 }
 
 // =============================================================================
@@ -245,6 +250,10 @@ bool SyncPoint::Data::has_point(const std::string& point) {
   std::unique_lock lock(mutex_);
   auto marked_point_iter = marked_thread_id_.find(point);
   return marked_point_iter != marked_thread_id_.end();
+}
+
+bool SyncPoint::Data::get_enable() {
+  return enabled_;
 }
 
 } // namespace doris

--- a/common/cpp/sync_point.h
+++ b/common/cpp/sync_point.h
@@ -153,6 +153,7 @@ public:
   // And/or call registered callback function, with argument `cb_args`
   void process(const std::string& point, std::vector<std::any>&& cb_args = {});
 
+  bool has_point(const std::string& point);
   // TODO: it might be useful to provide a function that blocks until all
   //       sync points are cleared.
   // We want this to be public so we can subclass the implementation
@@ -187,11 +188,13 @@ auto try_any_cast_ret(std::vector<std::any>& any) {
 #define SYNC_POINT_CALLBACK(x, ...) doris::SyncPoint::get_instance()->process(x, {__VA_ARGS__})
 #define SYNC_POINT_RETURN_WITH_VALUE(x, default_ret_val, ...) \
 { \
-  std::pair ret {default_ret_val, false}; \
-  std::vector<std::any> args {__VA_ARGS__}; \
-  args.emplace_back(&ret); \
-  doris::SyncPoint::get_instance()->process(x, std::move(args)); \
-  if (ret.second) return std::move(ret.first); \
+  if (doris::SyncPoint::get_instance()->has_point(x)) { \
+    std::pair ret {default_ret_val, false}; \
+    std::vector<std::any> args {__VA_ARGS__}; \
+    args.emplace_back(&ret); \
+    doris::SyncPoint::get_instance()->process(x, std::move(args)); \
+    if (ret.second) return std::move(ret.first); \
+  } \
 }
 #define SYNC_POINT_RETURN_WITH_VOID(x, ...) \
 { \

--- a/common/cpp/sync_point.h
+++ b/common/cpp/sync_point.h
@@ -153,7 +153,11 @@ public:
   // And/or call registered callback function, with argument `cb_args`
   void process(const std::string& point, std::vector<std::any>&& cb_args = {});
 
+  // Check if this point is registered
   bool has_point(const std::string& point);
+
+  // Get this point if enabled
+  bool get_enable();
   // TODO: it might be useful to provide a function that blocks until all
   //       sync points are cleared.
   // We want this to be public so we can subclass the implementation
@@ -188,11 +192,12 @@ auto try_any_cast_ret(std::vector<std::any>& any) {
 #define SYNC_POINT_CALLBACK(x, ...) doris::SyncPoint::get_instance()->process(x, {__VA_ARGS__})
 #define SYNC_POINT_RETURN_WITH_VALUE(x, default_ret_val, ...) \
 { \
-  if (doris::SyncPoint::get_instance()->has_point(x)) { \
+  auto sync_point = doris::SyncPoint::get_instance(); \
+  if (sync_point->get_enable() && sync_point->has_point(x)) { \
     std::pair ret {default_ret_val, false}; \
     std::vector<std::any> args {__VA_ARGS__}; \
     args.emplace_back(&ret); \
-    doris::SyncPoint::get_instance()->process(x, std::move(args)); \
+    sync_point->process(x, std::move(args)); \
     if (ret.second) return std::move(ret.first); \
   } \
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
You need to clearly describe your PR in this section:

1. What problem was fixed (it's best to include specific error reporting information). How it was fixed.
2. Which behaviors were modified. What was the previous behavior, what is it now, why was it modified, and what possible impacts might there be.
3. What features were added. Why was this function added?
4. Which code was refactored and why was this part of the code refactored?
5. Which functions were optimized and what is the difference before and after the optimization?

The description of the PR needs to enable reviewers to quickly and clearly understand the logic of the code modification.
-->
Fix open ENABLE_INJECTION_POINT complie switch， be log

```
W20241107 11:43:11.205868   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.275723   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.415167   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.484220   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.553351   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.622395   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.691509   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.830601   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.899286   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:11.967985   788 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:13.841727  1032 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:13.945942  1032 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:14.156761  1032 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:38.900395  3064 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:39.397446  3064 status.h:423] meet error status: [IO_ERROR]inject io error
W20241107 11:43:39.896116  3064 status.h:423] meet error status: [IO_ERROR]inject io error
```

For example, in the BE code:
```
TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileReader::read_at_impl",
                                   Status::IOError("inject io error"))
```

However, this sync point is not used in the BE, although it is used in the unit tests. But this macro, when expanded, will construct a default value, and Status::IOError will print the stack log as soon as it is constructed.


<!--
If there are related issues, please fill in the issue number.
- If you want the issue to be closed after the PR is merged, please use "close #12345". Otherwise, use "ref #12345".
-->
Issue Number: close #xxx

<!--
If this PR is a follow-up to a previous PR, for example, to fix a bug introduced by a related PR,
link the PR here.
-->
Related PR: #xxx

Problem Summary:


### Release note

<!-- bugfix, feat, behavior changed need a release note -->
<!-- Add a one-line release note for this PR. -->
None

