### PR TITLE
[Fix](Job)Fix the Calculation of the First Trigger Time and Add a Single-Time Scheduling Compensation Logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
@@ -172,9 +172,10 @@ public class JobExecutionConfiguration {
         long firstTriggerTime = windowStartTimeMs + (intervalMs - ((windowStartTimeMs - startTimeMs)
                 % intervalMs)) % intervalMs;
         if (firstTriggerTime < currentTimeMs) {
-            firstTriggerTime += intervalMs;
+            // Calculate how many intervals to add to get the largest trigger time < currentTimeMs
+            long intervalsToAdd = (currentTimeMs - firstTriggerTime) / intervalMs;
+            firstTriggerTime += intervalsToAdd * intervalMs;
         }
-
         if (firstTriggerTime > windowEndTimeMs) {
             return timestamps; // Return an empty list if there won't be any trigger time
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
@@ -60,14 +60,22 @@ public class JobExecutionConfigurationTest {
         Assertions.assertArrayEquals(new Long[]{100L, 700L}, delayTimes.toArray());
         delayTimes = configuration.getTriggerDelayTimes(
                 200000L, 0L, 1100000L);
-        Assertions.assertEquals(1, delayTimes.size());
-        Assertions.assertArrayEquals(new Long[]{500L}, delayTimes.toArray());
+        Assertions.assertEquals(2, delayTimes.size());
+        Assertions.assertArrayEquals(new Long[]{0L, 500L}, delayTimes.toArray());
         delayTimes = configuration.getTriggerDelayTimes(
                 1001000L, 0L, 1000000L);
         Assertions.assertEquals(1, delayTimes.size());
         timerDefinition.setStartTimeMs(2000L);
         timerDefinition.setIntervalUnit(IntervalUnit.SECOND);
         Assertions.assertArrayEquals(new Long[]{2L, 12L}, configuration.getTriggerDelayTimes(100000L, 100000L, 120000L).toArray());
+
+        timerDefinition.setIntervalUnit(IntervalUnit.SECOND);
+        long second = 1000L;
+        timerDefinition.setStartTimeMs(second);
+        timerDefinition.setInterval(1L);
+        Assertions.assertEquals(3, configuration.getTriggerDelayTimes(second * 5 + 10L, second * 3, second * 7).size());
+        Assertions.assertEquals(3, configuration.getTriggerDelayTimes(second * 5, second * 5, second * 7).size());
+
     }
 
     @Test


### PR DESCRIPTION
### Background:

| Time (ms) | Window Start (1000) | First Trigger Time (2000) | Current Time (3000) | Trigger Time (Incorrect Adjustment) | Window End (5000) |
|-----------|---------------------|---------------------------|---------------------|-------------------------------------|-------------------|
| 0         |                     |                           |                     |                                     |                   |
| 1000      | Start Time           |                           |                     |                                     |                   |
| 2000      | First Trigger Time   |                           |                     |                                     |                   |
| 3000      |                     | Current Time              |                     |                                     |                   |
| 4000      |                     |                           |                     | Trigger Time (incorrect)           |                   |
| 5000      |                     |                           |                     |                                     | Window End        |


The previous scheduling logic for calculating the first trigger time had the following issues:

If the current time (currentTimeMs) exceeds the start of the time window (windowStartTimeMs), the first trigger time could be skipped, causing some tasks to be missed. Minor delays during code execution (e.g., between window initialization and scheduling logic execution) could result in tasks being missed within the active time window. ### 

### Solution:

#### Adjustment of First Trigger Time Logic:

 When the initially calculated firstTriggerTime is less than or equal to the currentTimeMs, compute the number of missed intervals and directly adjust to the largest trigger time that is less than the currentTimeMs.
#### Single-Time Compensation Logic:

 Introduced a compensation mechanism to handle the slight delay caused by code execution. This ensures that tasks missed during the initialization phase are correctly scheduled.
The compensation is explicitly single-time to avoid impacting the normal scheduling logic.



### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

