### PR TITLE
[Fix](http)Enhanced Security Checks for Audit Log File Names

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLogFileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLogFileAction.java
@@ -32,6 +32,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
@@ -51,6 +53,23 @@ import javax.servlet.http.HttpServletResponse;
  */
 @RestController
 public class GetLogFileAction extends RestBaseController {
+    /**
+     * This method fetches internal logs via HTTP, which is no longer recommended and will
+     * be deprecated in future versions.
+     * <p>
+     * Using HTTP to fetch logs introduces serious security and performance issues:
+     * - **Security Risks**: Log content may expose sensitive information, allowing attackers to exploit the exposed
+     * HTTP endpoints.
+     * - **Performance Problems**: Frequent HTTP requests can cause significant system load, affecting the
+     * responsiveness and stability of the application.
+     * <p>
+     * It is strongly advised not to use this approach for accessing logs. Any new requirements should be
+     * handled using more secure, reliable, and efficient methods such as log aggregation tools (e.g., ELK, Splunk)
+     * or dedicated internal APIs.
+     * <p>
+     * **Note**: No new HTTP endpoints or types for log access will be accepted.
+     * Any further attempts to extend this HTTP-based log retrieval method will not be supported.
+     */
     private final Set<String> logFileTypes = Sets.newHashSet("fe.audit.log");
 
     @RequestMapping(path = "/api/get_log_file", method = {RequestMethod.GET, RequestMethod.HEAD})
@@ -79,7 +98,13 @@ public class GetLogFileAction extends RestBaseController {
             String fileInfos = getFileInfos(logType);
             response.setHeader("file_infos", fileInfos);
             return ResponseEntityBuilder.ok();
-        } else if (method.equals(RequestMethod.GET.name())) {
+        }
+        if (method.equals(RequestMethod.GET.name())) {
+            try {
+                checkAuditLogFileName(logFile);
+            } catch (SecurityException e) {
+                return ResponseEntityBuilder.internalError(e.getMessage());
+            }
             File log = getLogFile(logType, logFile);
             if (!log.exists() || !log.isFile()) {
                 return ResponseEntityBuilder.okWithCommonError("Log file not exist: " + log.getName());
@@ -95,6 +120,17 @@ public class GetLogFileAction extends RestBaseController {
             }
         }
         return ResponseEntityBuilder.ok();
+    }
+
+    private void checkAuditLogFileName(String logFile) {
+        if (!logFile.matches("^[a-zA-Z0-9._-]+$")) {
+            throw new SecurityException("Invalid file name");
+        }
+        Path normalizedPath = Paths.get(Config.audit_log_dir).resolve(logFile).normalize();
+        // check path is valid or not
+        if (!normalizedPath.startsWith(Config.audit_log_dir)) {
+            throw new SecurityException("Invalid file path: Access outside of permitted directory");
+        }
     }
 
     private String getFileInfos(String logType) {

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/GetLogFileActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/GetLogFileActionTest.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.httpv2.rest.GetLogFileAction;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class GetLogFileActionTest {
+
+    @TempDir
+    public File tempDir;
+
+    @BeforeAll
+    public static void before() {
+        File tempDir = new File("test/audit.log");
+        tempDir.mkdir();
+        Config.audit_log_dir = tempDir.getAbsolutePath();
+    }
+
+    @Test
+    public void test() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        //private method checkAuditLogFileName
+        GetLogFileAction action = new GetLogFileAction();
+        Method method = GetLogFileAction.class.getDeclaredMethod("checkAuditLogFileName", String.class);
+        method.setAccessible(true);
+        method.invoke(action, "audit.log");
+        method.invoke(action, "fe.audit.log.20241104-1");
+        Assertions.assertThrows(InvocationTargetException.class, () -> method.invoke(action, "../etc/passwd"));
+        Assertions.assertThrows(InvocationTargetException.class, () -> method.invoke(action,
+                "fe.audit.log.20241104-1/../../etc/passwd"));
+        Assertions.assertThrows(InvocationTargetException.class,
+                () -> method.invoke(action, "fe.audit.log.20241104-1; rm -rf /"));
+
+
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/GetLogFileActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/GetLogFileActionTest.java
@@ -42,7 +42,7 @@ public class GetLogFileActionTest {
     }
 
     @Test
-    public void test() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testCheckAuditLogFileName() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         //private method checkAuditLogFileName
         GetLogFileAction action = new GetLogFileAction();
         Method method = GetLogFileAction.class.getDeclaredMethod("checkAuditLogFileName", String.class);


### PR DESCRIPTION
## Purpose:

To improve the security of audit log files, a new method checkAuditLogFileName has been added to validate the file name and path to ensure they meet security requirements. This method is designed to prevent invalid file names and path traversal attacks, ensuring that only files within the designated directory can be accessed.↳

### Changes:

#### File Name Validation:

A regular expression check has been added to validate the file name: ^[a-zA-Z0-9._-]+$, restricting the file name to letters, numbers, dots, underscores, and hyphens.

 If the file name contains invalid characters (e.g., spaces, path traversal characters), a SecurityException is thrown with the message “Invalid file name.”
Path Validation:

The file name is resolved into a normalized path, and it is checked to ensure that it is within the allowed directory.

The path is constructed using Paths.get(Config.audit_log_dir).resolve(logFile).normalize(). If the path does not start with the specified audit log directory (Config.audit_log_dir), indicating an attempt to access outside the permitted directory (e.g., a path traversal attack), a SecurityException is thrown with the message “Invalid file path: Access outside of permitted directory.”


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
```
 calvinkirs@CalvinKirss-MBP fe % curl -u root: -I "http://127.0.0.1:8030/api/get_log_file?type=fe.audit.log&file=../LICENSE"                                 
HTTP/1.1 200 OK
Date: Tue, 26 Nov 2024 06:49:56 GMT
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
file_infos: {"fe.audit.log":2480,"fe.audit.log.20241030-1":87297,"fe.audit.log.20241031-1":1250,"fe.audit.log.20241101-1":260067,"fe.audit.log.20241106-1":523614,"fe.audit.log.20241107-1":83146,"fe.audit.log.20241108-1":190639,"fe.audit.log.20241110-1":5071,"fe.audit.log.20241111-1":668553,"fe.audit.log.20241119-1":471175,"fe.audit.log.20241120-1":17077,"fe.audit.log.20241125-1":760146}
Content-Type: application/json
Transfer-Encoding: chunked

calvinkirs@CalvinKirss-MBP fe % curl -u root: -X GET "http://127.0.0.1:8030/api/get_log_file?type=fe.audit.log&file=audit_log_dir/../LICENSE"               
{"msg":"Internal Error","code":500,"data":"Invalid file name","count":0}%                                                                                                                                     calvinkirs@CalvinKirss-MBP fe % curl -u root: -X GET "http://127.0.0.1:8030/api/get_log_file?type=fe.audit.log&file=audit_log_dir/%2e%2e%2f%2e%2e%2fetc%2fpasswd"
{"msg":"Internal Error","code":500,"data":"Invalid file name","count":0}%   
``` 

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

