### PR TITLE
[Fix](Nereids) fix floor/round/ceil/truncate functions type compute precision problem (#43422)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
@@ -694,12 +694,17 @@ public class NumericArithmetic {
         return input;
     }
 
+    private static Expression castDecimalV3Literal(DecimalV3Literal literal, int precision) {
+        return new DecimalV3Literal(DecimalV3Type.createDecimalV3Type(precision, literal.getValue().scale()),
+                literal.getValue());
+    }
+
     /**
      * round
      */
     @ExecFunction(name = "round")
     public static Expression round(DecimalV3Literal first) {
-        return first.round(0);
+        return castDecimalV3Literal(first.round(0), first.getValue().precision());
     }
 
     /**
@@ -707,7 +712,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "round")
     public static Expression round(DecimalV3Literal first, IntegerLiteral second) {
-        return first.round(second.getValue());
+        return castDecimalV3Literal(first.round(second.getValue()), first.getValue().precision());
     }
 
     /**
@@ -733,7 +738,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "ceil")
     public static Expression ceil(DecimalV3Literal first) {
-        return first.roundCeiling(0);
+        return castDecimalV3Literal(first.roundCeiling(0), first.getValue().precision());
     }
 
     /**
@@ -741,7 +746,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "ceil")
     public static Expression ceil(DecimalV3Literal first, IntegerLiteral second) {
-        return first.roundCeiling(second.getValue());
+        return castDecimalV3Literal(first.roundCeiling(second.getValue()), first.getValue().precision());
     }
 
     /**
@@ -767,7 +772,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "floor")
     public static Expression floor(DecimalV3Literal first) {
-        return first.roundFloor(0);
+        return castDecimalV3Literal(first.roundFloor(0), first.getValue().precision());
     }
 
     /**
@@ -775,7 +780,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "floor")
     public static Expression floor(DecimalV3Literal first, IntegerLiteral second) {
-        return first.roundFloor(second.getValue());
+        return castDecimalV3Literal(first.roundFloor(second.getValue()), first.getValue().precision());
     }
 
     /**
@@ -1136,21 +1141,10 @@ public class NumericArithmetic {
     public static Expression truncate(DecimalV3Literal first, IntegerLiteral second) {
         if (first.getValue().compareTo(BigDecimal.ZERO) == 0) {
             return first;
+        } else if (first.getValue().compareTo(BigDecimal.ZERO) < 0) {
+            return castDecimalV3Literal(first.roundCeiling(second.getValue()), first.getValue().precision());
         } else {
-            if (first.getValue().scale() < second.getValue()) {
-                return first;
-            }
-            if (second.getValue() < 0) {
-                double factor = Math.pow(10, Math.abs(second.getValue()));
-                return new DecimalV3Literal(
-                    DecimalV3Type.createDecimalV3Type(first.getValue().precision(), 0),
-                    BigDecimal.valueOf(Math.floor(first.getDouble() / factor) * factor));
-            }
-            if (first.getValue().compareTo(BigDecimal.ZERO) == -1) {
-                return first.roundCeiling(second.getValue());
-            } else {
-                return first.roundFloor(second.getValue());
-            }
+            return castDecimalV3Literal(first.roundFloor(second.getValue()), first.getValue().precision());
         }
     }
 

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
@@ -409,4 +409,29 @@ test {
 
 //Additional cases for Xor, Conv, and other mathematical functions
     testFoldConst("SELECT CONV(-10, 10, 2) AS conv_invalid_base") //Conv with negative input (may be undefined)
+
+    // fix floor/ceil/round function return type with DecimalV3 input
+    testFoldConst("with cte as (select floor(300.343) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(300.343) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(300.343) order by 1 limit 1) select * from cte")
+
+    testFoldConst("with cte as (select floor(300.343, 2) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(300.343, 2) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(300.343, 2) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select truncate(300.343, 2) order by 1 limit 1) select * from cte")
+
+    testFoldConst("with cte as (select floor(300.343, 0) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(300.343, 0) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(300.343, 0) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select truncate(300.343, 0) order by 1 limit 1) select * from cte")
+
+    testFoldConst("with cte as (select floor(300.343, -1) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(300.343, -1) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(300.343, -1) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select truncate(300.343, -1) order by 1 limit 1) select * from cte")
+
+    testFoldConst("with cte as (select floor(300.343, -4) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(300.343, -4) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(300.343, -4) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select truncate(300.343, -4) order by 1 limit 1) select * from cte")
 }


### PR DESCRIPTION
pick: #43422

- Problem function like ```select floor(300.343, 2)``` precision should be 5 and scale should be 2, but now is (6, 2) after compute precision, but after folding const on fe, it changed to (5, 2) but upper level of plan still expect the output of child to be (6, 2). So it would rise an exception when executing.

- How it was fixed  fix folding constant precision of floor/round/ceil/truncate functions from (5, 2) to (6, 2) in upper case

- Notion when second value is negative and it absolute value >= precision - value, it can not be expressed in fe which result is zero with decimal type (3, 0). like 000. So just let it go back and no using folding constant by fe.

- Related PR: #40744

- Release note Fix floor/round/ceil functions precision problem in folding constant

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

