### PR TITLE
[fix](sql) Fix error for show create table column comment

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -1019,7 +1019,7 @@ public class Column implements GsonPostProcessable {
             sb.append(" ON UPDATE ").append(defaultValue).append("");
         }
         if (StringUtils.isNotBlank(comment)) {
-            sb.append(" COMMENT '").append(getComment(true)).append("'");
+            sb.append(" COMMENT \"").append(getComment(true)).append("\"");
         }
         return sb.toString();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowCreateTableStmtTest.java
@@ -32,7 +32,7 @@ public class ShowCreateTableStmtTest extends TestWithFeService {
         createDatabase("test");
         useDatabase("test");
         createTable("create table table1\n"
-                + "(k1 int comment 'test column k1', k2 int comment 'test column k2')  comment 'test table1' "
+                + "(k1 int comment 'test column k1', k2 int comment 'test column k2', `timestamp` DATE NOT NULL COMMENT '[''0000-01-01'', ''9999-12-31'']')  comment 'test table1' "
                 + "PARTITION BY RANGE(`k1`)\n"
                 + "(\n"
                 + "    PARTITION `p01` VALUES LESS THAN (\"10\"),\n"
@@ -48,8 +48,18 @@ public class ShowCreateTableStmtTest extends TestWithFeService {
         String sql = "show create table table1";
         ShowResultSet showResultSet = showCreateTable(sql);
         String showSql = showResultSet.getResultRows().get(0).get(1);
-        Assertions.assertTrue(showSql.contains("`k1` int NULL COMMENT 'test column k1'"));
+        Assertions.assertTrue(showSql.contains("`k1` int NULL COMMENT \"test column k1\""));
         Assertions.assertTrue(showSql.contains("COMMENT 'test table1'"));
+    }
+
+    @Test
+    public void testColumnComment() throws Exception {
+        String sql = "show create table table1";
+        ShowResultSet showResultSet = showCreateTable(sql);
+        String showSql = showResultSet.getResultRows().get(0).get(1);
+        Assertions.assertTrue(showSql.contains("`k1` int NULL COMMENT \"test column k1\""));
+        Assertions.assertTrue(showSql.contains("`k2` int NULL COMMENT \"test column k2\""));
+        Assertions.assertTrue(showSql.contains("`timestamp` date NOT NULL COMMENT \"['0000-01-01', '9999-12-31']\""));
     }
 
     @Test


### PR DESCRIPTION
related : https://github.com/selectdb/ccr-syncer/pull/292
```
mysql> show create table t2\G;
*************************** 1. row ***************************
       Table: t2
Create Table: CREATE TABLE `t2` (
  `timestamp` date NOT NULL COMMENT '['0000-01-01', '9999-12-31']',
  `type` tinyint NOT NULL COMMENT '[-128, 127]',
  `user_id` bigint NULL COMMENT '[-9223372036854775808, 9223372036854775807]'
) ENGINE=OLAP
DUPLICATE KEY(`timestamp`, `type`)
DISTRIBUTED BY HASH(`type`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"min_load_replica_num" = "-1",
"is_being_synced" = "true",
"storage_medium" = "hdd",
"storage_format" = "V2",
"inverted_index_storage_format" = "V1",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"binlog.enable" = "true",
"binlog.ttl_seconds" = "86400",
"binlog.max_bytes" = "9223372036854775807",
"binlog.max_history_nums" = "9223372036854775807",
"enable_single_replica_compaction" = "false",
"group_commit_interval_ms" = "10000",
"group_commit_data_bytes" = "134217728"
);
1 row in set (0.00 sec)
```
execute
```
CREATE TABLE `t2` (
  `timestamp` date NOT NULL COMMENT '['0000-01-01', '9999-12-31']',
  `type` tinyint NOT NULL COMMENT '[-128, 127]',
  `user_id` bigint NULL COMMENT '[-9223372036854775808, 9223372036854775807]'
) ENGINE=OLAP
DUPLICATE KEY(`timestamp`, `type`)
DISTRIBUTED BY HASH(`type`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"min_load_replica_num" = "-1",
"is_being_synced" = "true",
"storage_medium" = "hdd",
"storage_format" = "V2",
"inverted_index_storage_format" = "V1",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"binlog.enable" = "true",
"binlog.ttl_seconds" = "86400",
"binlog.max_bytes" = "9223372036854775807",
"binlog.max_history_nums" = "9223372036854775807",
"enable_single_replica_compaction" = "false",
"group_commit_interval_ms" = "10000",
"group_commit_data_bytes" = "134217728"
);
```
```
	at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:306) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:250) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:209) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:237) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:417) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.apache.doris.nereids.exceptions.ParseException: 
mismatched input '<EOF>' expecting {')', ','}(line 18, pos 1)
```