### PR TITLE
[fix](load) restore "use_new_load_scan_node" in property map for compatibility

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -99,6 +99,9 @@ public class LoadStmt extends DdlStmt implements NotFallbackInParser {
     public static final String PRIORITY = "priority";
     public static final String LOAD_TO_SINGLE_TABLET = "load_to_single_tablet";
 
+    // deprecated, keeping this property to make LoadStmt#checkProperties() happy
+    public static final String USE_NEW_LOAD_SCAN_NODE = "use_new_load_scan_node";
+
     // for load data from Baidu Object Store(BOS)
     public static final String BOS_ENDPOINT = "bos_endpoint";
     public static final String BOS_ACCESSKEY = "bos_accesskey";
@@ -216,6 +219,12 @@ public class LoadStmt extends DdlStmt implements NotFallbackInParser {
                 }
             })
             .put(LOAD_TO_SINGLE_TABLET, new Function<String, Boolean>() {
+                @Override
+                public @Nullable Boolean apply(@Nullable String s) {
+                    return Boolean.valueOf(s);
+                }
+            })
+            .put(USE_NEW_LOAD_SCAN_NODE, new Function<String, Boolean>() {
                 @Override
                 public @Nullable Boolean apply(@Nullable String s) {
                     return Boolean.valueOf(s);

--- a/regression-test/suites/load_p2/broker_load/test_s3_load_properties.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_s3_load_properties.groovy
@@ -187,6 +187,19 @@ suite("test_s3_load_properties", "p2") {
 //                "", "", "", "","").addProperties("skip_lines", "10"))
 //    }
 
+    /* ========================================================== deprecated properties ========================================================== */
+    for (String table : basicTables) {
+        attributesList.add(new LoadAttributes("s3://${s3BucketName}/regression/load/data/basic_data.csv",
+                "${table}", "LINES TERMINATED BY \"\n\"", "COLUMNS TERMINATED BY \"|\"", "FORMAT AS \"CSV\"", "(k00,k01,k02,k03,k04,k05,k06,k07,k08,k09,k10,k11,k12,k13,k14,k15,k16,k17,k18)",
+                "", "", "", "", "")).addProperties("use_new_load_scan_node", "true")
+    }
+
+    for (String table : basicTables) {
+        attributesList.add(new LoadAttributes("s3://${s3BucketName}/regression/load/data/basic_data.csv",
+                "${table}", "LINES TERMINATED BY \"\n\"", "COLUMNS TERMINATED BY \"|\"", "FORMAT AS \"CSV\"", "(k00,k01,k02,k03,k04,k05,k06,k07,k08,k09,k10,k11,k12,k13,k14,k15,k16,k17,k18)",
+                "", "", "", "", "")).addProperties("use_new_load_scan_node", "false")
+    }
+
     /* ========================================================== wrong column sep ========================================================== */
     for (String table : basicTables) {
         attributesList.add(new LoadAttributes("s3://${s3BucketName}/regression/load/data/basic_data.csv",


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #43989

Problem Summary:

`LoadStmt#checkProperties()` will throw DdlException when encounter unknown properties.
So we have to keep the deprecated property keys in the map for compatibility.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Reverted the behavior change in #43989

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

