### PR TITLE
[fix](profile)  only printed for non-sink nodes in the merge profile.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -682,8 +682,17 @@ public class RuntimeProfile {
         if (planNodeMap == null || !planNodeMap.containsKey(child.nodeId())) {
             return;
         }
-        child.addPlanNodeInfos(planNodeMap.get(child.nodeId()));
-        planNodeMap.remove(child.nodeId());
+
+        /*
+         * The check for SINK_OPERATOR is performed because SINK_OPERATOR does not have
+         * a corresponding plan node ID.
+         * Currently, the plan node info is only printed for non-sink nodes in the merge
+         * profile.
+         */
+        if (name.contains("_SINK_OPERATOR")) {
+            child.addPlanNodeInfos(planNodeMap.get(child.nodeId()));
+            planNodeMap.remove(child.nodeId());
+        }
     }
 
     public void addPlanNodeInfos(String infos) {


### PR DESCRIPTION
### What problem does this PR solve?
 In the past, the result sink did not have a plan node ID, which led to incorrect plan info being output. 
 Now, the plan info for sinks is not printed.

before
```
MergedProfile  
          Fragments:
              Fragment  0:
                  Pipeline  :  0(instance_num=1):
                        -  WaitWorkerTime:  avg  30.984us,  max  30.984us,  min  30.984us
                      RESULT_SINK_OPERATOR  (id=0):
                            -  PlanInfo
                                  -  TABLE:  test.big_string_table(big_string_table),  PREAGGREGATION:  ON
                                  -  partitions=1/1  (big_string_table)
                                  -  tablets=3/3,  tabletList=113264,113266,113268
                                  -  cardinality=131072,  avgRowSize=13.638229,  numNodes=1
                                  -  pushAggOp=COUNT
                                  -  projections:  1
                                  -  project  output  tuple  id:  1
                          OLAP_SCAN_OPERATOR  (id=0.  nereids_id=156.  table  name  =  big_string_table(big_string_table)):
```
now
```
MergedProfile  
          Fragments:
              Fragment  0:
                  Pipeline  :  0(instance_num=1):
                        -  WaitWorkerTime:  avg  32.576us,  max  32.576us,  min  32.576us
                      RESULT_SINK_OPERATOR  (id=0):
                          OLAP_SCAN_OPERATOR  (id=0.  nereids_id=156.  table  name  =  big_string_table(big_string_table)):
                                -  PlanInfo
                                      -  TABLE:  test.big_string_table(big_string_table),  PREAGGREGATION:  ON
                                      -  partitions=1/1  (big_string_table)
                                      -  tablets=3/3,  tabletList=113264,113266,113268
                                      -  cardinality=131072,  avgRowSize=0.0,  numNodes=1
                                      -  pushAggOp=COUNT
                                      -  projections:  1
                                      -  project  output  tuple  id:  1
```


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

