### PR TITLE
[Fix]fix http query_info api return wrong column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -223,6 +223,10 @@ public class ProfileManager extends MasterDaemon {
     }
 
     public List<List<String>> getAllQueries() {
+        return getQueryInfoByColumnNameList(SummaryProfile.SUMMARY_KEYS);
+    }
+
+    public List<List<String>> getQueryInfoByColumnNameList(List<String> columnNameList) {
         List<List<String>> result = Lists.newArrayList();
         readLock.lock();
         try {
@@ -231,7 +235,7 @@ public class ProfileManager extends MasterDaemon {
                 ProfileElement profileElement = queueIdDeque.poll();
                 Map<String, String> infoStrings = profileElement.infoStrings;
                 List<String> row = Lists.newArrayList();
-                for (String str : SummaryProfile.SUMMARY_KEYS) {
+                for (String str : columnNameList) {
                     row.add(infoStrings.get(str));
                 }
                 result.add(row);


### PR DESCRIPTION
### What problem does this PR solve?
Fix ```/rest/v2/manager/query/query_info``` return data not match its column title.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

