### PR TITLE
[fix](auth)Fix the need for low-level table permissions when querying views in certain situations

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -174,6 +174,8 @@ public class StatementContext implements Closeable {
 
     private Backend groupCommitMergeBackend;
 
+    private boolean viewPrivChecked;
+
     public StatementContext() {
         this(ConnectContext.get(), null, 0);
     }
@@ -579,5 +581,13 @@ public class StatementContext implements Closeable {
     public void setGroupCommitMergeBackend(
             Backend groupCommitMergeBackend) {
         this.groupCommitMergeBackend = groupCommitMergeBackend;
+    }
+
+    public boolean isViewPrivChecked() {
+        return viewPrivChecked;
+    }
+
+    public void setViewPrivChecked(boolean viewPrivChecked) {
+        this.viewPrivChecked = viewPrivChecked;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -174,7 +174,7 @@ public class StatementContext implements Closeable {
 
     private Backend groupCommitMergeBackend;
 
-    private boolean viewPrivChecked;
+    private boolean privChecked;
 
     public StatementContext() {
         this(ConnectContext.get(), null, 0);
@@ -583,11 +583,11 @@ public class StatementContext implements Closeable {
         this.groupCommitMergeBackend = groupCommitMergeBackend;
     }
 
-    public boolean isViewPrivChecked() {
-        return viewPrivChecked;
+    public boolean isPrivChecked() {
+        return privChecked;
     }
 
-    public void setViewPrivChecked(boolean viewPrivChecked) {
-        this.viewPrivChecked = viewPrivChecked;
+    public void setPrivChecked(boolean privChecked) {
+        this.privChecked = privChecked;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
@@ -50,12 +50,12 @@ public class CheckPrivileges extends ColumnPruning {
     @Override
     public Plan rewriteRoot(Plan plan, JobContext jobContext) {
         // Only enter once, if repeated, the permissions of the table in the view will be checked
-        if (jobContext.getCascadesContext().getStatementContext().isViewPrivChecked()) {
+        if (jobContext.getCascadesContext().getStatementContext().isPrivChecked()) {
             return plan;
         }
         this.jobContext = jobContext;
         super.rewriteRoot(plan, jobContext);
-        jobContext.getCascadesContext().getStatementContext().setViewPrivChecked(true);
+        jobContext.getCascadesContext().getStatementContext().setPrivChecked(true);
         // don't rewrite plan
         return plan;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
@@ -49,6 +49,10 @@ public class CheckPrivileges extends ColumnPruning {
 
     @Override
     public Plan rewriteRoot(Plan plan, JobContext jobContext) {
+        // Only enter once, if repeated, the permissions of the table in the view will be checked
+        if (jobContext.getCascadesContext().getStatementContext().isViewPrivChecked()) {
+            return plan;
+        }
         this.jobContext = jobContext;
         super.rewriteRoot(plan, jobContext);
 
@@ -59,7 +63,7 @@ public class CheckPrivileges extends ColumnPruning {
     @Override
     public Plan visitLogicalView(LogicalView<? extends Plan> view, PruneContext context) {
         checkColumnPrivileges(view.getView(), computeUsedColumns(view, context.requiredSlots));
-
+        jobContext.getCascadesContext().getStatementContext().setViewPrivChecked(true);
         // stop check privilege in the view
         return view;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
@@ -55,7 +55,7 @@ public class CheckPrivileges extends ColumnPruning {
         }
         this.jobContext = jobContext;
         super.rewriteRoot(plan, jobContext);
-
+        jobContext.getCascadesContext().getStatementContext().setViewPrivChecked(true);
         // don't rewrite plan
         return plan;
     }
@@ -63,7 +63,6 @@ public class CheckPrivileges extends ColumnPruning {
     @Override
     public Plan visitLogicalView(LogicalView<? extends Plan> view, PruneContext context) {
         checkColumnPrivileges(view.getView(), computeUsedColumns(view, context.requiredSlots));
-        jobContext.getCascadesContext().getStatementContext().setViewPrivChecked(true);
         // stop check privilege in the view
         return view;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckPrivileges.java
@@ -63,6 +63,7 @@ public class CheckPrivileges extends ColumnPruning {
     @Override
     public Plan visitLogicalView(LogicalView<? extends Plan> view, PruneContext context) {
         checkColumnPrivileges(view.getView(), computeUsedColumns(view, context.requiredSlots));
+
         // stop check privilege in the view
         return view;
     }

--- a/regression-test/suites/auth_p0/test_select_view_auth.groovy
+++ b/regression-test/suites/auth_p0/test_select_view_auth.groovy
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_select_view_auth","p0,auth") {
+    String suiteName = "test_select_view_auth"
+    String user = "${suiteName}_user"
+    String pwd = 'C123_567p'
+    String dbName = "${suiteName}_db"
+    String tableName1 = "${suiteName}_table1"
+    String tableName2 = "${suiteName}_table2"
+    String viewName = "${suiteName}_view"
+
+    try_sql("drop user ${user}")
+    try_sql """drop table if exists ${dbName}.${tableName1}"""
+    try_sql """drop table if exists ${dbName}.${tableName2}"""
+    try_sql """drop view if exists ${dbName}.${viewName}"""
+    sql """drop database if exists ${dbName}"""
+
+    sql """create user '${user}' IDENTIFIED by '${pwd}'"""
+
+    //cloud-mode
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER ${validCluster} TO ${user}""";
+    }
+    sql """create database ${dbName}"""
+    sql("""use ${dbName}""")
+    sql """
+        CREATE TABLE IF NOT EXISTS ${dbName}.`${tableName1}` (
+            id BIGINT,
+            username VARCHAR(20)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${dbName}.`${tableName2}` (
+            id BIGINT,
+            username VARCHAR(20)
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+
+    sql """create view ${dbName}.${viewName} as select * from ${dbName}.${tableName1} union select * from ${dbName}.${tableName2};"""
+
+    sql """grant select_priv on regression_test to ${user}"""
+
+    // table column
+    connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
+        try {
+            sql "select * from ${dbName}.${viewName}"
+        } catch (Exception e) {
+            log.info(e.getMessage())
+            assertTrue(e.getMessage().contains("denied"))
+        }
+    }
+    sql """grant select_priv on ${dbName}.${viewName} to ${user}"""
+    connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
+        sql "select * from ${dbName}.${viewName}"
+    }
+
+    try_sql("drop user ${user}")
+    try_sql """drop table if exists ${dbName}.${tableName1}"""
+    try_sql """drop table if exists ${dbName}.${tableName2}"""
+    try_sql """drop view if exists ${dbName}.${viewName}"""
+    sql """drop database if exists ${dbName}"""
+}


### PR DESCRIPTION
### What problem does this PR solve?
fix when `create view v1 as select * from table1 union select * from table2` and user has select_priv of v1,but he can not `select * from v1`

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fix the need for low-level table permissions when querying views in certain situations
### Release note

Fix the need for low-level table permissions when querying views in certain situations

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

