### PR TITLE
[chore](sink) `enable_parallel_result_sink` default value is changed to false

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1203,7 +1203,7 @@ public class SessionVariable implements Serializable, Writable {
     private boolean enableSyncRuntimeFilterSize = true;
 
     @VariableMgr.VarAttr(name = ENABLE_PARALLEL_RESULT_SINK, needForward = true, fuzzy = true)
-    private boolean enableParallelResultSink = true;
+    private boolean enableParallelResultSink = false;
 
     @VariableMgr.VarAttr(name = "sort_phase_num", fuzzy = true, needForward = true,
             description = {"如设置为1，则只生成1阶段sort，设置为2，则只生成2阶段sort，设置其它值，优化器根据代价选择sort类型",

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/AnotherDemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/AnotherDemoTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.planner.ExchangeNode;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
@@ -120,7 +121,8 @@ public class AnotherDemoTest {
         }
         // 5. query
         // TODO: we can not process real query for now. So it has to be a explain query
-        String queryStr = "explain select /*+ SET_VAR(disable_nereids_rules=PRUNE_EMPTY_PARTITION) */ * from db1.tbl1";
+        String queryStr = "explain select /*+ SET_VAR(disable_nereids_rules=PRUNE_EMPTY_PARTITION, "
+                + "enable_parallel_result_sink=true) */ * from db1.tbl1";
         StmtExecutor stmtExecutor = new StmtExecutor(ctx, queryStr);
         stmtExecutor.execute();
         Planner planner = stmtExecutor.planner();
@@ -129,5 +131,16 @@ public class AnotherDemoTest {
         PlanFragment fragment = fragments.get(0);
         Assert.assertTrue(fragment.getPlanRoot() instanceof OlapScanNode);
         Assert.assertEquals(0, fragment.getChildren().size());
+
+        queryStr = "explain select /*+ SET_VAR(disable_nereids_rules=PRUNE_EMPTY_PARTITION, "
+                + "enable_parallel_result_sink=false) */ * from db1.tbl1";
+        stmtExecutor = new StmtExecutor(ctx, queryStr);
+        stmtExecutor.execute();
+        planner = stmtExecutor.planner();
+        fragments = planner.getFragments();
+        Assert.assertEquals(2, fragments.size());
+        fragment = fragments.get(0);
+        Assert.assertTrue(fragment.getPlanRoot() instanceof ExchangeNode);
+        Assert.assertEquals(1, fragment.getChildren().size());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.planner.ExchangeNode;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
@@ -108,7 +109,8 @@ public class DemoTest extends TestWithFeService {
 
         // 7. query
         // TODO: we can not process real query for now. So it has to be a explain query
-        String queryStr = "explain select /*+ SET_VAR(disable_nereids_rules=PRUNE_EMPTY_PARTITION) */ * from db1.tbl1";
+        String queryStr = "explain select /*+ SET_VAR(disable_nereids_rules=PRUNE_EMPTY_PARTITION, "
+                + "enable_parallel_result_sink=true) */ * from db1.tbl1";
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, queryStr);
         stmtExecutor.execute();
         Planner planner = stmtExecutor.planner();
@@ -117,5 +119,16 @@ public class DemoTest extends TestWithFeService {
         PlanFragment fragment = fragments.get(0);
         Assertions.assertTrue(fragment.getPlanRoot() instanceof OlapScanNode);
         Assertions.assertEquals(0, fragment.getChildren().size());
+
+        queryStr = "explain select /*+ SET_VAR(disable_nereids_rules=PRUNE_EMPTY_PARTITION, "
+                + "enable_parallel_result_sink=false) */ * from db1.tbl1";
+        stmtExecutor = new StmtExecutor(connectContext, queryStr);
+        stmtExecutor.execute();
+        planner = stmtExecutor.planner();
+        fragments = planner.getFragments();
+        Assertions.assertEquals(2, fragments.size());
+        fragment = fragments.get(0);
+        Assertions.assertTrue(fragment.getPlanRoot() instanceof ExchangeNode);
+        Assertions.assertEquals(1, fragment.getChildren().size());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For most queries, result sink will not become a performance bottleneck, but the parallel result sink will increase the pressure of RPC between fe and be.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

