### PR TITLE
[opt](nereids) enhance PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOneSide.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOneSide.java
@@ -76,7 +76,7 @@ public class PushDownAggThroughJoinOneSide implements RewriteRuleFactory {
                             return !funcs.isEmpty() && funcs.stream()
                                     .allMatch(f -> (f instanceof Min || f instanceof Max || f instanceof Sum
                                             || f instanceof Count && !f.isDistinct()
-                                            && f.child(0) instanceof Slot));
+                                            && (f.children().isEmpty() || f.child(0) instanceof Slot)));
                         })
                         .thenApply(ctx -> {
                             Set<Integer> enableNereidsRules = ctx.cascadesContext.getConnectContext()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOneSide.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOneSide.java
@@ -265,13 +265,7 @@ public class PushDownAggThroughJoinOneSide implements RewriteRuleFactory {
             newProjections.addAll(rightDifference);
             newAggChild = ((LogicalProject) agg.child()).withProjectsAndChild(newProjections, newJoin);
         }
-        // TODO: column prune project
-        LogicalAggregate<Plan> newAgg = agg.withAggOutputChild(newOutputExprs, newAggChild);
-        if (checkOutput(newAgg)) {
-            return newAgg;
-        } else {
-            return (LogicalAggregate<Plan>) agg;
-        }
+        return agg.withAggOutputChild(newOutputExprs, newAggChild);
     }
 
     private static Expression replaceAggFunc(AggregateFunction func, Slot inputSlot) {
@@ -279,26 +273,6 @@ public class PushDownAggThroughJoinOneSide implements RewriteRuleFactory {
             return new Sum(inputSlot);
         } else {
             return func.withChildren(inputSlot);
-        }
-    }
-
-    private static boolean checkOutput(LogicalAggregate agg) {
-        if (agg.child() instanceof LogicalProject) {
-            Set<Slot> joinOutputs = ((Plan) agg.child().child(0)).getOutputSet();
-            if (!joinOutputs.containsAll(((LogicalProject<?>) agg.child()).getInputSlots())) {
-                return false;
-            }
-            Set<Slot> projectOutputs = ((LogicalProject<?>) agg.child()).getOutputSet();
-            if (!projectOutputs.containsAll(agg.getInputSlots())) {
-                return false;
-            }
-            return true;
-        } else {
-            Set<Slot> joinOutputs = ((Plan) agg.child()).getOutputSet();
-            if (!joinOutputs.containsAll(agg.getInputSlots())) {
-                return false;
-            }
-            return true;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOneSide.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownAggThroughJoinOneSide.java
@@ -113,7 +113,6 @@ public class PushDownAggThroughJoinOneSide implements RewriteRuleFactory {
         );
     }
 
-
     /**
      * Push down Min/Max/Sum through join.
      */
@@ -121,8 +120,6 @@ public class PushDownAggThroughJoinOneSide implements RewriteRuleFactory {
             LogicalJoin<Plan, Plan> join, List<NamedExpression> projects) {
         List<Slot> leftOutput = join.left().getOutput();
         List<Slot> rightOutput = join.right().getOutput();
-
-
         Set<Slot> leftGroupBy = new HashSet<>();
         Set<Slot> rightGroupBy = new HashSet<>();
         for (Expression e : agg.getGroupByExpressions()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownMinMaxSumThroughJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownMinMaxSumThroughJoinTest.java
@@ -323,11 +323,11 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .printlnTree()
                 .matches(
-                        logicalAggregate(
-                                logicalJoin(
-                                        logicalOlapScan(),
+                        logicalJoin(
+                                logicalAggregate(
                                         logicalOlapScan()
-                                )
+                                ),
+                                logicalOlapScan()
                         )
                 );
     }
@@ -346,11 +346,9 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
-                        logicalAggregate(
-                                logicalJoin(
-                                        logicalOlapScan(),
-                                        logicalOlapScan()
-                                )
+                        logicalJoin(
+                                logicalAggregate(logicalOlapScan()),
+                                logicalAggregate(logicalOlapScan())
                         )
                 );
     }

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
@@ -1034,3 +1034,23 @@ Used:
 UnUsed: use_push_down_agg_through_join_one_side
 SyntaxError:
 
+-- !shape --
+PhysicalResultSink
+--PhysicalTopN[MERGE_SORT]
+----PhysicalTopN[LOCAL_SORT]
+------hashAgg[GLOBAL]
+--------hashAgg[LOCAL]
+----------hashJoin[INNER_JOIN] hashCondition=((dwd_tracking_sensor_init_tmp_ymd.dt = dw_user_b2c_tracking_info_tmp_ymd.dt) and (dwd_tracking_sensor_init_tmp_ymd.guid = dw_user_b2c_tracking_info_tmp_ymd.guid)) otherCondition=((dwd_tracking_sensor_init_tmp_ymd.dt >= substring(first_visit_time, 1, 10)))
+------------filter((dwd_tracking_sensor_init_tmp_ymd.dt = '2024-08-19') and (dwd_tracking_sensor_init_tmp_ymd.tracking_type = 'click'))
+--------------PhysicalOlapScan[dwd_tracking_sensor_init_tmp_ymd]
+------------filter((dw_user_b2c_tracking_info_tmp_ymd.dt = '2024-08-19'))
+--------------PhysicalOlapScan[dw_user_b2c_tracking_info_tmp_ymd]
+
+Hint log:
+Used:
+UnUsed: use_PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE
+SyntaxError:
+
+-- !agg_pushed --
+2	是	2024-08-19
+

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
@@ -1041,14 +1041,16 @@ PhysicalResultSink
 ------hashAgg[GLOBAL]
 --------hashAgg[LOCAL]
 ----------hashJoin[INNER_JOIN] hashCondition=((dwd_tracking_sensor_init_tmp_ymd.dt = dw_user_b2c_tracking_info_tmp_ymd.dt) and (dwd_tracking_sensor_init_tmp_ymd.guid = dw_user_b2c_tracking_info_tmp_ymd.guid)) otherCondition=((dwd_tracking_sensor_init_tmp_ymd.dt >= substring(first_visit_time, 1, 10)))
-------------filter((dwd_tracking_sensor_init_tmp_ymd.dt = '2024-08-19') and (dwd_tracking_sensor_init_tmp_ymd.tracking_type = 'click'))
---------------PhysicalOlapScan[dwd_tracking_sensor_init_tmp_ymd]
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------filter((dwd_tracking_sensor_init_tmp_ymd.dt = '2024-08-19') and (dwd_tracking_sensor_init_tmp_ymd.tracking_type = 'click'))
+------------------PhysicalOlapScan[dwd_tracking_sensor_init_tmp_ymd]
 ------------filter((dw_user_b2c_tracking_info_tmp_ymd.dt = '2024-08-19'))
 --------------PhysicalOlapScan[dw_user_b2c_tracking_info_tmp_ymd]
 
 Hint log:
-Used:
-UnUsed: use_PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE
+Used: use_PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE
+UnUsed:
 SyntaxError:
 
 -- !agg_pushed --

--- a/regression-test/suites/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.groovy
+++ b/regression-test/suites/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.groovy
@@ -426,4 +426,99 @@ suite("push_down_count_through_join_one_side") {
     qt_with_hint_groupby_pushdown_nested_queries """
         explain shape plan select /*+ USE_CBO_RULE(push_down_agg_through_join_one_side) */  count(*) from (select * from count_t_one_side where score > 20) t1 join (select * from count_t_one_side where id < 100) t2 on t1.id = t2.id group by t1.name;
     """
+
+    sql """
+    drop table if exists dw_user_b2c_tracking_info_tmp_ymd;
+    create table dw_user_b2c_tracking_info_tmp_ymd (
+        guid int,
+        dt varchar,
+        first_visit_time varchar
+    )Engine=Olap
+    DUPLICATE KEY(guid)
+    distributed by hash(dt) buckets 3
+    properties('replication_num' = '1');
+
+    insert into dw_user_b2c_tracking_info_tmp_ymd values (1, '2024-08-19', '2024-08-19');
+
+    drop table if exists dwd_tracking_sensor_init_tmp_ymd;
+    create table dwd_tracking_sensor_init_tmp_ymd (
+        guid int,
+        dt varchar,
+        tracking_type varchar
+    )Engine=Olap
+    DUPLICATE KEY(guid)
+    distributed by hash(dt) buckets 3
+    properties('replication_num' = '1');
+
+    insert into dwd_tracking_sensor_init_tmp_ymd values(1, '2024-08-19', 'click'), (1, '2024-08-19', 'click');
+    """
+    sql """ 
+    set ENABLE_NEREIDS_RULES = "PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE";
+    set disable_join_reorder=true;
+    """
+
+    qt_shape """
+    explain shape plan
+    SELECT /*+use_cbo_rule(PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE)*/
+        Count(*)                            AS accee593,
+       CASE
+         WHEN dwd_tracking_sensor_init_tmp_ymd.dt =
+              Substring(dw_user_b2c_tracking_info_tmp_ymd.first_visit_time, 1,
+              10) THEN
+         '是'
+         WHEN dwd_tracking_sensor_init_tmp_ymd.dt >
+              Substring(dw_user_b2c_tracking_info_tmp_ymd.first_visit_time, 1,
+              10) THEN
+         '否'
+         ELSE '-1'
+       end                                 AS a1302fb2,
+       dwd_tracking_sensor_init_tmp_ymd.dt AS ad466123
+    FROM   dwd_tracking_sensor_init_tmp_ymd
+        LEFT JOIN dw_user_b2c_tracking_info_tmp_ymd
+                ON dwd_tracking_sensor_init_tmp_ymd.guid =
+                    dw_user_b2c_tracking_info_tmp_ymd.guid
+                    AND dwd_tracking_sensor_init_tmp_ymd.dt =
+                        dw_user_b2c_tracking_info_tmp_ymd.dt
+    WHERE  dwd_tracking_sensor_init_tmp_ymd.dt = '2024-08-19'
+        AND dw_user_b2c_tracking_info_tmp_ymd.dt = '2024-08-19'
+        AND dwd_tracking_sensor_init_tmp_ymd.dt >=
+            Substring(dw_user_b2c_tracking_info_tmp_ymd.first_visit_time, 1, 10)
+        AND dwd_tracking_sensor_init_tmp_ymd.tracking_type = 'click'
+    GROUP  BY 2,
+            3
+    ORDER  BY 3 ASC
+    LIMIT  10000; 
+    """
+
+    qt_agg_pushed  """
+    SELECT /*+use_cbo_rule(PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE)*/
+        Count(*)                            AS accee593,
+       CASE
+         WHEN dwd_tracking_sensor_init_tmp_ymd.dt =
+              Substring(dw_user_b2c_tracking_info_tmp_ymd.first_visit_time, 1,
+              10) THEN
+         '是'
+         WHEN dwd_tracking_sensor_init_tmp_ymd.dt >
+              Substring(dw_user_b2c_tracking_info_tmp_ymd.first_visit_time, 1,
+              10) THEN
+         '否'
+         ELSE '-1'
+       end                                 AS a1302fb2,
+       dwd_tracking_sensor_init_tmp_ymd.dt AS ad466123
+    FROM   dwd_tracking_sensor_init_tmp_ymd
+        LEFT JOIN dw_user_b2c_tracking_info_tmp_ymd
+                ON dwd_tracking_sensor_init_tmp_ymd.guid =
+                    dw_user_b2c_tracking_info_tmp_ymd.guid
+                    AND dwd_tracking_sensor_init_tmp_ymd.dt =
+                        dw_user_b2c_tracking_info_tmp_ymd.dt
+    WHERE  dwd_tracking_sensor_init_tmp_ymd.dt = '2024-08-19'
+        AND dw_user_b2c_tracking_info_tmp_ymd.dt = '2024-08-19'
+        AND dwd_tracking_sensor_init_tmp_ymd.dt >=
+            Substring(dw_user_b2c_tracking_info_tmp_ymd.first_visit_time, 1, 10)
+        AND dwd_tracking_sensor_init_tmp_ymd.tracking_type = 'click'
+    GROUP  BY 2,
+            3
+    ORDER  BY 3 ASC
+    LIMIT  10000; 
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?
PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE has some restrictions

do not support count(*)
do not support join with other join conditions
do not support the project between agg and join that contains non-slot expressions
this pr removes above restrictions for pattern: agg-project-join
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

