### PR TITLE
[fix](meta-cache) fix refreshOnlyCatalogCache when use_meta_cache = false

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -418,6 +418,7 @@ public abstract class ExternalCatalog
             if (useMetaCache.get() && metaCache != null) {
                 metaCache.invalidateAll();
             } else if (!useMetaCache.get()) {
+                this.initialized = false;
                 for (ExternalDatabase<? extends ExternalTable> db : idToDb.values()) {
                     db.setUnInitialized(invalidCache);
                 }

--- a/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
@@ -28,14 +28,73 @@ test_use_meta_cache_db_hive
 test_use_meta_cache_tbl_hive
 
 -- !sql08 --
-test_use_meta_cache_tbl_hive
 
 -- !sql09 --
+p1=part1
+p1=part2
 
 -- !sql10 --
-test_use_meta_cache_db_hive
+p1=part1
+p1=part2
 
 -- !sql11 --
+
+-- !sql12 --
+
+-- !sql13 --
+test_use_meta_cache_db_hive
+
+-- !sql14 --
+
+-- !sql01 --
+
+-- !sql02 --
+test_use_meta_cache_db
+
+-- !sql03 --
+test_use_meta_cache_tbl
+
+-- !sql04 --
+
+-- !sql05 --
+
+-- !sql01 --
+
+-- !sql02 --
+
+-- !sql03 --
+test_use_meta_cache_db_hive
+
+-- !sql04 --
+
+-- !sql05 --
+
+-- !sql06 --
+test_use_meta_cache_tbl_hive
+
+-- !sql07 --
+test_use_meta_cache_tbl_hive
+
+-- !sql08 --
+
+-- !sql09 --
+p1=part1
+p1=part2
+
+-- !sql10 --
+p1=part1
+p1=part2
+
+-- !sql11 --
+test_use_meta_cache_partitioned_tbl_hive
+test_use_meta_cache_tbl_hive
+
+-- !sql12 --
+
+-- !sql13 --
+test_use_meta_cache_db_hive
+
+-- !sql14 --
 
 -- !sql01 --
 
@@ -66,12 +125,71 @@ test_use_meta_cache_db_hive
 test_use_meta_cache_tbl_hive
 
 -- !sql08 --
-test_use_meta_cache_tbl_hive
 
 -- !sql09 --
+p1=part1
+p1=part2
 
 -- !sql10 --
-test_use_meta_cache_db_hive
+p1=part1
+p1=part2
 
 -- !sql11 --
+
+-- !sql12 --
+
+-- !sql13 --
+test_use_meta_cache_db_hive
+
+-- !sql14 --
+
+-- !sql01 --
+
+-- !sql02 --
+test_use_meta_cache_db
+
+-- !sql03 --
+test_use_meta_cache_tbl
+
+-- !sql04 --
+
+-- !sql05 --
+
+-- !sql01 --
+
+-- !sql02 --
+
+-- !sql03 --
+test_use_meta_cache_db_hive
+
+-- !sql04 --
+
+-- !sql05 --
+
+-- !sql06 --
+test_use_meta_cache_tbl_hive
+
+-- !sql07 --
+test_use_meta_cache_tbl_hive
+
+-- !sql08 --
+
+-- !sql09 --
+p1=part1
+p1=part2
+
+-- !sql10 --
+p1=part1
+p1=part2
+
+-- !sql11 --
+test_use_meta_cache_partitioned_tbl_hive
+test_use_meta_cache_tbl_hive
+
+-- !sql12 --
+
+-- !sql13 --
+test_use_meta_cache_db_hive
+
+-- !sql14 --
 

--- a/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
@@ -34,17 +34,13 @@ p1=part1
 p1=part2
 
 -- !sql10 --
-p1=part1
-p1=part2
 
 -- !sql11 --
 
 -- !sql12 --
-
--- !sql13 --
 test_use_meta_cache_db_hive
 
--- !sql14 --
+-- !sql13 --
 
 -- !sql01 --
 
@@ -82,19 +78,15 @@ p1=part1
 p1=part2
 
 -- !sql10 --
-p1=part1
-p1=part2
-
--- !sql11 --
 test_use_meta_cache_partitioned_tbl_hive
 test_use_meta_cache_tbl_hive
 
--- !sql12 --
+-- !sql11 --
 
--- !sql13 --
+-- !sql12 --
 test_use_meta_cache_db_hive
 
--- !sql14 --
+-- !sql13 --
 
 -- !sql01 --
 
@@ -131,17 +123,13 @@ p1=part1
 p1=part2
 
 -- !sql10 --
-p1=part1
-p1=part2
 
 -- !sql11 --
 
 -- !sql12 --
-
--- !sql13 --
 test_use_meta_cache_db_hive
 
--- !sql14 --
+-- !sql13 --
 
 -- !sql01 --
 
@@ -179,17 +167,13 @@ p1=part1
 p1=part2
 
 -- !sql10 --
-p1=part1
-p1=part2
-
--- !sql11 --
 test_use_meta_cache_partitioned_tbl_hive
 test_use_meta_cache_tbl_hive
 
--- !sql12 --
+-- !sql11 --
 
--- !sql13 --
+-- !sql12 --
 test_use_meta_cache_db_hive
 
--- !sql14 --
+-- !sql13 --
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache.groovy
@@ -23,80 +23,116 @@ suite("test_hive_use_meta_cache", "p0,external,hive,external_docker,external_doc
         return;
     }
 
-    for (String hivePrefix : ["hive3", "hive3"]) {
+    for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
         try {
-            String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog = "test_${hivePrefix}_use_meta_cache"
-            String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+            def test_use_meta_cache = { Boolean use_meta_cache ->
+                String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+                String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
+                String use_meta_cache_string = use_meta_cache ? "true" : "false"
+                String catalog = "test_${hivePrefix}_use_meta_cache_${use_meta_cache}"
+                String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
-            sql """drop catalog if exists ${catalog}"""
-            sql """create catalog if not exists ${catalog} properties (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
-                'use_meta_cache' = 'true'
-            );"""
+                sql """drop catalog if exists ${catalog}"""
+                sql """create catalog if not exists ${catalog} properties (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                    'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
+                    'use_meta_cache' = '${use_meta_cache_string}'
+                );"""
+                
+                // create from Doris, the cache will be filled immediately
+                String database= "test_use_meta_cache_db"
+                String table = "test_use_meta_cache_tbl"
+                String database_hive = "test_use_meta_cache_db_hive"
+                String table_hive = "test_use_meta_cache_tbl_hive"
+                String partitioned_table_hive = "test_use_meta_cache_partitioned_tbl_hive"
+
+                sql "switch ${catalog}"
+                sql "drop database if exists ${database}"
+                sql "drop database if exists ${database_hive}"
+                order_qt_sql01 "show databases like '%${database}%'";
+                sql "drop database if exists ${database}"
+                sql "create database ${database}"
+                order_qt_sql02 "show databases like '%${database}%'";
+                sql "use ${database}"
+                sql "create table ${table} (k1 int)"
+                order_qt_sql03 "show tables"
+                sql "drop table ${table}"
+                order_qt_sql04 "show tables"
+                sql "drop database ${database}"
+                order_qt_sql05 "show databases like '%${database}%'";
             
-            // create from Doris, the cache will be filled immediately
-            String database= "test_use_meta_cache_db"
-            String table = "test_use_meta_cache_tbl"
-            String database_hive = "test_use_meta_cache_db_hive"
-            String table_hive = "test_use_meta_cache_tbl_hive"
-            sql "switch ${catalog}"
-            sql "drop database if exists ${database}"
-            sql "drop database if exists ${database_hive}"
-            order_qt_sql01 "show databases like '%${database}%'";
-            sql "drop database if exists ${database}"
-            sql "create database ${database}"
-            order_qt_sql02 "show databases like '%${database}%'";
-            sql "use ${database}"
-            sql "create table ${table} (k1 int)"
-            order_qt_sql03 "show tables"
-            sql "drop table ${table}"
-            order_qt_sql04 "show tables"
-            sql "drop database ${database}"
-            order_qt_sql05 "show databases like '%${database}%'";
-         
-            // create from Hive, the cache has different behavior
-            order_qt_sql01 "show databases like '%${database_hive}%'";
-            hive_docker "drop database if exists ${database_hive}"
-            hive_docker "create database ${database_hive}"
-            // not see
-            order_qt_sql02 "show databases like '%${database_hive}%'";
-            // but can use
-            sql "use ${database_hive}"
-            sql "refresh catalog ${catalog}"
-            // can see
-            order_qt_sql03 "show databases like '%${database_hive}%'";
-            // show tables first to fill cache
-            order_qt_sql04 "show tables"
-            hive_docker "create table ${database_hive}.${table_hive} (k1 int)"
-            // not see
-            order_qt_sql05 "show tables"
-            // but can select
-            sql "select * from ${table_hive}"
-            // still not see
-            order_qt_sql06 "show tables"
-            sql "refresh database ${database_hive}"
-            // can see
-            order_qt_sql07 "show tables"
-            hive_docker "drop table ${database_hive}.${table_hive}"
-            // still can see
-            order_qt_sql08 "show tables"
-            sql "refresh database ${database_hive}"
-            // can not see
-            order_qt_sql09 "show tables"
-            hive_docker "drop database ${database_hive}"
-            // still can see
-            order_qt_sql10 "show databases like '%${database_hive}%'";
-            sql "refresh catalog ${catalog}"
-            // can not see
-            order_qt_sql11 "show databases like '%${database_hive}%'";
+                // create from Hive, the cache has different behavior
+                order_qt_sql01 "show databases like '%${database_hive}%'";
+                hive_docker "drop database if exists ${database_hive}"
+                hive_docker "create database ${database_hive}"
+                // not see
+                order_qt_sql02 "show databases like '%${database_hive}%'";
+                if (use_meta_cache) {
+                    // if use meta cache, can use
+                    sql "use ${database_hive}"
+                    sql "refresh catalog ${catalog}"
+                } else {
+                    // if not use meta cache, can not use
+                    sql "refresh catalog ${catalog}"
+                    sql "use ${database_hive}"
+                }
+
+                // can see
+                order_qt_sql03 "show databases like '%${database_hive}%'";
+                // show tables first to fill cache
+                order_qt_sql04 "show tables"
+                hive_docker "create table ${database_hive}.${table_hive} (k1 int)"
+                // not see
+                order_qt_sql05 "show tables"
+                if (use_meta_cache) {
+                    // but can select
+                    sql "select * from ${table_hive}"
+                    // still not see
+                    order_qt_sql06 "show tables"
+                    sql "refresh database ${database_hive}"
+                } else {
+                    // if not use meta cache, can not select
+                    sql "refresh database ${database_hive}"
+                    sql "select * from ${table_hive}"
+                    order_qt_sql06 "show tables"
+                }
+                // can see
+                order_qt_sql07 "show tables"
+                
+                // test Hive Metastore table partition file listing
+                hive_docker "create table ${database_hive}.${partitioned_table_hive} (k1 int) partitioned by (p1 string)"
+                sql "refresh catalog ${catalog}"
+                order_qt_sql08 "show partitions from ${partitioned_table_hive}"
+                hive_docker "alter table ${database_hive}.${partitioned_table_hive} add partition (p1='part1')"
+                hive_docker "alter table ${database_hive}.${partitioned_table_hive} add partition (p1='part2')"
+                // cant not see
+                order_qt_sql09 "show partitions from ${partitioned_table_hive}"
+                sql "refresh database ${database_hive}"
+                // can see
+                order_qt_sql10 "show partitions from ${partitioned_table_hive}"
+
+                // drop tables
+                hive_docker "drop table ${database_hive}.${partitioned_table_hive}"
+                hive_docker "drop table ${database_hive}.${table_hive}"
+                // still can see
+                order_qt_sql11 "show tables"
+                sql "refresh database ${database_hive}"
+                // can not see
+                order_qt_sql12 "show tables"
+
+                // drop database
+                hive_docker "drop database ${database_hive}"
+                // still can see
+                order_qt_sql13 "show databases like '%${database_hive}%'";
+                sql "refresh catalog ${catalog}"
+                // can not see
+                order_qt_sql14 "show databases like '%${database_hive}%'";
+            }
+            test_use_meta_cache(true)
+            test_use_meta_cache(false)
         } finally {
         }
     }
 }
-
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache.groovy
@@ -107,28 +107,25 @@ suite("test_hive_use_meta_cache", "p0,external,hive,external_docker,external_doc
                 order_qt_sql08 "show partitions from ${partitioned_table_hive}"
                 hive_docker "alter table ${database_hive}.${partitioned_table_hive} add partition (p1='part1')"
                 hive_docker "alter table ${database_hive}.${partitioned_table_hive} add partition (p1='part2')"
-                // cant not see
+                // can see because partition file listing is not cached
                 order_qt_sql09 "show partitions from ${partitioned_table_hive}"
-                sql "refresh database ${database_hive}"
-                // can see
-                order_qt_sql10 "show partitions from ${partitioned_table_hive}"
 
                 // drop tables
                 hive_docker "drop table ${database_hive}.${partitioned_table_hive}"
                 hive_docker "drop table ${database_hive}.${table_hive}"
                 // still can see
-                order_qt_sql11 "show tables"
+                order_qt_sql10 "show tables"
                 sql "refresh database ${database_hive}"
                 // can not see
-                order_qt_sql12 "show tables"
+                order_qt_sql11 "show tables"
 
                 // drop database
                 hive_docker "drop database ${database_hive}"
                 // still can see
-                order_qt_sql13 "show databases like '%${database_hive}%'";
+                order_qt_sql12 "show databases like '%${database_hive}%'";
                 sql "refresh catalog ${catalog}"
                 // can not see
-                order_qt_sql14 "show databases like '%${database_hive}%'";
+                order_qt_sql13 "show databases like '%${database_hive}%'";
             }
             test_use_meta_cache(true)
             test_use_meta_cache(false)


### PR DESCRIPTION
### What problem does this PR solve?
Bug: When hive catalog set use_meta_cache=false, refresh catalog cannot update the database list.
Fix: Set initialized = false in `refreshOnlyCatalogCache()`.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

