### PR TITLE
[opt](Variant) avoid unnecessary mem for variant extracted columns

### DIFF
--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -1000,12 +1000,15 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema, bool ignore_extrac
         if (column->is_variant_type()) {
             ++_num_variant_columns;
         }
+
         _cols.emplace_back(std::move(column));
-        _vl_field_mem_size +=
-                sizeof(StringRef) + sizeof(char) * _cols.back()->name().size() + sizeof(size_t);
-        _field_name_to_index.emplace(StringRef(_cols.back()->name()), _num_columns);
-        _vl_field_mem_size += sizeof(int32_t) * 2;
-        _field_id_to_index[_cols.back()->unique_id()] = _num_columns;
+        if (!_cols.back()->is_extracted_column()) {
+            _vl_field_mem_size +=
+                    sizeof(StringRef) + sizeof(char) * _cols.back()->name().size() + sizeof(size_t);
+            _field_name_to_index.emplace(StringRef(_cols.back()->name()), _num_columns);
+            _vl_field_mem_size += sizeof(int32_t) * 2;
+            _field_id_to_index[_cols.back()->unique_id()] = _num_columns;
+        }
         _num_columns++;
     }
     for (auto& index_pb : schema.index()) {


### PR DESCRIPTION
### What problem does this PR solve?

_field_name_to_index and _field_id_to_index is unnecessary for variant subcolumns, since they use column path as identifier

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

