### PR TITLE
[fix](tools) tpcds-tools: fix TPCDS_DBGEN_DIR

### DIFF
--- a/tools/tpcds-tools/bin/build-tpcds-tools.sh
+++ b/tools/tpcds-tools/bin/build-tpcds-tools.sh
@@ -46,8 +46,8 @@ check_prerequest() {
 check_prerequest "unzip -h" "unzip"
 
 # download tpcds tools package first
-if [[ -d "${CURDIR}/DSGen-software-code-3.2.0rc1" ]]; then
-    echo "If you want to rebuild TPC-DS_Tools_v3.2.0 again, please delete ${CURDIR}/DSGen-software-code-3.2.0rc1 first."
+if [[ -d "${CURDIR}/DSGen-software-code-3.2.0rc2" ]]; then
+    echo "If you want to rebuild TPC-DS_Tools_v3.2.0 again, please delete ${CURDIR}/DSGen-software-code-3.2.0rc2 first."
 elif [[ -f "TPC-DS_Tools_v3.2.0rc2.zip" ]]; then
     unzip TPC-DS_Tools_v3.2.0rc2.zip -d "${CURDIR}/"
 else

--- a/tools/tpcds-tools/bin/gen-tpcds-data.sh
+++ b/tools/tpcds-tools/bin/gen-tpcds-data.sh
@@ -29,7 +29,7 @@ ROOT=$(
 )
 
 CURDIR="${ROOT}"
-TPCDS_DBGEN_DIR="${CURDIR}/DSGen-software-code-3.2.0rc1/tools"
+TPCDS_DBGEN_DIR="${CURDIR}/DSGen-software-code-3.2.0rc2/tools"
 
 usage() {
     echo "

--- a/tools/tpcds-tools/bin/gen-tpcds-queries.sh
+++ b/tools/tpcds-tools/bin/gen-tpcds-queries.sh
@@ -29,7 +29,7 @@ ROOT=$(
 )
 
 CURDIR="${ROOT}"
-TPCDS_DSQGEN_DIR="${CURDIR}/DSGen-software-code-3.2.0rc1/tools"
+TPCDS_DSQGEN_DIR="${CURDIR}/DSGen-software-code-3.2.0rc2/tools"
 TPCDS_QUERIE_DIR="${CURDIR}/../queries"
 
 usage() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #43668

Problem Summary:

This associated PR modified the TPCDD_DBGEN-DIR path, but omitted the file 'create tpcs-tables. sh'

```bash
bin/gen-tpcds-data.sh -s 100
Scale Factor: 100
Parallelism: 10
/test/doris/tools/tpcds-tools/bin/DSGen-software-code-3.2.0rc1/tools/dsdgen does not exist. Run build-tpcds-dsdgen.sh first to build it first.
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

