### PR TITLE
[fix](index) Fix CREATE/DROP INDEX stmt toSql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
@@ -212,6 +212,10 @@ public class AlterTableStmt extends DdlStmt implements NotFallbackInParser {
                     sb.append("DROP ROLLUP ");
                 }
                 sb.append(((AddRollupClause) op).getRollupName());
+            } else if (op instanceof CreateIndexClause) {
+                sb.append(((CreateIndexClause) op).toSql(true));
+            } else if (op instanceof DropIndexClause) {
+                sb.append(((DropIndexClause) op).toSql(true));
             } else {
                 sb.append(op.toSql());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateIndexClause.java
@@ -88,6 +88,10 @@ public class CreateIndexClause extends AlterTableClause {
 
     @Override
     public String toSql() {
+        return toSql(alter);
+    }
+
+    public String toSql(boolean alter) {
         if (alter) {
             return "ADD " + indexDef.toSql();
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropIndexClause.java
@@ -80,6 +80,10 @@ public class DropIndexClause extends AlterTableClause {
 
     @Override
     public String toSql() {
+        return toSql(alter);
+    }
+
+    public String toSql(boolean alter) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("DROP INDEX ").append("`" + indexName + "`");
         if (!alter) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
@@ -126,6 +126,7 @@ public class AlterTableStmtTest {
 
     @Test
     public void testCreateIndex() throws UserException {
+        // ALTER TABLE `db`.`table` ADD INDEX `index1` (`col1`) USING INVERTED COMMENT 'balabala'
         List<AlterClause> ops = Lists.newArrayList();
         ops.add(new CreateIndexClause(
                 new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "db", "table"),
@@ -138,12 +139,43 @@ public class AlterTableStmtTest {
     }
 
     @Test
+    public void testCreateIndexStmt() throws UserException {
+        // CREATE INDEX `index1` ON `db`.`table` (`col1`) USING INVERTED COMMENT 'balabala'
+        CreateIndexClause createIndexClause = new CreateIndexClause(
+                new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "db", "table"),
+                new IndexDef("index1", false, Lists.newArrayList("col1"), IndexDef.IndexType.INVERTED, null, "balabala"),
+                false);
+        List<AlterClause> ops = Lists.newArrayList();
+        ops.add(createIndexClause);
+        AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
+        stmt.analyze(analyzer);
+        Assert.assertEquals("CREATE INDEX `index1` ON `db`.`table` (`col1`) USING INVERTED COMMENT 'balabala'",
+                createIndexClause.toSql());
+        Assert.assertEquals("ALTER TABLE `testDb`.`testTbl` ADD INDEX `index1` (`col1`) USING INVERTED COMMENT 'balabala'",
+                stmt.toSql());
+    }
+
+    @Test
     public void testDropIndex() throws UserException {
+        // ALTER TABLE `db`.`table` DROP INDEX `index1`
         List<AlterClause> ops = Lists.newArrayList();
         ops.add(new DropIndexClause("index1", false,
                 new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "db", "table"), true));
         AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
         stmt.analyze(analyzer);
+        Assert.assertEquals("ALTER TABLE `testDb`.`testTbl` DROP INDEX `index1`", stmt.toSql());
+    }
+
+    @Test
+    public void testDropIndexStmt() throws UserException {
+        // DROP INDEX `index1` ON `db`.`table`
+        DropIndexClause dropIndexClause = new DropIndexClause("index1", false,
+                new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "db", "table"), false);
+        List<AlterClause> ops = Lists.newArrayList();
+        ops.add(dropIndexClause);
+        AlterTableStmt stmt = new AlterTableStmt(new TableName(internalCtl, "testDb", "testTbl"), ops);
+        stmt.analyze(analyzer);
+        Assert.assertEquals("DROP INDEX `index1` ON `db`.`table`", dropIndexClause.toSql());
         Assert.assertEquals("ALTER TABLE `testDb`.`testTbl` DROP INDEX `index1`", stmt.toSql());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Parsing `CREATE INDEX` and `DROP INDEX` will generate an `AlterTableStmt`, and the `AlterTableStmt ::toSql()` result is:

`ALTER TABLE <table> CREATE INDEX <index>(<column>)` and `ALTER TABLE <table> DROP INDEX <index> ON <table>`

This PR corrects the output to `ALTER TABLE <table> ADD/DROP INDEX ...`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

