### PR TITLE
[fix](store) Fix the issue where storage_page_size equals 0 in multi-FE scenarios

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -737,6 +737,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildStoreRowColumn();
         buildRowStoreColumns();
         buildRowStorePageSize();
+        buildStoragePageSize();
         buildSkipWriteIndexOnLoad();
         buildCompactionPolicy();
         buildTimeSeriesCompactionGoalSizeMbytes();

--- a/regression-test/suites/query_p0/system/test_storage_page_size.groovy
+++ b/regression-test/suites/query_p0/system/test_storage_page_size.groovy
@@ -33,7 +33,7 @@ suite ("test_storage_page_size") {
     test {
         sql "show create table table_1;"
         check { result, exception, startTime, endTime ->
-            assertFalse(result[0][1].contains("\"storage_page_size\" = \"65536\""))
+            assertFalse(result[0][1].contains("storage_page_size"))
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: 
https://github.com/apache/doris/pull/43690
https://github.com/apache/doris/pull/44080

Problem Summary:
1. Creating a table on a Follower will result in storage_page_size being equal to 0.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

