### PR TITLE
[opt](paimon)Optimize the display of splitstate to prevent too many splits

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -350,8 +350,20 @@ public class PaimonScanNode extends FileQueryScanNode {
 
         if (detailLevel == TExplainLevel.VERBOSE) {
             sb.append(prefix).append("PaimonSplitStats: \n");
-            for (SplitStat splitStat : splitStats) {
-                sb.append(String.format("%s  %s\n", prefix, splitStat));
+            int size = splitStats.size();
+            if (size <= 4) {
+                for (SplitStat splitStat : splitStats) {
+                    sb.append(String.format("%s  %s\n", prefix, splitStat));
+                }
+            } else {
+                for (int i = 0; i < 3; i++) {
+                    SplitStat splitStat = splitStats.get(i);
+                    sb.append(String.format("%s  %s\n", prefix, splitStat));
+                }
+                int other = size - 4;
+                sb.append(prefix).append("    ... other ").append(other).append(" files ...\n");
+                SplitStat split = splitStats.get(size - 1);
+                sb.append(String.format("%s  %s\n", prefix, split));
             }
         }
         return sb.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -361,7 +361,7 @@ public class PaimonScanNode extends FileQueryScanNode {
                     sb.append(String.format("%s  %s\n", prefix, splitStat));
                 }
                 int other = size - 4;
-                sb.append(prefix).append("    ... other ").append(other).append(" files ...\n");
+                sb.append(prefix).append("  ... other ").append(other).append(" paimon split stats ...\n");
                 SplitStat split = splitStats.get(size - 1);
                 sb.append(String.format("%s  %s\n", prefix, split));
             }

--- a/regression-test/suites/external_table_p0/paimon/paimon_tb_mix_format.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_tb_mix_format.groovy
@@ -52,7 +52,7 @@ suite("paimon_tb_mix_format", "p0,external,doris,external_docker,external_docker
 
         explain {
             sql("verbose select * from test_tb_mix_format")
-            contains("... other 16 files ...")
+            contains("... other 16 paimon split stats ...")
         }
     } finally {
         sql """set force_jni_scanner=false"""

--- a/regression-test/suites/external_table_p0/paimon/paimon_tb_mix_format.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_tb_mix_format.groovy
@@ -49,6 +49,11 @@ suite("paimon_tb_mix_format", "p0,external,doris,external_docker,external_docker
 
         sql """set force_jni_scanner=false"""
         qt_order """ select * from test_tb_mix_format order by par,id; """
+
+        explain {
+            sql("verbose select * from test_tb_mix_format")
+            contains("... other 16 files ...")
+        }
     } finally {
         sql """set force_jni_scanner=false"""
     }


### PR DESCRIPTION
### What problem does this PR solve?

When using `explain verbose`, the stat of the splits will be displayed. If there are too many splits, the display will be too redundant. 
Now a maximum of 4 items are displayed, and the rest are replaced by ellipsis.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

