### PR TITLE
[fix](api) make QueryDetailQueue.queryCapacity configurable

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2464,6 +2464,12 @@ public class Config extends ConfigBase {
     })
     public static int http_load_submitter_max_worker_threads = 2;
 
+    @ConfField(mutable = false, masterOnly = false, description = {
+            "缓存的最大Query数量，用于响应http请求/api/query_detail。",
+            "The max capacity of queries for query_detail api."
+    })
+    public static int http_query_detail_capacity = 10000;
+
     @ConfField(mutable = true, masterOnly = true, description = {
             "load label个数阈值，超过该个数后，对于已经完成导入作业或者任务，"
             + "其label会被删除，被删除的 label 可以被重用。 值为 -1 时，表示此阈值不生效。",

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetailQueue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetailQueue.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.common.Config;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -31,9 +33,12 @@ import java.util.Map;
 public class QueryDetailQueue {
     private static Map<String, QueryDetail> runningQueries = Maps.newHashMap();
     private static LinkedList<QueryDetail> totalQueries = new LinkedList<QueryDetail>();
-    private static int queryCapacity = 10000;
+    private static int queryCapacity = Config.http_query_detail_capacity;
 
     public static synchronized void addOrUpdateQueryDetail(QueryDetail queryDetail) {
+        if (queryCapacity <= 0) {
+            return;
+        }
         if (runningQueries.get(queryDetail.getQueryId()) == null) {
             if (queryDetail.getState() == QueryDetail.QueryMemState.RUNNING) {
                 runningQueries.put(queryDetail.getQueryId(), queryDetail);


### PR DESCRIPTION
### What problem does this PR solve?

Problem:
very large SQLs make FE OOM, here make the capacity configurable.

In branch-2.1 we already removed the usage by pr: https://github.com/apache/doris/pull/29999

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

