### PR TITLE
(fix)[db] Fix create database and create table data race

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -560,16 +560,20 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
      */
     @Override
     public Table getTableNullable(String tableName) {
+        readLock();
         if (Env.isStoredTableNamesLowerCase()) {
             tableName = tableName.toLowerCase();
         }
         if (Env.isTableNamesCaseInsensitive()) {
             tableName = lowerCaseToTableName.get(tableName.toLowerCase());
             if (tableName == null) {
+                readUnlock();
                 return null;
             }
         }
-        return nameToTable.get(tableName);
+        Table table = nameToTable.get(tableName);
+        readUnlock();
+        return table;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -93,7 +93,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
     private final Map<Long, Table> idToTable;
     private ConcurrentMap<String, Table> nameToTable;
     // table name lower case -> table name
-    private final Map<String, String> lowerCaseToTableName;
+    private final ConcurrentMap<String, String> lowerCaseToTableName;
 
     // user define function
     @SerializedName(value = "name2Function")
@@ -560,20 +560,16 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
      */
     @Override
     public Table getTableNullable(String tableName) {
-        readLock();
         if (Env.isStoredTableNamesLowerCase()) {
             tableName = tableName.toLowerCase();
         }
         if (Env.isTableNamesCaseInsensitive()) {
             tableName = lowerCaseToTableName.get(tableName.toLowerCase());
             if (tableName == null) {
-                readUnlock();
                 return null;
             }
         }
-        Table table = nameToTable.get(tableName);
-        readUnlock();
-        return table;
+        return nameToTable.get(tableName);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -441,8 +441,16 @@ public class InternalCatalog implements CatalogIf<Database> {
                     ErrorReport.reportDdlException(ErrorCode.ERR_DB_CREATE_EXISTS, fullDbName);
                 }
             } else {
-                unprotectCreateDb(db);
-                Env.getCurrentEnv().getEditLog().logCreateDb(db);
+                if (!db.tryWriteLock(100, TimeUnit.SECONDS)) {
+                    LOG.warn("try lock failed, create database failed {}", fullDbName);
+                    return;
+                }
+                try {
+                    unprotectCreateDb(db);
+                    Env.getCurrentEnv().getEditLog().logCreateDb(db);
+                } finally {
+                    db.writeUnlock();
+                }
             }
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -443,7 +443,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             } else {
                 if (!db.tryWriteLock(100, TimeUnit.SECONDS)) {
                     LOG.warn("try lock failed, create database failed {}", fullDbName);
-                    return;
+                    ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT, "create database " + fullDbName + " time out");
                 }
                 try {
                     unprotectCreateDb(db);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -443,7 +443,8 @@ public class InternalCatalog implements CatalogIf<Database> {
             } else {
                 if (!db.tryWriteLock(100, TimeUnit.SECONDS)) {
                     LOG.warn("try lock failed, create database failed {}", fullDbName);
-                    ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT, "create database " + fullDbName + " time out");
+                    ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT,
+                            "create database " + fullDbName + " time out");
                 }
                 try {
                     unprotectCreateDb(db);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

There may be a race condition between CREATE DATABASE and CREATE TABLE. When CREATE DATABASE is being executed, the edit log may get stuck, while fullNameToDb in getDbNullable can still return the database. As a result, the CREATE TABLE process continues, which may ultimately lead to a strange order in the edit log of BDBJE, where CREATE TABLE appears before CREATE DATABASE.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

