### PR TITLE
[Bug](bitmap-filter) fix wrong type cast on BitmapFilterColumnPredicate::evaluate

### DIFF
--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -40,7 +40,7 @@ public:
                                 const std::shared_ptr<BitmapFilterFuncBase>& filter, int)
             : ColumnPredicate(column_id),
               _filter(filter),
-              _specific_filter(static_cast<SpecificFilter*>(_filter.get())) {}
+              _specific_filter(assert_cast<SpecificFilter*>(_filter.get())) {}
     ~BitmapFilterColumnPredicate() override = default;
 
     PredicateType type() const override { return PredicateType::BITMAP_FILTER; }
@@ -87,8 +87,7 @@ private:
 
         uint16_t new_size = 0;
         new_size = _specific_filter->find_fixed_len_olap_engine(
-                (char*)assert_cast<
-                        const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*>(&column)
+                (char*)assert_cast<const vectorized::ColumnVector<CppType>*>(&column)
                         ->get_data()
                         .data(),
                 null_map, sel, size);

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -87,7 +87,8 @@ private:
 
         uint16_t new_size = 0;
         new_size = _specific_filter->find_fixed_len_olap_engine(
-                (char*)assert_cast<const vectorized::ColumnVector<CppType>*>(&column)
+                (char*)assert_cast<
+                        const vectorized::PredicateColumnType<PredicateEvaluateType<T>>*>(&column)
                         ->get_data()
                         .data(),
                 null_map, sel, size);

--- a/be/test/olap/bitmap_filter_column_predicate_test.cpp
+++ b/be/test/olap/bitmap_filter_column_predicate_test.cpp
@@ -128,7 +128,7 @@ TEST_F(BitmapFilterColumnPredicateTest, evaluate_column) {
     bitmap_value.add_many(filter_values.data(), filter_values.size());
     filter->insert(&bitmap_value);
 
-    auto column = vectorized::ColumnInt32::create();
+    auto column = vectorized::PredicateColumnType<TYPE_INT>::create();
     column->insert_many_fix_len_data(reinterpret_cast<const char*>(values.data()), values.size());
 
     uint16_t* sel = new uint16_t[column->size()];
@@ -162,7 +162,7 @@ TEST_F(BitmapFilterColumnPredicateTest, evaluate_column_nullable) {
     bitmap_value.add_many(filter_values.data(), filter_values.size());
     filter->insert(&bitmap_value);
 
-    auto column = vectorized::ColumnInt32::create();
+    auto column = vectorized::PredicateColumnType<TYPE_INT>::create();
     column->insert_many_fix_len_data(reinterpret_cast<const char*>(values.data()), values.size());
     auto flag = vectorized::ColumnUInt8::create();
     flag->insert_many_defaults(column->size());


### PR DESCRIPTION
### What problem does this PR solve?
fix wrong type cast on BitmapFilterColumnPredicate::evaluate
![img_v3_02gj_453c524a-5330-4180-9169-9760edcd74eg](https://github.com/user-attachments/assets/2b8e1fa7-2568-4cd8-bd00-aa58d107796b)

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

