### PR TITLE
[Fix](Variant) return NOT_FOUND if dict key not found in meta service

### DIFF
--- a/cloud/src/meta-service/meta_service_schema.cpp
+++ b/cloud/src/meta-service/meta_service_schema.cpp
@@ -326,13 +326,14 @@ void read_schema_dict(MetaServiceCode& code, std::string& msg, const std::string
     std::string column_dict_key = meta_schema_pb_dictionary_key({instance_id, index_id});
     ValueBuf dict_val;
     auto err = cloud::get(txn, column_dict_key, &dict_val);
-    if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to get dict, err=" << err << ", key = " << hex(column_dict_key);
         code = cast_as<ErrCategory::READ>(err);
         ss << "internal error, failed to get dict, err=" << err;
         msg = ss.str();
         return;
     }
-    if (err == TxnErrorCode::TXN_OK && !dict_val.to_pb(&dict)) [[unlikely]] {
+    if (!dict_val.to_pb(&dict)) [[unlikely]] {
         code = MetaServiceCode::PROTOBUF_PARSE_ERR;
         msg = "failed to parse SchemaCloudDictionary";
         return;


### PR DESCRIPTION
We should make sure the key exist if `read_schema_dict` other wise return NOT_FOUND to handle

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

