### PR TITLE
[fix](nereids) limit should not push into PartitionTopN when window's following frame is not current row

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/window_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/window_function.groovy
@@ -240,4 +240,46 @@ suite("window_function") {
     """
 
     qt_sql """ select LAST_VALUE(col_tinyint_undef_signed_not_null) over (partition by col_double_undef_signed_not_null, col_int_undef_signed, (col_float_undef_signed_not_null - col_int_undef_signed), round_bankers(col_int_undef_signed) order by pk rows between unbounded preceding and 4 preceding) AS col_alias56089 from table_200_undef_partitions2_keys3_properties4_distributed_by53 order by col_alias56089;  """
+
+    test {
+        sql """select *
+            from (
+                select
+                row_number() over(partition by c1 order by c2) rn,
+                lead(c2, 2, '') over(partition by c1 order by c2)
+                from (
+                  select 1 as c1, 'a' as c2
+                  union all
+                  select 1 as c1, 'b' as c2
+                  union all
+                  select 1 as c1, 'c' as c2
+                  union all
+                  select 1 as c1, 'd' as c2
+                  union all
+                  select 1 as c1, 'e' as c2
+                )t
+            )a where rn=1"""
+        result([[1L, "c"]])
+    }
+
+    test {
+        sql """select *
+            from (
+                select
+                row_number() over(partition by c1 order by c2) rn,
+                sum(c2) over(order by c2 range between unbounded preceding and unbounded following)
+                from (
+                  select 1 as c1, 5 as c2
+                  union all
+                  select 1 as c1, 6 as c2
+                  union all
+                  select 1 as c1, 7 as c2
+                  union all
+                  select 1 as c1, 8 as c2
+                  union all
+                  select 1 as c1, 9 as c2
+                )t
+            )a where rn=1"""
+        result([[1L, 35L]])
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

limit should not push into PartitionTopN when window's following frame is not current row

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

