### PR TITLE
[fix](Nereids) simplify conditional function generate wrong nullable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Coalesce;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.NullIf;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Nullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 
@@ -98,7 +99,7 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
      */
     private static Expression rewriteNullIf(NullIf nullIf) {
         if (nullIf.child(0) instanceof NullLiteral || nullIf.child(1) instanceof NullLiteral) {
-            return nullIf.child(0);
+            return new Nullable(nullIf.child(0));
         } else {
             return nullIf;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunctionTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.rules.expression.ExpressionRuleExecutor;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Coalesce;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.NullIf;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Nullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.types.BooleanType;
@@ -99,13 +100,14 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
         SlotReference slot = new SlotReference("a", StringType.INSTANCE, true);
         SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false);
         // nullif(null, slot) -> null
-        assertRewrite(new NullIf(NullLiteral.INSTANCE, slot), new NullLiteral(VarcharType.SYSTEM_DEFAULT));
+        assertRewrite(new NullIf(NullLiteral.INSTANCE, slot),
+                new Nullable(new NullLiteral(VarcharType.SYSTEM_DEFAULT)));
 
         // nullif(nullable_slot, null) -> slot
-        assertRewrite(new NullIf(slot, NullLiteral.INSTANCE), slot);
+        assertRewrite(new NullIf(slot, NullLiteral.INSTANCE), new Nullable(slot));
 
         // nullif(non-nullable_slot, null) -> non-nullable_slot
-        assertRewrite(new NullIf(nonNullableSlot, NullLiteral.INSTANCE), nonNullableSlot);
+        assertRewrite(new NullIf(nonNullableSlot, NullLiteral.INSTANCE), new Nullable(nonNullableSlot));
     }
 
 }

--- a/regression-test/data/nereids_rules_p0/simplify_conditional_function/simplify_conditional_function.out
+++ b/regression-test/data/nereids_rules_p0/simplify_conditional_function/simplify_conditional_function.out
@@ -131,3 +131,6 @@ abc
 ab
 abc
 
+-- !test_nullable_nullif --
+1	1
+

--- a/regression-test/suites/nereids_rules_p0/simplify_conditional_function/simplify_conditional_function.groovy
+++ b/regression-test/suites/nereids_rules_p0/simplify_conditional_function/simplify_conditional_function.groovy
@@ -49,4 +49,6 @@ suite("simplify_conditional_function") {
     qt_test_outer_ref_coalesce "select c1 from (select coalesce(null,a,c) c1,a,b from test_simplify_conditional_function order by c1,a,b limit 2) t group by c1 order by c1"
     qt_test_outer_ref_nvl "select c1 from (select ifnull(null, c) c1 from test_simplify_conditional_function order by 1 limit 2) t group by c1 order by c1"
     qt_test_outer_ref_nullif "select c1 from (select nullif(a, null) c1,c from test_simplify_conditional_function order by c1,c limit 2 ) t group by c1 order by c1"
+
+    qt_test_nullable_nullif "SELECT COUNT( DISTINCT NULLIF ( 1, NULL ) ), COUNT( DISTINCT 72 )"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #37613

Problem Summary:

because adjust nullable do not run after simplify confitional function, we should not change any output's nullable in this rule

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

