### PR TITLE
[fix](Nereids) alias function should use unbound slot as place holder

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/AliasUdf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/AliasUdf.java
@@ -21,23 +21,18 @@ import org.apache.doris.catalog.AliasFunction;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.analyzer.UnboundFunction;
-import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ScalarFunction;
-import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewriter;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.NullType;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -88,20 +83,10 @@ public class AliasUdf extends ScalarFunction implements ExplicitlyCastableSignat
         String functionSql = function.getOriginFunction().toSql();
         Expression parsedFunction = new NereidsParser().parseExpression(functionSql);
 
-        Map<String, SlotReference> replaceMap = Maps.newHashMap();
-        for (int i = 0; i < function.getNumArgs(); ++i) {
-            replaceMap.put(function.getParameters().get(i),
-                    new SlotReference(
-                            function.getParameters().get(i),
-                            DataType.fromCatalogType(function.getArgs()[i])));
-        }
-
-        Expression slotBoundFunction = VirtualSlotReplacer.INSTANCE.replace(parsedFunction, replaceMap);
-
         AliasUdf aliasUdf = new AliasUdf(
                 function.functionName(),
                 Arrays.stream(function.getArgs()).map(DataType::fromCatalogType).collect(Collectors.toList()),
-                ((UnboundFunction) slotBoundFunction),
+                ((UnboundFunction) parsedFunction),
                 function.getParameters());
 
         AliasUdfBuilder builder = new AliasUdfBuilder(aliasUdf);
@@ -122,18 +107,5 @@ public class AliasUdf extends ScalarFunction implements ExplicitlyCastableSignat
     @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitAliasUdf(this, context);
-    }
-
-    private static class VirtualSlotReplacer extends DefaultExpressionRewriter<Map<String, SlotReference>> {
-        public static final VirtualSlotReplacer INSTANCE = new VirtualSlotReplacer();
-
-        public Expression replace(Expression expression, Map<String, SlotReference> context) {
-            return expression.accept(this, context);
-        }
-
-        @Override
-        public Expression visitUnboundSlot(UnboundSlot slot, Map<String, SlotReference> context) {
-            return context.get(slot.getName());
-        }
     }
 }

--- a/regression-test/suites/nereids_p0/javaudf/test_alias_function.groovy
+++ b/regression-test/suites/nereids_p0/javaudf/test_alias_function.groovy
@@ -33,7 +33,7 @@ suite("nereids_test_alias_function") {
     CREATE ALIAS FUNCTION f2(DATETIMEV2(3), INT) with PARAMETER (datetime1, int1) as
         DATE_FORMAT(HOURS_ADD(
             date_trunc(datetime1, 'day'),
-            add(multiply(floor(divide(HOUR(datetime1), divide(24, int1))), 1), 1)), '%Y%m%d:%H')
+            add(multiply(floor(divide(day(datetime1), divide(24, int1))), 1), 1)), '%Y%m%d:%H')
     '''
     sql '''
     CREATE ALIAS FUNCTION f3(INT) with PARAMETER (int1) as
@@ -50,11 +50,11 @@ suite("nereids_test_alias_function") {
     }
     test {
         sql 'select f2(f1(\'2023-05-20\', 2), 3)'
-        result([['20230518:01']])
+        result([['20230518:03']])
     }
     test {
         sql 'select f3(4)'
-        result([['20230518:01']])
+        result([['20230518:04']])
     }
     test {
         sql 'select cast(f1(\'2023-06-01\', k1) as string) from test order by k1'
@@ -67,17 +67,17 @@ suite("nereids_test_alias_function") {
     test {
         sql 'select f2(f1(\'2023-05-20\', k1), 4) from test order by k1'
         result([
-                ['20230519:01'],
-                ['20230518:01'],
-                ['20230517:01']
+                ['20230519:04'],
+                ['20230518:04'],
+                ['20230517:03']
         ])
     }
     test {
         sql 'select f3(k1) from test order by k1'
         result([
                 ['20230518:01'],
-                ['20230518:01'],
-                ['20230518:01']
+                ['20230518:02'],
+                ['20230518:03']
         ])
     }
 


### PR DESCRIPTION
Related PR: #18257

Problem Summary:

when construct alias function for Nereids, should use unbound slot as placeholder.
Currently, we use SlotReference, then we could replace it by wrong parameter,
because SlotReference use ExprId as Unique Identifier.

For example, if placeholder's ExprId is 1, then all slots that ExprId equals one
will be replaced by input parameter.

### Release note

Fix the issus that wrong result when using alias function.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

