### PR TITLE
[fix](nereids)lag and lead function's nullability is wrong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
@@ -22,7 +22,6 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
-import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
@@ -72,7 +71,7 @@ public class Lag extends WindowFunction implements TernaryExpression, Explicitly
 
     @Override
     public boolean nullable() {
-        if (children.size() == 3 && child(2) instanceof NullLiteral) {
+        if (children.size() == 3 && child(2).nullable()) {
             return true;
         }
         return child(0).nullable();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lead.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lead.java
@@ -22,7 +22,6 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
-import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
@@ -74,7 +73,7 @@ public class Lead extends WindowFunction implements TernaryExpression, Explicitl
 
     @Override
     public boolean nullable() {
-        if (children.size() == 3 && child(2) instanceof NullLiteral) {
+        if (children.size() == 3 && child(2).nullable()) {
             return true;
         }
         return child(0).nullable();

--- a/regression-test/suites/nereids_p0/sql_functions/window_functions/test_lead_lag_nullable.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/window_functions/test_lead_lag_nullable.groovy
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_lead_lag_nullable") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+    sql """DROP TABLE IF EXISTS `test_lead_lag_ttt`; """
+    sql """ 
+        CREATE TABLE `test_lead_lag_ttt` (
+        `wtid` varchar(72) NOT NULL  ,
+        `rectime` datetime NOT NULL  ,
+        `id` bigint NOT NULL  ,
+        `if_delete` tinyint NOT NULL DEFAULT "0" ,
+        `endtime` datetime NULL ,
+        `std_state_code` int NULL ,
+        `stop_reason_code` int NULL ,
+        `remark` varchar(100) NULL,
+        `if_raw` tinyint NULL DEFAULT "1" ,
+        `create_time` datetime NULL ,
+        `update_time` datetime NULL ,
+        `uuid` varchar(50) NOT NULL 
+        ) ENGINE=OLAP
+        UNIQUE KEY(`wtid`, `rectime`, `id`, `if_delete`)
+        DISTRIBUTED BY HASH(`wtid`) BUCKETS 4
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"); 
+    """
+    sql """INSERT INTO test_lead_lag_ttt 
+            (wtid, rectime, id, if_delete, endtime, std_state_code, stop_reason_code, remark, if_raw, create_time, update_time, uuid)
+            VALUES
+            ('device001', '2024-11-15 08:00:00', 1, 0, NULL, 100, 5, '备注信息1', 1, '2024-11-15 08:10:00', '2024-11-15 08:20:00', 'uuid-0001'),
+            ('device001', '2024-11-15 09:00:00', 2, 0, NULL, 101, 10, '备注信息2', 1, '2024-11-15 09:10:00', '2024-11-15 09:20:00', 'uuid-0002'),
+            ('device002', '2024-11-15 10:00:00', 3, 0, NULL, 102, 20, '备注信息3', 1, '2024-11-15 10:10:00', '2024-11-15 10:20:00', 'uuid-0003'),
+            ('device003', '2024-11-15 11:00:00', 4, 0, NULL, 103, 15, '备注信息4', 1, '2024-11-15 11:10:00', '2024-11-15 11:20:00', 'uuid-0004'); """
+    
+    sql """INSERT
+            INTO
+            test_lead_lag_ttt (id,
+            uuid,
+            wtid,
+            create_time,
+            rectime,
+            if_delete,
+            std_state_code,
+            stop_reason_code,
+            endtime)
+            SELECT
+            id,
+            uuid,
+            wtid,
+            LAG(rectime, 1, NULL) OVER (PARTITION BY wtid
+            ORDER BY
+            rectime) AS create_time,
+            rectime,
+            if_delete,
+            std_state_code,
+            stop_reason_code,
+            LEAD(rectime, 1, NULL) OVER (PARTITION BY wtid
+            ORDER BY
+            rectime) AS endtime
+            FROM
+            test_lead_lag_ttt
+            WHERE
+            endtime is null;  """
+}
+


### PR DESCRIPTION
### What problem does this PR solve?
lag and lead function's nullability should depends on either first or third( if it has) param's nullability. 

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

