### PR TITLE
[fix](mtmv) Fix partition track column fail when 'select *' used in related partition side

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -428,11 +428,11 @@ public class MaterializedViewUtils {
             } else if ((joinType.isLeftJoin()
                     || joinType.isLeftSemiJoin()
                     || joinType.isLeftAntiJoin()) && useLeft) {
-                return visit(join.left(), context);
+                return join.left().accept(this, context);
             } else if ((joinType.isRightJoin()
                     || joinType.isRightAntiJoin()
                     || joinType.isRightSemiJoin()) && !useLeft) {
-                return visit(join.right(), context);
+                return join.right().accept(this, context);
             }
             context.addFailReason(String.format("partition column is in un supported join null generate side, "
                     + "current join type is %s", joinType));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/34781

Problem Summary:

Table def as following,  if create partition mv as following will throw exception

`ERROR 1105 (HY000): errCode = 2, detailMessage = Unable to find a suitable base table for partitioning, the fail reason is can't not find valid partition track column, because`

```sql
CREATE MATERIALIZED VIEW mv_10086
        BUILD IMMEDIATE REFRESH AUTO ON MANUAL
        partition by(l_orderkey)
        DISTRIBUTED BY RANDOM BUCKETS 2
        PROPERTIES ('replication_num' = '1') 
        AS 

           select l1.*, O_CUSTKEY
           from lineitem_list_partition l1
           left outer join orders_list_partition
           on l1.l_shipdate = o_orderdate;
```


```sql
CREATE TABLE `orders_list_partition` (
      `o_orderkey` BIGINT not NULL,
      `o_custkey` INT NULL,
      `o_orderstatus` VARCHAR(1) NULL,
      `o_totalprice` DECIMAL(15, 2)  NULL,
      `o_orderpriority` VARCHAR(15) NULL,
      `o_clerk` VARCHAR(15) NULL,
      `o_shippriority` INT NULL,
      `o_comment` VARCHAR(79) NULL,
      `o_orderdate` DATE NULL
    ) ENGINE=OLAP
    DUPLICATE KEY(`o_orderkey`, `o_custkey`)
    COMMENT 'OLAP'
    PARTITION BY list(o_orderkey) (
    PARTITION p1 VALUES in ('1'),
    PARTITION p2 VALUES in ('2'),
    PARTITION p3 VALUES in ('3'),
    PARTITION p4 VALUES in ('4')
    )
    DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 3
    PROPERTIES (
    "replication_num" = "1"
    );

CREATE TABLE `lineitem_list_partition` (
      `l_orderkey` BIGINT not NULL,
      `l_linenumber` INT NULL,
      `l_partkey` INT NULL,
      `l_suppkey` INT NULL,
      `l_quantity` DECIMAL(15, 2) NULL,
      `l_extendedprice` DECIMAL(15, 2) NULL,
      `l_discount` DECIMAL(15, 2) NULL,
      `l_tax` DECIMAL(15, 2) NULL,
      `l_returnflag` VARCHAR(1) NULL,
      `l_linestatus` VARCHAR(1) NULL,
      `l_commitdate` DATE NULL,
      `l_receiptdate` DATE NULL,
      `l_shipinstruct` VARCHAR(25) NULL,
      `l_shipmode` VARCHAR(10) NULL,
      `l_comment` VARCHAR(44) NULL,
      `l_shipdate` DATE NULL
    ) ENGINE=OLAP
    DUPLICATE KEY(l_orderkey, l_linenumber, l_partkey, l_suppkey )
    COMMENT 'OLAP'
    PARTITION BY list(l_orderkey) (
    PARTITION p1 VALUES in ('1'),
    PARTITION p2 VALUES in ('2'),
    PARTITION p3 VALUES in ('3')
    )
    DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 3
    PROPERTIES ("replication_num" = "1"
    );
```


### Release note

 Fix partition track column fail when 'select *' used in related partition side

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

