### PR TITLE
[fix](nereids) fix ptopN push down under multi winexprs with partial forbidden type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
@@ -218,7 +218,7 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
         for (NamedExpression windowExpr : windowExpressions) {
             if (windowExpr == null || windowExpr.children().size() != 1
                     || !(windowExpr.child(0) instanceof WindowExpression)) {
-                continue;
+                return null;
             }
             WindowExpression windowFunc = (WindowExpression) windowExpr.child(0);
 
@@ -226,12 +226,12 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
             if (!(windowFunc.getFunction() instanceof RowNumber
                     || windowFunc.getFunction() instanceof Rank
                     || windowFunc.getFunction() instanceof DenseRank)) {
-                continue;
+                return null;
             }
 
             // Check the partition key and order key.
             if (windowFunc.getPartitionKeys().isEmpty() && windowFunc.getOrderKeys().isEmpty()) {
-                continue;
+                return null;
             }
 
             // Check the window type and window frame.
@@ -240,10 +240,10 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
                 WindowFrame frame = windowFrame.get();
                 if (!(frame.getLeftBoundary().getFrameBoundType() == WindowFrame.FrameBoundType.UNBOUNDED_PRECEDING
                         && frame.getRightBoundary().getFrameBoundType() == WindowFrame.FrameBoundType.CURRENT_ROW)) {
-                    continue;
+                    return null;
                 }
             } else {
-                continue;
+                return null;
             }
 
             // Check filter conditions.

--- a/regression-test/data/nereids_syntax_p0/window_function.out
+++ b/regression-test/data/nereids_syntax_p0/window_function.out
@@ -561,3 +561,9 @@
 \N
 \N
 
+-- !multi_winf1 --
+1	c
+
+-- !multi_winf2 --
+1	35
+

--- a/regression-test/suites/nereids_rules_p0/push_down_filter_through_window/push_down_multi_filter_through_window.groovy
+++ b/regression-test/suites/nereids_rules_p0/push_down_filter_through_window/push_down_multi_filter_through_window.groovy
@@ -157,4 +157,24 @@ suite("push_down_multi_filter_through_window") {
         sql ("select * from (select row_number() over(partition by c1, c2 order by c3) as rn, rank() over(partition by c1 order by c3) as rk from push_down_multi_predicate_through_window_t) t where rn <= 1 or rk <= 1;")
         notContains "VPartitionTopN"
     }
+
+    explain {
+        sql ("select * from (select row_number() over(partition by c1, c2 order by c3) as rn, sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        notContains "VPartitionTopN"
+    }
+
+    explain {
+        sql ("select * from (select sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw, row_number() over(partition by c1, c2 order by c3) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        notContains "VPartitionTopN"
+    }
+
+    explain {
+        sql ("select * from (select row_number() over(partition by c1, c2 order by c3 rows between unbounded preceding and current row) as rn, sum(c2) over(order by c2) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        notContains "VPartitionTopN"
+    }
+
+    explain {
+        sql ("select * from (select sum(c2) over(order by c2) as sw, row_number() over(partition by c1, c2 order by c3  rows between unbounded preceding and current row) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        notContains "VPartitionTopN"
+    }
 }

--- a/regression-test/suites/nereids_rules_p0/push_down_filter_through_window/push_down_multi_filter_through_window.groovy
+++ b/regression-test/suites/nereids_rules_p0/push_down_filter_through_window/push_down_multi_filter_through_window.groovy
@@ -159,22 +159,22 @@ suite("push_down_multi_filter_through_window") {
     }
 
     explain {
-        sql ("select * from (select row_number() over(partition by c1, c2 order by c3) as rn, sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        sql ("select * from (select row_number() over(partition by c1, c2 order by c3) as rn, sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 and sw <= 1;")
         notContains "VPartitionTopN"
     }
 
     explain {
-        sql ("select * from (select sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw, row_number() over(partition by c1, c2 order by c3) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        sql ("select * from (select sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw, row_number() over(partition by c1, c2 order by c3) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 and sw <= 1;")
         notContains "VPartitionTopN"
     }
 
     explain {
-        sql ("select * from (select row_number() over(partition by c1, c2 order by c3 rows between unbounded preceding and current row) as rn, sum(c2) over(order by c2) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        sql ("select * from (select row_number() over(partition by c1, c2 order by c3 rows between unbounded preceding and current row) as rn, sum(c2) over(order by c2) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 and sw <= 1;")
         notContains "VPartitionTopN"
     }
 
     explain {
-        sql ("select * from (select sum(c2) over(order by c2) as sw, row_number() over(partition by c1, c2 order by c3  rows between unbounded preceding and current row) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 or sw <= 1;")
+        sql ("select * from (select sum(c2) over(order by c2) as sw, row_number() over(partition by c1, c2 order by c3  rows between unbounded preceding and current row) as rn from push_down_multi_predicate_through_window_t) t where rn <= 1 and sw <= 1;")
         notContains "VPartitionTopN"
     }
 }

--- a/regression-test/suites/nereids_syntax_p0/window_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/window_function.groovy
@@ -240,4 +240,43 @@ suite("window_function") {
     """
 
     qt_sql """ select LAST_VALUE(col_tinyint_undef_signed_not_null) over (partition by col_double_undef_signed_not_null, col_int_undef_signed, (col_float_undef_signed_not_null - col_int_undef_signed), round_bankers(col_int_undef_signed) order by pk rows between unbounded preceding and 4 preceding) AS col_alias56089 from table_200_undef_partitions2_keys3_properties4_distributed_by53 order by col_alias56089;  """
+
+    order_qt_multi_winf1 """
+        select *
+            from (
+                select
+                row_number() over(partition by c1 order by c2) rn,
+                lead(c2, 2, '') over(partition by c1 order by c2)
+                from (
+                  select 1 as c1, 'a' as c2
+                  union all
+                  select 1 as c1, 'b' as c2
+                  union all
+                  select 1 as c1, 'c' as c2
+                  union all
+                  select 1 as c1, 'd' as c2
+                  union all
+                  select 1 as c1, 'e' as c2
+                )t
+            )a where rn=1
+    """
+    order_qt_multi_winf2 """
+        select *
+            from (
+                select
+                row_number() over(partition by c1 order by c2) rn,
+                sum(c2) over(order by c2 range between unbounded preceding and unbounded following)
+                from (
+                  select 1 as c1, 5 as c2
+                  union all
+                  select 1 as c1, 6 as c2
+                  union all
+                  select 1 as c1, 7 as c2
+                  union all
+                  select 1 as c1, 8 as c2
+                  union all
+                  select 1 as c1, 9 as c2
+                )t
+            )a where rn=1
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #38393

Problem Summary: In the previous pr which supporting multi win expr ptopN pushdown, it handled partial forbidden type unexpectly and will lead some case to push down the pTopN wrongly.
plan before fixing:

```
explain shape plan select * from (select row_number() over(partition by c1, c2 order by c3) as rn, sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 and sw <= 1;
```

```
+------------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                    |
+------------------------------------------------------------------------------------+
| PhysicalResultSink                                                                 |
| --PhysicalProject                                                                  |
| ----filter((rn <= 1) and (sw <= 1))                                                |
| ------PhysicalWindow                                                               |
| --------PhysicalQuickSort[MERGE_SORT]                                              |
| ----------PhysicalDistribute[DistributionSpecGather]                               |
| ------------PhysicalQuickSort[LOCAL_SORT]                                          |
| --------------PhysicalWindow                                                       |
| ----------------PhysicalQuickSort[LOCAL_SORT]                                      |
| ------------------PhysicalDistribute[DistributionSpecHash]                         |
| --------------------PhysicalPartitionTopN                                          |
| ----------------------PhysicalOlapScan[push_down_multi_predicate_through_window_t] |
+------------------------------------------------------------------------------------+
```

plan after fixing: 
```
explain shape plan select * from (select row_number() over(partition by c1, c2 order by c3) as rn, sum(c2) over(order by c2 range between unbounded preceding and unbounded following) as sw from push_down_multi_predicate_through_window_t) t where rn <= 1 and sw <= 1;
```

```
+----------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                  |
+----------------------------------------------------------------------------------+
| PhysicalResultSink                                                               |
| --PhysicalProject                                                                |
| ----filter((rn <= 1) and (sw <= 1))                                              |
| ------PhysicalWindow                                                             |
| --------PhysicalQuickSort[MERGE_SORT]                                            |
| ----------PhysicalDistribute[DistributionSpecGather]                             |
| ------------PhysicalQuickSort[LOCAL_SORT]                                        |
| --------------PhysicalWindow                                                     |
| ----------------PhysicalQuickSort[LOCAL_SORT]                                    |
| ------------------PhysicalDistribute[DistributionSpecHash]                       |
| --------------------PhysicalOlapScan[push_down_multi_predicate_through_window_t] |
+----------------------------------------------------------------------------------+
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

