### PR TITLE
[fix](cloud-mow) get delete bitmap update lock should create a new Transaction when encounter TXN_TOO_OLD

### DIFF
--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -4516,7 +4516,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLock1) {
     ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
 }
 
-
 TEST(MetaServiceTest, GetDeleteBitmapUpdateLock2) {
     auto meta_service = get_meta_service();
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #37670

Problem Summary:
When the number of tablet is big, get delete bitmap update lock may cost over 5 seconds, which will lead to transaction timeout, we should create a new transaction to get the remaining tablet stats.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

