### PR TITLE
[fix](Planner) fix lateral view when use cte as input table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -113,6 +113,9 @@ public class InlineViewRef extends TableRef {
         baseTblSmap = new ExprSubstitutionMap();
         setJoinAttrs(origTblRef);
         explicitColLabels = view.getColLabels();
+        if (origTblRef.getLateralViewRefs() != null) {
+            lateralViewRefs = (ArrayList<LateralViewRef>) origTblRef.getLateralViewRefs().clone();
+        }
         // Set implicit aliases if no explicit one was given.
         if (hasExplicitAlias()) {
             return;
@@ -123,9 +126,6 @@ public class InlineViewRef extends TableRef {
             aliases = new String[]{view.getName()};
         } else {
             aliases = new String[]{name.toString(), view.getName()};
-        }
-        if (origTblRef.getLateralViewRefs() != null) {
-            lateralViewRefs = (ArrayList<LateralViewRef>) origTblRef.getLateralViewRefs().clone();
         }
     }
 

--- a/regression-test/data/query_p0/lateral_view/lateral_view.out
+++ b/regression-test/data/query_p0/lateral_view/lateral_view.out
@@ -7,6 +7,9 @@
 2	33
 2	44
 
+-- !sql_explode_bug_fix --
+\N
+
 -- !sql_explode_bitmap1 --
 1	1
 1	2

--- a/regression-test/suites/query_p0/lateral_view/lateral_view.groovy
+++ b/regression-test/suites/query_p0/lateral_view/lateral_view.groovy
@@ -33,6 +33,159 @@ suite("lateral_view") {
     sql "SET enable_nereids_planner=false"
 	qt_sql_explode_bitmap0 """ select dt, e1 from test_explode_bitmap lateral view explode_bitmap(user_id) tmp1 as e1 order by dt, e1;"""
 
+    sql """ DROP TABLE IF EXISTS `entity_37_label_summary` """
+    sql """
+        CREATE TABLE `entity_37_label_summary` (
+          `label_id` int(11) NOT NULL COMMENT '标签标识',
+          `update_time` datetime NOT NULL COMMENT '更新时间',
+          `label_value` varchar(128) NULL COMMENT '标签值',
+          `label_type` int(11) NULL COMMENT '标签类型',
+          `conf_score` DECIMAL(10, 2) NULL COMMENT '可信度分',
+          `act_score` DECIMAL(10, 2) NULL COMMENT 'ID 活跃度',
+          `source_dt` datetime NULL,
+          `seq_id_bitmap` bitmap BITMAP_UNION NOT NULL COMMENT 'SeqID集合'
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`label_id`, `update_time`, `label_value`, `label_type`, `conf_score`, `act_score`, `source_dt`)
+        COMMENT '标签汇总表'
+        PARTITION BY RANGE(`update_time`)
+        (PARTITION p20220512 VALUES [('0000-01-01 00:00:00'), ('2022-05-13 00:00:00')),
+        PARTITION p20220513 VALUES [('2022-05-13 00:00:00'), ('2022-05-14 00:00:00')),
+        PARTITION p20241124 VALUES [('2024-11-24 00:00:00'), ('2024-11-25 00:00:00')))
+        DISTRIBUTED BY HASH(`label_id`, `label_value`) BUCKETS 3
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "is_being_synced" = "false",
+        "dynamic_partition.enable" = "true",
+        "dynamic_partition.time_unit" = "DAY",
+        "dynamic_partition.time_zone" = "Asia/Shanghai",
+        "dynamic_partition.start" = "-2147483648",
+        "dynamic_partition.end" = "2",
+        "dynamic_partition.prefix" = "p",
+        "dynamic_partition.replication_allocation" = "tag.location.default: 1",
+        "dynamic_partition.buckets" = "3",
+        "dynamic_partition.create_history_partition" = "false",
+        "dynamic_partition.history_partition_num" = "-1",
+        "dynamic_partition.hot_partition_num" = "0",
+        "dynamic_partition.reserved_history_periods" = "NULL",
+        "dynamic_partition.storage_policy" = "",
+        "dynamic_partition.storage_medium" = "HDD",
+        "storage_format" = "V2",
+        "light_schema_change" = "true",
+        "disable_auto_compaction" = "false",
+        "enable_single_replica_compaction" = "false"
+        );
+    """
+
+    sql """ DROP TABLE IF EXISTS `entity_49_label_summary` """
+    sql """
+        CREATE TABLE `entity_49_label_summary` (
+          `label_id` int(11) NOT NULL COMMENT '标签标识',
+          `update_time` datetime NOT NULL COMMENT '更新时间',
+          `label_value` varchar(128) NULL COMMENT '标签值',
+          `label_type` int(11) NULL COMMENT '标签类型',
+          `conf_score` DECIMAL(10, 2) NULL COMMENT '可信度分',
+          `act_score` DECIMAL(10, 2) NULL COMMENT 'ID 活跃度',
+          `source_dt` datetime NULL,
+          `seq_id_bitmap` bitmap BITMAP_UNION NOT NULL COMMENT 'SeqID集合'
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`label_id`, `update_time`, `label_value`, `label_type`, `conf_score`, `act_score`, `source_dt`)
+        COMMENT '标签汇总表'
+        PARTITION BY RANGE(`update_time`)
+        (PARTITION p20220512 VALUES [('0000-01-01 00:00:00'), ('2022-05-13 00:00:00')),
+        PARTITION p20220513 VALUES [('2022-05-13 00:00:00'), ('2022-05-14 00:00:00')),
+        PARTITION p20241124 VALUES [('2024-11-24 00:00:00'), ('2024-11-25 00:00:00')))
+        DISTRIBUTED BY HASH(`label_id`, `label_value`) BUCKETS 3
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "is_being_synced" = "false",
+        "dynamic_partition.enable" = "true",
+        "dynamic_partition.time_unit" = "DAY",
+        "dynamic_partition.time_zone" = "Asia/Shanghai",
+        "dynamic_partition.start" = "-2147483648",
+        "dynamic_partition.end" = "2",
+        "dynamic_partition.prefix" = "p",
+        "dynamic_partition.replication_allocation" = "tag.location.default: 1",
+        "dynamic_partition.buckets" = "3",
+        "dynamic_partition.create_history_partition" = "false",
+        "dynamic_partition.history_partition_num" = "-1",
+        "dynamic_partition.hot_partition_num" = "0",
+        "dynamic_partition.reserved_history_periods" = "NULL",
+        "dynamic_partition.storage_policy" = "",
+        "dynamic_partition.storage_medium" = "HDD",
+        "storage_format" = "V2",
+        "light_schema_change" = "true",
+        "disable_auto_compaction" = "false",
+        "enable_single_replica_compaction" = "false"
+        );
+    """
+
+    qt_sql_explode_bug_fix """
+                with relation_bitmap as (
+            select
+                label_value,
+                bitmap_union(seq_id_bitmap) as seq_id_bitmap
+            from
+                entity_37_label_summary
+            where
+                label_id = 1
+                and label_type = 3
+                and (
+                    cast(source_dt as date) >= cast('2022-10-06' as date)
+                )
+                and (
+                    cast(source_dt as date) <= cast('2022-10-06' as date)
+                )
+            group by
+                label_value
+        ),
+        from_entity_bitmap as (
+            (
+                select
+                    bitmap_intersect(a.seq_id_bitmap) as seq_id_bitmap
+                from
+                    (
+                        select
+                            bitmap_union(ifnull(b.seq_id_bitmap, bitmap_empty())) as seq_id_bitmap
+                        from
+                            (
+                                select
+                                    update_time
+                                from
+                                    (
+                                        select
+                                            1 tmp
+                                    ) as a lateral view explode(['2024-11-21 13:38:33']) tmp as update_time
+                            ) a
+                            left join (
+                                select
+                                    *
+                                from
+                                    entity_49_label_summary
+                                where
+                                    label_id = 1606
+                                    and label_type = 1
+                                    and update_time in ('2024-11-21 13:38:33')
+                                    and (
+                                        cast(label_value as BOOLEAN) in (true, false)
+                                    )
+                            ) b on b.update_time = a.update_time
+                        group by
+                            a.update_time
+                    ) a
+            )
+        )
+        select
+            IFNULL(bitmap_union(rb.seq_id_bitmap), bitmap_empty()) as seq_id_bitmap
+        from
+            (
+                select
+                    seq_id as seq_id
+                from
+                    from_entity_bitmap b lateral view explode_bitmap(b.seq_id_bitmap) tmp as seq_id
+            ) __tt
+            join relation_bitmap rb on rb.label_value = __tt.seq_id;
+    """
+
     sql "SET enable_nereids_planner=true"
 	qt_sql_explode_bitmap1 """ select dt, e1 from test_explode_bitmap lateral view explode_bitmap(user_id) tmp1 as e1 order by dt, e1;"""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When using explode with cte as input, it would failed when analyze select list in Planner
Cause by missing lateral view message when copy lateralViewRef
Fix this problem by filling lateral view message to copied lateralViewRef

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

