### PR TITLE
[fix](nereids) fix bug: convert stringLikeLiteral to double

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -46,11 +46,12 @@ public abstract class StringLikeLiteral extends Literal {
      * get double value
      */
     public static double getDouble(String str) {
+        byte[] bytes = str.getBytes();
         long v = 0;
         int pos = 0;
-        int len = Math.min(str.length(), 7);
+        int len = Math.min(bytes.length, 7);
         while (pos < len) {
-            v += Byte.toUnsignedLong(str.getBytes()[pos]) << ((6 - pos) * 8);
+            v += Byte.toUnsignedLong(bytes[pos]) << ((6 - pos) * 8);
             pos++;
         }
         return (double) v;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.literal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+public class StringLikeLiteralTest {
+    @Test
+    public void testStrToDouble() {
+        String minStr = "商家+店长+场地+设备类型维度";
+        String maxStr = "商家维度";
+        double d1= StringLikeLiteral.getDouble(minStr);
+        double d2 = StringLikeLiteral.getDouble(maxStr);
+        Assertions.assertTrue(d1 < d2);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
@@ -19,12 +19,15 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 public class StringLikeLiteralTest {
     @Test
     public void testStrToDouble() {
+        // fix bug: maxStr.length = 4, maxStr.getBytes().length=12
+        // when converting str to double, bytes length is used instead of string length
         String minStr = "商家+店长+场地+设备类型维度";
         String maxStr = "商家维度";
-        double d1= StringLikeLiteral.getDouble(minStr);
+        double d1 = StringLikeLiteral.getDouble(minStr);
         double d2 = StringLikeLiteral.getDouble(maxStr);
         Assertions.assertTrue(d1 < d2);
     }


### PR DESCRIPTION
### What problem does this PR solve?
The optimizer maps different data types to Double, allowing for a unified comparison of literals.
StringLikeLiteral is regarded as a long int, and map the long int to double.
To extract the first N bytes from a string, you should use String.getBytes().length instead of String.length().

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

