### PR TITLE
[Fix](ms) Fix ci-uncaught ut coredump due to dynamic rate limit setting

### DIFF
--- a/cloud/script/run_all_tests.sh
+++ b/cloud/script/run_all_tests.sh
@@ -143,11 +143,13 @@ for i in *_test; do
             patchelf --set-rpath "$(pwd)" "${i}"
         fi
 
+        set -euo pipefail
         if [[ "${filter}" == "" ]]; then
             LLVM_PROFILE_FILE="./report/${i}.profraw" "./${i}" --gtest_print_time=true --gtest_output="xml:${i}.xml"
         else
             LLVM_PROFILE_FILE="./report/${i}.profraw" "./${i}" --gtest_print_time=true --gtest_output="xml:${i}.xml" --gtest_filter="${filter}"
         fi
+        set +euo pipefail
         unittest_files[${#unittest_files[*]}]="${i}"
         echo "--------------------------"
     fi

--- a/run-cloud-ut.sh
+++ b/run-cloud-ut.sh
@@ -228,6 +228,7 @@ cd test
 # FILTER: binary_name:gtest_filter
 # FILTER: meta_service_test:DetachSchemaKVTest.*
 # ./run_all_tests.sh --test "\"$(echo "${FILTER}" | awk -F: '{print $1}')\"" --filter "\"$(echo "${FILTER}" | awk -F: '{print $2}')\"" --fdb "\"${FDB}\""
+set -euo pipefail
 if [[ "_${ENABLE_CLANG_COVERAGE}" == "_ON" ]]; then
     bash -x ./run_all_tests.sh --coverage --test "$(echo "${FILTER}" | awk -F: '{print $1}')" --filter "$(echo "${FILTER}" | awk -F: '{print $2}')" --fdb "${FDB}"
 else


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #42413

Problem Summary:

UT failed with coredump in PR #42413 but was not detected by CI. Fix the problem.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

