### PR TITLE
[fix](cloud-mow) fix compaction missed rows dcheck fail

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -780,7 +780,7 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
             input_rowsets, rowid_conversion, 0, version.second + 1, missed_rows.get(),
             location_map.get(), tablet_meta()->delete_bitmap(), output_rowset_delete_bitmap.get());
     if (missed_rows) {
-        std::size_t missed_rows_size = missed_rows->size();
+        missed_rows_size = missed_rows->size();
         if (!allow_delete_in_cumu_compaction) {
             if (compaction_type == ReaderType::READER_CUMULATIVE_COMPACTION &&
                 tablet_state() == TABLET_RUNNING) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #43633 

Problem Summary:

Introduced through the cherry-pick of #43633 
```
F20241113 03:01:36.481637 19123 cloud_tablet.cpp:818] Check failed: missed_rows->size() == missed_rows_size (9 vs. 0)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

