### PR TITLE
[Enhancement](tools) Suppress warnings in TPCDS tools for old compiler

### DIFF
--- a/tools/tpcds-tools/bin/build-tpcds-tools.sh
+++ b/tools/tpcds-tools/bin/build-tpcds-tools.sh
@@ -32,7 +32,7 @@ ROOT=$(
 )
 
 CURDIR="${ROOT}"
-TPCDS_DBGEN_DIR="${CURDIR}/DSGen-software-code-3.2.0rc1/tools"
+TPCDS_DBGEN_DIR="${CURDIR}/DSGen-software-code-3.2.0rc2/tools"
 
 check_prerequest() {
     local CMD=$1
@@ -48,11 +48,11 @@ check_prerequest "unzip -h" "unzip"
 # download tpcds tools package first
 if [[ -d "${CURDIR}/DSGen-software-code-3.2.0rc1" ]]; then
     echo "If you want to rebuild TPC-DS_Tools_v3.2.0 again, please delete ${CURDIR}/DSGen-software-code-3.2.0rc1 first."
-elif [[ -f "${CURDIR}/TPC-DS_Tools_v3.2.0new.zip" ]]; then
-    unzip TPC-DS_Tools_v3.2.0new.zip -d "${CURDIR}/"
+elif [[ -f "TPC-DS_Tools_v3.2.0rc2.zip" ]]; then
+    unzip TPC-DS_Tools_v3.2.0rc2.zip -d "${CURDIR}/"
 else
-    wget "https://qa-build.oss-cn-beijing.aliyuncs.com/tools/TPC-DS_Tools_v3.2.0new.zip"
-    unzip TPC-DS_Tools_v3.2.0new.zip -d "${CURDIR}/"
+    wget "https://qa-build.oss-cn-beijing.aliyuncs.com/tools/TPC-DS_Tools_v3.2.0rc2.zip"
+    unzip TPC-DS_Tools_v3.2.0rc2.zip -d "${CURDIR}/"
 fi
 
 # compile tpcds-dsdgen


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/31124

Problem Summary:

add flags `-w` to tpcds tools' makefile so that we could use old version gcc to compile it. released a new package named `TPC-DS_Tools_v3.2.0rc2.zip` to use. script updated.

### Release note

TPC-DS tools now support any version of GCC

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

