### PR TITLE
[fix](cloud) serialize cache init to avoid unstable cache pick

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -425,36 +425,24 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
                    << ", reason=" << rest.msg();
         exit(-1);
     }
-    std::vector<std::thread> file_cache_init_threads;
 
-    std::list<doris::Status> cache_status;
+    doris::Status cache_status;
     for (auto& cache_path : cache_paths) {
         if (cache_path_set.find(cache_path.path) != cache_path_set.end()) {
             LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
             continue;
         }
 
-        file_cache_init_threads.emplace_back([&, status = &cache_status.emplace_back()]() {
-            *status = doris::io::FileCacheFactory::instance()->create_file_cache(
-                    cache_path.path, cache_path.init_settings());
-        });
-
-        cache_path_set.emplace(cache_path.path);
-    }
-
-    for (std::thread& thread : file_cache_init_threads) {
-        if (thread.joinable()) {
-            thread.join();
-        }
-    }
-    for (const auto& status : cache_status) {
-        if (!status.ok()) {
+        cache_status = doris::io::FileCacheFactory::instance()->create_file_cache(
+                cache_path.path, cache_path.init_settings());
+        if (!cache_status.ok()) {
             if (!doris::config::ignore_broken_disk) {
-                LOG(FATAL) << "failed to init file cache, err: " << status;
+                LOG(FATAL) << "failed to init file cache, err: " << cache_status;
                 exit(-1);
             }
-            LOG(WARNING) << "failed to init file cache, err: " << status;
+            LOG(WARNING) << "failed to init file cache, err: " << cache_status;
         }
+        cache_path_set.emplace(cache_path.path);
     }
 }
 


### PR DESCRIPTION
The original paralleled cache init will causing unstable pick of cache base path because the choice depends on the order of init which could be different after each BE reboot. Thus, cause cache missing and duplicate cache block across multiple caches (disk space waste).

This commit will serialize the init process of multiple cache and using fixed order, i.e. the order explicitly declared in be conf: file_cache_path.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

