### PR TITLE
Update FrontendsProcNode.java

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
@@ -223,10 +223,34 @@ public class FrontendsProcNode implements ProcNodeInterface {
                 LOG.warn("Failed to get InetAddress {}", addr);
                 continue;
             }
-            if (fe.getHost().equals(address.getHostAddress())) {
-                return true;
-            }
+
+    		//deal ip v6 :0: format error
+    		if(address.getHostAddress().contains(":0:") && fe.getHost().equals(formatIp(address.getHostAddress()))) {
+                    return true;
+                
+    		}else if (fe.getHost().equals(address.getHostAddress())) {
+                    return true;
+    		}
         }
         return false;
     }
+
+	private String formatIp(String context) {
+		
+		while(true) {
+			if(context.contains(":0:")) {
+				context=context.replaceAll(":0:", "::");
+			}else {
+				break;
+			}
+		}
+		
+		while(true) {
+			if(context.contains(":::")) {
+				context=context.replaceAll(":::", "::");
+			}else {
+				return context;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fix abnormal IPv6 address comparison

### What problem does this PR solve?

Issue Number: #42695 

Problem Summary:
类org.apache.doris.common.proc.FrontendsProcNode 的 isJoin 方法，匹配ipv6值时，参数 Frontend 的host属性值为 fe80::20c:29ff:fef9:3a18，而List allFeHosts 由于使用了java 的 InetAddress类 getHostAddress()获取ip 值为：fe80:0:0:0:20c:29ff:fef9:3a18

两个ip地址不相同，无法join。

### Release note

None

### Check List (For Author)

None

### Check List (For Reviewer who merge this PR)

None

