### PR TITLE
[fix](config) fe config sync_image_timeout_second should not be masterOnly

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2660,7 +2660,7 @@ public class Config extends ConfigBase {
     })
     public static boolean ignore_unknown_metadata_module = false;
 
-    @ConfField(mutable = true, masterOnly = true, description = {
+    @ConfField(mutable = true, description = {
             "从主节点同步image文件的超时时间，用户可根据${meta_dir}/image文件夹下面的image文件大小和节点间的网络环境调整，"
                     + "单位为秒，默认值300",
             "The timeout for FE Follower/Observer synchronizing an image file from the FE Master, can be adjusted by "


### PR DESCRIPTION
### What problem does this PR solve?
sync_image_timeout_second is for the follower，should not be  masterOnly

Issue Number: close #xxx

Related PR: #25768 

Problem Summary:

### Release note

