### PR TITLE
[fix](Nereids) fix fold constant of string_index in fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -695,7 +695,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "substring_index")
     public static Expression substringIndex(StringLikeLiteral first, StringLikeLiteral chr, IntegerLiteral number) {
-        String[] parts = first.getValue().split(chr.getValue());
+        String[] parts = first.getValue().split(chr.getValue(), -1);
         if (Math.abs(number.getValue()) >= parts.length) {
             return first;
         }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -774,5 +774,27 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("select append_trailing_char_if_absent('hello', ' ')")
     // Expected Output: 'hello '
 
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', -5)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', -4)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', -3)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', -2)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', -1)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', 0)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', 1)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', 2)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', 3)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', 4)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AAA','A', 5)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', -4)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', -3)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', -2)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', -1)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', 0)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', 1)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', 2)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', 3)")
+    testFoldConst("SELECT SUBSTRING_INDEX('哈哈哈AA+','A', 4)")
+
+
 
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #44666

Related PR: #xxx

Problem Summary:

select string_index('哈哈哈AAA','A', 1); would return whole string when 1 is larger equal than string.splitpart
So we should change splitpart limit to -1 to enable empty character in splitpart list

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

