### PR TITLE
[opt](arm)Remove negative optimizations of SSE2NEON on memcmp for ARM…

### DIFF
--- a/be/src/vec/common/memcmp_small.h
+++ b/be/src/vec/common/memcmp_small.h
@@ -38,7 +38,7 @@ int cmp(T a, T b) {
 /// Results don't depend on the values inside uninitialized memory but Memory Sanitizer cannot see it.
 /// Disable optimized functions if compile with Memory Sanitizer.
 
-#if (defined(__SSE2__) || defined(__aarch64__)) && !defined(MEMORY_SANITIZER)
+#if (defined(__SSE2__) && !defined(__aarch64__)) && !defined(MEMORY_SANITIZER)
 #include "util/sse_util.hpp"
 
 /** All functions works under the following assumptions:


### PR DESCRIPTION
… (#38759)
https://github.com/apache/doris/pull/38759
The main issue is that _mm_movemask_epi8 does not have a one-to-one corresponding instruction on ARM. Testing shows that it performs worse compared to using memcmp, which allows the compiler to generate the corresponding ARM instructions.
The following tests were conducted on ARM.
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
BM_memequal16_sse         3.77 ns         3.77 ns    743238946
BM_memequal16_orgin       2.11 ns         2.11 ns   1000000000
```

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

