### PR TITLE
[bugfix](hive)Fix split assignment leak. releated to issue (#40683).

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -126,7 +126,6 @@ public abstract class FileScanNode extends ExternalScanNode {
         output.append(prefix);
         if (isBatchMode()) {
             output.append("(approximate)");
-            splitAssignment.stop();
         }
         output.append("inputSplitNum=").append(selectedSplitNum).append(", totalFileSize=")
             .append(totalFileSize).append(", scanRanges=").append(scanRangeLocations.size()).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExplainCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExplainCommand.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.plans.Explainable;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
@@ -94,6 +95,9 @@ public class ExplainCommand extends Command implements NoForward {
             executor.handleExplainPlanProcessStmt(planner.getCascadesContext().getPlanProcesses());
         } else {
             executor.handleExplainStmt(planner.getExplainString(explainOptions), true);
+        }
+        for (ScanNode scanNode : planner.getScanNodes()) {
+            scanNode.stop();
         }
     }
 


### PR DESCRIPTION
Also fix stop split too early in select join statement when enable_profile is true. Releated to issue (#40683).

Case appearing condition:  use batchmode and set enable_profile=true，hive table has enough split （like more than 10）

### What problem does this PR solve?
Under enable_profile is true, in query with join like "select  dt.d_year,dt.d_moy from  date_dim dt ,store_sales where dt.d_date_sk = store_sales.ss_sold_date_sk group by dt.d_year, dt.d_moy order by  dt.d_year, dt.d_moy limit 100",
the old fix in commit 83797e36aeb stops SplitAssignment in FileScanNode.getNodeExplainString, that would be called in normal query (in StmtExecutor.updateProfile)，then BE would get empty split and make wrong result。
So i changed the place where SplitAssignment need stop in explain only statement.