### PR TITLE
[Fix](Job)Fix some issues in the Insert job.

### DIFF
--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -65,6 +65,10 @@ under the License.
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
         </dependency>

--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -65,10 +65,6 @@ under the License.
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
         </dependency>

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -155,6 +155,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         }
         for (T task : runningTasks) {
             task.cancel();
+            canceledTaskCount.incrementAndGet();
         }
         runningTasks = new CopyOnWriteArrayList<>();
         logUpdateOperation();
@@ -185,6 +186,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         runningTasks.stream().filter(task -> task.getTaskId().equals(taskId)).findFirst()
                 .orElseThrow(() -> new JobException("Not found task id: " + taskId)).cancel();
         runningTasks.removeIf(task -> task.getTaskId().equals(taskId));
+        canceledTaskCount.incrementAndGet();
         if (jobConfig.getExecuteType().equals(JobExecuteType.ONE_TIME)) {
             updateJobStatus(JobStatus.FINISHED);
         }
@@ -418,13 +420,13 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
     /**
      * Generates a common error message when the execution queue is full.
      *
-     * @param taskId                The ID of the task.
-     * @param queueConfigName       The name of the queue configuration.
+     * @param taskId                  The ID of the task.
+     * @param queueConfigName         The name of the queue configuration.
      * @param executeThreadConfigName The name of the execution thread configuration.
      * @return A formatted error message.
      */
     protected String commonFormatMsgWhenExecuteQueueFull(Long taskId, String queueConfigName,
-                                                            String executeThreadConfigName) {
+                                                         String executeThreadConfigName) {
         return String.format("Dispatch task failed, jobId: %d, jobName: %s, taskId: %d, the queue size is full, "
                         + "you can increase the queue size by setting the property "
                         + "%s in the fe.conf file or increase the value of "

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -209,6 +209,9 @@ public class InsertTask extends AbstractTask {
 
     @Override
     public void onFail() throws JobException {
+        if (isCanceled.get()) {
+            return;
+        }
         isFinished.set(true);
         super.onFail();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -189,6 +189,9 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
     public void alterJobStatus(Long jobId, JobStatus status) throws JobException {
         checkJobExist(jobId);
         jobMap.get(jobId).updateJobStatus(status);
+        if (status.equals(JobStatus.RUNNING)) {
+            jobScheduler.scheduleOneJob(jobMap.get(jobId));
+        }
         jobMap.get(jobId).logUpdateOperation();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
@@ -167,6 +167,9 @@ public abstract class AbstractTask implements Task {
             run();
             onSuccess();
         } catch (Exception e) {
+            if (TaskStatus.CANCELED.equals(status)) {
+                return;
+            }
             this.errMsg = e.getMessage();
             onFail();
             log.warn("execute task error, job id is {}, task id is {}", jobId, taskId, e);


### PR DESCRIPTION
### What problem does this PR solve?
- The job does not account for tasks in the Canceled state. 
- When a job is canceled, its status is marked as FAILED, and a NullPointerException (NPE) occurs because resources have already been released. 
```
java.lang.NullPointerException: Cannot invoke "org.apache.doris.qe.ConnectContext.getState()" because "this.ctx" is null
	at org.apache.doris.job.extensions.insert.InsertTask.run(InsertTask.java:200) ~[classes/:?]
	at org.apache.doris.job.task.AbstractTask.runTask(AbstractTask.java:167) ~[classes/:?]
	at org.apache.doris.job.executor.DefaultTaskExecutorHandler.onEvent(DefaultTaskExecutorHandler.java:50) ~[classes/:?]
	at org.apache.doris.job.executor.DefaultTaskExecutorHandler.onEvent(DefaultTaskExecutorHandler.java:33) ~[classes/:?]
	at com.lmax.disruptor.WorkProcessor.run(WorkProcessor.java:143) ~[disruptor-3.4.4.jar:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]15e8716a7ab9">
```

- The RESUME job does not immediately schedule the job.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
```

 mysql> select STATUS  from tasks('type'='insert') where JobName='test'\G
*************************** 1. row ***************************
STATUS: CANCELED
*************************** 2. row ***************************
STATUS: FAILED
*************************** 3. row ***************************
STATUS: CANCELED
3 rows in set (0.02 sec)

mysql> select * from jobs("type"="insert") where name='test' \G
*************************** 1. row ***************************
               Id: 5184843485340
             Name: test
          Definer: root
      ExecuteType: RECURRING
RecurringStrategy: EVERY 1 SECOND STARTS 2024-11-25 16:02:54
           Status: PAUSED
       ExecuteSql: INSERT INTO orders.image select * from orders.image
       CreateTime: 2024-11-25 16:02:53
 SucceedTaskCount: 0
  FailedTaskCount: 1
CanceledTaskCount: 2
          Comment: 
1 row in set (0.02 sec)

mysql> 
```


- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

