### PR TITLE
[Fix](merge-on-write) Should clear `GetDeleteBitmapUpdateLockResponse` when geting delete bitmap update lock fail and retry

### DIFF
--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -118,6 +118,12 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
                   << " status=" << res->status().ShortDebugString()
                   << " tablet=" << res->tablet_id()
                   << " delete_bitmap_count=" << res->segment_delete_bitmaps_size();
+    } else if constexpr (std::is_same_v<Response, GetDeleteBitmapUpdateLockResponse>) {
+        if (res->status().code() != MetaServiceCode::OK) {
+            res->clear_base_compaction_cnts();
+            res->clear_cumulative_compaction_cnts();
+            res->clear_cumulative_points();
+        }
     } else if constexpr (std::is_same_v<Response, GetObjStoreInfoResponse> ||
                          std::is_same_v<Response, GetStageResponse>) {
         std::string debug_string = res->DebugString();


### PR DESCRIPTION
### What problem does this PR solve?

Similar to https://github.com/apache/doris/pull/43261, `GetDeleteBitmapUpdateLockResponse` should be cleared after `get_delete_bitmap_update_lock` fails on MS. Otherwise BE may get staled compaction cnts and wrongly skip to sync rowsets before `update_delete_bitmap()` thus causing duplicate keys problem.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

