### PR TITLE
[fix](cluster key) fix bug if be enable enable_rowid_conversion_correctness_check

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -775,7 +775,8 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     }
 
     std::unique_ptr<std::map<RowsetSharedPtr, RowLocationPairList>> location_map;
-    if (config::enable_rowid_conversion_correctness_check) {
+    if (config::enable_rowid_conversion_correctness_check &&
+        tablet_schema()->cluster_key_idxes().empty()) {
         location_map = std::make_unique<std::map<RowsetSharedPtr, RowLocationPairList>>();
         LOG(INFO) << "Location Map inited succ for tablet:" << tablet_id();
     }

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -1604,10 +1604,6 @@ Status BaseTablet::check_rowid_conversion(
         VLOG_DEBUG << "check_rowid_conversion, location_map is empty";
         return Status::OK();
     }
-    if (!tablet_schema()->cluster_key_idxes().empty()) {
-        VLOG_DEBUG << "skip check_rowid_conversion for mow tables with cluster keys";
-        return Status::OK();
-    }
     std::vector<segment_v2::SegmentSharedPtr> dst_segments;
 
     RETURN_IF_ERROR(

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -908,7 +908,8 @@ Status CompactionMixin::modify_rowsets() {
             LOG(INFO) << "RowLocation Set inited succ for tablet:" << _tablet->tablet_id();
         }
         std::unique_ptr<std::map<RowsetSharedPtr, RowLocationPairList>> location_map;
-        if (config::enable_rowid_conversion_correctness_check) {
+        if (config::enable_rowid_conversion_correctness_check &&
+            tablet()->tablet_schema()->cluster_key_idxes().empty()) {
             location_map = std::make_unique<std::map<RowsetSharedPtr, RowLocationPairList>>();
             LOG(INFO) << "Location Map inited succ for tablet:" << _tablet->tablet_id();
         }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -1031,6 +1031,7 @@ class Config {
             excludeDirectorySet.add("schema_change_p0/unique_ck")
             List<String> excludeCases = ["test_table_properties", "test_create_table"
                 , "test_default_hll", "test_default_pi", "test_default_bitmap_empty"
+                , "test_full_compaction", "test_full_compaction_by_table_id"
                 // partial update
                 , "txn_insert", "test_update_schema_change", "test_generated_column_update", "test_nested_type_with_rowstore", "test_partial_update_generated_column", "nereids_partial_update_native_insert_stmt"
                 , "partial_update", "nereids_update_on_current_timestamp", "update_on_current_timestamp", "nereids_delete_mow_partial_update", "delete_mow_partial_update", "test_unique_table_auto_inc"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

fix:
```
terminate called after throwing an instance of 'std::system_error'
  what():  Resource deadlock avoided
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 1980528 ***
*** Aborted at 1733280745 (unix time) try "date -d @1733280745" if you are using GNU date ***
*** Current BE git commitID: 009e5a82c4 ***
*** SIGABRT unknown detail explain (@0x4290022570e) received by PID 2250510 (TID 2251330 OR 0x7f21b45dd700) from PID 2250510; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/meiyi/clion_workspace/doris/be/src/common/signal_handler.h:421
 1# 0x00007F24197AFB50 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x0000564E1F9917D1 in /mnt/disk2/meiyi/deployment/doris/output/be/lib/doris_be
 7# 0x0000564E1F991924 in /mnt/disk2/meiyi/deployment/doris/output/be/lib/doris_be
 8# std::__throw_system_error(int) at ../../../../../libstdc++-v3/src/c++11/system_error.cc:338
 9# std::__shared_mutex_pthread::lock_shared() at /mnt/disk2/meiyi/soft/ldb_toolchain_2/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/shared_mutex:232
10# std::shared_mutex::lock_shared() at /mnt/disk2/meiyi/soft/ldb_toolchain_2/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/shared_mutex:426
11# std::shared_lock<std::shared_mutex>::shared_lock(std::shared_mutex&) at /mnt/disk2/meiyi/soft/ldb_toolchain_2/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/shared_mutex:727
12# doris::BaseTablet::tablet_schema() const at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/base_tablet.h:91
13# doris::BaseTablet::check_rowid_conversion(std::shared_ptr<doris::Rowset>, std::map<std::shared_ptr<doris::Rowset>, std::__cxx11::list<std::pair<doris::RowLocation, doris::RowLocation>, std::allocator<std::pair<doris::RowLocation, doris::RowLocation> > >, std::less<std::shared_ptr<doris::Rowset> >, std::allocator<std::pair<std::shared_ptr<doris::Rowset> const, std::__cxx11::list<std::pair<doris::RowLocation, doris::RowLocation>, std::allocator<std::pair<doris::RowLocation, doris::RowLocation> > > > > > const&) at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/base_tablet.cpp:1607
14# doris::CompactionMixin::modify_rowsets() at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/compaction.cpp:1087
15# doris::CompactionMixin::execute_compact_impl(long) at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/compaction.cpp:472
16# doris::CompactionMixin::execute_compact() at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/compaction.cpp:425
17# doris::CumulativeCompaction::execute_compact() at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/cumulative_compaction.cpp:111
18# doris::Tablet::execute_compaction(doris::CompactionMixin&)::$_0::operator()() const at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/tablet.cpp:1850
19# doris::Tablet::execute_compaction(doris::CompactionMixin&) at /mnt/disk2/meiyi/clion_workspace/doris/be/src/olap/tablet.cpp:1850
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

