### PR TITLE
[feat](authorization)Centralizing Common Authorization Operations in Common Interface

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerDorisAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerDorisAccessController.java
@@ -218,14 +218,6 @@ public class RangerDorisAccessController extends RangerAccessController {
     public void checkColsPriv(UserIdentity currentUser, String ctl, String db, String tbl, Set<String> cols,
             PrivPredicate wanted) throws AuthorizationException {
         PrivBitSet checkedPrivs = PrivBitSet.of();
-        boolean hasTablePriv = checkGlobalPrivInternal(currentUser, wanted, checkedPrivs)
-                || checkCtlPrivInternal(currentUser, ctl, wanted, checkedPrivs)
-                || checkDbPrivInternal(currentUser, ctl, db, wanted, checkedPrivs)
-                || checkTblPrivInternal(currentUser, ctl, db, tbl, wanted, checkedPrivs);
-        if (hasTablePriv) {
-            return;
-        }
-
         for (String col : cols) {
             if (!checkColPrivInternal(currentUser, ctl, db, tbl, col, wanted, checkedPrivs.copy())) {
                 throw new AuthorizationException(String.format(

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/CatalogAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/CatalogAccessController.java
@@ -28,8 +28,10 @@ import java.util.Set;
 public interface CatalogAccessController {
     // ==== Catalog ====
     default boolean checkCtlPriv(boolean hasGlobal, UserIdentity currentUser, String ctl, PrivPredicate wanted) {
-        boolean res = checkCtlPriv(currentUser, ctl, wanted);
-        return hasGlobal || res;
+        if (hasGlobal) {
+            return true;
+        }
+        return checkCtlPriv(currentUser, ctl, wanted);
     }
 
     // ==== Global ====
@@ -40,26 +42,34 @@ public interface CatalogAccessController {
 
     // ==== Database ====
     default boolean checkDbPriv(boolean hasGlobal, UserIdentity currentUser, String ctl, String db,
-            PrivPredicate wanted) {
-        boolean res = checkDbPriv(currentUser, ctl, db, wanted);
-        return hasGlobal || res;
+                                PrivPredicate wanted) {
+        if (hasGlobal) {
+            return true;
+        }
+        return checkDbPriv(currentUser, ctl, db, wanted);
     }
 
     boolean checkDbPriv(UserIdentity currentUser, String ctl, String db, PrivPredicate wanted);
 
     // ==== Table ====
     default boolean checkTblPriv(boolean hasGlobal, UserIdentity currentUser, String ctl, String db, String tbl,
-            PrivPredicate wanted) {
-        boolean res = checkTblPriv(currentUser, ctl, db, tbl, wanted);
-        return hasGlobal || res;
+                                 PrivPredicate wanted) {
+        if (hasGlobal) {
+            return true;
+        }
+        return checkTblPriv(currentUser, ctl, db, tbl, wanted);
     }
 
     boolean checkTblPriv(UserIdentity currentUser, String ctl, String db, String tbl, PrivPredicate wanted);
 
     // ==== Column ====
     default void checkColsPriv(boolean hasGlobal, UserIdentity currentUser, String ctl, String db, String tbl,
-            Set<String> cols, PrivPredicate wanted) throws AuthorizationException {
+                               Set<String> cols, PrivPredicate wanted) throws AuthorizationException {
         try {
+            boolean hasTablePriv = checkTblPriv(hasGlobal, currentUser, ctl, db, tbl, wanted);
+            if (hasTablePriv) {
+                return;
+            }
             checkColsPriv(currentUser, ctl, db, tbl, cols, wanted);
         } catch (AuthorizationException e) {
             if (!hasGlobal) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -473,7 +473,7 @@ public class Role implements Writable, GsonPostProcessable {
         if (!colPrivilege.isPresent()) {
             throw new IllegalStateException("this privPredicate should not use checkColPriv:" + wanted);
         }
-        return checkTblPriv(ctl, db, tbl, wanted) || onlyCheckColPriv(ctl, db, tbl, col, colPrivilege.get());
+        return onlyCheckColPriv(ctl, db, tbl, col, colPrivilege.get());
     }
 
     private boolean onlyCheckColPriv(String ctl, String db, String tbl, String col,


### PR DESCRIPTION



### What problem does this PR solve?

#### Optimize Column-Level Permission Checks Using Table-Level Permissions:

Since having column-level permissions does not imply table-level permissions, but having table-level permissions does imply permissions on all columns within the table, we can streamline column permission checks. When checking column-level permissions, we can first check if the user has table-level permissions. If table-level permissions are granted, column-level checks become unnecessary. Only if table-level permissions are absent do we proceed with specific column-level permission checks.

###$ Global Permissions Shortcut: Global-level permissions typically grant full access across all operations.

Therefore, to optimize permission checks, we can add an early check for global permissions. If the user has global permissions, they are authorized, and further permission checks at the database, table, or column levels are unnecessary, allowing us to return immediately.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

