### PR TITLE
[fix](func) Fix BE core dump caused by buffer access out of bounds

### DIFF
--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -894,7 +894,7 @@ struct StringSpace {
             if (data[i] > 0) {
                 buffer.resize(data[i]);
                 for (size_t j = 0; j < data[i]; ++j) {
-                    buffer[i] = ' ';
+                    buffer[j] = ' ';
                 }
                 StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i,
                                             res_data, res_offsets);


### PR DESCRIPTION
Change-Id: I738a45d6cc68b21d9e77eb9649c19835925d5d45

### What problem does this PR solve?

Issue Number: close #xxx

Fix BE core dump caused by buffer access out of bounds

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

