### PR TITLE
[Improvement]add tip when check status type failed

### DIFF
--- a/be/test/common/status_test.cpp
+++ b/be/test/common/status_test.cpp
@@ -77,8 +77,16 @@ TEST_F(StatusTest, TStatusCodeWithStatus) {
             continue;
         }
         EXPECT_TRUE(tstatus_st.first < ErrorCode::MAX_ERROR_CODE_DEFINE_NUM);
-        EXPECT_TRUE(ErrorCode::error_states[tstatus_st.first].description.compare(
-                            tstatus_st.second) == 0);
+        bool ret = ErrorCode::error_states[tstatus_st.first].description.compare(
+                           tstatus_st.second) == 0;
+        if (!ret) {
+            std::cout << "ErrorCode::error_states's " << tstatus_st.first << " compare to "
+                      << tstatus_st.second
+                      << " failed. you need check whether TStatusCode defined in thrift "
+                         "is same with ERROR_CODES in status.h"
+                      << std::endl;
+        }
+        EXPECT_TRUE(ret);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Add tips when check TStatus failed.
```
ErrorCode::error_states's 47 compare to INVALID_JSON_PATH failed. you need check whether TStatusCode defined in thrift is same with ERROR_CODES in status.h
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

