### PR TITLE
[refine](exchange) remove be_number in VDataStreamRecvr:: remove_sender

### DIFF
--- a/be/src/vec/runtime/vdata_stream_mgr.cpp
+++ b/be/src/vec/runtime/vdata_stream_mgr.cpp
@@ -141,15 +141,15 @@ Status VDataStreamMgr::transmit_block(const PTransmitDataParams* request,
 
     bool eos = request->eos();
     if (request->has_block()) {
-        RETURN_IF_ERROR(recvr->add_block(
-                request->block(), request->sender_id(), request->be_number(), request->packet_seq(),
-                eos ? nullptr : done, wait_for_worker, cpu_time_stop_watch.elapsed_time()));
+        RETURN_IF_ERROR(recvr->add_block(request->block(), request->sender_id(),
+                                         request->packet_seq(), eos ? nullptr : done,
+                                         wait_for_worker, cpu_time_stop_watch.elapsed_time()));
     }
 
     if (eos) {
         Status exec_status =
                 request->has_exec_status() ? Status::create(request->exec_status()) : Status::OK();
-        recvr->remove_sender(request->sender_id(), request->be_number(), exec_status);
+        recvr->remove_sender(request->sender_id(), exec_status);
     }
     return Status::OK();
 }

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -84,7 +84,7 @@ public:
 
     std::vector<SenderQueue*> sender_queues() const { return _sender_queues; }
 
-    Status add_block(const PBlock& pblock, int sender_id, int be_number, int64_t packet_seq,
+    Status add_block(const PBlock& pblock, int sender_id, int64_t packet_seq,
                      ::google::protobuf::Closure** done, const int64_t wait_for_worker,
                      const uint64_t time_to_find_recvr);
 
@@ -98,7 +98,7 @@ public:
 
     // Indicate that a particular sender is done. Delegated to the appropriate
     // sender queue. Called from DataStreamMgr.
-    void remove_sender(int sender_id, int be_number, Status exec_status);
+    void remove_sender(int sender_id, Status exec_status);
 
     void cancel_stream(Status exec_status);
 
@@ -181,7 +181,7 @@ public:
 
     Status get_batch(Block* next_block, bool* eos);
 
-    Status add_block(const PBlock& pblock, int be_number, int64_t packet_seq,
+    Status add_block(const PBlock& pblock, int sender_id, int64_t packet_seq,
                      ::google::protobuf::Closure** done, const int64_t wait_for_worker,
                      const uint64_t time_to_find_recvr);
 
@@ -262,9 +262,13 @@ protected:
     std::unique_ptr<MemTracker> _queue_mem_tracker;
     std::list<std::pair<BlockUPtr, size_t>> _block_queue;
 
-    // sender_id
+    // sender_id indicates which instance within a fragment, while be_number indicates which instance
+    // across all fragments. For example, with 3 BEs and 8 instances, the range of sender_id would be 0 to 24,
+    // and the range of be_number would be from n + 0 to n + 24.
+    // In theory, we only need sender_id to distinguish all senders.
+    // sender_id => eos
     std::unordered_set<int> _sender_eos_set;
-    // be_number => packet_seq
+    // sender_id => packet_seq
     std::unordered_map<int, int64_t> _packet_seq_map;
     std::deque<std::pair<google::protobuf::Closure*, MonotonicStopWatch>> _pending_closures;
 

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -208,7 +208,7 @@ Status Channel::send_local_block(Block* block, bool eos, bool can_be_moved) {
         }
 
         if (eos) [[unlikely]] {
-            _local_recvr->remove_sender(sender_id, _be_number, Status::OK());
+            _local_recvr->remove_sender(sender_id, Status::OK());
             _parent->on_channel_finished(_fragment_instance_id.lo);
         }
         return Status::OK();

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -36,7 +36,7 @@ message PTransmitDataParams {
     required int32 node_id = 2;
     // Id of this fragment in its role as a sender.
     required int32 sender_id = 3;
-    required int32 be_number = 4;
+    required int32 be_number = 4; // Deprecated
 
     // if set to true, indicates that no more row batches will be sent
     // for this dest_node_id


### PR DESCRIPTION
### What problem does this PR solve?

sender_id indicates which instance within a fragment, while be_number indicates which instance 
across all fragments. For example, with 3 BEs and 8 instances, the range of sender_id would be 0 to 24, 
and the range of be_number would be from n + 0 to n + 24.
In theory, we only need sender_id to distinguish all senders.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

