### PR TITLE
[opt](olap) Cache only the metadata for the columns need to read in Segment

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -222,7 +222,7 @@ private:
     // open segment file and read the minimum amount of necessary information (footer)
     Status _open();
     Status _parse_footer(SegmentFooterPB* footer);
-    Status _create_column_readers(const SegmentFooterPB& footer);
+    Status _create_column_readers();
     Status _load_pk_bloom_filter();
     ColumnReader* _get_column_reader(const TabletColumn& col);
 
@@ -238,7 +238,8 @@ private:
 
     Status _create_column_readers_once();
 
-private:
+    Status _cache_columns_meta(const SegmentFooterPB& footer);
+
     friend class SegmentIterator;
     io::FileSystemSPtr _fs;
     io::FileReaderSPtr _file_reader;
@@ -285,7 +286,10 @@ private:
 
     DorisCallOnce<Status> _create_column_readers_once_call;
 
-    std::unique_ptr<SegmentFooterPB> _footer_pb;
+    std::unordered_map<uint32_t, ColumnMetaPB> _columns_meta;
+    std::unordered_map<vectorized::PathInData, ColumnMetaPB, vectorized::PathInData::Hash>
+            _columns_meta_by_path;
+    size_t _footer_bytes = 0;
 
     // used to hold short key index page in memory
     PageHandle _sk_index_handle;

--- a/be/test/olap/date_bloom_filter_test.cpp
+++ b/be/test/olap/date_bloom_filter_test.cpp
@@ -148,7 +148,7 @@ TEST_F(DateBloomFilterTest, query_index_test) {
 
     segment_v2::SegmentSharedPtr segment;
     EXPECT_TRUE(((BetaRowset*)rowset.get())->load_segment(0, &segment).ok());
-    auto st = segment->_create_column_readers(*(segment->_footer_pb));
+    auto st = segment->_create_column_readers();
     EXPECT_TRUE(st.ok());
 
     // date


### PR DESCRIPTION
### What problem does this PR solve?

For wide tables, it may be need to read data from only a few columns, so caching the entire file's footer metadata would be a waste of memory.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

