### PR TITLE
[fix](planner) query should be cancelled if limit reached

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -268,8 +268,9 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
             }
 
             size_t raw_bytes_threshold = config::doris_scanner_row_bytes;
-            size_t raw_bytes_read = 0; bool first_read = true;
-            bool has_limit = scanner->limit() > 0;
+            size_t raw_bytes_read = 0;
+            bool first_read = true;
+            int64_t limit = scanner->limit();
             while (!eos && raw_bytes_read < raw_bytes_threshold) {
                 if (UNLIKELY(ctx->done())) {
                     eos = true;
@@ -317,12 +318,15 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
                     ctx->inc_block_usage(free_block->allocated_bytes());
                     scan_task->cached_blocks.emplace_back(std::move(free_block), free_block_bytes);
                 }
-                if (has_limit) {
-                    // If this scanner has limit, return immediately and no need to wait raw_bytes_threshold.
+                if (limit < ctx->batch_size()) {
+                    // If this scanner has limit, and less than batch size,
+                    // return immediately and no need to wait raw_bytes_threshold.
                     // This can save time that each scanner may only return a small number of rows,
                     // but rows are enough from all scanners.
                     // If not break, the query like "select * from tbl where id=1 limit 10"
                     // may scan a lot data when the "id=1"'s filter ratio is high.
+                    // If limit is larger than batch size, this rule is skipped,
+                    // to avoid user specify a large limit and causing too much small blocks.
                     break;
                 }
             } // end for while

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -268,9 +268,7 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
             }
 
             size_t raw_bytes_threshold = config::doris_scanner_row_bytes;
-            size_t raw_bytes_read = 0;
-            bool first_read = true;
-            int64_t limit = scanner->limit();
+            size_t raw_bytes_read = 0; bool first_read = true; int64_t limit = scanner->limit();
             while (!eos && raw_bytes_read < raw_bytes_threshold) {
                 if (UNLIKELY(ctx->done())) {
                     eos = true;
@@ -318,7 +316,7 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
                     ctx->inc_block_usage(free_block->allocated_bytes());
                     scan_task->cached_blocks.emplace_back(std::move(free_block), free_block_bytes);
                 }
-                if (limit < ctx->batch_size()) {
+                if (limit > 0 && limit < ctx->batch_size()) {
                     // If this scanner has limit, and less than batch size,
                     // return immediately and no need to wait raw_bytes_threshold.
                     // This can save time that each scanner may only return a small number of rows,

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -156,6 +156,8 @@ public:
         _query_statistics = query_statistics;
     }
 
+    int64_t limit() const { return _limit; }
+
 protected:
     void _discard_conjuncts() {
         for (auto& conjunct : _conjuncts) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -723,11 +723,6 @@ public class NereidsPlanner extends Planner {
     }
 
     @Override
-    public boolean isBlockQuery() {
-        return true;
-    }
-
-    @Override
     public DescriptorTable getDescTable() {
         return descTable;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -79,10 +79,6 @@ public class OriginalPlanner extends Planner {
         this.analyzer = analyzer;
     }
 
-    public boolean isBlockQuery() {
-        return isBlockQuery;
-    }
-
     public PlannerContext getPlannerContext() {
         return plannerContext;
     }
@@ -276,17 +272,6 @@ public class OriginalPlanner extends Planner {
 
         if (queryStmt instanceof SelectStmt) {
             SelectStmt selectStmt = (SelectStmt) queryStmt;
-            if (queryStmt.getSortInfo() != null || selectStmt.getAggInfo() != null) {
-                isBlockQuery = true;
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("this is block query");
-                }
-            } else {
-                isBlockQuery = false;
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("this isn't block query");
-                }
-            }
             if (selectStmt.isTwoPhaseReadOptEnabled()) {
                 // Optimize query like `SELECT ... FROM <tbl> WHERE ... ORDER BY ... LIMIT ...`
                 if (singleNodePlan instanceof SortNode

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/Planner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/Planner.java
@@ -44,8 +44,6 @@ public abstract class Planner {
 
     protected ArrayList<PlanFragment> fragments = Lists.newArrayList();
 
-    protected boolean isBlockQuery = false;
-
     protected TQueryOptions queryOptions;
 
     public abstract List<ScanNode> getScanNodes();
@@ -114,10 +112,6 @@ public abstract class Planner {
 
     public List<PlanFragment> getFragments() {
         return fragments;
-    }
-
-    public boolean isBlockQuery() {
-        return isBlockQuery;
     }
 
     public TQueryOptions getQueryOptions() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
@@ -84,7 +84,6 @@ public class CoordinatorContext {
     // these are some constant parameters
     public final NereidsCoordinator coordinator;
     public final List<PlanFragment> fragments;
-    public final boolean isBlockQuery;
     public final DataSink dataSink;
     public final ExecutionProfile executionProfile;
     public final ConnectContext connectContext;
@@ -120,7 +119,6 @@ public class CoordinatorContext {
     private CoordinatorContext(
             NereidsCoordinator coordinator,
             ConnectContext connectContext,
-            boolean isBlockQuery,
             List<PipelineDistributedPlan> distributedPlans,
             List<PlanFragment> fragments,
             List<RuntimeFilter> runtimeFilters,
@@ -131,7 +129,6 @@ public class CoordinatorContext {
             TQueryOptions queryOptions,
             TDescriptorTable descriptorTable) {
         this.connectContext = connectContext;
-        this.isBlockQuery = isBlockQuery;
         this.fragments = fragments;
         this.distributedPlans = distributedPlans;
         this.topDistributedPlan = distributedPlans.get(distributedPlans.size() - 1);
@@ -161,7 +158,6 @@ public class CoordinatorContext {
             TDescriptorTable descriptorTable,
             ExecutionProfile executionProfile) {
         this.coordinator = coordinator;
-        this.isBlockQuery = true;
         this.fragments = fragments;
         this.distributedPlans = distributedPlans;
         this.topDistributedPlan = distributedPlans.get(distributedPlans.size() - 1);
@@ -290,7 +286,7 @@ public class CoordinatorContext {
                         .collect(Collectors.toList())
         );
         return new CoordinatorContext(
-                coordinator, connectContext, planner.isBlockQuery(),
+                coordinator, connectContext,
                 planner.getDistributedPlans().valueList(),
                 planner.getFragments(), planner.getRuntimeFilters(), planner.getTopnFilters(),
                 planner.getScanNodes(), executionProfile, queryGlobals, queryOptions, descriptorTable

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/LimitUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/LimitUtils.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.common.Status;
+import org.apache.doris.thrift.TStatusCode;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.function.Consumer;
+
+/**
+ * This is a utility class for limit related operations.
+ * Because current there are 2 places need to check limit rows, so put the logic here for unification.
+ *  - Coordinator.getNext();
+ *  - QueryProcessor.getNext();
+ */
+public class LimitUtils {
+    private static final Logger LOG = LogManager.getLogger(LimitUtils.class);
+    private static final Status LIMIT_REACH_STATUS = new Status(TStatusCode.LIMIT_REACH, "query reach limit");
+
+    // if reached limit rows, cancel this query immediately
+    // to avoid BE from reading more data.
+    public static boolean cancelIfReachLimit(RowBatch resultBatch, long limitRows, long numReceivedRows,
+            Consumer<Status> cancelFunc) {
+        boolean reachedLimit = false;
+        if (limitRows > 0 && numReceivedRows >= limitRows) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("reach limit rows: {}, received rows: {}, cancel query", limitRows, numReceivedRows);
+            }
+            cancelFunc.accept(LIMIT_REACH_STATUS);
+            // set this
+            resultBatch.setEos(true);
+            reachedLimit = true;
+        }
+        return reachedLimit;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/MultiFragmentsPipelineTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/MultiFragmentsPipelineTask.java
@@ -130,9 +130,10 @@ public class MultiFragmentsPipelineTask extends AbstractRuntimeTask<Integer, Sin
                                 LOG.warn("Failed to cancel query {} backend: {}, reason: {}",
                                         DebugUtil.printId(queryId), backend, status.toString());
                             }
+                        } else {
+                            LOG.warn("Failed to cancel query {} backend: {} reason: {}",
+                                    DebugUtil.printId(queryId), backend, "without status");
                         }
-                        LOG.warn("Failed to cancel query {} backend: {} reason: {}",
-                                DebugUtil.printId(queryId), backend, "without status");
                     }
 
                     public void onFailure(Throwable t) {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/LimitUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/LimitUtilsTest.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+
+import org.apache.doris.common.Status;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+public class LimitUtilsTest {
+
+    private static int res = 0;
+
+    @Test
+    public void testUpperBound() {
+        Consumer<Status> cancelFunc = batch -> res = 666;
+        RowBatch rowBatch = new RowBatch();
+        rowBatch.setEos(false);
+        // - no limit
+        Assert.assertFalse(LimitUtils.cancelIfReachLimit(rowBatch, 0, 10, cancelFunc));
+        Assert.assertFalse(rowBatch.isEos());
+        Assert.assertEquals(0, res);
+
+        // - not reach limit
+        Assert.assertFalse(LimitUtils.cancelIfReachLimit(rowBatch, 10, 1, cancelFunc));
+        Assert.assertFalse(rowBatch.isEos());
+        Assert.assertEquals(0, res);
+
+        // - reach limit
+        Assert.assertTrue(LimitUtils.cancelIfReachLimit(rowBatch, 10, 10, cancelFunc));
+        Assert.assertTrue(rowBatch.isEos());
+        Assert.assertEquals(666, res);
+
+        // - reach limit
+        res = 0;
+        rowBatch.setEos(false);
+        Assert.assertTrue(LimitUtils.cancelIfReachLimit(rowBatch, 10, 100, cancelFunc));
+        Assert.assertTrue(rowBatch.isEos());
+        Assert.assertEquals(666, res);
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When there is a `limit` cluse in SQL, if FE has obtained data with more than the `limit` number of rows,
it should send a cancel command to BE to cancel the query to prevent BE from reading more data.
However, this function has problems in the current code and does not work.
Especially in external table query, this may result in lots of unnecessary network io read.

1. `isBlockQuery`

    In the old optimizer, if a query statement contains a `sort` or `agg` node,
    `isBlockQuery` will be marked as true, otherwise it will be false.
    In the new optimizer, this value is always true.
  
    Regardless of the old or new optimizer, this logic is wrong.
    But only when `isBlockQuery = false` will the reach limit logic be triggered.

2. Calling problem of reach limit logic

    The reach limit logic judgment will only be performed when `eos = true` in the rowBatch returned by BE.
    This is wrong.
    Because for `limit N` queries, each BE's own `limit` is N. But for FE, as long as the total number of rows
    returned by all BEs exceeds N, the reach limit logic can be triggered.
    So it should not be processed only when `eos = true`.

The PR mainly changes:

1. Remove `isBlockQuery`

    `isBlockQuery` is only used in the reach limit logic. And it is not needed. Remove it completely.

2. Modify the judgment position of reach limit.

    When the number of rows obtained by FE is greater than the limit,
    it will check the reach limit logic.

3. fix wrong `limitRows` in `QueryProcessor`

    the limitRows should be got from the first fragment, not last.

4. In scanner scheduler on BE side, if scanner has limit, ignore the scan bytes threshold per round.

### Release note

[fix](planner) query should be cancelled if limit reached

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test
        test single and multi-be nodes with limit sql.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

