### PR TITLE
[fix](jdbc catalog) set `enable_jdbc_cast_predicate_push_down` default true

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -724,7 +724,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_JDBC_CAST_PREDICATE_PUSH_DOWN, needForward = true,
             description = {"是否允许将带有 CAST 表达式的谓词下推到 JDBC 外部表。",
                     "Whether to allow predicates with CAST expressions to be pushed down to JDBC external tables."})
-    public boolean enableJdbcCastPredicatePushDown = false;
+    public boolean enableJdbcCastPredicatePushDown = true;
 
     @VariableMgr.VarAttr(name = ROUND_PRECISE_DECIMALV2_VALUE)
     public boolean roundPreciseDecimalV2Value = false;

--- a/regression-test/suites/external_table_p0/jdbc/test_clickhouse_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_clickhouse_jdbc_catalog.groovy
@@ -83,17 +83,11 @@ suite("test_clickhouse_jdbc_catalog", "p0,external,clickhouse,external_docker,ex
             sql("select * from ts where from_unixtime(ts,'yyyyMMdd') >= '2022-01-01';")
             contains """QUERY: SELECT "id", "ts" FROM "doris_test"."ts" WHERE ((FROM_UNIXTIME("ts", '%Y%m%d') >= '2022-01-01'))"""
         }
-        explain {
-            sql("select * from ts where nvl(ts,null) >= '1';")
-            contains """QUERY: SELECT "id", "ts" FROM "doris_test"."ts"""
-        }
         order_qt_func_push2 """select * from ts where ts <= unix_timestamp(from_unixtime(ts,'yyyyMMdd'));"""
-        sql "set enable_jdbc_cast_predicate_push_down = true;"
         explain {
             sql("select * from ts where ts <= unix_timestamp(from_unixtime(ts,'yyyy-MM-dd'));")
             contains """QUERY: SELECT "id", "ts" FROM "doris_test"."ts" WHERE (("ts" <= toUnixTimestamp(FROM_UNIXTIME("ts", '%Y-%m-%d'))))"""
         }
-        sql "set enable_jdbc_cast_predicate_push_down = false;"
 
         order_qt_dt_with_tz """ select * from dt_with_tz order by id; """
 

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_push_cast.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_push_cast.groovy
@@ -34,6 +34,8 @@ suite("test_jdbc_catalog_push_cast", "p0,external,mysql,external_docker,external
             "driver_class" = "com.mysql.cj.jdbc.Driver"
         );"""
 
+        sql "set enable_jdbc_cast_predicate_push_down = false;"
+
         sql "use jdbc_catalog_push_cast.doris_test"
 
         qt_sql """select * from test_cast where date(datetime_c) = '2022-01-01';"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #42102

Problem Summary:

We found that after disabling pushdown of predicates with implicit casts, some users experienced slower queries, so we temporarily changed this parameter back to the default behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

