### PR TITLE
[Fix](log)To avoid SLF4J multiple binding issues and unnecessary dependency propagation.

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -857,6 +857,15 @@ under the License.
                 <artifactId>json-simple</artifactId>
                 <version>${json-simple.version}</version>
             </dependency>
+            <!--SLF4J requires only one binding implementation to be present at runtime. 
+            By setting the scope of other bindings, such as slf4j-reload4j, to test, 
+            we ensure that only the explicitly specified binding, like log4j-slf4j-impl, 
+            is used in the production environment, preventing runtime conflicts.-->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <scope>test</scope>
+            </dependency>
             <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### What problem does this PR solve?

```
2024-11-20 10:50:42,967 ERROR (main|1) [Util.report():128] SLF4J: Class path contains multiple SLF4J bindings.
2024-11-20 10:50:42,968 ERROR (main|1) [Util.report():128] SLF4J: Found binding in [jar:file:/Users/calvinkirs/.m2/repository/org/slf4j/slf4j-reload4j/1.7.36/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
2024-11-20 10:50:42,969 ERROR (main|1) [Util.report():128] SLF4J: Found binding in [jar:file:/Users/calvinkirs/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.18.0/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
2024-11-20 10:50:42,969 ERROR (main|1) [Util.report():128] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
2024-11-20 10:50:42,993 ERROR (main|1) [Util.report():128] SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
```
SLF4J requires only one binding implementatio to be present at runtime. By setting the scope of other bindings, such as slf4j-reload4j, to test, we ensure that only the explicitly specified binding, like log4j-slf4j-impl, is used in the production environment, preventing runtime conflicts.

**hadoop-auth** introduces **slf4j-reload4j**

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->

    - [x] Manual test (add detailed scripts or steps below)


- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

