### PR TITLE
[Bug](join) fix single null eq get wrong result

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1594,9 +1594,7 @@ RuntimeFilterType IRuntimeFilter::get_real_type() {
 }
 
 bool IRuntimeFilter::need_sync_filter_size() {
-    return (type() == RuntimeFilterType::IN_OR_BLOOM_FILTER ||
-            type() == RuntimeFilterType::BLOOM_FILTER) &&
-           _wrapper->get_build_bf_cardinality() && !_is_broadcast_join;
+    return _wrapper->get_build_bf_cardinality() && !_is_broadcast_join;
 }
 
 void IRuntimeFilter::update_filter(std::shared_ptr<RuntimePredicateWrapper> wrapper,

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1594,7 +1594,9 @@ RuntimeFilterType IRuntimeFilter::get_real_type() {
 }
 
 bool IRuntimeFilter::need_sync_filter_size() {
-    return _wrapper->get_build_bf_cardinality() && !_is_broadcast_join;
+    return (type() == RuntimeFilterType::IN_OR_BLOOM_FILTER ||
+            type() == RuntimeFilterType::BLOOM_FILTER) &&
+           _wrapper->get_build_bf_cardinality() && !_is_broadcast_join;
 }
 
 void IRuntimeFilter::update_filter(std::shared_ptr<RuntimePredicateWrapper> wrapper,

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -197,7 +197,10 @@ struct ProcessHashTableBuild {
         SCOPED_TIMER(_parent->_build_table_insert_timer);
         hash_table_ctx.hash_table->template prepare_build<JoinOpType>(_rows, _batch_size,
                                                                       *has_null_key);
-
+        // In order to make the null keys equal when using single null eq, all null keys need to be set to default value.
+        if (_build_raw_ptrs.size() == 1 && null_map) {
+            _build_raw_ptrs[0]->assume_mutable()->replace_column_null_data(null_map->data());
+        }
         hash_table_ctx.init_serialized_keys(_build_raw_ptrs, _rows,
                                             null_map ? null_map->data() : nullptr, true, true,
                                             hash_table_ctx.hash_table->get_bucket_size());

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -173,6 +173,10 @@ typename HashTableType::State ProcessHashTableProbe<JoinOpType>::_init_probe_sid
     if (!_parent->_ready_probe) {
         _parent->_ready_probe = true;
         hash_table_ctx.reset();
+        // In order to make the null keys equal when using single null eq, all null keys need to be set to default value.
+        if (_parent->_probe_columns.size() == 1 && null_map) {
+            _parent->_probe_columns[0]->assume_mutable()->replace_column_null_data(null_map);
+        }
         hash_table_ctx.init_serialized_keys(_parent->_probe_columns, probe_rows, null_map, true,
                                             false, hash_table_ctx.hash_table->get_bucket_size());
         hash_table_ctx.hash_table->pre_build_idxs(hash_table_ctx.bucket_nums,

--- a/regression-test/data/nereids_p0/join/test_mark_join.out
+++ b/regression-test/data/nereids_p0/join/test_mark_join.out
@@ -53,3 +53,10 @@
 -- !mark_join_null_conjunct --
 \N
 
+-- !mark_join8 --
+1	1	1	false
+2	2	2	false
+3	\N	\N	\N
+3	\N	3	\N
+4	\N	4	true
+

--- a/regression-test/data/query_p0/join/test_join.out
+++ b/regression-test/data/query_p0/join/test_join.out
@@ -3243,3 +3243,9 @@ false	true	true	false	false
 -- !sql --
 4
 
+-- !sql --
+2	\N
+
+-- !sql --
+2	\N
+

--- a/regression-test/suites/nereids_p0/join/test_mark_join.groovy
+++ b/regression-test/suites/nereids_p0/join/test_mark_join.groovy
@@ -142,4 +142,25 @@ suite("test_mark_join", "nereids_p0") {
     """
 
     qt_mark_join_null_conjunct """select null in ( select k1 from test_mark_join_t1);"""
+
+    qt_mark_join8 """
+            select
+                k1,
+                k2,
+                k3,
+                k1 not in (
+                    select
+                        test_mark_join_t2.k2
+                    from
+                        test_mark_join_t2
+                    where
+                        test_mark_join_t2.k3 <=> test_mark_join_t1.k3
+                ) vv
+            from
+                test_mark_join_t1
+            order by
+                1,
+                2,
+                3;
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?
introduced by https://github.com/apache/doris/pull/42398
In order to make the null keys equal when using single null eq, all null keys need to be set to default value.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

