### PR TITLE
[improve](backup) Add the commit seq at the backup job level.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -427,11 +427,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 continue;
             }
             if (tbl.getType() != TableType.OLAP) {
-                if (abstractBackupTableRefClause == null || abstractBackupTableRefClause.isExclude()) {
-                    // If there is no table ref clause or is exclude ref cause, skip the tables not supported.
-                    tblRefsNotSupport.add(tblRef);
-                    continue;
-                } else if (Config.ignore_backup_not_support_table_type) {
+                if (Config.ignore_backup_not_support_table_type) {
                     LOG.warn("Table '{}' is a {} table, can not backup and ignore it."
                             + "Only OLAP(Doris)/ODBC/VIEW table can be backed up",
                             tblName, tbl.getType().toString());

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -52,6 +52,7 @@ import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.fs.remote.AzureFileSystem;
 import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.fs.remote.S3FileSystem;
+import org.apache.doris.persist.BarrierLog;
 import org.apache.doris.task.DirMoveTask;
 import org.apache.doris.task.DownloadTask;
 import org.apache.doris.task.SnapshotTask;
@@ -370,20 +371,32 @@ public class BackupHandler extends MasterDaemon implements Writable {
                     + " is read only");
         }
 
-        // Determine the tables to be backed up
+        long commitSeq = 0;
         Set<String> tableNames = Sets.newHashSet();
         AbstractBackupTableRefClause abstractBackupTableRefClause = stmt.getAbstractBackupTableRefClause();
-        if (abstractBackupTableRefClause == null) {
-            tableNames = db.getTableNamesWithLock();
-        } else if (abstractBackupTableRefClause.isExclude()) {
-            tableNames = db.getTableNamesWithLock();
-            for (TableRef tableRef : abstractBackupTableRefClause.getTableRefList()) {
-                if (!tableNames.remove(tableRef.getName().getTbl())) {
-                    LOG.info("exclude table " + tableRef.getName().getTbl()
-                            + " of backup stmt is not exists in db " + db.getFullName());
+
+        // Obtain the snapshot commit seq, any creating table binlog will be visible.
+        db.readLock();
+        try {
+            BarrierLog log = new BarrierLog(db.getId(), db.getFullName());
+            commitSeq = env.getEditLog().logBarrier(log);
+
+            // Determine the tables to be backed up
+            if (abstractBackupTableRefClause == null) {
+                tableNames = db.getTableNames();
+            } else if (abstractBackupTableRefClause.isExclude()) {
+                tableNames = db.getTableNames();
+                for (TableRef tableRef : abstractBackupTableRefClause.getTableRefList()) {
+                    if (!tableNames.remove(tableRef.getName().getTbl())) {
+                        LOG.info("exclude table " + tableRef.getName().getTbl()
+                                + " of backup stmt is not exists in db " + db.getFullName());
+                    }
                 }
             }
+        } finally {
+            db.readUnlock();
         }
+
         List<TableRef> tblRefs = Lists.newArrayList();
         if (abstractBackupTableRefClause != null && !abstractBackupTableRefClause.isExclude()) {
             tblRefs = abstractBackupTableRefClause.getTableRefList();
@@ -401,12 +414,24 @@ public class BackupHandler extends MasterDaemon implements Writable {
         for (TableRef tblRef : tblRefs) {
             String tblName = tblRef.getName().getTbl();
             Table tbl = db.getTableOrDdlException(tblName);
+
+            // filter the table types which are not supported by local backup.
+            if (repository == null && tbl.getType() != TableType.OLAP
+                    && tbl.getType() != TableType.VIEW && tbl.getType() != TableType.MATERIALIZED_VIEW) {
+                tblRefsNotSupport.add(tblRef);
+                continue;
+            }
+
             if (tbl.getType() == TableType.VIEW || tbl.getType() == TableType.ODBC
                     || tbl.getType() == TableType.MATERIALIZED_VIEW) {
                 continue;
             }
             if (tbl.getType() != TableType.OLAP) {
-                if (Config.ignore_backup_not_support_table_type) {
+                if (abstractBackupTableRefClause == null || abstractBackupTableRefClause.isExclude()) {
+                    // If there is no table ref clause or is exclude ref cause, skip the tables not supported.
+                    tblRefsNotSupport.add(tblRef);
+                    continue;
+                } else if (Config.ignore_backup_not_support_table_type) {
                     LOG.warn("Table '{}' is a {} table, can not backup and ignore it."
                             + "Only OLAP(Doris)/ODBC/VIEW table can be backed up",
                             tblName, tbl.getType().toString());
@@ -448,7 +473,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         tblRefs.removeAll(tblRefsNotSupport);
 
         // Check if label already be used
-        long repoId = -1;
+        long repoId = Repository.KEEP_ON_LOCAL_REPO_ID;
         if (repository != null) {
             List<String> existSnapshotNames = Lists.newArrayList();
             Status st = repository.listSnapshots(existSnapshotNames);
@@ -470,7 +495,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // Create a backup job
         BackupJob backupJob = new BackupJob(stmt.getLabel(), db.getId(),
                 ClusterNamespace.getNameFromFullName(db.getFullName()),
-                tblRefs, stmt.getTimeoutMs(), stmt.getContent(), env, repoId);
+                tblRefs, stmt.getTimeoutMs(), stmt.getContent(), env, repoId, commitSeq);
         // write log
         env.getEditLog().logBackupJob(backupJob);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
@@ -34,14 +34,18 @@ public class Snapshot {
     @SerializedName(value = "expired_at")
     private long expiredAt = 0;
 
+    @SerializedName(value = "commitSeq")
+    private long commitSeq = 0;
+
     public Snapshot() {
     }
 
-    public Snapshot(String label, byte[] meta, byte[] jobInfo, long expiredAt) {
+    public Snapshot(String label, byte[] meta, byte[] jobInfo, long expiredAt, long commitSeq) {
         this.label = label;
         this.meta = meta;
         this.jobInfo = jobInfo;
         this.expiredAt = expiredAt;
+        this.commitSeq = commitSeq;
     }
 
     public byte[] getMeta() {
@@ -60,6 +64,10 @@ public class Snapshot {
         return System.currentTimeMillis() > expiredAt;
     }
 
+    public long getCommitSeq() {
+        return commitSeq;
+    }
+
     public String toJson() {
         return GsonUtils.GSON.toJson(this);
     }
@@ -71,6 +79,7 @@ public class Snapshot {
                 + ", meta=" + meta
                 + ", jobInfo=" + jobInfo
                 + ", expiredAt=" + expiredAt
+                + ", commitSeq=" + commitSeq
                 + '}';
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -551,6 +551,10 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
         }
     }
 
+    public Set<String> getTableNames() {
+        return new HashSet<>(this.nameToTable.keySet());
+    }
+
     /**
      * This is a thread-safe method when nameToTable is a concurrent hash map
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/BarrierLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/BarrierLog.java
@@ -46,6 +46,11 @@ public class BarrierLog implements Writable {
     public BarrierLog() {
     }
 
+    public BarrierLog(long dbId, String dbName) {
+        this.dbId = dbId;
+        this.dbName = dbName;
+    }
+
     public BarrierLog(long dbId, String dbName, long tableId, String tableName) {
         this.dbId = dbId;
         this.dbName = dbName;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -2952,9 +2952,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             byte[] meta = snapshot.getMeta();
             byte[] jobInfo = snapshot.getJobInfo();
             long expiredAt = snapshot.getExpiredAt();
+            long commitSeq = snapshot.getCommitSeq();
 
-            LOG.info("get snapshot info, snapshot: {}, meta size: {}, job info size: {}, expired at: {}",
-                    label, meta.length, jobInfo.length, expiredAt);
+            LOG.info("get snapshot info, snapshot: {}, meta size: {}, job info size: {}, "
+                    + "expired at: {}, commit seq: {}", label, meta.length, jobInfo.length, expiredAt, commitSeq);
             if (request.isEnableCompress()) {
                 meta = GZIPUtils.compress(meta);
                 jobInfo = GZIPUtils.compress(jobInfo);
@@ -2967,6 +2968,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setMeta(meta);
             result.setJobInfo(jobInfo);
             result.setExpiredAt(expiredAt);
+            result.setCommitSeq(commitSeq);
         }
 
         return result;

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -215,7 +215,7 @@ public class BackupJobTest {
                 new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME),
                 null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repo.getId());
+                env, repo.getId(), 0);
     }
 
     @Test
@@ -351,7 +351,7 @@ public class BackupJobTest {
                 new TableRef(new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, "unknown_tbl"),
                         null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repo.getId());
+                env, repo.getId(), 0);
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());
@@ -368,7 +368,7 @@ public class BackupJobTest {
                 new TableRef(new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME),
                         null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-            env, repo.getId());
+            env, repo.getId(), 123);
 
         job.write(out);
         out.flush();
@@ -383,6 +383,7 @@ public class BackupJobTest {
         Assert.assertEquals(job.getDbId(), job2.getDbId());
         Assert.assertEquals(job.getCreateTime(), job2.getCreateTime());
         Assert.assertEquals(job.getType(), job2.getType());
+        Assert.assertEquals(job.getCommitSeq(), job2.getCommitSeq());
 
         // 3. delete files
         in.close();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1364,6 +1364,7 @@ struct TGetSnapshotResult {
     4: optional Types.TNetworkAddress master_address
     5: optional bool compressed;
     6: optional i64 expiredAt;  // in millis
+    7: optional i64 commit_seq;
 }
 
 struct TTableRef {


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: https://github.com/selectdb/ccr-syncer/pull/237

Problem Summary:

When a backup job is created, it will read the database and obtain a set of table refs. If there is a table creation statement running simultaneously and the new table is not included in the table refs, then the job commit seq obtained by the CCR syncer only through the commit seq of the tables included in the snapshot may be greater than that of the new table. Consequently, the table will be lost during the synchronization process.

This PR acquires a commit seq within the database read lock as the commit seq of the entire snapshot. In this way, the CCR syncer can continue to synchronize the binlog starting from this value. Thus, the table creation statements running in parallel with the backup job will either be included in the table refs or their binlog can be observed by the snapshot commit sequence.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

