### PR TITLE
[Enchancement](runtime-filter) improvement for datetimev2 bloom filter hash method

### DIFF
--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -128,7 +128,6 @@ public:
         _runtime_bloom_filter_min_size = params->runtime_bloom_filter_min_size;
         _runtime_bloom_filter_max_size = params->runtime_bloom_filter_max_size;
         _null_aware = params->null_aware;
-        _enable_fixed_len_to_uint32_v2 = params->enable_fixed_len_to_uint32_v2;
         _bloom_filter_size_calculated_by_ndv = params->bloom_filter_size_calculated_by_ndv;
         _limit_length();
     }
@@ -235,6 +234,8 @@ public:
 
     void set_contain_null_and_null_aware() { _bloom_filter->set_contain_null_and_null_aware(); }
 
+    void set_enable_fixed_len_to_uint32_v2() { _enable_fixed_len_to_uint32_v2 = true; }
+
     size_t get_size() const { return _bloom_filter ? _bloom_filter->size() : 0; }
 
     void light_copy(BloomFilterFuncBase* bloomfilter_func) {
@@ -242,6 +243,7 @@ public:
         _bloom_filter_alloced = other_func->_bloom_filter_alloced;
         _bloom_filter = other_func->_bloom_filter;
         _inited = other_func->_inited;
+        _enable_fixed_len_to_uint32_v2 |= other_func->_enable_fixed_len_to_uint32_v2;
     }
 
     virtual void insert(const void* data) = 0;

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -26,15 +26,39 @@
 #include "vec/common/string_ref.h"
 
 namespace doris {
+// there are problems with the implementation of the old datetimev2. for compatibility reason, we will keep this code temporary.
+struct fixed_len_to_uint32 {
+    template <typename T>
+    uint32_t operator()(T value) {
+        if constexpr (sizeof(T) <= sizeof(uint32_t)) {
+            if constexpr (std::is_same_v<T, DateV2Value<DateV2ValueType>>) {
+                return (uint32_t)value.to_int64();
+            } else {
+                return (uint32_t)value;
+            }
+        }
+        return std::hash<T>()(value);
+    }
+};
+
+struct fixed_len_to_uint32_v2 {
+    template <typename T>
+    uint32_t operator()(T value) {
+        if constexpr (sizeof(T) <= sizeof(uint32_t)) {
+            if constexpr (std::is_same_v<T, DateV2Value<DateV2ValueType>>) {
+                return (uint32_t)value.to_date_int_val();
+            } else {
+                return (uint32_t)value;
+            }
+        }
+        return std::hash<T>()(value);
+    }
+};
 
 class BloomFilterAdaptor {
 public:
-    BloomFilterAdaptor(bool null_aware = false) : _null_aware(null_aware) {
+    BloomFilterAdaptor(bool null_aware) : _null_aware(null_aware) {
         _bloom_filter = std::make_shared<doris::BlockBloomFilter>();
-    }
-
-    static int64_t optimal_bit_num(int64_t expect_num, double fpp) {
-        return doris::segment_v2::BloomFilter::optimal_bit_num(expect_num, fpp) / 8;
     }
 
     static BloomFilterAdaptor* create(bool null_aware) {
@@ -57,27 +81,23 @@ public:
 
     size_t size() { return _bloom_filter->directory().size; }
 
-    template <typename T>
-    bool test(T data) const {
-        return _bloom_filter->find(data);
-    }
+    bool test(uint32_t data) const { return _bloom_filter->find(data); }
 
-    // test_element/find_element only used on vectorized engine
-    template <typename T>
+    template <typename fixed_len_to_uint32_method, typename T>
     bool test_element(T element) const {
         if constexpr (std::is_same_v<T, StringRef>) {
             return _bloom_filter->find(element);
         } else {
-            return _bloom_filter->find(HashUtil::fixed_len_to_uint32(element));
+            return _bloom_filter->find(fixed_len_to_uint32_method()(element));
         }
     }
 
-    template <typename T>
+    template <typename fixed_len_to_uint32_method, typename T>
     void add_element(T element) {
         if constexpr (std::is_same_v<T, StringRef>) {
             _bloom_filter->insert(element);
         } else {
-            _bloom_filter->insert(HashUtil::fixed_len_to_uint32(element));
+            _bloom_filter->insert(fixed_len_to_uint32_method()(element));
         }
     }
 
@@ -108,6 +128,7 @@ public:
         _runtime_bloom_filter_min_size = params->runtime_bloom_filter_min_size;
         _runtime_bloom_filter_max_size = params->runtime_bloom_filter_max_size;
         _null_aware = params->null_aware;
+        _enable_fixed_len_to_uint32_v2 = params->enable_fixed_len_to_uint32_v2;
         _bloom_filter_size_calculated_by_ndv = params->bloom_filter_size_calculated_by_ndv;
         _limit_length();
     }
@@ -255,9 +276,10 @@ protected:
     int64_t _runtime_bloom_filter_max_size;
     bool _build_bf_exactly = false;
     bool _bloom_filter_size_calculated_by_ndv = false;
+    bool _enable_fixed_len_to_uint32_v2 = false;
 };
 
-template <typename T, bool need_trim = false>
+template <typename fixed_len_to_uint32_method, typename T, bool need_trim = false>
 uint16_t find_batch_olap(const BloomFilterAdaptor& bloom_filter, const char* data,
                          const uint8* nullmap, uint16_t* offsets, int number,
                          const bool is_parse_column) {
@@ -281,7 +303,8 @@ uint16_t find_batch_olap(const BloomFilterAdaptor& bloom_filter, const char* dat
         if (nullmap == nullptr) {
             for (int i = 0; i < number; i++) {
                 uint16_t idx = offsets[i];
-                if (!bloom_filter.test_element(get_element(data, idx))) {
+                if (!bloom_filter.test_element<fixed_len_to_uint32_method>(
+                            get_element(data, idx))) {
                     continue;
                 }
                 offsets[new_size++] = idx;
@@ -294,7 +317,8 @@ uint16_t find_batch_olap(const BloomFilterAdaptor& bloom_filter, const char* dat
                         continue;
                     }
                 } else {
-                    if (!bloom_filter.test_element(get_element(data, idx))) {
+                    if (!bloom_filter.test_element<fixed_len_to_uint32_method>(
+                                get_element(data, idx))) {
                         continue;
                     }
                 }
@@ -304,7 +328,7 @@ uint16_t find_batch_olap(const BloomFilterAdaptor& bloom_filter, const char* dat
     } else {
         if (nullmap == nullptr) {
             for (int i = 0; i < number; i++) {
-                if (!bloom_filter.test_element(get_element(data, i))) {
+                if (!bloom_filter.test_element<fixed_len_to_uint32_method>(get_element(data, i))) {
                     continue;
                 }
                 offsets[new_size++] = i;
@@ -316,7 +340,8 @@ uint16_t find_batch_olap(const BloomFilterAdaptor& bloom_filter, const char* dat
                         continue;
                     }
                 } else {
-                    if (!bloom_filter.test_element(get_element(data, i))) {
+                    if (!bloom_filter.test_element<fixed_len_to_uint32_method>(
+                                get_element(data, i))) {
                         continue;
                     }
                 }
@@ -327,16 +352,17 @@ uint16_t find_batch_olap(const BloomFilterAdaptor& bloom_filter, const char* dat
     return new_size;
 }
 
-template <class T>
+template <typename fixed_len_to_uint32_method, class T>
 struct CommonFindOp {
-    uint16_t find_batch_olap_engine(const BloomFilterAdaptor& bloom_filter, const char* data,
-                                    const uint8* nullmap, uint16_t* offsets, int number,
-                                    const bool is_parse_column) {
-        return find_batch_olap<T>(bloom_filter, data, nullmap, offsets, number, is_parse_column);
+    static uint16_t find_batch_olap_engine(const BloomFilterAdaptor& bloom_filter, const char* data,
+                                           const uint8* nullmap, uint16_t* offsets, int number,
+                                           const bool is_parse_column) {
+        return find_batch_olap<fixed_len_to_uint32_method, T>(bloom_filter, data, nullmap, offsets,
+                                                              number, is_parse_column);
     }
 
-    void insert_batch(BloomFilterAdaptor& bloom_filter, const vectorized::ColumnPtr& column,
-                      size_t start) const {
+    static void insert_batch(BloomFilterAdaptor& bloom_filter, const vectorized::ColumnPtr& column,
+                             size_t start) {
         const auto size = column->size();
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const vectorized::ColumnNullable*>(column.get());
@@ -348,7 +374,7 @@ struct CommonFindOp {
             const T* data = (T*)col.get_raw_data().data;
             for (size_t i = start; i < size; i++) {
                 if (!nullmap[i]) {
-                    bloom_filter.add_element(*(data + i));
+                    bloom_filter.add_element<fixed_len_to_uint32_method>(*(data + i));
                 } else {
                     bloom_filter.set_contain_null();
                 }
@@ -356,13 +382,13 @@ struct CommonFindOp {
         } else {
             const T* data = (T*)column->get_raw_data().data;
             for (size_t i = start; i < size; i++) {
-                bloom_filter.add_element(*(data + i));
+                bloom_filter.add_element<fixed_len_to_uint32_method>(*(data + i));
             }
         }
     }
 
-    void find_batch(const BloomFilterAdaptor& bloom_filter, const vectorized::ColumnPtr& column,
-                    uint8_t* results) const {
+    static void find_batch(const BloomFilterAdaptor& bloom_filter,
+                           const vectorized::ColumnPtr& column, uint8_t* results) {
         const T* __restrict data = nullptr;
         const uint8_t* __restrict nullmap = nullptr;
         if (column->is_nullable()) {
@@ -382,31 +408,32 @@ struct CommonFindOp {
         if (nullmap) {
             for (size_t i = 0; i < size; i++) {
                 if (!nullmap[i]) {
-                    results[i] = bloom_filter.test_element(data[i]);
+                    results[i] = bloom_filter.test_element<fixed_len_to_uint32_method>(data[i]);
                 } else {
                     results[i] = bloom_filter.contain_null();
                 }
             }
         } else {
             for (size_t i = 0; i < size; i++) {
-                results[i] = bloom_filter.test_element(data[i]);
+                results[i] = bloom_filter.test_element<fixed_len_to_uint32_method>(data[i]);
             }
         }
     }
 
-    void insert(BloomFilterAdaptor& bloom_filter, const void* data) const {
-        bloom_filter.add_element(*(T*)data);
+    static void insert(BloomFilterAdaptor& bloom_filter, const void* data) {
+        bloom_filter.add_element<fixed_len_to_uint32_method>(*(T*)data);
     }
 };
 
-struct StringFindOp : CommonFindOp<StringRef> {
+template <typename fixed_len_to_uint32_method>
+struct StringFindOp : CommonFindOp<fixed_len_to_uint32_method, StringRef> {
     static void insert_batch(BloomFilterAdaptor& bloom_filter, const vectorized::ColumnPtr& column,
                              size_t start) {
         auto _insert_batch_col_str = [&](const auto& col, const uint8_t* __restrict nullmap,
                                          size_t start, size_t size) {
             for (size_t i = start; i < size; i++) {
                 if (nullmap == nullptr || !nullmap[i]) {
-                    bloom_filter.add_element(col.get_data_at(i));
+                    bloom_filter.add_element<fixed_len_to_uint32_method>(col.get_data_at(i));
                 } else {
                     bloom_filter.set_contain_null();
                 }
@@ -451,20 +478,23 @@ struct StringFindOp : CommonFindOp<StringRef> {
             if (nullable->has_null()) {
                 for (size_t i = 0; i < col.size(); i++) {
                     if (!nullmap[i]) {
-                        results[i] = bloom_filter.test_element(col.get_data_at(i));
+                        results[i] = bloom_filter.test_element<fixed_len_to_uint32_method>(
+                                col.get_data_at(i));
                     } else {
                         results[i] = bloom_filter.contain_null();
                     }
                 }
             } else {
                 for (size_t i = 0; i < col.size(); i++) {
-                    results[i] = bloom_filter.test_element(col.get_data_at(i));
+                    results[i] = bloom_filter.test_element<fixed_len_to_uint32_method>(
+                            col.get_data_at(i));
                 }
             }
         } else {
             const auto& col = assert_cast<const vectorized::ColumnString*>(column.get());
             for (size_t i = 0; i < col->size(); i++) {
-                results[i] = bloom_filter.test_element(col->get_data_at(i));
+                results[i] =
+                        bloom_filter.test_element<fixed_len_to_uint32_method>(col->get_data_at(i));
             }
         }
     }
@@ -472,34 +502,35 @@ struct StringFindOp : CommonFindOp<StringRef> {
 
 // We do not need to judge whether data is empty, because null will not appear
 // when filer used by the storage engine
-struct FixedStringFindOp : public StringFindOp {
+template <typename fixed_len_to_uint32_method>
+struct FixedStringFindOp : public StringFindOp<fixed_len_to_uint32_method> {
     static uint16_t find_batch_olap_engine(const BloomFilterAdaptor& bloom_filter, const char* data,
                                            const uint8* nullmap, uint16_t* offsets, int number,
                                            const bool is_parse_column) {
-        return find_batch_olap<StringRef, true>(bloom_filter, data, nullmap, offsets, number,
-                                                is_parse_column);
+        return find_batch_olap<fixed_len_to_uint32_method, StringRef, true>(
+                bloom_filter, data, nullmap, offsets, number, is_parse_column);
     }
 };
 
-template <PrimitiveType type>
+template <typename fixed_len_to_uint32_method, PrimitiveType type>
 struct BloomFilterTypeTraits {
     using T = typename PrimitiveTypeTraits<type>::CppType;
-    using FindOp = CommonFindOp<T>;
+    using FindOp = CommonFindOp<fixed_len_to_uint32_method, T>;
 };
 
-template <>
-struct BloomFilterTypeTraits<TYPE_CHAR> {
-    using FindOp = FixedStringFindOp;
+template <typename fixed_len_to_uint32_method>
+struct BloomFilterTypeTraits<fixed_len_to_uint32_method, TYPE_CHAR> {
+    using FindOp = FixedStringFindOp<fixed_len_to_uint32_method>;
 };
 
-template <>
-struct BloomFilterTypeTraits<TYPE_VARCHAR> {
-    using FindOp = StringFindOp;
+template <typename fixed_len_to_uint32_method>
+struct BloomFilterTypeTraits<fixed_len_to_uint32_method, TYPE_VARCHAR> {
+    using FindOp = StringFindOp<fixed_len_to_uint32_method>;
 };
 
-template <>
-struct BloomFilterTypeTraits<TYPE_STRING> {
-    using FindOp = StringFindOp;
+template <typename fixed_len_to_uint32_method>
+struct BloomFilterTypeTraits<fixed_len_to_uint32_method, TYPE_STRING> {
+    using FindOp = StringFindOp<fixed_len_to_uint32_method>;
 };
 
 template <PrimitiveType type>
@@ -511,16 +542,28 @@ public:
 
     void insert(const void* data) override {
         DCHECK(_bloom_filter != nullptr);
-        dummy.insert(*_bloom_filter, data);
+        if (_enable_fixed_len_to_uint32_v2) {
+            OpV2::insert(*_bloom_filter, data);
+        } else {
+            Op::insert(*_bloom_filter, data);
+        }
     }
 
     void insert_fixed_len(const vectorized::ColumnPtr& column, size_t start) override {
         DCHECK(_bloom_filter != nullptr);
-        dummy.insert_batch(*_bloom_filter, column, start);
+        if (_enable_fixed_len_to_uint32_v2) {
+            OpV2::insert_batch(*_bloom_filter, column, start);
+        } else {
+            Op::insert_batch(*_bloom_filter, column, start);
+        }
     }
 
     void find_fixed_len(const vectorized::ColumnPtr& column, uint8_t* results) override {
-        dummy.find_batch(*_bloom_filter, column, results);
+        if (_enable_fixed_len_to_uint32_v2) {
+            OpV2::find_batch(*_bloom_filter, column, results);
+        } else {
+            Op::find_batch(*_bloom_filter, column, results);
+        }
     }
 
     template <bool is_nullable>
@@ -542,12 +585,18 @@ public:
 
     uint16_t find_fixed_len_olap_engine(const char* data, const uint8* nullmap, uint16_t* offsets,
                                         int number, bool is_parse_column) override {
-        return dummy.find_batch_olap_engine(*_bloom_filter, data, nullmap, offsets, number,
-                                            is_parse_column);
+        if (_enable_fixed_len_to_uint32_v2) {
+            return OpV2::find_batch_olap_engine(*_bloom_filter, data, nullmap, offsets, number,
+                                                is_parse_column);
+        } else {
+            return Op::find_batch_olap_engine(*_bloom_filter, data, nullmap, offsets, number,
+                                              is_parse_column);
+        }
     }
 
 private:
-    typename BloomFilterTypeTraits<type>::FindOp dummy;
+    using Op = typename BloomFilterTypeTraits<fixed_len_to_uint32, type>::FindOp;
+    using OpV2 = typename BloomFilterTypeTraits<fixed_len_to_uint32_v2, type>::FindOp;
 };
 
 } // namespace doris

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1359,6 +1359,8 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(desc->src_expr, build_ctx));
 
     RuntimeFilterParams params;
+    params.enable_fixed_len_to_uint32_v2 = options->__isset.enable_fixed_len_to_uint32_v2 &&
+                                          options->enable_fixed_len_to_uint32_v2;
     params.filter_id = _filter_id;
     params.filter_type = _runtime_filter_type;
     params.column_return_type = build_ctx->root()->type().type;

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -740,6 +740,12 @@ public:
         return Status::OK();
     }
 
+    void set_enable_fixed_len_to_uint32_v2() {
+        if (is_bloomfilter()) {
+            _context->bloom_filter_func->set_enable_fixed_len_to_uint32_v2();
+        }
+    }
+
     // used by shuffle runtime filter
     // assign this filter by protobuf
     Status assign(const PBloomFilter* bloom_filter, butil::IOBufAsZeroCopyInputStream* data,
@@ -1357,10 +1363,10 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     _expr_order = desc->expr_order;
     vectorized::VExprContextSPtr build_ctx;
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(desc->src_expr, build_ctx));
+    _enable_fixed_len_to_uint32_v2 = options->__isset.enable_fixed_len_to_uint32_v2 &&
+                                     options->enable_fixed_len_to_uint32_v2;
 
     RuntimeFilterParams params;
-    params.enable_fixed_len_to_uint32_v2 = options->__isset.enable_fixed_len_to_uint32_v2 &&
-                                           options->enable_fixed_len_to_uint32_v2;
     params.filter_id = _filter_id;
     params.filter_type = _runtime_filter_type;
     params.column_return_type = build_ctx->root()->type().type;
@@ -1409,7 +1415,11 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     }
 
     _wrapper = std::make_shared<RuntimePredicateWrapper>(&params);
-    return _wrapper->init(&params);
+    RETURN_IF_ERROR(_wrapper->init(&params));
+    if (_enable_fixed_len_to_uint32_v2) {
+        _wrapper->set_enable_fixed_len_to_uint32_v2();
+    }
+    return Status::OK();
 }
 
 Status IRuntimeFilter::serialize(PMergeFilterRequest* request, void** data, int* len) {
@@ -1606,6 +1616,9 @@ void IRuntimeFilter::update_filter(std::shared_ptr<RuntimePredicateWrapper> wrap
         wrapper->_column_return_type = _wrapper->_column_return_type;
     }
     _wrapper = wrapper;
+    if (_enable_fixed_len_to_uint32_v2) {
+        _wrapper->set_enable_fixed_len_to_uint32_v2();
+    }
     update_runtime_filter_type_to_profile(local_merge_time);
     signal();
 }

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1360,7 +1360,7 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
 
     RuntimeFilterParams params;
     params.enable_fixed_len_to_uint32_v2 = options->__isset.enable_fixed_len_to_uint32_v2 &&
-                                          options->enable_fixed_len_to_uint32_v2;
+                                           options->enable_fixed_len_to_uint32_v2;
     params.filter_id = _filter_id;
     params.filter_type = _runtime_filter_type;
     params.column_return_type = build_ctx->root()->type().type;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -134,8 +134,6 @@ struct RuntimeFilterParams {
     bool bitmap_filter_not_in;
     bool build_bf_exactly;
 
-    bool enable_fixed_len_to_uint32_v2 = false;
-
     bool bloom_filter_size_calculated_by_ndv = false;
     bool null_aware = false;
 };
@@ -426,6 +424,8 @@ protected:
 
     int64_t _synced_size = -1;
     std::shared_ptr<pipeline::CountedFinishDependency> _dependency;
+
+    bool _enable_fixed_len_to_uint32_v2 = false;
 };
 
 // avoid expose RuntimePredicateWrapper

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -134,6 +134,8 @@ struct RuntimeFilterParams {
     bool bitmap_filter_not_in;
     bool build_bf_exactly;
 
+    bool enable_fixed_len_to_uint32_v2 = false;
+
     bool bloom_filter_size_calculated_by_ndv = false;
     bool null_aware = false;
 };

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -37,7 +37,7 @@ public:
     using SpecificFilter = BitmapFilterFunc<T>;
 
     BitmapFilterColumnPredicate(uint32_t column_id,
-                                const std::shared_ptr<BitmapFilterFuncBase>& filter, int)
+                                const std::shared_ptr<BitmapFilterFuncBase>& filter)
             : ColumnPredicate(column_id),
               _filter(filter),
               _specific_filter(assert_cast<SpecificFilter*>(_filter.get())) {}

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -598,8 +598,7 @@ ColumnPredicate* TabletReader::_parse_to_predicate(
         return nullptr;
     }
     const TabletColumn& column = materialize_column(_tablet_schema->column(index));
-    return create_column_predicate(index, bloom_filter.second, column.type(),
-                                   _reader_context.runtime_state->be_exec_version(), &column);
+    return create_column_predicate(index, bloom_filter.second, column.type(), &column);
 }
 
 ColumnPredicate* TabletReader::_parse_to_predicate(
@@ -609,8 +608,7 @@ ColumnPredicate* TabletReader::_parse_to_predicate(
         return nullptr;
     }
     const TabletColumn& column = materialize_column(_tablet_schema->column(index));
-    return create_column_predicate(index, in_filter.second, column.type(),
-                                   _reader_context.runtime_state->be_exec_version(), &column);
+    return create_column_predicate(index, in_filter.second, column.type(), &column);
 }
 
 ColumnPredicate* TabletReader::_parse_to_predicate(
@@ -620,8 +618,7 @@ ColumnPredicate* TabletReader::_parse_to_predicate(
         return nullptr;
     }
     const TabletColumn& column = materialize_column(_tablet_schema->column(index));
-    return create_column_predicate(index, bitmap_filter.second, column.type(),
-                                   _reader_context.runtime_state->be_exec_version(), &column);
+    return create_column_predicate(index, bitmap_filter.second, column.type(), &column);
 }
 
 ColumnPredicate* TabletReader::_parse_to_predicate(const FunctionFilter& function_filter) {
@@ -631,8 +628,7 @@ ColumnPredicate* TabletReader::_parse_to_predicate(const FunctionFilter& functio
     }
     const TabletColumn& column = materialize_column(_tablet_schema->column(index));
     return create_column_predicate(index, std::make_shared<FunctionFilter>(function_filter),
-                                   column.type(), _reader_context.runtime_state->be_exec_version(),
-                                   &column);
+                                   column.type(), &column);
 }
 
 Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -38,14 +38,6 @@ namespace doris {
 // Utility class to compute hash values.
 class HashUtil {
 public:
-    template <typename T>
-    static uint32_t fixed_len_to_uint32(T value) {
-        if constexpr (sizeof(T) <= sizeof(uint32_t)) {
-            return (uint32_t)value;
-        }
-        return std::hash<T>()(value);
-    }
-
     static uint32_t zlib_crc_hash(const void* data, uint32_t bytes, uint32_t hash) {
         return crc32(hash, (const unsigned char*)data, bytes);
     }

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1275,8 +1275,6 @@ public:
         }
     }
 
-    operator int64_t() const { return to_int64(); }
-
     int64_t to_int64() const {
         if constexpr (is_datetime) {
             return (date_v2_value_.year_ * 10000L + date_v2_value_.month_ * 100 +

--- a/be/test/olap/bitmap_filter_column_predicate_test.cpp
+++ b/be/test/olap/bitmap_filter_column_predicate_test.cpp
@@ -42,7 +42,7 @@ public:
     template <PrimitiveType type>
     BitmapFilterColumnPredicate<type> create_predicate(
             const std::shared_ptr<BitmapFilterFunc<type>>& filter) {
-        return BitmapFilterColumnPredicate<type>(0, filter, 0);
+        return BitmapFilterColumnPredicate<type>(0, filter);
     }
 
     const std::string kTestDir = "./ut_dir/bitmap_filter_column_predicate_test";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1182,7 +1182,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = "enable_fixed_len_to_uint32_v2", needForward = true, description = {
             "使用新版本fixed_len_to_uint32_v2,对datetimev2类型bloom filter做了优化",
             "Using the new version fixed_len_to_uint32_v2, the datetimev2 type bloom filter has been optimized" })
-    public boolean enableFixedLenToUint32V2 = false;
+    public boolean enableFixedLenToUint32V2 = true;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MODE, needForward = true)
     private String runtimeFilterMode = "GLOBAL";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1182,7 +1182,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = "enable_fixed_len_to_uint32_v2", needForward = true, description = {
             "使用新版本fixed_len_to_uint32_v2,对datetimev2类型bloom filter做了优化",
             "Using the new version fixed_len_to_uint32_v2, the datetimev2 type bloom filter has been optimized" })
-    public boolean enableFixedLenToUint32V2 = true;
+    public boolean enableFixedLenToUint32V2 = false;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MODE, needForward = true)
     private String runtimeFilterMode = "GLOBAL";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1179,6 +1179,11 @@ public class SessionVariable implements Serializable, Writable {
             "Ignore the rf when it encounters an error" })
     public boolean ignoreRuntimeFilterError = false;
 
+    @VariableMgr.VarAttr(name = "enable_fixed_len_to_uint32_v2", needForward = true, description = {
+            "使用新版本fixed_len_to_uint32_v2,对datetimev2类型bloom filter做了优化",
+            "Using the new version fixed_len_to_uint32_v2, the datetimev2 type bloom filter has been optimized" })
+    public boolean enableFixedLenToUint32V2 = true;
+
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MODE, needForward = true)
     private String runtimeFilterMode = "GLOBAL";
 
@@ -3984,6 +3989,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setOrcMaxMergeDistanceBytes(orcMaxMergeDistanceBytes);
         tResult.setOrcOnceMaxReadBytes(orcOnceMaxReadBytes);
         tResult.setIgnoreRuntimeFilterError(ignoreRuntimeFilterError);
+        tResult.setEnableFixedLenToUint32V2(enableFixedLenToUint32V2);
 
         return tResult;
     }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -358,6 +358,8 @@ struct TQueryOptions {
   140: optional i64 orc_max_merge_distance_bytes = 1048576;
 
   141: optional bool ignore_runtime_filter_error = false;
+  142: optional bool enable_fixed_len_to_uint32_v2 = false;
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
### What problem does this PR solve?
improvement for datetimev2 bloom filter hash method
In the past, datetimev2 use to_int64 to get a 64bit data and truncate to 32bit data, then use this 32bit data to build the bloom filter. this can lead to poor performance and bad filterability.
![QQ_1733370322588](https://github.com/user-attachments/assets/8f0ce027-5b49-4198-b040-5bef51844477)


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

