### PR TITLE
[Fix]Reset Connection's resource tag in OlapScanNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -265,8 +265,6 @@ public class MysqlProto {
             }
         }
 
-        // set resource tag if has
-        context.setResourceTags(Env.getCurrentEnv().getAuth().getResourceTags(qualifiedUser));
         return true;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -765,6 +765,7 @@ public class OlapScanNode extends ScanNode {
         boolean skipMissingVersion = false;
         ConnectContext context = ConnectContext.get();
         if (context != null) {
+            context.resetResourceTags();
             allowedTags = context.getResourceTags();
             needCheckTags = context.isResourceTagsSet();
             useFixReplica = context.getSessionVariable().useFixReplica;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -80,6 +80,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.netty.util.concurrent.FastThreadLocal;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
@@ -1048,9 +1049,11 @@ public class ConnectContext {
         return resourceTags;
     }
 
-    public void setResourceTags(Set<Tag> resourceTags) {
-        this.resourceTags = resourceTags;
-        this.isResourceTagsSet = !this.resourceTags.isEmpty();
+    public void resetResourceTags() {
+        if (!StringUtils.isEmpty(this.qualifiedUser)) {
+            this.resourceTags = Env.getCurrentEnv().getAuth().getResourceTags(this.qualifiedUser);
+            this.isResourceTagsSet = !this.resourceTags.isEmpty();
+        }
     }
 
     public void setCurrentConnectedFEIp(String ip) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -655,9 +655,6 @@ public abstract class ConnectProcessor {
             ctx.setUserVars(userVariableFromThrift(request.getUserVariables()));
         }
 
-        // set resource tag
-        ctx.setResourceTags(Env.getCurrentEnv().getAuth().getResourceTags(ctx.qualifiedUser));
-
         ctx.setThreadLocalInfo();
         StmtExecutor executor = null;
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
@@ -205,7 +205,8 @@ public class ResourceTagQueryTest {
         Assert.assertEquals(1, userTags.size());
 
         // update connection context and query
-        connectContext.setResourceTags(userTags);
+        connectContext.setQualifiedUser(Auth.ROOT_USER);
+        connectContext.resetResourceTags();
         String queryStr = "explain select * from test.tbl1";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);
         System.out.println(explainString);
@@ -221,7 +222,8 @@ public class ResourceTagQueryTest {
         }
 
         // update connection context and query, it will failed because no zone1 backend
-        connectContext.setResourceTags(userTags);
+        connectContext.setQualifiedUser(Auth.ROOT_USER);
+        connectContext.resetResourceTags();
         Assert.assertTrue(connectContext.isResourceTagsSet());
         queryStr = "explain select * from test.tbl1";
         String error = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, queryStr);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Currently Tag is set to ConnectionContext when mysql client is connected, but when user's tag property changes, tag in ConnectionContext not changed, this may cause query in the connection using the stale tag, user has to reconnect mysql client then user's new property will take effect.

So we can still store Tag in ConnectionContext, but reset it when local select table's replica.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

