### PR TITLE
[fix](variable) Resolve the issue of returning content exceptions when dealing with non master set error variables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -158,7 +158,7 @@ public class VariableMgr {
     }
 
     // Set value to a variable
-    private static boolean setValue(Object obj, SessionVariableField sessionVariableField, String value)
+    private static void setValue(Object obj, SessionVariableField sessionVariableField, String value)
             throws DdlException {
 
         Field field = sessionVariableField.getField();
@@ -241,7 +241,6 @@ public class VariableMgr {
             VariableVarCallbacks.call(attr.name(), value);
         }
 
-        return true;
     }
 
     // revert the operator[set_var] on select/*+ SET_VAR()*/  sql;
@@ -299,7 +298,7 @@ public class VariableMgr {
         setVarInternal(sessionVariable, setVar, varCtx);
     }
 
-    public static String findSimilarSessionVarNames(String inputName) {
+    private static String findSimilarSessionVarNames(String inputName) {
         JaroWinklerDistance jaroWinklerDistance = new JaroWinklerDistance();
         StringJoiner joiner = new StringJoiner(", ", "{", "}");
         ctxByDisplayVarName.keySet().stream()
@@ -321,7 +320,8 @@ public class VariableMgr {
             throws DdlException {
         VarContext varCtx = getVarContext(setVar.getVariable());
         if (varCtx == null) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable());
+            ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable(),
+                    findSimilarSessionVarNames(setVar.getVariable()));
         }
         try {
             checkUpdate(setVar, varCtx.getFlag());
@@ -760,7 +760,7 @@ public class VariableMgr {
                     row.add(getValue(ctx.getObj(), ctx.getField()));
                 }
 
-                if (row.size() > 1 && VariableVarConverters.hasConverter(row.get(0))) {
+                if (VariableVarConverters.hasConverter(row.get(0))) {
                     try {
                         row.set(1, VariableVarConverters.decode(row.get(0), Long.valueOf(row.get(1))));
                     } catch (DdlException e) {


### PR DESCRIPTION
…n dealing with non master set error variables

### What problem does this PR solve?

When setting an incorrect variable to a non master, the returned content is abnormal:

`
mysql> set global group_by_and_having_use= false;

ERROR 1193 (HY000): errCode = 2, detailMessage = Unknown system variable '%s',the similar variables are %s
`

![image](https://github.com/user-attachments/assets/48ef1760-b7b9-4ec3-9caf-b9ae09e1de07)


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ - ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ - ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

