### PR TITLE
[fix](Nereids) fix new coordinator compute a wrong scanRangeNum

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -270,6 +270,17 @@ public class PlanChecker {
         return this;
     }
 
+    public NereidsPlanner plan(String sql) {
+        StatementContext statementContext = new StatementContext(connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        NereidsPlanner planner = new NereidsPlanner(statementContext);
+        LogicalPlan parsedPlan = new NereidsParser().parseSingle(sql);
+        LogicalPlanAdapter parsedPlanAdaptor = new LogicalPlanAdapter(parsedPlan, statementContext);
+        statementContext.setParsedStatement(parsedPlanAdaptor);
+        planner.planWithLock(parsedPlanAdaptor);
+        return planner;
+    }
+
     public PlanChecker dpHypOptimize() {
         double now = System.currentTimeMillis();
         cascadesContext.getStatementContext().setDpHyp(true);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.catalog.EnvFactory;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class NereidsCoordinatorTest extends TestWithFeService {
+    @BeforeAll
+    public void init() throws Exception {
+        FeConstants.runningUnitTest = true;
+
+        createDatabase("test");
+        useDatabase("test");
+
+        createTable("create table tbl(id int) distributed by hash(id) buckets 10 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testNereidsCoordinatorScanRangeNum() throws IOException {
+        NereidsPlanner planner = plan("select * from test.tbl");
+        NereidsCoordinator coordinator
+            = (NereidsCoordinator) EnvFactory.getInstance().createCoordinator(connectContext, null, planner, null);
+        int scanRangeNum = coordinator.getScanRangeNum();
+        Assertions.assertEquals(10, scanRangeNum);
+    }
+
+    @Test
+    public void testNereidsCoordinatorScanRangeNum2() throws IOException {
+        NereidsPlanner planner = plan("select * from information_schema.columns");
+        NereidsCoordinator coordinator
+            = (NereidsCoordinator) EnvFactory.getInstance().createCoordinator(connectContext, null, planner, null);
+        int scanRangeNum = coordinator.getScanRangeNum();
+        Assertions.assertEquals(0, scanRangeNum);
+    }
+
+    private NereidsPlanner plan(String sql) throws IOException {
+        ConnectContext connectContext = createDefaultCtx();
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION,OLAP_SCAN_TABLET_PRUNE");
+        connectContext.setThreadLocalInfo();
+
+        UUID uuid = UUID.randomUUID();
+        connectContext.setQueryId(new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
+        NereidsPlanner planner = PlanChecker.from(connectContext).plan(sql);
+        return planner;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
@@ -45,8 +45,8 @@ public class NereidsCoordinatorTest extends TestWithFeService {
     @Test
     public void testNereidsCoordinatorScanRangeNum() throws IOException {
         NereidsPlanner planner = plan("select * from test.tbl");
-        NereidsCoordinator coordinator
-            = (NereidsCoordinator) EnvFactory.getInstance().createCoordinator(connectContext, null, planner, null);
+        NereidsCoordinator coordinator = (NereidsCoordinator) EnvFactory.getInstance()
+                .createCoordinator(connectContext, null, planner, null);
         int scanRangeNum = coordinator.getScanRangeNum();
         Assertions.assertEquals(10, scanRangeNum);
     }
@@ -54,8 +54,8 @@ public class NereidsCoordinatorTest extends TestWithFeService {
     @Test
     public void testNereidsCoordinatorScanRangeNum2() throws IOException {
         NereidsPlanner planner = plan("select * from information_schema.columns");
-        NereidsCoordinator coordinator
-            = (NereidsCoordinator) EnvFactory.getInstance().createCoordinator(connectContext, null, planner, null);
+        NereidsCoordinator coordinator = (NereidsCoordinator) EnvFactory.getInstance()
+                .createCoordinator(connectContext, null, planner, null);
         int scanRangeNum = coordinator.getScanRangeNum();
         Assertions.assertEquals(0, scanRangeNum);
     }


### PR DESCRIPTION
### What problem does this PR solve?

fix new coordinator compute a wrong scanRangeNum, introduced by #41730

This bug will show a wrong progress in s3 load:
```
Progress: 0.00%(73/2147483647)
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

