### PR TITLE
[chore](autopick)When the PR is merged, adding a label afterward should also trigger the workflow.

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -21,6 +21,7 @@ on:
   pull_request_target:
     types:
       - closed
+      - labeled
     branches:
       - master
 permissions:
@@ -30,7 +31,7 @@ permissions:
 jobs:
   auto_cherry_pick:
     runs-on: ubuntu-latest
-    if: ${{ (contains(github.event.pull_request.labels.*.name, 'dev/3.0.x') || contains(github.event.pull_request.labels.*.name, 'dev/2.1.x')) && github.event.pull_request.merged == true }}
+    if: ${{(contains(github.event.pull_request.labels.*.name, 'dev/3.0.x') || contains(github.event.pull_request.labels.*.name, 'dev/2.1.x') ||github.event.label.name == 'dev/3.0.x' || github.event.label.name == 'dev/2.1.x') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -54,7 +55,7 @@ jobs:
               echo "SHA matches: $calculated_sha"
             fi
       - name: Auto cherry-pick to branch-3.0
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'dev/3.0.x') }}
+        if: ${{ ((github.event.action == 'labeled' && github.event.label.name == 'dev/3.0.x'))|| ((github.event_name == 'pull_request_target' && github.event.action == 'closed') && contains(github.event.pull_request.labels.*.name, 'dev/3.0.x')) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_NAME: ${{ github.repository }}
@@ -62,7 +63,7 @@ jobs:
         run: |
           python tools/auto-pick-script.py ${{ github.event.pull_request.number }} branch-3.0  
       - name: Auto cherry-pick to branch-2.1
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'dev/2.1.x') }}
+        if: ${{ ((github.event.action == 'labeled' && github.event.label.name == 'dev/2.1.x'))|| ((github.event_name == 'pull_request_target' && github.event.action == 'closed') && contains(github.event.pull_request.labels.*.name, 'dev/2.1.x')) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_NAME: ${{ github.repository }}


### PR DESCRIPTION
## Important Note:
There’s a potential issue here: if the label was added before the merge and later removed and then readd, the workflow may still be triggered again. Please avoid performing these operations repeatedly, as CI resources are valuable.


