### PR TITLE
[fix](regression) warmup_show_stmt flaky by concurrent execution

### DIFF
--- a/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/hotspot/test_warmup_show_stmt_2.groovy
+++ b/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/hotspot/test_warmup_show_stmt_2.groovy
@@ -95,7 +95,7 @@ suite("test_warmup_show_stmt_2") {
         assertEquals(result[i].get("TableName"), "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer")
     }
     if (!found) {
-        org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
+        org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}")
     }
 
     result = sql_return_maparray """ show cache hotspot "/regression_cluster_name0" """
@@ -127,6 +127,6 @@ suite("test_warmup_show_stmt_2") {
         break
     }
     if (!found) {
-        org.junit.Assert.assertTrue("cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
+        org.junit.Assert.assertTrue("cannot find expected cache hotspot ${hotTableName}")
     }
 }

--- a/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/hotspot/test_warmup_show_stmt_2.groovy
+++ b/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/hotspot/test_warmup_show_stmt_2.groovy
@@ -94,9 +94,7 @@ suite("test_warmup_show_stmt_2") {
         assertEquals(result[i].get("ComputeGroupName"), "regression_cluster_name0")
         assertEquals(result[i].get("TableName"), "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer")
     }
-    if (!found) {
-        org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}")
-    }
+    org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}", found)
 
     result = sql_return_maparray """ show cache hotspot "/regression_cluster_name0" """
     log.info(result.toString())
@@ -126,7 +124,5 @@ suite("test_warmup_show_stmt_2") {
         assertEquals(result[i].get("TableName"), "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer")
         break
     }
-    if (!found) {
-        org.junit.Assert.assertTrue("cannot find expected cache hotspot ${hotTableName}")
-    }
+    org.junit.Assert.assertTrue("cannot find expected cache hotspot ${hotTableName}", found)
 }

--- a/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/hotspot/test_warmup_show_stmt_2.groovy
+++ b/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/hotspot/test_warmup_show_stmt_2.groovy
@@ -38,7 +38,7 @@ suite("test_warmup_show_stmt_2") {
         |"exec_mem_limit" = "8589934592",
         |"load_parallelism" = "3")""".stripMargin()
 
-    def load_customer_once =  { 
+    def load_customer_once =  {
         def uniqueID = Math.abs(UUID.randomUUID().hashCode()).toString()
         def loadLabel = table + "_" + uniqueID
         // load data from cos
@@ -84,14 +84,18 @@ suite("test_warmup_show_stmt_2") {
     log.info(result.toString())
     org.junit.Assert.assertTrue("result.size() " + result.size() + " > 0", result.size() > 0)
     def hotTableName = "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer"
+    def found = false
     for (int i = 0; i < result.size(); ++i) {
         if (!result[i].get("TableName").equals(hotTableName)) {
-            org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
             continue
         }
+        found = true
         assertEquals(result[i].get("ComputeGroupId"), "regression_cluster_id0")
         assertEquals(result[i].get("ComputeGroupName"), "regression_cluster_name0")
         assertEquals(result[i].get("TableName"), "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer")
+    }
+    if (!found) {
+        org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
     }
 
     result = sql_return_maparray """ show cache hotspot "/regression_cluster_name0" """
@@ -111,14 +115,18 @@ suite("test_warmup_show_stmt_2") {
     result = sql_return_maparray """ show cache hotspot "/" """
     log.info(result.toString())
     org.junit.Assert.assertTrue("result.size() " + result.size() + " > 0", result.size() > 0)
+    found = false
     for (int i = 0; i < result.size(); ++i) {
         if (!result[i].get("TableName").equals(hotTableName)) {
-            org.junit.Assert.assertTrue("cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
             continue
         }
+        found = true
         assertEquals(result[i].get("ComputeGroupId"), "regression_cluster_id0")
         assertEquals(result[i].get("ComputeGroupName"), "regression_cluster_name0")
         assertEquals(result[i].get("TableName"), "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer")
         break
+    }
+    if (!found) {
+        org.junit.Assert.assertTrue("cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
    def hotTableName = "regression_test_cloud_p0_cache_multi_cluster_warm_up_hotspot.customer"
    for (int i = 0; i < result.size(); ++i) {
        if (!result[i].get("TableName").equals(hotTableName)) {
            org.junit.Assert.assertTrue(getLineNumber() + "cannot find expected cache hotspot ${hotTableName}", result.size() > i + 1)
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

