### PR TITLE
[fix](mtmv) Fix materialized view not chosen by cbo when join is rewritten by materialized view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -111,7 +111,11 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                 aggMvBonus = rows > 1.0 ? 1.0 : rows * 0.5;
             }
         }
-        return CostV1.ofCpu(context.getSessionVariable(), rows - aggMvBonus);
+        double defaultFactor = 1D;
+        if (context.getSessionVariable() != null) {
+            defaultFactor = context.getSessionVariable().scanCostFactor;
+        }
+        return CostV1.ofCpu(context.getSessionVariable(), (rows - aggMvBonus) * defaultFactor);
     }
 
     private Set<Column> getColumnForRangePredicate(Set<Expression> expressions) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -113,52 +113,50 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         }
         double defaultFactor = 1D;
         if (context.getSessionVariable() != null) {
-            /**
-             * Such query as following:
-             *             SELECT
-             *               s_acctbal,
-             *               s_name,
-             *               n_name,
-             *               p_partkey,
-             *               p_mfgr,
-             *               s_address,
-             *               s_phone,
-             *               s_comment
-             *             FROM
-             *               part,
-             *               supplier,
-             *               partsupp,
-             *               nation,
-             *               region
-             *             WHERE
-             *               p_partkey = ps_partkey
-             *               AND s_suppkey = ps_suppkey
-             *               AND s_nationkey = n_nationkey
-             *               AND n_regionkey = r_regionkey
-             *               AND r_name = 'EUROPE';
-             *  If query can be rewritten by materialized view as following:
-             *             SELECT
-             *               s_acctbal,
-             *               s_name,
-             *               n_name,
-             *               p_partkey,
-             *               p_mfgr,
-             *               s_address,
-             *               s_phone,
-             *               s_comment
-             *             FROM
-             *               mv,
-             *               region
-             *             WHERE
-             *               p_partkey = ps_partkey
-             *               AND s_suppkey = ps_suppkey
-             *               AND p_size = 15
-             *               AND p_type LIKE '%BRASS'
-             *               AND s_nationkey = n_nationkey
-             *               AND n_regionkey = r_regionkey
-             *               AND r_name = 'EUROPE';
-             *  The cost of mv scan factor should be lower, becuase the rewrite has obvious benefit.
-             * */
+            //Such query as following:
+            //            SELECT
+            //              s_acctbal,
+            //              s_name,
+            //              n_name,
+            //              p_partkey,
+            //              p_mfgr,
+            //              s_address,
+            //              s_phone,
+            //              s_comment
+            //            FROM
+            //              part,
+            //              supplier,
+            //              partsupp,
+            //              nation,
+            //              region
+            //            WHERE
+            //              p_partkey = ps_partkey
+            //              AND s_suppkey = ps_suppkey
+            //              AND s_nationkey = n_nationkey
+            //              AND n_regionkey = r_regionkey
+            //              AND r_name = 'EUROPE';
+            // If query can be rewritten by materialized view as following:
+            //            SELECT
+            //              s_acctbal,
+            //              s_name,
+            //              n_name,
+            //              p_partkey,
+            //              p_mfgr,
+            //              s_address,
+            //              s_phone,
+            //              s_comment
+            //            FROM
+            //              mv,
+            //              region
+            //            WHERE
+            //              p_partkey = ps_partkey
+            //              AND s_suppkey = ps_suppkey
+            //              AND p_size = 15
+            //              AND p_type LIKE '%BRASS'
+            //              AND s_nationkey = n_nationkey
+            //              AND n_regionkey = r_regionkey
+            //              AND r_name = 'EUROPE';
+            // The cost of mv scan factor should be lower, because the rewrite has obvious benefit.
             defaultFactor = context.getSessionVariable().scanCostFactor;
         }
         return CostV1.ofCpu(context.getSessionVariable(), (rows - aggMvBonus) * defaultFactor);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -113,6 +113,52 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         }
         double defaultFactor = 1D;
         if (context.getSessionVariable() != null) {
+            /**
+             * Such query as following:
+             *             SELECT
+             *               s_acctbal,
+             *               s_name,
+             *               n_name,
+             *               p_partkey,
+             *               p_mfgr,
+             *               s_address,
+             *               s_phone,
+             *               s_comment
+             *             FROM
+             *               part,
+             *               supplier,
+             *               partsupp,
+             *               nation,
+             *               region
+             *             WHERE
+             *               p_partkey = ps_partkey
+             *               AND s_suppkey = ps_suppkey
+             *               AND s_nationkey = n_nationkey
+             *               AND n_regionkey = r_regionkey
+             *               AND r_name = 'EUROPE';
+             *  If query can be rewritten by materialized view as following:
+             *             SELECT
+             *               s_acctbal,
+             *               s_name,
+             *               n_name,
+             *               p_partkey,
+             *               p_mfgr,
+             *               s_address,
+             *               s_phone,
+             *               s_comment
+             *             FROM
+             *               mv,
+             *               region
+             *             WHERE
+             *               p_partkey = ps_partkey
+             *               AND s_suppkey = ps_suppkey
+             *               AND p_size = 15
+             *               AND p_type LIKE '%BRASS'
+             *               AND s_nationkey = n_nationkey
+             *               AND n_regionkey = r_regionkey
+             *               AND r_name = 'EUROPE';
+             *  The cost of mv scan factor should be lower, becuase the rewrite has obvious benefit.
+             * */
             defaultFactor = context.getSessionVariable().scanCostFactor;
         }
         return CostV1.ofCpu(context.getSessionVariable(), (rows - aggMvBonus) * defaultFactor);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2040,7 +2040,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_MATERIALIZED_VIEW_NEST_REWRITE, needForward = true,
             description = {"是否允许嵌套物化视图改写",
                     "Whether enable materialized view nest rewrite"})
-    public boolean enableMaterializedViewNestRewrite = true;
+    public boolean enableMaterializedViewNestRewrite = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SYNC_MV_COST_BASED_REWRITE, needForward = true,
             description = {"是否允许基于代价改写同步物化视图",

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1408,6 +1408,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = "filter_cost_factor", needForward = true)
     public double filterCostFactor = 0.0001;
 
+    @VariableMgr.VarAttr(name = "scan_cost_factor", needForward = true)
+    public double scanCostFactor = 0.0005;
+
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 
@@ -2037,7 +2040,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_MATERIALIZED_VIEW_NEST_REWRITE, needForward = true,
             description = {"是否允许嵌套物化视图改写",
                     "Whether enable materialized view nest rewrite"})
-    public boolean enableMaterializedViewNestRewrite = false;
+    public boolean enableMaterializedViewNestRewrite = true;
 
     @VariableMgr.VarAttr(name = ENABLE_SYNC_MV_COST_BASED_REWRITE, needForward = true,
             description = {"是否允许基于代价改写同步物化视图",

--- a/regression-test/data/nereids_rules_p0/mv/tpch/mv_tpch_test.out
+++ b/regression-test/data/nereids_rules_p0/mv/tpch/mv_tpch_test.out
@@ -11629,3 +11629,133 @@ Supplier#000000977	13
 30	87	646748.02
 31	87	647372.50
 
+-- !query23_before --
+-314.06	Supplier#000000510	ROMANIA	17242	15	LARGE ANODIZED BRASS	Manufacturer#4	VmXQl ,vY8JiEseo8Mv4zscvNCfsY	29-207-852-3454	 bold deposits. carefully even d	EUROPE
+-435.02	Supplier#000000295	UNITED KINGDOM	8036	15	MEDIUM PLATED BRASS	Manufacturer#4	gpm7fahY9j6YyTr Dozul	33-998-989-3147	en requests according to the 	EUROPE
+-820.89	Supplier#000000409	GERMANY	2156	15	LARGE ANODIZED BRASS	Manufacturer#5	LyXUYFz7aXrvy65kKAbTatGzGS,NDBcdtD	17-719-517-9836	y final, slow theodolites. furiously regular req	EUROPE
+-845.44	Supplier#000000704	ROMANIA	9926	15	PROMO ANODIZED BRASS	Manufacturer#5	hQvlBqbqqnA5Dgo1BffRBX78tkkRu	29-300-896-5991	ctions. carefully sly requ	EUROPE
+-942.73	Supplier#000000563	GERMANY	5797	15	LARGE POLISHED BRASS	Manufacturer#1	Rc7U1cRUhYs03JD	17-108-537-2691	slyly furiously final decoys; silent, special realms poach f	EUROPE
+-963.79	Supplier#000000065	RUSSIA	13275	15	SMALL ANODIZED BRASS	Manufacturer#4	BsAnHUmSFArppKrM	32-444-835-2434	l ideas wake carefully around the regular packages. furiously ruthless pinto bea	EUROPE
+1342.17	Supplier#000000384	GERMANY	13120	15	PROMO PLATED BRASS	Manufacturer#5	zMr51gtJ0Vu83Dk	17-554-428-8511	taphs cajole furiously blithely final 	EUROPE
+1381.97	Supplier#000000104	FRANCE	18103	15	STANDARD BURNISHED BRASS	Manufacturer#3	Dcl4yGrzqv3OPeRO49bKh78XmQEDR7PBXIs0m	16-434-972-6922	gular ideas. bravely bold deposits haggle through the carefully final deposits. slyly unusual idea	EUROPE
+165.76	Supplier#000000769	FRANCE	1015	15	MEDIUM BRUSHED BRASS	Manufacturer#4	ak2320fUkG	16-655-591-2134	ly ironic ideas. quickly ironic platelets hag	EUROPE
+167.56	Supplier#000000290	FRANCE	2037	15	PROMO PLATED BRASS	Manufacturer#1	6Bk06GVtwZaKqg01	16-675-286-5102	 the theodolites. ironic, ironic deposits above 	EUROPE
+2221.25	Supplier#000000771	ROMANIA	13981	15	ECONOMY POLISHED BRASS	Manufacturer#2	lwZ I15rq9kmZXUNhl	29-986-304-9006	nal foxes eat slyly about the fluffily permanent id	EUROPE
+2963.09	Supplier#000000840	ROMANIA	3080	15	STANDARD ANODIZED BRASS	Manufacturer#2	iYzUIypKhC0Y	29-781-337-5584	eep blithely regular dependencies. blithely regular platelets sublate alongside o	EUROPE
+2972.26	Supplier#000000016	RUSSIA	1015	15	MEDIUM BRUSHED BRASS	Manufacturer#4	YjP5C55zHDXL7LalK27zfQnwejdpin4AMpvh	32-822-502-4215	ously express ideas haggle quickly dugouts? fu	EUROPE
+3294.68	Supplier#000000350	GERMANY	4841	15	ECONOMY BURNISHED BRASS	Manufacturer#4	KIFxV73eovmwhh	17-113-181-4017	e slyly special foxes. furiously unusual deposits detect carefully carefully ruthless foxes. quick	EUROPE
+3526.53	Supplier#000000553	FRANCE	17018	15	MEDIUM BRUSHED BRASS	Manufacturer#3	a,liVofXbCJ	16-599-552-3755	lar dinos nag slyly brave	EUROPE
+3526.53	Supplier#000000553	FRANCE	8036	15	MEDIUM PLATED BRASS	Manufacturer#4	a,liVofXbCJ	16-599-552-3755	lar dinos nag slyly brave	EUROPE
+4315.15	Supplier#000000509	FRANCE	18972	15	LARGE ANODIZED BRASS	Manufacturer#2	SF7dR8V5pK	16-298-154-3365	ronic orbits are furiously across the requests. quickly express ideas across the special, bold	EUROPE
+4324.51	Supplier#000000957	UNITED KINGDOM	10956	15	ECONOMY POLISHED BRASS	Manufacturer#5	mSpFa,4jJ5R40k10YOvGEtl4KYjo	33-616-674-6155	hily after the fluffily regular dependencies. deposits nag regular, silent accounts. i	EUROPE
+4518.31	Supplier#000000149	FRANCE	18344	15	LARGE BRUSHED BRASS	Manufacturer#5	pVyWsjOidpHKp4NfKU4yLeym	16-660-553-2456	ts detect along the foxes. final Tiresias are. idly pending deposits haggle; even, blithe pin	EUROPE
+4586.49	Supplier#000000680	RUSSIA	5679	15	ECONOMY POLISHED BRASS	Manufacturer#3	UhvDfdEfJh,Qbe7VZb8uSGO2TU 0jEa6nXZXE	32-522-382-1620	 the regularly regular dependencies. carefully bold excuses under th	EUROPE
+4672.25	Supplier#000000239	RUSSIA	12238	15	STANDARD BRUSHED BRASS	Manufacturer#1	XO101kgHrJagK2FL1U6QCaTE ncCsMbeuTgK6o8	32-396-654-6826	arls wake furiously deposits. even, regular depen	EUROPE
+4680.75	Supplier#000000326	GERMANY	13325	15	ECONOMY PLATED BRASS	Manufacturer#1	9kFiCwhcBldg4xwm	17-390-604-7483	quests could use furiously across the ironic, even f	EUROPE
+4941.88	Supplier#000000321	ROMANIA	7320	15	SMALL ANODIZED BRASS	Manufacturer#5	pLngFl5yeMcHyov	29-573-279-1406	y final requests impress s	EUROPE
+5069.27	Supplier#000000328	GERMANY	16327	15	LARGE BRUSHED BRASS	Manufacturer#1	SMm24d WG62	17-231-513-5721	he unusual ideas. slyly final packages a	EUROPE
+5322.35	Supplier#000000587	GERMANY	3080	15	STANDARD ANODIZED BRASS	Manufacturer#2	58,gb EuMperMCg2lv XUQ9vi4GzhO2a	17-128-699-9949	thin pinto beans boost silently. ruthless deposits haggle quickly above the slyly unusual th	EUROPE
+5364.99	Supplier#000000785	RUSSIA	13784	15	ECONOMY ANODIZED BRASS	Manufacturer#4	W VkHBpQyD3qjQjWGpWicOpmILFehmEdWy67kUGY	32-297-653-2203	 packages boost carefully. express ideas along	EUROPE
+5408.07	Supplier#000000623	GERMANY	6854	15	ECONOMY BRUSHED BRASS	Manufacturer#4	dSSQ3dTYwThbLppbetVUeuPfBIUF	17-593-337-7365	ial frays use. carefully special foxes wake carefully slyly pending deposits-- final requests a	EUROPE
+5733.61	Supplier#000000121	FRANCE	13120	15	PROMO PLATED BRASS	Manufacturer#5	CWGri,tKI 7gDcDsI	16-275-849-2485	against the ironic, permanent pinto beans. doggedly pending deposits sleep agai	EUROPE
+6173.87	Supplier#000000408	RUSSIA	18139	15	PROMO BRUSHED BRASS	Manufacturer#1	qcor1u,vJXAokjnL5,dilyYNmh	32-858-724-2950	blithely pending packages cajole furiously slyly pending notornis. slyly final 	EUROPE
+6177.35	Supplier#000000053	GERMANY	5797	15	LARGE POLISHED BRASS	Manufacturer#1	i9v3 EsYCfLKFU6PIt8iihBOHBB37yR7b3GD7Rt	17-886-101-6083	onic, special deposits wake furio	EUROPE
+6329.90	Supplier#000000996	GERMANY	10735	15	ECONOMY ANODIZED BRASS	Manufacturer#2	Wx4dQwOAwWjfSCGupfrM	17-447-811-3282	 ironic forges cajole blithely agai	EUROPE
+6721.70	Supplier#000000954	FRANCE	4191	15	ECONOMY BURNISHED BRASS	Manufacturer#3	P3O5p UFz1QsLmZX	16-537-341-8517	ect blithely blithely final acco	EUROPE
+6820.35	Supplier#000000007	UNITED KINGDOM	13217	15	MEDIUM BURNISHED BRASS	Manufacturer#5	s,4TicNGB4uO6PaSqNBUq	33-990-965-2201	s unwind silently furiously regular courts. final requests are deposits. requests wake quietly blit	EUROPE
+683.07	Supplier#000000651	RUSSIA	4888	15	SMALL BRUSHED BRASS	Manufacturer#4	oWekiBV6s,1g	32-181-426-4490	ly regular requests cajole abou	EUROPE
+704.83	Supplier#000000323	RUSSIA	3563	15	MEDIUM PLATED BRASS	Manufacturer#1	0LEOmcTTomY1F0y	32-563-275-6438	accounts. unusual requests haggle slyly special packages. always silent instructions e	EUROPE
+7144.78	Supplier#000000276	FRANCE	13275	15	SMALL ANODIZED BRASS	Manufacturer#4	KdVDs6EGfWVsPdjuCh9iep	16-752-344-8255	cial, ironic theodolites against the decoys cajole slyly ironic foxes. carefull	EUROPE
+7205.20	Supplier#000000477	GERMANY	10956	15	ECONOMY POLISHED BRASS	Manufacturer#5	VtaNKN5Mqui5yh7j2ldd5waf	17-180-144-7991	 excuses wake express deposits. furiously careful asymptotes according to the carefull	EUROPE
+727.89	Supplier#000000470	ROMANIA	6213	15	MEDIUM ANODIZED BRASS	Manufacturer#3	XckbzsAgBLbUkdfjgJEPjmUMTM8ebSMEvI	29-165-289-1523	gular excuses. furiously regular excuses sleep slyly caref	EUROPE
+7392.78	Supplier#000000170	UNITED KINGDOM	7655	15	PROMO ANODIZED BRASS	Manufacturer#2	RtsXQ,SunkA XHy9	33-803-340-5398	ake carefully across the quickly	EUROPE
+7431.00	Supplier#000000311	RUSSIA	13784	15	ECONOMY ANODIZED BRASS	Manufacturer#4	yjGDnCKi4Wmtim H3n9p	32-445-679-8585	uriously final requests integrate. sheaves against the furiously final accounts are evenly abo	EUROPE
+7448.46	Supplier#000000690	ROMANIA	9430	15	ECONOMY PLATED BRASS	Manufacturer#2	nK6Lv WWUh59jE525	29-330-952-4018	nic pinto beans doubt blithely b	EUROPE
+747.88	Supplier#000000243	FRANCE	17242	15	LARGE ANODIZED BRASS	Manufacturer#4	8aQ3HGeOXxgYeMAXZQe B5y2RKEF5jdmN3Qb	16-554-376-5494	kly silent requests among the blithely regular foxes use fu	EUROPE
+765.69	Supplier#000000799	RUSSIA	11276	15	SMALL ANODIZED BRASS	Manufacturer#2	jwFN7ZB3T9sMF	32-579-339-1495	nusual requests. furiously unusual epitaphs integrate. slyly 	EUROPE
+8069.74	Supplier#000000656	ROMANIA	7655	15	PROMO ANODIZED BRASS	Manufacturer#2	mQXqRMgstvOI	29-633-362-8481	ronic packages integrate. even excuses integrate carefully ruthlessly bold packages. regular ideas a	EUROPE
+8096.98	Supplier#000000574	RUSSIA	13784	15	ECONOMY ANODIZED BRASS	Manufacturer#4	2O8 sy9g2mlBOuEjzj0pA2pevk,	32-866-246-8752	ully after the regular requests. slyly final dependencies wake slyly along the busy deposit	EUROPE
+8096.98	Supplier#000000574	RUSSIA	323	15	MEDIUM BRUSHED BRASS	Manufacturer#4	2O8 sy9g2mlBOuEjzj0pA2pevk,	32-866-246-8752	ully after the regular requests. slyly final dependencies wake slyly along the busy deposit	EUROPE
+8271.39	Supplier#000000146	RUSSIA	4637	15	SMALL BURNISHED BRASS	Manufacturer#5	rBDNgCr04x0sfdzD5,gFOutCiG2	32-792-619-3155	s cajole quickly special requests. quickly enticing theodolites h	EUROPE
+8430.52	Supplier#000000646	FRANCE	11384	15	STANDARD POLISHED BRASS	Manufacturer#3	IUzsmT,2oBgjhWP2TlXTL6IkJH,4h,1SJRt	16-601-220-5489	ites among the always final ideas kindle according to the theodolites. notornis in	EUROPE
+8488.53	Supplier#000000367	RUSSIA	6854	15	ECONOMY BRUSHED BRASS	Manufacturer#4	E Sv9brQVf43Mzz	32-458-198-9557	ages. carefully final excuses nag finally. carefully ironic deposits abov	EUROPE
+8615.50	Supplier#000000812	FRANCE	10551	15	STANDARD BRUSHED BRASS	Manufacturer#2	8qh4tezyScl5bidLAysvutB,,ZI2dn6xP	16-585-724-6633	y quickly regular deposits? quickly pending packages after the caref	EUROPE
+8615.50	Supplier#000000812	FRANCE	13811	15	STANDARD BURNISHED BRASS	Manufacturer#4	8qh4tezyScl5bidLAysvutB,,ZI2dn6xP	16-585-724-6633	y quickly regular deposits? quickly pending packages after the caref	EUROPE
+8702.02	Supplier#000000333	RUSSIA	11810	15	MEDIUM ANODIZED BRASS	Manufacturer#3	MaVf XgwPdkiX4nfJGOis8Uu2zKiIZH	32-508-202-6136	oss the deposits cajole carefully even pinto beans. regular foxes detect alo	EUROPE
+9032.15	Supplier#000000959	GERMANY	4958	15	STANDARD BRUSHED BRASS	Manufacturer#4	8grA EHBnwOZhO	17-108-642-3106	nding dependencies nag furiou	EUROPE
+906.07	Supplier#000000138	ROMANIA	8363	15	SMALL BURNISHED BRASS	Manufacturer#4	utbplAm g7RmxVfYoNdhcrQGWuzRqPe0qHSwbKw	29-533-434-6776	ickly unusual requests cajole. accounts above the furiously special excuses 	EUROPE
+91.39	Supplier#000000949	UNITED KINGDOM	9430	15	ECONOMY PLATED BRASS	Manufacturer#2	a,UE,6nRVl2fCphkOoetR1ajIzAEJ1Aa1G1HV	33-332-697-2768	pinto beans. carefully express requests hagg	EUROPE
+9192.10	Supplier#000000115	UNITED KINGDOM	13325	15	ECONOMY PLATED BRASS	Manufacturer#1	nJ 2t0f7Ve,wL1,6WzGBJLNBUCKlsV	33-597-248-1220	es across the carefully express accounts boost caref	EUROPE
+9198.31	Supplier#000000025	RUSSIA	12238	15	STANDARD BRUSHED BRASS	Manufacturer#1	RCQKONXMFnrodzz6w7fObFVV6CUm2q	32-431-945-3541	ely regular deposits. carefully regular sauternes engage furiously above the regular accounts. idly 	EUROPE
+9453.01	Supplier#000000802	ROMANIA	10021	15	SMALL BRUSHED BRASS	Manufacturer#5	,6HYXb4uaHITmtMBj4Ak57Pd	29-342-882-6463	gular frets. permanently special multipliers believe blithely alongs	EUROPE
+9453.01	Supplier#000000802	ROMANIA	13275	15	SMALL ANODIZED BRASS	Manufacturer#4	,6HYXb4uaHITmtMBj4Ak57Pd	29-342-882-6463	gular frets. permanently special multipliers believe blithely alongs	EUROPE
+9508.37	Supplier#000000070	FRANCE	17268	15	ECONOMY PLATED BRASS	Manufacturer#4	INWNH2w,OOWgNDq0BRCcBwOMQc6PdFDc4	16-821-608-1166	ests sleep quickly express ideas. ironic ideas haggle about the final T	EUROPE
+9508.37	Supplier#000000070	FRANCE	3563	15	MEDIUM PLATED BRASS	Manufacturer#1	INWNH2w,OOWgNDq0BRCcBwOMQc6PdFDc4	16-821-608-1166	ests sleep quickly express ideas. ironic ideas haggle about the final T	EUROPE
+9759.38	Supplier#000000044	GERMANY	17242	15	LARGE ANODIZED BRASS	Manufacturer#4	kERxlLDnlIZJdN66zAPHklyL	17-713-930-5667	x. carefully quiet account	EUROPE
+9828.21	Supplier#000000647	UNITED KINGDOM	13120	15	PROMO PLATED BRASS	Manufacturer#5	x5U7MBZmwfG9	33-258-202-4782	s the slyly even ideas poach fluffily 	EUROPE
+
+-- !query23_after --
+-314.06	Supplier#000000510	ROMANIA	17242	15	LARGE ANODIZED BRASS	Manufacturer#4	VmXQl ,vY8JiEseo8Mv4zscvNCfsY	29-207-852-3454	 bold deposits. carefully even d	EUROPE
+-435.02	Supplier#000000295	UNITED KINGDOM	8036	15	MEDIUM PLATED BRASS	Manufacturer#4	gpm7fahY9j6YyTr Dozul	33-998-989-3147	en requests according to the 	EUROPE
+-820.89	Supplier#000000409	GERMANY	2156	15	LARGE ANODIZED BRASS	Manufacturer#5	LyXUYFz7aXrvy65kKAbTatGzGS,NDBcdtD	17-719-517-9836	y final, slow theodolites. furiously regular req	EUROPE
+-845.44	Supplier#000000704	ROMANIA	9926	15	PROMO ANODIZED BRASS	Manufacturer#5	hQvlBqbqqnA5Dgo1BffRBX78tkkRu	29-300-896-5991	ctions. carefully sly requ	EUROPE
+-942.73	Supplier#000000563	GERMANY	5797	15	LARGE POLISHED BRASS	Manufacturer#1	Rc7U1cRUhYs03JD	17-108-537-2691	slyly furiously final decoys; silent, special realms poach f	EUROPE
+-963.79	Supplier#000000065	RUSSIA	13275	15	SMALL ANODIZED BRASS	Manufacturer#4	BsAnHUmSFArppKrM	32-444-835-2434	l ideas wake carefully around the regular packages. furiously ruthless pinto bea	EUROPE
+1342.17	Supplier#000000384	GERMANY	13120	15	PROMO PLATED BRASS	Manufacturer#5	zMr51gtJ0Vu83Dk	17-554-428-8511	taphs cajole furiously blithely final 	EUROPE
+1381.97	Supplier#000000104	FRANCE	18103	15	STANDARD BURNISHED BRASS	Manufacturer#3	Dcl4yGrzqv3OPeRO49bKh78XmQEDR7PBXIs0m	16-434-972-6922	gular ideas. bravely bold deposits haggle through the carefully final deposits. slyly unusual idea	EUROPE
+165.76	Supplier#000000769	FRANCE	1015	15	MEDIUM BRUSHED BRASS	Manufacturer#4	ak2320fUkG	16-655-591-2134	ly ironic ideas. quickly ironic platelets hag	EUROPE
+167.56	Supplier#000000290	FRANCE	2037	15	PROMO PLATED BRASS	Manufacturer#1	6Bk06GVtwZaKqg01	16-675-286-5102	 the theodolites. ironic, ironic deposits above 	EUROPE
+2221.25	Supplier#000000771	ROMANIA	13981	15	ECONOMY POLISHED BRASS	Manufacturer#2	lwZ I15rq9kmZXUNhl	29-986-304-9006	nal foxes eat slyly about the fluffily permanent id	EUROPE
+2963.09	Supplier#000000840	ROMANIA	3080	15	STANDARD ANODIZED BRASS	Manufacturer#2	iYzUIypKhC0Y	29-781-337-5584	eep blithely regular dependencies. blithely regular platelets sublate alongside o	EUROPE
+2972.26	Supplier#000000016	RUSSIA	1015	15	MEDIUM BRUSHED BRASS	Manufacturer#4	YjP5C55zHDXL7LalK27zfQnwejdpin4AMpvh	32-822-502-4215	ously express ideas haggle quickly dugouts? fu	EUROPE
+3294.68	Supplier#000000350	GERMANY	4841	15	ECONOMY BURNISHED BRASS	Manufacturer#4	KIFxV73eovmwhh	17-113-181-4017	e slyly special foxes. furiously unusual deposits detect carefully carefully ruthless foxes. quick	EUROPE
+3526.53	Supplier#000000553	FRANCE	17018	15	MEDIUM BRUSHED BRASS	Manufacturer#3	a,liVofXbCJ	16-599-552-3755	lar dinos nag slyly brave	EUROPE
+3526.53	Supplier#000000553	FRANCE	8036	15	MEDIUM PLATED BRASS	Manufacturer#4	a,liVofXbCJ	16-599-552-3755	lar dinos nag slyly brave	EUROPE
+4315.15	Supplier#000000509	FRANCE	18972	15	LARGE ANODIZED BRASS	Manufacturer#2	SF7dR8V5pK	16-298-154-3365	ronic orbits are furiously across the requests. quickly express ideas across the special, bold	EUROPE
+4324.51	Supplier#000000957	UNITED KINGDOM	10956	15	ECONOMY POLISHED BRASS	Manufacturer#5	mSpFa,4jJ5R40k10YOvGEtl4KYjo	33-616-674-6155	hily after the fluffily regular dependencies. deposits nag regular, silent accounts. i	EUROPE
+4518.31	Supplier#000000149	FRANCE	18344	15	LARGE BRUSHED BRASS	Manufacturer#5	pVyWsjOidpHKp4NfKU4yLeym	16-660-553-2456	ts detect along the foxes. final Tiresias are. idly pending deposits haggle; even, blithe pin	EUROPE
+4586.49	Supplier#000000680	RUSSIA	5679	15	ECONOMY POLISHED BRASS	Manufacturer#3	UhvDfdEfJh,Qbe7VZb8uSGO2TU 0jEa6nXZXE	32-522-382-1620	 the regularly regular dependencies. carefully bold excuses under th	EUROPE
+4672.25	Supplier#000000239	RUSSIA	12238	15	STANDARD BRUSHED BRASS	Manufacturer#1	XO101kgHrJagK2FL1U6QCaTE ncCsMbeuTgK6o8	32-396-654-6826	arls wake furiously deposits. even, regular depen	EUROPE
+4680.75	Supplier#000000326	GERMANY	13325	15	ECONOMY PLATED BRASS	Manufacturer#1	9kFiCwhcBldg4xwm	17-390-604-7483	quests could use furiously across the ironic, even f	EUROPE
+4941.88	Supplier#000000321	ROMANIA	7320	15	SMALL ANODIZED BRASS	Manufacturer#5	pLngFl5yeMcHyov	29-573-279-1406	y final requests impress s	EUROPE
+5069.27	Supplier#000000328	GERMANY	16327	15	LARGE BRUSHED BRASS	Manufacturer#1	SMm24d WG62	17-231-513-5721	he unusual ideas. slyly final packages a	EUROPE
+5322.35	Supplier#000000587	GERMANY	3080	15	STANDARD ANODIZED BRASS	Manufacturer#2	58,gb EuMperMCg2lv XUQ9vi4GzhO2a	17-128-699-9949	thin pinto beans boost silently. ruthless deposits haggle quickly above the slyly unusual th	EUROPE
+5364.99	Supplier#000000785	RUSSIA	13784	15	ECONOMY ANODIZED BRASS	Manufacturer#4	W VkHBpQyD3qjQjWGpWicOpmILFehmEdWy67kUGY	32-297-653-2203	 packages boost carefully. express ideas along	EUROPE
+5408.07	Supplier#000000623	GERMANY	6854	15	ECONOMY BRUSHED BRASS	Manufacturer#4	dSSQ3dTYwThbLppbetVUeuPfBIUF	17-593-337-7365	ial frays use. carefully special foxes wake carefully slyly pending deposits-- final requests a	EUROPE
+5733.61	Supplier#000000121	FRANCE	13120	15	PROMO PLATED BRASS	Manufacturer#5	CWGri,tKI 7gDcDsI	16-275-849-2485	against the ironic, permanent pinto beans. doggedly pending deposits sleep agai	EUROPE
+6173.87	Supplier#000000408	RUSSIA	18139	15	PROMO BRUSHED BRASS	Manufacturer#1	qcor1u,vJXAokjnL5,dilyYNmh	32-858-724-2950	blithely pending packages cajole furiously slyly pending notornis. slyly final 	EUROPE
+6177.35	Supplier#000000053	GERMANY	5797	15	LARGE POLISHED BRASS	Manufacturer#1	i9v3 EsYCfLKFU6PIt8iihBOHBB37yR7b3GD7Rt	17-886-101-6083	onic, special deposits wake furio	EUROPE
+6329.90	Supplier#000000996	GERMANY	10735	15	ECONOMY ANODIZED BRASS	Manufacturer#2	Wx4dQwOAwWjfSCGupfrM	17-447-811-3282	 ironic forges cajole blithely agai	EUROPE
+6721.70	Supplier#000000954	FRANCE	4191	15	ECONOMY BURNISHED BRASS	Manufacturer#3	P3O5p UFz1QsLmZX	16-537-341-8517	ect blithely blithely final acco	EUROPE
+6820.35	Supplier#000000007	UNITED KINGDOM	13217	15	MEDIUM BURNISHED BRASS	Manufacturer#5	s,4TicNGB4uO6PaSqNBUq	33-990-965-2201	s unwind silently furiously regular courts. final requests are deposits. requests wake quietly blit	EUROPE
+683.07	Supplier#000000651	RUSSIA	4888	15	SMALL BRUSHED BRASS	Manufacturer#4	oWekiBV6s,1g	32-181-426-4490	ly regular requests cajole abou	EUROPE
+704.83	Supplier#000000323	RUSSIA	3563	15	MEDIUM PLATED BRASS	Manufacturer#1	0LEOmcTTomY1F0y	32-563-275-6438	accounts. unusual requests haggle slyly special packages. always silent instructions e	EUROPE
+7144.78	Supplier#000000276	FRANCE	13275	15	SMALL ANODIZED BRASS	Manufacturer#4	KdVDs6EGfWVsPdjuCh9iep	16-752-344-8255	cial, ironic theodolites against the decoys cajole slyly ironic foxes. carefull	EUROPE
+7205.20	Supplier#000000477	GERMANY	10956	15	ECONOMY POLISHED BRASS	Manufacturer#5	VtaNKN5Mqui5yh7j2ldd5waf	17-180-144-7991	 excuses wake express deposits. furiously careful asymptotes according to the carefull	EUROPE
+727.89	Supplier#000000470	ROMANIA	6213	15	MEDIUM ANODIZED BRASS	Manufacturer#3	XckbzsAgBLbUkdfjgJEPjmUMTM8ebSMEvI	29-165-289-1523	gular excuses. furiously regular excuses sleep slyly caref	EUROPE
+7392.78	Supplier#000000170	UNITED KINGDOM	7655	15	PROMO ANODIZED BRASS	Manufacturer#2	RtsXQ,SunkA XHy9	33-803-340-5398	ake carefully across the quickly	EUROPE
+7431.00	Supplier#000000311	RUSSIA	13784	15	ECONOMY ANODIZED BRASS	Manufacturer#4	yjGDnCKi4Wmtim H3n9p	32-445-679-8585	uriously final requests integrate. sheaves against the furiously final accounts are evenly abo	EUROPE
+7448.46	Supplier#000000690	ROMANIA	9430	15	ECONOMY PLATED BRASS	Manufacturer#2	nK6Lv WWUh59jE525	29-330-952-4018	nic pinto beans doubt blithely b	EUROPE
+747.88	Supplier#000000243	FRANCE	17242	15	LARGE ANODIZED BRASS	Manufacturer#4	8aQ3HGeOXxgYeMAXZQe B5y2RKEF5jdmN3Qb	16-554-376-5494	kly silent requests among the blithely regular foxes use fu	EUROPE
+765.69	Supplier#000000799	RUSSIA	11276	15	SMALL ANODIZED BRASS	Manufacturer#2	jwFN7ZB3T9sMF	32-579-339-1495	nusual requests. furiously unusual epitaphs integrate. slyly 	EUROPE
+8069.74	Supplier#000000656	ROMANIA	7655	15	PROMO ANODIZED BRASS	Manufacturer#2	mQXqRMgstvOI	29-633-362-8481	ronic packages integrate. even excuses integrate carefully ruthlessly bold packages. regular ideas a	EUROPE
+8096.98	Supplier#000000574	RUSSIA	13784	15	ECONOMY ANODIZED BRASS	Manufacturer#4	2O8 sy9g2mlBOuEjzj0pA2pevk,	32-866-246-8752	ully after the regular requests. slyly final dependencies wake slyly along the busy deposit	EUROPE
+8096.98	Supplier#000000574	RUSSIA	323	15	MEDIUM BRUSHED BRASS	Manufacturer#4	2O8 sy9g2mlBOuEjzj0pA2pevk,	32-866-246-8752	ully after the regular requests. slyly final dependencies wake slyly along the busy deposit	EUROPE
+8271.39	Supplier#000000146	RUSSIA	4637	15	SMALL BURNISHED BRASS	Manufacturer#5	rBDNgCr04x0sfdzD5,gFOutCiG2	32-792-619-3155	s cajole quickly special requests. quickly enticing theodolites h	EUROPE
+8430.52	Supplier#000000646	FRANCE	11384	15	STANDARD POLISHED BRASS	Manufacturer#3	IUzsmT,2oBgjhWP2TlXTL6IkJH,4h,1SJRt	16-601-220-5489	ites among the always final ideas kindle according to the theodolites. notornis in	EUROPE
+8488.53	Supplier#000000367	RUSSIA	6854	15	ECONOMY BRUSHED BRASS	Manufacturer#4	E Sv9brQVf43Mzz	32-458-198-9557	ages. carefully final excuses nag finally. carefully ironic deposits abov	EUROPE
+8615.50	Supplier#000000812	FRANCE	10551	15	STANDARD BRUSHED BRASS	Manufacturer#2	8qh4tezyScl5bidLAysvutB,,ZI2dn6xP	16-585-724-6633	y quickly regular deposits? quickly pending packages after the caref	EUROPE
+8615.50	Supplier#000000812	FRANCE	13811	15	STANDARD BURNISHED BRASS	Manufacturer#4	8qh4tezyScl5bidLAysvutB,,ZI2dn6xP	16-585-724-6633	y quickly regular deposits? quickly pending packages after the caref	EUROPE
+8702.02	Supplier#000000333	RUSSIA	11810	15	MEDIUM ANODIZED BRASS	Manufacturer#3	MaVf XgwPdkiX4nfJGOis8Uu2zKiIZH	32-508-202-6136	oss the deposits cajole carefully even pinto beans. regular foxes detect alo	EUROPE
+9032.15	Supplier#000000959	GERMANY	4958	15	STANDARD BRUSHED BRASS	Manufacturer#4	8grA EHBnwOZhO	17-108-642-3106	nding dependencies nag furiou	EUROPE
+906.07	Supplier#000000138	ROMANIA	8363	15	SMALL BURNISHED BRASS	Manufacturer#4	utbplAm g7RmxVfYoNdhcrQGWuzRqPe0qHSwbKw	29-533-434-6776	ickly unusual requests cajole. accounts above the furiously special excuses 	EUROPE
+91.39	Supplier#000000949	UNITED KINGDOM	9430	15	ECONOMY PLATED BRASS	Manufacturer#2	a,UE,6nRVl2fCphkOoetR1ajIzAEJ1Aa1G1HV	33-332-697-2768	pinto beans. carefully express requests hagg	EUROPE
+9192.10	Supplier#000000115	UNITED KINGDOM	13325	15	ECONOMY PLATED BRASS	Manufacturer#1	nJ 2t0f7Ve,wL1,6WzGBJLNBUCKlsV	33-597-248-1220	es across the carefully express accounts boost caref	EUROPE
+9198.31	Supplier#000000025	RUSSIA	12238	15	STANDARD BRUSHED BRASS	Manufacturer#1	RCQKONXMFnrodzz6w7fObFVV6CUm2q	32-431-945-3541	ely regular deposits. carefully regular sauternes engage furiously above the regular accounts. idly 	EUROPE
+9453.01	Supplier#000000802	ROMANIA	10021	15	SMALL BRUSHED BRASS	Manufacturer#5	,6HYXb4uaHITmtMBj4Ak57Pd	29-342-882-6463	gular frets. permanently special multipliers believe blithely alongs	EUROPE
+9453.01	Supplier#000000802	ROMANIA	13275	15	SMALL ANODIZED BRASS	Manufacturer#4	,6HYXb4uaHITmtMBj4Ak57Pd	29-342-882-6463	gular frets. permanently special multipliers believe blithely alongs	EUROPE
+9508.37	Supplier#000000070	FRANCE	17268	15	ECONOMY PLATED BRASS	Manufacturer#4	INWNH2w,OOWgNDq0BRCcBwOMQc6PdFDc4	16-821-608-1166	ests sleep quickly express ideas. ironic ideas haggle about the final T	EUROPE
+9508.37	Supplier#000000070	FRANCE	3563	15	MEDIUM PLATED BRASS	Manufacturer#1	INWNH2w,OOWgNDq0BRCcBwOMQc6PdFDc4	16-821-608-1166	ests sleep quickly express ideas. ironic ideas haggle about the final T	EUROPE
+9759.38	Supplier#000000044	GERMANY	17242	15	LARGE ANODIZED BRASS	Manufacturer#4	kERxlLDnlIZJdN66zAPHklyL	17-713-930-5667	x. carefully quiet account	EUROPE
+9828.21	Supplier#000000647	UNITED KINGDOM	13120	15	PROMO PLATED BRASS	Manufacturer#5	x5U7MBZmwfG9	33-258-202-4782	s the slyly even ideas poach fluffily 	EUROPE
+


### PR DESCRIPTION
### What problem does this PR solve?
            Such query as following:
```sql                        SELECT
                          s_acctbal,
                          s_name,
                          n_name,
                          p_partkey,
                          p_mfgr,
                          s_address,
                          s_phone,
                          s_comment
                        FROM
                          part,
                          supplier,
                          partsupp,
                          nation,
                          region
                        WHERE
                          p_partkey = ps_partkey
                          AND s_suppkey = ps_suppkey
                          AND s_nationkey = n_nationkey
                          AND n_regionkey = r_regionkey
                          AND r_name = 'EUROPE';
```
             If query can be rewritten by materialized view as following:
```sql                SELECT
                          s_acctbal,
                          s_name,
                          n_name,
                          p_partkey,
                          p_mfgr,
                          s_address,
                          s_phone,
                          s_comment
                        FROM
                          mv,
                          region
                        WHERE
                          p_partkey = ps_partkey
                          AND s_suppkey = ps_suppkey
                          AND p_size = 15
                          AND p_type LIKE '%BRASS'
                          AND s_nationkey = n_nationkey
                          AND n_regionkey = r_regionkey
                          AND r_name = 'EUROPE';
```
The cost of mv scan factor should be lower, because the rewrite has obvious benefit.

Related PR: #xxx

Problem Summary:
Fix materialized view not chosen by cbo when join is rewritten by materialized view
### Release note

Fix materialized view not chosen by cbo when join is rewritten by materialized view

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

