### PR TITLE
[fix](runtime filter) Disable `build_bf_exactly` if `sync_filter_size…

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1355,18 +1355,19 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     params.runtime_bloom_filter_max_size = options->__isset.runtime_bloom_filter_max_size
                                                    ? options->runtime_bloom_filter_max_size
                                                    : 0;
-    // We build runtime filter by exact distinct count iff three conditions are met:
+    auto sync_filter_size = desc->__isset.sync_filter_size && desc->sync_filter_size;
+    // We build runtime filter by exact distinct count if all of 3 conditions are met:
     // 1. Only 1 join key
-    // 2. Do not have remote target (e.g. do not need to merge), or broadcast join
-    // 3. Bloom filter
+    // 2. Bloom filter
+    // 3. Size of all bloom filters will be same (size will be sync or this is a broadcast join).
     params.build_bf_exactly =
             build_bf_exactly && (_runtime_filter_type == RuntimeFilterType::BLOOM_FILTER ||
                                  _runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
 
     params.bloom_filter_size_calculated_by_ndv = desc->bloom_filter_size_calculated_by_ndv;
 
-    if (!desc->__isset.sync_filter_size || !desc->sync_filter_size) {
-        params.build_bf_exactly &= (!_has_remote_target || _is_broadcast_join);
+    if (!sync_filter_size) {
+        params.build_bf_exactly &= !_is_broadcast_join;
     }
 
     if (desc->__isset.bloom_filter_size_bytes) {


### PR DESCRIPTION
…` is disabled

### What problem does this PR solve?

When a bloom filter has multiple targets, it should use a size which is estimated by FE.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

