### PR TITLE
[fix](cloud-mow) tablet_id should use int64_t to avoid truncation problem when removing old delete bitmap

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1194,7 +1194,7 @@ void DeleteBitmap::remove_stale_delete_bitmap_from_queue(const std::vector<std::
     std::shared_lock l(stale_delete_bitmap_lock);
     //<rowset_id, start_version, end_version>
     std::vector<std::tuple<std::string, uint64_t, uint64_t>> to_delete;
-    auto tablet_id = -1;
+    int64_t tablet_id = -1;
     for (auto& version_str : vector) {
         auto it = _stale_delete_bitmap.find(version_str);
         if (it != _stale_delete_bitmap.end()) {


### PR DESCRIPTION
tablet_id is int64_t, use int32_t may have truncation problem, which will lead to send wrong tablet_id to ms, and do nothing on remove old delete bitmap
pick:https://github.com/apache/doris/pull/43956