### PR TITLE
[test](mtmv) Add inject statistic when mv rewrite regression test to make sure rewrite result stable

### DIFF
--- a/regression-test/data/mv_p0/ssb/q_1_1/q_1_1.out
+++ b/regression-test/data/mv_p0/ssb/q_1_1/q_1_1.out
@@ -6,10 +6,13 @@
 19930101	1	1	1	1	1	1	1	1	1	1	100	1	1	1	2023-06-09	shipmode	name	address	city	nation	AMERICA	phone	mktsegment	name	address	city	nation	AMERICA	phone	name	MFGR#1	category	brand	color	type	4	container
 19930101	1	1	1	1	1	1	1	1	1	1	100	1	1	1	2023-06-09	shipmode	name	address	city	nation	AMERICA	phone	mktsegment	name	address	city	nation	AMERICA	phone	name	MFGR#1	category	brand	color	type	4	container
 19930101	2	2	2	2	2	2	2	2	2	2	2	2	2	2	2023-06-09	shipmode	name	address	city	nation	region	phone	mktsegment	name	address	city	nation	region	phone	name	mfgr	category	brand	color	type	4	container
+19930101	2	2	2	2	2	2	2	2	2	2	2	2	2	2	2023-06-09	shipmode	name	address	city	nation	region	phone	mktsegment	name	address	city	nation	region	phone	name	mfgr	category	brand	color	type	4	container
+19930101	2	2	2	2	2	2	2	2	2	2	2	2	2	2	2023-06-09	shipmode	name	address	city	nation	region	phone	mktsegment	name	address	city	nation	region	phone	name	mfgr	category	brand	color	type	4	container
+19930101	2	2	2	2	2	2	2	2	2	2	2	2	2	2	2023-06-09	shipmode	name	address	city	nation	region	phone	mktsegment	name	address	city	nation	region	phone	name	mfgr	category	brand	color	type	4	container
 
 -- !select_mv --
-4
+16
 
 -- !select --
-4
+16
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1979,9 +1979,8 @@ class Suite implements GroovyInterceptable {
             check { result ->
                 boolean success = true;
                 for (String mv_name : mv_names) {
-                    success = success && result.contains("${mv_name} chose")
+                    Assert.assertEquals(true, result.contains("${mv_name} chose"))
                 }
-                Assert.assertEquals(true, success)
             }
         }
     }

--- a/regression-test/suites/mv_p0/agg_have_dup_base/agg_have_dup_base.groovy
+++ b/regression-test/suites/mv_p0/agg_have_dup_base/agg_have_dup_base.groovy
@@ -37,6 +37,8 @@ suite ("agg_have_dup_base") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k4 set stats ('row_count'='5');"""
+
     createMV( "create materialized view k12s3m as select k1,sum(k2),max(k2) from d_table group by k1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/agg_have_dup_base/agg_have_dup_base.groovy
+++ b/regression-test/suites/mv_p0/agg_have_dup_base/agg_have_dup_base.groovy
@@ -37,8 +37,6 @@ suite ("agg_have_dup_base") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
-    sql """alter table d_table modify column k4 set stats ('row_count'='5');"""
-
     createMV( "create materialized view k12s3m as select k1,sum(k2),max(k2) from d_table group by k1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -62,6 +60,8 @@ suite ("agg_have_dup_base") {
     qt_select_mv "select unix_timestamp(k1) tmp,sum(k2) from d_table group by tmp order by tmp;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='5');"""
+
     mv_rewrite_success("select k1,sum(k2),max(k2) from d_table group by k1;", "k12s3m")
 
     mv_rewrite_success("select k1,sum(k2) from d_table group by k1;", "k12s3m")

--- a/regression-test/suites/mv_p0/agg_no_group/agg_no_group.groovy
+++ b/regression-test/suites/mv_p0/agg_no_group/agg_no_group.groovy
@@ -55,8 +55,6 @@ suite ("agg_no_group") {
                 (3, 1, 1, 2, '2023-10-19', 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', null, 'c', 'd', 'xxxxxxxxx'),
                 (1, 3, 2, 2, '2023-10-17', 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy');"""
 
-    sql """alter table lineitem_2_agg modify column l_comment set stats ('row_count'='7');"""
-
     test {
         sql """CREATE MATERIALIZED VIEW mv_name_2_3_5  AS  
         select l_shipdate, l_partkey, l_orderkey from lineitem_2_agg"""

--- a/regression-test/suites/mv_p0/agg_no_group/agg_no_group.groovy
+++ b/regression-test/suites/mv_p0/agg_no_group/agg_no_group.groovy
@@ -55,6 +55,8 @@ suite ("agg_no_group") {
                 (3, 1, 1, 2, '2023-10-19', 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', null, 'c', 'd', 'xxxxxxxxx'),
                 (1, 3, 2, 2, '2023-10-17', 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy');"""
 
+    sql """alter table lineitem_2_agg modify column l_comment set stats ('row_count'='7');"""
+
     test {
         sql """CREATE MATERIALIZED VIEW mv_name_2_3_5  AS  
         select l_shipdate, l_partkey, l_orderkey from lineitem_2_agg"""

--- a/regression-test/suites/mv_p0/agg_state/diffrent_serialize/diffrent_serialize.groovy
+++ b/regression-test/suites/mv_p0/agg_state/diffrent_serialize/diffrent_serialize.groovy
@@ -37,6 +37,8 @@ suite ("diffrent_serialize") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,3,null,'c';"
 
+    sql """alter table d_table modify column k4 set stats ('row_count'='7');"""
+
     createMV("create materialized view mv1_1 as select k1,bitmap_intersect(to_bitmap(k2)) from d_table group by k1;")
     createMV("create materialized view mv1 as select k1,bitmap_agg(k2) from d_table group by k1;")
     createMV("create materialized view mv1_2 as select k1, multi_distinct_group_concat(k4) from d_table group by k1 order by k1;")

--- a/regression-test/suites/mv_p0/agg_state/test_agg_state_max_by.groovy
+++ b/regression-test/suites/mv_p0/agg_state/test_agg_state_max_by.groovy
@@ -40,7 +40,6 @@ suite ("test_agg_state_max_by") {
     sql "insert into d_table select 1,-3,null,'c';"
     sql "insert into d_table(k4,k2) values('d',4);"
 
-    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     createMV("create materialized view k1mb as select k1,max_by(k2,k3) from d_table group by k1;")
 
     sql "insert into d_table select 1,-4,-4,'d';"
@@ -70,6 +69,7 @@ suite ("test_agg_state_max_by") {
     qt_select_star "select * from d_table order by 1,2;"
     mv_rewrite_success("select k1,max_by(k2,k3) from d_table group by k1 order by 1,2;", "k1mb")
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,max_by(k2,k3) from d_table group by k1 order by 1,2;", "k1mb")
     qt_select_mv "select k1,max_by(k2,k3) from d_table group by k1 order by 1,2;"
 
@@ -102,6 +102,7 @@ suite ("test_agg_state_max_by") {
     qt_select_star "select * from d_table order by 1,2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     sql "analyze table d_table with sync;"
     sql """set enable_stats=false;"""
 
@@ -115,6 +116,7 @@ suite ("test_agg_state_max_by") {
     qt_select_mv "select k1,max_by(k2,abs(k3)) from d_table group by k1 order by 1,2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,max_by(k2+k3,abs(k3)) from d_table group by k1 order by 1,2;", "k1mbcp1")
     mv_rewrite_success("select k1,max_by(k2+k3,k3) from d_table group by k1 order by 1,2;", "k1mbcp2")
     mv_rewrite_success("select k1,max_by(k2,abs(k3)) from d_table group by k1 order by 1,2;", "k1mbcp3")

--- a/regression-test/suites/mv_p0/agg_state/test_agg_state_max_by.groovy
+++ b/regression-test/suites/mv_p0/agg_state/test_agg_state_max_by.groovy
@@ -40,6 +40,7 @@ suite ("test_agg_state_max_by") {
     sql "insert into d_table select 1,-3,null,'c';"
     sql "insert into d_table(k4,k2) values('d',4);"
 
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     createMV("create materialized view k1mb as select k1,max_by(k2,k3) from d_table group by k1;")
 
     sql "insert into d_table select 1,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/case_ignore/case_ignore.groovy
+++ b/regression-test/suites/mv_p0/case_ignore/case_ignore.groovy
@@ -55,6 +55,7 @@ suite ("case_ignore") {
     qt_select_mv "select K1,abs(K2) from d_table order by K1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,abs(k2) from d_table order by k1;", "k12a")
     mv_rewrite_success("select K1,abs(K2) from d_table order by K1;", "k12a")
 

--- a/regression-test/suites/mv_p0/case_ignore/case_ignore.groovy
+++ b/regression-test/suites/mv_p0/case_ignore/case_ignore.groovy
@@ -37,6 +37,8 @@ suite ("case_ignore") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k4 set stats ('row_count'='4');"""
+
     createMV ("create materialized view k12a as select K1,abs(K2) from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/contain_cast/mv_contains_cast.groovy
+++ b/regression-test/suites/mv_p0/contain_cast/mv_contains_cast.groovy
@@ -91,6 +91,8 @@ suite("mv_contains_cast") {
 
     order_qt_query_before "${query_sql}"
 
+    sql """alter table test modify column event_type set stats ('row_count'='10');"""
+
     createMV("""
     CREATE MATERIALIZED VIEW sync_mv
     AS

--- a/regression-test/suites/mv_p0/count_star/count_star.groovy
+++ b/regression-test/suites/mv_p0/count_star/count_star.groovy
@@ -38,8 +38,6 @@ suite ("count_star") {
     sql "insert into d_table select 3,-3,null,'c';"
     sql "insert into d_table values(1,1,1,'a'),(1,1,1,'a');"
 
-    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
-
     createMV ("create materialized view kstar as select k1,k4,count(*) from d_table group by k1,k4;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -66,6 +64,8 @@ suite ("count_star") {
     qt_select_mv "select count(*) from d_table where k3=1;"
 
     sql """set enable_stats=true;"""
+
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,k4,count(*) from d_table group by k1,k4;", "kstar")
     mv_rewrite_success("select k1,k4,count(*) from d_table where k1=1 group by k1,k4;", "kstar")
     mv_rewrite_fail("select k1,k4,count(*) from d_table where k3=1 group by k1,k4;", "kstar")

--- a/regression-test/suites/mv_p0/count_star/count_star.groovy
+++ b/regression-test/suites/mv_p0/count_star/count_star.groovy
@@ -38,6 +38,8 @@ suite ("count_star") {
     sql "insert into d_table select 3,-3,null,'c';"
     sql "insert into d_table values(1,1,1,'a'),(1,1,1,'a');"
 
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
+
     createMV ("create materialized view kstar as select k1,k4,count(*) from d_table group by k1,k4;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/dis_26495/dis_26495.groovy
+++ b/regression-test/suites/mv_p0/dis_26495/dis_26495.groovy
@@ -28,6 +28,8 @@ suite ("dis_26495") {
 
     sql """insert into doris_test values (1,2,max_by_state(1,2));"""
 
+    sql """alter table doris_test modify column agg_st_1 set stats ('row_count'='1');"""
+
     streamLoad {
         table "doris_test"
         set 'column_separator', ','

--- a/regression-test/suites/mv_p0/k1ap2spa/k1ap2spa.groovy
+++ b/regression-test/suites/mv_p0/k1ap2spa/k1ap2spa.groovy
@@ -37,8 +37,6 @@ suite ("k1ap2spa") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
-
     createMV("create materialized view k1ap2spa as select abs(k1)+1,sum(abs(k2+1)) from d_table group by abs(k1)+1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -53,6 +51,8 @@ suite ("k1ap2spa") {
     qt_select_mv "select abs(k1)+1 t,sum(abs(k2+1)) from d_table group by t order by t;"
 
     sql """set enable_stats=true;"""
+
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
 
     mv_rewrite_success("select abs(k1)+1 t,sum(abs(k2+1)) from d_table group by t order by t;", "k1ap2spa")
 

--- a/regression-test/suites/mv_p0/k1ap2spa/k1ap2spa.groovy
+++ b/regression-test/suites/mv_p0/k1ap2spa/k1ap2spa.groovy
@@ -37,6 +37,8 @@ suite ("k1ap2spa") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
+
     createMV("create materialized view k1ap2spa as select abs(k1)+1,sum(abs(k2+1)) from d_table group by abs(k1)+1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/k1s2m3/k1s2m3.groovy
+++ b/regression-test/suites/mv_p0/k1s2m3/k1s2m3.groovy
@@ -37,6 +37,7 @@ suite ("k1s2m3") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='6');"""
     createMV("create materialized view k1s2m3 as select k1,sum(k2*k3) from d_table group by k1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/k1s2m3_auto_inc/k1s2m3_auto_inc.groovy
+++ b/regression-test/suites/mv_p0/k1s2m3_auto_inc/k1s2m3_auto_inc.groovy
@@ -43,7 +43,6 @@ suite ("k1s2m3_auto_inc") {
         exception "The materialized view can not involved auto increment column"
     }
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='2');"""
     createMV("create materialized view k3ap2spa as select k3,sum(abs(k2+1)) from d_table group by k3;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -58,5 +57,6 @@ suite ("k1s2m3_auto_inc") {
     qt_select_mv "select k3,sum(abs(k2+1)) from d_table group by k3 order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='2');"""
     mv_rewrite_success("select k3,sum(abs(k2+1)) from d_table group by k3 order by 1;", "k3ap2spa")
 }

--- a/regression-test/suites/mv_p0/k1s2m3_auto_inc/k1s2m3_auto_inc.groovy
+++ b/regression-test/suites/mv_p0/k1s2m3_auto_inc/k1s2m3_auto_inc.groovy
@@ -43,6 +43,7 @@ suite ("k1s2m3_auto_inc") {
         exception "The materialized view can not involved auto increment column"
     }
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='2');"""
     createMV("create materialized view k3ap2spa as select k3,sum(abs(k2+1)) from d_table group by k3;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/multi_agg_with_same_slot/multi_agg_with_same_slot.groovy
+++ b/regression-test/suites/mv_p0/multi_agg_with_same_slot/multi_agg_with_same_slot.groovy
@@ -39,6 +39,7 @@ suite ("multi_agg_with_same_slot") {
     sql "insert into d_table select 2,2,2,'b',2;"
     sql "insert into d_table select 3,-3,null,'c',-3;"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     createMV("create materialized view kmv as select k1,k2,avg(k3),max(k3) from d_table group by k1,k2;")
     createMV("create materialized view kmv2 as select k1,k2,avg(k5),max(k5) from d_table group by k1,k2;")
 

--- a/regression-test/suites/mv_p0/multi_agg_with_same_slot/multi_agg_with_same_slot.groovy
+++ b/regression-test/suites/mv_p0/multi_agg_with_same_slot/multi_agg_with_same_slot.groovy
@@ -39,7 +39,6 @@ suite ("multi_agg_with_same_slot") {
     sql "insert into d_table select 2,2,2,'b',2;"
     sql "insert into d_table select 3,-3,null,'c',-3;"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     createMV("create materialized view kmv as select k1,k2,avg(k3),max(k3) from d_table group by k1,k2;")
     createMV("create materialized view kmv2 as select k1,k2,avg(k5),max(k5) from d_table group by k1,k2;")
 
@@ -65,6 +64,7 @@ suite ("multi_agg_with_same_slot") {
 
     sql """set enable_stats=true;"""
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1,k2,avg(k3),max(k3) from d_table group by k1,k2 order by 1,2;", "kmv")
     mv_rewrite_success("select k1,k2,avg(k3)+max(k3) from d_table group by k1,k2 order by 1,2;", "kmv")
     mv_rewrite_success("select k1,k2,avg(k3)+max(k3) from d_table group by grouping sets((k1),(k1,k2),()) order by 1,2;", "kmv")

--- a/regression-test/suites/mv_p0/multi_slot_k123p/multi_slot_k123p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k123p/multi_slot_k123p.groovy
@@ -37,8 +37,6 @@ suite ("multi_slot_k123p") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
-
     createMV ("create materialized view k123p as select k1,k2+k3 from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -65,5 +63,6 @@ suite ("multi_slot_k123p") {
     qt_select_mv "select k1,version() from d_table order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1,k2+k3 from d_table order by k1;", "k123p")
 }

--- a/regression-test/suites/mv_p0/multi_slot_k123p/multi_slot_k123p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k123p/multi_slot_k123p.groovy
@@ -37,6 +37,8 @@ suite ("multi_slot_k123p") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
+
     createMV ("create materialized view k123p as select k1,k2+k3 from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3p/multi_slot_k1a2p2ap3p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3p/multi_slot_k1a2p2ap3p.groovy
@@ -38,6 +38,8 @@ suite ("multi_slot_k1a2p2ap3p") {
 
     sql "insert into d_table values(1,1,1,'a'),(2,2,2,'b'),(3,-3,null,'c');"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='7');"""
+
     createMV ("create materialized view k1a2p2ap3p as select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3p/multi_slot_k1a2p2ap3p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3p/multi_slot_k1a2p2ap3p.groovy
@@ -38,8 +38,6 @@ suite ("multi_slot_k1a2p2ap3p") {
 
     sql "insert into d_table values(1,1,1,'a'),(2,2,2,'b'),(3,-3,null,'c');"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='7');"""
-
     createMV ("create materialized view k1a2p2ap3p as select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -53,6 +51,7 @@ suite ("multi_slot_k1a2p2ap3p") {
     qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='7');"""
     mv_rewrite_success("select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
 
 }

--- a/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3ps/multi_slot_k1a2p2ap3ps.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3ps/multi_slot_k1a2p2ap3ps.groovy
@@ -45,7 +45,6 @@ suite ("multi_slot_k1a2p2ap3ps") {
     }
     assertTrue(createFail);
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     createMV ("create materialized view k1a2p2ap3ps as select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -62,6 +61,7 @@ suite ("multi_slot_k1a2p2ap3ps") {
     qt_select_base "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2 order by abs(k1)+k2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by abs(k1)+k2+1", "k1a2p2ap3ps")
 
     mv_rewrite_fail("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2 order by abs(k1)+k2", "k1a2p2ap3ps")

--- a/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3ps/multi_slot_k1a2p2ap3ps.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3ps/multi_slot_k1a2p2ap3ps.groovy
@@ -45,6 +45,7 @@ suite ("multi_slot_k1a2p2ap3ps") {
     }
     assertTrue(createFail);
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     createMV ("create materialized view k1a2p2ap3ps as select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/multi_slot_k1p2ap3p/multi_slot_k1p2ap3p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1p2ap3p/multi_slot_k1p2ap3p.groovy
@@ -37,6 +37,8 @@ suite ("multi_slot_k1p2ap3p") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
+
     createMV ("create materialized view k1p2ap3p as select k1+1,abs(k2+2)+k3+3 from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/multi_slot_k1p2ap3p/multi_slot_k1p2ap3p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1p2ap3p/multi_slot_k1p2ap3p.groovy
@@ -37,8 +37,6 @@ suite ("multi_slot_k1p2ap3p") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-
     createMV ("create materialized view k1p2ap3p as select k1+1,abs(k2+2)+k3+3 from d_table;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -52,5 +50,6 @@ suite ("multi_slot_k1p2ap3p") {
     qt_select_mv "select k1+1,abs(k2+2)+k3+3 from d_table order by k1+1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1+1,abs(k2+2)+k3+3 from d_table order by k1+1;", "k1p2ap3p")
 }

--- a/regression-test/suites/mv_p0/multi_slot_k1p2ap3ps/multi_slot_k1p2ap3ps.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1p2ap3ps/multi_slot_k1p2ap3ps.groovy
@@ -36,6 +36,7 @@ suite ("multi_slot_k1p2ap3ps") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     createMV ("create materialized view k1p2ap3ps as select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"

--- a/regression-test/suites/mv_p0/multi_slot_k1p2ap3ps/multi_slot_k1p2ap3ps.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1p2ap3ps/multi_slot_k1p2ap3ps.groovy
@@ -36,7 +36,6 @@ suite ("multi_slot_k1p2ap3ps") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     createMV ("create materialized view k1p2ap3ps as select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1;")
 
     sql "insert into d_table select -4,-4,-4,'d';"
@@ -51,5 +50,6 @@ suite ("multi_slot_k1p2ap3ps") {
     qt_select_mv "select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1 order by k1+1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1 order by k1+1;", "k1p2ap3ps")
 }

--- a/regression-test/suites/mv_p0/multi_slot_multi_mv/multi_slot_multi_mv.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_multi_mv/multi_slot_multi_mv.groovy
@@ -35,7 +35,6 @@ suite ("multi_slot_multi_mv") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     createMV ("create materialized view k1a2p2ap3p as select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table;")
 
     createMV("create materialized view k1a2p2ap3ps as select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1;")
@@ -83,6 +82,7 @@ suite ("multi_slot_multi_mv") {
     qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     for (def i = 0; i < retry_times; ++i) {
         boolean is_k1a2p2ap3p = false
         boolean is_k1a2p2ap3ps = false

--- a/regression-test/suites/mv_p0/multi_slot_multi_mv/multi_slot_multi_mv.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_multi_mv/multi_slot_multi_mv.groovy
@@ -35,6 +35,7 @@ suite ("multi_slot_multi_mv") {
     sql "insert into d_table select 2,2,2,'b';"
     sql "insert into d_table select 3,-3,null,'c';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     createMV ("create materialized view k1a2p2ap3p as select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table;")
 
     createMV("create materialized view k1a2p2ap3ps as select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1;")

--- a/regression-test/suites/mv_p0/mv_with_view/mv_with_view.groovy
+++ b/regression-test/suites/mv_p0/mv_with_view/mv_with_view.groovy
@@ -36,6 +36,8 @@ suite ("mv_with_view") {
     sql """insert into d_table select 1,1,1,'a';"""
     sql """insert into d_table select 2,2,2,'b';"""
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
+
     createMV("create materialized view k312 as select k3,k1,k2 from d_table;")
 
     sql """insert into d_table select 3,-3,null,'c';"""

--- a/regression-test/suites/mv_p0/mv_with_view/mv_with_view.groovy
+++ b/regression-test/suites/mv_p0/mv_with_view/mv_with_view.groovy
@@ -36,8 +36,6 @@ suite ("mv_with_view") {
     sql """insert into d_table select 1,1,1,'a';"""
     sql """insert into d_table select 2,2,2,'b';"""
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
-
     createMV("create materialized view k312 as select k3,k1,k2 from d_table;")
 
     sql """insert into d_table select 3,-3,null,'c';"""
@@ -69,6 +67,7 @@ suite ("mv_with_view") {
     qt_select_mv "select * from v_k124 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from d_table order by k1;", "k312")
 
     sql """

--- a/regression-test/suites/mv_p0/null_insert/null_insert.groovy
+++ b/regression-test/suites/mv_p0/null_insert/null_insert.groovy
@@ -48,6 +48,8 @@ suite ("null_insert") {
 
     sql """INSERT INTO `test` (`date`) VALUES ('2023-07-19');"""
 
+    sql """alter table test modify column date set stats ('row_count'='3');"""
+
     createMV("""CREATE materialized view mv_test AS
                 SELECT date, vid, os, ver, ip_country, hll_union(hll_hash(uid))
                 FROM test

--- a/regression-test/suites/mv_p0/null_insert/null_insert.groovy
+++ b/regression-test/suites/mv_p0/null_insert/null_insert.groovy
@@ -48,8 +48,6 @@ suite ("null_insert") {
 
     sql """INSERT INTO `test` (`date`) VALUES ('2023-07-19');"""
 
-    sql """alter table test modify column date set stats ('row_count'='3');"""
-
     createMV("""CREATE materialized view mv_test AS
                 SELECT date, vid, os, ver, ip_country, hll_union(hll_hash(uid))
                 FROM test
@@ -78,6 +76,7 @@ suite ("null_insert") {
                     GROUP BY date,vid,os,ver,ip_country;"""
 
     sql """set enable_stats=true;"""
+    sql """alter table test modify column date set stats ('row_count'='3');"""
     mv_rewrite_success("""SELECT date, vid, os, ver, ip_country, hll_union(hll_hash(uid))
                 FROM test
                 GROUP BY date,vid,os,ver,ip_country;""", "mv_test")

--- a/regression-test/suites/mv_p0/routine_load_hll/routine_load_hll.groovy
+++ b/regression-test/suites/mv_p0/routine_load_hll/routine_load_hll.groovy
@@ -36,8 +36,6 @@ suite ("routine_load_hll") {
 
     sql """insert into test(event_id,time_stamp,device_id) values('ad_sdk_request','2024-03-04 00:00:00',hll_hash('a'));"""
 
-    sql """alter table test modify column event_id set stats ('row_count'='2');"""
-
     createMV("""create materialized view m_view as select time_stamp, hll_union(device_id) from test group by time_stamp;""")
 
         sql """insert into test(event_id,time_stamp,device_id) values('ad_sdk_request','2024-03-04 00:00:00',hll_hash('b'));"""
@@ -60,5 +58,6 @@ suite ("routine_load_hll") {
     qt_select_mv "select time_stamp, hll_union_agg(device_id) from test group by time_stamp order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table test modify column event_id set stats ('row_count'='2');"""
     mv_rewrite_success("select time_stamp, hll_union_agg(device_id) from test group by time_stamp order by 1;", "m_view")
 }

--- a/regression-test/suites/mv_p0/routine_load_hll/routine_load_hll.groovy
+++ b/regression-test/suites/mv_p0/routine_load_hll/routine_load_hll.groovy
@@ -36,6 +36,8 @@ suite ("routine_load_hll") {
 
     sql """insert into test(event_id,time_stamp,device_id) values('ad_sdk_request','2024-03-04 00:00:00',hll_hash('a'));"""
 
+    sql """alter table test modify column event_id set stats ('row_count'='2');"""
+
     createMV("""create materialized view m_view as select time_stamp, hll_union(device_id) from test group by time_stamp;""")
 
         sql """insert into test(event_id,time_stamp,device_id) values('ad_sdk_request','2024-03-04 00:00:00',hll_hash('b'));"""

--- a/regression-test/suites/mv_p0/ssb/multiple_no_where/multiple_no_where.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_no_where/multiple_no_where.groovy
@@ -108,6 +108,7 @@ suite ("multiple_no_where") {
 
     sql """analyze table lineorder_flat with sync;"""
     sql """set enable_stats=false;"""
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
 
     mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat

--- a/regression-test/suites/mv_p0/ssb/multiple_no_where/multiple_no_where.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_no_where/multiple_no_where.groovy
@@ -108,7 +108,6 @@ suite ("multiple_no_where") {
 
     sql """analyze table lineorder_flat with sync;"""
     sql """set enable_stats=false;"""
-    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
 
     mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat

--- a/regression-test/suites/mv_p0/ssb/multiple_ssb/multiple_ssb.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_ssb/multiple_ssb.groovy
@@ -87,8 +87,6 @@ suite ("multiple_ssb") {
         exception "not in select list"
     }
 
-
-sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
     createMV ("""create materialized view lineorder_q_1_1 as 
                 SELECT LO_ORDERKEY, SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat
@@ -242,6 +240,7 @@ sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_cou
     qt_select_count_3 "select LO_ORDERPRIORITY, count(1) from lineorder_flat where LO_ORDERPRIORITY in ('1','2','3') group by LO_ORDERPRIORITY order by 1,2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
     mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat
                 WHERE

--- a/regression-test/suites/mv_p0/ssb/multiple_ssb/multiple_ssb.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_ssb/multiple_ssb.groovy
@@ -87,6 +87,8 @@ suite ("multiple_ssb") {
         exception "not in select list"
     }
 
+
+sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
     createMV ("""create materialized view lineorder_q_1_1 as 
                 SELECT LO_ORDERKEY, SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat

--- a/regression-test/suites/mv_p0/ssb/multiple_ssb_between/multiple_ssb_between.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_ssb_between/multiple_ssb_between.groovy
@@ -151,6 +151,8 @@ suite ("multiple_ssb_between") {
 
     sql "analyze table lineorder_flat with sync;"
     sql """set enable_stats=true;"""
+
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
     
     mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat

--- a/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
@@ -90,11 +90,10 @@ suite ("mv_ssb_q_1_1") {
                     AND LO_ORDERDATE <= 19931231
                     AND LO_DISCOUNT >= 1 AND LO_DISCOUNT <= 3
                     AND LO_QUANTITY < 25
-                GROUP BY
-                    LO_ORDERKEY;""")
+                GROUP BY LO_ORDERKEY;""")
 
     sql """INSERT INTO lineorder_flat (LO_ORDERDATE, LO_ORDERKEY, LO_LINENUMBER, LO_CUSTKEY, LO_PARTKEY, LO_SUPPKEY, LO_ORDERPRIORITY, LO_SHIPPRIORITY, LO_QUANTITY, LO_EXTENDEDPRICE, LO_ORDTOTALPRICE, LO_DISCOUNT, LO_REVENUE, LO_SUPPLYCOST, LO_TAX, LO_COMMITDATE, LO_SHIPMODE,C_NAME,C_ADDRESS,C_CITY,C_NATION,C_REGION,C_PHONE,C_MKTSEGMENT,S_NAME,S_ADDRESS,S_CITY,S_NATION,S_REGION,S_PHONE,P_NAME,P_MFGR,P_CATEGORY,P_BRAND,P_COLOR,P_TYPE,P_SIZE,P_CONTAINER) 
-            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
+            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
 
     qt_select_star "select * from lineorder_flat order by 1,2, P_MFGR;"
 

--- a/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
@@ -75,10 +75,10 @@ suite ("mv_ssb_q_1_1") {
     // Add more data when insert into firstly to make sure use mv easier
     sql """INSERT INTO lineorder_flat (LO_ORDERDATE, LO_ORDERKEY, LO_LINENUMBER, LO_CUSTKEY, LO_PARTKEY, LO_SUPPKEY, LO_ORDERPRIORITY, LO_SHIPPRIORITY, LO_QUANTITY, LO_EXTENDEDPRICE, LO_ORDTOTALPRICE, LO_DISCOUNT, LO_REVENUE, LO_SUPPLYCOST, LO_TAX, LO_COMMITDATE, LO_SHIPMODE, C_NAME, C_ADDRESS, C_CITY, C_NATION, C_REGION, C_PHONE, C_MKTSEGMENT, S_NAME, S_ADDRESS, S_CITY, S_NATION, S_REGION, S_PHONE, P_NAME, P_MFGR, P_CATEGORY, P_BRAND, P_COLOR,P_TYPE,P_SIZE,P_CONTAINER) 
             VALUES (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
-            (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
-            (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
-            (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
-            (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container');"""
+             (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
+             (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
+             (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
+             (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container');"""
 
     sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='6');"""
 
@@ -93,8 +93,11 @@ suite ("mv_ssb_q_1_1") {
                 GROUP BY LO_ORDERKEY;""")
 
     sql """INSERT INTO lineorder_flat (LO_ORDERDATE, LO_ORDERKEY, LO_LINENUMBER, LO_CUSTKEY, LO_PARTKEY, LO_SUPPKEY, LO_ORDERPRIORITY, LO_SHIPPRIORITY, LO_QUANTITY, LO_EXTENDEDPRICE, LO_ORDTOTALPRICE, LO_DISCOUNT, LO_REVENUE, LO_SUPPLYCOST, LO_TAX, LO_COMMITDATE, LO_SHIPMODE,C_NAME,C_ADDRESS,C_CITY,C_NATION,C_REGION,C_PHONE,C_MKTSEGMENT,S_NAME,S_ADDRESS,S_CITY,S_NATION,S_REGION,S_PHONE,P_NAME,P_MFGR,P_CATEGORY,P_BRAND,P_COLOR,P_TYPE,P_SIZE,P_CONTAINER) 
-            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
-
+            VALUES 
+            (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container'),
+            (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container'),
+            (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container'),
+            (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
     qt_select_star "select * from lineorder_flat order by 1,2, P_MFGR;"
 
     sql "analyze table lineorder_flat with sync;"

--- a/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
@@ -90,10 +90,11 @@ suite ("mv_ssb_q_1_1") {
                     AND LO_ORDERDATE <= 19931231
                     AND LO_DISCOUNT >= 1 AND LO_DISCOUNT <= 3
                     AND LO_QUANTITY < 25
-                GROUP BY LO_ORDERKEY;""")
+                GROUP BY
+                    LO_ORDERKEY;""")
 
     sql """INSERT INTO lineorder_flat (LO_ORDERDATE, LO_ORDERKEY, LO_LINENUMBER, LO_CUSTKEY, LO_PARTKEY, LO_SUPPKEY, LO_ORDERPRIORITY, LO_SHIPPRIORITY, LO_QUANTITY, LO_EXTENDEDPRICE, LO_ORDTOTALPRICE, LO_DISCOUNT, LO_REVENUE, LO_SUPPLYCOST, LO_TAX, LO_COMMITDATE, LO_SHIPMODE,C_NAME,C_ADDRESS,C_CITY,C_NATION,C_REGION,C_PHONE,C_MKTSEGMENT,S_NAME,S_ADDRESS,S_CITY,S_NATION,S_REGION,S_PHONE,P_NAME,P_MFGR,P_CATEGORY,P_BRAND,P_COLOR,P_TYPE,P_SIZE,P_CONTAINER) 
-            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
+            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
 
     qt_select_star "select * from lineorder_flat order by 1,2, P_MFGR;"
 

--- a/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_1_1/q_1_1.groovy
@@ -80,6 +80,8 @@ suite ("mv_ssb_q_1_1") {
             (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container'),
             (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#1', 'category', 'brand', 'color', 'type', 4 ,'container');"""
 
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='6');"""
+
     createMV ("""create materialized view lineorder_q_1_1 as 
                 SELECT LO_ORDERKEY, SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat
@@ -88,11 +90,10 @@ suite ("mv_ssb_q_1_1") {
                     AND LO_ORDERDATE <= 19931231
                     AND LO_DISCOUNT >= 1 AND LO_DISCOUNT <= 3
                     AND LO_QUANTITY < 25
-                GROUP BY
-                    LO_ORDERKEY;""")
+                GROUP BY LO_ORDERKEY;""")
 
     sql """INSERT INTO lineorder_flat (LO_ORDERDATE, LO_ORDERKEY, LO_LINENUMBER, LO_CUSTKEY, LO_PARTKEY, LO_SUPPKEY, LO_ORDERPRIORITY, LO_SHIPPRIORITY, LO_QUANTITY, LO_EXTENDEDPRICE, LO_ORDTOTALPRICE, LO_DISCOUNT, LO_REVENUE, LO_SUPPLYCOST, LO_TAX, LO_COMMITDATE, LO_SHIPMODE,C_NAME,C_ADDRESS,C_CITY,C_NATION,C_REGION,C_PHONE,C_MKTSEGMENT,S_NAME,S_ADDRESS,S_CITY,S_NATION,S_REGION,S_PHONE,P_NAME,P_MFGR,P_CATEGORY,P_BRAND,P_COLOR,P_TYPE,P_SIZE,P_CONTAINER) 
-            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
+            VALUES (19930101 , 2 , 2 , 2 , 2 , 2 ,'2',2 ,2 ,2 ,2 ,2 ,2 ,2 ,'2023-06-09','shipmode','name','address','city','nation','region','phone','mktsegment','name','address','city','nation','region','phone','name','mfgr','category','brand','color','type',4,'container');"""
 
     qt_select_star "select * from lineorder_flat order by 1,2, P_MFGR;"
 

--- a/regression-test/suites/mv_p0/ssb/q_2_1/q_2_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_2_1/q_2_1.groovy
@@ -93,6 +93,8 @@ suite ("mv_ssb_q_2_1") {
 
     qt_select_star "select * from lineorder_flat order by 1,2,P_MFGR;"
 
+  sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='2');"""
+
     mv_rewrite_success("""SELECT
                 SUM(LO_REVENUE), (LO_ORDERDATE DIV 10000) AS YEAR,
                 P_BRAND

--- a/regression-test/suites/mv_p0/ssb/q_3_1/q_3_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_3_1/q_3_1.groovy
@@ -98,6 +98,8 @@ suite ("mv_ssb_q_3_1") {
 
     sql """analyze table lineorder_flat with sync;"""
 
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='2');"""
+
     mv_rewrite_success("""SELECT
                 C_NATION,
                 S_NATION, (LO_ORDERDATE DIV 10000) AS YEAR,

--- a/regression-test/suites/mv_p0/ssb/q_4_1/q_4_1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_4_1/q_4_1.groovy
@@ -92,6 +92,8 @@ suite ("mv_ssb_q_4_1") {
 
     sql """analyze table lineorder_flat with sync;"""
 
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='2');"""
+
     mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
                 C_NATION,
                 SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit

--- a/regression-test/suites/mv_p0/ssb/q_4_1_r1/q_4_1_r1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_4_1_r1/q_4_1_r1.groovy
@@ -97,8 +97,6 @@ suite ("q_4_1_r1") {
     sql """analyze table lineorder_flat with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
-
     mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
             C_NATION,
             SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit
@@ -121,6 +119,7 @@ suite ("q_4_1_r1") {
                 GROUP BY YEAR, C_NATION
                 ORDER BY YEAR ASC, C_NATION ASC;"""
     sql """set enable_stats=true;"""
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
     mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
             C_NATION,
             SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit

--- a/regression-test/suites/mv_p0/ssb/q_4_1_r1/q_4_1_r1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_4_1_r1/q_4_1_r1.groovy
@@ -97,6 +97,8 @@ suite ("q_4_1_r1") {
     sql """analyze table lineorder_flat with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
+
     mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
             C_NATION,
             SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit

--- a/regression-test/suites/mv_p0/sum_count/sum_count.groovy
+++ b/regression-test/suites/mv_p0/sum_count/sum_count.groovy
@@ -51,6 +51,7 @@ suite ("sum_count") {
     sql "analyze table d_table with sync;"
     sql """set enable_stats=true;"""
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,k4,sum(k2),count(k2) from d_table group by k1,k4;", "kavg")
     
     qt_select_mv "select k1,k4,sum(k2),count(k2) from d_table group by k1,k4 order by 1,2;"

--- a/regression-test/suites/mv_p0/sum_divede_count/sum_devide_count.groovy
+++ b/regression-test/suites/mv_p0/sum_divede_count/sum_devide_count.groovy
@@ -45,6 +45,7 @@ suite ("sum_devide_count") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
 
     mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;", "kavg")
     qt_select_mv "select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;"

--- a/regression-test/suites/mv_p0/sum_divede_count/sum_devide_count.groovy
+++ b/regression-test/suites/mv_p0/sum_divede_count/sum_devide_count.groovy
@@ -45,7 +45,7 @@ suite ("sum_devide_count") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
-    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
+
 
     mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;", "kavg")
     qt_select_mv "select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;"
@@ -60,6 +60,7 @@ suite ("sum_devide_count") {
     qt_select_mv "select sum(k2)/count(k2) from d_table;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;", "kavg")
 
     mv_rewrite_success("select k1,sum(k2)/count(k2) from d_table group by k1 order by k1;", "kavg")

--- a/regression-test/suites/mv_p0/test_28741/test_28741.groovy
+++ b/regression-test/suites/mv_p0/test_28741/test_28741.groovy
@@ -68,8 +68,8 @@ suite ("test_28741") {
     sql """analyze table test with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table test modify column a set stats ('row_count'='2');"""
     mv_rewrite_fail("select b1 from test where t >= '2023-12-20 17:21:00'", "mv_test")
-    qt_select "select b1 from test where t >= '2023-12-20 17:21:00'"
 
     sql """set enable_stats=true;"""
     mv_rewrite_fail("select b1 from test where t >= '2023-12-20 17:21:00'", "mv_test")

--- a/regression-test/suites/mv_p0/test_28741/test_28741.groovy
+++ b/regression-test/suites/mv_p0/test_28741/test_28741.groovy
@@ -68,9 +68,9 @@ suite ("test_28741") {
     sql """analyze table test with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table test modify column a set stats ('row_count'='2');"""
     mv_rewrite_fail("select b1 from test where t >= '2023-12-20 17:21:00'", "mv_test")
 
     sql """set enable_stats=true;"""
+    sql """alter table test modify column a set stats ('row_count'='2');"""
     mv_rewrite_fail("select b1 from test where t >= '2023-12-20 17:21:00'", "mv_test")
 }

--- a/regression-test/suites/mv_p0/test_approx_count_distinct/test_approx_count_distinct.groovy
+++ b/regression-test/suites/mv_p0/test_approx_count_distinct/test_approx_count_distinct.groovy
@@ -40,6 +40,8 @@ suite ("test_approx_count_distinct") {
     sql """analyze table user_tags with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 

--- a/regression-test/suites/mv_p0/test_approx_count_distinct/test_approx_count_distinct.groovy
+++ b/regression-test/suites/mv_p0/test_approx_count_distinct/test_approx_count_distinct.groovy
@@ -40,8 +40,6 @@ suite ("test_approx_count_distinct") {
     sql """analyze table user_tags with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
-
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 
@@ -52,6 +50,7 @@ suite ("test_approx_count_distinct") {
     qt_select_mv "select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;"
 
     sql """set enable_stats=true;"""
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
 
     mv_rewrite_success("select user_id, ndv(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")

--- a/regression-test/suites/mv_p0/test_base/test_base.groovy
+++ b/regression-test/suites/mv_p0/test_base/test_base.groovy
@@ -46,6 +46,7 @@ suite ("test_base") {
     sql "analyze table dwd with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table dwd modify column id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT created_at, id  FROM dwd where created_at = '2020-09-09 00:00:00' order by 1, 2;", "dwd_mv")
     qt_select_mv "SELECT created_at, id FROM dwd order by 1, 2;"
 

--- a/regression-test/suites/mv_p0/test_base/test_base.groovy
+++ b/regression-test/suites/mv_p0/test_base/test_base.groovy
@@ -46,7 +46,6 @@ suite ("test_base") {
     sql "analyze table dwd with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table dwd modify column id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT created_at, id  FROM dwd where created_at = '2020-09-09 00:00:00' order by 1, 2;", "dwd_mv")
     qt_select_mv "SELECT created_at, id FROM dwd order by 1, 2;"
 
@@ -54,6 +53,7 @@ suite ("test_base") {
     qt_select_mv "SELECT id,created_at FROM dwd order by 1, 2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dwd modify column id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT created_at, id  FROM dwd where created_at = '2020-09-09 00:00:00' order by 1, 2;", "dwd_mv")
 
     mv_rewrite_success("SELECT id,created_at  FROM dwd where id is not null order by 1, 2;", "dwd_mv")

--- a/regression-test/suites/mv_p0/test_casewhen/test_casewhen.groovy
+++ b/regression-test/suites/mv_p0/test_casewhen/test_casewhen.groovy
@@ -34,6 +34,7 @@ suite ("test_casewhen") {
     sql """analyze table sales_records with sync;"""
     sql """set enable_stats=false;"""
 
+sql """alter table sales_records modify column record_id set stats ('row_count'='4');"""
     qt_select_star "select * from sales_records order by 1,2;"
 
     mv_rewrite_success("select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;", "store_amt")

--- a/regression-test/suites/mv_p0/test_casewhen/test_casewhen.groovy
+++ b/regression-test/suites/mv_p0/test_casewhen/test_casewhen.groovy
@@ -34,12 +34,12 @@ suite ("test_casewhen") {
     sql """analyze table sales_records with sync;"""
     sql """set enable_stats=false;"""
 
-sql """alter table sales_records modify column record_id set stats ('row_count'='4');"""
     qt_select_star "select * from sales_records order by 1,2;"
 
     mv_rewrite_success("select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;", "store_amt")
     qt_select_mv "select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table sales_records modify column record_id set stats ('row_count'='4');"""
     mv_rewrite_success("select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;", "store_amt")
 }

--- a/regression-test/suites/mv_p0/test_create_mv/test_create_mv.groovy
+++ b/regression-test/suites/mv_p0/test_create_mv/test_create_mv.groovy
@@ -49,6 +49,8 @@ suite("test_create_mv") {
 
     sql """ insert into ${tableName} values ('2024-03-20 10:00:00', 'a', 'b', 1) """
 
+    sql """alter table test_mv_10010 modify column load_time set stats ('row_count'='1');"""
+
     sql """
         create materialized view mv_1 as
         select 

--- a/regression-test/suites/mv_p0/test_create_mv_complex_type/test_create_mv_complex_type.groovy
+++ b/regression-test/suites/mv_p0/test_create_mv_complex_type/test_create_mv_complex_type.groovy
@@ -37,6 +37,8 @@ suite ("create_mv_complex_type") {
 
     sql """insert into base_table select 1, 100000, 1.0, '{"jsonk1": 123}', [100, 200], {"k1": 10}, {1, 2};"""
 
+    sql """alter table base_table modify column c_int set stats ('row_count'='1');"""
+
     def success = false
 
     // 1. special column - mv dup key

--- a/regression-test/suites/mv_p0/test_doc_e4/test_doc_e4.groovy
+++ b/regression-test/suites/mv_p0/test_doc_e4/test_doc_e4.groovy
@@ -44,7 +44,6 @@ suite ("test_doc_e4") {
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;", "k1a2p2ap3ps")
     qt_select_mv "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;"
 
@@ -58,6 +57,7 @@ suite ("test_doc_e4") {
     qt_select_mv "select year(k4)+month(k4) from d_table where year(k4) = 2020 order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;", "k1a2p2ap3ps")
 
     mv_rewrite_success("select bin(abs(k1)+k2+1),sum(abs(k2+2)+k3+3) from d_table group by bin(abs(k1)+k2+1);", "k1a2p2ap3ps")

--- a/regression-test/suites/mv_p0/test_doc_e4/test_doc_e4.groovy
+++ b/regression-test/suites/mv_p0/test_doc_e4/test_doc_e4.groovy
@@ -44,6 +44,7 @@ suite ("test_doc_e4") {
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;", "k1a2p2ap3ps")
     qt_select_mv "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;"
 

--- a/regression-test/suites/mv_p0/test_dup_group_by_mv_abs/test_dup_group_by_mv_abs.groovy
+++ b/regression-test/suites/mv_p0/test_dup_group_by_mv_abs/test_dup_group_by_mv_abs.groovy
@@ -44,7 +44,6 @@ suite ("test_dup_group_by_mv_abs") {
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     qt_select_star "select * from d_table order by k1;"
 
     mv_rewrite_success("select k1,sum(abs(k2)) from d_table group by k1;", "k12sa")
@@ -54,6 +53,7 @@ suite ("test_dup_group_by_mv_abs") {
     qt_select_mv_sub "select sum(abs(k2)) from d_table group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,sum(abs(k2)) from d_table group by k1;", "k12sa")
     mv_rewrite_success("select sum(abs(k2)) from d_table group by k1;", "k12sa")
 }

--- a/regression-test/suites/mv_p0/test_dup_group_by_mv_abs/test_dup_group_by_mv_abs.groovy
+++ b/regression-test/suites/mv_p0/test_dup_group_by_mv_abs/test_dup_group_by_mv_abs.groovy
@@ -44,6 +44,7 @@ suite ("test_dup_group_by_mv_abs") {
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     qt_select_star "select * from d_table order by k1;"
 
     mv_rewrite_success("select k1,sum(abs(k2)) from d_table group by k1;", "k12sa")

--- a/regression-test/suites/mv_p0/test_dup_group_by_mv_plus/test_dup_group_by_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_group_by_mv_plus/test_dup_group_by_mv_plus.groovy
@@ -43,6 +43,7 @@ suite ("test_dup_group_by_mv_plus") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     qt_select_star "select * from d_table order by k1;"
 

--- a/regression-test/suites/mv_p0/test_dup_group_by_mv_plus/test_dup_group_by_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_group_by_mv_plus/test_dup_group_by_mv_plus.groovy
@@ -43,7 +43,6 @@ suite ("test_dup_group_by_mv_plus") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -54,6 +53,7 @@ suite ("test_dup_group_by_mv_plus") {
     qt_select_mv_sub "select sum(k2+1) from d_table group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,sum(k2+1) from d_table group by k1;", "k12sp")
     mv_rewrite_success("select sum(k2+1) from d_table group by k1;", "k12sp")
 

--- a/regression-test/suites/mv_p0/test_dup_mv_abs/test_dup_mv_abs.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_abs/test_dup_mv_abs.groovy
@@ -43,7 +43,6 @@ suite ("test_dup_mv_abs") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -66,6 +65,7 @@ suite ("test_dup_mv_abs") {
     qt_select_group_mv_not "select sum(abs(k2)) from d_table group by k3 order by k3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,abs(k2) from d_table order by k1;", "k12a")
 
     mv_rewrite_success("select abs(k2) from d_table order by k1;", "k12a")

--- a/regression-test/suites/mv_p0/test_dup_mv_abs/test_dup_mv_abs.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_abs/test_dup_mv_abs.groovy
@@ -43,6 +43,7 @@ suite ("test_dup_mv_abs") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     qt_select_star "select * from d_table order by k1;"
 

--- a/regression-test/suites/mv_p0/test_dup_mv_bin/test_dup_mv_bin.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_bin/test_dup_mv_bin.groovy
@@ -42,7 +42,6 @@ suite ("test_dup_mv_bin") {
 
     sql "analyze table d_table with sync;"
     sql """set enable_stats=false;"""
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -65,6 +64,7 @@ suite ("test_dup_mv_bin") {
     qt_select_group_mv_not "select group_concat(bin(k2)) from d_table group by k3 order by k3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,bin(k2) from d_table order by k1;", "k12b")
 
     mv_rewrite_success("select bin(k2) from d_table order by k1;", "k12b")

--- a/regression-test/suites/mv_p0/test_dup_mv_bin/test_dup_mv_bin.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_bin/test_dup_mv_bin.groovy
@@ -42,6 +42,7 @@ suite ("test_dup_mv_bin") {
 
     sql "analyze table d_table with sync;"
     sql """set enable_stats=false;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     qt_select_star "select * from d_table order by k1;"
 

--- a/regression-test/suites/mv_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
@@ -42,6 +42,7 @@ suite ("test_dup_mv_bitmap_hash") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;", "k1g2bm")
     qt_select_mv "select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;"

--- a/regression-test/suites/mv_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
@@ -42,11 +42,11 @@ suite ("test_dup_mv_bitmap_hash") {
 
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;", "k1g2bm")
     qt_select_mv "select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;"
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;", "k1g2bm")
 
     createMV "create materialized view k1g3bm as select k1,bitmap_union(bitmap_hash(k3)) from d_table group by k1;"
@@ -59,11 +59,13 @@ suite ("test_dup_mv_bitmap_hash") {
     qt_select_star "select * from d_table order by k1,k2,k3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     sql """analyze table d_table with sync;"""
     sql """set enable_stats=false;"""
 
     mv_rewrite_success("select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1;", "k1g3bm")
     qt_select_mv_sub "select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1 order by k1;"
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1;", "k1g3bm")
 }

--- a/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
@@ -70,7 +70,7 @@ suite ("test_dup_mv_plus") {
     qt_select_mv "select k1,k2+1 from d_table order by k2;"
 
     sql """set enable_stats=true;"""
-    sql """alter table table_ngrambf modify column siteid set stats ('row_count'='2');"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='3');"""
     mv_rewrite_success("select k1,k2+1 from d_table order by k1;", "k12p")
 
     mv_rewrite_success("select k2+1 from d_table order by k1;", "k12p")

--- a/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
@@ -37,6 +37,7 @@ suite ("test_dup_mv_plus") {
     sql "insert into d_table select 3,-3,null,'c';"
 
     createMV ("create materialized view k12p as select k1,k2+1 from d_table;")
+    sql """alter table table_ngrambf modify column siteid set stats ('row_count'='2');"""
 
     sql "insert into d_table select -4,-4,-4,'d';"
 

--- a/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
@@ -37,7 +37,6 @@ suite ("test_dup_mv_plus") {
     sql "insert into d_table select 3,-3,null,'c';"
 
     createMV ("create materialized view k12p as select k1,k2+1 from d_table;")
-    sql """alter table table_ngrambf modify column siteid set stats ('row_count'='2');"""
 
     sql "insert into d_table select -4,-4,-4,'d';"
 
@@ -71,7 +70,7 @@ suite ("test_dup_mv_plus") {
     qt_select_mv "select k1,k2+1 from d_table order by k2;"
 
     sql """set enable_stats=true;"""
-
+    sql """alter table table_ngrambf modify column siteid set stats ('row_count'='2');"""
     mv_rewrite_success("select k1,k2+1 from d_table order by k1;", "k12p")
 
     mv_rewrite_success("select k2+1 from d_table order by k1;", "k12p")

--- a/regression-test/suites/mv_p0/test_dup_mv_repeat/test_dup_mv_repeat.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_repeat/test_dup_mv_repeat.groovy
@@ -36,7 +36,6 @@ suite ("test_dup_mv_repeat") {
         """
 
     sql "insert into db1 values('2020-01-01','abc',123),('2020-01-02','def',456);"
-    sql """alter table db1 modify column dt set stats ('row_count'='2');"""
 
     createMV ("create materialized view dbviwe as select dt,s,sum(n) as n from db1 group by dt,s;")
 
@@ -48,6 +47,7 @@ suite ("test_dup_mv_repeat") {
     qt_select_mv "SELECT s AS s, sum(n) / count(DISTINCT dt) AS n FROM  db1 GROUP BY  GROUPING SETS((s)) order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table db1 modify column dt set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT s AS s, sum(n) / count(DISTINCT dt) AS n FROM  db1 GROUP BY  GROUPING SETS((s)) order by 1;",
             "dbviwe")
 }

--- a/regression-test/suites/mv_p0/test_dup_mv_repeat/test_dup_mv_repeat.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_repeat/test_dup_mv_repeat.groovy
@@ -36,6 +36,7 @@ suite ("test_dup_mv_repeat") {
         """
 
     sql "insert into db1 values('2020-01-01','abc',123),('2020-01-02','def',456);"
+    sql """alter table db1 modify column dt set stats ('row_count'='2');"""
 
     createMV ("create materialized view dbviwe as select dt,s,sum(n) as n from db1 group by dt,s;")
 

--- a/regression-test/suites/mv_p0/test_dup_mv_year/test_dup_mv_year.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_year/test_dup_mv_year.groovy
@@ -36,7 +36,6 @@ suite ("test_dup_mv_year") {
     sql "insert into d_table select 2,'2013-12-31','2013-12-31 01:02:03';"
     sql "insert into d_table select 3,'2023-12-31','2023-12-31 01:02:03';"
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     createMV "create materialized view k12y as select k1,year(k2) from d_table;"
 
     sql """analyze table d_table with sync;"""
@@ -46,6 +45,7 @@ suite ("test_dup_mv_year") {
     qt_select_mv "select k1,year(k2) from d_table order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,year(k2) from d_table order by k1;", "k12y")
 
     createMV "create materialized view k13y as select k1,year(k3) from d_table;"

--- a/regression-test/suites/mv_p0/test_dup_mv_year/test_dup_mv_year.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_year/test_dup_mv_year.groovy
@@ -36,6 +36,7 @@ suite ("test_dup_mv_year") {
     sql "insert into d_table select 2,'2013-12-31','2013-12-31 01:02:03';"
     sql "insert into d_table select 3,'2023-12-31','2023-12-31 01:02:03';"
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     createMV "create materialized view k12y as select k1,year(k2) from d_table;"
 
     sql """analyze table d_table with sync;"""

--- a/regression-test/suites/mv_p0/test_duplicate_mv/test_duplicate_mv.groovy
+++ b/regression-test/suites/mv_p0/test_duplicate_mv/test_duplicate_mv.groovy
@@ -39,6 +39,8 @@ suite ("test_duplicate_mv") {
    sql "insert into duplicate_table select 2,3,4,5;"
    sql "insert into duplicate_table select 1,2,3,4;"
 
+    sql """alter table duplicate_table modify column k1 set stats ('row_count'='3');"""
+
     qt_select_star "select * from duplicate_table order by k1;"
 
     mv_rewrite_success("select k1, k2, k3, k4 from duplicate_table group by k1, k2, k3, k4;", "deduplicate")

--- a/regression-test/suites/mv_p0/test_mv_dp/test_mv_dp.groovy
+++ b/regression-test/suites/mv_p0/test_mv_dp/test_mv_dp.groovy
@@ -56,6 +56,8 @@ suite ("test_mv_dp") {
         time 10000 // limit inflight 10s
     }
 */
+
+    sql """alter table dp modify column d set stats ('row_count'='4');"""
     mv_rewrite_success("""select d,
                         bitmap_union_count(bitmap_from_array(cast(uid_list as array<bigint>))),
                         bitmap_union_count(bitmap_from_array(if(status='success', cast(uid_list as array<bigint>), array())))

--- a/regression-test/suites/mv_p0/test_mv_dp/test_mv_dp.groovy
+++ b/regression-test/suites/mv_p0/test_mv_dp/test_mv_dp.groovy
@@ -57,7 +57,6 @@ suite ("test_mv_dp") {
     }
 */
 
-    sql """alter table dp modify column d set stats ('row_count'='4');"""
     mv_rewrite_success("""select d,
                         bitmap_union_count(bitmap_from_array(cast(uid_list as array<bigint>))),
                         bitmap_union_count(bitmap_from_array(if(status='success', cast(uid_list as array<bigint>), array())))
@@ -70,6 +69,7 @@ suite ("test_mv_dp") {
                     from dp
                     group by d order by 1;"""
     sql """set enable_stats=true;"""
+    sql """alter table dp modify column d set stats ('row_count'='4');"""
     mv_rewrite_success("""select d,
                         bitmap_union_count(bitmap_from_array(cast(uid_list as array<bigint>))),
                         bitmap_union_count(bitmap_from_array(if(status='success', cast(uid_list as array<bigint>), array())))

--- a/regression-test/suites/mv_p0/test_mv_mor/test_mv_mor.groovy
+++ b/regression-test/suites/mv_p0/test_mv_mor/test_mv_mor.groovy
@@ -39,6 +39,8 @@ suite ("test_mv_mor") {
     sql "insert into u_table select 1,1,1,2;"
     sql "insert into u_table select 1,2,1,2;"
 
+    sql """alter table u_table modify column k1 set stats ('row_count'='2');"""
+
     // do not match mv coz preagg is off, mv need contains all key column to make row count correct
     mv_rewrite_success("select k1,k2+k3 from u_table order by k1;", "k123p")
     qt_select_mv "select k1,k2+k3 from u_table order by k1;"

--- a/regression-test/suites/mv_p0/test_mv_mow/test_mv_mow.groovy
+++ b/regression-test/suites/mv_p0/test_mv_mow/test_mv_mow.groovy
@@ -40,6 +40,7 @@ suite ("test_mv_mow") {
     sql "insert into u_table select 1,1,1,2;"
     sql "insert into u_table select 1,2,1,2;"
 
+    sql """alter table u_table modify column k1 set stats ('row_count'='2');"""
     
     sql """set enable_stats=false;"""
 

--- a/regression-test/suites/mv_p0/test_mv_mow/test_mv_mow.groovy
+++ b/regression-test/suites/mv_p0/test_mv_mow/test_mv_mow.groovy
@@ -40,7 +40,6 @@ suite ("test_mv_mow") {
     sql "insert into u_table select 1,1,1,2;"
     sql "insert into u_table select 1,2,1,2;"
 
-    sql """alter table u_table modify column k1 set stats ('row_count'='2');"""
     
     sql """set enable_stats=false;"""
 
@@ -51,5 +50,6 @@ suite ("test_mv_mow") {
     qt_select_mv "select mv_k1 from `u_table` index `k123p` order by 1;"
     qt_select_mv "select `mv_(k2 + k3)` from `u_table` index `k123p` order by 1;"
     sql """set enable_stats=true;"""
+    sql """alter table u_table modify column k1 set stats ('row_count'='2');"""
     mv_rewrite_success("select k1,k2+k3 from u_table order by k1;", "k123p")
 }

--- a/regression-test/suites/mv_p0/test_ndv/test_ndv.groovy
+++ b/regression-test/suites/mv_p0/test_ndv/test_ndv.groovy
@@ -40,6 +40,8 @@ suite ("test_ndv") {
     sql """analyze table user_tags with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 

--- a/regression-test/suites/mv_p0/test_ndv/test_ndv.groovy
+++ b/regression-test/suites/mv_p0/test_ndv/test_ndv.groovy
@@ -40,8 +40,6 @@ suite ("test_ndv") {
     sql """analyze table user_tags with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
-
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 
@@ -52,6 +50,7 @@ suite ("test_ndv") {
     qt_select_mv "select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;"
 
     sql """set enable_stats=true;"""
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
 
     mv_rewrite_success("select user_id, ndv(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")

--- a/regression-test/suites/mv_p0/test_nvl/test_nvl.groovy
+++ b/regression-test/suites/mv_p0/test_nvl/test_nvl.groovy
@@ -43,7 +43,6 @@ suite ("test_nvl") {
 
     sql """analyze table dwd with sync;"""
     sql """set enable_stats=false;"""
-    sql """alter table dwd modify column id set stats ('row_count'='2');"""
 
     mv_rewrite_success("select nvl(id,0) from dwd order by 1;", "dwd_mv")
     qt_select_mv "select nvl(id,0) from dwd order by 1;"
@@ -52,6 +51,7 @@ suite ("test_nvl") {
     qt_select_mv "select ifnull(id,0) from dwd order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dwd modify column id set stats ('row_count'='2');"""
     mv_rewrite_success("select nvl(id,0) from dwd order by 1;", "dwd_mv")
 
     mv_rewrite_success("select ifnull(id,0) from dwd order by 1;", "dwd_mv")

--- a/regression-test/suites/mv_p0/test_nvl/test_nvl.groovy
+++ b/regression-test/suites/mv_p0/test_nvl/test_nvl.groovy
@@ -43,6 +43,7 @@ suite ("test_nvl") {
 
     sql """analyze table dwd with sync;"""
     sql """set enable_stats=false;"""
+    sql """alter table dwd modify column id set stats ('row_count'='2');"""
 
     mv_rewrite_success("select nvl(id,0) from dwd order by 1;", "dwd_mv")
     qt_select_mv "select nvl(id,0) from dwd order by 1;"

--- a/regression-test/suites/mv_p0/test_o2/test_o2.groovy
+++ b/regression-test/suites/mv_p0/test_o2/test_o2.groovy
@@ -55,13 +55,12 @@ suite ("test_o2") {
     sql """analyze table o2_order_events with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table o2_order_events modify column ts set stats ('row_count'='2');"""
-
     mv_rewrite_success("select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;",
             "o2_order_events_mv")
     qt_select_mv "select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;"
 
     sql """set enable_stats=true;"""
+    sql """alter table o2_order_events modify column ts set stats ('row_count'='2');"""
     mv_rewrite_success("select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;",
             "o2_order_events_mv")
 }

--- a/regression-test/suites/mv_p0/test_o2/test_o2.groovy
+++ b/regression-test/suites/mv_p0/test_o2/test_o2.groovy
@@ -55,6 +55,8 @@ suite ("test_o2") {
     sql """analyze table o2_order_events with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table o2_order_events modify column ts set stats ('row_count'='2');"""
+
     mv_rewrite_success("select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;",
             "o2_order_events_mv")
     qt_select_mv "select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;"

--- a/regression-test/suites/mv_p0/test_substr/test_substr.groovy
+++ b/regression-test/suites/mv_p0/test_substr/test_substr.groovy
@@ -51,13 +51,12 @@ suite ("test_substr") {
     sql """analyze table dwd with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table dwd modify column id set stats ('row_count'='2');"""
-
     mv_rewrite_success("SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);",
             "dwd_mv")
     qt_select_mv "SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);"
 
     sql """set enable_stats=true;"""
+    sql """alter table dwd modify column id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);",
             "dwd_mv")
 }

--- a/regression-test/suites/mv_p0/test_substr/test_substr.groovy
+++ b/regression-test/suites/mv_p0/test_substr/test_substr.groovy
@@ -51,6 +51,8 @@ suite ("test_substr") {
     sql """analyze table dwd with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table dwd modify column id set stats ('row_count'='2');"""
+
     mv_rewrite_success("SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);",
             "dwd_mv")
     qt_select_mv "SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);"

--- a/regression-test/suites/mv_p0/test_tbl_name/test_tbl_name.groovy
+++ b/regression-test/suites/mv_p0/test_tbl_name/test_tbl_name.groovy
@@ -42,6 +42,8 @@ suite ("test_tbl_name") {
     sql """analyze table functionality_olap with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table functionality_olap modify column id set stats ('row_count'='2');"""
+
     mv_rewrite_success("""select 
             functionality_olap.id as id,
             sum(functionality_olap.score) as score_max

--- a/regression-test/suites/mv_p0/test_tbl_name/test_tbl_name.groovy
+++ b/regression-test/suites/mv_p0/test_tbl_name/test_tbl_name.groovy
@@ -42,8 +42,6 @@ suite ("test_tbl_name") {
     sql """analyze table functionality_olap with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table functionality_olap modify column id set stats ('row_count'='2');"""
-
     mv_rewrite_success("""select 
             functionality_olap.id as id,
             sum(functionality_olap.score) as score_max
@@ -68,6 +66,7 @@ suite ("test_tbl_name") {
         group by id order by 1,2;
         """
     sql """set enable_stats=true;"""
+    sql """alter table functionality_olap modify column id set stats ('row_count'='2');"""
     mv_rewrite_success("""select 
             functionality_olap.id as id,
             sum(functionality_olap.score) as score_max

--- a/regression-test/suites/mv_p0/test_upper_alias/test_upper_alias.groovy
+++ b/regression-test/suites/mv_p0/test_upper_alias/test_upper_alias.groovy
@@ -52,6 +52,8 @@ suite ("test_upper_alias") {
     sql "analyze table test_0401 with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table test_0401 modify column d_b set stats ('row_count'='3');"""
+
     mv_rewrite_success("SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;", "test_0401_mv");
     qt_select_mv "SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;"
 

--- a/regression-test/suites/mv_p0/test_upper_alias/test_upper_alias.groovy
+++ b/regression-test/suites/mv_p0/test_upper_alias/test_upper_alias.groovy
@@ -52,8 +52,6 @@ suite ("test_upper_alias") {
     sql "analyze table test_0401 with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table test_0401 modify column d_b set stats ('row_count'='3');"""
-
     mv_rewrite_success("SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;", "test_0401_mv");
     qt_select_mv "SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;"
 
@@ -64,6 +62,7 @@ suite ("test_upper_alias") {
     qt_select_mv "SELECT d_a AS d_b FROM test_0401 order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table test_0401 modify column d_b set stats ('row_count'='3');"""
     mv_rewrite_any_success("SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;",
             ["test_0401_mv", "test_0401_mv2"])
 

--- a/regression-test/suites/mv_p0/test_user_activity/test_user_activity.groovy
+++ b/regression-test/suites/mv_p0/test_user_activity/test_user_activity.groovy
@@ -48,13 +48,12 @@ suite ("test_user_activity") {
     sql """analyze table u_axx with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table u_axx modify column r_xx set stats ('row_count'='3');"""
-
     mv_rewrite_success("select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;",
             "session_distribution_2")
     qt_select_group_mv "select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;"
 
     sql """set enable_stats=true;"""
+    sql """alter table u_axx modify column r_xx set stats ('row_count'='3');"""
     mv_rewrite_success("select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;",
             "session_distribution_2")
 }

--- a/regression-test/suites/mv_p0/test_user_activity/test_user_activity.groovy
+++ b/regression-test/suites/mv_p0/test_user_activity/test_user_activity.groovy
@@ -48,6 +48,8 @@ suite ("test_user_activity") {
     sql """analyze table u_axx with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table u_axx modify column r_xx set stats ('row_count'='3');"""
+
     mv_rewrite_success("select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;",
             "session_distribution_2")
     qt_select_group_mv "select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;"

--- a/regression-test/suites/mv_p0/unique/unique.groovy
+++ b/regression-test/suites/mv_p0/unique/unique.groovy
@@ -52,8 +52,6 @@ suite ("unique") {
         exception "The materialized view not support value column before key column"
     }
 
-    sql """alter table u_table modify column k1 set stats ('row_count'='3');"""
-
     createMV("create materialized view kadj as select k3,k2,k1,k4 from u_table;")
 
     createMV("create materialized view kadj2 as select k1,k3,k2,length(k4) from u_table;")
@@ -75,6 +73,7 @@ suite ("unique") {
     qt_select_star "select * from u_table order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table u_table modify column k1 set stats ('row_count'='3');"""
     mv_rewrite_success("select k3,length(k1),k2 from u_table order by 1,2,3;", "k31l42")
 
     // todo: support match query

--- a/regression-test/suites/mv_p0/unique/unique.groovy
+++ b/regression-test/suites/mv_p0/unique/unique.groovy
@@ -52,6 +52,8 @@ suite ("unique") {
         exception "The materialized view not support value column before key column"
     }
 
+    sql """alter table u_table modify column k1 set stats ('row_count'='3');"""
+
     createMV("create materialized view kadj as select k3,k2,k1,k4 from u_table;")
 
     createMV("create materialized view kadj2 as select k1,k3,k2,length(k4) from u_table;")

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV1/testAggQueryOnAggMV1.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV1/testAggQueryOnAggMV1.groovy
@@ -36,6 +36,7 @@ suite ("testAggQueryOnAggMV1") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
+sql """alter table emps modify column time_col set stats ('row_count'='4');"""
 
     createMV("create materialized view emps_mv as select deptno, sum(salary), max(commission) from emps group by deptno;")
     createMV("create materialized view emps_mv_count_key as select deptno, count(deptno) from emps group by deptno;")

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV10/testAggQueryOnAggMV10.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV10/testAggQueryOnAggMV10.groovy
@@ -36,8 +36,6 @@ suite ("testAggQueryOnAggMV10") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view emps_mv as select deptno, commission, sum(salary) from emps group by deptno, commission;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
@@ -53,6 +51,7 @@ suite ("testAggQueryOnAggMV10") {
     qt_select_mv "select deptno, commission, sum(salary) + 1 from emps group by rollup (deptno, commission) order by 1,2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select deptno, commission, sum(salary) + 1 from emps group by rollup (deptno, commission);",

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV10/testAggQueryOnAggMV10.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV10/testAggQueryOnAggMV10.groovy
@@ -36,6 +36,8 @@ suite ("testAggQueryOnAggMV10") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view emps_mv as select deptno, commission, sum(salary) from emps group by deptno, commission;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV11/testAggQueryOnAggMV11.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV11/testAggQueryOnAggMV11.groovy
@@ -36,6 +36,8 @@ suite ("testAggQueryOnAggMV11") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view emps_mv as select deptno, count(salary) from emps group by deptno;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV11/testAggQueryOnAggMV11.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV11/testAggQueryOnAggMV11.groovy
@@ -36,8 +36,6 @@ suite ("testAggQueryOnAggMV11") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view emps_mv as select deptno, count(salary) from emps group by deptno;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
@@ -52,6 +50,7 @@ suite ("testAggQueryOnAggMV11") {
     qt_select_mv "select deptno, count(salary) + count(1) from emps group by deptno order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_fail("select deptno, count(salary) + count(1) from emps group by deptno;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV2/testAggQueryOnAggMV2.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV2/testAggQueryOnAggMV2.groovy
@@ -34,8 +34,6 @@ suite ("testAggQueryOnAggMV2") {
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into emps values("2020-01-02",2,"b",2,7,2);"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
-
     explain {
         sql("select deptno, sum(salary) from emps group by deptno order by deptno;")
         contains "(emps)"
@@ -55,6 +53,7 @@ suite ("testAggQueryOnAggMV2") {
     qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where (sum_salary * 2) > 3 order by deptno ;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where (sum_salary * 2) > 3 order by deptno ;",

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV2/testAggQueryOnAggMV2.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV2/testAggQueryOnAggMV2.groovy
@@ -34,6 +34,8 @@ suite ("testAggQueryOnAggMV2") {
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into emps values("2020-01-02",2,"b",2,7,2);"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
+
     explain {
         sql("select deptno, sum(salary) from emps group by deptno order by deptno;")
         contains "(emps)"

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV3/testAggQueryOnAggMV3.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV3/testAggQueryOnAggMV3.groovy
@@ -38,8 +38,6 @@ suite ("testAggQueryOnAggMV3") {
     sql """insert into emps values("2020-01-04",4,"d",21,4,4);"""
 
 
-sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view emps_mv as select deptno, commission, sum(salary) from emps group by deptno, commission;")
 
     sql "analyze table emps with sync;"
@@ -57,6 +55,7 @@ sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     qt_select_mv "select commission, sum(salary) from emps where commission = 100 group by commission order by commission;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select commission, sum(salary) from emps where deptno > 0 and commission * (deptno + commission) = 100 group by commission order by commission;",

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV3/testAggQueryOnAggMV3.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV3/testAggQueryOnAggMV3.groovy
@@ -38,6 +38,7 @@ suite ("testAggQueryOnAggMV3") {
     sql """insert into emps values("2020-01-04",4,"d",21,4,4);"""
 
 
+sql """alter table emps modify column time_col set stats ('row_count'='4');"""
 
     createMV("create materialized view emps_mv as select deptno, commission, sum(salary) from emps group by deptno, commission;")
 

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV5/testAggQuqeryOnAggMV5.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV5/testAggQuqeryOnAggMV5.groovy
@@ -43,6 +43,8 @@ suite ("testAggQuqeryOnAggMV5") {
     sql """analyze table emps with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV5/testAggQuqeryOnAggMV5.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV5/testAggQuqeryOnAggMV5.groovy
@@ -43,8 +43,6 @@ suite ("testAggQuqeryOnAggMV5") {
     sql """analyze table emps with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
@@ -53,6 +51,7 @@ suite ("testAggQuqeryOnAggMV5") {
     qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where sum_salary>10 order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where sum_salary>0;",

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV6/testAggQuqeryOnAggMV6.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV6/testAggQuqeryOnAggMV6.groovy
@@ -43,8 +43,6 @@ suite ("testAggQuqeryOnAggMV6") {
     sql """analyze table emps with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
@@ -53,6 +51,7 @@ suite ("testAggQuqeryOnAggMV6") {
     qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from emps where deptno>=20 group by deptno) a where sum_salary>10 order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps where deptno>=0 group by deptno) a where sum_salary>10;",

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV6/testAggQuqeryOnAggMV6.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV6/testAggQuqeryOnAggMV6.groovy
@@ -43,6 +43,8 @@ suite ("testAggQuqeryOnAggMV6") {
     sql """analyze table emps with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
@@ -43,6 +43,8 @@ suite ("testAggQuqeryOnAggMV7") {
     sql """analyze table emps with sync;"""
     sql """set enable_stats=false;"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
@@ -52,6 +52,7 @@ suite ("testAggQuqeryOnAggMV7") {
     qt_select_mv "select deptno, sum(salary) from emps where deptno>=20 group by deptno order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select deptno, sum(salary) from emps where deptno>=20 group by deptno;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
@@ -43,8 +43,6 @@ suite ("testAggQuqeryOnAggMV7") {
     sql """analyze table emps with sync;"""
     sql """set enable_stats=false;"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
@@ -52,6 +50,7 @@ suite ("testAggQuqeryOnAggMV7") {
     qt_select_mv "select deptno, sum(salary) from emps where deptno>=20 group by deptno order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 

--- a/regression-test/suites/mv_p0/ut/testAggTableCountDistinctInBitmapType/testAggTableCountDistinctInBitmapType.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggTableCountDistinctInBitmapType/testAggTableCountDistinctInBitmapType.groovy
@@ -29,8 +29,6 @@ suite ("testAggTableCountDistinctInBitmapType") {
     sql """insert into test_tb values(3,to_bitmap(3));"""
 
 
-sql """alter table test_tb modify column k1 set stats ('row_count'='3');"""
-
     sql "analyze table test_tb with sync;"
     sql """set enable_stats=false;"""
 
@@ -44,6 +42,7 @@ sql """alter table test_tb modify column k1 set stats ('row_count'='3');"""
     qt_select_mv "select k1, count(distinct v1) from test_tb group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table test_tb modify column k1 set stats ('row_count'='3');"""
     explain {
         sql("select k1, count(distinct v1) from test_tb group by k1;")
         contains "bitmap_union_count"

--- a/regression-test/suites/mv_p0/ut/testAggTableCountDistinctInBitmapType/testAggTableCountDistinctInBitmapType.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggTableCountDistinctInBitmapType/testAggTableCountDistinctInBitmapType.groovy
@@ -29,6 +29,8 @@ suite ("testAggTableCountDistinctInBitmapType") {
     sql """insert into test_tb values(3,to_bitmap(3));"""
 
 
+sql """alter table test_tb modify column k1 set stats ('row_count'='3');"""
+
     sql "analyze table test_tb with sync;"
     sql """set enable_stats=false;"""
 

--- a/regression-test/suites/mv_p0/ut/testAggregateMVCalcAggFunctionQuery/testAggregateMVCalcAggFunctionQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggregateMVCalcAggFunctionQuery/testAggregateMVCalcAggFunctionQuery.groovy
@@ -43,6 +43,8 @@ suite ("testAggregateMVCalcAggFunctionQuery") {
     sql "analyze table emps with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 

--- a/regression-test/suites/mv_p0/ut/testAggregateMVCalcAggFunctionQuery/testAggregateMVCalcAggFunctionQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggregateMVCalcAggFunctionQuery/testAggregateMVCalcAggFunctionQuery.groovy
@@ -43,8 +43,6 @@ suite ("testAggregateMVCalcAggFunctionQuery") {
     sql "analyze table emps with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
@@ -52,6 +50,7 @@ suite ("testAggregateMVCalcAggFunctionQuery") {
     qt_select_mv "select deptno, sum(salary + 1) from emps where deptno > 10 group by deptno order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_fail("select deptno, sum(salary + 1) from emps where deptno > 10 group by deptno;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testBitmapUnionInQuery/testBitmapUnionInQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testBitmapUnionInQuery/testBitmapUnionInQuery.groovy
@@ -39,8 +39,6 @@ suite ("testBitmapUnionInQuery") {
     sql "analyze table user_tags with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
-
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 
@@ -53,7 +51,7 @@ suite ("testBitmapUnionInQuery") {
     qt_select_mv "select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) a from user_tags group by user_id having a>1 order by a;"
 
     sql """set enable_stats=true;"""
-
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
 
     mv_rewrite_success("select user_id, bitmap_union_count(to_bitmap(tag_id)) a from user_tags group by user_id having a>1 order by a;",

--- a/regression-test/suites/mv_p0/ut/testBitmapUnionInQuery/testBitmapUnionInQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testBitmapUnionInQuery/testBitmapUnionInQuery.groovy
@@ -39,6 +39,8 @@ suite ("testBitmapUnionInQuery") {
     sql "analyze table user_tags with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 

--- a/regression-test/suites/mv_p0/ut/testCountDistinctToBitmap/testCountDistinctToBitmap.groovy
+++ b/regression-test/suites/mv_p0/ut/testCountDistinctToBitmap/testCountDistinctToBitmap.groovy
@@ -66,6 +66,10 @@ suite ("testCountDistinctToBitmap") {
     sql """insert into user_tags2 values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags2 values("2020-01-02",2,"b",2);"""
 
+
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+    sql """alter table user_tags2 modify column time_col set stats ('row_count'='3');"""
+
     createMV("create materialized view user_tags_mv as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags2 group by user_id;")
 
     sql """insert into user_tags2 values("2020-01-01",1,"a",2);"""

--- a/regression-test/suites/mv_p0/ut/testIncorrectMVRewriteInSubquery/testIncorrectMVRewriteInSubquery.groovy
+++ b/regression-test/suites/mv_p0/ut/testIncorrectMVRewriteInSubquery/testIncorrectMVRewriteInSubquery.groovy
@@ -31,8 +31,6 @@ suite ("testIncorrectMVRewriteInSubquery") {
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 
-    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
-
     createMV("create materialized view user_tags_mv as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;")
 
     sql """insert into user_tags values("2020-01-01",1,"a",2);"""
@@ -49,6 +47,7 @@ suite ("testIncorrectMVRewriteInSubquery") {
     qt_select_mv "select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags where user_name in (select user_name from user_tags group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;"
 
     sql """set enable_stats=true;"""
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
 
     mv_rewrite_fail("select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags where user_name in (select user_name from user_tags group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;",

--- a/regression-test/suites/mv_p0/ut/testIncorrectMVRewriteInSubquery/testIncorrectMVRewriteInSubquery.groovy
+++ b/regression-test/suites/mv_p0/ut/testIncorrectMVRewriteInSubquery/testIncorrectMVRewriteInSubquery.groovy
@@ -31,6 +31,8 @@ suite ("testIncorrectMVRewriteInSubquery") {
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     createMV("create materialized view user_tags_mv as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;")
 
     sql """insert into user_tags values("2020-01-01",1,"a",2);"""

--- a/regression-test/suites/mv_p0/ut/testIncorrectRewriteCountDistinct/testIncorrectRewriteCountDistinct.groovy
+++ b/regression-test/suites/mv_p0/ut/testIncorrectRewriteCountDistinct/testIncorrectRewriteCountDistinct.groovy
@@ -28,8 +28,6 @@ suite ("testIncorrectRewriteCountDistinct") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
-
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 
@@ -47,6 +45,7 @@ suite ("testIncorrectRewriteCountDistinct") {
     qt_select_mv "select user_name, count(distinct tag_id) from user_tags group by user_name order by user_name;"
 
     sql """set enable_stats=true;"""
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
 
     mv_rewrite_fail("select user_name, count(distinct tag_id) from user_tags group by user_name;", "user_tags_mv")

--- a/regression-test/suites/mv_p0/ut/testIncorrectRewriteCountDistinct/testIncorrectRewriteCountDistinct.groovy
+++ b/regression-test/suites/mv_p0/ut/testIncorrectRewriteCountDistinct/testIncorrectRewriteCountDistinct.groovy
@@ -28,6 +28,8 @@ suite ("testIncorrectRewriteCountDistinct") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 

--- a/regression-test/suites/mv_p0/ut/testJoinOnLeftProjectToJoin/testJoinOnLeftProjectToJoin.groovy
+++ b/regression-test/suites/mv_p0/ut/testJoinOnLeftProjectToJoin/testJoinOnLeftProjectToJoin.groovy
@@ -29,6 +29,8 @@ suite ("testJoinOnLeftProjectToJoin") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into emps values("2020-01-02",2,"b",2,7,2);"""
@@ -42,6 +44,8 @@ suite ("testJoinOnLeftProjectToJoin") {
             cost int) 
         partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
+
+    sql """alter table depts modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into depts values("2020-01-02",2,"b",2);"""
     sql """insert into depts values("2020-01-03",3,"c",3);"""

--- a/regression-test/suites/mv_p0/ut/testJoinOnLeftProjectToJoin/testJoinOnLeftProjectToJoin.groovy
+++ b/regression-test/suites/mv_p0/ut/testJoinOnLeftProjectToJoin/testJoinOnLeftProjectToJoin.groovy
@@ -29,8 +29,6 @@ suite ("testJoinOnLeftProjectToJoin") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
-
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into emps values("2020-01-02",2,"b",2,7,2);"""
@@ -63,6 +61,7 @@ suite ("testJoinOnLeftProjectToJoin") {
     qt_select_mv "select * from (select deptno , sum(salary) from emps group by deptno) A join (select deptno, max(cost) from depts group by deptno ) B on A.deptno = B.deptno order by A.deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_all_success("select * from (select deptno , sum(salary) from emps group by deptno) A join (select deptno, max(cost) from depts group by deptno ) B on A.deptno = B.deptno;",
             ["emps_mv", "depts_mv"])
 }

--- a/regression-test/suites/mv_p0/ut/testNDVToHll/testNDVToHll.groovy
+++ b/regression-test/suites/mv_p0/ut/testNDVToHll/testNDVToHll.groovy
@@ -30,8 +30,6 @@ suite ("testNDVToHll") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
-
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 
@@ -52,6 +50,7 @@ suite ("testNDVToHll") {
     qt_select_mv "select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;"
 
     sql """set enable_stats=true;"""
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
 
     mv_rewrite_success("select user_id, ndv(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")

--- a/regression-test/suites/mv_p0/ut/testNDVToHll/testNDVToHll.groovy
+++ b/regression-test/suites/mv_p0/ut/testNDVToHll/testNDVToHll.groovy
@@ -30,6 +30,8 @@ suite ("testNDVToHll") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 

--- a/regression-test/suites/mv_p0/ut/testOrderByQueryOnProjectView/testOrderByQueryOnProjectView.groovy
+++ b/regression-test/suites/mv_p0/ut/testOrderByQueryOnProjectView/testOrderByQueryOnProjectView.groovy
@@ -42,8 +42,6 @@ suite ("testOrderByQueryOnProjectView") {
     sql "analyze table emps with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
@@ -51,6 +49,7 @@ suite ("testOrderByQueryOnProjectView") {
     qt_select_mv "select empid from emps order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select empid from emps where deptno > 0 order by deptno;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testOrderByQueryOnProjectView/testOrderByQueryOnProjectView.groovy
+++ b/regression-test/suites/mv_p0/ut/testOrderByQueryOnProjectView/testOrderByQueryOnProjectView.groovy
@@ -42,6 +42,8 @@ suite ("testOrderByQueryOnProjectView") {
     sql "analyze table emps with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 

--- a/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
@@ -31,6 +31,8 @@ suite ("testProjectionMV1") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
@@ -31,8 +31,6 @@ suite ("testProjectionMV1") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
-
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 
@@ -63,6 +61,7 @@ suite ("testProjectionMV1") {
     qt_select_mv "select deptno, sum(empid) from emps group by deptno order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select empid, deptno from emps where deptno > 0 order by empid;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testProjectionMV2/testProjectionMV2.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV2/testProjectionMV2.groovy
@@ -31,8 +31,6 @@ suite ("testProjectionMV2") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
-
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 
@@ -53,6 +51,7 @@ suite ("testProjectionMV2") {
     qt_select_base "select name from emps where deptno -1 = 0 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select empid + 1 from emps where deptno = 1 order by empid;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testProjectionMV2/testProjectionMV2.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV2/testProjectionMV2.groovy
@@ -31,6 +31,8 @@ suite ("testProjectionMV2") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/mv_p0/ut/testProjectionMV3/testProjectionMV3.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV3/testProjectionMV3.groovy
@@ -34,8 +34,6 @@ suite ("testProjectionMV3") {
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
-
     def result = "null"
 
     createMV("create materialized view emps_mv as select deptno, empid, name from emps order by deptno;")
@@ -55,6 +53,7 @@ suite ("testProjectionMV3") {
     qt_select_mv2 "select name from emps where deptno = 1 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_success("select empid + 1, name from emps where deptno = 1 order by empid;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testProjectionMV3/testProjectionMV3.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV3/testProjectionMV3.groovy
@@ -34,6 +34,8 @@ suite ("testProjectionMV3") {
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
+
     def result = "null"
 
     createMV("create materialized view emps_mv as select deptno, empid, name from emps order by deptno;")

--- a/regression-test/suites/mv_p0/ut/testProjectionMV4/testProjectionMV4.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV4/testProjectionMV4.groovy
@@ -31,6 +31,8 @@ suite ("testProjectionMV4") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/mv_p0/ut/testProjectionMV4/testProjectionMV4.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV4/testProjectionMV4.groovy
@@ -31,8 +31,6 @@ suite ("testProjectionMV4") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
-
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 
@@ -54,6 +52,7 @@ suite ("testProjectionMV4") {
     qt_select_base "select empid from emps where deptno > 1 and empid > 1 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     mv_rewrite_fail("select empid from emps where deptno > 1 and empid > 1 order by empid;", "emps_mv")

--- a/regression-test/suites/mv_p0/ut/testQueryOnStar/testQueryOnStar.groovy
+++ b/regression-test/suites/mv_p0/ut/testQueryOnStar/testQueryOnStar.groovy
@@ -58,4 +58,5 @@ suite ("testQueryOnStar") {
     sql """insert into tpch_tiny_region values(1,'a','a');"""
 
     qt_select_mv "select ref_1.`empid` as c0 from tpch_tiny_region as ref_0 left join emps as ref_1 on (ref_0.`r_comment` = ref_1.`name` ) where true order by ref_0.`r_regionkey`,ref_0.`r_regionkey` desc ,ref_0.`r_regionkey`,ref_0.`r_regionkey`;"    
+
 }

--- a/regression-test/suites/mv_p0/ut/testSelectMVWithTableAlias/testSelectMVWithTableAlias.groovy
+++ b/regression-test/suites/mv_p0/ut/testSelectMVWithTableAlias/testSelectMVWithTableAlias.groovy
@@ -29,6 +29,8 @@ suite ("testSelectMVWithTableAlias") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table user_tags modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into user_tags values("2020-01-01",1,"a",1);"""
     sql """insert into user_tags values("2020-01-02",2,"b",2);"""
 

--- a/regression-test/suites/mv_p0/ut/testSingleMVMultiUsage/testSingleMVMultiUsage.groovy
+++ b/regression-test/suites/mv_p0/ut/testSingleMVMultiUsage/testSingleMVMultiUsage.groovy
@@ -35,8 +35,6 @@ suite ("testSingleMVMultiUsage") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
-        sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view emps_mv as select deptno, empid, salary from emps order by deptno;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
@@ -54,6 +52,7 @@ suite ("testSingleMVMultiUsage") {
     }
     qt_select_mv "select * from (select deptno, empid from emps where deptno>100) A join (select deptno, empid from emps where deptno >200) B using (deptno) order by 1;"
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     explain {

--- a/regression-test/suites/mv_p0/ut/testSingleMVMultiUsage/testSingleMVMultiUsage.groovy
+++ b/regression-test/suites/mv_p0/ut/testSingleMVMultiUsage/testSingleMVMultiUsage.groovy
@@ -35,6 +35,8 @@ suite ("testSingleMVMultiUsage") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
+        sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view emps_mv as select deptno, empid, salary from emps order by deptno;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""

--- a/regression-test/suites/mv_p0/ut/testSubQuery/testSubQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testSubQuery/testSubQuery.groovy
@@ -38,8 +38,6 @@ suite ("testSubQuery") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view emps_mv as select deptno, empid from emps;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
@@ -53,5 +51,6 @@ suite ("testSubQuery") {
     qt_select_mv "select empid, deptno, salary from emps e1 where empid = (select max(empid) from emps where deptno = e1.deptno) order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testSubQuery/testSubQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testSubQuery/testSubQuery.groovy
@@ -38,6 +38,7 @@ suite ("testSubQuery") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
 
     createMV("create materialized view emps_mv as select deptno, empid from emps;")
 

--- a/regression-test/suites/mv_p0/ut/testUnionDistinct/testUnionDistinct.groovy
+++ b/regression-test/suites/mv_p0/ut/testUnionDistinct/testUnionDistinct.groovy
@@ -35,6 +35,9 @@ suite ("testUnionDistinct") {
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
+
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view emps_mv as select empid, deptno from emps order by empid, deptno;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""

--- a/regression-test/suites/mv_p0/ut/testUnionDistinct/testUnionDistinct.groovy
+++ b/regression-test/suites/mv_p0/ut/testUnionDistinct/testUnionDistinct.groovy
@@ -36,8 +36,6 @@ suite ("testUnionDistinct") {
     sql """insert into emps values("2020-01-03",3,"c",3,3,3);"""
 
 
-    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view emps_mv as select empid, deptno from emps order by empid, deptno;")
 
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
@@ -55,6 +53,7 @@ suite ("testUnionDistinct") {
     }
     qt_select_mv "select * from (select empid, deptno from emps where empid >1 union select empid, deptno from emps where empid <0) t order by 1;"
     sql """set enable_stats=true;"""
+    sql """alter table emps modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 
     explain {

--- a/regression-test/suites/nereids_rules_p0/mv/agg_on_none_agg/agg_on_none_agg.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_on_none_agg/agg_on_none_agg.groovy
@@ -57,6 +57,8 @@ suite("agg_on_none_agg") {
     (5, 2, 'o', 1.2, '2023-12-12', 'c','d',2, 'mi');  
     """
 
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
+
     sql """
     drop table if exists lineitem
     """
@@ -95,6 +97,8 @@ suite("agg_on_none_agg") {
     (5, 2, 3, 6, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-12-12', '2023-12-12', '2023-12-13', 'c', 'd', 'xxxxxxxxx');
     """
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+
     sql """
     drop table if exists partsupp
     """
@@ -119,6 +123,8 @@ suite("agg_on_none_agg") {
     (2, 3, 9, 10.01, 'supply1'),
     (2, 3, 10, 11.01, 'supply2');
     """
+
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
 
     sql """analyze table orders with sync;"""
     sql """analyze table lineitem with sync;"""

--- a/regression-test/suites/nereids_rules_p0/mv/agg_optimize_when_uniform/agg_optimize_when_uniform.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_optimize_when_uniform/agg_optimize_when_uniform.groovy
@@ -120,6 +120,10 @@ suite("agg_optimize_when_uniform") {
     (2, 3, 10, 11.01, 'supply2');
     """
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     sql """analyze table lineitem with sync;"""
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""

--- a/regression-test/suites/nereids_rules_p0/mv/agg_variety/agg_variety.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_variety/agg_variety.groovy
@@ -95,6 +95,8 @@ suite("agg_variety") {
     (5, 2, 3, 6, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-12-12', '2023-12-12', '2023-12-13', 'c', 'd', 'xxxxxxxxx');
     """
 
+
+
     sql """
     drop table if exists partsupp
     """
@@ -123,6 +125,10 @@ suite("agg_variety") {
     sql """analyze table orders with sync;"""
     sql """analyze table lineitem with sync;"""
     sql """analyze table partsupp with sync;"""
+
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
 
     def check_rewrite_but_not_chose = { mv_sql, query_sql, mv_name ->
 

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -132,6 +132,9 @@ suite("aggregate_with_roll_up") {
     sql """analyze table partsupp with sync"""
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
 
     // multi table
     // filter inside + left + use roll up dimension
@@ -840,7 +843,6 @@ suite("aggregate_with_roll_up") {
             bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)),
             bitmap_union_count(to_bitmap(case when o_shippriority > 0 and o_orderkey IN (1, 2, 3) then o_custkey else null end)),
             bitmap_union_count(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)),
-            bitmap_union_count(to_bitmap(case when o_shippriority > 0 and o_orderkey IN (1, 2, 3) then o_custkey else null end)) + bitmap_union_count(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)),
             count(distinct case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)
             from lineitem
             left join orders on l_orderkey = o_orderkey and l_shipdate = o_orderdate

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -843,6 +843,7 @@ suite("aggregate_with_roll_up") {
             bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)),
             bitmap_union_count(to_bitmap(case when o_shippriority > 0 and o_orderkey IN (1, 2, 3) then o_custkey else null end)),
             bitmap_union_count(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)),
+            bitmap_union_count(to_bitmap(case when o_shippriority > 0 and o_orderkey IN (1, 2, 3) then o_custkey else null end)) + bitmap_union_count(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)),
             count(distinct case when o_shippriority > 1 and o_orderkey IN (3, 4, 5) then o_custkey else null end)
             from lineitem
             left join orders on l_orderkey = o_orderkey and l_shipdate = o_orderdate

--- a/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
@@ -121,6 +121,12 @@ suite("aggregate_without_roll_up") {
     (2, 3, 10, 11.01, 'supply2');
     """
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // single table
     // with filter
     def mv1_0 = """

--- a/regression-test/suites/nereids_rules_p0/mv/availability/grace_period.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/availability/grace_period.groovy
@@ -49,6 +49,7 @@ suite("grace_period") {
       "replication_num" = "1"
     );
     """
+    sql """alter table orders_partition modify column o_comment set stats ('row_count'='3');"""
 
     sql """
     drop table if exists lineitem_partition
@@ -81,6 +82,7 @@ suite("grace_period") {
       "replication_num" = "1"
     );
     """
+    sql """alter table lineitem_partition modify column l_comment set stats ('row_count'='3');"""
 
     sql """
     insert into orders_partition values 

--- a/regression-test/suites/nereids_rules_p0/mv/availability/materialized_view_switch.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/availability/materialized_view_switch.groovy
@@ -124,6 +124,11 @@ suite("materialized_view_switch") {
       analyze table orders with sync;
       analyze table partsupp with sync;
     """
+
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     def mv_name = """
         select l_shipdate, o_orderdate, l_partkey, l_suppkey, o_orderkey
         from lineitem

--- a/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_date_datetrunc_part_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_date_datetrunc_part_up.groovy
@@ -71,6 +71,7 @@ suite("mtmv_range_date_datetrunc_date_part_up") {
     (1, 2, 3, null, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-29 03:00:00'),
     (2, 3, 2, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', null, '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-10-29 04:00:00');
     """
+    sql """alter table ${tb_name} modify column l_comment set stats ('row_count'='5');"""
 
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"

--- a/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_date_part_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_date_part_up.groovy
@@ -119,6 +119,8 @@ suite("mtmv_range_date_part_up") {
     (1, 3, 2, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-29');
     """
 
+    sql """alter table lineitem_range_date modify column l_comment set stats ('row_count'='7');"""
+
     def get_part = { def mv_name ->
         def part_res = sql """show partitions from ${mv_name}"""
         return part_res.size()

--- a/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_date_part_up_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_date_part_up_rewrite.groovy
@@ -113,6 +113,9 @@ suite("mtmv_range_date_part_up_rewrite") {
     (4, 5, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-31'); 
     """
 
+    sql """alter table lineitem_range_date_union modify column l_comment set stats ('row_count'='7');"""
+    sql """alter table orders_range_date_union modify column o_comment set stats ('row_count'='10');"""
+
     sql """DROP MATERIALIZED VIEW if exists ${mv_prefix}_mv1;"""
     sql """CREATE MATERIALIZED VIEW ${mv_prefix}_mv1 BUILD IMMEDIATE REFRESH AUTO ON MANUAL partition by(date_trunc(`col1`, 'month')) DISTRIBUTED BY RANDOM BUCKETS 2 PROPERTIES ('replication_num' = '1') AS  
         select date_trunc(`l_shipdate`, 'day') as col1, l_shipdate, l_orderkey from lineitem_range_date_union as t1 left join orders_range_date_union as t2 on t1.l_orderkey = t2.o_orderkey group by col1, l_shipdate, l_orderkey;"""

--- a/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_datetime_part_up_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/create_part_and_up/range_datetime_part_up_rewrite.groovy
@@ -98,6 +98,7 @@ suite("mtmv_range_datetime_part_up_rewrite") {
     (3, 1, 1, 2, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', null, 'c', 'd', 'xxxxxxxxx', '2023-10-29 02:00:00'),
     (1, 3, 2, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-29 00:00:00');
     """
+    sql """alter table lineitem_range_datetime_union modify column l_comment set stats ('row_count'='7');"""
 
     sql """
     insert into orders_range_datetime_union values 
@@ -112,6 +113,7 @@ suite("mtmv_range_datetime_part_up_rewrite") {
     (3, 2, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-29 00:00:00'),
     (4, 5, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-29 02:00:00'); 
     """
+    sql """alter table orders_range_datetime_union modify column o_comment set stats ('row_count'='10');"""
 
     sql """DROP MATERIALIZED VIEW if exists ${mv_prefix}_mv1;"""
     sql """CREATE MATERIALIZED VIEW ${mv_prefix}_mv1 BUILD IMMEDIATE REFRESH AUTO ON MANUAL partition by(date_trunc(`col1`, 'month')) DISTRIBUTED BY RANDOM BUCKETS 2 PROPERTIES ('replication_num' = '1') AS  
@@ -174,6 +176,7 @@ suite("mtmv_range_datetime_part_up_rewrite") {
     sql """alter table lineitem_range_datetime_union add partition p4 values [("2023-11-29 03:00:00"), ("2023-11-29 04:00:00"));"""
     sql """insert into lineitem_range_datetime_union values 
         (1, null, 3, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-18', '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-11-29 03:00:00')"""
+    sql """alter table lineitem_range_datetime_union modify column l_comment set stats ('row_count'='8');"""
     for (int i = 0; i < mv_name_list.size(); i++) {
         mv_rewrite_success(query_stmt_list[i], mv_name_list[i])
         compare_res(query_stmt_list[i] + " order by 1,2,3")
@@ -187,6 +190,7 @@ suite("mtmv_range_datetime_part_up_rewrite") {
 
     sql """insert into lineitem_range_datetime_union values 
         (3, null, 3, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-18', '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-11-29 03:00:00');"""
+    sql """alter table lineitem_range_datetime_union modify column l_comment set stats ('row_count'='9');"""
     for (int i = 0; i < mv_name_list.size(); i++) {
         mv_rewrite_success(query_stmt_list[i], mv_name_list[i])
         compare_res(query_stmt_list[i] + " order by 1,2,3")

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_1.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_1.groovy
@@ -98,6 +98,9 @@ suite("partition_mv_rewrite_dimension_1") {
     (1, 3, 2, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17');
     """
 
+    sql """alter table orders_1 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_1 modify column l_comment set stats ('row_count'='7');"""
+
     sql """analyze table orders_1 with sync;"""
     sql """analyze table lineitem_1 with sync;"""
 

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_3.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_3.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_3") {
     sql """analyze table orders_2_3 with sync;"""
     sql """analyze table lineitem_2_3 with sync;"""
 
+    sql """alter table orders_2_3 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_3 modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_4.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_4.groovy
@@ -124,6 +124,10 @@ suite("partition_mv_rewrite_dimension_2_4") {
     (3, null, 1, 99.5, 'yy'); 
     """
 
+    sql """alter table orders_2_4 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_4 modify column l_comment set stats ('row_count'='7');"""
+    sql """alter table partsupp_2_4 modify column ps_comment set stats ('row_count'='3');"""
+
     sql """analyze table orders_2_4 with sync;"""
     sql """analyze table lineitem_2_4 with sync;"""
     sql """analyze table partsupp_2_4 with sync;"""

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_5.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_5.groovy
@@ -124,6 +124,10 @@ suite("partition_mv_rewrite_dimension_2_5") {
     (3, null, 1, 99.5, 'yy'); 
     """
 
+    sql """alter table orders_2_5 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_5 modify column l_comment set stats ('row_count'='7');"""
+    sql """alter table partsupp_2_5 modify column ps_comment set stats ('row_count'='3');"""
+
     sql """analyze table orders_2_5 with sync;"""
     sql """analyze table lineitem_2_5 with sync;"""
     sql """analyze table partsupp_2_5 with sync;"""

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_6.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_6.groovy
@@ -124,6 +124,15 @@ suite("partition_mv_rewrite_dimension_2_6") {
     (3, null, 1, 99.5, 'yy'); 
     """
 
+    sql """insert into orders_2_6 values (...);"""
+    sql """alter table orders_2_6 modify column o_comment set stats ('row_count'='10');"""
+
+    sql """insert into lineitem_2_6 values (...);"""
+    sql """alter table lineitem_2_6 modify column l_comment set stats ('row_count'='7');"""
+
+    sql """insert into partsupp_2_6 values (...);"""
+    sql """alter table partsupp_2_6 modify column ps_comment set stats ('row_count'='3');"""
+
     sql """analyze table orders_2_6 with sync;"""
     sql """analyze table lineitem_2_6 with sync;"""
     sql """analyze table partsupp_2_6 with sync;"""

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_6.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_6.groovy
@@ -124,13 +124,10 @@ suite("partition_mv_rewrite_dimension_2_6") {
     (3, null, 1, 99.5, 'yy'); 
     """
 
-    sql """insert into orders_2_6 values (...);"""
     sql """alter table orders_2_6 modify column o_comment set stats ('row_count'='10');"""
 
-    sql """insert into lineitem_2_6 values (...);"""
     sql """alter table lineitem_2_6 modify column l_comment set stats ('row_count'='7');"""
 
-    sql """insert into partsupp_2_6 values (...);"""
     sql """alter table partsupp_2_6 modify column ps_comment set stats ('row_count'='3');"""
 
     sql """analyze table orders_2_6 with sync;"""

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_full_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_full_join.groovy
@@ -102,6 +102,8 @@ suite("partition_mv_rewrite_dimension_2_full_join") {
     sql """analyze table orders_2_full_join with sync;"""
     sql """analyze table lineitem_2_full_join with sync;"""
 
+    sql """alter table orders_2_full_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_full_join modify column l_comment set stats ('row_count'='7');"""
 
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_inner_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_2") {
     sql """analyze table orders_2_2 with sync;"""
     sql """analyze table lineitem_2_2 with sync;"""
 
+    sql """alter table orders_2_2 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_2 modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_anti_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_anti_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_left_anti_join") {
     sql """analyze table orders_2_left_anti_join with sync;"""
     sql """analyze table lineitem_2_left_anti_join with sync;"""
 
+    sql """alter table orders_2_left_anti_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_left_anti_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_1") {
     sql """analyze table orders_2_1 with sync;"""
     sql """analyze table lineitem_2_1 with sync;"""
 
+    sql """alter table orders_2_1 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_1 modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_semi_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_semi_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_left_semi_join") {
     sql """analyze table orders_2_left_semi_join with sync;"""
     sql """analyze table lineitem_2_left_semi_join with sync;"""
 
+    sql """alter table orders_2_left_semi_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_left_semi_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_anti_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_anti_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_right_anti_join") {
     sql """analyze table orders_2_right_anti_join with sync;"""
     sql """analyze table lineitem_2_right_anti_join with sync;"""
 
+    sql """alter table orders_2_right_anti_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_right_anti_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_right_join") {
     sql """analyze table orders_2_right_join with sync;"""
     sql """analyze table lineitem_2_right_join with sync;"""
 
+    sql """alter table orders_2_right_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_right_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_semi_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_semi_join.groovy
@@ -102,6 +102,9 @@ suite("partition_mv_rewrite_dimension_2_right_semi_join") {
     sql """analyze table orders_2_right_semi_join with sync;"""
     sql """analyze table lineitem_2_right_semi_join with sync;"""
 
+    sql """alter table orders_2_right_semi_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_2_right_semi_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_self_conn.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_self_conn.groovy
@@ -101,6 +101,9 @@ suite("partition_mv_rewrite_dimension_self_conn") {
     sql """analyze table orders_self_conn with sync;"""
     sql """analyze table lineitem_self_conn with sync;"""
 
+    sql """alter table orders_self_conn modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_self_conn modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_2_join_agg/dimension_join_agg_negative.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_2_join_agg/dimension_join_agg_negative.groovy
@@ -101,6 +101,9 @@ suite("dimension_join_agg_negative") {
     sql """analyze table orders_negative with sync;"""
     sql """analyze table lineitem_negative with sync;"""
 
+    sql """alter table orders_negative modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_negative modify column l_comment set stats ('row_count'='7');"""
+
     // left join + agg (function + group by + +-*/ + filter)
     def left_mv_stmt_1 = """select t1.o_orderdate, t1.o_shippriority, t1.o_orderkey 
             from (select o_orderkey, o_custkey, o_orderstatus, o_orderdate, o_shippriority from orders_negative group by o_orderkey, o_custkey, o_orderstatus, o_orderdate, o_shippriority) as t1

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_equal/filter_equal_or_notequal.groovy
@@ -99,6 +99,9 @@ suite("filter_equal_or_notequal_case") {
     sql """analyze table orders_1 with sync;"""
     sql """analyze table lineitem_1 with sync;"""
 
+    sql """alter table orders_1 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_1 modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/full_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/full_join_filter.groovy
@@ -105,6 +105,9 @@ suite("full_join_filter") {
     sql """analyze table orders_full_join with sync;"""
     sql """analyze table lineitem_full_join with sync;"""
 
+    sql """alter table orders_full_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_full_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/inner_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/inner_join_filter.groovy
@@ -105,6 +105,9 @@ suite("inner_join_filter") {
     sql """analyze table orders_inner_join with sync;"""
     sql """analyze table lineitem_inner_join with sync;"""
 
+    sql """alter table orders_inner_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_inner_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_anti_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_anti_join_filter.groovy
@@ -107,6 +107,9 @@ suite("left_anti_join_filter") {
     sql """analyze table orders_left_anti_join with sync;"""
     sql """analyze table lineitem_left_anti_join with sync;"""
 
+    sql """alter table orders_left_anti_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_left_anti_join modify column l_comment set stats ('row_count'='9');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_join_filter.groovy
@@ -105,6 +105,9 @@ suite("left_join_filter") {
     sql """analyze table orders_left_join with sync;"""
     sql """analyze table lineitem_left_join with sync;"""
 
+    sql """alter table orders_left_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_left_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_semi_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_semi_join_filter.groovy
@@ -105,6 +105,9 @@ suite("left_semi_join_filter") {
     sql """analyze table orders_left_semi_join with sync;"""
     sql """analyze table lineitem_left_semi_join with sync;"""
 
+    sql """alter table orders_left_semi_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_left_semi_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_anti_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_anti_join_filter.groovy
@@ -107,6 +107,9 @@ suite("right_anti_join_filter") {
     sql """analyze table orders_right_anti_join with sync;"""
     sql """analyze table lineitem_right_anti_join with sync;"""
 
+    sql """alter table orders_right_anti_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_right_anti_join modify column l_comment set stats ('row_count'='9');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_join_filter.groovy
@@ -105,6 +105,9 @@ suite("right_join_filter") {
     sql """analyze table orders_right_join with sync;"""
     sql """analyze table lineitem_right_join with sync;"""
 
+    sql """alter table orders_right_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_right_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_semi_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_semi_join_filter.groovy
@@ -107,6 +107,9 @@ suite("right_semi_join_filter") {
     sql """analyze table orders_right_semi_join with sync;"""
     sql """analyze table lineitem_right_semi_join with sync;"""
 
+    sql """alter table orders_right_semi_join modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_right_semi_join modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/direct_query/direct_query.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/direct_query/direct_query.groovy
@@ -131,6 +131,9 @@ suite("direct_query_mv") {
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column o_comment set stats ('row_count'='15');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
 
     create_async_mv(db, "mv1_0",
             """

--- a/regression-test/suites/nereids_rules_p0/mv/grouping_sets/grouping_sets.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/grouping_sets/grouping_sets.groovy
@@ -127,6 +127,9 @@ suite("materialized_view_grouping_sets") {
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='7');"""
+
     // query has group sets, and mv doesn't
     // single table grouping sets without grouping scalar function
     def mv1_0 =

--- a/regression-test/suites/nereids_rules_p0/mv/join/dphyp_inner/inner_join_dphyp.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/dphyp_inner/inner_join_dphyp.groovy
@@ -123,6 +123,10 @@ suite("inner_join_dphyp") {
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // without filter
     def mv1_0 = "select  lineitem.L_LINENUMBER, orders.O_CUSTKEY " +
             "from lineitem " +

--- a/regression-test/suites/nereids_rules_p0/mv/join/dphyp_outer/outer_join_dphyp.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/dphyp_outer/outer_join_dphyp.groovy
@@ -123,6 +123,10 @@ suite("outer_join_dphyp") {
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // without filter
     def mv1_0 = "select  lineitem.L_LINENUMBER, orders.O_CUSTKEY " +
             "from lineitem " +

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -122,6 +122,10 @@ suite("inner_join") {
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // without filter
     def mv1_0 =
             """

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -278,8 +278,19 @@ suite("outer_join") {
     sql """analyze table lineitem with sync;"""
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
+    sql """analyze table lineitem_null with sync;"""
+    sql """analyze table orders_null with sync;"""
     sql """analyze table orders_same_col with sync;"""
     sql """analyze table lineitem_same_col with sync;"""
+
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table lineitem_same_col modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table orders_same_col modify column o_comment set stats ('row_count'='18');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+    sql """alter table lineitem_null modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders_null modify column o_comment set stats ('row_count'='5');"""
+
 
     // without filter
     def mv1_0 = "select  lineitem.L_LINENUMBER, orders.O_CUSTKEY " +

--- a/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/inner_join_infer_and_derive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/inner_join_infer_and_derive.groovy
@@ -106,6 +106,9 @@ suite("inner_join_infer_and_derive") {
     sql """analyze table orders_inner with sync;"""
     sql """analyze table lineitem_inner with sync;"""
 
+    sql """alter table orders_inner modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_inner modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/left_join_infer_and_derive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/left_join_infer_and_derive.groovy
@@ -106,6 +106,8 @@ suite("left_join_infer_and_derive") {
     sql """analyze table orders_left with sync;"""
     sql """analyze table lineitem_left with sync;"""
 
+    sql """alter table orders_left modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_left modify column l_comment set stats ('row_count'='7');"""
 
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"

--- a/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/right_join_infer_and_derive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/right_join_infer_and_derive.groovy
@@ -106,6 +106,9 @@ suite("right_join_infer_and_derive") {
     sql """analyze table orders_right with sync;"""
     sql """analyze table lineitem_right with sync;"""
 
+    sql """alter table orders_right modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_right modify column l_comment set stats ('row_count'='7');"""
+
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
         def origin_res = sql stmt

--- a/regression-test/suites/nereids_rules_p0/mv/negative/negative_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/negative/negative_test.groovy
@@ -127,6 +127,9 @@ suite("negative_partition_mv_rewrite") {
     sql """analyze table lineitem_1 with sync;"""
     sql """analyze table partsupp_1 with sync;"""
 
+    sql """alter table orders_1 modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table lineitem_1 modify column l_comment set stats ('row_count'='7');"""
+
     def mv_name = "mv_1"
     def mtmv_sql = """
         select l_shipdate, o_orderdate, l_partkey, l_suppkey 

--- a/regression-test/suites/nereids_rules_p0/mv/nested/nested_materialized_view.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/nested/nested_materialized_view.groovy
@@ -202,11 +202,6 @@ suite("nested_materialized_view") {
     sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
     sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
     sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
-    sql """alter table lineorder modify column lo_comment set stats ('row_count'='100');"""
-    sql """alter table customer modify column c_comment set stats ('row_count'='50');"""
-    sql """alter table supplier modify column s_comment set stats ('row_count'='30');"""
-    sql """alter table part modify column p_comment set stats ('row_count'='40');"""
-    sql """alter table date modify column d_comment set stats ('row_count'='20');"""
 
     // simple nested materialized view
     def mv1_0_inner_mv = """

--- a/regression-test/suites/nereids_rules_p0/mv/nested/nested_materialized_view.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/nested/nested_materialized_view.groovy
@@ -199,6 +199,15 @@ suite("nested_materialized_view") {
     (2, 3, 10, 11.01, 'supply2');
     """
 
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+    sql """alter table lineorder modify column lo_comment set stats ('row_count'='100');"""
+    sql """alter table customer modify column c_comment set stats ('row_count'='50');"""
+    sql """alter table supplier modify column s_comment set stats ('row_count'='30');"""
+    sql """alter table part modify column p_comment set stats ('row_count'='40');"""
+    sql """alter table date modify column d_comment set stats ('row_count'='20');"""
+
     // simple nested materialized view
     def mv1_0_inner_mv = """
             select

--- a/regression-test/suites/nereids_rules_p0/mv/nested_mtmv/nested_mtmv.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/nested_mtmv/nested_mtmv.groovy
@@ -96,12 +96,20 @@ suite("nested_mtmv") {
     insert into orders_1 values 
     (null, 1, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-17'),
     (1, null, 'o', 109.2, 'c','d',2, 'mm', '2023-10-17'),
+    (1, null, 'o', 109.2, 'c','d',2, 'mm', '2023-10-17'),
+    (3, 3, null, 99.5, 'a', 'b', 1, 'yy', '2023-10-19'),
     (3, 3, null, 99.5, 'a', 'b', 1, 'yy', '2023-10-19'),
     (1, 2, 'o', null, 'a', 'b', 1, 'yy', '2023-10-20'),
+    (1, 2, 'o', null, 'a', 'b', 1, 'yy', '2023-10-20'),
+    (2, 3, 'k', 109.2, null,'d',2, 'mm', '2023-10-21'),
     (2, 3, 'k', 109.2, null,'d',2, 'mm', '2023-10-21'),
     (3, 1, 'k', 99.5, 'a', null, 1, 'yy', '2023-10-22'),
+    (3, 1, 'k', 99.5, 'a', null, 1, 'yy', '2023-10-22'),
+    (1, 3, 'o', 99.5, 'a', 'b', null, 'yy', '2023-10-19'),
     (1, 3, 'o', 99.5, 'a', 'b', null, 'yy', '2023-10-19'),
     (2, 1, 'o', 109.2, 'c','d',2, null, '2023-10-18'),
+    (2, 1, 'o', 109.2, 'c','d',2, null, '2023-10-18'),
+    (3, 2, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-17'),
     (3, 2, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-17'),
     (4, 5, 'k', 99.5, 'a', 'b', 1, 'yy', '2023-10-19'); 
     """
@@ -109,13 +117,17 @@ suite("nested_mtmv") {
     sql """
     insert into lineitem_1 values 
     (null, 1, 2, 3, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17'),
+    (null, 1, 2, 3, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17'),
     (1, 1, 3, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-18', '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-10-17'),
     (3, 3, 3, 2, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', '2023-10-19', 'c', 'd', 'xxxxxxxxx', '2023-10-19'),
+    (3, 3, 3, 2, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', '2023-10-19', 'c', 'd', 'xxxxxxxxx', '2023-10-19'),
     (1, 2, 3, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17'),
+    (2, 1, 2, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', null, '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-10-18'),
     (2, 1, 2, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', null, '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-10-18'),
     (3, 1, 3, 1, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', null, 'c', 'd', 'xxxxxxxxx', '2023-10-19'),
     (1, 2, 1, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17'),
     (2, 2, 2, 2, 5.5, 6.5, 7.5, 8.5, 'o', 'k', null, '2023-10-18', 'a', 'b', 'yyyyyyyyy', '2023-10-18'),
+    (3, 3, 3, 3, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', null, 'c', 'd', 'xxxxxxxxx', '2023-10-19'),
     (3, 3, 3, 3, 7.5, 8.5, 9.5, 10.5, 'k', 'o', '2023-10-19', null, 'c', 'd', 'xxxxxxxxx', '2023-10-19'),
     (1, 1, 1, 1, 5.5, 6.5, 7.5, 8.5, 'o', 'k', '2023-10-17', '2023-10-17', 'a', 'b', 'yyyyyyyyy', '2023-10-17');
     """
@@ -123,7 +135,10 @@ suite("nested_mtmv") {
     sql"""
     insert into partsupp_1 values 
     (1, 1, 1, 99.5, 'yy'),
+    (1, 1, 1, 99.5, 'yy'),
     (2, 2, 2, 109.2, 'mm'),
+    (2, 2, 2, 109.2, 'mm'),
+    (3, 3, 1, 99.5, 'yy'),
     (3, 3, 1, 99.5, 'yy'),
     (3, null, 1, 99.5, 'yy'); 
     """
@@ -132,9 +147,9 @@ suite("nested_mtmv") {
     sql """analyze table lineitem_1 with sync;"""
     sql """analyze table partsupp_1 with sync;"""
 
-    sql """alter table orders_1 modify column o_orderdate set stats ('row_count'='10');"""
-    sql """alter table lineitem_1 modify column l_shipdate set stats ('row_count'='10');"""
-    sql """alter table partsupp_1 modify column ps_comment set stats ('row_count'='4');"""
+    sql """alter table orders_1 modify column o_orderdate set stats ('row_count'='17');"""
+    sql """alter table lineitem_1 modify column l_shipdate set stats ('row_count'='14');"""
+    sql """alter table partsupp_1 modify column ps_comment set stats ('row_count'='7');"""
 
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"
@@ -724,28 +739,16 @@ suite("nested_mtmv") {
         group by t1.l_orderkey, t2.l_partkey, t1.l_suppkey, t2.o_orderkey, t1.o_custkey, t2.ps_partkey, t1.ps_suppkey, t2.agg1, t1.agg2, t2.agg3, t1.agg4, t2.agg5, t1.agg6
         """
 
-    explain {
-        sql("${sql_2}")
-        contains "${mv_2}(${mv_2})"
-    }
+    mv_rewrite_any_success(sql_2, [mv_1, mv_2])
     compare_res(sql_2 + " order by 1,2,3,4,5,6,7,8,9,10,11,12,13")
 
-    explain {
-        sql("${sql_3}")
-        contains "${mv_3}(${mv_3})"
-    }
+    mv_rewrite_any_success(sql_3, [mv_3, mv_4])
     compare_res(sql_3 + " order by 1,2,3,4,5,6,7,8,9,10,11,12,13")
 
-    explain {
-        sql("${sql_4}")
-        contains "${mv_4}(${mv_4})"
-    }
+    mv_rewrite_any_success(sql_4, [mv_3, mv_4])
     compare_res(sql_4 + " order by 1,2,3,4,5,6,7,8,9,10,11,12,13")
 
-    explain {
-        sql("${sql_5}")
-        contains "${mv_5}(${mv_5})"
-    }
+    mv_rewrite_any_success(sql_5, [mv_3, mv_4, mv_5])
     compare_res(sql_5 + " order by 1,2,3,4,5,6,7,8,9,10,11,12,13")
 
 }

--- a/regression-test/suites/nereids_rules_p0/mv/nested_mtmv_switch/nested_mtmv_rewrite_switch.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/nested_mtmv_switch/nested_mtmv_rewrite_switch.groovy
@@ -99,6 +99,9 @@ suite("nested_mtmv_rewrite_switch") {
     sql """analyze table orders_2 with sync;"""
     sql """analyze table lineitem_2 with sync;"""
 
+    sql """alter table orders_2 modify column o_orderdate set stats ('row_count'='10');"""
+    sql """alter table lineitem_2 modify column l_shipdate set stats ('row_count'='7');"""
+
 
     def compare_res = { def stmt ->
         sql "SET enable_materialized_view_rewrite=false"

--- a/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/anti/other_join_conjuncts_anti.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/anti/other_join_conjuncts_anti.groovy
@@ -140,6 +140,10 @@ suite("other_join_conjuncts_anti") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
+    sql """alter table orders modify column lo_orderdate set stats ('row_count'='18');"""
+   sql """alter table lineitem modify column lo_orderdate set stats ('row_count'='10');"""
+sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // =, !=, >, <, <=, >=
     // left anti join other conjuncts in join condition
     def mv1_0 =

--- a/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/inner/other_join_conjuncts_inner.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/inner/other_join_conjuncts_inner.groovy
@@ -140,6 +140,10 @@ suite("other_join_conjuncts_inner") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
+    sql """alter table orders modify column lo_orderdate set stats ('row_count'='18');"""
+    sql """alter table lineitem modify column lo_orderdate set stats ('row_count'='10');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // =, !=, >, <, <=, >=
     // other conjuncts in join condition
     def mv1_0 =

--- a/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/outer/other_join_conjuncts_outer.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/outer/other_join_conjuncts_outer.groovy
@@ -140,6 +140,10 @@ suite("other_join_conjuncts_outer") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
+    sql """alter table orders modify column lo_orderdate set stats ('row_count'='18');"""
+    sql """alter table lineitem modify column lo_orderdate set stats ('row_count'='10');"""
+    sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // =, !=, >, <, <=, >=
     // left outer join
     // other conjuncts in join condition
@@ -1372,9 +1376,8 @@ suite("other_join_conjuncts_outer") {
               ps_partkey
             from
               orders
-              full outer join lineitem on l_orderkey = o_orderkey and l_shipdate <= o_orderdate
-              full outer join partsupp on ps_partkey = l_partkey
-              where l_orderkey + o_orderkey != ps_availqty;
+              full outer join lineitem on l_orderkey = o_orderkey 
+              full outer join partsupp on ps_partkey = l_partkey;
             """
     def query9_4 =
             """
@@ -1386,8 +1389,9 @@ suite("other_join_conjuncts_outer") {
               ps_partkey
             from
               orders
-              full outer join lineitem on l_orderkey = o_orderkey 
-              full outer join partsupp on ps_partkey = l_partkey;
+              full outer join lineitem on l_orderkey = o_orderkey and l_shipdate < o_orderdate
+              full outer join partsupp on ps_partkey = l_partkey
+              where l_orderkey + o_orderkey != ps_availqty;
             """
     order_qt_query9_4_before "${query9_4}"
     // mv has other conjuncts but query not

--- a/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/outer/other_join_conjuncts_outer.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/outer/other_join_conjuncts_outer.groovy
@@ -1376,8 +1376,9 @@ suite("other_join_conjuncts_outer") {
               ps_partkey
             from
               orders
-              full outer join lineitem on l_orderkey = o_orderkey 
-              full outer join partsupp on ps_partkey = l_partkey;
+              full outer join lineitem on l_orderkey = o_orderkey and l_shipdate <= o_orderdate
+              full outer join partsupp on ps_partkey = l_partkey
+              where l_orderkey + o_orderkey != ps_availqty;
             """
     def query9_4 =
             """
@@ -1389,9 +1390,8 @@ suite("other_join_conjuncts_outer") {
               ps_partkey
             from
               orders
-              full outer join lineitem on l_orderkey = o_orderkey and l_shipdate < o_orderdate
-              full outer join partsupp on ps_partkey = l_partkey
-              where l_orderkey + o_orderkey != ps_availqty;
+              full outer join lineitem on l_orderkey = o_orderkey 
+              full outer join partsupp on ps_partkey = l_partkey;
             """
     order_qt_query9_4_before "${query9_4}"
     // mv has other conjuncts but query not

--- a/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/semi/other_join_conjuncts_semi.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/other_join_conjuncts/semi/other_join_conjuncts_semi.groovy
@@ -140,6 +140,10 @@ suite("other_join_conjuncts_semi") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
+    sql """alter table orders modify column lo_orderdate set stats ('row_count'='18');"""
+   sql """alter table lineitem modify column lo_orderdate set stats ('row_count'='10');"""
+sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // left self join
     def mv1_0 =
             """

--- a/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
@@ -480,6 +480,10 @@ suite("partition_mv_rewrite") {
         analyze table orders with sync;
         """
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='3');"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='6');"""
+    sql """alter table lineitem_static modify column l_comment set stats ('row_count'='4');"""
+
     // should rewrite successful when union rewrite enalbe if base table add new partition
     mv_rewrite_success(roll_up_all_partition_sql, "mv_10086", true,
             is_partition_statistics_ready(db, ["lineitem", "orders", "mv_10086"]))

--- a/regression-test/suites/nereids_rules_p0/mv/same_name/sync_async_same_name.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/same_name/sync_async_same_name.groovy
@@ -57,6 +57,8 @@ suite("sync_async_same_name") {
     (5, 2, 'o', 1.2, '2023-12-12', 'c','d',2, 'mi');  
     """
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+
     sql """analyze table orders with sync;"""
 
     def common_mv_name = 'common_mv_name'

--- a/regression-test/suites/nereids_rules_p0/mv/scan/scan_table.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/scan/scan_table.groovy
@@ -123,6 +123,10 @@ suite("mv_scan_table") {
     sql """analyze table lineitem with sync;"""
     sql """analyze table partsupp with sync;"""
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+   sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
+
     // with filter
     def mv1_0 =
             """

--- a/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
@@ -52,9 +52,8 @@ suite("single_table_without_aggregate") {
     """
 
     sql "analyze table orders with sync;"
-    sql """set enable_stats=false;"""
-
     sql """alter table orders modify column o_comment set stats ('row_count'='2');"""
+    sql """set enable_stats=false;"""
 
     def check_rewrite = { mv_sql, query_sql, mv_name ->
 

--- a/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
@@ -54,6 +54,8 @@ suite("single_table_without_aggregate") {
     sql "analyze table orders with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='2');"""
+
     def check_rewrite = { mv_sql, query_sql, mv_name ->
 
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name} ON orders"""

--- a/regression-test/suites/nereids_rules_p0/mv/union_all_compensate/union_all_compensate.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_all_compensate/union_all_compensate.groovy
@@ -180,6 +180,9 @@ suite("union_all_compensate") {
     mv_rewrite_fail(query1_0, "test_agg_mv")
     order_qt_query1_1_after "${query1_0}"
 
+    sql """alter table test_table1 modify column num set stats ('row_count'='20');"""
+    sql """alter table test_table2 modify column num set stats ('row_count'='16');"""
+
 
     // Aggregate, if query group by expression doesn't use the partition column, but the invalid partition is in the
     // grace_period, should not compensate union all, but should rewritten successfully

--- a/regression-test/suites/nereids_rules_p0/mv/union_rewrite/partition_curd_union_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_rewrite/partition_curd_union_rewrite.groovy
@@ -78,6 +78,9 @@ suite ("partition_curd_union_rewrite") {
     );
     """
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='3');"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='3');"""
+
     sql"""
     insert into orders values 
     (1, 1, 'ok', 99.5, '2023-10-17', 'a', 'b', 1, 'yy'),

--- a/regression-test/suites/nereids_rules_p0/mv/union_rewrite/partition_curd_union_rewrite_hive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_rewrite/partition_curd_union_rewrite_hive.groovy
@@ -155,6 +155,9 @@ suite ("partition_curd_union_rewrite_hive") {
         sql """create database if not exists ${db}"""
         sql """use ${db}"""
 
+        sql """alter table ${orders_tb_name} modify column o_comment set stats ('row_count'='3');"""
+sql """alter table ${lineitem_tb_name} modify column l_comment set stats ('row_count'='3');"""
+
         def mv_def_sql = """
             select l_shipdate, o_orderdate, l_partkey,
             l_suppkey, sum(o_totalprice) as sum_total

--- a/regression-test/suites/nereids_rules_p0/mv/union_rewrite/usercase_union_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_rewrite/usercase_union_rewrite.groovy
@@ -90,6 +90,9 @@ suite ("usercase_union_rewrite") {
     sql """analyze table orders_user with sync;"""
     sql """analyze table lineitem_user with sync;"""
 
+    sql """alter table orders_user modify column o_comment set stats ('row_count'='4');"""
+    sql """alter table lineitem_user modify column l_comment set stats ('row_count'='3');"""
+
     def create_mv_orders = { mv_name, mv_sql ->
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name};"""
         sql """DROP TABLE IF EXISTS ${mv_name}"""

--- a/regression-test/suites/nereids_rules_p0/mv/unsafe_equals/null_un_safe_equals.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/unsafe_equals/null_un_safe_equals.groovy
@@ -57,6 +57,8 @@ suite("null_unsafe_equals") {
     (5, 2, 'o', 1.2, '2023-12-12', 'c','d', null, 'mi');  
     """
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+
     def mv1_0 =
             """
             select count(*), o_orderstatus, o_comment

--- a/regression-test/suites/nereids_rules_p0/mv/variant/variant_mv.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/variant/variant_mv.groovy
@@ -87,6 +87,9 @@ suite("variant_mv") {
     sql """analyze table github_events1 with sync;"""
     sql """analyze table github_events2 with sync;"""
 
+    sql """alter table github_events1 modify column created_at set stats ('row_count'='3');"""
+    sql """alter table github_events2 modify column created_at set stats ('row_count'='3');"""
+
     // variant appear in where both slot and in expression
     def mv1_0 = """
     SELECT

--- a/regression-test/suites/nereids_rules_p0/mv/with_auth/with_select_table_auth.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/with_auth/with_select_table_auth.groovy
@@ -112,6 +112,9 @@ suite("with_select_table_auth","p0,auth") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='18');"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+
     sql """grant select_priv on ${db}.orders to ${user_name}"""
     sql """grant select_priv on ${db}.lineitem to ${user_name}"""
     sql """grant select_priv on regression_test to ${user_name}"""

--- a/regression-test/suites/nereids_rules_p0/mv/with_sql_limit/query_with_sql_limit.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/with_sql_limit/query_with_sql_limit.groovy
@@ -143,6 +143,10 @@ suite("query_with_sql_limit") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
+    sql """alter table orders modify column o_comment set stats ('row_count'='18');"""
+    sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
+ sql """alter table partsupp modify column ps_comment set stats ('row_count'='3');"""
+
     // test sql_select_limit default, default 9223372036854775807
     sql """set sql_select_limit = 2;"""
     def mv1_0 =

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/aggHaveDupBase.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/aggHaveDupBase.groovy
@@ -36,6 +36,7 @@ suite ("aggHaveDupBase") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
+    sql """alter table agg_have_dup_base modify column k1 set stats ('row_count'='5');"""
 
     sql "insert into agg_have_dup_base select 1,1,1,'a';"
     sql "insert into agg_have_dup_base select 2,2,2,'b';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
@@ -36,6 +36,9 @@ suite ("case_ignore") {
     sql "insert into case_ignore select 2,2,2,'b';"
     sql "insert into case_ignore select 3,-3,null,'c';"
 
+
+    sql """alter table case_ignore modify column k1 set stats ('row_count'='4');"""
+
     createMV ("create materialized view k12a as select K1,abs(K2) from case_ignore;")
     sleep(3000)
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
@@ -37,8 +37,6 @@ suite ("case_ignore") {
     sql "insert into case_ignore select 3,-3,null,'c';"
 
 
-    sql """alter table case_ignore modify column k1 set stats ('row_count'='4');"""
-
     createMV ("create materialized view k12a as select K1,abs(K2) from case_ignore;")
     sleep(3000)
 
@@ -58,6 +56,7 @@ suite ("case_ignore") {
     order_qt_select_mv "select K1,abs(K2) from case_ignore order by K1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table case_ignore modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,abs(k2) from case_ignore order by k1;", "k12a")
 
     mv_rewrite_success("select K1,abs(K2) from case_ignore order by K1;", "k12a")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
@@ -39,6 +39,8 @@ suite ("dup_gb_mv_abs") {
     createMV ("create materialized view k12sa as select k1,sum(abs(k2)) from dup_gb_mv_abs group by k1;")
     sleep(3000)
 
+    sql """alter table dup_gb_mv_abs modify column k1 set stats ('row_count'='4');"""
+
     sql "insert into dup_gb_mv_abs select -4,-4,-4,'d';"
 
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
@@ -39,8 +39,6 @@ suite ("dup_gb_mv_abs") {
     createMV ("create materialized view k12sa as select k1,sum(abs(k2)) from dup_gb_mv_abs group by k1;")
     sleep(3000)
 
-    sql """alter table dup_gb_mv_abs modify column k1 set stats ('row_count'='4');"""
-
     sql "insert into dup_gb_mv_abs select -4,-4,-4,'d';"
 
     sql "SET experimental_enable_nereids_planner=true"
@@ -59,6 +57,7 @@ suite ("dup_gb_mv_abs") {
     order_qt_select_mv_sub "select sum(abs(k2)) from dup_gb_mv_abs group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_gb_mv_abs modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,sum(abs(k2)) from dup_gb_mv_abs group by k1;", "k12sa")
 
     mv_rewrite_success("select sum(abs(k2)) from dup_gb_mv_abs group by k1;", "k12sa")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
@@ -31,6 +31,7 @@ suite ("dup_gb_mv_plus") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
+    sql """alter table dup_gb_mv_plus modify column k1 set stats ('row_count'='4');"""
 
     sql "insert into dup_gb_mv_plus select 1,1,1,'a';"
     sql "insert into dup_gb_mv_plus select 2,2,2,'b';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
@@ -31,7 +31,6 @@ suite ("dup_gb_mv_plus") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
-    sql """alter table dup_gb_mv_plus modify column k1 set stats ('row_count'='4');"""
 
     sql "insert into dup_gb_mv_plus select 1,1,1,'a';"
     sql "insert into dup_gb_mv_plus select 2,2,2,'b';"
@@ -58,6 +57,7 @@ suite ("dup_gb_mv_plus") {
     order_qt_select_mv_sub "select sum(k2+1) from dup_gb_mv_plus group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_gb_mv_plus modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,sum(k2+1) from dup_gb_mv_plus group by k1;", "k12sp")
 
     mv_rewrite_success("select sum(k2+1) from dup_gb_mv_plus group by k1;", "k12sp")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
@@ -31,8 +31,6 @@ suite ("dup_mv_abs") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
-    sql """alter table dup_mv_abs modify column k1 set stats ('row_count'='4');"""
-
     sql "insert into dup_mv_abs select 1,1,1,'a';"
     sql "insert into dup_mv_abs select 2,2,2,'b';"
     sql "insert into dup_mv_abs select 3,-3,null,'c';"
@@ -70,6 +68,7 @@ suite ("dup_mv_abs") {
     order_qt_select_group_mv_not "select sum(abs(k2)) from dup_mv_abs group by k3 order by k3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_mv_abs modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,abs(k2) from dup_mv_abs order by k1;", "k12a")
 
     mv_rewrite_success("select abs(k2) from dup_mv_abs order by k1;", "k12a")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
@@ -31,6 +31,7 @@ suite ("dup_mv_abs") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
+    sql """alter table dup_mv_abs modify column k1 set stats ('row_count'='4');"""
 
     sql "insert into dup_mv_abs select 1,1,1,'a';"
     sql "insert into dup_mv_abs select 2,2,2,'b';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
@@ -31,6 +31,7 @@ suite ("dup_mv_bin") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
+    sql """alter table dup_mv_bin modify column k1 set stats ('row_count'='4');"""
 
     sql "insert into dup_mv_bin select 1,1,1,'a';"
     sql "insert into dup_mv_bin select 2,2,2,'b';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
@@ -31,7 +31,6 @@ suite ("dup_mv_bin") {
             distributed BY hash(k1) buckets 3
             properties("replication_num" = "1");
         """
-    sql """alter table dup_mv_bin modify column k1 set stats ('row_count'='4');"""
 
     sql "insert into dup_mv_bin select 1,1,1,'a';"
     sql "insert into dup_mv_bin select 2,2,2,'b';"
@@ -70,6 +69,7 @@ suite ("dup_mv_bin") {
     order_qt_select_group_mv_not "select group_concat(bin(k2)) from dup_mv_bin group by k3 order by k3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_mv_bin modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,bin(k2) from dup_mv_bin order by k1;", "k12b")
 
     mv_rewrite_success("select bin(k2) from dup_mv_bin order by k1;", "k12b")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
@@ -29,8 +29,6 @@ suite ("dup_mv_bm_hash") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table dup_mv_bm_hash modify column k1 set stats ('row_count'='5');"""
-
     sql "insert into dup_mv_bm_hash select 1,1,'a';"
     sql "insert into dup_mv_bm_hash select 2,2,'b';"
     sql "insert into dup_mv_bm_hash select 3,3,'c';"
@@ -47,6 +45,7 @@ suite ("dup_mv_bm_hash") {
     order_qt_select_mv "select bitmap_union_count(to_bitmap(k2)) from dup_mv_bm_hash group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_mv_bm_hash modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from dup_mv_bm_hash group by k1 order by k1;", "dup_mv_bm_hash_mv1")
 
     createMV("create materialized view dup_mv_bm_hash_mv2 as select k1,bitmap_union(bitmap_hash(k3)) from dup_mv_bm_hash group by k1;")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
@@ -29,6 +29,8 @@ suite ("dup_mv_bm_hash") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table dup_mv_bm_hash modify column k1 set stats ('row_count'='5');"""
+
     sql "insert into dup_mv_bm_hash select 1,1,'a';"
     sql "insert into dup_mv_bm_hash select 2,2,'b';"
     sql "insert into dup_mv_bm_hash select 3,3,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
@@ -46,6 +46,7 @@ suite ("dup_mv_plus") {
     sql "analyze table dup_mv_plus with sync;"
     sql """set enable_stats=false;"""
 
+     sql """alter table dup_mv_plus modify column k1 set stats ('row_count'='4');"""
 
     order_qt_select_star "select * from dup_mv_plus order by k1;"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
@@ -46,8 +46,6 @@ suite ("dup_mv_plus") {
     sql "analyze table dup_mv_plus with sync;"
     sql """set enable_stats=false;"""
 
-     sql """alter table dup_mv_plus modify column k1 set stats ('row_count'='4');"""
-
     order_qt_select_star "select * from dup_mv_plus order by k1;"
 
     mv_rewrite_success("select k1,k2+1 from dup_mv_plus order by k1;", "k12p")
@@ -87,6 +85,7 @@ suite ("dup_mv_plus") {
     order_qt_select_mv "select k1,k2+1 from dup_mv_plus order by k2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_mv_plus modify column k1 set stats ('row_count'='4');"""
 
     mv_rewrite_success("select k1,k2+1 from dup_mv_plus order by k1;", "k12p")
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
@@ -29,8 +29,6 @@ suite ("dup_mv_year") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table dup_mv_year modify column k1 set stats ('row_count'='4');"""
-
     sql "insert into dup_mv_year select 1,'2003-12-31','2003-12-31 01:02:03';"
     sql "insert into dup_mv_year select 2,'2013-12-31','2013-12-31 01:02:03';"
     sql "insert into dup_mv_year select 3,'2023-12-31','2023-12-31 01:02:03';"
@@ -47,6 +45,7 @@ suite ("dup_mv_year") {
     order_qt_select_mv "select k1,year(k2) from dup_mv_year order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table dup_mv_year modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1,year(k2) from dup_mv_year order by k1;", "k12y")
 
     createMV "create materialized view k13y as select k1,year(k3) from dup_mv_year;"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
@@ -29,6 +29,8 @@ suite ("dup_mv_year") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table dup_mv_year modify column k1 set stats ('row_count'='4');"""
+
     sql "insert into dup_mv_year select 1,'2003-12-31','2003-12-31 01:02:03';"
     sql "insert into dup_mv_year select 2,'2013-12-31','2013-12-31 01:02:03';"
     sql "insert into dup_mv_year select 3,'2023-12-31','2023-12-31 01:02:03';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
@@ -32,8 +32,6 @@ suite ("multi_slot1") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table multi_slot1 modify column k1 set stats ('row_count'='4');"""
-
     sql "insert into multi_slot1 select 1,1,1,'a';"
     sql "insert into multi_slot1 select 2,2,2,'b';"
     sql "insert into multi_slot1 select 3,-3,null,'c';"
@@ -54,5 +52,6 @@ suite ("multi_slot1") {
     order_qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot1 order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table multi_slot1 modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot1 order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
@@ -32,6 +32,8 @@ suite ("multi_slot1") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table multi_slot1 modify column k1 set stats ('row_count'='4');"""
+
     sql "insert into multi_slot1 select 1,1,1,'a';"
     sql "insert into multi_slot1 select 2,2,2,'b';"
     sql "insert into multi_slot1 select 3,-3,null,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
@@ -36,6 +36,8 @@ suite ("multi_slot2") {
     sql "insert into multi_slot2 select 2,2,2,'b';"
     sql "insert into multi_slot2 select 3,-3,null,'c';"
 
+    sql """alter table multi_slot2 modify column k1 set stats ('row_count'='4');"""
+
     boolean createFail = false;
     try {
         sql "create materialized view k1a2p2ap3ps as select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2;"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
@@ -36,8 +36,6 @@ suite ("multi_slot2") {
     sql "insert into multi_slot2 select 2,2,2,'b';"
     sql "insert into multi_slot2 select 3,-3,null,'c';"
 
-    sql """alter table multi_slot2 modify column k1 set stats ('row_count'='4');"""
-
     boolean createFail = false;
     try {
         sql "create materialized view k1a2p2ap3ps as select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2;"
@@ -67,6 +65,7 @@ suite ("multi_slot2") {
     order_qt_select_base "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2 order by abs(k1)+k2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table multi_slot2 modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2+1 order by abs(k1)+k2+1",
             "k1a2p2ap3ps")
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
@@ -40,6 +40,8 @@ suite ("multi_slot3") {
 
     sleep(3000)
 
+    sql """alter table multi_slot3 modify column k1 set stats ('row_count'='4');"""
+
     sql "insert into multi_slot3 select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
@@ -40,8 +40,6 @@ suite ("multi_slot3") {
 
     sleep(3000)
 
-    sql """alter table multi_slot3 modify column k1 set stats ('row_count'='4');"""
-
     sql "insert into multi_slot3 select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
@@ -55,5 +53,6 @@ suite ("multi_slot3") {
     order_qt_select_mv "select k1+1,abs(k2+2)+k3+3 from multi_slot3 order by k1+1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table multi_slot3 modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select k1+1,abs(k2+2)+k3+3 from multi_slot3 order by k1+1;", "k1p2ap3p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
@@ -37,6 +37,8 @@ suite ("multi_slot4") {
     sql "insert into multi_slot4 select 3,-3,null,'c';"
     sql "insert into multi_slot4 select 3,-3,null,'c';"
 
+    sql """alter table multi_slot4 modify column k1 set stats ('row_count'='5');"""
+
     createMV ("create materialized view k1p2ap3ps as select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1;")
 
     sleep(3000)

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
@@ -37,8 +37,6 @@ suite ("multi_slot4") {
     sql "insert into multi_slot4 select 3,-3,null,'c';"
     sql "insert into multi_slot4 select 3,-3,null,'c';"
 
-    sql """alter table multi_slot4 modify column k1 set stats ('row_count'='5');"""
-
     createMV ("create materialized view k1p2ap3ps as select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1;")
 
     sleep(3000)
@@ -58,5 +56,6 @@ suite ("multi_slot4") {
     order_qt_select_mv "select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1 order by k1+1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table multi_slot4 modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1 order by k1+1;", "k1p2ap3ps")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
@@ -32,8 +32,6 @@ suite ("multi_slot5") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table multi_slot5 modify column k1 set stats ('row_count'='5');"""
-
     sql "insert into multi_slot5 select 1,1,1,'a';"
     sql "insert into multi_slot5 select 2,2,2,'b';"
     sql "insert into multi_slot5 select 3,-3,null,'c';"
@@ -60,5 +58,6 @@ suite ("multi_slot5") {
     order_qt_select_mv "select k1,version() from multi_slot5 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table multi_slot5 modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1,k2+k3 from multi_slot5 order by k1;", "k123p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
@@ -32,6 +32,8 @@ suite ("multi_slot5") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table multi_slot5 modify column k1 set stats ('row_count'='5');"""
+
     sql "insert into multi_slot5 select 1,1,1,'a';"
     sql "insert into multi_slot5 select 2,2,2,'b';"
     sql "insert into multi_slot5 select 3,-3,null,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
@@ -30,6 +30,8 @@ suite ("multi_slot6") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table multi_slot6 modify column k1 set stats ('row_count'='4');"""
+
     sql "insert into multi_slot6 select 1,1,1,'a';"
     sql "insert into multi_slot6 select 2,2,2,'b';"
     sql "insert into multi_slot6 select 3,-3,null,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
@@ -30,8 +30,6 @@ suite ("multi_slot6") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table multi_slot6 modify column k1 set stats ('row_count'='4');"""
-
     sql "insert into multi_slot6 select 1,1,1,'a';"
     sql "insert into multi_slot6 select 2,2,2,'b';"
     sql "insert into multi_slot6 select 3,-3,null,'c';"
@@ -86,5 +84,6 @@ suite ("multi_slot6") {
     order_qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot6 order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
 
     sql """set enable_stats=true;"""
+    sql """alter table multi_slot6 modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot6 order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
@@ -33,8 +33,6 @@ suite ("mv_with_view") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-
     sql """insert into d_table select 1,1,1,'a';"""
     sql """insert into d_table select 2,2,2,'b';"""
 
@@ -69,6 +67,7 @@ suite ("mv_with_view") {
     qt_select_mv "select * from v_k124 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from d_table order by k1;", "k312")
 
     sql """

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
@@ -33,6 +33,8 @@ suite ("mv_with_view") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
+
     sql """insert into d_table select 1,1,1,'a';"""
     sql """insert into d_table select 2,2,2,'b';"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
@@ -47,6 +47,7 @@ suite ("single_slot") {
     sql "analyze table single_slot with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table single_slot modify column k1 set stats ('row_count'='4');"""
 
     order_qt_select_star "select * from single_slot order by k1;"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
@@ -47,8 +47,6 @@ suite ("single_slot") {
     sql "analyze table single_slot with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table single_slot modify column k1 set stats ('row_count'='4');"""
-
     order_qt_select_star "select * from single_slot order by k1;"
 
     explain {
@@ -59,5 +57,6 @@ suite ("single_slot") {
     order_qt_select_mv "select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;"
 
     sql """set enable_stats=true;"""
+    sql """alter table single_slot modify column k1 set stats ('row_count'='4');"""
     mv_rewrite_success("select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;", "k1ap2spa")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
@@ -30,8 +30,6 @@ suite ("sum_devide_count") {
             properties("replication_num" = "1");
         """
 
-    sql """alter table sum_devide_count modify column k1 set stats ('row_count'='5');"""
-
     sql "insert into sum_devide_count select 1,1,1,'a';"
     sql "insert into sum_devide_count select 2,2,2,'b';"
     sql "insert into sum_devide_count select 3,-3,null,'c';"
@@ -64,7 +62,7 @@ suite ("sum_devide_count") {
     order_qt_select_mv "select sum(k2)/count(k2) from sum_devide_count;"
 
     sql """set enable_stats=true;"""
-
+    sql """alter table sum_devide_count modify column k1 set stats ('row_count'='5');"""
     mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from sum_devide_count group by k1,k4 order by k1,k4;", "kavg")
 
     mv_rewrite_success("select k1,sum(k2)/count(k2) from sum_devide_count group by k1 order by k1;", "kavg")

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
@@ -30,6 +30,8 @@ suite ("sum_devide_count") {
             properties("replication_num" = "1");
         """
 
+    sql """alter table sum_devide_count modify column k1 set stats ('row_count'='5');"""
+
     sql "insert into sum_devide_count select 1,1,1,'a';"
     sql "insert into sum_devide_count select 2,2,2,'b';"
     sql "insert into sum_devide_count select 3,-3,null,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
@@ -38,8 +38,6 @@ suite ("unique_mv") {
             );
         """
 
-    sql """alter table c5816_t modify column org_id set stats ('row_count'='1');"""
-
     createMV("""create materialized view mv_1 as select call_uuid,org_id,call_time,id,campaign_id,aa from c5816_t""")
     sql """insert into c5816_t values (1,2,"2023-11-20 00:00:00",4,"adc",12);"""
 
@@ -49,6 +47,7 @@ suite ("unique_mv") {
     mv_rewrite_success("SELECT * FROM c5816_t WHERE call_uuid='adc';", "mv_1")
 
     sql """set enable_stats=true;"""
+    sql """alter table c5816_t modify column org_id set stats ('row_count'='1');"""
     mv_rewrite_success("SELECT * FROM c5816_t WHERE call_uuid='adc';", "mv_1")
 
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
@@ -38,6 +38,8 @@ suite ("unique_mv") {
             );
         """
 
+    sql """alter table c5816_t modify column org_id set stats ('row_count'='1');"""
+
     createMV("""create materialized view mv_1 as select call_uuid,org_id,call_time,id,campaign_id,aa from c5816_t""")
     sql """insert into c5816_t values (1,2,"2023-11-20 00:00:00",4,"adc",12);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
@@ -37,7 +37,6 @@ suite ("MVMultiUsage") {
     sql """insert into MVMultiUsage values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into MVMultiUsage values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table MVMultiUsage modify column time_col set stats ('row_count'='4');"""
 
     createMV("create materialized view MVMultiUsage_mv as select deptno, empid, salary from MVMultiUsage order by deptno;")
 
@@ -60,6 +59,8 @@ suite ("MVMultiUsage") {
     order_qt_select_mv "select * from (select deptno, empid from MVMultiUsage where deptno>100) A join (select deptno, empid from MVMultiUsage where deptno >200) B using (deptno) order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table MVMultiUsage modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from MVMultiUsage order by empid;", "MVMultiUsage_mv")
     explain {
         sql("select * from (select deptno, empid from MVMultiUsage where deptno>100) A join (select deptno, empid from MVMultiUsage where deptno >200) B using (deptno);")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
@@ -37,6 +37,8 @@ suite ("MVMultiUsage") {
     sql """insert into MVMultiUsage values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into MVMultiUsage values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table MVMultiUsage modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view MVMultiUsage_mv as select deptno, empid, salary from MVMultiUsage order by deptno;")
 
     sleep(3000)

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
@@ -30,7 +30,6 @@ suite ("MVWithAs") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table MVWithAs modify column time_col set stats ('row_count'='7');"""
 
     sql """insert into MVWithAs values("2020-01-01",1,"a",1);"""
     sql """insert into MVWithAs values("2020-01-01",1,"a",1);"""
@@ -55,6 +54,8 @@ suite ("MVWithAs") {
     order_qt_select_mv "select count(tag_id) from MVWithAs t;"
 
     sql """set enable_stats=true;"""
+    sql """alter table MVWithAs modify column time_col set stats ('row_count'='7');"""
+
     mv_rewrite_fail("select * from MVWithAs order by time_col;", "MVWithAs_mv")
 
     mv_rewrite_success("select count(tag_id) from MVWithAs t;", "MVWithAs_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
@@ -30,6 +30,8 @@ suite ("MVWithAs") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table MVWithAs modify column time_col set stats ('row_count'='7');"""
+
     sql """insert into MVWithAs values("2020-01-01",1,"a",1);"""
     sql """insert into MVWithAs values("2020-01-01",1,"a",1);"""
     sql """insert into MVWithAs values("2020-01-01",1,"a",1);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggCDInBitmap.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggCDInBitmap.groovy
@@ -34,8 +34,6 @@ suite ("aggCDInBitmap") {
     sql "analyze table aggCDInBitmap with sync;"
     sql """set enable_stats=false;"""
 
-    sql """alter table aggCDInBitmap modify column k1 set stats ('row_count'='3');"""
-
     order_qt_select_star "select * from aggCDInBitmap order by 1;"
 
 
@@ -46,6 +44,7 @@ suite ("aggCDInBitmap") {
     order_qt_select_mv "select k1, count(distinct v1) from aggCDInBitmap group by k1 order by k1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggCDInBitmap modify column k1 set stats ('row_count'='3');"""
     explain {
         sql("select k1, count(distinct v1) from aggCDInBitmap group by k1;")
         contains "bitmap_union_count"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggCDInBitmap.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggCDInBitmap.groovy
@@ -34,6 +34,7 @@ suite ("aggCDInBitmap") {
     sql "analyze table aggCDInBitmap with sync;"
     sql """set enable_stats=false;"""
 
+    sql """alter table aggCDInBitmap modify column k1 set stats ('row_count'='3');"""
 
     order_qt_select_star "select * from aggCDInBitmap order by 1;"
 
@@ -49,5 +50,5 @@ suite ("aggCDInBitmap") {
         sql("select k1, count(distinct v1) from aggCDInBitmap group by k1;")
         contains "bitmap_union_count"
     }
-
+    
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
@@ -38,6 +38,7 @@ suite ("aggMVCalcAggFun") {
     sql """insert into aggMVCalcAggFun values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggMVCalcAggFun values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table aggMVCalcAggFun modify column time_col set stats ('row_count'='4');"""
 
     createMV("create materialized view aggMVCalcAggFunMv as select deptno, empid, sum(salary) from aggMVCalcAggFun group by empid, deptno;")
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
@@ -38,8 +38,6 @@ suite ("aggMVCalcAggFun") {
     sql """insert into aggMVCalcAggFun values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggMVCalcAggFun values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table aggMVCalcAggFun modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view aggMVCalcAggFunMv as select deptno, empid, sum(salary) from aggMVCalcAggFun group by empid, deptno;")
 
     sleep(3000)
@@ -56,6 +54,7 @@ suite ("aggMVCalcAggFun") {
     order_qt_select_mv "select deptno, sum(salary + 1) from aggMVCalcAggFun where deptno > 10 group by deptno order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggMVCalcAggFun modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from aggMVCalcAggFun order by empid;", "aggMVCalcAggFunMv")\
 
     mv_rewrite_fail("select deptno, sum(salary + 1) from aggMVCalcAggFun where deptno > 10 group by deptno;", "aggMVCalcAggFunMv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
@@ -38,6 +38,8 @@ suite ("aggOnAggMV1") {
     sql """insert into aggOnAggMV1 values("2020-01-03",3,"c",3,3,3);"""
 
 
+    sql """alter table aggOnAggMV1 modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view aggOnAggMV1_mv as select deptno, sum(salary), max(commission) from aggOnAggMV1 group by deptno ;")
 
     sleep(3000)

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
@@ -38,8 +38,6 @@ suite ("aggOnAggMV1") {
     sql """insert into aggOnAggMV1 values("2020-01-03",3,"c",3,3,3);"""
 
 
-    sql """alter table aggOnAggMV1 modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view aggOnAggMV1_mv as select deptno, sum(salary), max(commission) from aggOnAggMV1 group by deptno ;")
 
     sleep(3000)
@@ -56,6 +54,7 @@ suite ("aggOnAggMV1") {
     order_qt_select_mv "select sum(salary), deptno from aggOnAggMV1 group by deptno order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV1 modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from aggOnAggMV1 order by empid;", "aggOnAggMV1_mv")
 
     mv_rewrite_success("select sum(salary), deptno from aggOnAggMV1 group by deptno order by deptno;", "aggOnAggMV1_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
@@ -33,8 +33,6 @@ suite ("aggOnAggMV10") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table aggOnAggMV10 modify column time_col set stats ('row_count'='4');"""
-
     sql """insert into aggOnAggMV10 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV10 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV10 values("2020-01-03",3,"c",3,3,3);"""
@@ -56,6 +54,7 @@ suite ("aggOnAggMV10") {
     order_qt_select_mv "select deptno, commission, sum(salary) + 1 from aggOnAggMV10 group by rollup (deptno, commission) order by 1,2;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV10 modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from aggOnAggMV10 order by empid;", "aggOnAggMV10_mv")
 
     mv_rewrite_success("select deptno, commission, sum(salary) + 1 from aggOnAggMV10 group by rollup (deptno, commission);",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
@@ -33,6 +33,8 @@ suite ("aggOnAggMV10") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV10 modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into aggOnAggMV10 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV10 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV10 values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
@@ -33,7 +33,6 @@ suite ("aggOnAggMV11") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table aggOnAggMV11 modify column time_col set stats ('row_count'='4');"""
 
     sql """insert into aggOnAggMV11 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV11 values("2020-01-02",2,"b",2,2,2);"""
@@ -56,6 +55,8 @@ suite ("aggOnAggMV11") {
     order_qt_select_mv "select deptno, count(salary) + count(1) from aggOnAggMV11 group by deptno order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV11 modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from aggOnAggMV11 order by empid;", "aggOnAggMV11_mv")
 
     mv_rewrite_fail("select deptno, count(salary) + count(1) from aggOnAggMV11 group by deptno;",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
@@ -33,6 +33,8 @@ suite ("aggOnAggMV11") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV11 modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into aggOnAggMV11 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV11 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV11 values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
@@ -30,6 +30,8 @@ suite ("aggOnAggMV2") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV2 modify column time_col set stats ('row_count'='3');"""
+
     
     sql """insert into aggOnAggMV2 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV2 values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
@@ -30,8 +30,6 @@ suite ("aggOnAggMV2") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table aggOnAggMV2 modify column time_col set stats ('row_count'='3');"""
-
     
     sql """insert into aggOnAggMV2 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV2 values("2020-01-03",3,"c",3,3,3);"""
@@ -58,6 +56,7 @@ suite ("aggOnAggMV2") {
     order_qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV2 group by deptno) a where (sum_salary * 2) > 3 order by deptno ;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV2 modify column time_col set stats ('row_count'='3');"""
     mv_rewrite_fail("select * from aggOnAggMV2 order by empid;", "aggOnAggMV2_mv")
 
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV2 group by deptno) a where (sum_salary * 2) > 3 order by deptno ;", "aggOnAggMV2_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
@@ -33,6 +33,8 @@ suite ("aggOnAggMV3") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV3 modify column time_col set stats ('row_count'='5');"""
+
     sql """insert into aggOnAggMV3 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV3 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV3 values("2020-01-03",3,"c",3,3,10);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
@@ -33,8 +33,6 @@ suite ("aggOnAggMV3") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table aggOnAggMV3 modify column time_col set stats ('row_count'='5');"""
-
     sql """insert into aggOnAggMV3 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV3 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV3 values("2020-01-03",3,"c",3,3,10);"""
@@ -58,6 +56,7 @@ suite ("aggOnAggMV3") {
     order_qt_select_mv "select commission, sum(salary) from aggOnAggMV3 where commission * (deptno + commission) = 100 group by commission order by commission;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV3 modify column time_col set stats ('row_count'='5');"""
     mv_rewrite_fail("select * from aggOnAggMV3 order by empid;", "aggOnAggMV3_mv")
 
     mv_rewrite_success("select commission, sum(salary) from aggOnAggMV3 where commission * (deptno + commission) = 100 group by commission order by commission;",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV5.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV5.groovy
@@ -33,6 +33,8 @@ suite ("aggOnAggMV5") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV5 modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into aggOnAggMV5 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV5 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV5 values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
@@ -33,8 +33,6 @@ suite ("aggOnAggMV6") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table aggOnAggMV6 modify column time_col set stats ('row_count'='4');"""
-
     sql """insert into aggOnAggMV6 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV6 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV6 values("2020-01-03",3,"c",3,3,3);"""
@@ -56,6 +54,7 @@ suite ("aggOnAggMV6") {
     order_qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV6 where deptno>=20 group by deptno) a where sum_salary>10 order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV6 modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from aggOnAggMV6 order by empid;", "aggOnAggMV6_mv")
 
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV6 where deptno>=20 group by deptno) a where sum_salary>10;",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
@@ -33,6 +33,8 @@ suite ("aggOnAggMV6") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV6 modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into aggOnAggMV6 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV6 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV6 values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
@@ -33,6 +33,8 @@ suite ("aggOnAggMV7") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table aggOnAggMV7 modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into aggOnAggMV7 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV7 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV7 values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
@@ -33,8 +33,6 @@ suite ("aggOnAggMV7") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table aggOnAggMV7 modify column time_col set stats ('row_count'='4');"""
-
     sql """insert into aggOnAggMV7 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into aggOnAggMV7 values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggOnAggMV7 values("2020-01-03",3,"c",3,3,3);"""
@@ -56,6 +54,7 @@ suite ("aggOnAggMV7") {
     order_qt_select_mv "select deptno, sum(salary) from aggOnAggMV7 where deptno>=20 group by deptno order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table aggOnAggMV7 modify column time_col set stats ('row_count'='4');"""
     mv_rewrite_fail("select * from aggOnAggMV7 order by empid;", "aggOnAggMV7_mv")
 
     mv_rewrite_success("select deptno, sum(salary) from aggOnAggMV7 where deptno>=20 group by deptno;",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
@@ -30,6 +30,8 @@ suite ("bitmapUnionIn") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table bitmapUnionIn modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into bitmapUnionIn values("2020-01-01",1,"a",1);"""
     sql """insert into bitmapUnionIn values("2020-01-02",2,"b",2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
@@ -30,7 +30,6 @@ suite ("bitmapUnionIn") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table bitmapUnionIn modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into bitmapUnionIn values("2020-01-01",1,"a",1);"""
     sql """insert into bitmapUnionIn values("2020-01-02",2,"b",2);"""
@@ -52,6 +51,8 @@ suite ("bitmapUnionIn") {
     order_qt_select_mv "select user_id, bitmap_union_count(to_bitmap(tag_id)) a from bitmapUnionIn group by user_id having a>1 order by a;"
 
     sql """set enable_stats=true;"""
+    sql """alter table bitmapUnionIn modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from bitmapUnionIn order by time_col;", "bitmapUnionIn_mv")
 
     mv_rewrite_success("select user_id, bitmap_union_count(to_bitmap(tag_id)) a from bitmapUnionIn group by user_id having a>1 order by a;",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/distinctQuery.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/distinctQuery.groovy
@@ -37,6 +37,8 @@ suite ("distinctQuery") {
     sql """insert into distinctQuery values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into distinctQuery values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table distinctQuery modify column time_col set stats ('row_count'='5');"""
+
     createMV("create materialized view distinctQuery_mv as select deptno, count(salary) from distinctQuery group by deptno;")
 
     createMV("create materialized view distinctQuery_mv2 as select empid, deptno, count(salary) from distinctQuery group by empid, deptno;")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
@@ -31,7 +31,6 @@ suite ("incMVReInSub") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table incMVReInSub modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into incMVReInSub values("2020-01-01",1,"a",1);"""
     sql """insert into incMVReInSub values("2020-01-02",2,"b",2);"""
@@ -54,6 +53,8 @@ suite ("incMVReInSub") {
     order_qt_select_mv "select user_id, bitmap_union(to_bitmap(tag_id)) from incMVReInSub where user_name in (select user_name from incMVReInSub group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;"
 
     sql """set enable_stats=true;"""
+    sql """alter table incMVReInSub modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from incMVReInSub order by time_col;", "incMVReInSub_mv")
 
     mv_rewrite_fail("select user_id, bitmap_union(to_bitmap(tag_id)) from incMVReInSub where user_name in (select user_name from incMVReInSub group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;",

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
@@ -31,6 +31,8 @@ suite ("incMVReInSub") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table incMVReInSub modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into incMVReInSub values("2020-01-01",1,"a",1);"""
     sql """insert into incMVReInSub values("2020-01-02",2,"b",2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incRewriteCD.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incRewriteCD.groovy
@@ -31,7 +31,6 @@ suite ("incRewriteCD") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table incRewriteCD modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into incRewriteCD values("2020-01-01",1,"a",1);"""
     sql """insert into incRewriteCD values("2020-01-02",2,"b",2);"""
@@ -52,6 +51,8 @@ suite ("incRewriteCD") {
     order_qt_select_mv "select user_name, count(distinct tag_id) from incRewriteCD group by user_name order by user_name;"
 
     sql """set enable_stats=true;"""
+    sql """alter table incRewriteCD modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from incRewriteCD order by time_col;", "incRewriteCD_mv")
 
     mv_rewrite_fail("select user_name, count(distinct tag_id) from incRewriteCD group by user_name;", "incRewriteCD_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incRewriteCD.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incRewriteCD.groovy
@@ -31,6 +31,8 @@ suite ("incRewriteCD") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table incRewriteCD modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into incRewriteCD values("2020-01-01",1,"a",1);"""
     sql """insert into incRewriteCD values("2020-01-02",2,"b",2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
@@ -51,7 +51,6 @@ suite ("joinOnCalcToJoin") {
     sql """insert into joinOnCalcToJoin_1 values("2020-01-03",3,"c",3);"""
     sql """insert into joinOnCalcToJoin_1 values("2020-01-02",2,"b",1);"""
 
-    sql """alter table joinOnCalcToJoin_1 modify column time_col set stats ('row_count'='3');"""
 
     createMV("create materialized view joinOnLeftPToJoin_mv as select empid, deptno from joinOnCalcToJoin;")
     sleep(3000)
@@ -66,6 +65,8 @@ suite ("joinOnCalcToJoin") {
             ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
 
     sql """set enable_stats=true;"""
+    sql """alter table joinOnCalcToJoin_1 modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_all_success("select * from (select empid, deptno from joinOnCalcToJoin where empid = 0) A join (select deptno, cost from joinOnCalcToJoin_1 where deptno > 0) B on A.deptno = B.deptno;",
             ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
@@ -35,6 +35,8 @@ suite ("joinOnCalcToJoin") {
     sql """insert into joinOnCalcToJoin values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into joinOnCalcToJoin values("2020-01-02",2,"b",2,7,2);"""
 
+    sql """alter table joinOnCalcToJoin modify column time_col set stats ('row_count'='3');"""
+
     sql """ DROP TABLE IF EXISTS joinOnCalcToJoin_1; """
     sql """
         create table joinOnCalcToJoin_1 (
@@ -48,6 +50,8 @@ suite ("joinOnCalcToJoin") {
     sql """insert into joinOnCalcToJoin_1 values("2020-01-02",2,"b",2);"""
     sql """insert into joinOnCalcToJoin_1 values("2020-01-03",3,"c",3);"""
     sql """insert into joinOnCalcToJoin_1 values("2020-01-02",2,"b",1);"""
+
+    sql """alter table joinOnCalcToJoin_1 modify column time_col set stats ('row_count'='3');"""
 
     createMV("create materialized view joinOnLeftPToJoin_mv as select empid, deptno from joinOnCalcToJoin;")
     sleep(3000)

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
@@ -47,7 +47,6 @@ suite ("joinOnLeftPToJoin") {
         partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table joinOnLeftPToJoin_1 modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into joinOnLeftPToJoin_1 values("2020-01-02",2,"b",2);"""
     sql """insert into joinOnLeftPToJoin_1 values("2020-01-03",3,"c",3);"""
@@ -68,6 +67,8 @@ suite ("joinOnLeftPToJoin") {
     order_qt_select_mv "select * from (select deptno , sum(salary) from joinOnLeftPToJoin group by deptno) A join (select deptno, max(cost) from joinOnLeftPToJoin_1 group by deptno ) B on A.deptno = B.deptno order by A.deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table joinOnLeftPToJoin_1 modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_all_success("select * from (select deptno , sum(salary) from joinOnLeftPToJoin group by deptno) A join (select deptno, max(cost) from joinOnLeftPToJoin_1 group by deptno ) B on A.deptno = B.deptno;",
             ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
@@ -31,6 +31,8 @@ suite ("joinOnLeftPToJoin") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table joinOnLeftPToJoin modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into joinOnLeftPToJoin values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into joinOnLeftPToJoin values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into joinOnLeftPToJoin values("2020-01-02",2,"b",2,7,2);"""
@@ -44,6 +46,8 @@ suite ("joinOnLeftPToJoin") {
             cost int) 
         partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
+
+    sql """alter table joinOnLeftPToJoin_1 modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into joinOnLeftPToJoin_1 values("2020-01-02",2,"b",2);"""
     sql """insert into joinOnLeftPToJoin_1 values("2020-01-03",3,"c",3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
@@ -1,3 +1,4 @@
+// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
@@ -1,4 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
@@ -64,4 +63,6 @@ suite ("onStar") {
     sql """insert into onStar_tpch values(1,'a','a');"""
 
     order_qt_select_mv "select ref_1.`empid` as c0 from onStar_tpch as ref_0 left join onStar as ref_1 on (ref_0.`r_comment` = ref_1.`name` ) where true order by ref_0.`r_regionkey`,ref_0.`r_regionkey` desc ,ref_0.`r_regionkey`,ref_0.`r_regionkey`;"
+
+    sql """alter table onStar_tpch modify column r_regionkey set stats ('row_count'='1');"""
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
@@ -63,6 +63,4 @@ suite ("onStar") {
     sql """insert into onStar_tpch values(1,'a','a');"""
 
     order_qt_select_mv "select ref_1.`empid` as c0 from onStar_tpch as ref_0 left join onStar as ref_1 on (ref_0.`r_comment` = ref_1.`name` ) where true order by ref_0.`r_regionkey`,ref_0.`r_regionkey` desc ,ref_0.`r_regionkey`,ref_0.`r_regionkey`;"
-
-    sql """alter table onStar_tpch modify column r_regionkey set stats ('row_count'='1');"""
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
@@ -33,6 +33,8 @@ suite ("onlyGroupBy") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table onlyGroupBy modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into onlyGroupBy values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into onlyGroupBy values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into onlyGroupBy values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
@@ -33,7 +33,6 @@ suite ("onlyGroupBy") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table onlyGroupBy modify column time_col set stats ('row_count'='4');"""
 
     sql """insert into onlyGroupBy values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into onlyGroupBy values("2020-01-02",2,"b",2,2,2);"""
@@ -49,5 +48,7 @@ suite ("onlyGroupBy") {
     mv_rewrite_success("select deptno from onlyGroupBy group by deptno;", "onlyGroupBy_mv")
 
     sql """set enable_stats=true;"""
+    sql """alter table onlyGroupBy modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_success("select deptno from onlyGroupBy group by deptno;", "onlyGroupBy_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
@@ -34,8 +34,6 @@ suite ("orderByOnPView") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table orderByOnPView modify column time_col set stats ('row_count'='4');"""
-
     sql """insert into orderByOnPView values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into orderByOnPView values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into orderByOnPView values("2020-01-03",3,"c",3,3,3);"""
@@ -56,6 +54,8 @@ suite ("orderByOnPView") {
     order_qt_select_mv "select empid from orderByOnPView order by deptno;"
 
     sql """set enable_stats=true;"""
+    sql """alter table orderByOnPView modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from orderByOnPView where time_col='2020-01-01' order by empid;", "orderByOnPView_mv")
 
     mv_rewrite_success("select empid from orderByOnPView where deptno = 0 order by deptno;", "orderByOnPView_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
@@ -34,6 +34,8 @@ suite ("orderByOnPView") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table orderByOnPView modify column time_col set stats ('row_count'='4');"""
+
     sql """insert into orderByOnPView values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into orderByOnPView values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into orderByOnPView values("2020-01-03",3,"c",3,3,3);"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
@@ -33,6 +33,8 @@ suite ("projectMV1") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table projectMV1 modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into projectMV1 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV1 values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
@@ -33,7 +33,6 @@ suite ("projectMV1") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table projectMV1 modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into projectMV1 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV1 values("2020-01-02",2,"b",2,2,2);"""
@@ -54,6 +53,8 @@ suite ("projectMV1") {
     order_qt_select_mv "select empid, deptno from projectMV1 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table projectMV1 modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from projectMV1 where time_col='2020-01-01' order by empid;", "projectMV1_mv")
 
     mv_rewrite_success("select empid, deptno from projectMV1 where deptno=0 order by empid;", "projectMV1_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
@@ -33,7 +33,6 @@ suite ("projectMV2") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table projectMV2 modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into projectMV2 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV2 values("2020-01-02",2,"b",2,2,2);"""
@@ -57,6 +56,8 @@ suite ("projectMV2") {
     order_qt_select_base "select name from projectMV2 where deptno -1 = 0 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table projectMV2 modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from projectMV2 order by empid;", "projectMV2_mv")
 
     mv_rewrite_success("select empid + 1 from projectMV2 where deptno = 1 order by empid;", "projectMV2_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
@@ -33,6 +33,8 @@ suite ("projectMV2") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table projectMV2 modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into projectMV2 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV2 values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
@@ -33,7 +33,6 @@ suite ("projectMV3") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table projectMV3 modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into projectMV3 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV3 values("2020-01-02",2,"b",2,2,2);"""
@@ -59,6 +58,8 @@ suite ("projectMV3") {
     order_qt_select_mv2 "select name from projectMV3 where deptno -1 = 0 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table projectMV3 modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from projectMV3 order by empid;", "projectMV3_mv")
 
     mv_rewrite_success("select empid + 1, name from projectMV3 where deptno = 1 order by empid;", "projectMV3_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
@@ -33,6 +33,8 @@ suite ("projectMV3") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table projectMV3 modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into projectMV3 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV3 values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
@@ -33,6 +33,8 @@ suite ("projectMV4") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
+    sql """alter table projectMV4 modify column time_col set stats ('row_count'='3');"""
+
     sql """insert into projectMV4 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV4 values("2020-01-02",2,"b",2,2,2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
@@ -33,7 +33,6 @@ suite ("projectMV4") {
             partition by range (time_col) (partition p1 values less than MAXVALUE) distributed by hash(time_col) buckets 3 properties('replication_num' = '1');
         """
 
-    sql """alter table projectMV4 modify column time_col set stats ('row_count'='3');"""
 
     sql """insert into projectMV4 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV4 values("2020-01-02",2,"b",2,2,2);"""
@@ -59,6 +58,8 @@ suite ("projectMV4") {
     order_qt_select_base "select empid from projectMV4 where deptno > 1 and empid > 1 order by empid;"
 
     sql """set enable_stats=true;"""
+    sql """alter table projectMV4 modify column time_col set stats ('row_count'='3');"""
+
     mv_rewrite_fail("select * from projectMV4 order by empid;", "projectMV4_mv")
 
     mv_rewrite_success("select name from projectMV4 where deptno > 1 and salary > 1 and name = 'a' order by name;", "projectMV4_mv")

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
@@ -37,6 +37,7 @@ suite ("subQuery") {
     sql """insert into subQuery values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into subQuery values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table subQuery modify column time_col set stats ('row_count'='4');"""
 
     createMV("create materialized view subQuery_mv as select deptno, empid from subQuery;")
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
@@ -37,8 +37,6 @@ suite ("subQuery") {
     sql """insert into subQuery values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into subQuery values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table subQuery modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view subQuery_mv as select deptno, empid from subQuery;")
 
     sleep(3000)
@@ -61,6 +59,7 @@ suite ("subQuery") {
      */
 
      sql """set enable_stats=true;"""
+     sql """alter table subQuery modify column time_col set stats ('row_count'='4');"""
 
     mv_rewrite_fail("select * from subQuery order by empid;", "subQuery_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
@@ -37,6 +37,8 @@ suite ("unionDis") {
     sql """insert into unionDis values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into unionDis values("2020-01-03",3,"c",3,3,3);"""
 
+    sql """alter table unionDis modify column time_col set stats ('row_count'='4');"""
+
     createMV("create materialized view unionDis_mv as select empid, deptno from unionDis order by empid, deptno;")
 
     sleep(3000)

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
@@ -37,8 +37,6 @@ suite ("unionDis") {
     sql """insert into unionDis values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into unionDis values("2020-01-03",3,"c",3,3,3);"""
 
-    sql """alter table unionDis modify column time_col set stats ('row_count'='4');"""
-
     createMV("create materialized view unionDis_mv as select empid, deptno from unionDis order by empid, deptno;")
 
     sleep(3000)
@@ -60,6 +58,8 @@ suite ("unionDis") {
     order_qt_select_mv "select * from (select empid, deptno from unionDis where empid >1 union select empid, deptno from unionDis where empid <0) t order by 1;"
 
     sql """set enable_stats=true;"""
+    sql """alter table unionDis modify column time_col set stats ('row_count'='4');"""
+
     mv_rewrite_fail("select * from unionDis order by empid;", "unionDis_mv")
 
     explain {

--- a/regression-test/suites/nereids_syntax_p0/rollup/agg.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/agg.groovy
@@ -44,6 +44,7 @@ suite("agg") {
             AGGREGATE KEY (siteid,citycode,username)
             DISTRIBUTED BY HASH(siteid) BUCKETS 5 properties("replication_num" = "1");
         """
+    sql """alter table test_rollup_agg1 modify column siteid set stats ('row_count'='3');"""
     sql """ALTER TABLE ${tbName} ADD ROLLUP rollup_city(citycode, pv);"""
     int max_try_secs = 60
     String res = "NOT_FINISHED"

--- a/regression-test/suites/nereids_syntax_p0/rollup/agg_date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/agg_date.groovy
@@ -44,6 +44,7 @@ suite("agg_date", "rollup") {
             AGGREGATE KEY (datek1, datetimek1, datetimek2, datetimek3)
             DISTRIBUTED BY HASH(datek1) BUCKETS 5 properties("replication_num" = "1");
         """
+    sql """alter table test_rollup_agg_date1 modify column datek1 set stats ('row_count'='2');"""
     sql """ALTER TABLE ${tbName} ADD ROLLUP rollup_date(datek1,datetimek2,datetimek1,datetimek3,datev1,datetimev1,datetimev2,datetimev3);"""
     int max_try_secs = 60
     while (max_try_secs--) {

--- a/regression-test/suites/nereids_syntax_p0/rollup/bitmap.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/bitmap.groovy
@@ -34,6 +34,7 @@ suite("bitmap", "rollup") {
             ) 
             DISTRIBUTED BY HASH(k1) properties("replication_num" = "1");
         """
+    sql """alter table test_materialized_view_bitmap1 modify column k1 set stats ('row_count'='2');"""
 
     sql "CREATE MATERIALIZED VIEW test_neg as select k1,bitmap_union(to_bitmap(k2)), bitmap_union(to_bitmap(k3)) FROM ${tbName1} GROUP BY k1;"
     max_try_secs = 60

--- a/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
@@ -39,6 +39,8 @@ suite("date", "rollup") {
             DISTRIBUTED BY HASH(record_id) properties("replication_num" = "1");
         """
 
+    sql """alter table test_materialized_view_date1 modify column record_id set stats ('row_count'='2');"""
+
     createMV("CREATE materialized VIEW amt_max1 AS SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id;")
     createMV("CREATE materialized VIEW amt_max2 AS SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id;")
     createMV("CREATE materialized VIEW amt_max3 AS SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id;")

--- a/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
@@ -39,8 +39,6 @@ suite("date", "rollup") {
             DISTRIBUTED BY HASH(record_id) properties("replication_num" = "1");
         """
 
-    sql """alter table test_materialized_view_date1 modify column record_id set stats ('row_count'='2');"""
-
     createMV("CREATE materialized VIEW amt_max1 AS SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id;")
     createMV("CREATE materialized VIEW amt_max2 AS SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id;")
     createMV("CREATE materialized VIEW amt_max3 AS SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id;")
@@ -63,6 +61,7 @@ suite("date", "rollup") {
 
     mv_rewrite_success("SELECT store_id, max(sale_datetime3) FROM ${tbName1} GROUP BY store_id", "amt_max4")
     sql """set enable_stats=true;"""
+    sql """alter table test_materialized_view_date1 modify column record_id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id", "amt_max1")
 
     mv_rewrite_success("SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id", "amt_max2")

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll/hll.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll/hll.groovy
@@ -26,7 +26,6 @@ suite("hll", "rollup") {
             ) 
             DISTRIBUTED BY HASH(record_id) properties("replication_num" = "1");
         """
-    sql """alter table test_materialized_view_hll1 modify column record_id set stats ('row_count'='2');"""
 
     createMV "CREATE materialized VIEW amt_count AS SELECT store_id, hll_union(hll_hash(sale_amt)) FROM test_materialized_view_hll1 GROUP BY store_id;"
 
@@ -47,6 +46,7 @@ suite("hll", "rollup") {
             "amt_count")
 
     sql """set enable_stats=true;"""
+    sql """alter table test_materialized_view_hll1 modify column record_id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll1 GROUP BY store_id;",
             "amt_count")
 }

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll/hll.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll/hll.groovy
@@ -26,6 +26,7 @@ suite("hll", "rollup") {
             ) 
             DISTRIBUTED BY HASH(record_id) properties("replication_num" = "1");
         """
+    sql """alter table test_materialized_view_hll1 modify column record_id set stats ('row_count'='2');"""
 
     createMV "CREATE materialized VIEW amt_count AS SELECT store_id, hll_union(hll_hash(sale_amt)) FROM test_materialized_view_hll1 GROUP BY store_id;"
 

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc/hll_with_light_sc.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc/hll_with_light_sc.groovy
@@ -27,6 +27,7 @@ suite("hll_with_light_sc", "rollup") {
             ) 
             DISTRIBUTED BY HASH(record_id) properties("replication_num" = "1", "light_schema_change" = "true");
         """
+    sql """alter table test_materialized_view_hll_with_light_sc1 modify column record_id set stats ('row_count'='2');"""
 
     createMV "CREATE materialized VIEW amt_count1 AS SELECT store_id, hll_union(hll_hash(sale_amt)) FROM test_materialized_view_hll_with_light_sc1 GROUP BY store_id;"
 

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc/hll_with_light_sc.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc/hll_with_light_sc.groovy
@@ -27,7 +27,6 @@ suite("hll_with_light_sc", "rollup") {
             ) 
             DISTRIBUTED BY HASH(record_id) properties("replication_num" = "1", "light_schema_change" = "true");
         """
-    sql """alter table test_materialized_view_hll_with_light_sc1 modify column record_id set stats ('row_count'='2');"""
 
     createMV "CREATE materialized VIEW amt_count1 AS SELECT store_id, hll_union(hll_hash(sale_amt)) FROM test_materialized_view_hll_with_light_sc1 GROUP BY store_id;"
 
@@ -44,6 +43,7 @@ suite("hll_with_light_sc", "rollup") {
             "amt_count1")
 
     sql """set enable_stats=true;"""
+    sql """alter table test_materialized_view_hll_with_light_sc1 modify column record_id set stats ('row_count'='2');"""
     mv_rewrite_success("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll_with_light_sc1 GROUP BY store_id;",
             "amt_count1")
 }


### PR DESCRIPTION
### What problem does this PR solve?

The result of successful rewriting by the cbo optimizer depends on the statistics. 
The priority of the optimizer consumption statistics in descending order is 
1. the injected statistics
2. the statistics reported by be
3. and the statistics analyzed actively. 

When the pipeline runs the case, the statistics reported by be may not be timely. Therefore, the outcome that leads to the cbo optimizer's successful selection of overwrites is not very certain, so the statistics are currently injected manually in the test cases

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

