### PR TITLE
[fix](s3) do not replace https scheme if specified

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -95,7 +95,7 @@ public class S3Resource extends Resource {
 
         // the endpoint for ping need add uri scheme.
         String pingEndpoint = properties.get(S3Properties.ENDPOINT);
-        if (!pingEndpoint.startsWith("http://")) {
+        if (!pingEndpoint.startsWith("http://") && !pingEndpoint.startsWith("https://")) {
             pingEndpoint = "http://" + properties.get(S3Properties.ENDPOINT);
             properties.put(S3Properties.ENDPOINT, pingEndpoint);
             properties.put(S3Properties.Env.ENDPOINT, pingEndpoint);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
@@ -222,4 +222,20 @@ public class S3ResourceTest {
         modify.put("s3.access_key", "aaa");
         s3Resource.modifyProperties(modify);
     }
+
+    @Test
+    public void testHttpScheme() throws DdlException {
+        // if https:// is set, it should be replaced with http://
+        Map<String, String> properties = new HashMap<>();
+        properties.put("AWS_ENDPOINT", "https://aaa");
+        properties.put("AWS_REGION", "bbb");
+        properties.put("AWS_ROOT_PATH", "/path/to/root");
+        properties.put("AWS_ACCESS_KEY", "xxx");
+        properties.put("AWS_SECRET_KEY", "yyy");
+        properties.put("AWS_BUCKET", "test-bucket");
+        properties.put("s3_validity_check", "false");
+        S3Resource s3Resource = new S3Resource("s3_2");
+        s3Resource.setProperties(properties);
+        Assert.assertEquals(s3Resource.getProperty(S3Properties.ENDPOINT), "https://aaa");
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When creating s3 resource with endpoint, if user already specify `https://` schema in endpoint url,
we should not replace it with `http://`.

### Release note

[fix](s3) fix bug that s3 resource do not support `https://`

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

