### PR TITLE
[fix](mtmv)When compatibility fails, null pointers should not be reported

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
@@ -112,8 +112,7 @@ public class BaseTableInfo {
 
     // if compatible failed due catalog dropped, ctlName will be null
     public boolean isInternalTable() {
-        //
-        if (StringUtils.isEmpty(ctlName)) {
+        if (!StringUtils.isEmpty(ctlName)) {
             return InternalCatalog.INTERNAL_CATALOG_NAME.equals(ctlName);
         } else {
             return InternalCatalog.INTERNAL_CATALOG_ID == ctlId;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
@@ -110,6 +110,16 @@ public class BaseTableInfo {
         this.tableName = tableName;
     }
 
+    // if compatible failed due catalog dropped, ctlName will be null
+    public boolean isInternalTable() {
+        //
+        if (StringUtils.isEmpty(ctlName)) {
+            return InternalCatalog.INTERNAL_CATALOG_NAME.equals(ctlName);
+        } else {
+            return InternalCatalog.INTERNAL_CATALOG_ID == ctlId;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtil.java
@@ -28,7 +28,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.CatalogMgr;
-import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeExtractAndTransform;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
@@ -96,7 +95,7 @@ public class MTMVUtil {
     public static boolean mtmvContainsExternalTable(MTMV mtmv) {
         Set<BaseTableInfo> baseTables = mtmv.getRelation().getBaseTablesOneLevel();
         for (BaseTableInfo baseTableInfo : baseTables) {
-            if (!baseTableInfo.getCtlName().equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
+            if (!baseTableInfo.isInternalTable()) {
                 return true;
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?
The ID stored in the previous version and the name stored in the new version need to be checked for compatibility. If the catalog is deleted or rebuilt, compatibility will fail, but null pointers should not be reported

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When compatibility fails, null pointers should not be reported


### Release note

When compatibility fails, null pointers should not be reported

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

