### PR TITLE
[fix](unique key) getEnableUniqueKeyMergeOnWrite should check keys type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2831,6 +2831,9 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         if (tableProperty == null) {
             return false;
         }
+        if (getKeysType() != KeysType.UNIQUE_KEYS) {
+            return false;
+        }
         return tableProperty.getEnableUniqueKeyMergeOnWrite();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Some user can create Duplicate keys table with `enable_unique_key_merge_on_write=true` in version 1.2, when they upgrade to version 2.0, some logic in BE treat such table as an unique key mow table, make a wrong query plan, which cause BE core.

In the method `OlapTable::getEnableUniqueKeyMergeOnWrite()`, we should check if the table is a unique key table.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

