### PR TITLE
[fix](iceberg)Bring field_id with parquet files And fix map type's key optional

### DIFF
--- a/be/src/vec/exec/format/table/iceberg/arrow_schema_util.cpp
+++ b/be/src/vec/exec/format/table/iceberg/arrow_schema_util.cpp
@@ -82,7 +82,7 @@ Status ArrowSchemaUtil::convert_to(const iceberg::NestedField& field,
         break;
 
     case iceberg::TypeID::DECIMAL: {
-        DecimalType* dt = dynamic_cast<DecimalType*>(field.field_type());
+        auto dt = dynamic_cast<DecimalType*>(field.field_type());
         arrow_type = arrow::decimal(dt->get_precision(), dt->get_scale());
         break;
     }

--- a/be/src/vec/exec/format/table/iceberg/arrow_schema_util.cpp
+++ b/be/src/vec/exec/format/table/iceberg/arrow_schema_util.cpp
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exec/format/table/iceberg/arrow_schema_util.h"
+
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
+namespace doris {
+namespace iceberg {
+
+const char* ArrowSchemaUtil::PARQUET_FIELD_ID = "PARQUET:field_id";
+const char* ArrowSchemaUtil::ORIGINAL_TYPE = "originalType";
+const char* ArrowSchemaUtil::MAP_TYPE_VALUE = "mapType";
+
+Status ArrowSchemaUtil::Convert(const Schema* schema, const std::string& timezone,
+                                std::vector<std::shared_ptr<arrow::Field>>& fields) {
+    for (const auto& column : schema->columns()) {
+        std::shared_ptr<arrow::Field> arrow_field;
+        RETURN_IF_ERROR(ConvertTo(column, &arrow_field, timezone));
+        fields.push_back(arrow_field);
+    }
+    return Status::OK();
+}
+
+Status ArrowSchemaUtil::ConvertTo(const iceberg::NestedField& field,
+                                  std::shared_ptr<arrow::Field>* arrow_field,
+                                  const std::string& timezone) {
+    std::shared_ptr<arrow::DataType> arrow_type;
+    std::unordered_map<std::string, std::string> metadata;
+    metadata[PARQUET_FIELD_ID] = std::to_string(field.field_id());
+
+    switch (field.field_type()->type_id()) {
+    case iceberg::TypeID::BOOLEAN:
+        arrow_type = arrow::boolean();
+        break;
+
+    case iceberg::TypeID::INTEGER:
+        arrow_type = arrow::int32();
+        break;
+
+    case iceberg::TypeID::LONG:
+        arrow_type = arrow::int64();
+        break;
+
+    case iceberg::TypeID::FLOAT:
+        arrow_type = arrow::float32();
+        break;
+
+    case iceberg::TypeID::DOUBLE:
+        arrow_type = arrow::float64();
+        break;
+
+    case iceberg::TypeID::DATE:
+        arrow_type = arrow::date32();
+        break;
+
+    case iceberg::TypeID::TIMESTAMP: {
+        arrow_type = std::make_shared<arrow::TimestampType>(arrow::TimeUnit::MICRO, timezone);
+        break;
+    }
+
+    case iceberg::TypeID::BINARY:
+    case iceberg::TypeID::STRING:
+    case iceberg::TypeID::UUID:
+    case iceberg::TypeID::FIXED:
+        arrow_type = arrow::utf8();
+        break;
+
+    case iceberg::TypeID::DECIMAL: {
+        DecimalType* dt = dynamic_cast<DecimalType*>(field.field_type());
+        arrow_type = arrow::decimal(dt->get_precision(), dt->get_scale());
+        break;
+    }
+
+    case iceberg::TypeID::STRUCT: {
+        std::vector<std::shared_ptr<arrow::Field>> element_fields;
+        StructType* st = field.field_type()->as_struct_type();
+        for (const auto& column : st->fields()) {
+            std::shared_ptr<arrow::Field> element_field;
+            RETURN_IF_ERROR(ConvertTo(column, &element_field, timezone));
+            element_fields.push_back(element_field);
+        }
+        arrow_type = arrow::struct_(element_fields);
+        break;
+    }
+
+    case iceberg::TypeID::LIST: {
+        std::shared_ptr<arrow::Field> item_field;
+        ListType* list_type = field.field_type()->as_list_type();
+        RETURN_IF_ERROR(ConvertTo(list_type->element_field(), &item_field, timezone));
+        arrow_type = arrow::list(item_field);
+        break;
+    }
+
+    case iceberg::TypeID::MAP: {
+        std::shared_ptr<arrow::Field> key_field;
+        std::shared_ptr<arrow::Field> value_field;
+        MapType* map_type = field.field_type()->as_map_type();
+        RETURN_IF_ERROR(ConvertTo(map_type->key_field(), &key_field, timezone));
+        RETURN_IF_ERROR(ConvertTo(map_type->value_field(), &value_field, timezone));
+        metadata[ORIGINAL_TYPE] = MAP_TYPE_VALUE;
+        arrow_type = std::make_shared<arrow::MapType>(key_field, value_field);
+        break;
+    }
+
+    case iceberg::TypeID::TIME:
+    default:
+        return Status::InternalError("Unsupported field type:" + field.field_type()->to_string());
+    }
+
+    std::shared_ptr<arrow::KeyValueMetadata> schema_metadata =
+            std::make_shared<arrow::KeyValueMetadata>(metadata);
+    *arrow_field =
+            arrow::field(field.field_name(), arrow_type, field.is_optional(), schema_metadata);
+    return Status::OK();
+}
+
+} // namespace iceberg
+} // namespace doris

--- a/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
+++ b/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
@@ -23,6 +23,7 @@
 // #include <unistd.h>
 
 #include <arrow/type.h>
+
 #include <shared_mutex>
 
 #include "vec/exec/format/table/iceberg/schema.h"

--- a/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
+++ b/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
@@ -17,11 +17,6 @@
 
 #pragma once
 
-// #include <arrow/io/type_fwd.h>
-// #include <sys/stat.h>
-// #include <sys/types.h>
-// #include <unistd.h>
-
 #include <arrow/type.h>
 
 #include <shared_mutex>

--- a/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
+++ b/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
@@ -33,7 +33,7 @@ namespace iceberg {
 
 class ArrowSchemaUtil {
 public:
-    static Status Convert(const Schema* schema, const std::string& timezone,
+    static Status convert(const Schema* schema, const std::string& timezone,
                           std::vector<std::shared_ptr<arrow::Field>>& fields);
 
 private:
@@ -41,9 +41,9 @@ private:
     static const char* ORIGINAL_TYPE;
     static const char* MAP_TYPE_VALUE;
 
-    static Status ConvertTo(const iceberg::NestedField& field,
-                            std::shared_ptr<arrow::Field>* arrow_field,
-                            const std::string& timezone);
+    static Status convert_to(const iceberg::NestedField& field,
+                             std::shared_ptr<arrow::Field>* arrow_field,
+                             const std::string& timezone);
 };
 
 } // namespace iceberg

--- a/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
+++ b/be/src/vec/exec/format/table/iceberg/arrow_schema_util.h
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+// #include <arrow/io/type_fwd.h>
+// #include <sys/stat.h>
+// #include <sys/types.h>
+// #include <unistd.h>
+
+#include <arrow/type.h>
+#include <shared_mutex>
+
+#include "vec/exec/format/table/iceberg/schema.h"
+
+namespace doris {
+namespace iceberg {
+
+class ArrowSchemaUtil {
+public:
+    static Status Convert(const Schema* schema, const std::string& timezone,
+                          std::vector<std::shared_ptr<arrow::Field>>& fields);
+
+private:
+    static const char* PARQUET_FIELD_ID;
+    static const char* ORIGINAL_TYPE;
+    static const char* MAP_TYPE_VALUE;
+
+    static Status ConvertTo(const iceberg::NestedField& field,
+                            std::shared_ptr<arrow::Field>* arrow_field,
+                            const std::string& timezone);
+};
+
+} // namespace iceberg
+} // namespace doris

--- a/be/src/vec/exec/format/table/iceberg/types.cpp
+++ b/be/src/vec/exec/format/table/iceberg/types.cpp
@@ -25,8 +25,9 @@ namespace iceberg {
 std::unique_ptr<MapType> MapType::of_optional(int key_id, int value_id,
                                               std::unique_ptr<Type> key_type,
                                               std::unique_ptr<Type> value_type) {
+    // key is always required
     auto key_field =
-            std::make_unique<NestedField>(true, key_id, "key", std::move(key_type), std::nullopt);
+            std::make_unique<NestedField>(false, key_id, "key", std::move(key_type), std::nullopt);
     auto value_field = std::make_unique<NestedField>(true, value_id, "value", std::move(value_type),
                                                      std::nullopt);
     return std::unique_ptr<MapType>(new MapType(std::move(key_field), std::move(value_field)));

--- a/be/src/vec/exec/format/table/iceberg/types.h
+++ b/be/src/vec/exec/format/table/iceberg/types.h
@@ -265,6 +265,10 @@ public:
         ss << "decimal(" << precision << ", " << scale << ")";
         return ss.str();
     }
+
+    int get_precision() { return precision; }
+
+    int get_scale() { return scale; }
 };
 
 class BinaryType : public PrimitiveType {

--- a/be/src/vec/exec/format/table/iceberg/types.h
+++ b/be/src/vec/exec/format/table/iceberg/types.h
@@ -266,9 +266,9 @@ public:
         return ss.str();
     }
 
-    int get_precision() { return precision; }
+    int get_precision() const { return precision; }
 
-    int get_scale() { return scale; }
+    int get_scale() const { return scale; }
 };
 
 class BinaryType : public PrimitiveType {

--- a/be/src/vec/runtime/vparquet_transformer.cpp
+++ b/be/src/vec/runtime/vparquet_transformer.cpp
@@ -234,6 +234,7 @@ VParquetTransformer::VParquetTransformer(RuntimeState* state, doris::io::FileWri
           _parquet_disable_dictionary(parquet_disable_dictionary),
           _parquet_version(parquet_version),
           _iceberg_schema_json(iceberg_schema_json) {
+    _iceberg_schema = nullptr;
     _outstream = std::shared_ptr<ParquetOutputStream>(new ParquetOutputStream(file_writer));
 }
 

--- a/be/src/vec/runtime/vparquet_transformer.cpp
+++ b/be/src/vec/runtime/vparquet_transformer.cpp
@@ -65,6 +65,7 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_nullable.h"
+#include "vec/exec/format/table/iceberg/arrow_schema_util.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 #include "vec/functions/function_helpers.h"
@@ -202,21 +203,20 @@ void ParquetBuildHelper::build_version(parquet::WriterProperties::Builder& build
     }
 }
 
-VParquetTransformer::VParquetTransformer(RuntimeState* state, doris::io::FileWriter* file_writer,
-                                         const VExprContextSPtrs& output_vexpr_ctxs,
-                                         std::vector<std::string> column_names,
-                                         TParquetCompressionType::type compression_type,
-                                         bool parquet_disable_dictionary,
-                                         TParquetVersion::type parquet_version,
-                                         bool output_object_data,
-                                         const std::string* iceberg_schema_json)
+VParquetTransformer::VParquetTransformer(
+        RuntimeState* state, doris::io::FileWriter* file_writer,
+        const VExprContextSPtrs& output_vexpr_ctxs, std::vector<std::string> column_names,
+        TParquetCompressionType::type compression_type, bool parquet_disable_dictionary,
+        TParquetVersion::type parquet_version, bool output_object_data,
+        const std::string* iceberg_schema_json, const iceberg::Schema* iceberg_schema)
         : VFileFormatTransformer(state, output_vexpr_ctxs, output_object_data),
           _column_names(std::move(column_names)),
           _parquet_schemas(nullptr),
           _compression_type(compression_type),
           _parquet_disable_dictionary(parquet_disable_dictionary),
           _parquet_version(parquet_version),
-          _iceberg_schema_json(iceberg_schema_json) {
+          _iceberg_schema_json(iceberg_schema_json),
+          _iceberg_schema(iceberg_schema) {
     _outstream = std::shared_ptr<ParquetOutputStream>(new ParquetOutputStream(file_writer));
 }
 
@@ -265,21 +265,24 @@ Status VParquetTransformer::_parse_properties() {
 
 Status VParquetTransformer::_parse_schema() {
     std::vector<std::shared_ptr<arrow::Field>> fields;
-    for (size_t i = 0; i < _output_vexpr_ctxs.size(); i++) {
-        std::shared_ptr<arrow::DataType> type;
-        RETURN_IF_ERROR(convert_to_arrow_type(_output_vexpr_ctxs[i]->root()->type(), &type,
-                                              _state->timezone()));
-        if (_parquet_schemas != nullptr) {
+
+    if (_parquet_schemas != nullptr) {
+        for (size_t i = 0; i < _output_vexpr_ctxs.size(); i++) {
+            std::shared_ptr<arrow::DataType> type;
+            RETURN_IF_ERROR(convert_to_arrow_type(_output_vexpr_ctxs[i]->root()->type(), &type,
+                                                  _state->timezone()));
             std::shared_ptr<arrow::Field> field =
                     arrow::field(_parquet_schemas->operator[](i).schema_column_name, type,
                                  _output_vexpr_ctxs[i]->root()->is_nullable());
             fields.emplace_back(field);
-        } else {
-            std::shared_ptr<arrow::Field> field = arrow::field(
-                    _column_names[i], type, _output_vexpr_ctxs[i]->root()->is_nullable());
-            fields.emplace_back(field);
         }
+    } else if (_iceberg_schema != nullptr) {
+        RETURN_IF_ERROR(
+                iceberg::ArrowSchemaUtil::Convert(_iceberg_schema, _state->timezone(), fields));
+    } else {
+        return Status::InternalError("parquet_schema and iceberg_schema all null!");
     }
+
     if (_iceberg_schema_json != nullptr) {
         std::shared_ptr<arrow::KeyValueMetadata> schema_metadata =
                 arrow::KeyValueMetadata::Make({"iceberg.schema"}, {*_iceberg_schema_json});

--- a/be/src/vec/runtime/vparquet_transformer.cpp
+++ b/be/src/vec/runtime/vparquet_transformer.cpp
@@ -272,11 +272,11 @@ Status VParquetTransformer::_parse_schema() {
         for (size_t i = 0; i < _output_vexpr_ctxs.size(); i++) {
             std::shared_ptr<arrow::DataType> type;
             RETURN_IF_ERROR(convert_to_arrow_type(_output_vexpr_ctxs[i]->root()->type(), &type,
-                                                _state->timezone()));
+                                                  _state->timezone()));
             if (_parquet_schemas != nullptr) {
                 std::shared_ptr<arrow::Field> field =
                         arrow::field(_parquet_schemas->operator[](i).schema_column_name, type,
-                                    _output_vexpr_ctxs[i]->root()->is_nullable());
+                                     _output_vexpr_ctxs[i]->root()->is_nullable());
                 fields.emplace_back(field);
             } else {
                 std::shared_ptr<arrow::Field> field = arrow::field(

--- a/be/src/vec/runtime/vparquet_transformer.h
+++ b/be/src/vec/runtime/vparquet_transformer.h
@@ -27,6 +27,7 @@
 #include <parquet/types.h>
 #include <stdint.h>
 
+#include "vec/exec/format/table/iceberg/schema.h"
 #include "vfile_format_transformer.h"
 
 namespace doris {
@@ -95,7 +96,8 @@ public:
                         std::vector<std::string> column_names,
                         TParquetCompressionType::type compression_type,
                         bool parquet_disable_dictionary, TParquetVersion::type parquet_version,
-                        bool output_object_data, const std::string* iceberg_schema_json = nullptr);
+                        bool output_object_data, const std::string* iceberg_schema_json = nullptr,
+                        const iceberg::Schema* iceberg_schema = nullptr);
 
     VParquetTransformer(RuntimeState* state, doris::io::FileWriter* file_writer,
                         const VExprContextSPtrs& output_vexpr_ctxs,
@@ -132,6 +134,7 @@ private:
     const TParquetVersion::type _parquet_version;
     const std::string* _iceberg_schema_json;
     uint64_t _write_size = 0;
+    const iceberg::Schema* _iceberg_schema;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/sink/writer/iceberg/viceberg_partition_writer.cpp
+++ b/be/src/vec/sink/writer/iceberg/viceberg_partition_writer.cpp
@@ -84,7 +84,7 @@ Status VIcebergPartitionWriter::open(RuntimeState* state, RuntimeProfile* profil
         _file_format_transformer.reset(new VParquetTransformer(
                 state, _file_writer.get(), _write_output_expr_ctxs, _write_column_names,
                 parquet_compression_type, parquet_disable_dictionary, TParquetVersion::PARQUET_1_0,
-                false, _iceberg_schema_json));
+                false, _iceberg_schema_json, &_schema));
         return _file_format_transformer->open();
     }
     case TFileFormatType::FORMAT_ORC: {

--- a/be/test/vec/exec/format/table/iceberg/arrow_schema_util_test.cpp
+++ b/be/test/vec/exec/format/table/iceberg/arrow_schema_util_test.cpp
@@ -47,7 +47,7 @@ TEST(ArrowSchemaUtilTest, test_simple_field) {
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
     Status st;
-    st = ArrowSchemaUtil::Convert(&schema, "utc", fields);
+    st = ArrowSchemaUtil::convert(&schema, "utc", fields);
     EXPECT_TRUE(st.ok());
     EXPECT_EQ(2, fields.size());
     EXPECT_EQ("field1", fields[0]->name());
@@ -105,7 +105,7 @@ TEST(ArrowSchemaUtilTest, test_stuct_field) {
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
     Status st;
-    st = ArrowSchemaUtil::Convert(schema.get(), "utc", fields);
+    st = ArrowSchemaUtil::convert(schema.get(), "utc", fields);
     EXPECT_TRUE(st.ok());
     EXPECT_EQ(1, fields.size());
     EXPECT_EQ("st_col", fields[0]->name());
@@ -157,7 +157,7 @@ TEST(ArrowSchemaUtilTest, test_map_field) {
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
     Status st;
-    st = ArrowSchemaUtil::Convert(schema.get(), "utc", fields);
+    st = ArrowSchemaUtil::convert(schema.get(), "utc", fields);
     EXPECT_TRUE(st.ok());
     EXPECT_EQ(1, fields.size());
     EXPECT_EQ("map_col", fields[0]->name());
@@ -204,7 +204,7 @@ TEST(ArrowSchemaUtilTest, test_list_field) {
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
     Status st;
-    st = ArrowSchemaUtil::Convert(schema.get(), "utc", fields);
+    st = ArrowSchemaUtil::convert(schema.get(), "utc", fields);
     EXPECT_TRUE(st.ok());
     EXPECT_EQ(1, fields.size());
     EXPECT_EQ("list_col", fields[0]->name());

--- a/be/test/vec/exec/format/table/iceberg/arrow_schema_util_test.cpp
+++ b/be/test/vec/exec/format/table/iceberg/arrow_schema_util_test.cpp
@@ -1,0 +1,221 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exec/format/table/iceberg/arrow_schema_util.h"
+
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+#include <gtest/gtest.h>
+
+#include "vec/exec/format/table/iceberg/schema.h"
+#include "vec/exec/format/table/iceberg/schema_parser.h"
+
+namespace doris {
+namespace iceberg {
+
+class ArrowSchemaUtilTest : public testing::Test {
+public:
+    ArrowSchemaUtilTest() = default;
+    virtual ~ArrowSchemaUtilTest() = default;
+};
+
+const std::string_view pfid = "PARQUET:field_id";
+
+TEST(ArrowSchemaUtilTest, test_simple_field) {
+    std::vector<NestedField> nested_fields;
+    nested_fields.reserve(2);
+    NestedField field1(false, 1, "field1", std::make_unique<IntegerType>(), std::nullopt);
+    NestedField field2(false, 2, "field2", std::make_unique<StringType>(), std::nullopt);
+    nested_fields.emplace_back(std::move(field1));
+    nested_fields.emplace_back(std::move(field2));
+
+    Schema schema(1, std::move(nested_fields));
+
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    Status st;
+    st = ArrowSchemaUtil::Convert(&schema, "utc", fields);
+    EXPECT_TRUE(st.ok());
+    EXPECT_EQ(2, fields.size());
+    EXPECT_EQ("field1", fields[0]->name());
+    EXPECT_EQ("field2", fields[1]->name());
+    EXPECT_TRUE(fields[0]->HasMetadata());
+    EXPECT_TRUE(fields[1]->HasMetadata());
+    EXPECT_EQ("1", fields[0]->metadata()->Get(pfid).ValueUnsafe());
+    EXPECT_EQ("2", fields[1]->metadata()->Get(pfid).ValueUnsafe());
+}
+
+TEST(ArrowSchemaUtilTest, test_stuct_field) {
+    // struct_json comes from :
+    //     Schema schema = new Schema(
+    //     Types.NestedField.optional(
+    //         21, "st_col", Types.StructType.of(
+    //             Types.NestedField.optional(32, "st_col_c1", Types.IntegerType.get()),
+    //             Types.NestedField.optional(43, "st_col_c2", Types.StringType.get())
+    //         )
+    //     )
+    // );
+    // StringWriter writer = new StringWriter();
+    // JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    // SchemaParser.toJson(schema.asStruct(), generator);
+    // generator.flush();
+    // System.out.println(writer.toString());
+
+    const std::string struct_json = R"({
+        "type": "struct",
+        "fields": [
+            {
+                "id": 21,
+                "name": "st_col",
+                "required": false,
+                "type": {
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "id": 32,
+                            "name": "st_col_c1",
+                            "required": false,
+                            "type": "int"
+                        },
+                        {
+                            "id": 43,
+                            "name": "st_col_c2",
+                            "required": false,
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        ]
+    })";
+    std::unique_ptr<Schema> schema = SchemaParser::from_json(struct_json);
+
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    Status st;
+    st = ArrowSchemaUtil::Convert(schema.get(), "utc", fields);
+    EXPECT_TRUE(st.ok());
+    EXPECT_EQ(1, fields.size());
+    EXPECT_EQ("st_col", fields[0]->name());
+    EXPECT_EQ("21", fields[0]->metadata()->Get(pfid).ValueUnsafe());
+
+    arrow::StructType* arrow_struct = dynamic_cast<arrow::StructType*>(fields[0]->type().get());
+    auto map_fields = arrow_struct->fields();
+    EXPECT_EQ(2, arrow_struct->fields().size());
+    EXPECT_EQ("st_col_c1", map_fields.at(0).get()->name());
+    EXPECT_EQ("st_col_c2", map_fields.at(1).get()->name());
+    EXPECT_EQ("32", map_fields.at(0).get()->metadata()->Get(pfid).ValueUnsafe());
+    EXPECT_EQ("43", map_fields.at(1).get()->metadata()->Get(pfid).ValueUnsafe());
+}
+
+TEST(ArrowSchemaUtilTest, test_map_field) {
+    // map_json comes from :
+    // Schema schema = new Schema(
+    //     Types.NestedField.optional(
+    //         21, "map_col", Types.MapType.ofOptional(
+    //             32, 43, Types.IntegerType.get(), Types.StringType.get()
+    //         )
+    //     )
+    // );
+    // StringWriter writer = new StringWriter();
+    // JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    // SchemaParser.toJson(schema.asStruct(), generator);
+    // generator.flush();
+    // System.out.println(writer.toString());
+
+    const std::string map_json = R"({
+        "type": "struct",
+        "fields": [
+            {
+                "id": 21,
+                "name": "map_col",
+                "required": false,
+                "type": {
+                    "type": "map",
+                    "key-id": 32,
+                    "key": "int",
+                    "value-id": 43,
+                    "value": "string",
+                    "value-required": false
+                }
+            }
+        ]
+    })";
+    std::unique_ptr<Schema> schema = SchemaParser::from_json(map_json);
+
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    Status st;
+    st = ArrowSchemaUtil::Convert(schema.get(), "utc", fields);
+    EXPECT_TRUE(st.ok());
+    EXPECT_EQ(1, fields.size());
+    EXPECT_EQ("map_col", fields[0]->name());
+    EXPECT_EQ("21", fields[0]->metadata()->Get(pfid).ValueUnsafe());
+
+    arrow::MapType* arrow_map = dynamic_cast<arrow::MapType*>(fields[0]->type().get());
+    auto map_fields = arrow_map->fields();
+    EXPECT_EQ(1, arrow_map->fields().size());
+    EXPECT_EQ("key", arrow_map->key_field()->name());
+    EXPECT_EQ("value", arrow_map->item_field()->name());
+    EXPECT_EQ("32", arrow_map->key_field()->metadata()->Get(pfid).ValueUnsafe());
+    EXPECT_EQ("43", arrow_map->item_field()->metadata()->Get(pfid).ValueUnsafe());
+}
+
+TEST(ArrowSchemaUtilTest, test_list_field) {
+    // list_json comes from :
+    // Schema schema = new Schema(
+    //     Types.NestedField.optional(
+    //         21, "list_col", Types.ListType.ofOptional(
+    //             32, Types.IntegerType.get())));
+    // StringWriter writer = new StringWriter();
+    // JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    // SchemaParser.toJson(schema.asStruct(), generator);
+    // generator.flush();
+    // System.out.println(writer.toString());
+
+    const std::string list_json = R"({
+        "type": "struct",
+        "fields": [
+            {
+                "id": 21,
+                "name": "list_col",
+                "required": false,
+                "type": {
+                    "type": "list",
+                    "element-id": 32,
+                    "element": "int",
+                    "element-required": false
+                }
+            }
+        ]
+    })";
+    std::unique_ptr<Schema> schema = SchemaParser::from_json(list_json);
+
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    Status st;
+    st = ArrowSchemaUtil::Convert(schema.get(), "utc", fields);
+    EXPECT_TRUE(st.ok());
+    EXPECT_EQ(1, fields.size());
+    EXPECT_EQ("list_col", fields[0]->name());
+    EXPECT_EQ("21", fields[0]->metadata()->Get(pfid).ValueUnsafe());
+
+    arrow::ListType* arrow_list = dynamic_cast<arrow::ListType*>(fields[0]->type().get());
+    auto map_fields = arrow_list->fields();
+    EXPECT_EQ(1, arrow_list->fields().size());
+    EXPECT_EQ("element", arrow_list->value_field()->name());
+    EXPECT_EQ("32", arrow_list->value_field()->metadata()->Get(pfid).ValueUnsafe());
+}
+
+} // namespace iceberg
+} // namespace doris

--- a/be/test/vec/exec/format/table/iceberg/schema_parser_test.cpp
+++ b/be/test/vec/exec/format/table/iceberg/schema_parser_test.cpp
@@ -78,6 +78,15 @@ const std::string valid_map_json = R"({
     "value-required": true
 })";
 
+const std::string valid_map_json2 = R"({
+    "type": "map",
+    "key-id": 4,
+    "key": "string",
+    "value-id": 5,
+    "value": "int",
+    "value-required": false
+})";
+
 const std::string nested_list_json = R"({
     "type": "list",
     "element-id": 6,
@@ -209,7 +218,23 @@ TEST(SchemaParserTest, parse_valid_map) {
             SchemaParser::_type_from_json(rapidjson::Document().Parse(valid_map_json.c_str()));
     ASSERT_NE(type, nullptr);
     EXPECT_EQ(type->to_string(), "map<string, int>");
+    EXPECT_TRUE(type->is_map_type());
+    MapType* mt = type->as_map_type();
+    EXPECT_TRUE(mt->field(4)->is_required());
+    EXPECT_TRUE(mt->field(5)->is_required());
 }
+
+TEST(SchemaParserTest, parse_valid_map2) {
+    std::unique_ptr<Type> type =
+            SchemaParser::_type_from_json(rapidjson::Document().Parse(valid_map_json2.c_str()));
+    ASSERT_NE(type, nullptr);
+    EXPECT_EQ(type->to_string(), "map<string, int>");
+    EXPECT_TRUE(type->is_map_type());
+    MapType* mt = type->as_map_type();
+    EXPECT_TRUE(mt->field(4)->is_required());
+    EXPECT_TRUE(mt->field(5)->is_optional());
+}
+
 
 TEST(SchemaParserTest, parse_nested_list) {
     rapidjson::Document doc;

--- a/be/test/vec/exec/format/table/iceberg/schema_parser_test.cpp
+++ b/be/test/vec/exec/format/table/iceberg/schema_parser_test.cpp
@@ -235,7 +235,6 @@ TEST(SchemaParserTest, parse_valid_map2) {
     EXPECT_TRUE(mt->field(5)->is_optional());
 }
 
-
 TEST(SchemaParserTest, parse_nested_list) {
     rapidjson::Document doc;
     doc.Parse(nested_list_json.c_str());


### PR DESCRIPTION
### What problem does this PR solve?

1. Column IDs are required to be stored as [field IDs](http://github.com/apache/parquet-format/blob/40699d05bd24181de6b1457babbee2c16dce3803/src/main/thrift/parquet.thrift#L459) on the parquet schema.
ref: https://iceberg.apache.org/spec/?h=field+id#parquet
So, we should add field ids.
2. For `MapType`, its key is always required.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

