### PR TITLE
[Feature] Support enable_fuzzy_compression

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1619,6 +1619,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static boolean enable_restore_snapshot_rpc_compression = true;
 
+    @ConfField(mutable = true, description = {
+        "是否为表随机选择压缩算法",
+        "should randomly select a compression algorithm for the table"
+    })
+    public static boolean enable_fuzzy_compression = false;
+
     /**
      * Control the max num of tablets per backup job involved.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -62,6 +62,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -1022,10 +1023,16 @@ public class PropertyAnalyzer {
     // analyzeCompressionType will parse the compression type from properties
     public static TCompressionType analyzeCompressionType(Map<String, String> properties) throws AnalysisException {
         String compressionType = "";
+        boolean enableFuzzyCompression = Config.enable_fuzzy_compression;
         if (properties != null && properties.containsKey(PROPERTIES_COMPRESSION)) {
             compressionType = properties.get(PROPERTIES_COMPRESSION);
             properties.remove(PROPERTIES_COMPRESSION);
         } else {
+            if (enableFuzzyCompression) {
+                Random random = new Random();
+                int randomValue = random.nextInt(8) + 1;
+                return TCompressionType.findByValue(randomValue);
+            }
             return TCompressionType.LZ4F;
         }
 

--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -83,5 +83,7 @@ enable_advance_next_id = true
 # enable deadlock detection
 enable_deadlock_detection = true
 max_lock_hold_threshold_seconds = 10
+# enable fuzzy compression
+enable_fuzzy_compression=true
 
 force_olap_table_replication_allocation=tag.location.default:1


### PR DESCRIPTION
### What problem does this PR solve?

If enable_fuzzy_compression is enabled, the compression algorithm is randomly selected. If not enabled, the default is ZSTD or depend on table property

If both a compression algorithm and a random selection compression algorithm are specified, the random selection takes precedence.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

