### PR TITLE
[thirdparty](patch) Fix brpc (1.4.0) security issue CVE-2023-31039

### DIFF
--- a/thirdparty/patches/brpc-1.5.0-remove-wordexp.patch
+++ b/thirdparty/patches/brpc-1.5.0-remove-wordexp.patch
@@ -1,0 +1,36 @@
+diff --git a/src/brpc/server.cpp b/src/brpc/server.cpp
+index 380ebb20d4..b4758ad8c8 100644
+--- a/src/brpc/server.cpp
++++ b/src/brpc/server.cpp
+@@ -16,7 +16,6 @@
+ // under the License.
+ 
+ 
+-#include <wordexp.h>                                // wordexp
+ #include <iomanip>
+ #include <arpa/inet.h>                              // inet_aton
+ #include <fcntl.h>                                  // O_CREAT
+@@ -1716,23 +1715,7 @@ void Server::GenerateVersionIfNeeded() {
+     }
+ }
+ 
+-static std::string ExpandPath(const std::string &path) {
+-    if (path.empty()) {
+-        return std::string();
+-    }
+-    std::string ret;
+-    wordexp_t p;
+-    wordexp(path.c_str(), &p, 0);
+-    CHECK_EQ(p.we_wordc, 1u);
+-    if (p.we_wordc == 1) {
+-        ret = p.we_wordv[0];
+-    }
+-    wordfree(&p);
+-    return ret;
+-}
+-
+ void Server::PutPidFileIfNeeded() {
+-    _options.pid_file = ExpandPath(_options.pid_file);
+     if (_options.pid_file.empty()) {
+         return;
+     }


### PR DESCRIPTION
patch brpc https://github.com/apache/brpc/pull/2218 (fixed in 1.5.0) to fix https://www.cve.org/CVERecord?id=CVE-2023-31039

### What problem does this PR solve?

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

