### PR TITLE
[fix](segcompaction) fix coredump for inverted index file writer close in segment compaction

### DIFF
--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -324,7 +324,7 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
     }
     RETURN_IF_ERROR(_writer->_rename_compacted_segments(begin, end));
     if (_inverted_index_file_writer != nullptr) {
-        _inverted_index_file_writer.release();
+        _inverted_index_file_writer.reset();
     }
     if (VLOG_DEBUG_IS_ON) {
         _writer->vlog_buffer.clear();

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -324,7 +324,6 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
     }
     RETURN_IF_ERROR(_writer->_rename_compacted_segments(begin, end));
     if (_inverted_index_file_writer != nullptr) {
-        RETURN_IF_ERROR(_inverted_index_file_writer->close());
         _inverted_index_file_writer.release();
     }
     if (VLOG_DEBUG_IS_ON) {

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -323,7 +323,10 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
                                       _writer->_num_segcompacted);
     }
     RETURN_IF_ERROR(_writer->_rename_compacted_segments(begin, end));
-
+    if (_inverted_index_file_writer != nullptr) {
+        RETURN_IF_ERROR(_inverted_index_file_writer->close());
+        _inverted_index_file_writer.release();
+    }
     if (VLOG_DEBUG_IS_ON) {
         _writer->vlog_buffer.clear();
         for (const auto& entry : std::filesystem::directory_iterator(ctx.tablet_path)) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -45,6 +45,10 @@ ExecEnv::~ExecEnv() {
 }
 
 #ifdef BE_TEST
+void ExecEnv::set_inverted_index_searcher_cache(
+        segment_v2::InvertedIndexSearcherCache* inverted_index_searcher_cache) {
+    _inverted_index_searcher_cache = inverted_index_searcher_cache;
+}
 void ExecEnv::set_storage_engine(std::unique_ptr<BaseStorageEngine>&& engine) {
     _storage_engine = std::move(engine);
 }

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -273,6 +273,8 @@ public:
     }
 
     void set_storage_engine(std::unique_ptr<BaseStorageEngine>&& engine);
+    void set_inverted_index_searcher_cache(
+            segment_v2::InvertedIndexSearcherCache* inverted_index_searcher_cache);
     void set_cache_manager(CacheManager* cm) { this->_cache_manager = cm; }
     void set_process_profile(ProcessProfile* pp) { this->_process_profile = pp; }
     void set_tablet_schema_cache(TabletSchemaCache* c) { this->_tablet_schema_cache = c; }

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -49,6 +49,7 @@ using namespace ErrorCode;
 static const uint32_t MAX_PATH_LEN = 1024;
 static StorageEngine* l_engine = nullptr;
 static const std::string lTestDir = "./data_test/data/segcompaction_test";
+constexpr static std::string_view tmp_dir = "./data_test/tmp";
 
 class SegCompactionTest : public testing::Test {
 public:
@@ -71,6 +72,21 @@ public:
 
         std::vector<StorePath> paths;
         paths.emplace_back(config::storage_root_path, -1);
+
+        // tmp dir
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(tmp_dir).ok());
+        EXPECT_TRUE(io::global_local_filesystem()->create_directory(tmp_dir).ok());
+        paths.emplace_back(std::string(tmp_dir), 1024000000);
+        auto tmp_file_dirs = std::make_unique<segment_v2::TmpFileDirs>(paths);
+        EXPECT_TRUE(tmp_file_dirs->init().ok());
+        ExecEnv::GetInstance()->set_tmp_file_dir(std::move(tmp_file_dirs));
+
+        // use memory limit
+        int64_t inverted_index_cache_limit = 0;
+        _inverted_index_searcher_cache =
+                InvertedIndexSearcherCache::create_global_instance(inverted_index_cache_limit, 256);
+
+        ExecEnv::GetInstance()->set_inverted_index_searcher_cache(_inverted_index_searcher_cache);
 
         doris::EngineOptions options;
         options.store_paths = paths;
@@ -140,6 +156,7 @@ protected:
         tablet_schema_pb.set_num_rows_per_row_block(1024);
         tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
         tablet_schema_pb.set_next_column_unique_id(4);
+        tablet_schema_pb.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::V2);
 
         ColumnPB* column_1 = tablet_schema_pb.add_column();
         column_1->set_unique_id(1);
@@ -150,6 +167,11 @@ protected:
         column_1->set_index_length(4);
         column_1->set_is_nullable(true);
         column_1->set_is_bf_column(false);
+        auto tablet_index_1 = tablet_schema_pb.add_index();
+        tablet_index_1->set_index_id(1);
+        tablet_index_1->set_index_name("column_1");
+        tablet_index_1->set_index_type(IndexType::INVERTED);
+        tablet_index_1->add_col_unique_id(1);
 
         ColumnPB* column_2 = tablet_schema_pb.add_column();
         column_2->set_unique_id(2);
@@ -162,6 +184,11 @@ protected:
         column_2->set_is_key(true);
         column_2->set_is_nullable(true);
         column_2->set_is_bf_column(false);
+        auto tablet_index_2 = tablet_schema_pb.add_index();
+        tablet_index_2->set_index_id(2);
+        tablet_index_2->set_index_name("column_2");
+        tablet_index_2->set_index_type(IndexType::INVERTED);
+        tablet_index_2->add_col_unique_id(2);
 
         for (int i = 1; i <= num_value_col; i++) {
             ColumnPB* v_column = tablet_schema_pb.add_column();
@@ -245,6 +272,7 @@ protected:
 
 private:
     std::unique_ptr<DataDir> _data_dir;
+    InvertedIndexSearcherCache* _inverted_index_searcher_cache;
 };
 
 TEST_F(SegCompactionTest, SegCompactionThenRead) {
@@ -300,6 +328,13 @@ TEST_F(SegCompactionTest, SegCompactionThenRead) {
         ls.push_back("10047_4.dat");
         ls.push_back("10047_5.dat");
         ls.push_back("10047_6.dat");
+        ls.push_back("10047_0.idx");
+        ls.push_back("10047_1.idx");
+        ls.push_back("10047_2.idx");
+        ls.push_back("10047_3.idx");
+        ls.push_back("10047_4.idx");
+        ls.push_back("10047_5.idx");
+        ls.push_back("10047_6.idx");
         EXPECT_TRUE(check_dir(ls));
     }
 
@@ -502,6 +537,13 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
         ls.push_back("10048_4.dat"); // O
         ls.push_back("10048_5.dat"); // oooooooo
         ls.push_back("10048_6.dat"); // O
+        ls.push_back("10048_0.idx"); // oooo
+        ls.push_back("10048_1.idx"); // O
+        ls.push_back("10048_2.idx"); // O
+        ls.push_back("10048_3.idx"); // o
+        ls.push_back("10048_4.idx"); // O
+        ls.push_back("10048_5.idx"); // oooooooo
+        ls.push_back("10048_6.idx"); // O
         EXPECT_TRUE(check_dir(ls));
     }
 }
@@ -628,6 +670,11 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_OoOoO) {
         ls.push_back("10049_2.dat"); // O
         ls.push_back("10049_3.dat"); // o
         ls.push_back("10049_4.dat"); // O
+        ls.push_back("10049_0.idx"); // O
+        ls.push_back("10049_1.idx"); // o
+        ls.push_back("10049_2.idx"); // O
+        ls.push_back("10049_3.idx"); // o
+        ls.push_back("10049_4.idx"); // O
         EXPECT_TRUE(check_dir(ls));
     }
 }
@@ -789,6 +836,10 @@ TEST_F(SegCompactionTest, SegCompactionThenReadUniqueTableSmall) {
         ls.push_back("10051_1.dat");
         ls.push_back("10051_2.dat");
         ls.push_back("10051_3.dat");
+        ls.push_back("10051_0.idx");
+        ls.push_back("10051_1.idx");
+        ls.push_back("10051_2.idx");
+        ls.push_back("10051_3.idx");
         EXPECT_TRUE(check_dir(ls));
     }
 
@@ -1049,6 +1100,10 @@ TEST_F(SegCompactionTest, SegCompactionThenReadAggTableSmall) {
         ls.push_back("10052_1.dat");
         ls.push_back("10052_2.dat");
         ls.push_back("10052_3.dat");
+        ls.push_back("10052_0.idx");
+        ls.push_back("10052_1.idx");
+        ls.push_back("10052_2.idx");
+        ls.push_back("10052_3.idx");
         EXPECT_TRUE(check_dir(ls));
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #41625

Problem Summary:
Fix coredump when doing segcompaction after refactor of inverted index file writer.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

