### PR TITLE
[improve](join) reuse the join block to reduce malloc memory

### DIFF
--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -516,23 +516,20 @@ Status NestedLoopJoinProbeOperatorX::pull(RuntimeState* state, vectorized::Block
                                   local_state._matched_rows_done
                         : local_state._matched_rows_done);
 
+        size_t join_block_column_size = local_state._join_block.columns();
         {
-            vectorized::Block tmp_block = local_state._join_block;
-
-            // Here make _join_block release the columns' ptr
-            local_state._join_block.set_columns(local_state._join_block.clone_empty_columns());
-
-            local_state.add_tuple_is_null_column(&tmp_block);
+            local_state.add_tuple_is_null_column(&local_state._join_block);
             {
                 SCOPED_TIMER(local_state._join_filter_timer);
                 RETURN_IF_ERROR(vectorized::VExprContext::filter_block(
-                        local_state._conjuncts, &tmp_block, tmp_block.columns()));
+                        local_state._conjuncts, &local_state._join_block,
+                        local_state._join_block.columns()));
             }
-            RETURN_IF_ERROR(local_state._build_output_block(&tmp_block, block, false));
+            RETURN_IF_ERROR(
+                    local_state._build_output_block(&local_state._join_block, block, false));
             local_state._reset_tuple_is_null_column();
         }
-        local_state._join_block.clear_column_data();
-
+        vectorized::Block::erase_useless_column(&local_state._join_block, join_block_column_size);
         if (!(*eos) and !local_state._need_more_input_data) {
             auto func = [&](auto&& join_op_variants, auto set_build_side_flag,
                             auto set_probe_side_flag) {

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -529,7 +529,7 @@ Status NestedLoopJoinProbeOperatorX::pull(RuntimeState* state, vectorized::Block
                     local_state._build_output_block(&local_state._join_block, block, false));
             local_state._reset_tuple_is_null_column();
         }
-        vectorized::Block::erase_useless_column(&local_state._join_block, join_block_column_size);
+        local_state._join_block.clear_column_data(join_block_column_size);
         if (!(*eos) and !local_state._need_more_input_data) {
             auto func = [&](auto&& join_op_variants, auto set_build_side_flag,
                             auto set_probe_side_flag) {


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
before in the pull function, it's use tmp_block to reference data and swap with output_block.
and then create empty column in join_block, so insert into data at next time, it's need malloc memory again.


after fixed:
```
mysql [ssb]>set parallel_pipeline_task_num = 0;
mysql [ssb]>select count(c_custkey) from (select c_custkey from customer cross join dates)t;
+------------------+
| count(c_custkey) |
+------------------+
|       7668000000 |
+------------------+
1 row in set (0.32 sec)

mysql [ssb]>set parallel_pipeline_task_num = 1;
Query OK, 0 rows affected (0.00 sec)

mysql [ssb]>select count(c_custkey) from (select c_custkey from customer cross join dates)t;
+------------------+
| count(c_custkey) |
+------------------+
|       7668000000 |
+------------------+
1 row in set (5.61 sec)
```

before
```
mysql [ssb]>set parallel_pipeline_task_num = 0;
Query OK, 0 rows affected (0.00 sec)

mysql [ssb]>select count(c_custkey) from (select c_custkey from customer cross join dates)t;
+------------------+
| count(c_custkey) |
+------------------+
|       7668000000 |
+------------------+
1 row in set (2.79 sec)

mysql [ssb]>set parallel_pipeline_task_num = 1;
Query OK, 0 rows affected (0.00 sec)

mysql [ssb]>select count(c_custkey) from (select c_custkey from customer cross join dates)t;
+------------------+
| count(c_custkey) |
+------------------+
|       7668000000 |
+------------------+
1 row in set (10.21 sec)
```



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

