### PR TITLE
[fix](compaction)Fix cluster key column duplicated in value columns group

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -199,6 +199,10 @@ void Merger::vertical_split_columns(const TabletSchema& tablet_schema,
     }
     VLOG_NOTICE << "sequence_col_idx=" << sequence_col_idx
                 << ", delete_sign_idx=" << delete_sign_idx;
+    // for duplicate no keys
+    if (!key_columns.empty()) {
+        column_groups->emplace_back(key_columns);
+    }
 
     std::vector<uint32_t> value_columns;
 
@@ -216,10 +220,6 @@ void Merger::vertical_split_columns(const TabletSchema& tablet_schema,
         value_columns.push_back(i);
     }
 
-    // for duplicate no keys
-    if (!key_columns.empty()) {
-        column_groups->emplace_back(std::move(key_columns));
-    }
     if (!value_columns.empty()) {
         column_groups->push_back(value_columns);
     }

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -199,10 +199,6 @@ void Merger::vertical_split_columns(const TabletSchema& tablet_schema,
     }
     VLOG_NOTICE << "sequence_col_idx=" << sequence_col_idx
                 << ", delete_sign_idx=" << delete_sign_idx;
-    // for duplicate no keys
-    if (!key_columns.empty()) {
-        column_groups->emplace_back(std::move(key_columns));
-    }
 
     std::vector<uint32_t> value_columns;
 
@@ -220,6 +216,10 @@ void Merger::vertical_split_columns(const TabletSchema& tablet_schema,
         value_columns.push_back(i);
     }
 
+    // for duplicate no keys
+    if (!key_columns.empty()) {
+        column_groups->emplace_back(std::move(key_columns));
+    }
     if (!value_columns.empty()) {
         column_groups->push_back(value_columns);
     }

--- a/regression-test/data/inverted_index_p0/array_contains/test_index_compaction_unique_keys_arr.out
+++ b/regression-test/data/inverted_index_p0/array_contains/test_index_compaction_unique_keys_arr.out
@@ -67,3 +67,71 @@
 2	bason	bason hate pear	99
 3	bason	bason hate pear	99
 
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+
+-- !sql --
+1	bason	bason hate pear	99
+2	bason	bason hate pear	99
+3	bason	bason hate pear	99
+

--- a/regression-test/suites/inverted_index_p0/array_contains/test_index_compaction_unique_keys_arr.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_index_compaction_unique_keys_arr.groovy
@@ -152,6 +152,7 @@ suite("test_index_compaction_unique_keys_arr", "array_contains_inverted_index") 
                 index index_score (score) using inverted
             ) ENGINE=OLAP
             UNIQUE KEY(`id`)
+            CLUSTER BY (`score`)
             COMMENT 'OLAP'
             DISTRIBUTED BY HASH(`id`) BUCKETS 1
             PROPERTIES ( 

--- a/regression-test/suites/inverted_index_p0/array_contains/test_index_compaction_unique_keys_arr.groovy
+++ b/regression-test/suites/inverted_index_p0/array_contains/test_index_compaction_unique_keys_arr.groovy
@@ -112,6 +112,95 @@ suite("test_index_compaction_unique_keys_arr", "array_contains_inverted_index") 
         }
     }
 
+    def run_test = { table_name -> 
+
+        sql """ INSERT INTO ${table_name} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${table_name} VALUES (1, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${table_name} VALUES (2, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${table_name} VALUES (2, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${table_name} VALUES (3, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${table_name} VALUES (3, "bason", "bason hate pear", 99); """
+
+        qt_sql """ select * from ${table_name} order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where name match "andy" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where hobbies match "pear" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where score < 100 order by id, name, hobbies, score """
+
+        //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
+        def tablets = sql_return_maparray """ show tablets from ${table_name}; """
+        def dedup_tablets = deduplicate_tablets(tablets)
+
+        // In the p0 testing environment, there are no expected operations such as scaling down BE (backend) services
+        // if tablets or dedup_tablets is empty, exception is thrown, and case fail
+        int replicaNum = Math.floor(tablets.size() / dedup_tablets.size())
+        if (replicaNum != 1 && replicaNum != 3)
+        {
+            assert(false);
+        }
+
+        // before full compaction, there are 7 rowsets.
+        int rowsetCount = get_rowset_count.call(tablets);
+        assert (rowsetCount == 7 * replicaNum)
+
+        // trigger full compactions for all tablets in ${table_name}
+        trigger_full_compaction_on_tablets.call(tablets)
+
+        // wait for full compaction done
+        wait_full_compaction_done.call(tablets)
+
+        // after full compaction, there is only 1 rowset.
+        rowsetCount = get_rowset_count.call(tablets);
+        if (isCloudMode) {
+            assert (rowsetCount == (1 + 1) * replicaNum)
+        } else {
+            assert (rowsetCount == 1 * replicaNum)
+        }
+
+        qt_sql """ select * from ${table_name} order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where name match "andy" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where hobbies match "pear" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where score < 100 order by id, name, hobbies, score """
+
+        // insert more data and trigger full compaction again
+        sql """ INSERT INTO ${table_name} VALUES (1, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${table_name} VALUES (1, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${table_name} VALUES (2, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${table_name} VALUES (2, "bason", "bason hate pear", 99); """
+        sql """ INSERT INTO ${table_name} VALUES (3, "andy", "andy love apple", 100); """
+        sql """ INSERT INTO ${table_name} VALUES (3, "bason", "bason hate pear", 99); """
+
+        qt_sql """ select * from ${table_name} order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where name match "andy" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where hobbies match "pear" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where score < 100 order by id, name, hobbies, score """
+
+        rowsetCount = get_rowset_count.call(tablets);
+        if (isCloudMode) {
+            assert (rowsetCount == (7 + 1) * replicaNum)
+        } else {
+            assert (rowsetCount == 7 * replicaNum)
+        }
+
+        // trigger full compactions for all tablets in ${table_name}
+        trigger_full_compaction_on_tablets.call(tablets)
+
+        // wait for full compaction done
+        wait_full_compaction_done.call(tablets)
+
+        // after full compaction, there is only 1 rowset.
+        rowsetCount = get_rowset_count.call(tablets);
+        if (isCloudMode) {
+            assert (rowsetCount == (1 + 1) * replicaNum)
+        } else {
+            assert (rowsetCount == 1 * replicaNum)
+        }
+
+        qt_sql """ select * from ${table_name} order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where name match "andy" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where hobbies match "pear" order by id, name, hobbies, score """
+        qt_sql """ select * from ${table_name} where score < 100 order by id, name, hobbies, score """
+    }
+
     boolean invertedIndexCompactionEnable = false
     boolean has_update_be_config = false
     try {
@@ -152,7 +241,6 @@ suite("test_index_compaction_unique_keys_arr", "array_contains_inverted_index") 
                 index index_score (score) using inverted
             ) ENGINE=OLAP
             UNIQUE KEY(`id`)
-            CLUSTER BY (`score`)
             COMMENT 'OLAP'
             DISTRIBUTED BY HASH(`id`) BUCKETS 1
             PROPERTIES ( 
@@ -162,91 +250,31 @@ suite("test_index_compaction_unique_keys_arr", "array_contains_inverted_index") 
             );
         """
 
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (2, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (2, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (3, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (3, "bason", "bason hate pear", 99); """
+        run_test.call(tableName)
 
-        qt_sql """ select * from ${tableName} order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where name match "andy" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where hobbies match "pear" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where score < 100 order by id, name, hobbies, score """
-
-        //TabletId,ReplicaId,BackendId,SchemaHash,Version,LstSuccessVersion,LstFailedVersion,LstFailedTime,LocalDataSize,RemoteDataSize,RowCount,State,LstConsistencyCheckTime,CheckVersion,VersionCount,PathHash,MetaUrl,CompactionStatus
-        def tablets = sql_return_maparray """ show tablets from ${tableName}; """
-        def dedup_tablets = deduplicate_tablets(tablets)
-
-        // In the p0 testing environment, there are no expected operations such as scaling down BE (backend) services
-        // if tablets or dedup_tablets is empty, exception is thrown, and case fail
-        int replicaNum = Math.floor(tablets.size() / dedup_tablets.size())
-        if (replicaNum != 1 && replicaNum != 3)
-        {
-            assert(false);
-        }
-
-        // before full compaction, there are 7 rowsets.
-        int rowsetCount = get_rowset_count.call(tablets);
-        assert (rowsetCount == 7 * replicaNum)
-
-        // trigger full compactions for all tablets in ${tableName}
-        trigger_full_compaction_on_tablets.call(tablets)
-
-        // wait for full compaction done
-        wait_full_compaction_done.call(tablets)
-
-        // after full compaction, there is only 1 rowset.
-        rowsetCount = get_rowset_count.call(tablets);
-        if (isCloudMode) {
-            assert (rowsetCount == (1 + 1) * replicaNum)
-        } else {
-            assert (rowsetCount == 1 * replicaNum)
-        }
-
-        qt_sql """ select * from ${tableName} order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where name match "andy" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where hobbies match "pear" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where score < 100 order by id, name, hobbies, score """
-
-        // insert more data and trigger full compaction again
-        sql """ INSERT INTO ${tableName} VALUES (1, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (1, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (2, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (2, "bason", "bason hate pear", 99); """
-        sql """ INSERT INTO ${tableName} VALUES (3, "andy", "andy love apple", 100); """
-        sql """ INSERT INTO ${tableName} VALUES (3, "bason", "bason hate pear", 99); """
-
-        qt_sql """ select * from ${tableName} order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where name match "andy" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where hobbies match "pear" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where score < 100 order by id, name, hobbies, score """
-
-        rowsetCount = get_rowset_count.call(tablets);
-        if (isCloudMode) {
-            assert (rowsetCount == (7 + 1) * replicaNum)
-        } else {
-            assert (rowsetCount == 7 * replicaNum)
-        }
-
-        // trigger full compactions for all tablets in ${tableName}
-        trigger_full_compaction_on_tablets.call(tablets)
-
-        // wait for full compaction done
-        wait_full_compaction_done.call(tablets)
-
-        // after full compaction, there is only 1 rowset.
-        rowsetCount = get_rowset_count.call(tablets);
-        if (isCloudMode) {
-            assert (rowsetCount == (1 + 1) * replicaNum)
-        } else {
-            assert (rowsetCount == 1 * replicaNum)
-        }
-
-        qt_sql """ select * from ${tableName} order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where name match "andy" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where hobbies match "pear" order by id, name, hobbies, score """
-        qt_sql """ select * from ${tableName} where score < 100 order by id, name, hobbies, score """
+        tableName = "test_index_compaction_unique_keys_arr_cluster_key"
+        sql """ DROP TABLE IF EXISTS ${tableName}; """
+        sql """
+            CREATE TABLE ${tableName} (
+                `id` int(11) NULL,
+                `name` varchar(255) NULL,
+                `hobbies` text NULL,
+                `score` int(11) NULL,
+                index index_name (name) using inverted,
+                index index_hobbies (hobbies) using inverted properties("parser"="english"),
+                index index_score (score) using inverted
+            ) ENGINE=OLAP
+            UNIQUE KEY(`id`)
+            CLUSTER BY (`score`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`id`) BUCKETS 1
+            PROPERTIES ( 
+                "replication_num" = "1",
+                "disable_auto_compaction" = "true",
+                "enable_unique_key_merge_on_write" = "true"
+            );
+        """
+        run_test.call(tableName)
 
     } finally {
         if (has_update_be_config) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #44609

Related pr: #40372

Problem Summary:

`key_columns` will be used after move.
This will cause skip in construction of `value_columns` useless.
cluster key  column will be duplicated added in value column group.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

