### PR TITLE
[fix](jvm)fix jvm metrics memory leak.

### DIFF
--- a/be/src/util/jvm_metrics.cpp
+++ b/be/src/util/jvm_metrics.cpp
@@ -485,8 +485,8 @@ Status JvmStats::refresh(JvmMetrics* jvm_metrics) const {
     jvm_metrics->jvm_thread_count->set_value(threadCount < 0 ? 0 : threadCount);
 
     for (int i = 0; i < threadCount; i++) {
-        JNI_CALL_METHOD_CHECK_EXCEPTION(jobject, threadInfo, env,
-                                        GetObjectArrayElement((jobjectArray)threadInfos, i));
+        JNI_CALL_METHOD_CHECK_EXCEPTION_DELETE_REF(
+                jobject, threadInfo, env, GetObjectArrayElement((jobjectArray)threadInfos, i));
 
         if (threadInfo == nullptr) {
             continue;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #42507

Problem Summary:
fix jvm metrics memory leak.

when you set `enable_jvm_monitor=true` in be.conf, you can find that be jvm memory is slowly growing.
By analyzing the hprof file, we can find that there are a large number of `java.lang.management.ThreadInfo` objects.
The specific cause of the memory leak is: jni does not manually delete the local reference after getting the object from the array, resulting in the object not being GC.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->
just fix memory leak no logic has been changed
- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

