### PR TITLE
[improvement](mysql)Support mysql COM_RESET_CONNECTION command.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -342,6 +342,11 @@ public class ConnectContext {
         return lastDBOfCatalog.get(catalog);
     }
 
+    // Used by COM_RESET_CONNECTION
+    public void clearLastDBOfCatalog() {
+        lastDBOfCatalog.clear();
+    }
+
     public void setNotEvalNondeterministicFunction(boolean notEvalNondeterministicFunction) {
         this.notEvalNondeterministicFunction = notEvalNondeterministicFunction;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -44,6 +44,7 @@ import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.SqlUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlPacket;
@@ -195,6 +196,12 @@ public abstract class ConnectProcessor {
 
     // Do nothing for now.
     protected void handleDebug() {
+        ctx.getState().setOk();
+    }
+
+    protected void handleResetConnection() {
+        ctx.changeDefaultCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
+        ctx.clearLastDBOfCatalog();
         ctx.getState().setOk();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -264,6 +264,9 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             case COM_SET_OPTION:
                 handleSetOption();
                 break;
+            case COM_RESET_CONNECTION:
+                handleResetConnection();
+                break;
             default:
                 ctx.getState().setError(ErrorCode.ERR_UNKNOWN_COM_ERROR, "Unsupported command(" + command + ")");
                 LOG.warn("Unsupported command(" + command + ")");


### PR DESCRIPTION
### What problem does this PR solve?
Support mysql COM_RESET_CONNECTION command.
Doris server side reset default catalog and return ctx.getState().setOk()

Python test code:
```
import mysql.connector

connection = mysql.connector.connect(
    host="172.20.32.136", 
    port=29030,
    user="root", 
    password="", 
    database=""
)
print(connection.cmd_reset_connection())
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

