### PR TITLE
[opt](cloud) Simplify default config file of meta-service (#43381)

### DIFF
--- a/cloud/conf/doris_cloud.conf
+++ b/cloud/conf/doris_cloud.conf
@@ -15,33 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# // meta_service
 brpc_listen_port = 5000
-brpc_num_threads = -1
-brpc_idle_timeout_sec = 30
 fdb_cluster = xxx:yyy@127.0.0.1:4500
-fdb_cluster_file_path = ./conf/fdb.cluster
+# http request to meta-service needs this token for auth
 http_token = greedisgood9999
+# use CIDR to mask if there are multiple NICs
+# priority_networks = 192.168.0.1/24
 
-# // doris txn config
-label_keep_max_second = 259200
-expired_txn_scan_key_nums = 1000
-
-# // logging
+# logging
 log_dir = ./log/
-# info warn error
+# candidates: info warn error
 log_level = info
 log_size_mb = 1024
 log_filenum_quota = 10
-log_immediate_flush = false
 # log_verbose_modules = *
 
-# // recycler config
-recycle_interval_seconds = 3600
-retention_seconds = 259200
-recycle_concurrency = 16
-# recycle_whitelist =
-# recycle_blacklist =
-
-# //max stage num
-max_num_stages = 40

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -22,7 +22,8 @@
 namespace doris::cloud::config {
 
 CONF_Int32(brpc_listen_port, "5000");
-CONF_Int32(brpc_num_threads, "-1");
+CONF_Int32(brpc_num_threads, "64");
+// connections without data transmission for so many seconds will be closed
 // Set -1 to disable it.
 CONF_Int32(brpc_idle_timeout_sec, "-1");
 CONF_String(hostname, "");
@@ -65,10 +66,10 @@ CONF_mInt64(dropped_partition_retention_seconds, "10800"); // 3h
 CONF_Strings(recycle_whitelist, ""); // Comma seprated list
 // These instances will not be recycled, only effective when whitelist is empty.
 CONF_Strings(recycle_blacklist, ""); // Comma seprated list
-CONF_mInt32(instance_recycler_worker_pool_size, "8");
+CONF_mInt32(instance_recycler_worker_pool_size, "32");
 CONF_Bool(enable_checker, "false");
 // The parallelism for parallel recycle operation
-CONF_Int32(recycle_pool_parallelism, "10");
+CONF_Int32(recycle_pool_parallelism, "40");
 // Currently only used for recycler test
 CONF_Bool(enable_inverted_check, "false");
 // interval for scanning instances to do checks and inspections


### PR DESCRIPTION
Remove some entries in the default doris_cloud.conf which may make users
hard to understand.

pick #43381