### PR TITLE
[fix](backup) fix concurrent releasesnapshot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -887,7 +887,7 @@ public class BackupJob extends AbstractJob {
                  localMetaInfoFilePath, localJobInfoFilePath, this);
     }
 
-    private void releaseSnapshots() {
+    private synchronized void releaseSnapshots() {
         if (snapshotInfos.isEmpty()) {
             return;
         }


### PR DESCRIPTION
Backup releasesnapshot gets error when cancel backup concurrently

### What problem does this PR solve?
```
2024-11-04 10:40:49,563 WARN (mysql-nio-pool-1|323) [StmtExecutor.handleDdlStmt():2871] DDL statement(CANCEL RESTORE FROM `partmore`;) process failed.
java.util.ConcurrentModificationException: null
        at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719) ~[?:?]
        at java.util.LinkedHashMap$LinkedValueIterator.next(LinkedHashMap.java:746) ~[?:?]
        at com.google.common.collect.StandardTable.size(StandardTable.java:124) ~[guava-32.1.2-jre.jar:?]
        at com.google.common.collect.HashBasedTable.size(HashBasedTable.java:49) ~[guava-32.1.2-jre.jar:?]
        at org.apache.doris.backup.RestoreJob.releaseSnapshots(RestoreJob.java:2122) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.backup.RestoreJob.cancelInternal(RestoreJob.java:2293) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.backup.RestoreJob.cancel(RestoreJob.java:2192) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.backup.BackupHandler.cancel(BackupHandler.java:683) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.cancelBackup(Env.java:4514) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:266) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2858) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:990) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:598) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:524) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:337) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:218) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:284) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:312) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:479) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

