### PR TITLE
[fix](arrow-flight-sql) Arrow Flight support multiple endpoints

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -19,7 +19,6 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.BoolLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
-import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FloatLiteral;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.LiteralExpr;
@@ -63,11 +62,11 @@ import org.apache.doris.plsql.executor.PlSqlOperation;
 import org.apache.doris.plugin.AuditEvent.AuditEventBuilder;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.service.arrowflight.results.FlightSqlChannel;
+import org.apache.doris.service.arrowflight.results.FlightSqlEndpointsLocation;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.Histogram;
 import org.apache.doris.system.Backend;
 import org.apache.doris.task.LoadTaskInfo;
-import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TResultSinkType;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
@@ -134,10 +133,7 @@ public class ConnectContext {
     protected volatile String peerIdentity;
     private final Map<String, String> preparedQuerys = new HashMap<>();
     private String runningQuery;
-    private TNetworkAddress resultFlightServerAddr;
-    private TNetworkAddress resultInternalServiceAddr;
-    private ArrayList<Expr> resultOutputExprs;
-    private TUniqueId finstId;
+    private final List<FlightSqlEndpointsLocation> flightSqlEndpointsLocations = Lists.newArrayList();
     private boolean returnResultFromLocal = true;
     // mysql net
     protected volatile MysqlChannel mysqlChannel;
@@ -730,36 +726,16 @@ public class ConnectContext {
         return runningQuery;
     }
 
-    public void setResultFlightServerAddr(TNetworkAddress resultFlightServerAddr) {
-        this.resultFlightServerAddr = resultFlightServerAddr;
+    public void addFlightSqlEndpointsLocation(FlightSqlEndpointsLocation flightSqlEndpointsLocation) {
+        this.flightSqlEndpointsLocations.add(flightSqlEndpointsLocation);
     }
 
-    public TNetworkAddress getResultFlightServerAddr() {
-        return resultFlightServerAddr;
+    public List<FlightSqlEndpointsLocation> getFlightSqlEndpointsLocations() {
+        return flightSqlEndpointsLocations;
     }
 
-    public void setResultInternalServiceAddr(TNetworkAddress resultInternalServiceAddr) {
-        this.resultInternalServiceAddr = resultInternalServiceAddr;
-    }
-
-    public TNetworkAddress getResultInternalServiceAddr() {
-        return resultInternalServiceAddr;
-    }
-
-    public void setResultOutputExprs(ArrayList<Expr> resultOutputExprs) {
-        this.resultOutputExprs = resultOutputExprs;
-    }
-
-    public ArrayList<Expr> getResultOutputExprs() {
-        return resultOutputExprs;
-    }
-
-    public void setFinstId(TUniqueId finstId) {
-        this.finstId = finstId;
-    }
-
-    public TUniqueId getFinstId() {
-        return finstId;
+    public void clearFlightSqlEndpointsLocations() {
+        flightSqlEndpointsLocations.clear();
     }
 
     public void setReturnResultFromLocal(boolean returnResultFromLocal) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -52,6 +52,7 @@ import org.apache.doris.qe.runtime.SingleFragmentPipelineTask;
 import org.apache.doris.qe.runtime.ThriftPlansBuilder;
 import org.apache.doris.resource.workloadgroup.QueryQueue;
 import org.apache.doris.resource.workloadgroup.QueueToken;
+import org.apache.doris.service.arrowflight.results.FlightSqlEndpointsLocation;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TErrorTabletInfo;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -90,7 +91,7 @@ public class NereidsCoordinator extends Coordinator {
         this.coordinatorContext.setJobProcessor(buildJobProcessor(coordinatorContext));
 
         Preconditions.checkState(!planner.getFragments().isEmpty()
-                        && coordinatorContext.instanceNum.get() > 0, "Fragment and Instance can not be empty˚");
+                && coordinatorContext.instanceNum.get() > 0, "Fragment and Instance can not be empty˚");
     }
 
     // broker load
@@ -431,18 +432,22 @@ public class NereidsCoordinator extends Coordinator {
         if (dataSink instanceof ResultSink || dataSink instanceof ResultFileSink) {
             if (connectContext != null && !connectContext.isReturnResultFromLocal()) {
                 Preconditions.checkState(connectContext.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL));
-
-                AssignedJob firstInstance = topPlan.getInstanceJobs().get(0);
-                BackendWorker worker = (BackendWorker) firstInstance.getAssignedWorker();
-                Backend backend = worker.getBackend();
-
-                connectContext.setFinstId(firstInstance.instanceId());
-                if (backend.getArrowFlightSqlPort() < 0) {
-                    throw new IllegalStateException("be arrow_flight_sql_port cannot be empty.");
+                for (AssignedJob instance : topPlan.getInstanceJobs()) {
+                    BackendWorker worker = (BackendWorker) instance.getAssignedWorker();
+                    Backend backend = worker.getBackend();
+                    if (backend.getArrowFlightSqlPort() < 0) {
+                        throw new IllegalStateException("be arrow_flight_sql_port cannot be empty.");
+                    }
+                    TUniqueId finstId;
+                    if (connectContext.getSessionVariable().enableParallelResultSink()) {
+                        finstId = getQueryId();
+                    } else {
+                        finstId = instance.instanceId();
+                    }
+                    connectContext.addFlightSqlEndpointsLocation(new FlightSqlEndpointsLocation(finstId,
+                            backend.getArrowFlightAddress(), backend.getBrpcAddress(),
+                            topPlan.getFragmentJob().getFragment().getOutputExprs()));
                 }
-                connectContext.setResultFlightServerAddr(backend.getArrowFlightAddress());
-                connectContext.setResultInternalServiceAddr(backend.getBrpcAddress());
-                connectContext.setResultOutputExprs(topPlan.getFragmentJob().getFragment().getOutputExprs());
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
@@ -31,6 +31,7 @@ import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.rpc.BackendServiceProxy;
 import org.apache.doris.rpc.RpcException;
+import org.apache.doris.service.arrowflight.results.FlightSqlEndpointsLocation;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
@@ -58,7 +59,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoCloseable {
     private static final Logger LOG = LogManager.getLogger(FlightSqlConnectProcessor.class);
-    private TNetworkAddress publicAccessAddr = new TNetworkAddress();
+    private Schema arrowSchema;
 
     public FlightSqlConnectProcessor(ConnectContext context) {
         super(context);
@@ -67,8 +68,8 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
         context.setReturnResultFromLocal(true);
     }
 
-    public TNetworkAddress getPublicAccessAddr() {
-        return publicAccessAddr;
+    public Schema getArrowSchema() {
+        return arrowSchema;
     }
 
     public void prepare(MysqlCommand command) {
@@ -107,80 +108,87 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
     //     handleFieldList(tableName);
     // }
 
-    public Schema fetchArrowFlightSchema(int timeoutMs) {
-        TNetworkAddress address = ctx.getResultInternalServiceAddr();
-        TUniqueId tid;
-        if (ctx.getSessionVariable().enableParallelResultSink()) {
-            tid = ctx.queryId();
-        } else {
-            // only one instance
-            tid = ctx.getFinstId();
+    public void fetchArrowFlightSchema(int timeoutMs) {
+        if (ctx.getFlightSqlEndpointsLocations().isEmpty()) {
+            throw new RuntimeException("fetch arrow flight schema failed, no FlightSqlEndpointsLocations.");
         }
-        ArrayList<Expr> resultOutputExprs = ctx.getResultOutputExprs();
-        Types.PUniqueId queryId = Types.PUniqueId.newBuilder().setHi(tid.hi).setLo(tid.lo).build();
-        try {
-            InternalService.PFetchArrowFlightSchemaRequest request =
-                    InternalService.PFetchArrowFlightSchemaRequest.newBuilder()
-                            .setFinstId(queryId)
-                            .build();
+        for (FlightSqlEndpointsLocation endpointLoc : ctx.getFlightSqlEndpointsLocations()) {
+            TNetworkAddress address = endpointLoc.getResultInternalServiceAddr();
+            TUniqueId tid = endpointLoc.getFinstId();
+            ArrayList<Expr> resultOutputExprs = endpointLoc.getResultOutputExprs();
+            Types.PUniqueId queryId = Types.PUniqueId.newBuilder().setHi(tid.hi).setLo(tid.lo).build();
+            try {
+                InternalService.PFetchArrowFlightSchemaRequest request
+                        = InternalService.PFetchArrowFlightSchemaRequest.newBuilder().setFinstId(queryId).build();
 
-            Future<InternalService.PFetchArrowFlightSchemaResult> future
-                    = BackendServiceProxy.getInstance().fetchArrowFlightSchema(address, request);
-            InternalService.PFetchArrowFlightSchemaResult pResult;
-            pResult = future.get(timeoutMs, TimeUnit.MILLISECONDS);
-            if (pResult == null) {
-                throw new RuntimeException(String.format("fetch arrow flight schema timeout, queryId: %s",
-                        DebugUtil.printId(tid)));
-            }
-            Status resultStatus = new Status(pResult.getStatus());
-            if (resultStatus.getErrorCode() != TStatusCode.OK) {
-                throw new RuntimeException(String.format("fetch arrow flight schema failed, queryId: %s, errmsg: %s",
-                        DebugUtil.printId(tid), resultStatus));
-            }
-            if (pResult.hasBeArrowFlightIp()) {
-                publicAccessAddr.setHostname(pResult.getBeArrowFlightIp().toStringUtf8());
-            }
-            if (pResult.hasBeArrowFlightPort()) {
-                publicAccessAddr.setPort(pResult.getBeArrowFlightPort());
-            }
-            if (pResult.hasSchema() && pResult.getSchema().size() > 0) {
-                RootAllocator rootAllocator = new RootAllocator(Integer.MAX_VALUE);
-                ArrowStreamReader arrowStreamReader = new ArrowStreamReader(
-                        new ByteArrayInputStream(pResult.getSchema().toByteArray()),
-                        rootAllocator
-                );
-                try {
-                    VectorSchemaRoot root = arrowStreamReader.getVectorSchemaRoot();
-                    List<FieldVector> fieldVectors = root.getFieldVectors();
-                    if (fieldVectors.size() != resultOutputExprs.size()) {
-                        throw new RuntimeException(String.format(
-                                "Schema size %s' is not equal to arrow field size %s, queryId: %s.",
-                                fieldVectors.size(), resultOutputExprs.size(), DebugUtil.printId(tid)));
-                    }
-                    return root.getSchema();
-                } catch (Exception e) {
-                    throw new RuntimeException("Read Arrow Flight Schema failed.", e);
+                Future<InternalService.PFetchArrowFlightSchemaResult> future = BackendServiceProxy.getInstance()
+                        .fetchArrowFlightSchema(address, request);
+                InternalService.PFetchArrowFlightSchemaResult pResult;
+                pResult = future.get(timeoutMs, TimeUnit.MILLISECONDS);
+                if (pResult == null) {
+                    throw new RuntimeException(
+                            String.format("fetch arrow flight schema timeout, queryId: %s", DebugUtil.printId(tid)));
                 }
-            } else {
-                throw new RuntimeException(String.format("get empty arrow flight schema, queryId: %s",
-                        DebugUtil.printId(tid)));
+                Status resultStatus = new Status(pResult.getStatus());
+                if (resultStatus.getErrorCode() != TStatusCode.OK) {
+                    throw new RuntimeException(
+                            String.format("fetch arrow flight schema failed, queryId: %s, errmsg: %s",
+                                    DebugUtil.printId(tid), resultStatus));
+                }
+
+                TNetworkAddress resultPublicAccessAddr = new TNetworkAddress();
+                if (pResult.hasBeArrowFlightIp()) {
+                    resultPublicAccessAddr.setHostname(pResult.getBeArrowFlightIp().toStringUtf8());
+                }
+                if (pResult.hasBeArrowFlightPort()) {
+                    resultPublicAccessAddr.setPort(pResult.getBeArrowFlightPort());
+                }
+                endpointLoc.setResultPublicAccessAddr(resultPublicAccessAddr);
+                if (pResult.hasSchema() && pResult.getSchema().size() > 0) {
+                    RootAllocator rootAllocator = new RootAllocator(Integer.MAX_VALUE);
+                    ArrowStreamReader arrowStreamReader = new ArrowStreamReader(
+                            new ByteArrayInputStream(pResult.getSchema().toByteArray()), rootAllocator);
+                    try {
+                        Schema schema;
+                        VectorSchemaRoot root = arrowStreamReader.getVectorSchemaRoot();
+                        List<FieldVector> fieldVectors = root.getFieldVectors();
+                        if (fieldVectors.size() != resultOutputExprs.size()) {
+                            throw new RuntimeException(
+                                    String.format("Schema size %s' is not equal to arrow field size %s, queryId: %s.",
+                                            fieldVectors.size(), resultOutputExprs.size(), DebugUtil.printId(tid)));
+                        }
+                        schema = root.getSchema();
+                        if (arrowSchema == null) {
+                            arrowSchema = schema;
+                        } else if (!arrowSchema.equals(schema)) {
+                            throw new RuntimeException(String.format(
+                                    "The schema returned by results BE is different, first schema: %s, "
+                                            + "new schema: %s, queryId: %s，backend: %s", arrowSchema, schema,
+                                    DebugUtil.printId(tid), address));
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException("Read Arrow Flight Schema failed.", e);
+                    }
+                } else {
+                    throw new RuntimeException(
+                            String.format("get empty arrow flight schema, queryId: %s", DebugUtil.printId(tid)));
+                }
+            } catch (RpcException e) {
+                throw new RuntimeException(
+                        String.format("arrow flight schema fetch catch rpc exception, queryId: %s，backend: %s",
+                                DebugUtil.printId(tid), address), e);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(
+                        String.format("arrow flight schema future get interrupted exception, queryId: %s，backend: %s",
+                                DebugUtil.printId(tid), address), e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(
+                        String.format("arrow flight schema future get execution exception, queryId: %s，backend: %s",
+                                DebugUtil.printId(tid), address), e);
+            } catch (TimeoutException e) {
+                throw new RuntimeException(String.format("arrow flight schema fetch timeout, queryId: %s，backend: %s",
+                        DebugUtil.printId(tid), address), e);
             }
-        } catch (RpcException e) {
-            throw new RuntimeException(String.format(
-                    "arrow flight schema fetch catch rpc exception, queryId: %s，backend: %s",
-                    DebugUtil.printId(tid), address), e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(String.format(
-                    "arrow flight schema future get interrupted exception, queryId: %s，backend: %s",
-                    DebugUtil.printId(tid), address), e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(String.format(
-                    "arrow flight schema future get execution exception, queryId: %s，backend: %s",
-                    DebugUtil.printId(tid), address), e);
-        } catch (TimeoutException e) {
-            throw new RuntimeException(String.format(
-                    "arrow flight schema fetch timeout, queryId: %s，backend: %s",
-                    DebugUtil.printId(tid), address), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/results/FlightSqlEndpointsLocation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/results/FlightSqlEndpointsLocation.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.service.arrowflight.results;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TUniqueId;
+
+import java.util.ArrayList;
+
+public class FlightSqlEndpointsLocation {
+    private TUniqueId finstId;
+    private TNetworkAddress resultFlightServerAddr;
+    private TNetworkAddress resultInternalServiceAddr;
+    private TNetworkAddress resultPublicAccessAddr;
+    private ArrayList<Expr> resultOutputExprs;
+
+    public FlightSqlEndpointsLocation(TUniqueId finstId, TNetworkAddress resultFlightServerAddr,
+            TNetworkAddress resultInternalServiceAddr, ArrayList<Expr> resultOutputExprs) {
+        this.finstId = finstId;
+        this.resultFlightServerAddr = resultFlightServerAddr;
+        this.resultInternalServiceAddr = resultInternalServiceAddr;
+        this.resultPublicAccessAddr = new TNetworkAddress();
+        this.resultOutputExprs = resultOutputExprs;
+    }
+
+    public TUniqueId getFinstId() {
+        return finstId;
+    }
+
+    public TNetworkAddress getResultFlightServerAddr() {
+        return resultFlightServerAddr;
+    }
+
+    public TNetworkAddress getResultInternalServiceAddr() {
+        return resultInternalServiceAddr;
+    }
+
+    public void setResultPublicAccessAddr(TNetworkAddress resultPublicAccessAddr) {
+        this.resultPublicAccessAddr = resultPublicAccessAddr;
+    }
+
+    public TNetworkAddress getResultPublicAccessAddr() {
+        return resultPublicAccessAddr;
+    }
+
+    public ArrayList<Expr> getResultOutputExprs() {
+        return resultOutputExprs;
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

By default, the query results of all BE nodes will be aggregated to one BE node. ADBC Client will only receive one endpoint and pull data from the BE node corresponding to this endpoint.

`set global enable_parallel_result_sink=true;` to allow each BE to return query results separately. ADBC Client will receive multiple endpoints and pull data from each endpoint.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

