### PR TITLE
[ecosystem](kettle) add delete mode for kettle plugin

### DIFF
--- a/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/DorisStreamLoader.java
+++ b/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/DorisStreamLoader.java
@@ -91,6 +91,7 @@ public class DorisStreamLoader extends BaseStep implements StepInterface {
                 .setFormatMeta(data.formatMeta)
                 .setFieldDelimiter(loadProperties.getProperty(FIELD_DELIMITER_KEY, FIELD_DELIMITER_DEFAULT))
                 .setLogChannelInterface(log)
+                .setDeletable(options.isDeletable())
                 .build();
       }
 
@@ -120,6 +121,8 @@ public class DorisStreamLoader extends BaseStep implements StepInterface {
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (DorisStreamLoaderMeta) smi;
     data = (DorisStreamLoaderData) sdi;
+    logDebug("Initializing step with meta : " + meta.toString());
+
     if (super.init(smi, sdi)){
       Properties streamHeaders = new Properties();
       String streamLoadProp = meta.getStreamLoadProp();
@@ -141,7 +144,10 @@ public class DorisStreamLoader extends BaseStep implements StepInterface {
               .withBufferFlushMaxBytes(meta.getBufferFlushMaxBytes())
               .withBufferFlushMaxRows(meta.getBufferFlushMaxRows())
               .withMaxRetries(meta.getMaxRetries())
-              .withStreamLoadProp(streamHeaders).build();
+              .withStreamLoadProp(streamHeaders)
+              .withDeletable(meta.isDeletable()).build();
+
+      logDetailed("Initializing step with options: " + options.toString());
       streamLoad = new DorisBatchStreamLoad(options, log);
       return true;
     }

--- a/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/DorisStreamLoaderMeta.java
+++ b/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/DorisStreamLoaderMeta.java
@@ -53,7 +53,7 @@ import java.util.List;
   description = "BaseStep.TypeTooltipDesc.DorisStreamLoader",
   categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.Bulk",
   image = "doris.svg",
-  documentationUrl = "https://doris.apache.org/docs/dev/data-operate/import/import-way/stream-load-manual/",
+  documentationUrl = "https://doris.apache.org/docs/dev/ecosystem/kettle/",
   i18nPackageName = "org.pentaho.di.trans.steps.dorisstreamloader" )
 @InjectionSupported( localizationPrefix = "DorisStreamLoader.Injection.", groups = { "FIELDS" } )
 public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInterface {
@@ -84,6 +84,8 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
 
   private int maxRetries;
 
+  private boolean deletable;
+
   /** Field name of the target table */
   @Injection( name = "FIELD_TABLE", group = "FIELDS" )
   private String[] fieldTable;
@@ -111,8 +113,8 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
       bufferFlushMaxRows = Long.valueOf(XMLHandler.getTagValue(stepnode, "bufferFlushMaxRows"));
       bufferFlushMaxBytes = Long.valueOf(XMLHandler.getTagValue(stepnode, "bufferFlushMaxBytes"));
       maxRetries = Integer.valueOf(XMLHandler.getTagValue(stepnode, "maxRetries"));
-
       streamLoadProp = XMLHandler.getTagValue(stepnode, "streamLoadProp");
+      deletable = "Y".equalsIgnoreCase(XMLHandler.getTagValue(stepnode, "deletable"));
 
       // Field data mapping
       int nrvalues = XMLHandler.countNodes(stepnode, "mapping");
@@ -145,7 +147,7 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
     bufferFlushMaxBytes = 10 * 1024 * 1024;
     maxRetries = 3;
     streamLoadProp = "format:json;read_json_by_line:true";
-
+    deletable = false;
     allocate(0);
   }
 
@@ -161,6 +163,7 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
     retval.append("    ").append(XMLHandler.addTagValue("bufferFlushMaxBytes", bufferFlushMaxBytes));
     retval.append("    ").append(XMLHandler.addTagValue("maxRetries", maxRetries));
     retval.append("    ").append(XMLHandler.addTagValue("streamLoadProp", streamLoadProp));
+    retval.append("    ").append(XMLHandler.addTagValue("deletable", deletable));
 
     for (int i = 0; i < fieldTable.length; i++) {
       retval.append("      <mapping>").append(Const.CR);
@@ -189,6 +192,7 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
       maxRetries = Integer.valueOf(rep.getStepAttributeString(id_step, "maxRetries"));
 
       streamLoadProp = rep.getStepAttributeString(id_step, "streamLoadProp");
+      deletable = rep.getStepAttributeBoolean(id_step, "deletable");
       int nrvalues = rep.countNrStepAttributes(id_step, "stream_name");
       allocate(nrvalues);
 
@@ -217,6 +221,7 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
       rep.saveStepAttribute(id_transformation, id_step, "bufferFlushMaxRows", bufferFlushMaxRows);
       rep.saveStepAttribute(id_transformation, id_step, "bufferFlushMaxBytes", bufferFlushMaxBytes);
       rep.saveStepAttribute(id_transformation, id_step, "maxRetries", maxRetries);
+      rep.saveStepAttribute(id_transformation, id_step, "deletable", deletable);
 
       for (int i = 0; i < fieldTable.length; i++) {
         rep.saveStepAttribute(id_transformation, id_step, i, "stream_name", fieldTable[i]);
@@ -328,7 +333,15 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
     this.maxRetries = maxRetries;
   }
 
-  public String[] getFieldTable() {
+  public boolean isDeletable() {
+      return deletable;
+  }
+
+  public void setDeletable(boolean deletable) {
+      this.deletable = deletable;
+  }
+
+    public String[] getFieldTable() {
     return fieldTable;
   }
 
@@ -361,6 +374,7 @@ public class DorisStreamLoaderMeta extends BaseStepMeta implements StepMetaInter
             ", bufferFlushMaxRows=" + bufferFlushMaxRows +
             ", bufferFlushMaxBytes=" + bufferFlushMaxBytes +
             ", maxRetries=" + maxRetries +
+            ", deletable=" + deletable +
             ", fieldTable=" + Arrays.toString(fieldTable) +
             ", fieldStream=" + Arrays.toString(fieldStream) +
             '}';

--- a/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/load/DorisBatchStreamLoad.java
+++ b/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/load/DorisBatchStreamLoad.java
@@ -185,7 +185,7 @@ public class DorisBatchStreamLoad implements Serializable {
      * @param record
      * @throws IOException
      */
-    public synchronized void writeRecord(String database, String table, byte[] record) {
+    public void writeRecord(String database, String table, byte[] record) {
         checkFlushException();
         String bufferKey = getTableIdentifier(database, table);
         BatchRecordBuffer buffer =
@@ -233,19 +233,15 @@ public class DorisBatchStreamLoad implements Serializable {
         }
     }
 
-    public synchronized boolean bufferFullFlush(String bufferKey) {
+    public boolean bufferFullFlush(String bufferKey) {
         return doFlush(bufferKey, false, true);
-    }
-
-    public synchronized boolean intervalFlush() {
-        return doFlush(null, false, false);
     }
 
     /**
      * Force flush and wait for success.
      * @return
      */
-    public synchronized boolean forceFlush() {
+    public  boolean forceFlush() {
         return doFlush(null, true, false);
     }
 
@@ -417,11 +413,6 @@ public class DorisBatchStreamLoad implements Serializable {
                             }
                             load(bf.getLabelName(), bf);
                         }
-                    }
-
-                    if (flushQueue.size() < flushQueueSize) {
-                        // Avoid waiting for 2 rounds of intervalMs
-                        doFlush(null, false, false);
                     }
                 } catch (Exception e) {
                     log.logError("worker running error", e);

--- a/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/load/DorisOptions.java
+++ b/extension/kettle/impl/src/main/java/org/pentaho/di/trans/steps/dorisstreamloader/load/DorisOptions.java
@@ -35,8 +35,9 @@ public class DorisOptions {
     private long bufferFlushMaxBytes;
     private Properties streamLoadProp;
     private int maxRetries;
+    private boolean deletable;
 
-    public DorisOptions(String fenodes, String username, String password, String database, String table, long bufferFlushMaxRows, long bufferFlushMaxBytes, Properties streamLoadProp, int maxRetries) {
+    public DorisOptions(String fenodes, String username, String password, String database, String table, long bufferFlushMaxRows, long bufferFlushMaxBytes, Properties streamLoadProp, int maxRetries, boolean deletable) {
         this.fenodes = fenodes;
         this.username = username;
         this.password = password;
@@ -46,6 +47,7 @@ public class DorisOptions {
         this.bufferFlushMaxBytes = bufferFlushMaxBytes;
         this.streamLoadProp = streamLoadProp;
         this.maxRetries = maxRetries;
+        this.deletable = deletable;
     }
 
     public String getFenodes() {
@@ -84,6 +86,26 @@ public class DorisOptions {
         return maxRetries;
     }
 
+    public boolean isDeletable() {
+        return deletable;
+    }
+
+    @Override
+    public String toString() {
+        return "DorisOptions{" +
+            "fenodes='" + fenodes + '\'' +
+            ", username='" + username + '\'' +
+            ", password='" + password + '\'' +
+            ", database='" + database + '\'' +
+            ", table='" + table + '\'' +
+            ", bufferFlushMaxRows=" + bufferFlushMaxRows +
+            ", bufferFlushMaxBytes=" + bufferFlushMaxBytes +
+            ", streamLoadProp=" + streamLoadProp +
+            ", maxRetries=" + maxRetries +
+            ", deletable=" + deletable +
+            '}';
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -98,6 +120,7 @@ public class DorisOptions {
         private long bufferFlushMaxBytes = DEFAULT_BUFFER_FLUSH_MAX_BYTES;
         private int maxRetries = DEFAULT_MAX_RETRIES;
         private Properties streamLoadProp = new Properties();
+        private boolean deletable = false;
 
         public Builder withFenodes(String fenodes) {
             this.fenodes = fenodes;
@@ -144,6 +167,11 @@ public class DorisOptions {
             return this;
         }
 
+        public Builder withDeletable(boolean deletable) {
+            this.deletable = deletable;
+            return this;
+        }
+
         public DorisOptions build() {
             Preconditions.checkArgument(fenodes != null, "Fenodes must not be null");
             Preconditions.checkArgument(username != null, "Username must not be null");
@@ -153,7 +181,7 @@ public class DorisOptions {
             Preconditions.checkArgument(bufferFlushMaxRows >= 10000, "BufferFlushMaxRows must be greater than 10000");
             Preconditions.checkArgument(bufferFlushMaxBytes >= 10 * 1024 * 1024, "BufferFlushMaxBytes must be greater than 10MB");
             Preconditions.checkArgument(maxRetries >= 0, "MaxRetries must be greater than 0");
-            return new DorisOptions(fenodes, username, password, database, table, bufferFlushMaxRows, bufferFlushMaxBytes, streamLoadProp, maxRetries);
+            return new DorisOptions(fenodes, username, password, database, table, bufferFlushMaxRows, bufferFlushMaxBytes, streamLoadProp, maxRetries, deletable);
         }
     }
 }

--- a/extension/kettle/ui/src/main/java/org/pentaho/di/ui/trans/steps/dorisstreamloader/DorisStreamLoaderDialog.java
+++ b/extension/kettle/ui/src/main/java/org/pentaho/di/ui/trans/steps/dorisstreamloader/DorisStreamLoaderDialog.java
@@ -743,7 +743,6 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
 
     protected void setComboBoxes() {
         // Something was changed in the row.
-        //
         final Map<String, Integer> fields = new HashMap<String, Integer>();
 
         // Add the currentMeta fields...

--- a/extension/kettle/ui/src/main/java/org/pentaho/di/ui/trans/steps/dorisstreamloader/DorisStreamLoaderDialog.java
+++ b/extension/kettle/ui/src/main/java/org/pentaho/di/ui/trans/steps/dorisstreamloader/DorisStreamLoaderDialog.java
@@ -72,13 +72,12 @@ import java.util.Set;
  * Dialog class for the Doris stream loader step.
  */
 @PluginDialog(id = "DorisStreamLoaderStep", image = "doris.svg", pluginType = PluginDialog.PluginType.STEP,
-        documentationUrl = "https://doris.apache.org/docs/dev/data-operate/import/import-way/stream-load-manual/")
+        documentationUrl = "https://doris.apache.org/docs/dev/ecosystem/kettle/")
 @InjectionSupported(localizationPrefix = "DorisKettleConnector.Injection.", groups = {"FIELDS"})
 public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialogInterface {
     private static Class<?> PKG = DorisStreamLoaderDialog.class; // for i18n purposes, needed by Translator2!!
 
     private DorisStreamLoaderMeta input;
-
 
     private Label wlFenodes;
     private TextVar wFenodes;
@@ -116,6 +115,10 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
     private Label wlMaxRetries;
     private TextVar wMaxRetries;
     private FormData fdlMaxRetries, fdMaxRetries;
+
+    private Label wlDeletable;
+    private Button wDeletable;
+    private FormData fdlDeletable, fdDeletable;
 
     private Label wlReturn;
     private TableView wReturn;
@@ -347,7 +350,7 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
         wMaxRetries = new TextVar(transMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
         props.setLook(wMaxRetries);
         wMaxRetries.addModifyListener(lsMod);
-        wPassword.addFocusListener(lsFocusLost);
+        wMaxRetries.addFocusListener(lsFocusLost);
         fdMaxRetries = new FormData();
         fdMaxRetries.left = new FormAttachment(middle, 0);
         fdMaxRetries.right = new FormAttachment(100, 0);
@@ -374,6 +377,31 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
         fdStreamLoadProp.top = new FormAttachment(wMaxRetries, margin * 2);
         wStreamLoadProp.setLayoutData(fdStreamLoadProp);
 
+        //deletable line ...
+        wlDeletable = new Label(shell, SWT.RIGHT);
+        wlDeletable.setText(BaseMessages.getString(PKG, "DorisStreamLoaderDialog.Deletable.Label"));
+        props.setLook(wlDeletable);
+        fdlDeletable = new FormData();
+        fdlDeletable.left = new FormAttachment(0, 0);
+        fdlDeletable.right = new FormAttachment(middle, -margin);
+        fdlDeletable.top = new FormAttachment(wStreamLoadProp, margin * 2);
+        wlDeletable.setLayoutData(fdlDeletable);
+
+        wDeletable = new Button(shell, SWT.CHECK | SWT.LEFT);
+        props.setLook(wDeletable);
+        wDeletable.setSelection(false);
+        fdDeletable = new FormData();
+        fdDeletable.left = new FormAttachment(middle, 0);
+        fdDeletable.right = new FormAttachment(100, 0);
+        fdDeletable.top = new FormAttachment(wStreamLoadProp, margin * 2);
+        wDeletable.setLayoutData(fdDeletable);
+        wDeletable.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent selectionEvent) {
+                input.setChanged();
+            }
+        });
+
         // OK and cancel buttons
         wOK = new Button( shell, SWT.PUSH );
         wOK.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );
@@ -387,7 +415,7 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
         props.setLook(wlReturn);
         fdlReturn = new FormData();
         fdlReturn.left = new FormAttachment(0, 0);
-        fdlReturn.top = new FormAttachment(wStreamLoadProp, margin);
+        fdlReturn.top = new FormAttachment(wDeletable, margin);
         wlReturn.setLayoutData(fdlReturn);
 
         int UpInsCols = 2;
@@ -537,6 +565,7 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
         wBufferFlushMaxRows.setText(Const.NVL(String.valueOf(input.getBufferFlushMaxRows()),"50000"));
         wBufferFlushMaxBytes.setText(Const.NVL(String.valueOf(input.getBufferFlushMaxBytes()),"104857600"));
         wMaxRetries.setText(Const.NVL(String.valueOf(input.getMaxRetries()),"3"));
+        wDeletable.setSelection(input.isDeletable());
 
         if (input.getFieldTable() != null) {
             for (int i = 0; i < input.getFieldTable().length; i++) {
@@ -706,6 +735,7 @@ public class DorisStreamLoaderDialog extends BaseStepDialog implements StepDialo
         inf.setBufferFlushMaxBytes(Long.valueOf(wBufferFlushMaxBytes.getText()));
         inf.setMaxRetries(Integer.valueOf(wMaxRetries.getText()));
         inf.setStreamLoadProp(wStreamLoadProp.getText());
+        inf.setDeletable(wDeletable.getSelection());
 
         stepname = wStepname.getText();
 

--- a/extension/kettle/ui/src/main/resources/org/pentaho/di/ui/trans/steps/dorisstreamloader/messages/messages_en_US.properties
+++ b/extension/kettle/ui/src/main/resources/org/pentaho/di/ui/trans/steps/dorisstreamloader/messages/messages_en_US.properties
@@ -27,6 +27,7 @@ DorisStreamLoaderDialog.StreamLoadProp.Label=StreamLoad Properties
 DorisStreamLoaderDialog.BufferFlushMaxRows.Label=Maximum rows for load
 DorisStreamLoaderDialog.BufferFlushMaxBytes.Label=Maximum bytes for load
 DorisStreamLoaderDialog.MaxRetries.Label=Load retries
+DorisStreamLoaderDialog.Deletable.Label=Delete Mode
 DorisStreamLoaderDialog.Fields.Label=Fields to load\:
 DorisStreamLoaderDialog.ColumnInfo.TableField=Table field
 DorisStreamLoaderDialog.ColumnInfo.StreamField=Stream field

--- a/extension/kettle/ui/src/main/resources/org/pentaho/di/ui/trans/steps/dorisstreamloader/messages/messages_zh_CN.properties
+++ b/extension/kettle/ui/src/main/resources/org/pentaho/di/ui/trans/steps/dorisstreamloader/messages/messages_zh_CN.properties
@@ -27,6 +27,7 @@ DorisStreamLoaderDialog.StreamLoadProp.Label=Stream Load\u5c5e\u6027
 DorisStreamLoaderDialog.BufferFlushMaxRows.Label=\u5355\u6b21\u5bfc\u5165\u6700\u5927\u884c\u6570
 DorisStreamLoaderDialog.BufferFlushMaxBytes.Label=\u5355\u6b21\u5bfc\u5165\u6700\u5927\u5b57\u8282
 DorisStreamLoaderDialog.MaxRetries.Label=\u5bfc\u5165\u91cd\u8bd5\u6b21\u6570
+DorisStreamLoaderDialog.Deletable.Label=\u5220\u9664\u6a21\u5f0f
 DorisStreamLoaderDialog.Fields.Label=\u8981\u52a0\u8f7d\u7684\u5b57\u6bb5\:
 DorisStreamLoaderDialog.ColumnInfo.TableField=\u8868\u5b57\u6bb5
 DorisStreamLoaderDialog.ColumnInfo.StreamField=\u6d41\u5b57\u6bb5


### PR DESCRIPTION
### What problem does this PR solve?

The current Kettle component can only add new data. In some scenarios, it is necessary to delete upstream data, so a delete option is added.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (Currently, kettle plugin does not have automatic testing, which will be added later)
            1. mvn clean package -DskipTests to compile plugin
            2. Create a new job on the kettle platform
            3. Check the delete option
            4. Test whether the data is deleted
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/1347

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

