### PR TITLE
[fix](cloud-mow) MS should create new Transaction to continue geting delete bitmap when encounter TXN_TOO_OLD

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -214,6 +214,9 @@ CONF_mInt64(max_s3_client_retry, "10");
 // Max aborted txn num for the same label name
 CONF_mInt64(max_num_aborted_txn, "100");
 
+// Max byte getting delete bitmap can return, default is 1GB
+CONF_mInt64(max_get_delete_bitmap_byte, "1073741824");
+
 CONF_Bool(enable_cloud_txn_lazy_commit, "true");
 CONF_Int32(txn_lazy_commit_rowsets_thresold, "1000");
 CONF_Int32(txn_lazy_commit_num_threads, "8");

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -116,7 +116,8 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
         }
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
                   << " status=" << res->status().ShortDebugString()
-                  << " delete_bitmap_size=" << res->segment_delete_bitmaps_size();
+                  << " tablet=" << res->tablet_id()
+                  << " delete_bitmap_count=" << res->segment_delete_bitmaps_size();
     } else if constexpr (std::is_same_v<Response, GetObjStoreInfoResponse> ||
                          std::is_same_v<Response, GetStageResponse>) {
         std::string debug_string = res->DebugString();

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1421,6 +1421,7 @@ message GetDeleteBitmapResponse {
     repeated int64 versions = 4;
     // Serialized roaring bitmaps indexed with {rowset_id, segment_id, version}
     repeated bytes segment_delete_bitmaps = 5;
+    optional int64 tablet_id = 6;
 }
 
 message RemoveDeleteBitmapRequest {


### PR DESCRIPTION
When delete bitmap count is big, geting delete bitmap may encounter TXN_TOO_OLD, ms should create a new transaction to reading the remaining data instead of returning TXN_TOO_OLD code.
pick pr:https://github.com/apache/doris/pull/43509