### PR TITLE
[fix](column_complex) wrong type of Field returned by ColumnComplex

### DIFF
--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -488,7 +488,7 @@ Status process_single_column(const rapidjson::Value& col, PrimitiveType sub_type
                              bool pure_doc_value, vectorized::Array& array) {
     T val;
     RETURN_IF_ERROR(handle_value<T>(col, sub_type, pure_doc_value, val));
-    array.push_back(val);
+    array.push_back(vectorized::Field(val));
     return Status::OK();
 }
 

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include <vector>
 
 #include "olap/hll.h"
@@ -129,13 +131,14 @@ public:
     MutableColumnPtr clone_resized(size_t size) const override;
 
     void insert(const Field& x) override {
+        DCHECK_EQ(x.get_type(), Field::TypeToEnum<T>::value);
         const T& s = doris::vectorized::get<const T&>(x);
         data.push_back(s);
     }
 
     Field operator[](size_t n) const override {
         assert(n < size());
-        return {reinterpret_cast<const char*>(&data[n]), sizeof(data[n])};
+        return Field(data[n]);
     }
 
     void get(size_t n, Field& res) const override {

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -105,11 +105,13 @@ public:
     }
 
     Field operator[](size_t n) const override {
-        return {_data.data() + n * _item_size, _item_size};
+        return Field(
+                String(reinterpret_cast<const char*>(_data.data() + n * _item_size), _item_size));
     }
 
     void get(size_t n, Field& res) const override {
-        res.assign_string(_data.data() + n * _item_size, _item_size);
+        res = Field(
+                String(reinterpret_cast<const char*>(_data.data() + n * _item_size), _item_size));
     }
 
     StringRef get_data_at(size_t n) const override {

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -122,7 +122,7 @@ public:
 
     Field operator[](size_t n) const override {
         assert(n < size());
-        return Field(&chars[offset_at(n)], size_at(n));
+        return Field(String(reinterpret_cast<const char*>(&chars[offset_at(n)]), size_at(n)));
     }
 
     void get(size_t n, Field& res) const override {
@@ -132,7 +132,7 @@ public:
             res = JsonbField(reinterpret_cast<const char*>(&chars[offset_at(n)]), size_at(n));
             return;
         }
-        res.assign_string(&chars[offset_at(n)], size_at(n));
+        res = Field(String(reinterpret_cast<const char*>(&chars[offset_at(n)]), size_at(n)));
     }
 
     StringRef get_data_at(size_t n) const override {

--- a/be/src/vec/common/schema_util.cpp
+++ b/be/src/vec/common/schema_util.cpp
@@ -572,7 +572,7 @@ Status extract(ColumnPtr source, const PathInData& path, MutableColumnPtr& dst) 
                                  : std::make_shared<DataTypeJsonb>();
     ColumnsWithTypeAndName arguments {
             {source, json_type, ""},
-            {type_string->create_column_const(1, Field(jsonpath.data(), jsonpath.size())),
+            {type_string->create_column_const(1, Field(String(jsonpath.data(), jsonpath.size()))),
              type_string, ""}};
     auto function =
             SimpleFunctionFactory::instance().get_function("jsonb_extract", arguments, json_type);

--- a/be/src/vec/core/field.cpp
+++ b/be/src/vec/core/field.cpp
@@ -74,7 +74,7 @@ void read_binary(Array& x, BufferReadable& buf) {
         case Field::Types::String: {
             std::string value;
             doris::vectorized::read_string_binary(value, buf);
-            x.push_back(value);
+            x.push_back(Field(value));
             break;
         }
         case Field::Types::JSONB: {

--- a/be/src/vec/data_types/data_type_fixed_length_object.h
+++ b/be/src/vec/data_types/data_type_fixed_length_object.h
@@ -60,7 +60,7 @@ public:
         return doris::FieldType::OLAP_FIELD_TYPE_NONE;
     }
 
-    Field get_default() const override { return String(); }
+    Field get_default() const override { return Field(String()); }
 
     [[noreturn]] Field get_field(const TExprNode& node) const override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,

--- a/be/src/vec/data_types/data_type_jsonb.h
+++ b/be/src/vec/data_types/data_type_jsonb.h
@@ -78,7 +78,7 @@ public:
         DCHECK_EQ(node.node_type, TExprNodeType::JSON_LITERAL);
         DCHECK(node.__isset.json_literal);
         JsonBinaryValue value(node.json_literal.value);
-        return String(value.value(), value.size());
+        return Field(String(value.value(), value.size()));
     }
 
     bool equals(const IDataType& rhs) const override;

--- a/be/src/vec/data_types/data_type_object.h
+++ b/be/src/vec/data_types/data_type_object.h
@@ -81,10 +81,10 @@ public:
 
     Field get_field(const TExprNode& node) const override {
         if (node.__isset.string_literal) {
-            return node.string_literal.value;
+            return Field(node.string_literal.value);
         }
         if (node.node_type == TExprNodeType::NULL_LITERAL) {
-            return Field();
+            return {};
         }
         std::stringstream error_string;
         node.printTo(error_string);

--- a/be/src/vec/data_types/data_type_string.cpp
+++ b/be/src/vec/data_types/data_type_string.cpp
@@ -66,7 +66,7 @@ Status DataTypeString::from_string(ReadBuffer& rb, IColumn* column) const {
 }
 
 Field DataTypeString::get_default() const {
-    return String();
+    return Field(String());
 }
 
 MutableColumnPtr DataTypeString::create_column() const {

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -75,7 +75,7 @@ public:
     Field get_field(const TExprNode& node) const override {
         DCHECK_EQ(node.node_type, TExprNodeType::STRING_LITERAL);
         DCHECK(node.__isset.string_literal);
-        return node.string_literal.value;
+        return Field(node.string_literal.value);
     }
 
     bool equals(const IDataType& rhs) const override;

--- a/be/src/vec/data_types/serde/data_type_object_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_object_serde.cpp
@@ -26,6 +26,7 @@
 #include "vec/common/assert_cast.h"
 #include "vec/common/schema_util.h"
 #include "vec/core/field.h"
+#include "vec/core/types.h"
 
 #ifdef __AVX2__
 #include "util/jsonb_parser_simd.h"
@@ -117,11 +118,11 @@ void DataTypeObjectSerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbV
     Field field;
     if (arg->isBinary()) {
         const auto* blob = static_cast<const JsonbBlobVal*>(arg);
-        field.assign_jsonb(blob->getBlob(), blob->getBlobLen());
+        field = JsonbField(blob->getBlob(), blob->getBlobLen());
     } else if (arg->isString()) {
         // not a valid jsonb type, insert as string
         const auto* str = static_cast<const JsonbStringVal*>(arg);
-        field.assign_string(str->getBlob(), str->getBlobLen());
+        field = Field(String(str->getBlob(), str->getBlobLen()));
     } else {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR, "Invalid jsonb type");
     }

--- a/be/src/vec/json/parse2column.cpp
+++ b/be/src/vec/json/parse2column.cpp
@@ -149,7 +149,7 @@ void parse_json_to_variant(IColumn& column, const char* src, size_t length,
         }
         // Treat as string
         PathInData root_path;
-        Field field(src, length);
+        Field field(String(src, length));
         result = ParseResult {{root_path}, {field}};
     }
     auto& [paths, values] = *result;

--- a/be/test/olap/rowset/segment_v2/inverted_index/compaction/index_compaction_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/compaction/index_compaction_test.cpp
@@ -289,8 +289,8 @@ TEST_F(IndexCompactionTest, write_index_test) {
         auto columns = block.mutate_columns();
         for (const auto& row : data[i]) {
             vectorized::Field key = Int32(row.key);
-            vectorized::Field v1 = row.word;
-            vectorized::Field v2 = row.url;
+            vectorized::Field v1(row.word);
+            vectorized::Field v2(row.url);
             vectorized::Field v3 = Int32(row.num);
             columns[0]->insert(key);
             columns[1]->insert(v1);

--- a/be/test/olap/rowset/segment_v2/inverted_index/compaction/index_compaction_with_deleted_term.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/compaction/index_compaction_with_deleted_term.cpp
@@ -582,8 +582,8 @@ TEST_F(IndexCompactionDeleteTest, delete_index_test) {
         auto columns = block.mutate_columns();
         for (const auto& row : data[i]) {
             vectorized::Field key = Int32(row.key);
-            vectorized::Field v1 = row.word;
-            vectorized::Field v2 = row.url;
+            vectorized::Field v1(row.word);
+            vectorized::Field v2(row.url);
             vectorized::Field v3 = Int32(row.num);
             columns[0]->insert(key);
             columns[1]->insert(v1);

--- a/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
@@ -71,7 +71,7 @@ TEST_P(AggMinMaxByTest, min_max_by_test) {
             min_pair.first = str_val;
             min_pair.second = i;
         }
-        column_vector_key_str->insert(cast_to_nearest_field_type(str_val));
+        column_vector_key_str->insert(Field(cast_to_nearest_field_type(str_val)));
     }
 
     // Prepare test function and parameters.

--- a/be/test/vec/columns/column_hash_func_test.cpp
+++ b/be/test/vec/columns/column_hash_func_test.cpp
@@ -242,7 +242,7 @@ TEST(HashFuncTest, StructTypeTestWithSepcificValueCrcHash) {
 
     Tuple t;
     t.push_back(Int64(1));
-    t.push_back(String("hello"));
+    t.push_back(Field(String("hello")));
 
     DataTypePtr a = std::make_shared<DataTypeStruct>(dataTypes);
     std::cout << a->get_name() << std::endl;

--- a/be/test/vec/columns/column_nullable_test.h
+++ b/be/test/vec/columns/column_nullable_test.h
@@ -83,7 +83,7 @@ inline MutableColumnPtr create_nested_column(size_t input_rows_count) {
         if constexpr (std::is_integral_v<T>) {
             column->insert(rand() % std::numeric_limits<T>::max());
         } else if constexpr (std::is_same_v<T, String>) {
-            column->insert(generate_random_string(rand() % 512));
+            column->insert(Field(generate_random_string(rand() % 512)));
         } else if constexpr (std::is_same_v<T, Decimal64>) {
             column->insert(Int64(rand() % std::numeric_limits<Int64>::max()));
         } else {

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -17,8 +17,10 @@
 
 #include "vec/columns/column_complex.h"
 
+#include <glog/logging.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
 #include <stddef.h>
 
 #include <memory>
@@ -26,6 +28,8 @@
 
 #include "agent/be_exec_version_manager.h"
 #include "gtest/gtest_pred_impl.h"
+#include "util/bitmap_value.h"
+#include "vec/core/field.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_quantilestate.h"
@@ -72,17 +76,30 @@ public:
     }
 
     void check_serialize_and_deserialize(MutableColumnPtr& col) {
-        auto column = assert_cast<ColumnBitmap*>(col.get());
+        auto* column = assert_cast<ColumnBitmap*>(col.get());
         auto size = _bitmap_type.get_uncompressed_serialized_bytes(
                 *column, BeExecVersionManager::get_newest_version());
         std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
-        auto result = _bitmap_type.serialize(*column, buf.get(),
-                                             BeExecVersionManager::get_newest_version());
+        auto* result = _bitmap_type.serialize(*column, buf.get(),
+                                              BeExecVersionManager::get_newest_version());
         ASSERT_EQ(result, buf.get() + size);
 
         auto column2 = _bitmap_type.create_column();
         _bitmap_type.deserialize(buf.get(), &column2, BeExecVersionManager::get_newest_version());
         check_bitmap_column(*column, *column2.get());
+    }
+
+    void check_field_type(MutableColumnPtr& col) {
+        auto& column = assert_cast<ColumnBitmap&>(*col.get());
+        auto dst_column = ColumnBitmap::create();
+        const auto rows = column.size();
+        for (size_t i = 0; i != rows; ++i) {
+            auto field = column[i];
+            ASSERT_EQ(field.get_type(), Field::Types::Bitmap);
+            dst_column->insert(field);
+        }
+
+        check_bitmap_column(column, *dst_column);
     }
 
 private:
@@ -94,7 +111,7 @@ public:
     virtual void SetUp() override {}
     virtual void TearDown() override {}
 
-    void check_bitmap_column(const IColumn& l, const IColumn& r) {
+    void check_quantile_state_column(const IColumn& l, const IColumn& r) {
         ASSERT_EQ(l.size(), r.size());
         const auto& l_col = assert_cast<const ColumnQuantileState&>(l);
         const auto& r_col = assert_cast<const ColumnQuantileState&>(r);
@@ -117,7 +134,20 @@ public:
         auto column2 = _quantile_state_type.create_column();
         _quantile_state_type.deserialize(buf.get(), &column2,
                                          BeExecVersionManager::get_newest_version());
-        check_bitmap_column(*column, *column2.get());
+        check_quantile_state_column(*column, *column2.get());
+    }
+
+    void check_field_type(MutableColumnPtr& col) {
+        auto& column = assert_cast<ColumnQuantileState&>(*col.get());
+        auto dst_column = ColumnQuantileState::create();
+        const auto rows = column.size();
+        for (size_t i = 0; i != rows; ++i) {
+            auto field = column[i];
+            ASSERT_EQ(field.get_type(), Field::Types::QuantileState);
+            dst_column->insert(field);
+        }
+
+        check_quantile_state_column(column, *dst_column);
     }
 
 private:
@@ -153,6 +183,38 @@ TEST_F(ColumnBitmapTest, ColumnBitmapReadWrite) {
     EXPECT_TRUE(bitmap.contains(1000000));
 }
 
+TEST_F(ColumnBitmapTest, OperatorValidate) {
+    auto column = _bitmap_type.create_column();
+
+    // empty column
+    check_serialize_and_deserialize(column);
+
+    // bitmap with lots of rows
+    const size_t row_size = 128;
+    auto& data = assert_cast<ColumnBitmap&>(*column.get()).get_data();
+    data.reserve(row_size);
+
+    for (size_t i = 0; i != row_size; ++i) {
+        BitmapValue bitmap_value;
+        for (size_t j = 0; j <= i; ++j) {
+            bitmap_value.add(j);
+        }
+        data.emplace_back(std::move(bitmap_value));
+    }
+
+    auto& bitmap_column = assert_cast<ColumnBitmap&>(*column.get());
+    for (size_t i = 0; i != row_size; ++i) {
+        auto field = bitmap_column[i];
+        ASSERT_EQ(field.get_type(), Field::Types::Bitmap);
+        const auto& bitmap = vectorized::get<BitmapValue&>(field);
+
+        ASSERT_EQ(bitmap.cardinality(), i + 1);
+        for (size_t j = 0; j <= i; ++j) {
+            ASSERT_TRUE(bitmap.contains(j));
+        }
+    }
+}
+
 TEST_F(ColumnQuantileStateTest, ColumnQuantileStateReadWrite) {
     auto column = _quantile_state_type.create_column();
     // empty column
@@ -178,6 +240,21 @@ TEST_F(ColumnQuantileStateTest, ColumnQuantileStateReadWrite) {
         data[0].add_value(i);
     }
     check_serialize_and_deserialize(column);
+}
+
+TEST_F(ColumnQuantileStateTest, OperatorValidate) {
+    auto column = _quantile_state_type.create_column();
+
+    // empty column
+    check_serialize_and_deserialize(column);
+
+    // bitmap with lots of rows
+    const size_t row_size = 20000;
+    auto& data = assert_cast<ColumnQuantileState&>(*column.get()).get_data();
+    data.resize(row_size);
+    check_serialize_and_deserialize(column);
+
+    check_field_type(column);
 }
 
 } // namespace doris::vectorized

--- a/be/test/vec/core/field_test.cpp
+++ b/be/test/vec/core/field_test.cpp
@@ -39,7 +39,7 @@ TEST(VFieldTest, field_string) {
     ASSERT_EQ(f.get<String>(), "Hello, world (4)");
     f = Array {Field {String {"Hello, world (5)"}}};
     ASSERT_EQ(f.get<Array>()[0].get<String>(), "Hello, world (5)");
-    f = Array {String {"Hello, world (6)"}};
+    f = Array {Field(String {"Hello, world (6)"})};
     ASSERT_EQ(f.get<Array>()[0].get<String>(), "Hello, world (6)");
 }
 

--- a/be/test/vec/data_types/serde/data_type_serde_pb_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_pb_test.cpp
@@ -583,10 +583,10 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTestStruct) {
     DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
     Tuple t1, t2;
-    t1.push_back(String("amory cute"));
+    t1.push_back(Field(String("amory cute")));
     t1.push_back(__int128_t(37));
     t1.push_back(true);
-    t2.push_back("null");
+    t2.push_back(Field("null"));
     t2.push_back(__int128_t(26));
     t2.push_back(false);
     MutableColumnPtr struct_column = st->create_column();
@@ -614,7 +614,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTestStruct2) {
     DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
     Tuple t1, t2;
-    t1.push_back(String("amory cute"));
+    t1.push_back(Field(String("amory cute")));
     t1.push_back(37);
     t1.push_back(true);
     t2.push_back("null");

--- a/be/test/vec/data_types/serde/data_type_to_string_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_to_string_test.cpp
@@ -45,9 +45,9 @@ TEST(ToStringMethodTest, DataTypeToStringTest) {
     a1.push_back(Null());
     a1.push_back(UInt64(12345678));
     a1.push_back(UInt64(0));
-    a2.push_back(String("hello amory"));
-    a2.push_back("NULL");
-    a2.push_back(String("cute amory"));
+    a2.push_back(Field(String("hello amory")));
+    a2.push_back(Field("NULL"));
+    a2.push_back(Field(String("cute amory")));
     a2.push_back(Null());
     Map m;
     m.push_back(a1);
@@ -55,11 +55,11 @@ TEST(ToStringMethodTest, DataTypeToStringTest) {
 
     Tuple t;
     t.push_back(Int128(12345454342));
-    t.push_back(String("amory cute"));
+    t.push_back(Field(String("amory cute")));
     t.push_back(UInt64(0));
 
     cases.field_values = {UInt64(12),
-                          String(" hello amory , cute amory "),
+                          Field(String(" hello amory , cute amory ")),
                           DecimalField<Decimal32>(-12345678, 0),
                           a1,
                           a2,

--- a/be/test/vec/function/function_array_element_test.cpp
+++ b/be/test/vec/function/function_array_element_test.cpp
@@ -148,7 +148,7 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::Int32};
 
-        Array vec = {Field("abc", 3), Field("", 0), Field("def", 3)};
+        Array vec = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
         DataSet data_set = {{{vec, 1}, std::string("abc")},
                             {{vec, 2}, std::string("")},
                             {{vec, 10}, Null()},

--- a/be/test/vec/function/function_array_index_test.cpp
+++ b/be/test/vec/function/function_array_index_test.cpp
@@ -152,7 +152,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::String};
 
-        Array vec = {Field("abc", 3), Field("", 0), Field("def", 3)};
+        Array vec = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
         DataSet data_set = {{{vec, std::string("abc")}, UInt8(1)},
                             {{vec, std::string("aaa")}, UInt8(0)},
                             {{vec, std::string("")}, UInt8(1)},
@@ -252,7 +252,7 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::String};
 
-        Array vec = {Field("abc", 3), Field("", 0), Field("def", 3)};
+        Array vec = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
         DataSet data_set = {{{vec, std::string("abc")}, Int64(1)},
                             {{vec, std::string("aaa")}, Int64(0)},
                             {{vec, std::string("")}, Int64(2)},

--- a/be/test/vec/function/function_array_size_test.cpp
+++ b/be/test/vec/function/function_array_size_test.cpp
@@ -47,8 +47,8 @@ TEST(function_array_size_test, size) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field("abc", 3), Field("", 0), Field("def", 3)};
-        Array vec2 = {Field("abc", 3), Field("123", 0), Field("def", 3)};
+        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        Array vec2 = {Field(String("abc", 3)), Field(String("123", 0)), Field(String("def", 3))};
         DataSet data_set = {{{vec1}, Int64(3)},
                             {{vec2}, Int64(3)},
                             {{Null()}, Null()},
@@ -76,8 +76,8 @@ TEST(function_array_size_test, cardinality) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field("abc", 3), Field("", 0), Field("def", 3)};
-        Array vec2 = {Field("abc", 3), Field("123", 0), Field("def", 3)};
+        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        Array vec2 = {Field(String("abc", 3)), Field(String("123", 0)), Field(String("def", 3))};
         DataSet data_set = {{{vec1}, Int64(3)},
                             {{vec2}, Int64(3)},
                             {{Null()}, Null()},
@@ -105,8 +105,8 @@ TEST(function_array_size_test, array_size) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field("abc", 3), Field("", 0), Field("def", 3)};
-        Array vec2 = {Field("abc", 3), Field("123", 0), Field("def", 3)};
+        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        Array vec2 = {Field(String("abc", 3)), Field(String("123", 0)), Field(String("def", 3))};
         DataSet data_set = {{{vec1}, Int64(3)},
                             {{vec2}, Int64(3)},
                             {{Null()}, Null()},

--- a/be/test/vec/function/function_arrays_overlap_test.cpp
+++ b/be/test/vec/function/function_arrays_overlap_test.cpp
@@ -124,9 +124,9 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::Array,
                                     TypeIndex::String};
 
-        Array vec1 = {Field("abc", 3), Field("", 0), Field("def", 3)};
-        Array vec2 = {Field("abc", 3)};
-        Array vec3 = {Field("", 0)};
+        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        Array vec2 = {Field(String("abc", 3))};
+        Array vec3 = {Field(String("", 0))};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)},
                             {{vec1, vec3}, UInt8(1)},
                             {{Null(), vec1}, Null()},

--- a/be/test/vec/function/function_compressed_materialization_test.cpp
+++ b/be/test/vec/function/function_compressed_materialization_test.cpp
@@ -111,7 +111,7 @@ void encode_and_decode(size_t len_of_varchar, std::string function_name) {
                 continue;
             } else {
                 std::string random_bytes = generate_random_len_and_random_bytes(m);
-                col_source_str_mutate->insert(Field(random_bytes.c_str(), random_bytes.size()));
+                col_source_str_mutate->insert(Field(random_bytes));
             }
         }
 
@@ -185,7 +185,7 @@ TEST(CompressedMaterializationTest, abnormal_test) {
 
     for (size_t i = 0; i < input_rows_count; ++i) {
         std::string random_bytes = generate_random_bytes(16);
-        col_source_str_mutate->insert(Field(random_bytes.c_str(), random_bytes.size()));
+        col_source_str_mutate->insert(Field(random_bytes));
     }
 
     auto col_source_str = std::move(col_source_str_mutate);

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -1417,11 +1417,11 @@ TEST(function_string_test, function_concat_ws_test) {
     {
         BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field("", 0), Field("", 0), Field("", 0)};
-        Array vec2 = {Field("123", 3), Field("456", 3), Field("789", 3)};
-        Array vec3 = {Field("", 0), Field("?", 1), Field("", 0)};
-        Array vec4 = {Field("abc", 3), Field("", 0), Field("def", 3)};
-        Array vec5 = {Field("abc", 3), Field("def", 3), Field("ghi", 3)};
+        Array vec1 = {Field(String("", 0)), Field(String("", 0)), Field(String("", 0))};
+        Array vec2 = {Field(String("123", 3)), Field(String("456", 3)), Field(String("789", 3))};
+        Array vec3 = {Field(String("", 0)), Field(String("?", 1)), Field(String("", 0))};
+        Array vec4 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        Array vec5 = {Field(String("abc", 3)), Field(String("def", 3)), Field(String("ghi", 3))};
         DataSet data_set = {{{std::string("-"), vec1}, std::string("--")},
                             {{std::string(""), vec2}, std::string("123456789")},
                             {{std::string("-"), vec3}, std::string("-?-")},

--- a/be/test/vec/function/table_function_test.cpp
+++ b/be/test/vec/function/table_function_test.cpp
@@ -97,7 +97,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     // explode_outer(Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {std::string("abc"), std::string(""), std::string("def")};
+        Array vec = {Field(std::string("abc")), Field(std::string("")), Field(std::string("def"))};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::String};
@@ -144,7 +144,7 @@ TEST_F(TableFunctionTest, vexplode) {
     // explode(Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {std::string("abc"), std::string(""), std::string("def")};
+        Array vec = {Field(std::string("abc")), Field(std::string("")), Field(std::string("def"))};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::String};

--- a/be/test/vec/jsonb/serialize_test.cpp
+++ b/be/test/vec/jsonb/serialize_test.cpp
@@ -294,7 +294,7 @@ TEST(BlockSerializeTest, Struct) {
         DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
         DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
         Tuple t1, t2;
-        t1.push_back(String("amory cute"));
+        t1.push_back(Field(String("amory cute")));
         t1.push_back(__int128_t(37));
         t1.push_back(true);
         t2.push_back("null");

--- a/regression-test/data/datatype_p0/complex_types/test_map.out
+++ b/regression-test/data/datatype_p0/complex_types/test_map.out
@@ -14,3 +14,6 @@
 6	3	{"key3":"value3", "key33":"value33", "key3333":"value333"}	6	3
 7	4	{"key4":"value4", "key44":"value44", "key444":"value444", "key4444":"value4444"}	\N	\N
 
+-- !sql2 --
+3	true	true	true
+


### PR DESCRIPTION
### What problem does this PR solve?

`ColumnComplex::operator[](size_t n)` always return String Field type.

```
*** Query id: b73dc1a149a469b-ac1b822f8fe0a8a2 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1731047590 (unix time) try "date -d @1731047590" if you are using GNU date ***
*** Current BE git commitID: 55e92da7e7 ***
*** SIGSEGV address not mapped to object (@0x58) received by PID 2528792 (TID 2533139 OR 0x7f6add64b700) from PID 88; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/doris/be/src/common/signal_handler.h:421
 1# 0x00007F6FEE12BB50 in /lib64/libc.so.6
 2# doris::BitmapValue::BitmapValue(doris::BitmapValue const&) at /mnt/disk1/doris/be/src/util/bitmap_value.h:850
 3# void std::vector<doris::BitmapValue, std::allocator<doris::BitmapValue> >::_M_realloc_insert<doris::BitmapValue const&>(__gnu_cxx::__normal_iterator<doris::BitmapValue*, std::vector<doris::BitmapValue, std::allocator<doris::BitmapValue> > >, doris::BitmapValue const&) in /mnt/disk1/doris/be/output/lib/doris_be
 4# doris::vectorized::ColumnNullable::insert(doris::vectorized::Field const&) at /mnt/disk1/doris/be/src/vec/columns/column_nullable.cpp:334
 5# doris::vectorized::AggregateFunctionMapAggData<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::add(doris::vectorized::Field const&, doris::vectorized::Field const&) in /mnt/disk1/doris/be/output/lib/doris_be
 6# doris::vectorized::AggregateFunctionMapAgg<doris::vectorized::AggregateFunctionMapAggData<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::deserialize_and_merge_from_column(char*, doris::vectorized::IColumn const&, doris::vectorized::Arena*) const at /mnt/disk1/doris/be/src/vec/aggregate_functions/aggregate_function_map.h:287
 7# doris::pipeline::AggSinkLocalState::_merge_without_key(doris::vectorized::Block*) at /mnt/disk1/doris/be/src/pipeline/exec/aggregation_sink_operator.cpp:389
 8# doris::pipeline::AggSinkLocalState::Executor<true, true>::execute(doris::pipeline::AggSinkLocalState*, doris::vectorized::Block*) at /mnt/disk1/doris/be/src/pipeline/exec/aggregation_sink_operator.h:73
 9# doris::pipeline::AggSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at /mnt/disk1/doris/be/src/pipeline/exec/aggregation_sink_operator.cpp:744
10# doris::pipeline::PipelineXTask::execute(bool*) at /mnt/disk1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:332
11# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /mnt/disk1/doris/be/src/pipeline/task_scheduler.cpp:347
12# doris::ThreadPool::dispatch_thread() in /mnt/disk1/doris/be/output/lib/doris_be
13# doris::Thread::supervise_thread(void*) at /mnt/disk1/doris/be/src/util/thread.cpp:499
14# start_thread in /lib64/libpthread.so.0
15# __clone in /lib64/libc.so.6
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

