### PR TITLE
[fix](nereids) fix months_add/ months_sub/ years_add/years_sub compute wrong result because SimplifyArithmeticComparisonRule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
@@ -64,7 +64,7 @@ public class SimplifyArithmeticComparisonRule implements ExpressionPatternRuleFa
             .put(Divide.class, Multiply.class)
             // ATTN: YearsAdd, MonthsAdd can not reverse
             //       for example, months_add(date '2024-01-31', 1) = date '2024-02-29' can not reverse to
-            //       date '2024-01-31' = months_sub('2024-02-29', 1)
+            //       date '2024-01-31' = months_sub(date '2024-02-29', 1)
             .put(WeeksSub.class, WeeksAdd.class)
             .put(WeeksAdd.class, WeeksSub.class)
             .put(DaysSub.class, DaysAdd.class)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
@@ -32,14 +32,10 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.HoursAdd;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.HoursSub;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.MinutesAdd;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.MinutesSub;
-import org.apache.doris.nereids.trees.expressions.functions.scalar.MonthsAdd;
-import org.apache.doris.nereids.trees.expressions.functions.scalar.MonthsSub;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.SecondsAdd;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.SecondsSub;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeeksAdd;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeeksSub;
-import org.apache.doris.nereids.trees.expressions.functions.scalar.YearsAdd;
-import org.apache.doris.nereids.trees.expressions.functions.scalar.YearsSub;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
@@ -66,10 +62,9 @@ public class SimplifyArithmeticComparisonRule implements ExpressionPatternRuleFa
             .put(Add.class, Subtract.class)
             .put(Subtract.class, Add.class)
             .put(Divide.class, Multiply.class)
-            .put(YearsSub.class, YearsAdd.class)
-            .put(YearsAdd.class, YearsSub.class)
-            .put(MonthsSub.class, MonthsAdd.class)
-            .put(MonthsAdd.class, MonthsSub.class)
+            // ATTN: YearsSub, MonthsSub can not reverse
+            //       for example, months_add(date '2024-01-31', 1) = date '2024-02-29' can not reverse to
+            //       date '2024-01-31' = months_sub('2024-02-29')
             .put(WeeksSub.class, WeeksAdd.class)
             .put(WeeksAdd.class, WeeksSub.class)
             .put(DaysSub.class, DaysAdd.class)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
@@ -62,9 +62,9 @@ public class SimplifyArithmeticComparisonRule implements ExpressionPatternRuleFa
             .put(Add.class, Subtract.class)
             .put(Subtract.class, Add.class)
             .put(Divide.class, Multiply.class)
-            // ATTN: YearsSub, MonthsSub can not reverse
+            // ATTN: YearsAdd, MonthsAdd can not reverse
             //       for example, months_add(date '2024-01-31', 1) = date '2024-02-29' can not reverse to
-            //       date '2024-01-31' = months_sub('2024-02-29')
+            //       date '2024-01-31' = months_sub('2024-02-29', 1)
             .put(WeeksSub.class, WeeksAdd.class)
             .put(WeeksAdd.class, WeeksSub.class)
             .put(DaysSub.class, DaysAdd.class)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyArithmeticRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyArithmeticRuleTest.java
@@ -151,10 +151,10 @@ class SimplifyArithmeticRuleTest extends ExpressionRewriteTestHelper {
                     FoldConstantRule.INSTANCE
                 )
         ));
-        assertRewriteAfterTypeCoercion("years_add(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2020-01-01 00:00:00')");
-        assertRewriteAfterTypeCoercion("years_sub(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2022-01-01 00:00:00')");
-        assertRewriteAfterTypeCoercion("months_add(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2020-12-01 00:00:00')");
-        assertRewriteAfterTypeCoercion("months_sub(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2021-02-01 00:00:00')");
+        assertRewriteAfterTypeCoercion("years_add(IA, 1) > '2021-01-01 00:00:00'", "(years_add(cast(IA as DATETIMEV2(0)), 1) > '2021-01-01 00:00:00')");
+        assertRewriteAfterTypeCoercion("years_sub(IA, 1) > '2021-01-01 00:00:00'", "(years_sub(cast(IA as DATETIMEV2(0)), 1) > '2021-01-01 00:00:00')");
+        assertRewriteAfterTypeCoercion("months_add(IA, 1) > '2021-01-01 00:00:00'", "(months_add(cast(IA as DATETIMEV2(0)), 1) > '2021-01-01 00:00:00')");
+        assertRewriteAfterTypeCoercion("months_sub(IA, 1) > '2021-01-01 00:00:00'", "(months_sub(cast(IA as DATETIMEV2(0)), 1) > '2021-01-01 00:00:00')");
         assertRewriteAfterTypeCoercion("weeks_add(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2020-12-25 00:00:00')");
         assertRewriteAfterTypeCoercion("weeks_sub(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2021-01-08 00:00:00')");
         assertRewriteAfterTypeCoercion("days_add(IA, 1) > '2021-01-01 00:00:00'", "(cast(IA as DATETIMEV2(0)) > '2020-12-31 00:00:00')");

--- a/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -720,4 +720,17 @@ suite("test_date_function") {
 
 
     qt_sql_time_value """ select  cast(4562632 as time),  hour(cast(4562632 as time)) ,  minute(cast(4562632 as time)) , second(cast(4562632 as time)); """
+
+    def test_simplify = {
+        sql "drop table if exists test_int_date"
+        sql "create table test_int_date(dt int) distributed by hash(dt) properties('replication_num'='1');"
+        test {
+            sql "select months_add(dt, 1) = date '2024-02-29' from (select date '2024-01-31' as dt)a"
+            result([[true]])
+        }
+        test {
+            sql "select years_add(dt, 1) = date '2025-02-28' from (select date '2024-02-29' as dt)a"
+            result([[true]])
+        }
+    }()
 }

--- a/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -722,8 +722,6 @@ suite("test_date_function") {
     qt_sql_time_value """ select  cast(4562632 as time),  hour(cast(4562632 as time)) ,  minute(cast(4562632 as time)) , second(cast(4562632 as time)); """
 
     def test_simplify = {
-        sql "drop table if exists test_int_date"
-        sql "create table test_int_date(dt int) distributed by hash(dt) properties('replication_num'='1');"
         test {
             sql "select months_add(dt, 1) = date '2024-02-29' from (select date '2024-01-31' as dt)a"
             result([[true]])

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -818,4 +818,17 @@ suite("test_date_function") {
     qt_sql_varchar1 """ select dt, fmt, unix_timestamp(dt, fmt) as k1 from date_varchar order by k1,dt,fmt; """
     qt_sql_varchar1 """ select dt, unix_timestamp(dt, "%Y-%m-%d") as k1 from date_varchar order by k1,dt,fmt; """
     qt_sql_varchar1 """ select fmt, unix_timestamp("1990-12-12", fmt) as k1 from date_varchar order by k1,dt,fmt; """
+
+    def test_simplify = {
+        sql "drop table if exists test_int_date"
+        sql "create table test_int_date(dt int) distributed by hash(dt) properties('replication_num'='1');"
+        test {
+            sql "select months_add(dt, 1) = date '2024-02-29' from (select date '2024-01-31' as dt)a"
+            result([[true]])
+        }
+        test {
+            sql "select years_add(dt, 1) = date '2025-02-28' from (select date '2024-02-29' as dt)a"
+            result([[true]])
+        }
+    }()
 }

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -818,4 +818,19 @@ suite("test_date_function") {
     qt_sql_varchar1 """ select dt, fmt, unix_timestamp(dt, fmt) as k1 from date_varchar order by k1,dt,fmt; """
     qt_sql_varchar1 """ select dt, unix_timestamp(dt, "%Y-%m-%d") as k1 from date_varchar order by k1,dt,fmt; """
     qt_sql_varchar1 """ select fmt, unix_timestamp("1990-12-12", fmt) as k1 from date_varchar order by k1,dt,fmt; """
+
+
+
+    def test_simplify = {
+        sql "drop table if exists test_int_date"
+        sql "create table test_int_date(dt int) distributed by hash(dt) properties('replication_num'='1');"
+        test {
+            sql "select months_add(dt, 1) = date '2024-02-29' from (select date '2024-01-31' as dt)a"
+            result([[true]])
+        }
+        test {
+            sql "select years_add(dt, 1) = date '2025-02-28' from (select date '2024-02-29' as dt)a"
+            result([[true]])
+        }
+    }()
 }

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -818,19 +818,4 @@ suite("test_date_function") {
     qt_sql_varchar1 """ select dt, fmt, unix_timestamp(dt, fmt) as k1 from date_varchar order by k1,dt,fmt; """
     qt_sql_varchar1 """ select dt, unix_timestamp(dt, "%Y-%m-%d") as k1 from date_varchar order by k1,dt,fmt; """
     qt_sql_varchar1 """ select fmt, unix_timestamp("1990-12-12", fmt) as k1 from date_varchar order by k1,dt,fmt; """
-
-
-
-    def test_simplify = {
-        sql "drop table if exists test_int_date"
-        sql "create table test_int_date(dt int) distributed by hash(dt) properties('replication_num'='1');"
-        test {
-            sql "select months_add(dt, 1) = date '2024-02-29' from (select date '2024-01-31' as dt)a"
-            result([[true]])
-        }
-        test {
-            sql "select years_add(dt, 1) = date '2025-02-28' from (select date '2024-02-29' as dt)a"
-            result([[true]])
-        }
-    }()
 }

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -820,8 +820,6 @@ suite("test_date_function") {
     qt_sql_varchar1 """ select fmt, unix_timestamp("1990-12-12", fmt) as k1 from date_varchar order by k1,dt,fmt; """
 
     def test_simplify = {
-        sql "drop table if exists test_int_date"
-        sql "create table test_int_date(dt int) distributed by hash(dt) properties('replication_num'='1');"
         test {
             sql "select months_add(dt, 1) = date '2024-02-29' from (select date '2024-01-31' as dt)a"
             result([[true]])


### PR DESCRIPTION
### What problem does this PR solve?

fix months_add/ months_sub/ years_add/years_sub compute wrong result because SimplifyArithmeticComparisonRule
introduced by #25180

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

