### PR TITLE
[fix](Nereids) fold const return type does not matched with type coercion

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
@@ -704,7 +704,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "round")
     public static Expression round(DecimalV3Literal first) {
-        return castDecimalV3Literal(first.round(0), first.getValue().precision());
+        return castDecimalV3Literal(first.round(0), ((DecimalV3Type) first.getDataType()).getPrecision());
     }
 
     /**
@@ -712,7 +712,8 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "round")
     public static Expression round(DecimalV3Literal first, IntegerLiteral second) {
-        return castDecimalV3Literal(first.round(second.getValue()), first.getValue().precision());
+        return castDecimalV3Literal(first.round(second.getValue()),
+                ((DecimalV3Type) first.getDataType()).getPrecision());
     }
 
     /**
@@ -738,7 +739,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "ceil")
     public static Expression ceil(DecimalV3Literal first) {
-        return castDecimalV3Literal(first.roundCeiling(0), first.getValue().precision());
+        return castDecimalV3Literal(first.roundCeiling(0), ((DecimalV3Type) first.getDataType()).getPrecision());
     }
 
     /**
@@ -746,7 +747,8 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "ceil")
     public static Expression ceil(DecimalV3Literal first, IntegerLiteral second) {
-        return castDecimalV3Literal(first.roundCeiling(second.getValue()), first.getValue().precision());
+        return castDecimalV3Literal(first.roundCeiling(second.getValue()),
+                ((DecimalV3Type) first.getDataType()).getPrecision());
     }
 
     /**
@@ -772,7 +774,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "floor")
     public static Expression floor(DecimalV3Literal first) {
-        return castDecimalV3Literal(first.roundFloor(0), first.getValue().precision());
+        return castDecimalV3Literal(first.roundFloor(0), ((DecimalV3Type) first.getDataType()).getPrecision());
     }
 
     /**
@@ -780,7 +782,8 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "floor")
     public static Expression floor(DecimalV3Literal first, IntegerLiteral second) {
-        return castDecimalV3Literal(first.roundFloor(second.getValue()), first.getValue().precision());
+        return castDecimalV3Literal(first.roundFloor(second.getValue()),
+                ((DecimalV3Type) first.getDataType()).getPrecision());
     }
 
     /**
@@ -1142,9 +1145,11 @@ public class NumericArithmetic {
         if (first.getValue().compareTo(BigDecimal.ZERO) == 0) {
             return first;
         } else if (first.getValue().compareTo(BigDecimal.ZERO) < 0) {
-            return castDecimalV3Literal(first.roundCeiling(second.getValue()), first.getValue().precision());
+            return castDecimalV3Literal(first.roundCeiling(second.getValue()),
+                    ((DecimalV3Type) first.getDataType()).getPrecision());
         } else {
-            return castDecimalV3Literal(first.roundFloor(second.getValue()), first.getValue().precision());
+            return castDecimalV3Literal(first.roundFloor(second.getValue()),
+                    ((DecimalV3Type) first.getDataType()).getPrecision());
         }
     }
 

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
@@ -434,4 +434,13 @@ test {
     testFoldConst("with cte as (select round(300.343, -4) order by 1 limit 1) select * from cte")
     testFoldConst("with cte as (select ceil(300.343, -4) order by 1 limit 1) select * from cte")
     testFoldConst("with cte as (select truncate(300.343, -4) order by 1 limit 1) select * from cte")
+
+    testFoldConst("with cte as (select floor(3) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(3) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(3) order by 1 limit 1) select * from cte")
+
+    testFoldConst("with cte as (select floor(3, 2) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select round(3, 2) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select ceil(3, 2) order by 1 limit 1) select * from cte")
+    testFoldConst("with cte as (select truncate(3, 2) order by 1 limit 1) select * from cte")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #44021

Related PR: #40744 
Problem Summary:
when executing floor(1) it would castTo decimalV3(3,0) because it need (3,0) to contain it's message.
But after fold const, it lost precision(3) because decimalV3 literal class does not have mechanism to save precision
Solved: after folding constant, we need to change result type to the type we wanted

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

