### PR TITLE
[fix](arrow-flight-sql) Revert `arrow_flight_sql` group from regression test

### DIFF
--- a/regression-test/suites/nereids_p0/show/test_show_create_table_nereids.groovy
+++ b/regression-test/suites/nereids_p0/show/test_show_create_table_nereids.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_create_table_nereids", "query") {
+suite("test_show_create_table_nereids", "query,arrow_flight_sql") {
     String tb_name = "tb_show_create_table";
     try {  
         sql """drop table if exists ${tb_name} """

--- a/regression-test/suites/nereids_p0/show/test_show_create_view.groovy
+++ b/regression-test/suites/nereids_p0/show/test_show_create_view.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_create_view", "query") {
+suite("test_show_create_view", "query,arrow_flight_sql") {
     String view_name = "view_show_create_view";
     String table_name = "table_for_view_test";
     try {

--- a/regression-test/suites/query_p0/aggregate/aggregate_count1.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate_count1.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-suite("aggregate_count1", "query") {
+suite("aggregate_count1", "query,arrow_flight_sql") {
     sql """ DROP TABLE IF EXISTS aggregate_count1 """
     sql """create table if not exists aggregate_count1 (
                 name varchar(128),

--- a/regression-test/suites/query_p0/aggregate/select_distinct.groovy
+++ b/regression-test/suites/query_p0/aggregate/select_distinct.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("select_distinct") {
+suite("select_distinct", "arrow_flight_sql") {
     sql """DROP TABLE IF EXISTS decimal_a;"""
     sql """DROP TABLE IF EXISTS decimal_b;"""
     sql """DROP TABLE IF EXISTS decimal_c;"""

--- a/regression-test/suites/query_p0/casesensetive_column/join_with_column_casesensetive.groovy
+++ b/regression-test/suites/query_p0/casesensetive_column/join_with_column_casesensetive.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("join_with_column_casesensetive") {
+suite("join_with_column_casesensetive", "arrow_flight_sql") {
     def tables=["ad_order_data_v1","ad_order_data"]
 
     for (String table in tables) {

--- a/regression-test/suites/query_p0/cast/test_cast.groovy
+++ b/regression-test/suites/query_p0/cast/test_cast.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_cast') {
+suite('test_cast', "arrow_flight_sql") {
     def date = "date '2020-01-01'"
     def datev2 = "datev2 '2020-01-01'"
     def datetime = "timestamp '2020-01-01 12:34:45'"

--- a/regression-test/suites/query_p0/except/test_query_except.groovy
+++ b/regression-test/suites/query_p0/except/test_query_except.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_query_except") {
+suite("test_query_except", "arrow_flight_sql") {
     // test query except, depend on query_test_data_load.groovy
     sql "use test_query_db"
     qt_select_except1 """

--- a/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
+++ b/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_group_concat", "query,p0") {
+suite("test_group_concat", "query,p0,arrow_flight_sql") {
     qt_select """
                 SELECT group_concat(k6) FROM test_query_db.test where k6='false'
               """

--- a/regression-test/suites/query_p0/grouping_sets/test_grouping_sets1.groovy
+++ b/regression-test/suites/query_p0/grouping_sets/test_grouping_sets1.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_grouping_sets1") {
+suite("test_grouping_sets1", "arrow_flight_sql") {
     qt_select """
         select 
             col1

--- a/regression-test/suites/query_p0/having/having.groovy
+++ b/regression-test/suites/query_p0/having/having.groovy
@@ -19,7 +19,7 @@
 // /testing/trino-product-tests/src/main/resources/sql-tests/testcases/aggregate
 // and modified by Doris.
 
-suite("having", "query,p0") {
+suite("having", "query,p0,arrow_flight_sql") {
     sql """DROP TABLE IF EXISTS supplier"""
     sql """CREATE TABLE `supplier` (
             `s_suppkey` int(11) NOT NULL,

--- a/regression-test/suites/query_p0/intersect/test_intersect.groovy
+++ b/regression-test/suites/query_p0/intersect/test_intersect.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_intersect") {
+suite("test_intersect", "arrow_flight_sql") {
     qt_select """
                 SELECT * FROM (SELECT k1 FROM test_query_db.baseall
                     INTERSECT SELECT k1 FROM test_query_db.test) a ORDER BY k1

--- a/regression-test/suites/query_p0/join/test_join2.groovy
+++ b/regression-test/suites/query_p0/join/test_join2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_join2", "query,p0") {
+suite("test_join2", "query,p0,arrow_flight_sql") {
     def DBname = "regression_test_join2"
     def TBname1 = "J1_TBL"
     def TBname2 = "J2_TBL"

--- a/regression-test/suites/query_p0/join/test_left_join1.groovy
+++ b/regression-test/suites/query_p0/join/test_left_join1.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_left_join1", "query,p0") {
+suite("test_left_join1", "query,p0,arrow_flight_sql") {
 
     def tableName = "test_left_join1"
     sql """drop table if exists ${tableName}"""

--- a/regression-test/suites/query_p0/join/test_nestedloop_outer_join.groovy
+++ b/regression-test/suites/query_p0/join/test_nestedloop_outer_join.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_nestedloop_outer_join", "query_p0") {
+suite("test_nestedloop_outer_join", "query_p0,arrow_flight_sql") {
     def tbl1 = "test_nestedloop_outer_join1"
     def tbl2 = "test_nestedloop_outer_join2"
 

--- a/regression-test/suites/query_p0/join/test_partitioned_hash_join.groovy
+++ b/regression-test/suites/query_p0/join/test_partitioned_hash_join.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_partitioned_hash_join", "query,p0") {
+suite("test_partitioned_hash_join", "query,p0,arrow_flight_sql") {
     sql "drop table if exists test_partitioned_hash_join_l"
     sql "drop table if exists test_partitioned_hash_join_r"
     sql """ create table test_partitioned_hash_join_l (

--- a/regression-test/suites/query_p0/lateral_view/lateral_view.groovy
+++ b/regression-test/suites/query_p0/lateral_view/lateral_view.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("lateral_view") {
+suite("lateral_view", "arrow_flight_sql") {
     sql """ DROP TABLE IF EXISTS `test_explode_bitmap` """
 	sql """
 		CREATE TABLE `test_explode_bitmap` (

--- a/regression-test/suites/query_p0/limit/OffsetInSubqueryWithJoin.groovy
+++ b/regression-test/suites/query_p0/limit/OffsetInSubqueryWithJoin.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_offset_in_subquery_with_join", "query") {
+suite("test_offset_in_subquery_with_join", "query,arrow_flight_sql") {
     // define a sql table
     def testTable = "test_offset_in_subquery_with_join"
 

--- a/regression-test/suites/query_p0/literal_view/lietral_test.groovy
+++ b/regression-test/suites/query_p0/literal_view/lietral_test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("literal_view_test") {
+suite("literal_view_test", "arrow_flight_sql") {
 
     sql """DROP TABLE IF EXISTS table1"""
 

--- a/regression-test/suites/query_p0/operator/test_set_operator.groovy
+++ b/regression-test/suites/query_p0/operator/test_set_operator.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_set_operators", "query,p0") {
+suite("test_set_operators", "query,p0,arrow_flight_sql") {
 
     sql """
         DROP TABLE IF EXISTS t1;

--- a/regression-test/suites/query_p0/operator/test_sort_operator.groovy
+++ b/regression-test/suites/query_p0/operator/test_sort_operator.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_sort_operator", "query,p0") {
+suite("test_sort_operator", "query,p0,arrow_flight_sql") {
 
     sql """
         DROP TABLE IF EXISTS dim_org_ful;

--- a/regression-test/suites/query_p0/session_variable/test_default_limit.groovy
+++ b/regression-test/suites/query_p0/session_variable/test_default_limit.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_default_limit') {
+suite('test_default_limit', "arrow_flight_sql") {
     sql 'drop table if exists baseall'
     sql 'drop table if exists bigtable'
 

--- a/regression-test/suites/query_p0/show/test_show_create_materialized_view.groovy
+++ b/regression-test/suites/query_p0/show/test_show_create_materialized_view.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_create_materialized_view", "query") {
+suite("test_show_create_materialized_view", "query,arrow_flight_sql") {
     String tableName = "table_for_mv_test";
     String mvName = "mv_show_create_materialized_view";
     try {  

--- a/regression-test/suites/query_p0/show/test_show_create_table.groovy
+++ b/regression-test/suites/query_p0/show/test_show_create_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_create_table", "query") {
+suite("test_show_create_table", "query,arrow_flight_sql") {
     String tb_name = "tb_show_create_table";
     try {  
         sql """drop table if exists ${tb_name} """

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_aggregate_all_functions") {
+suite("test_aggregate_all_functions", "arrow_flight_sql") {
 
     sql "set batch_size = 4096"
     

--- a/regression-test/suites/query_p0/sql_functions/case_function/test_case_function_null.groovy
+++ b/regression-test/suites/query_p0/sql_functions/case_function/test_case_function_null.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_case_function_null", "query,p0") {
+suite("test_case_function_null", "query,p0,arrow_flight_sql") {
     sql """ drop table if exists case_null0 """
     sql """ create table case_null0 (
                 `c0` decimalv3(17, 1) NULL,

--- a/regression-test/suites/query_p0/sql_functions/hash_functions/test_hash_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/hash_functions/test_hash_function.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_hash_function") {
+suite("test_hash_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
     sql "set enable_profile = true;"
 

--- a/regression-test/suites/query_p0/sql_functions/ip_functions/test_ip_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/ip_functions/test_ip_functions.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_ip_functions") {
+suite("test_ip_functions", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "SELECT ipv4_num_to_string(-1);"

--- a/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_insert.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_insert.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_query_json_insert", "query") {
+suite("test_query_json_insert", "query,arrow_flight_sql") {
     qt_sql "select json_insert('{\"a\": 1, \"b\": [2, 3]}', '\$', null);"
     qt_sql "select json_insert('{\"k\": [1, 2]}', '\$.k[0]', null, '\$.[1]', null);"
     def tableName = "test_query_json_insert"

--- a/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_json_function") {
+suite("test_json_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "SELECT get_json_double('{\"k1\":1.3, \"k2\":\"2\"}', \"\$.k1\");"

--- a/regression-test/suites/query_p0/sql_functions/math_functions/test_conv.groovy
+++ b/regression-test/suites/query_p0/sql_functions/math_functions/test_conv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_conv") {
+suite("test_conv", "arrow_flight_sql") {
     qt_select "SELECT CONV(15,10,2)"
 
     sql """ drop table if exists test_conv; """

--- a/regression-test/suites/query_p0/sql_functions/search_functions/test_multi_string_search.groovy
+++ b/regression-test/suites/query_p0/sql_functions/search_functions/test_multi_string_search.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_multi_string_search") {
+suite("test_multi_string_search", "arrow_flight_sql") {
     def table_name = "test_multi_string_search_strings"
 
     sql """ DROP TABLE IF EXISTS ${table_name} """

--- a/regression-test/suites/query_p0/sql_functions/spatial_functions/test_gis_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/spatial_functions/test_gis_function.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_gis_function") {
+suite("test_gis_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "SELECT ST_AsText(ST_Point(24.7, 56.7));"

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_string_function") {
+suite("test_string_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "select elt(0, \"hello\", \"doris\");"

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode_split.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode_split.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("explode_split") {
+suite("explode_split", "arrow_flight_sql") {
     def tableName = "test_lv_str"
 
     sql """ DROP TABLE IF EXISTS ${tableName} """

--- a/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_alias_function') {
+suite('test_alias_function', "arrow_flight_sql") {
     sql '''
         CREATE ALIAS FUNCTION IF NOT EXISTS f1(DATETIMEV2(3), INT)
             with PARAMETER (datetime1, int1) as date_trunc(days_sub(datetime1, int1), 'day')'''

--- a/regression-test/suites/query_p0/sql_functions/test_predicate.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_predicate.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_predicate") {
+suite("test_predicate", "arrow_flight_sql") {
     sql """drop table if exists t1;"""
     sql """
             create table t1 (

--- a/regression-test/suites/query_p0/sql_functions/width_bucket_fuctions/test_width_bucket_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/width_bucket_fuctions/test_width_bucket_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_width_bucket_function") {
+suite("test_width_bucket_function", "arrow_flight_sql") {
     qt_sql "select width_bucket(1, 2, 3, 2)"
     qt_sql "select width_bucket(null, 2, 3, 2)"
     qt_sql "select width_bucket(6, 2, 6, 4)"

--- a/regression-test/suites/query_p0/subquery/test_subquery2.groovy
+++ b/regression-test/suites/query_p0/subquery/test_subquery2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_subquery2") {
+suite("test_subquery2", "arrow_flight_sql") {
     
     sql """DROP TABLE IF EXISTS subquerytest2"""
     

--- a/regression-test/suites/query_p0/test_data_type_marks.groovy
+++ b/regression-test/suites/query_p0/test_data_type_marks.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_data_type_marks") {
+suite("test_data_type_marks", "arrow_flight_sql") {
     def tbName = "org"
     sql "DROP TABLE IF EXISTS ${tbName}"
     sql """

--- a/regression-test/suites/query_p0/test_dict_with_null.groovy
+++ b/regression-test/suites/query_p0/test_dict_with_null.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("dict_with_null", "query") {
+suite("dict_with_null", "query,arrow_flight_sql") {
     def tableName = "test_dict_with_null"
     sql "DROP TABLE IF EXISTS ${tableName}"
     sql """

--- a/regression-test/suites/query_p0/test_orderby_nullliteral.groovy
+++ b/regression-test/suites/query_p0/test_orderby_nullliteral.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("orderby_nullliteral", "query") {
+suite("orderby_nullliteral", "query,arrow_flight_sql") {
 
     def tableName = "test_orderby_nullliteral"
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/query_p0/test_select_constant.groovy
+++ b/regression-test/suites/query_p0/test_select_constant.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_select_constant") {
+suite("test_select_constant", "arrow_flight_sql") {
     qt_select1 'select 100, "test", date("2021-01-02");'
     qt_select_geo1 'SELECT ST_AsText(ST_Point(123.12345678901234567890,89.1234567890));'
 }

--- a/regression-test/suites/query_p0/test_select_with_predicate_like.groovy
+++ b/regression-test/suites/query_p0/test_select_with_predicate_like.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_select_with_predicate_like") {
+suite("test_select_with_predicate_like", "arrow_flight_sql") {
     def tables=["test_basic_agg"]
 
     for (String table in tables) {

--- a/regression-test/suites/query_p0/test_select_with_predicate_prune.groovy
+++ b/regression-test/suites/query_p0/test_select_with_predicate_prune.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_select_with_predicate_prune") {
+suite("test_select_with_predicate_prune", "arrow_flight_sql") {
     sql """
         drop table if exists `test_select_with_predicate_prune`;
     """

--- a/regression-test/suites/query_p0/type_inference/test_largeint.groovy
+++ b/regression-test/suites/query_p0/type_inference/test_largeint.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_largeint") {
+suite("test_largeint", "arrow_flight_sql") {
     def tbName = "test_largeint"
     sql "DROP TABLE IF EXISTS ${tbName}"
     sql """

--- a/regression-test/suites/query_p0/with/test_with_and_two_phase_agg.groovy
+++ b/regression-test/suites/query_p0/with/test_with_and_two_phase_agg.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_with_and_two_phase_agg") {
+suite("test_with_and_two_phase_agg", "arrow_flight_sql") {
     def tableName = "test_with_and_two_phase_agg_table"
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """


### PR DESCRIPTION
### What problem does this PR solve?

After pipeline `P0 Regression (Doris Regression)` executes `./run-regression-test.sh --run -g p0`, it will execute `./run-regression-test.sh -g arrow_flight_sql` to run regression-test again, can use `jdbc:arrow-flight-sql` to run all Suites whose group contains arrow_flight_sql.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

