### PR TITLE
[feature](security) Support block specific query with AST names

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3225,8 +3225,9 @@ public class Config extends ConfigBase {
                     + "the behavior of forwarding queries."})
     public static boolean force_forward_all_queries = false;
 
-    @ConfField(description = {"用于禁用某些SQL，配置项为AST的class simple name列表，用逗号间隔开",
-            "For disabling certain SQL queries, the configuration item is a list of simple class names of AST,"
-                    + " separated by commas."})
+    @ConfField(description = {"用于禁用某些SQL，配置项为AST的class simple name列表(例如CreateRepositoryStmt,"
+            + "CreatePolicyCommand)，用逗号间隔开",
+            "For disabling certain SQL queries, the configuration item is a list of simple class names of AST"
+                    + "(for example CreateRepositoryStmt, CreatePolicyCommand), separated by commas."})
     public static String block_sql_ast_names = "";
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3224,4 +3224,9 @@ public class Config extends ConfigBase {
             "For testing purposes, all queries are forcibly forwarded to the master to verify"
                     + "the behavior of forwarding queries."})
     public static boolean force_forward_all_queries = false;
+
+    @ConfField(description = {"用于禁用某些SQL，配置项为AST的class simple name列表，用逗号间隔开",
+            "For disabling certain SQL queries, the configuration item is a list of simple class names of AST,"
+                    + " separated by commas."})
+    public static String block_sql_ast_names = "";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -246,6 +246,7 @@ import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.JournalObservable;
 import org.apache.doris.qe.QueryCancelWorker;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.resource.AdmissionControl;
 import org.apache.doris.resource.Tag;
@@ -1113,6 +1114,8 @@ public class Env {
             notifyNewFETypeTransfer(FrontendNodeType.MASTER);
         }
         queryCancelWorker.start();
+
+        StmtExecutor.initBlockSqlAstNames();
     }
 
     // wait until FE is ready.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -833,15 +833,17 @@ public class StmtExecutor {
     }
 
     public static void initBlockSqlAstNames() {
+        blockSqlAstNames.clear();
         blockSqlAstNames = Pattern.compile(",")
                 .splitAsStream(Config.block_sql_ast_names)
+                .map(String::trim)
                 .collect(Collectors.toSet());
         if (blockSqlAstNames.isEmpty() && !Config.block_sql_ast_names.isEmpty()) {
             blockSqlAstNames.add(Config.block_sql_ast_names);
         }
     }
 
-    private void checkSqlBlocked(Class<?> clazz) throws UserException {
+    public void checkSqlBlocked(Class<?> clazz) throws UserException {
         if (blockSqlAstNames.contains(clazz.getSimpleName())) {
             throw new UserException("SQL is blocked with AST name: " + clazz.getSimpleName());
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -43,6 +43,8 @@ import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.DateType;
 import org.apache.doris.nereids.types.DecimalV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.StmtExecutor;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -702,6 +704,40 @@ public class NereidsParserTest extends ParserTestBase {
 
         for (String sql : sqls) {
             nereidsParser.parseSingle(sql);
+        }
+    }
+
+    @Test
+    public void testBlockSqlAst() {
+        String sql = "plan replayer dump select `AD``D` from t1 where a = 1";
+        NereidsParser nereidsParser = new NereidsParser();
+        LogicalPlan logicalPlan = nereidsParser.parseSingle(sql);
+
+        Config.block_sql_ast_names = "ReplayCommand";
+        StmtExecutor.initBlockSqlAstNames();
+        StmtExecutor stmtExecutor = new StmtExecutor(new ConnectContext(), "");
+        try {
+            stmtExecutor.checkSqlBlocked(logicalPlan.getClass());
+            Assertions.fail();
+        } catch (Exception ignore) {
+            // do nothing
+        }
+
+        Config.block_sql_ast_names = "CreatePolicyCommand, ReplayCommand";
+        StmtExecutor.initBlockSqlAstNames();
+        try {
+            stmtExecutor.checkSqlBlocked(logicalPlan.getClass());
+            Assertions.fail();
+        } catch (Exception ignore) {
+            // do nothing
+        }
+
+        Config.block_sql_ast_names = "";
+        StmtExecutor.initBlockSqlAstNames();
+        try {
+            stmtExecutor.checkSqlBlocked(logicalPlan.getClass());
+        } catch (Exception ex) {
+            Assertions.fail(ex);
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -19,6 +19,8 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.CreateFileStmt;
+import org.apache.doris.analysis.CreateFunctionStmt;
 import org.apache.doris.analysis.DdlStmt;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.KillStmt;
@@ -281,46 +283,6 @@ public class StmtExecutorTest {
         stmtExecutor.execute();
 
         Assert.assertEquals(QueryState.MysqlStateType.EOF, state.getStateType());
-    }
-
-    @Test
-    public void testBlockSqlAst(@Mocked UseStmt useStmt, @Mocked SqlParser parser) throws Exception {
-        new Expectations() {
-            {
-                Config.block_sql_ast_names = "UseStmt";
-                minTimes = 0;
-
-                useStmt.analyze((Analyzer) any);
-                minTimes = 0;
-
-                useStmt.getDatabase();
-                minTimes = 0;
-                result = "testDb";
-
-                useStmt.getRedirectStatus();
-                minTimes = 0;
-                result = RedirectStatus.NO_FORWARD;
-
-                useStmt.getCatalogName();
-                minTimes = 0;
-                result = InternalCatalog.INTERNAL_CATALOG_NAME;
-
-                Symbol symbol = new Symbol(0, Lists.newArrayList(useStmt));
-                parser.parse();
-                minTimes = 0;
-                result = symbol;
-            }
-        };
-
-        StmtExecutor.initBlockSqlAstNames();
-        StmtExecutor executor = new StmtExecutor(ctx, "");
-        try {
-            executor.execute();
-            Assert.fail();
-        } catch (Exception ignore) {
-
-        }
-        Assert.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
     }
 
     @Test
@@ -841,5 +803,92 @@ public class StmtExecutorTest {
         executor.execute();
 
         Assert.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
+    }
+
+    @Test
+    public void testBlockSqlAst(@Mocked UseStmt useStmt, @Mocked CreateFileStmt createFileStmt,
+            @Mocked CreateFunctionStmt createFunctionStmt, @Mocked SqlParser parser) throws Exception {
+        new Expectations() {
+            {
+                useStmt.analyze((Analyzer) any);
+                minTimes = 0;
+
+                useStmt.getDatabase();
+                minTimes = 0;
+                result = "testDb";
+
+                useStmt.getRedirectStatus();
+                minTimes = 0;
+                result = RedirectStatus.NO_FORWARD;
+
+                useStmt.getCatalogName();
+                minTimes = 0;
+                result = InternalCatalog.INTERNAL_CATALOG_NAME;
+
+                Symbol symbol = new Symbol(0, Lists.newArrayList(createFileStmt));
+                parser.parse();
+                minTimes = 0;
+                result = symbol;
+            }
+        };
+
+        Config.block_sql_ast_names = "CreateFileStmt";
+        StmtExecutor.initBlockSqlAstNames();
+        StmtExecutor executor = new StmtExecutor(ctx, "");
+        try {
+            executor.execute();
+        } catch (Exception ignore) {
+            // do nothing
+        }
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
+        Assert.assertTrue(state.getErrorMessage().contains("SQL is blocked with AST name: CreateFileStmt"));
+
+        Config.block_sql_ast_names = "AlterStmt, CreateFileStmt";
+        StmtExecutor.initBlockSqlAstNames();
+        executor = new StmtExecutor(ctx, "");
+        try {
+            executor.execute();
+        } catch (Exception ignore) {
+            // do nothing
+        }
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
+        Assert.assertTrue(state.getErrorMessage().contains("SQL is blocked with AST name: CreateFileStmt"));
+
+        new Expectations() {
+            {
+                Symbol symbol = new Symbol(0, Lists.newArrayList(createFunctionStmt));
+                parser.parse();
+                minTimes = 0;
+                result = symbol;
+            }
+        };
+        Config.block_sql_ast_names = "CreateFunctionStmt, CreateFileStmt";
+        StmtExecutor.initBlockSqlAstNames();
+        executor = new StmtExecutor(ctx, "");
+        try {
+            executor.execute();
+        } catch (Exception ignore) {
+            // do nothing
+        }
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
+        Assert.assertTrue(state.getErrorMessage().contains("SQL is blocked with AST name: CreateFunctionStmt"));
+
+        new Expectations() {
+            {
+                Symbol symbol = new Symbol(0, Lists.newArrayList(useStmt));
+                parser.parse();
+                minTimes = 0;
+                result = symbol;
+            }
+        };
+        executor = new StmtExecutor(ctx, "");
+        executor.execute();
+        Assert.assertEquals(QueryState.MysqlStateType.OK, state.getStateType());
+
+        Config.block_sql_ast_names = "";
+        StmtExecutor.initBlockSqlAstNames();
+        executor = new StmtExecutor(ctx, "");
+        executor.execute();
+        Assert.assertEquals(QueryState.MysqlStateType.OK, state.getStateType());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Support block specific query with AST names when necessary for security reasons, configure the name list in fe.conf, for example:

```
block_sql_ast_names="CreateFileStmt, CreateFunctionStmt"
```

### Release note

Support to block some SQL statements, e.g. CreateFileStmt, when necessary for security reasons.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

