### PR TITLE
[fix](planner)show tablet command return wrong result when having limit and offset

### DIFF
--- a/regression-test/suites/show_p0/test_show_tablet.groovy
+++ b/regression-test/suites/show_p0/test_show_tablet.groovy
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_tablet") {
+    sql """drop table if exists show_tablets_test_t;"""
+    sql """create table show_tablets_test_t (
+                id BIGINT,
+                username VARCHAR(20)
+            )
+            DISTRIBUTED BY HASH(id) BUCKETS 5
+            PROPERTIES (
+                "replication_num" = "1"
+            );"""
+    def res = sql """SHOW TABLETS FROM show_tablets_test_t limit 5, 1;"""
+    assertTrue(res.size() == 0)
+
+    res = sql """SHOW TABLETS FROM show_tablets_test_t limit 3, 5;"""
+    assertTrue(res.size() == 2)
+
+    res = sql """SHOW TABLETS FROM show_tablets_test_t limit 10;"""
+    assertTrue(res.size() == 5)
+}


### PR DESCRIPTION
### What problem does this PR solve?
`show tablets from t order by x limit y, z` produce wrong result. The original code sort the limit results, while the correct way is to limit the sorting results. This pr fix it.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

