### PR TITLE
Optimize the time statistics in the profile's plan time for scan nodes, including total time, average time, maximum and minimum times.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileSpan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileSpan.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.common.profile;
 
-import org.apache.doris.qe.ConnectContext;
-
 public class ProfileSpan implements AutoCloseable {
 
     public interface TimingOperation {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileSpan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileSpan.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.profile;
+
+import org.apache.doris.qe.ConnectContext;
+
+public class ProfileSpan implements AutoCloseable {
+
+    public interface TimingOperation {
+        void execute(String id, String step);
+    }
+
+    public static final ProfileSpan EMPTY_PROFILE_SPAN = new ProfileSpan("", "",
+            (id, step) -> {},
+            (id, step) -> {}
+    );
+
+    private final String id;
+    private final String step;
+    private final TimingOperation finishOperation;
+
+    public ProfileSpan(String id, String step,
+            TimingOperation startOperation,
+            TimingOperation finishOperation) {
+        this.id = id;
+        this.step = step;
+        this.finishOperation = finishOperation;
+        startOperation.execute(id, step);
+    }
+
+    @Override
+    public void close() {
+        finishOperation.execute(id, step);
+    }
+
+    public static ProfileSpan create(String id, String step) {
+        if (ConnectContext.get().getExecutor() != null) {
+            SummaryProfile summaryProfile = ConnectContext.get().getExecutor().getSummaryProfile();
+            return new ProfileSpan(id, step, (id1, step1) -> summaryProfile.getNodeTimer(id1).startStep(step1),
+                    (id2, step2) -> summaryProfile.getNodeTimer(id2).stopStep(step2));
+        } else {
+            return EMPTY_PROFILE_SPAN;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileSpan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileSpan.java
@@ -48,11 +48,10 @@ public class ProfileSpan implements AutoCloseable {
         finishOperation.execute(id, step);
     }
 
-    public static ProfileSpan create(String id, String step) {
-        if (ConnectContext.get().getExecutor() != null) {
-            SummaryProfile summaryProfile = ConnectContext.get().getExecutor().getSummaryProfile();
-            return new ProfileSpan(id, step, (id1, step1) -> summaryProfile.getNodeTimer(id1).startStep(step1),
-                    (id2, step2) -> summaryProfile.getNodeTimer(id2).stopStep(step2));
+    public static ProfileSpan create(SummaryProfile sp, String id, String step) {
+        if (sp != null) {
+            return new ProfileSpan(id, step, (id1, step1) -> sp.getNodeTimer(id1).startStep(step1),
+                    (id2, step2) -> sp.getNodeTimer(id2).stopStep(step2));
         } else {
             return EMPTY_PROFILE_SPAN;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * SummaryProfile is part of a query profile.
@@ -379,7 +380,7 @@ public class SummaryProfile {
 
     // Step Name -> TimeStats
     @SerializedName(value = "scanNodesStats")
-    private final Map<String, TimeStats> scanNodesStats = new HashMap<>();
+    private final Map<String, TimeStats> scanNodesStats = new ConcurrentHashMap<>();
 
     public static class NestedStepTimer {
 
@@ -393,6 +394,7 @@ public class SummaryProfile {
             private final String name;
             private final long startTime;
             private final StepInfo parent;
+
             private final List<StepInfo> children = new ArrayList<>();
 
             StepInfo(String name, long startTime, StepInfo parent) {
@@ -426,12 +428,12 @@ public class SummaryProfile {
 
         @VisibleForTesting
         public Map<String, TimeStats> getScanNodesStats() {
-            return scanNodesStats;
+            return ImmutableMap.copyOf(scanNodesStats);
         }
     }
 
     // ScanNodeId -> NestedStepTimer
-    private final Map<String, NestedStepTimer> scanNodeTimers = new HashMap<>();
+    private final Map<String, NestedStepTimer> scanNodeTimers = new ConcurrentHashMap<>();
 
     public NestedStepTimer createNodeTimer(String nodeId) {
         NestedStepTimer timer = new NestedStepTimer(scanNodesStats);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -26,6 +26,7 @@ import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TUnit;
 import org.apache.doris.transaction.TransactionType;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -421,6 +422,11 @@ public class SummaryProfile {
             long duration = System.currentTimeMillis() - currentStep.startTime;
             scanNodesStats.computeIfAbsent(currentStep.name, k -> new TimeStats()).accept(duration);
             currentStep = currentStep.parent;
+        }
+
+        @VisibleForTesting
+        public Map<String, TimeStats> getScanNodesStats() {
+            return scanNodesStats;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -62,6 +62,7 @@ public class RuntimeProfile {
     public static String MIN_TIME_PRE = "min ";
     public static String AVG_TIME_PRE = "avg ";
     public static String SUM_TIME_PRE = "sum ";
+    public static String CNT_TIME_PRE = "count ";
     @SerializedName(value = "counterTotalTime")
     private Counter counterTotalTime;
     @SerializedName(value = "localTimePercent")

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -106,8 +106,9 @@ public abstract class FileQueryScanNode extends FileScanNode {
     public FileQueryScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
                              StatisticalType statisticalType, boolean needCheckColumnPriv) {
         super(id, desc, planNodeName, statisticalType, needCheckColumnPriv);
-        if (ConnectContext.get().getExecutor() != null) {
-            ConnectContext.get().getExecutor().getSummaryProfile().createNodeTimer(id.toString());
+        SummaryProfile sp = ConnectContext.getSummaryProfileSafety();
+        if (sp != null) {
+            sp.createNodeTimer(id.toString());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -41,7 +41,6 @@ import org.apache.doris.datasource.hive.source.HiveScanNode;
 import org.apache.doris.datasource.hive.source.HiveSplit;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.spi.Split;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.system.Backend;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -54,6 +54,7 @@ public class SplitAssignment {
     private Split sampleSplit = null;
     private final AtomicBoolean isStop = new AtomicBoolean(false);
     private final AtomicBoolean scheduleFinished = new AtomicBoolean(false);
+    private SummaryProfile summaryProfile;
 
     private UserException exception = null;
 
@@ -62,12 +63,14 @@ public class SplitAssignment {
             SplitGenerator splitGenerator,
             SplitToScanRange splitToScanRange,
             Map<String, String> locationProperties,
-            List<String> pathPartitionKeys) {
+            List<String> pathPartitionKeys,
+            SummaryProfile summaryProfile) {
         this.backendPolicy = backendPolicy;
         this.splitGenerator = splitGenerator;
         this.splitToScanRange = splitToScanRange;
         this.locationProperties = locationProperties;
         this.pathPartitionKeys = pathPartitionKeys;
+        this.summaryProfile = summaryProfile;
     }
 
     public void init() throws UserException {
@@ -125,7 +128,8 @@ public class SplitAssignment {
                 sampleSplit = splits.get(0);
                 assignLock.notify();
             }
-            try (ProfileSpan ignored = ProfileSpan.create(scanNodeId, SummaryProfile.CREATE_SCAN_RANGE_TIME)) {
+            try (ProfileSpan ignored = ProfileSpan.create(
+                    summaryProfile, scanNodeId, SummaryProfile.CREATE_SCAN_RANGE_TIME)) {
                 try {
                     batch = backendPolicy.computeScanRangeAssignment(splits);
                 } catch (UserException e) {
@@ -177,5 +181,9 @@ public class SplitAssignment {
 
     public boolean isStop() {
         return isStop.get();
+    }
+
+    public SummaryProfile getSummaryProfile() {
+        return summaryProfile;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -18,6 +18,8 @@
 package org.apache.doris.datasource;
 
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.profile.ProfileSpan;
+import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.spi.Split;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TScanRangeLocations;
@@ -113,7 +115,7 @@ public class SplitAssignment {
         return sampleSplit;
     }
 
-    public void addToQueue(List<Split> splits) {
+    public void addToQueue(List<Split> splits, String scanNodeId) {
         if (splits.isEmpty()) {
             return;
         }
@@ -123,10 +125,12 @@ public class SplitAssignment {
                 sampleSplit = splits.get(0);
                 assignLock.notify();
             }
-            try {
-                batch = backendPolicy.computeScanRangeAssignment(splits);
-            } catch (UserException e) {
-                exception = e;
+            try (ProfileSpan ignored = ProfileSpan.create(scanNodeId, SummaryProfile.CREATE_SCAN_RANGE_TIME)) {
+                try {
+                    batch = backendPolicy.computeScanRangeAssignment(splits);
+                } catch (UserException e) {
+                    exception = e;
+                }
             }
         }
         if (batch != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -28,6 +28,8 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.profile.ProfileSpan;
+import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.FileQueryScanNode;
@@ -124,42 +126,41 @@ public class HiveScanNode extends FileQueryScanNode {
     }
 
     protected List<HivePartition> getPartitions() throws AnalysisException {
-        List<HivePartition> resPartitions = Lists.newArrayList();
-        HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
-                .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
-        List<Type> partitionColumnTypes = hmsTable.getPartitionColumnTypes();
-        if (!partitionColumnTypes.isEmpty()) {
-            // partitioned table
-            Collection<PartitionItem> partitionItems;
-            // partitions has benn pruned by Nereids, in PruneFileScanPartition,
-            // so just use the selected partitions.
-            this.totalPartitionNum = selectedPartitions.totalPartitionNum;
-            partitionItems = selectedPartitions.selectedPartitions.values();
-            Preconditions.checkNotNull(partitionItems);
-            this.selectedPartitionNum = partitionItems.size();
+        try (ProfileSpan ignored = ProfileSpan.create(id.toString(), SummaryProfile.GET_PARTITIONS_TIME)) {
+            List<HivePartition> resPartitions = Lists.newArrayList();
+            HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
+                    .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
+            List<Type> partitionColumnTypes = hmsTable.getPartitionColumnTypes();
+            if (!partitionColumnTypes.isEmpty()) {
+                // partitioned table
+                Collection<PartitionItem> partitionItems;
+                // partitions has benn pruned by Nereids, in PruneFileScanPartition,
+                // so just use the selected partitions.
+                this.totalPartitionNum = selectedPartitions.totalPartitionNum;
+                partitionItems = selectedPartitions.selectedPartitions.values();
+                Preconditions.checkNotNull(partitionItems);
+                this.selectedPartitionNum = partitionItems.size();
 
-            // get partitions from cache
-            List<List<String>> partitionValuesList = Lists.newArrayListWithCapacity(partitionItems.size());
-            for (PartitionItem item : partitionItems) {
-                partitionValuesList.add(
-                        ((ListPartitionItem) item).getItems().get(0).getPartitionValuesAsStringListForHive());
+                // get partitions from cache
+                List<List<String>> partitionValuesList = Lists.newArrayListWithCapacity(partitionItems.size());
+                for (PartitionItem item : partitionItems) {
+                    partitionValuesList.add(
+                            ((ListPartitionItem) item).getItems().get(0).getPartitionValuesAsStringListForHive());
+                }
+                resPartitions = cache.getAllPartitionsWithCache(hmsTable.getDbName(), hmsTable.getName(),
+                        partitionValuesList);
+            } else {
+                // non partitioned table, create a dummy partition to save location and inputformat,
+                // so that we can unify the interface.
+                HivePartition dummyPartition = new HivePartition(hmsTable.getDbName(), hmsTable.getName(), true,
+                        hmsTable.getRemoteTable().getSd().getInputFormat(),
+                        hmsTable.getRemoteTable().getSd().getLocation(), null, Maps.newHashMap());
+                this.totalPartitionNum = 1;
+                this.selectedPartitionNum = 1;
+                resPartitions.add(dummyPartition);
             }
-            resPartitions = cache.getAllPartitionsWithCache(hmsTable.getDbName(), hmsTable.getName(),
-                    partitionValuesList);
-        } else {
-            // non partitioned table, create a dummy partition to save location and inputformat,
-            // so that we can unify the interface.
-            HivePartition dummyPartition = new HivePartition(hmsTable.getDbName(), hmsTable.getName(), true,
-                    hmsTable.getRemoteTable().getSd().getInputFormat(),
-                    hmsTable.getRemoteTable().getSd().getLocation(), null, Maps.newHashMap());
-            this.totalPartitionNum = 1;
-            this.selectedPartitionNum = 1;
-            resPartitions.add(dummyPartition);
+            return resPartitions;
         }
-        if (ConnectContext.get().getExecutor() != null) {
-            ConnectContext.get().getExecutor().getSummaryProfile().setGetPartitionsFinishTime();
-        }
-        return resPartitions;
     }
 
     @Override
@@ -174,9 +175,8 @@ public class HiveScanNode extends FileQueryScanNode {
                     .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
             String bindBrokerName = hmsTable.getCatalog().bindBrokerName();
             List<Split> allFiles = Lists.newArrayList();
-            getFileSplitByPartitions(cache, prunedPartitions, allFiles, bindBrokerName);
-            if (ConnectContext.get().getExecutor() != null) {
-                ConnectContext.get().getExecutor().getSummaryProfile().setGetPartitionFilesFinishTime();
+            try (ProfileSpan ignored = ProfileSpan.create(id.toString(), SummaryProfile.GET_PARTITION_FILES_TIME)) {
+                getFileSplitByPartitions(cache, prunedPartitions, allFiles, bindBrokerName);
             }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("get #{} files for table: {}.{}, cost: {} ms",
@@ -213,12 +213,15 @@ public class HiveScanNode extends FileQueryScanNode {
                     CompletableFuture.runAsync(() -> {
                         try {
                             List<Split> allFiles = Lists.newArrayList();
-                            getFileSplitByPartitions(
-                                    cache, Collections.singletonList(partition), allFiles, bindBrokerName);
+                            try (ProfileSpan ignored = ProfileSpan.create(id.toString(),
+                                    SummaryProfile.GET_PARTITION_FILES_TIME)) {
+                                getFileSplitByPartitions(
+                                        cache, Collections.singletonList(partition), allFiles, bindBrokerName);
+                            }
                             if (allFiles.size() > numSplitsPerPartition.get()) {
                                 numSplitsPerPartition.set(allFiles.size());
                             }
-                            splitAssignment.addToQueue(allFiles);
+                            splitAssignment.addToQueue(allFiles, id.toString());
                         } catch (IOException e) {
                             batchException.set(new UserException(e.getMessage(), e));
                         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -126,7 +126,8 @@ public class HiveScanNode extends FileQueryScanNode {
     }
 
     protected List<HivePartition> getPartitions() throws AnalysisException {
-        try (ProfileSpan ignored = ProfileSpan.create(id.toString(), SummaryProfile.GET_PARTITIONS_TIME)) {
+        try (ProfileSpan ignored = ProfileSpan.create(
+                ConnectContext.getSummaryProfileSafety(), id.toString(), SummaryProfile.GET_PARTITIONS_TIME)) {
             List<HivePartition> resPartitions = Lists.newArrayList();
             HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
                     .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
@@ -175,7 +176,8 @@ public class HiveScanNode extends FileQueryScanNode {
                     .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
             String bindBrokerName = hmsTable.getCatalog().bindBrokerName();
             List<Split> allFiles = Lists.newArrayList();
-            try (ProfileSpan ignored = ProfileSpan.create(id.toString(), SummaryProfile.GET_PARTITION_FILES_TIME)) {
+            try (ProfileSpan ignored = ProfileSpan.create(
+                    ConnectContext.getSummaryProfileSafety(), id.toString(), SummaryProfile.GET_PARTITION_FILES_TIME)) {
                 getFileSplitByPartitions(cache, prunedPartitions, allFiles, bindBrokerName);
             }
             if (LOG.isDebugEnabled()) {
@@ -213,8 +215,8 @@ public class HiveScanNode extends FileQueryScanNode {
                     CompletableFuture.runAsync(() -> {
                         try {
                             List<Split> allFiles = Lists.newArrayList();
-                            try (ProfileSpan ignored = ProfileSpan.create(id.toString(),
-                                    SummaryProfile.GET_PARTITION_FILES_TIME)) {
+                            try (ProfileSpan ignored = ProfileSpan.create(splitAssignment.getSummaryProfile(),
+                                    id.toString(), SummaryProfile.GET_PARTITION_FILES_TIME)) {
                                 getFileSplitByPartitions(
                                         cache, Collections.singletonList(partition), allFiles, bindBrokerName);
                             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -425,7 +425,7 @@ public class HudiScanNode extends HiveScanNode {
                         if (allFiles.size() > numSplitsPerPartition.get()) {
                             numSplitsPerPartition.set(allFiles.size());
                         }
-                        splitAssignment.addToQueue(allFiles);
+                        splitAssignment.addToQueue(allFiles, id.toString());
                     } catch (IOException e) {
                         batchException.set(new UserException(e.getMessage(), e));
                     } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -41,6 +41,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.CatalogIf;
@@ -1395,5 +1396,12 @@ public class ConnectContext {
 
     public byte[] getAuthPluginData() {
         return mysqlHandshakePacket == null ? null : mysqlHandshakePacket.getAuthPluginData();
+    }
+
+    public static SummaryProfile getSummaryProfileSafety() {
+        if (ConnectContext.get() != null && ConnectContext.get().getExecutor() != null) {
+            return ConnectContext.get().getExecutor().getSummaryProfile();
+        }
+        return null;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileSpanWithStepTimerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileSpanWithStepTimerTest.java
@@ -1,0 +1,271 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.profile;
+
+import org.apache.doris.common.profile.SummaryProfile.NestedStepTimer;
+import org.apache.doris.common.profile.SummaryProfile.TimeStats;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.DoubleSummaryStatistics;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class ProfileSpanWithStepTimerTest {
+    private static final double TIMING_ERROR_MARGIN = 0.3; // Allow 30% error margin for timing tests
+
+    private static final long MIN_SLEEP_TIME = 10; // Minimum sleep time to avoid too short durations
+
+    private SummaryProfile summaryProfile;
+
+    @Before
+    public void setUp() {
+        summaryProfile = new SummaryProfile();
+    }
+
+    @Test
+    public void testBasicTiming() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+        long expectedTime = 100;
+
+        long startTime = System.nanoTime();
+        try (ProfileSpan span = ProfileSpan.create(summaryProfile, nodeId, "step1")) {
+            sleep(expectedTime);
+        }
+        long actualTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+        TimeStats stepStats = timer.getScanNodesStats().get("step1");
+        Assert.assertNotNull("Stats should exist for step1", stepStats);
+        Assert.assertEquals("Should have 1 execution", 1, stepStats.getCount());
+        assertTimingWithinRange(expectedTime, stepStats.getSum());
+        assertTimingWithinRange(expectedTime, actualTime);
+    }
+
+    @Test
+    public void testNestedSpans() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+        long innerTime = 100;
+        long outerTime = 200;
+
+        long startTime = System.nanoTime();
+        try (ProfileSpan outerSpan = ProfileSpan.create(summaryProfile, nodeId, "outer")) {
+            sleep(50);
+            try (ProfileSpan innerSpan = ProfileSpan.create(summaryProfile, nodeId, "inner")) {
+                sleep(innerTime);
+            }
+            sleep(50);
+        }
+        long actualTotalTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+        TimeStats outerStats = timer.getScanNodesStats().get("outer");
+        TimeStats innerStats = timer.getScanNodesStats().get("inner");
+
+        Assert.assertNotNull("Outer stats should exist", outerStats);
+        Assert.assertNotNull("Inner stats should exist", innerStats);
+
+        assertTimingWithinRange(innerTime, innerStats.getSum());
+        assertTimingWithinRange(actualTotalTime, outerStats.getSum());
+    }
+
+    @Test
+    public void testMultipleExecutions() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+        long expectedTime = 50;
+
+        List<Long> measurements = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            long start = System.nanoTime();
+            try (ProfileSpan span = ProfileSpan.create(summaryProfile, nodeId, "step1")) {
+                sleep(expectedTime);
+            }
+            measurements.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+        }
+
+        TimeStats stats = timer.getScanNodesStats().get("step1");
+        Assert.assertEquals("Should have 2 executions", 2, stats.getCount());
+
+        double avgTime = measurements.stream().mapToLong(Long::longValue).average().orElse(0.0);
+        assertTimingWithinRange(expectedTime, (long) avgTime);
+    }
+
+    @Test
+    public void testParallelSteps() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+        long expectedTime = 100;
+
+        List<Long> timings = new ArrayList<>();
+        for (String step : new String[]{"parallel1", "parallel2"}) {
+            long start = System.nanoTime();
+            try (ProfileSpan span = ProfileSpan.create(summaryProfile, nodeId, step)) {
+                sleep(expectedTime);
+            }
+            timings.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+        }
+
+        DoubleSummaryStatistics stats = timings.stream()
+                .mapToDouble(Long::doubleValue)
+                .summaryStatistics();
+
+        Assert.assertTrue("Steps should have similar duration",
+                Math.abs(stats.getMax() - stats.getMin()) <= expectedTime * TIMING_ERROR_MARGIN);
+    }
+
+    @Test
+    public void testComplexScenario() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+
+        long startTime = System.nanoTime();
+        executeComplexScenario(nodeId);
+        long totalTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+        Map<String, TimeStats> stats = timer.getScanNodesStats();
+        Assert.assertEquals("Should have all steps", 6, stats.size());
+
+        // 使用实际测量的总时间而不是预期时间
+        assertTimingWithinRange(totalTime, stats.get("transaction").getSum());
+        verifyStepStats(stats);
+    }
+
+    private void executeComplexScenario(String nodeId) {
+        try (ProfileSpan transaction = ProfileSpan.create(summaryProfile, nodeId, "transaction")) {
+            sleep(50);
+            try (ProfileSpan prepare = ProfileSpan.create(summaryProfile, nodeId, "prepare")) {
+                sleep(100);
+            }
+            try (ProfileSpan execute = ProfileSpan.create(summaryProfile, nodeId, "execute")) {
+                try (ProfileSpan subquery1 = ProfileSpan.create(summaryProfile, nodeId, "subquery1")) {
+                    sleep(150);
+                }
+                try (ProfileSpan subquery2 = ProfileSpan.create(summaryProfile, nodeId, "subquery2")) {
+                    sleep(200);
+                }
+            }
+            try (ProfileSpan commit = ProfileSpan.create(summaryProfile, nodeId, "commit")) {
+                sleep(50);
+            }
+        }
+    }
+
+    @Test
+    public void testExceptionHandling() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+        long expectedTime = 100;
+
+        long startTime = System.nanoTime();
+        try {
+            try (ProfileSpan span = ProfileSpan.create(summaryProfile, nodeId, "errorStep")) {
+                sleep(expectedTime);
+                throw new RuntimeException("Test exception");
+            }
+        } catch (RuntimeException e) {
+            // Expected exception
+        }
+        long actualTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+        TimeStats stats = timer.getScanNodesStats().get("errorStep");
+        Assert.assertNotNull("Stats should exist despite exception", stats);
+        Assert.assertEquals("Should have 1 execution", 1, stats.getCount());
+        assertTimingWithinRange(expectedTime, actualTime);
+    }
+
+    @Test
+    public void testTimingAccuracy() {
+        String nodeId = "node1";
+        NestedStepTimer timer = summaryProfile.createNodeTimer(nodeId);
+
+        List<Long> measurements = new ArrayList<>();
+        int iterations = 10;
+        long targetTime = 50;
+
+        for (int i = 0; i < iterations; i++) {
+            long start = System.nanoTime();
+            try (ProfileSpan span = ProfileSpan.create(summaryProfile, nodeId, "accuracy" + i)) {
+                sleep(targetTime);
+            }
+            measurements.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
+        }
+
+        DoubleSummaryStatistics stats = measurements.stream()
+                .mapToDouble(Long::doubleValue)
+                .summaryStatistics();
+
+        System.out.printf("Timing statistics for %d ms target:%n", targetTime);
+        System.out.printf("  Average: %.2f ms%n", stats.getAverage());
+        System.out.printf("  Min: %.2f ms%n", stats.getMin());
+        System.out.printf("  Max: %.2f ms%n", stats.getMax());
+        System.out.printf("  StdDev: %.2f ms%n", calculateStdDev(measurements, stats.getAverage()));
+
+        assertTimingWithinRange(targetTime, (long) stats.getAverage());
+    }
+
+    private void assertTimingWithinRange(long expected, long actual) {
+        long allowedDelta = (long)(expected * TIMING_ERROR_MARGIN);
+        long minExpected = Math.max(expected - allowedDelta, MIN_SLEEP_TIME);
+        long maxExpected = expected + allowedDelta;
+
+        Assert.assertTrue(
+                String.format(
+                        "Timing %d ms should be between %d ms and %d ms",
+                        actual, minExpected, maxExpected
+                ),
+                actual >= minExpected && actual <= maxExpected
+        );
+    }
+
+    private void verifyStepStats(Map<String, TimeStats> stats) {
+        for (Map.Entry<String, TimeStats> entry : stats.entrySet()) {
+            TimeStats timeStats = entry.getValue();
+            Assert.assertTrue(
+                    String.format("Stats for %s should be reasonable", entry.getKey()),
+                    timeStats.getMin() <= timeStats.getAverage() &&
+                            timeStats.getAverage() <= timeStats.getMax()
+            );
+        }
+    }
+
+    private double calculateStdDev(List<Long> measurements, double mean) {
+        return Math.sqrt(measurements.stream()
+                .mapToDouble(m -> Math.pow(m - mean, 2))
+                .average()
+                .orElse(0.0));
+    }
+
+    private void sleep(long targetMillis) {
+        long start = System.nanoTime();
+        long targetNanos = TimeUnit.MILLISECONDS.toNanos(targetMillis);
+
+        while (System.nanoTime() - start < targetNanos) {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileSpanWithStepTimerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileSpanWithStepTimerTest.java
@@ -171,10 +171,10 @@ public class ProfileSpanWithStepTimerTest {
         }
 
         TimeStats stats1 = timer1.getScanNodesStats().get("step1");
-        Assert.assertEquals("Should have 2 executions", 2, stats1.getCount());
+        Assert.assertEquals("Should have 1 executions", 2, stats1.getCount());
 
         TimeStats stats2 = timer2.getScanNodesStats().get("step1");
-        Assert.assertEquals("Should have 2 executions", 2, stats2.getCount());
+        Assert.assertEquals("Should have 1 executions", 2, stats2.getCount());
     }
 
     private void verifyStepDuration(String step, Map<String, TimeStats> scanNodeStats, long expectedDuration) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Previously, the plan time in the profile only recorded the time for individual scan nodes, without aggregating the timing statistics across all scan nodes.

### Release note

The purpose of this improvement is to collect timing statistics for all scan nodes within the plan time section of the profile, including the total time, average time, maximum and minimum times across all nodes.

Introduce `NestedStepTimer` to count the time of each step, and calculate the sum, avg, min, max, and count time of each step. Note：Each StepTimer instance must be used by a single thread only. It is not thread-safe for multiple threads to operate on the same StepTimer instance.

Introduce `ProfileSpan` to use the try-with-resource mechanism to encapsulate the calculation statistics time.
e.g.
```
try (ProfileSpan transaction = ProfileSpan.create(summaryProfile, nodeId, "transaction")) {
    sleep(50);
    
    try (ProfileSpan prepare = ProfileSpan.create(summaryProfile, nodeId, "prepare")) {
        sleep(100);
    }
    
    try (ProfileSpan execute = ProfileSpan.create(summaryProfile, nodeId, "execute")) {
        try (ProfileSpan subquery1 = ProfileSpan.create(summaryProfile, nodeId, "subquery1")) {
            sleep(150);
        }
        
        try (ProfileSpan subquery2 = ProfileSpan.create(summaryProfile, nodeId, "subquery2")) {
            sleep(200);
        }
    }
    
    try (ProfileSpan commit = ProfileSpan.create(summaryProfile, nodeId, "commit")) {
        sleep(50);
    }
}
```

### Result
```
-  Plan  Time:  1s288ms
          -  JoinReorder  Time:  N/A
          -  CreateSingleNode  Time:  N/A
          -  QueryDistributed  Time:  N/A
          -  Init  Scan  Node  Time:  sum  99ms,  count  4,  avg  24ms,  max  84ms,  min  2ms
          -  Finalize  Scan  Node  Time:  sum  868ms,  count  4,  avg  217ms,  max  841ms,  min  5ms
              -  Get  Splits  Time:  sum  827ms,  count  4,  avg  206ms,  max  803ms,  min  5ms
                  -  Get  Partitions  Time:  sum  41ms,  count  4,  avg  10ms,  max  41ms,  min  0ms
                  -  Get  Partition  Files  Time:  sum  785ms,  count  4,  avg  196ms,  max  762ms,  min  5ms
              -  Create  Scan  Range  Time:  sum  40ms,  count  4,  avg  10ms,  max  37ms,  min  0ms
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [X] Unit Test: `ProfileSpanWithStepTimerTest`.
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

