### PR TITLE
[Feature](stream-load)(config) implement streamload via http stream

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -552,6 +552,8 @@ DEFINE_Int32(stream_load_record_expire_time_secs, "28800");
 DEFINE_mInt64(clean_stream_load_record_interval_secs, "1800");
 // enable stream load commit txn on BE directly, bypassing FE. Only for cloud.
 DEFINE_mBool(enable_stream_load_commit_txn_on_be, "false");
+// Whether to enable use httpstream to perform streamload , the default is true.
+DEFINE_mBool(enable_streamload_by_httpstream, "true");
 // The buffer size to store stream table function schema info
 DEFINE_Int64(stream_tvf_buffer_size, "1048576"); // 1MB
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -599,6 +599,8 @@ DECLARE_Int32(stream_load_record_expire_time_secs);
 DECLARE_mInt64(clean_stream_load_record_interval_secs);
 // enable stream load commit txn on BE directly, bypassing FE. Only for cloud.
 DECLARE_mBool(enable_stream_load_commit_txn_on_be);
+// Whether to enable use httpstream to perform streamload , the default is true.
+DECLARE_mBool(enable_streamload_by_httpstream);
 // The buffer size to store stream table function schema info
 DECLARE_Int64(stream_tvf_buffer_size);
 

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -85,14 +85,12 @@ static const string CHUNK = "chunked";
 TStreamLoadPutResult k_stream_load_put_result;
 #endif
 
-
-
-bool _check_headers(HttpRequest* req, std::shared_ptr<StreamLoadContext>& ctx){
-#define __RETURN_FALSE_IF_SET(PROPERTIY_KEY) \
-        if(!req->header(PROPERTIY_KEY).empty()){\
-            LOG(INFO) << "PROPERTIY_KEY" << PROPERTIY_KEY ; \
-            return false; \
-        }
+bool _check_headers(HttpRequest* req, std::shared_ptr<StreamLoadContext>& ctx) {
+#define __RETURN_FALSE_IF_SET(PROPERTIY_KEY)           \
+    if (!req->header(PROPERTIY_KEY).empty()) {         \
+        LOG(INFO) << "PROPERTIY_KEY" << PROPERTIY_KEY; \
+        return false;                                  \
+    }
     __RETURN_FALSE_IF_SET(HTTP_COLUMNS)
     //__RETURN_FALSE_IF_SET(HTTP_LABEL_KEY)
     __RETURN_FALSE_IF_SET(HTTP_WHERE)
@@ -100,21 +98,24 @@ bool _check_headers(HttpRequest* req, std::shared_ptr<StreamLoadContext>& ctx){
     __RETURN_FALSE_IF_SET(HTTP_ESCAPE)
     __RETURN_FALSE_IF_SET(HTTP_MAX_FILTER_RATIO)
     __RETURN_FALSE_IF_SET(HTTP_READ_JSON_BY_LINE)
-    
+
 #undef __RETURN_FALSE_IF_SET
-    LoadUtil::parse_format(req->header(HTTP_FORMAT_KEY), req->header(HTTP_COMPRESS_TYPE), &ctx->format,
-                           &ctx->compress_type);
-    if(ctx->compress_type == TFileCompressType::LZ4FRAME || ctx->compress_type == TFileCompressType::LZ4BLOCK){
+    LoadUtil::parse_format(req->header(HTTP_FORMAT_KEY), req->header(HTTP_COMPRESS_TYPE),
+                           &ctx->format, &ctx->compress_type);
+    if (ctx->compress_type == TFileCompressType::LZ4FRAME ||
+        ctx->compress_type == TFileCompressType::LZ4BLOCK) {
         return false;
     }
-    if(ctx->format == TFileFormatType::FORMAT_PARQUET|| ctx->format == TFileFormatType::FORMAT_ORC){
+    if (ctx->format == TFileFormatType::FORMAT_PARQUET ||
+        ctx->format == TFileFormatType::FORMAT_ORC) {
         return false;
     }
-    if(!req->header(HTTP_STRICT_MODE).empty() || to_lower(req->header(HTTP_STRICT_MODE)) == "true"){
+    if (!req->header(HTTP_STRICT_MODE).empty() ||
+        to_lower(req->header(HTTP_STRICT_MODE)) == "true") {
         return false;
     }
 
-    LOG(INFO) << "check true"; 
+    LOG(INFO) << "check true";
     return true;
 }
 
@@ -136,7 +137,7 @@ void StreamLoadAction::handle(HttpRequest* req) {
     if (ctx == nullptr) {
         return;
     }
-    if (config::enable_streamload_by_httpstream && _check_headers(req,ctx)) {
+    if (config::enable_streamload_by_httpstream && _check_headers(req, ctx)) {
         if (ctx->sql_str.empty()) {
             auto st = _parse_header(req, ctx);
             if (!st.ok()) {
@@ -237,7 +238,7 @@ int StreamLoadAction::on_header(HttpRequest* req) {
 
     std::shared_ptr<StreamLoadContext> ctx = std::make_shared<StreamLoadContext>(_exec_env);
 
-    if (config::enable_streamload_by_httpstream && _check_headers(req,ctx)) {
+    if (config::enable_streamload_by_httpstream && _check_headers(req, ctx)) {
         if (ctx->sql_str.empty()) {
             auto st = _parse_header(req, ctx);
             if (!st.ok()) {
@@ -411,7 +412,7 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
         return;
     }
 
-    if (config::enable_streamload_by_httpstream && _check_headers(req,ctx)) {
+    if (config::enable_streamload_by_httpstream && _check_headers(req, ctx)) {
         if (ctx->sql_str.empty()) {
             auto st = _parse_header(req, ctx);
             if (!st.ok()) {
@@ -1267,7 +1268,7 @@ Status StreamLoadAction::_parse_header(HttpRequest* req, std::shared_ptr<StreamL
     url_decode(req->param(HTTP_DB_KEY), &db_name);
     url_decode(req->param(HTTP_TABLE_KEY), &table_name);
 
-    if(!req->header(HTTP_LABEL_KEY).empty()){
+    if (!req->header(HTTP_LABEL_KEY).empty()) {
         ctx->label = req->header(HTTP_LABEL_KEY);
     }
 
@@ -1443,14 +1444,14 @@ Status StreamLoadAction::_parse_header(HttpRequest* req, std::shared_ptr<StreamL
     __ADD_IF_EXIST(HTTP_UNIQUE_KEY_UPDATE_MODE)
     __ADD_IF_EXIST(HTTP_MEMTABLE_ON_SINKNODE)
     __ADD_IF_EXIST(HTTP_LOAD_STREAM_PER_NODE)
-//    __ADD_IF_EXIST(HTTP_GROUP_COMMIT)
+    //    __ADD_IF_EXIST(HTTP_GROUP_COMMIT)
     __ADD_IF_EXIST(HTTP_CLOUD_CLUSTER)
     __ADD_IF_EXIST(HTTP_UNIQUE_KEY_UPDATE_MODE)
     __ADD_IF_EXIST(HTTP_ESCAPE)
     __ADD_IF_EXIST(HTTP_ENCLOSE)
 #undef __ADD_IF_EXIST
 
-// #define __ADD_IF_EXIST(PROPERTIY_KEY)                                                              \
+    // #define __ADD_IF_EXIST(PROPERTIY_KEY)                                                              \
 //     if (!req->header(PROPERTIY_KEY).empty()) {                                                     \
 //         if (pri) {                                                                                 \
 //             sql += ",";                                                                            \
@@ -1459,11 +1460,7 @@ Status StreamLoadAction::_parse_header(HttpRequest* req, std::shared_ptr<StreamL
 //         sql += "\"" + PROPERTIY_KEY + "\" = \"" + req->header(PROPERTIY_KEY) + "\""; \
 //     }
 
-
-
-
-// #undef __ADD_IF_EXIST
-
+    // #undef __ADD_IF_EXIST
 
     sql += ") ";
 

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -92,12 +92,12 @@ bool _check_headers(HttpRequest* req, std::shared_ptr<StreamLoadContext>& ctx) {
         return false;                                  \
     }
     __RETURN_FALSE_IF_SET(HTTP_COLUMNS)
-    //__RETURN_FALSE_IF_SET(HTTP_LABEL_KEY)
     __RETURN_FALSE_IF_SET(HTTP_WHERE)
     __RETURN_FALSE_IF_SET(HTTP_ENCLOSE)
     __RETURN_FALSE_IF_SET(HTTP_ESCAPE)
     __RETURN_FALSE_IF_SET(HTTP_MAX_FILTER_RATIO)
     __RETURN_FALSE_IF_SET(HTTP_READ_JSON_BY_LINE)
+    __RETURN_FALSE_IF_SET(HTTP_TIMEZONE)
 
 #undef __RETURN_FALSE_IF_SET
     LoadUtil::parse_format(req->header(HTTP_FORMAT_KEY), req->header(HTTP_COMPRESS_TYPE),
@@ -1014,6 +1014,7 @@ int StreamLoadAction::_httpstream_on_header(HttpRequest* req,
                                             std::shared_ptr<StreamLoadContext> ctx) {
     req->set_handler_ctx(ctx);
 
+    ctx->label = req->header(HTTP_LABEL_KEY);
     ctx->load_type = TLoadType::MANUL_LOAD;
     ctx->load_src_type = TLoadSourceType::RAW;
     ctx->two_phase_commit = req->header(HTTP_TWO_PHASE_COMMIT) == "true";

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -107,7 +107,7 @@ bool _check_headers(HttpRequest* req, std::shared_ptr<StreamLoadContext>& ctx){
     if(ctx->compress_type == TFileCompressType::LZ4FRAME || ctx->compress_type == TFileCompressType::LZ4BLOCK){
         return false;
     }
-    if(ctx->format == TFileFormatType::FORMAT_PARQUET|| ctx->format == TFileFormatType::FORMAT_ORC || ctx->format == TFileFormatType::FORMAT_ORC){
+    if(ctx->format == TFileFormatType::FORMAT_PARQUET|| ctx->format == TFileFormatType::FORMAT_ORC){
         return false;
     }
     if(!req->header(HTTP_STRICT_MODE).empty() || to_lower(req->header(HTTP_STRICT_MODE)) == "true"){

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -52,6 +52,15 @@ private:
     void _save_stream_load_record(std::shared_ptr<StreamLoadContext> ctx, const std::string& str);
     Status _handle_group_commit(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
 
+    void _httpstream_handle(HttpRequest* req, std::shared_ptr<StreamLoadContext> ctx);
+    int _httpstream_on_header(HttpRequest* req, std::shared_ptr<StreamLoadContext> ctx);
+    void _httpstream_on_chunk_data(HttpRequest* req, std::shared_ptr<StreamLoadContext> ctx);
+    Status httpstream_process_put(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
+    Status _http_stream_on_header(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
+    Status _http_stream_handle(HttpRequest* req, std::shared_ptr<StreamLoadContext> ctx);
+
+    Status _parse_header(HttpRequest* req, std::shared_ptr<StreamLoadContext> ctx);
+
 private:
     ExecEnv* _exec_env;
 

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -945,10 +945,15 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
 Status CsvReader::_parse_col_nums(size_t* col_nums) {
     const uint8_t* ptr = nullptr;
     size_t size = 0;
-    RETURN_IF_ERROR(_line_reader->read_line(&ptr, &size, &_line_reader_eof, _io_ctx));
+    while(true){
+        RETURN_IF_ERROR(_line_reader->read_line(&ptr, &size, &_line_reader_eof, _io_ctx));
+        if(size != 0 || _line_reader_eof){
+            break;
+        }
+    }
     if (size == 0) {
         return Status::InternalError<false>(
-                "The first line is empty, can not parse column numbers");
+            "The line is all empty, can not parse column numbers");
     }
     if (!validate_utf8(const_cast<char*>(reinterpret_cast<const char*>(ptr)), size)) {
         return Status::InternalError<false>("Only support csv data in utf8 codec");

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -945,15 +945,14 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
 Status CsvReader::_parse_col_nums(size_t* col_nums) {
     const uint8_t* ptr = nullptr;
     size_t size = 0;
-    while(true){
+    while (true) {
         RETURN_IF_ERROR(_line_reader->read_line(&ptr, &size, &_line_reader_eof, _io_ctx));
-        if(size != 0 || _line_reader_eof){
+        if (size != 0 || _line_reader_eof) {
             break;
         }
     }
     if (size == 0) {
-        return Status::InternalError<false>(
-            "The line is all empty, can not parse column numbers");
+        return Status::InternalError<false>("The line is all empty, can not parse column numbers");
     }
     if (!validate_utf8(const_cast<char*>(reinterpret_cast<const char*>(ptr)), size)) {
         return Status::InternalError<false>("Only support csv data in utf8 codec");

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -945,8 +945,10 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
 Status CsvReader::_parse_col_nums(size_t* col_nums) {
     const uint8_t* ptr = nullptr;
     size_t size = 0;
+    RETURN_IF_ERROR(_line_reader->read_line(&ptr, &size, &_line_reader_eof, _io_ctx));
     if (size == 0) {
-        return Status::InternalError<false>("The line is all empty, can not parse column numbers");
+        return Status::InternalError<false>(
+                "The first line is empty, can not parse column numbers");
     }
     if (!validate_utf8(const_cast<char*>(reinterpret_cast<const char*>(ptr)), size)) {
         return Status::InternalError<false>("Only support csv data in utf8 codec");

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -945,12 +945,6 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
 Status CsvReader::_parse_col_nums(size_t* col_nums) {
     const uint8_t* ptr = nullptr;
     size_t size = 0;
-    while (true) {
-        RETURN_IF_ERROR(_line_reader->read_line(&ptr, &size, &_line_reader_eof, _io_ctx));
-        if (size != 0 || _line_reader_eof) {
-            break;
-        }
-    }
     if (size == 0) {
         return Status::InternalError<false>("The line is all empty, can not parse column numbers");
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  #36773 

Problem Summary:

Currently we can put data to doris via http using streamload or http stream. httpstream transforms data via sql in a header while streamload via special header. Sql is more easier to use.

In future, we would suggest http stream for users, and we also need keep only one in internal implementation. So we can add a config option to enable implement streamload via ways of httpstream.

We can transform streamload headers to a sql internally and implement streamload in ways of httstream.

Problem Solution:

1. Add a new BE config `enable_streamload_by_httpstream`
2. Perform streamload via httpstream if `enable_streamload_by_httpstream=true`
3. Manual test the implementation by previous regression test `streamLoad_action`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

