### PR TITLE
[fix](auth)fix be enable http auth, some request link never return.

### DIFF
--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -108,7 +108,7 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
         auth_result.status.status_code = TStatusCode::type::OK;
         auth_result.status.error_msgs.clear();
     } else {
-        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST);
+        HttpChannel::send_reply(req, HttpStatus::FORBIDDEN);
         return -1;
     }
 #endif

--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -35,6 +35,7 @@ HttpHandlerWithAuth::HttpHandlerWithAuth(ExecEnv* exec_env, TPrivilegeHier::type
         : _exec_env(exec_env), _hier(hier), _type(type) {}
 
 int HttpHandlerWithAuth::on_header(HttpRequest* req) {
+    //if u return value isn't 0,u should `send_reply`,Avoid requesting links that never return.
     TCheckAuthRequest auth_request;
     TCheckAuthResult auth_result;
     AuthInfo auth_info;
@@ -83,6 +84,10 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
 
 #ifndef BE_TEST
     TNetworkAddress master_addr = _exec_env->cluster_info()->master_fe_addr;
+    if (master_addr.hostname.empty() || master_addr.port == 0) {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST);
+        return -1;
+    }
     {
         auto status = ThriftRpcHelper::rpc<FrontendServiceClient>(
                 master_addr.hostname, master_addr.port,
@@ -90,6 +95,7 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
                     client->checkAuth(auth_result, auth_request);
                 });
         if (!status) {
+            HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST);
             return -1;
         }
     }
@@ -98,6 +104,7 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
         auth_result.status.status_code = TStatusCode::type::OK;
         auth_result.status.error_msgs.clear();
     } else {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST);
         return -1;
     }
 #endif

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -413,7 +413,7 @@ TEST_F(HttpClientTest, enable_http_auth) {
         EXPECT_TRUE(!st.ok());
         std::cout << "response = " << response << "\n";
         std::cout << "st.msg() = " << st.msg() << "\n";
-        EXPECT_TRUE(st.msg().find("Operation timed out after") != std::string::npos);
+        EXPECT_TRUE(st.msg().find("403") != std::string::npos);
     }
 
     {
@@ -474,7 +474,7 @@ TEST_F(HttpClientTest, enable_http_auth) {
         EXPECT_TRUE(!st.ok());
         std::cout << "response = " << response << "\n";
         std::cout << "st.msg() = " << st.msg() << "\n";
-        EXPECT_TRUE(st.msg().find("Operation timed out after") != std::string::npos);
+        EXPECT_TRUE(st.msg().find("403") != std::string::npos);
     }
 
     // valid token
@@ -521,7 +521,7 @@ TEST_F(HttpClientTest, enable_http_auth) {
         EXPECT_TRUE(!st.ok());
         std::cout << "response = " << response << "\n";
         std::cout << "st.msg() = " << st.msg() << "\n";
-        EXPECT_TRUE(st.msg().find("Operation timed out after") != std::string::npos);
+        EXPECT_TRUE(st.msg().find("403") != std::string::npos);
     }
 
     std::vector<std::string> check_get_list = {"/api/clear_cache/aa",
@@ -566,7 +566,7 @@ TEST_F(HttpClientTest, enable_http_auth) {
             EXPECT_TRUE(!st.ok());
             std::cout << "response = " << response << "\n";
             std::cout << "st.msg() = " << st.msg() << "\n";
-            EXPECT_TRUE(st.msg().find("Operation timed out after") != std::string::npos);
+            EXPECT_TRUE(st.msg().find("403") != std::string::npos);
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
if you `enable_all_http_auth = true` in be.conf, then restart be, and keep using `curl   -u  "xxxx:xxxx" http://127.0.0.1:8040/api/health` while be is starting. You may encounter a situation where the link does not return. 
Reason:
When be is still starting, there is no information about fe master. When you make an api request to be http port, be needs to request authentication information from fe, which will cause it to request a machine with empty ip and port 0. This rpc call will definitely fail (this is not equivalent to a password error). After receiving this failure, be does not `send_reply` to the api requester, so this api request cannot be returned.
 


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

