### PR TITLE
[opt](pr-template) add checklist back

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,39 @@
 ### What problem does this PR solve?
-<!--
-You need to clearly describe your PR in this section:
 
-1. What problem was fixed (it's best to include specific error reporting information). How it was fixed.
-2. Which behaviors were modified. What was the previous behavior, what is it now, why was it modified, and what possible impacts might there be.
-3. What features were added. Why was this function added?
-4. Which code was refactored and why was this part of the code refactored?
-5. Which functions were optimized and what is the difference before and after the optimization?
-
-The description of the PR needs to enable reviewers to quickly and clearly understand the logic of the code modification.
--->
-
-<!--
-If there are related issues, please fill in the issue number.
-- If you want the issue to be closed after the PR is merged, please use "close #12345". Otherwise, use "ref #12345".
--->
 Issue Number: close #xxx
 
-<!--
-If this PR is a follow-up to a previous PR, for example, to fix a bug introduced by a related PR,
-link the PR here.
--->
 Related PR: #xxx
 
 Problem Summary:
 
-
 ### Release note
 
-<!-- bugfix, feat, behavior changed need a release note -->
-<!-- Add a one-line release note for this PR. -->
 None
+
+### Check List (For Author)
+
+- Test <!-- At least one of them must be included. -->
+    - [ ] Regression test
+    - [ ] Unit Test
+    - [ ] Manual test (add detailed scripts or steps below)
+    - [ ] No need to test or manual test. Explain why:
+        - [ ] This is a refactor/code format and no logic has been changed.
+        - [ ] Previous test can cover this change.
+        - [ ] No code files have been changed.
+        - [ ] Other reason <!-- Add your reason?  -->
+
+- Behavior changed:
+    - [ ] No.
+    - [ ] Yes. <!-- Explain the behavior change -->
+
+- Does this need documentation?
+    - [ ] No.
+    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->
+
+### Check List (For Reviewer who merge this PR)
+
+- [ ] Confirm the release note
+- [ ] Confirm test cases
+- [ ] Confirm document
+- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Non-Committer can not modify the commend post by github robot.
So I have to add check list back to pr template
