### PR TITLE
[fix](build index)Fix non-master nodes cannot see the latest build index job status

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
@@ -348,6 +348,7 @@ public class IndexChangeJob implements Writable {
             olapTable.readUnlock();
         }
         this.jobState = JobState.RUNNING;
+        // DO NOT write edit log here, tasks will be sent again if FE restart or master changed.
         LOG.info("transfer inverted index job {} state to {}", jobId, this.jobState);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -556,7 +556,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         this.jobState = JobState.RUNNING;
 
-        // DO NOT write edit log here, tasks will be send again if FE restart or master changed.
+        // DO NOT write edit log here, tasks will be sent again if FE restart or master changed.
         LOG.info("transfer schema change job {} state to {}", jobId, this.jobState);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBuildIndexStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBuildIndexStmt.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.proc.BuildIndexProcDir;
 import org.apache.doris.common.proc.ProcNodeInterface;
 import org.apache.doris.common.proc.ProcService;
 import org.apache.doris.common.util.OrderByPair;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Strings;
@@ -223,5 +224,14 @@ public class ShowBuildIndexStmt extends ShowStmt implements NotFallbackInParser 
         }
 
         return builder.build();
+    }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        if (ConnectContext.get().getSessionVariable().getForwardToMaster()) {
+            return RedirectStatus.FORWARD_NO_SYNC;
+        } else {
+            return RedirectStatus.NO_FORWARD;
+        }
     }
 }

--- a/regression-test/suites/fault_injection_p0/test_build_index_with_clone_fault.groovy
+++ b/regression-test/suites/fault_injection_p0/test_build_index_with_clone_fault.groovy
@@ -58,6 +58,7 @@ suite("test_build_index_with_clone_fault_injection", "nonConcurrent"){
         while (attempt < maxRetries) {
             def show_build_index = sql_return_maparray("show build index where TableName = \"${tbl}\" ORDER BY JobId DESC LIMIT 1")
             if (show_build_index && show_build_index.size() > 0) {
+                logger.info("show build index result: ${show_build_index}")
                 def currentState = show_build_index[0].State
                 def currentMsg = show_build_index[0].Msg
                 if ((currentState == expectedState && currentMsg == expectedMsg) || currentState == "FINISHED") {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Non-master nodes cannot see the latest build index job status, this will cause the case `test_build_index_with_clone_fault_injection` unstable.

We add forward_to_master in show build index statement to get the latest job status.

### Release note

Fix non-master nodes cannot see the latest build index job status

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

