### PR TITLE
[refactor](column) remove get_family_name interface in column

### DIFF
--- a/be/src/vec/columns/column.cpp
+++ b/be/src/vec/columns/column.cpp
@@ -30,7 +30,7 @@ namespace doris::vectorized {
 
 std::string IColumn::dump_structure() const {
     std::stringstream res;
-    res << get_family_name() << "(size = " << size();
+    res << get_name() << "(size = " << size();
 
     ColumnCallback callback = [&](ColumnPtr& subcolumn) {
         res << ", " << subcolumn->dump_structure();

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -88,10 +88,7 @@ public:
     using Offsets = PaddedPODArray<Offset>;
 
     /// Name of a Column. It is used in info messages.
-    virtual std::string get_name() const { return get_family_name(); }
-
-    /// Name of a Column kind, without parameters (example: FixedString, Array).
-    virtual const char* get_family_name() const = 0;
+    virtual std::string get_name() const = 0;
 
     /** If column isn't constant, returns nullptr (or itself).
       * If column is constant, transforms constant to full column (if column type allows such transform) and return it.
@@ -462,8 +459,7 @@ public:
       * For array/map/struct types, we compare with nested column element and offsets size
       */
     virtual int compare_at(size_t n, size_t m, const IColumn& rhs, int nan_direction_hint) const {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "compare_at for " + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "compare_at for " + get_name());
     }
 
     /**
@@ -485,7 +481,7 @@ public:
     virtual void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                                  Permutation& res) const {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_permutation for " + std::string(get_family_name()));
+                               "get_permutation for " + get_name());
     }
 
     /** Copies each element according offsets parameter.

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -119,7 +119,6 @@ public:
     using ColumnOffsets = ColumnVector<Offset64>;
 
     std::string get_name() const override;
-    const char* get_family_name() const override { return "Array"; }
     bool is_column_array() const override { return true; }
     bool is_variable_length() const override { return true; }
 

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -124,7 +124,7 @@ public:
 
     void resize(size_t n) override { data.resize(n); }
 
-    const char* get_family_name() const override { return TypeName<T>::get(); }
+    std::string get_name() const override { return TypeName<T>::get(); }
 
     MutableColumnPtr clone_resized(size_t size) const override;
 

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -121,8 +121,6 @@ public:
 
     std::string get_name() const override { return "Const(" + data->get_name() + ")"; }
 
-    const char* get_family_name() const override { return "Const"; }
-
     void resize(size_t new_size) override { s = new_size; }
 
     MutableColumnPtr clone_resized(size_t new_size) const override {

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -102,7 +102,7 @@ private:
     ColumnDecimal(const ColumnDecimal& src) : data(src.data), scale(src.scale) {}
 
 public:
-    const char* get_family_name() const override { return TypeName<T>::get(); }
+    std::string get_name() const override { return TypeName<T>::get(); }
 
     bool is_numeric() const override { return false; }
     bool is_column_decimal() const override { return true; }

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -122,7 +122,7 @@ public:
 
     void reserve(size_t n) override { _codes.reserve(n); }
 
-    const char* get_family_name() const override { return "ColumnDictionary"; }
+    std::string get_name() const override { return "ColumnDictionary"; }
 
     MutableColumnPtr clone_resized(size_t size) const override {
         DCHECK(size == 0);

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -49,7 +49,7 @@ private:
               _data(src._data.begin(), src._data.end()) {}
 
 public:
-    const char* get_family_name() const override { return "ColumnFixedLengthObject"; }
+    std::string get_name() const override { return "ColumnFixedLengthObject"; }
 
     size_t size() const override { return _item_count; }
 

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -77,7 +77,6 @@ public:
     }
 
     std::string get_name() const override;
-    const char* get_family_name() const override { return "Map"; }
 
     void for_each_subcolumn(ColumnCallback callback) override {
         callback(keys_column);

--- a/be/src/vec/columns/column_nothing.h
+++ b/be/src/vec/columns/column_nothing.h
@@ -40,7 +40,7 @@ private:
     void insert(const Field&) override { ++s; }
 
 public:
-    const char* get_family_name() const override { return "Nothing"; }
+    std::string get_name() const override { return "Nothing"; }
     MutableColumnPtr clone_dummy(size_t s_) const override { return ColumnNothing::create(s_); }
 
     bool structure_equals(const IColumn& rhs) const override {

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -147,7 +147,6 @@ public:
     bool could_shrinked_column() override;
     bool is_variable_length() const override { return nested_column->is_variable_length(); }
 
-    const char* get_family_name() const override { return "Nullable"; }
     std::string get_name() const override { return "Nullable(" + nested_column->get_name() + ")"; }
     MutableColumnPtr clone_resized(size_t size) const override;
     size_t size() const override {

--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -1935,7 +1935,7 @@ void ColumnObject::update_crc_with_value(size_t start, size_t end, uint32_t& has
 
 std::string ColumnObject::debug_string() const {
     std::stringstream res;
-    res << get_family_name() << "(num_row = " << num_rows;
+    res << get_name() << "(num_row = " << num_rows;
     for (auto& entry : subcolumns) {
         if (entry->data.is_finalized()) {
             res << "[column:" << entry->data.data[0]->dump_structure()
@@ -1952,8 +1952,8 @@ Status ColumnObject::sanitize() const {
     for (const auto& subcolumn : subcolumns) {
         if (subcolumn->data.is_finalized()) {
             auto column = subcolumn->data.get_least_common_type()->create_column();
-            std::string original = subcolumn->data.get_finalized_column().get_family_name();
-            std::string expected = column->get_family_name();
+            std::string original = subcolumn->data.get_finalized_column().get_name();
+            std::string expected = column->get_name();
             if (original != expected) {
                 return Status::InternalError("Incompatible type between {} and {}, debug_info:",
                                              original, expected, debug_string());

--- a/be/src/vec/columns/column_object.h
+++ b/be/src/vec/columns/column_object.h
@@ -373,13 +373,10 @@ public:
 
     std::string get_name() const override {
         if (is_scalar_variant()) {
-            return "var_scalar(" + get_root()->get_name() + ")";
+            return "variant_scalar(" + get_root()->get_name() + ")";
         }
         return "variant";
     }
-
-    /// Part of interface
-    const char* get_family_name() const override { return "Variant"; }
 
     size_t size() const override;
 
@@ -462,132 +459,121 @@ public:
     // Not implemented
     MutableColumnPtr get_shrinked_column() override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_shrinked_column" + std::string(get_family_name()));
+                               "get_shrinked_column" + get_name());
     }
 
     Int64 get_int(size_t /*n*/) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_int" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "get_int" + get_name());
     }
 
     bool get_bool(size_t /*n*/) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_bool" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "get_bool" + get_name());
     }
 
     void insert_many_fix_len_data(const char* pos, size_t num) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_many_fix_len_data" + std::string(get_family_name()));
+                               "insert_many_fix_len_data" + get_name());
     }
 
     void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict,
                                size_t data_num, uint32_t dict_num = 0) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_many_dict_data" + std::string(get_family_name()));
+                               "insert_many_dict_data" + get_name());
     }
 
     void insert_many_binary_data(char* data_array, uint32_t* len_array,
                                  uint32_t* start_offset_array, size_t num) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_many_binary_data" + std::string(get_family_name()));
+                               "insert_many_binary_data" + get_name());
     }
 
     void insert_many_continuous_binary_data(const char* data, const uint32_t* offsets,
                                             const size_t num) override {
-        throw doris::Exception(
-                ErrorCode::NOT_IMPLEMENTED_ERROR,
-                "insert_many_continuous_binary_data" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "insert_many_continuous_binary_data" + get_name());
     }
 
     void insert_many_strings(const StringRef* strings, size_t num) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_many_strings" + std::string(get_family_name()));
+                               "insert_many_strings" + get_name());
     }
 
     void insert_many_strings_overflow(const StringRef* strings, size_t num,
                                       size_t max_length) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_many_strings_overflow" + std::string(get_family_name()));
+                               "insert_many_strings_overflow" + get_name());
     }
 
     void insert_many_raw_data(const char* pos, size_t num) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_many_raw_data" + std::string(get_family_name()));
+                               "insert_many_raw_data" + get_name());
     }
 
     size_t get_max_row_byte_size() const override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_max_row_byte_size" + std::string(get_family_name()));
+                               "get_max_row_byte_size" + get_name());
     }
 
     void serialize_vec(std::vector<StringRef>& keys, size_t num_rows,
                        size_t max_row_byte_size) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "serialize_vec" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "serialize_vec" + get_name());
     }
 
     void serialize_vec_with_null_map(std::vector<StringRef>& keys, size_t num_rows,
                                      const uint8_t* null_map) const override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "serialize_vec_with_null_map" + std::string(get_family_name()));
+                               "serialize_vec_with_null_map" + get_name());
     }
 
     void deserialize_vec(std::vector<StringRef>& keys, const size_t num_rows) override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "deserialize_vec" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "deserialize_vec" + get_name());
     }
 
     void deserialize_vec_with_null_map(std::vector<StringRef>& keys, const size_t num_rows,
                                        const uint8_t* null_map) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "deserialize_vec_with_null_map" + std::string(get_family_name()));
+                               "deserialize_vec_with_null_map" + get_name());
     }
 
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) const {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "filter_by_selector" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "filter_by_selector" + get_name());
     }
 
     bool structure_equals(const IColumn&) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "structure_equals" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "structure_equals" + get_name());
     }
 
     StringRef get_raw_data() const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_raw_data" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "get_raw_data" + get_name());
     }
 
     size_t size_of_value_if_fixed() const override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "size_of_value_if_fixed" + std::string(get_family_name()));
+                               "size_of_value_if_fixed" + get_name());
     }
 
     StringRef get_data_at(size_t) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "get_data_at" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "get_data_at" + get_name());
     }
 
     StringRef serialize_value_into_arena(size_t n, Arena& arena,
                                          char const*& begin) const override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "serialize_value_into_arena" + std::string(get_family_name()));
+                               "serialize_value_into_arena" + get_name());
     }
 
     const char* deserialize_and_insert_from_arena(const char* pos) override {
-        throw doris::Exception(
-                ErrorCode::NOT_IMPLEMENTED_ERROR,
-                "deserialize_and_insert_from_arena" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "deserialize_and_insert_from_arena" + get_name());
     }
 
     void insert_data(const char* pos, size_t length) override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "insert_data" + std::string(get_family_name()));
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, "insert_data" + get_name());
     }
 
     void replace_column_data(const IColumn&, size_t row, size_t self_row) override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "replace_column_data" + std::string(get_family_name()));
+                               "replace_column_data" + get_name());
     }
 
 private:

--- a/be/src/vec/columns/column_set.h
+++ b/be/src/vec/columns/column_set.h
@@ -38,7 +38,7 @@ public:
     ColumnSet(size_t s_, const ConstSetPtr& data_) : data(data_) { s = s_; }
     ColumnSet(const ColumnSet&) = default;
 
-    const char* get_family_name() const override { return "Set"; }
+    std::string get_name() const override { return "Set"; }
     MutableColumnPtr clone_dummy(size_t s_) const override { return ColumnSet::create(s_, data); }
 
     ConstSetPtr get_data() const { return data; }

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -105,7 +105,7 @@ public:
     bool is_variable_length() const override { return true; }
     // used in string ut testd
     void sanity_check() const;
-    const char* get_family_name() const override { return "String"; }
+    std::string get_name() const override { return "String"; }
 
     size_t size() const override { return offsets.size(); }
 

--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -83,7 +83,6 @@ public:
 
     std::string get_name() const override;
     bool is_column_struct() const override { return true; }
-    const char* get_family_name() const override { return "Struct"; }
     MutableColumnPtr clone_empty() const override;
     MutableColumnPtr clone_resized(size_t size) const override;
     size_t size() const override { return columns.at(0)->size(); }

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -265,11 +265,6 @@ void ColumnVector<T>::get_permutation(bool reverse, size_t limit, int nan_direct
 }
 
 template <typename T>
-const char* ColumnVector<T>::get_family_name() const {
-    return TypeName<T>::get();
-}
-
-template <typename T>
 MutableColumnPtr ColumnVector<T>::clone_resized(size_t size) const {
     auto res = this->create();
     if constexpr (std::is_same_v<T, vectorized::Int64>) {

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -337,7 +337,7 @@ public:
 
     void resize(size_t n) override { data.resize(n); }
 
-    const char* get_family_name() const override;
+    std::string get_name() const override { return TypeName<T>::get(); }
 
     MutableColumnPtr clone_resized(size_t size) const override;
 

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -328,7 +328,7 @@ public:
 
     void reserve(size_t n) override { data.reserve(n); }
 
-    const char* get_family_name() const override { return TypeName<T>::get(); }
+    std::string get_name() const override { return TypeName<T>::get(); }
 
     MutableColumnPtr clone_resized(size_t size) const override {
         DCHECK(size == 0);

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -1387,7 +1387,7 @@ public:
                         fmt::format("unsupported nested array of type {} for function {}",
                                     is_column_nullable(array_column.get_data())
                                             ? array_column.get_data().get_name()
-                                            : array_column.get_data().get_family_name(),
+                                            : array_column.get_data().get_name(),
                                     get_name()));
             }
             // Concat string in array

--- a/be/src/vec/functions/match.cpp
+++ b/be/src/vec/functions/match.cpp
@@ -109,12 +109,11 @@ Status FunctionMatchBase::execute_impl(FunctionContext* context, Block& block,
     if (source_col->is_column_array()) {
         array_col = check_and_get_column<ColumnArray>(source_col.get());
         if (array_col && !array_col->get_data().is_column_string()) {
-            return Status::NotSupported(
-                    fmt::format("unsupported nested array of type {} for function {}",
-                                is_column_nullable(array_col->get_data())
-                                        ? array_col->get_data().get_name()
-                                        : array_col->get_data().get_family_name(),
-                                get_name()));
+            return Status::NotSupported(fmt::format(
+                    "unsupported nested array of type {} for function {}",
+                    is_column_nullable(array_col->get_data()) ? array_col->get_data().get_name()
+                                                              : array_col->get_data().get_name(),
+                    get_name()));
         }
 
         if (is_column_nullable(array_col->get_data())) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
```
    virtual std::string get_name() const { return get_family_name(); }
    virtual const char* get_family_name() const = 0;
```

   have two same function in column, now remove get_family_name interface


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

