### PR TITLE
Revert "[refine](column) Remove some unnecessary get_int functions."

### DIFF
--- a/be/src/vec/functions/array/function_array_slice.h
+++ b/be/src/vec/functions/array/function_array_slice.h
@@ -75,11 +75,9 @@ public:
         auto offset_column =
                 block.get_by_position(arguments[1]).column->convert_to_full_column_if_const();
         ColumnPtr length_column = nullptr;
-        const ColumnInt64* length_column_int64 = nullptr;
         if (arguments.size() > 2) {
             length_column =
                     block.get_by_position(arguments[2]).column->convert_to_full_column_if_const();
-            length_column_int64 = assert_cast<const ColumnInt64*>(length_column.get());
         }
         // extract src array column
         ColumnArrayExecutionData src;
@@ -94,8 +92,7 @@ public:
         ColumnArrayMutableData dst = create_mutable_data(src.nested_col, is_nullable);
         dst.offsets_ptr->reserve(input_rows_count);
         // execute
-        const auto* offset_column_int64 = assert_cast<const ColumnInt64*>(offset_column.get());
-        slice_array(dst, src, *offset_column_int64, length_column_int64);
+        slice_array(dst, src, *offset_column, length_column.get());
         ColumnPtr res_column = assemble_column_array(dst);
         block.replace_by_position(result, std::move(res_column));
         return Status::OK();

--- a/be/src/vec/functions/array/function_array_utils.cpp
+++ b/be/src/vec/functions/array/function_array_utils.cpp
@@ -78,12 +78,12 @@ MutableColumnPtr assemble_column_array(ColumnArrayMutableData& data) {
 }
 
 void slice_array(ColumnArrayMutableData& dst, ColumnArrayExecutionData& src,
-                 const ColumnInt64& offset_column, const ColumnInt64* length_column) {
+                 const IColumn& offset_column, const IColumn* length_column) {
     size_t cur = 0;
     for (size_t row = 0; row < src.offsets_ptr->size(); ++row) {
         size_t off = (*src.offsets_ptr)[row - 1];
         size_t len = (*src.offsets_ptr)[row] - off;
-        Int64 start = offset_column.get_element(row);
+        Int64 start = offset_column.get_int(row);
         if (len == 0 || start == 0) {
             dst.offsets_ptr->push_back(cur);
             continue;
@@ -98,7 +98,7 @@ void slice_array(ColumnArrayMutableData& dst, ColumnArrayExecutionData& src,
         }
         Int64 end;
         if (length_column) {
-            Int64 size = length_column->get_element(row);
+            Int64 size = length_column->get_int(row);
             end = std::max((Int64)off, std::min((Int64)(off + len), start + size));
         } else {
             end = off + len;

--- a/be/src/vec/functions/array/function_array_utils.h
+++ b/be/src/vec/functions/array/function_array_utils.h
@@ -91,7 +91,7 @@ MutableColumnPtr assemble_column_array(ColumnArrayMutableData& data);
 
 // array[offset:length]
 void slice_array(ColumnArrayMutableData& dst, ColumnArrayExecutionData& src,
-                 const ColumnInt64& offset_column, const ColumnInt64* length_column);
+                 const IColumn& offset_column, const IColumn* length_column);
 
 using ColumnArrayExecutionDatas = std::vector<ColumnArrayExecutionData>;
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -479,6 +479,34 @@ struct DateTimeOp {
         }
     }
 
+    // use for (const DateTime, ColumnNumber) -> other_type
+    static void constant_vector(const FromType1& from, PaddedPODArray<ToType>& vec_to,
+                                NullMap& null_map, const IColumn& delta) {
+        size_t size = delta.size();
+        vec_to.resize(size);
+        null_map.resize_fill(size, false);
+
+        for (size_t i = 0; i < size; ++i) {
+            vec_to[i] = Transform::execute(from, delta.get_int(i),
+                                           reinterpret_cast<bool&>(null_map[i]));
+        }
+    }
+    static void constant_vector(const FromType1& from, PaddedPODArray<ToType>& vec_to,
+                                const IColumn& delta) {
+        size_t size = delta.size();
+        vec_to.resize(size);
+        bool invalid = true;
+
+        for (size_t i = 0; i < size; ++i) {
+            vec_to[i] = Transform::execute(from, delta.get_int(i), invalid);
+
+            if (UNLIKELY(invalid)) {
+                throw Exception(ErrorCode::OUT_OF_BOUND, "Operation {} {} {} out of range",
+                                Transform::name, from, delta.get_int(i));
+            }
+        }
+    }
+
     static void constant_vector(const FromType1& from, PaddedPODArray<ToType>& vec_to,
                                 NullMap& null_map, const PaddedPODArray<FromType2>& delta) {
         size_t size = delta.size();
@@ -619,10 +647,9 @@ struct DateTimeAddIntervalImpl {
                                         col_to->get_data(), null_map->get_data(),
                                         delta_vec_column->get_data());
                 } else {
-                    return Status::RuntimeError(
-                            "Illegal column {} of first argument of function {}",
-                            block.get_by_position(arguments[0]).column->get_name(),
-                            Transform::name);
+                    Op::constant_vector(sources_const->template get_value<FromType1>(),
+                                        col_to->get_data(), null_map->get_data(),
+                                        *not_nullable_column_ptr_arg1);
                 }
                 if (const auto* nullable_col = check_and_get_column<ColumnNullable>(
                             block.get_by_position(arguments[0]).column.get())) {
@@ -650,10 +677,9 @@ struct DateTimeAddIntervalImpl {
                     Op::constant_vector(sources_const->template get_value<FromType1>(),
                                         col_to->get_data(), delta_vec_column->get_data());
                 } else {
-                    return Status::RuntimeError(
-                            "Illegal column {} of first argument of function {}",
-                            block.get_by_position(arguments[0]).column->get_name(),
-                            Transform::name);
+                    Op::constant_vector(sources_const->template get_value<FromType1>(),
+                                        col_to->get_data(),
+                                        *block.get_by_position(arguments[1]).column);
                 }
                 block.replace_by_position(result, std::move(col_to));
             }

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -45,7 +45,6 @@
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_struct.h"
-#include "vec/columns/columns_number.h"
 #include "vec/common/assert_cast.h"
 #include "vec/core/block.h"
 #include "vec/core/types.h"
@@ -533,7 +532,6 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
     } else if (const auto* src_nullable_column =
                        check_and_get_column<vectorized::ColumnNullable>(src_column_ptr)) {
         auto src_nested_column_ptr = src_nullable_column->get_nested_column_ptr();
-        const auto* src_int_64 = assert_cast<const ColumnInt64*>(src_nested_column_ptr.get());
         const auto& null_map_data = src_nullable_column->get_null_map_data();
         dst_values.reserve(rows);
         for (size_t i = 0; i < rows; i++) {
@@ -547,7 +545,7 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
 
         for (size_t i = 0; i < rows; i++) {
             dst_values.emplace_back((null_map_data[i] != 0) ? _auto_inc_id_allocator.next_id()
-                                                            : src_int_64->get_element(i));
+                                                            : src_nested_column_ptr->get_int(i));
         }
     } else {
         return Status::OK();


### PR DESCRIPTION
Reverts apache/doris#44017

In this pr, for some code path that `col2`'s type is not `FromType2` we assert it's wrong and throw error. but in fact because of some misuse in our code, **many date function didn't specify the `FromType2`**. so the "wrong" path is useful now. Only when we fixed all the calling with wrong `FromType2`, this pr could be applied.