### PR TITLE
[improvement](thrift) Limit max cached client size for BE thrift connection to master FE.

### DIFF
--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -72,7 +72,8 @@ MasterServerClient* MasterServerClient::instance() {
 
 MasterServerClient::MasterServerClient(const ClusterInfo* cluster_info)
         : _cluster_info(cluster_info),
-          _client_cache(std::make_unique<FrontendServiceClientCache>(config::max_master_fe_client_cache_size)) {
+          _client_cache(std::make_unique<FrontendServiceClientCache>(
+                  config::max_master_fe_client_cache_size)) {
     _client_cache->init_metrics("master_fe");
 }
 

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "common/status.h"
+#include "runtime/client_cache.h"
 
 namespace doris {
 class TConfirmUnusedRemoteFilesRequest;
@@ -67,6 +68,7 @@ private:
 
     // Not owner. Reference to the ExecEnv::_cluster_info
     const ClusterInfo* _cluster_info;
+    std::unique_ptr<FrontendServiceClientCache> _client_cache;
 };
 
 class AgentUtils {

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -710,6 +710,8 @@ DEFINE_mInt32(es_http_timeout_ms, "5000");
 // TODO(cmy): use different config to set different client cache if necessary.
 DEFINE_Int32(max_client_cache_size_per_host, "10");
 
+DEFINE_Int32(max_master_fe_client_cache_size, "10");
+
 // Dir to save files downloaded by SmallFileMgr
 DEFINE_String(small_file_dir, "${DORIS_HOME}/lib/small_file/");
 // path gc

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -750,6 +750,8 @@ DECLARE_mInt32(es_http_timeout_ms);
 // TODO(cmy): use different config to set different client cache if necessary.
 DECLARE_Int32(max_client_cache_size_per_host);
 
+DECLARE_Int32(max_master_fe_client_cache_size);
+
 // Dir to save files downloaded by SmallFileMgr
 DECLARE_String(small_file_dir);
 // path gc


### PR DESCRIPTION
### What problem does this PR solve?
- Avoid too many connections: limit max cached client size for BE thrift connection to master FE. Before this PR,  the thrift clients to master FE were always cached and never released.
- Add metrics for client numbers.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

