### PR TITLE
[Fix](cases) Make auto&dynamic cases sleep long enough

### DIFF
--- a/regression-test/suites/partition_p0/auto_partition/test_auto_dynamic.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_dynamic.groovy
@@ -134,7 +134,7 @@ suite("test_auto_dynamic", "nonConcurrent") {
     }
 
     sql """ admin set frontend config ('dynamic_partition_check_interval_seconds' = '1') """
-    sleep(2000)
+    sleep(10000)
     part_result = sql " show partitions from auto_dynamic "
     log.info("${part_result}".toString())
     assertEquals(part_result.size, 3)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/42210

Problem Summary:

in the pr above we make daemon thread may need 5s+ to be aware of session variables' change. so we need sleep much longer.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

