### PR TITLE
[fix](runtime filter) Fix unreasonable wrong status

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1292,8 +1292,8 @@ Status FragmentMgr::sync_filter_size(const PSyncFilterSizeRequest* request) {
         if (auto q_ctx = _get_or_erase_query_ctx(query_id)) {
             query_ctx = q_ctx;
         } else {
-            return Status::InvalidArgument(
-                    "Sync filter size failed: Query context (query-id: {}) not found",
+            return Status::EndOfFile(
+                    "Sync filter size failed: Query context (query-id: {}) already finished",
                     queryid.to_string());
         }
     }
@@ -1313,8 +1313,8 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
         if (auto q_ctx = _get_or_erase_query_ctx(query_id)) {
             query_ctx = q_ctx;
         } else {
-            return Status::InvalidArgument(
-                    "Merge filter size failed: Query context (query-id: {}) not found",
+            return Status::EndOfFile(
+                    "Merge filter size failed: Query context (query-id: {}) already finished",
                     queryid.to_string());
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Introduced by #43627 

Query could be finished when runtime filter was sent to a global runtime filter merger. Here we should return `EOF` status instead of `InvalidArgument`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

