### PR TITLE
[enhancement](plugin) logstash: add retry queue without blocking tasks

### DIFF
--- a/extension/logstash/lib/logstash/outputs/doris.rb
+++ b/extension/logstash/lib/logstash/outputs/doris.rb
@@ -223,7 +223,7 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
       req_count += 1
       @logger.warn("Will do retry #{req_count} after #{sleep_for} secs.")
       timer_task = RetryTimerTask.new(@retry_queue, @count_block_queue, [documents, http_headers, event_num, req_count])
-      @count_block_queue.add(0)
+      @count_block_queue.put(0)
       @timer.schedule(timer_task, sleep_for*1000)
    end
 

--- a/extension/logstash/lib/logstash/outputs/doris.rb
+++ b/extension/logstash/lib/logstash/outputs/doris.rb
@@ -159,12 +159,8 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
 
    private
    def send_events(events)
-      documents = ""
-      event_num = 0
-      events.each do |event|
-         documents << event_body(event) << "\n"
-         event_num += 1
-      end
+      documents = events.map { |event| event_body(event) }.join("\n")
+      event_num = events.size
 
       # @logger.info("get event num: #{event_num}")
       @logger.debug("get documents: #{documents}")

--- a/extension/logstash/lib/logstash/outputs/doris.rb
+++ b/extension/logstash/lib/logstash/outputs/doris.rb
@@ -205,7 +205,7 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
 
       @logger.warn("FAILED doris stream load response:\n#{response}")
       # if there are data quality issues, we do not retry
-      if (status == 'Fail' && response_json['ErrorURL'] != nil) || (@max_retries >= 0 && req_count > @max_retries)
+      if (status == 'Fail' && response_json['Message'].start_with?("[DATA_QUALITY_ERROR]")) || (@max_retries >= 0 && req_count > @max_retries)
          @logger.warn("DROP this batch after failed #{req_count} times.")
          if @save_on_failure
             @logger.warn("Try save to disk.Disk file path : #{@save_dir}/#{@table}_#{@save_file}")

--- a/extension/logstash/lib/logstash/outputs/doris.rb
+++ b/extension/logstash/lib/logstash/outputs/doris.rb
@@ -208,8 +208,8 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
       end
 
       @logger.warn("FAILED doris stream load response:\n#{response}")
-      # if status is Fail, we do not retry
-      if status == 'Fail' || (@max_retries >= 0 && req_count > @max_retries)
+      # if there are data quality issues, we do not retry
+      if (status == 'Fail' && response_json['ErrorURL'] != nil) || (@max_retries >= 0 && req_count > @max_retries)
          @logger.warn("DROP this batch after failed #{req_count} times.")
          if @save_on_failure
             @logger.warn("Try save to disk.Disk file path : #{@save_dir}/#{@table}_#{@save_file}")

--- a/extension/logstash/lib/logstash/outputs/doris.rb
+++ b/extension/logstash/lib/logstash/outputs/doris.rb
@@ -22,7 +22,7 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 require "logstash/json"
 require 'logstash/util/formater'
-require 'logstash/util/retry_timer_task'
+require 'logstash/util/delay_event'
 require "uri"
 require "securerandom"
 require "json"
@@ -44,7 +44,7 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
    config :db, :validate => :string, :required => true
    # the table which data is loaded to
    config :table, :validate => :string, :required => true
-   # label prefix of a stream load requst.
+   # label prefix of a stream load request.
    config :label_prefix, :validate => :string, :default => "logstash"
    # user name
    config :user, :validate => :string, :required => true
@@ -73,6 +73,7 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
 
    config :log_progress_interval, :validate => :number, :default => 10
 
+   config :retry_queue_size, :validate => :number, :default => 128
 
    def print_plugin_info()
       @plugins = Gem::Specification.find_all{|spec| spec.name =~ /logstash-output-doris/ }
@@ -132,15 +133,10 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
          end
       end
 
-      # Run named Timer as daemon thread
-      @timer = java.util.Timer.new("Doris Output #{self.params['id']}", true)
-      # The queue in Timer is unbounded and uncontrollable, so use a new queue to control the amount
-      @count_block_queue = java.util.concurrent.ArrayBlockingQueue.new(128)
-
-      @retry_queue = Queue.new
+      @retry_queue = java.util.concurrent.DelayQueue.new
       retry_thread = Thread.new do
-         while popped = @retry_queue.pop
-            documents, http_headers, event_num, req_count = popped
+         while popped = @retry_queue.take
+            documents, http_headers, event_num, req_count = popped.event
             handle_request(documents, http_headers, event_num, req_count)
          end
       end
@@ -148,8 +144,14 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
       print_plugin_info()
    end # def register
 
-   def close
-      @timer.cancel
+   private
+   def add_event_to_retry_queue(delay_event, block)
+      if block
+         while @retry_queue.size >= @retry_queue_size
+            sleep(1)
+         end
+      end
+      @retry_queue.add(delay_event)
    end
 
    def multi_receive(events)
@@ -187,25 +189,29 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
       begin
          response_json = JSON.parse(response.body)
       rescue => _
-         @logger.warn("doris stream load response: #{response} is not a valid JSON")
+         @logger.warn("doris stream load response is not a valid JSON:\n#{response}")
       end
 
       status = response_json["Status"]
 
       if status == 'Label Already Exists'
-         @logger.warn("Label already exists: #{response_json['Label']}, skip #{event_num} records.")
+         @logger.warn("Label already exists: #{response_json['Label']}, skip #{event_num} records:\n#{response}")
          return
       end
 
       if status == "Success" || status == "Publish Timeout"
          @total_bytes.addAndGet(documents.size)
          @total_rows.addAndGet(event_num)
+         if @log_request or @logger.debug?
+            @logger.info("doris stream load response:\n#{response}")
+         end
          return
       end
 
       @logger.warn("FAILED doris stream load response:\n#{response}")
       # if there are data quality issues, we do not retry
-      if (status == 'Fail' && response_json['Message'].start_with?("[DATA_QUALITY_ERROR]")) || (@max_retries >= 0 && req_count > @max_retries)
+      if (status == 'Fail' && response_json['Message'].start_with?("[DATA_QUALITY_ERROR]")) || (@max_retries >= 0 && req_count-1 > @max_retries)
+      # if @max_retries >= 0 && req_count-1 > @max_retries
          @logger.warn("DROP this batch after failed #{req_count} times.")
          if @save_on_failure
             @logger.warn("Try save to disk.Disk file path : #{@save_dir}/#{@table}_#{@save_file}")
@@ -217,10 +223,9 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
       # add to retry_queue
       sleep_for = sleep_for_attempt(req_count)
       req_count += 1
-      @logger.warn("Will do retry #{req_count} after #{sleep_for} secs.")
-      timer_task = RetryTimerTask.new(@retry_queue, @count_block_queue, [documents, http_headers, event_num, req_count])
-      @count_block_queue.put(0)
-      @timer.schedule(timer_task, sleep_for*1000)
+      @logger.warn("Will do the #{req_count-1}th retry after #{sleep_for} secs.")
+      delay_event = DelayEvent.new(sleep_for, [documents, http_headers, event_num, req_count])
+      add_event_to_retry_queue(delay_event, req_count <= 1)
    end
 
    private
@@ -247,11 +252,7 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
          log_failure("doris stream load request error: #{e}")
       end
 
-      if @log_request or @logger.debug?
-         @logger.info("doris stream load response:\n#{response}")
-      end
-
-      return response
+      response
    end # def make_request
 
    # Format the HTTP body

--- a/extension/logstash/lib/logstash/outputs/doris.rb
+++ b/extension/logstash/lib/logstash/outputs/doris.rb
@@ -139,7 +139,7 @@ class LogStash::Outputs::Doris < LogStash::Outputs::Base
       end
       @logger.info("max retry queue size: #{@max_retry_queue_mb}MB")
 
-         @retry_queue = java.util.concurrent.DelayQueue.new
+      @retry_queue = java.util.concurrent.DelayQueue.new
       # retry queue size in bytes
       @retry_queue_bytes = java.util.concurrent.atomic.AtomicLong.new(0)
       retry_thread = Thread.new do

--- a/extension/logstash/lib/logstash/util/delay_event.rb
+++ b/extension/logstash/lib/logstash/util/delay_event.rb
@@ -41,4 +41,12 @@ class DelayEvent
    def event
       @event
    end
+
+   def documents
+      @event[0]
+   end
+
+   def first_retry
+      @event[3] == 2
+   end
 end

--- a/extension/logstash/lib/logstash/util/delay_event.rb
+++ b/extension/logstash/lib/logstash/util/delay_event.rb
@@ -30,11 +30,14 @@ class DelayEvent
       unit.convert(delay, java.util.concurrent.TimeUnit::SECONDS)
    end
 
-def compare_to(other)
-   d = self.get_delay(java.util.concurrent.TimeUnit::SECONDS) - other.get_delay(java.util.concurrent.TimeUnit::SECONDS)
-   return 0 if d == 0
-   d < 0 ? -1 : 1
-end
+   def compare_to(other)
+      d = self.start_time - other.start_time
+      return 0 if d == 0
+      d < 0 ? -1 : 1
+   end
+
+   def start_time
+      @start_time
    end
 
    def event

--- a/extension/logstash/lib/logstash/util/delay_event.rb
+++ b/extension/logstash/lib/logstash/util/delay_event.rb
@@ -30,12 +30,11 @@ class DelayEvent
       unit.convert(delay, java.util.concurrent.TimeUnit::SECONDS)
    end
 
-   def compare_to(other)
-      d = self.get_delay(java.util.concurrent.TimeUnit::SECONDS) - other.get_delay(java.util.concurrent.TimeUnit::SECONDS)
-      if d == 0
-         0
-      end
-      d < 0 ? -1 : 1
+def compare_to(other)
+   d = self.get_delay(java.util.concurrent.TimeUnit::SECONDS) - other.get_delay(java.util.concurrent.TimeUnit::SECONDS)
+   return 0 if d == 0
+   d < 0 ? -1 : 1
+end
    end
 
    def event

--- a/extension/logstash/lib/logstash/util/retry_timer_task.rb
+++ b/extension/logstash/lib/logstash/util/retry_timer_task.rb
@@ -18,8 +18,9 @@
 require 'java'
 
 class RetryTimerTask < java.util.TimerTask
-   def initialize(retry_queue, event)
+   def initialize(retry_queue, count_block_queue, event)
       @retry_queue = retry_queue
+      @count_block_queue = count_block_queue
       # event style: [documents, http_headers, event_num, req_count]
       @event = event
       super()
@@ -27,5 +28,6 @@ class RetryTimerTask < java.util.TimerTask
 
    def run
       @retry_queue << @event
+      @count_block_queue.pull
    end
 end

--- a/extension/logstash/lib/logstash/util/retry_timer_task.rb
+++ b/extension/logstash/lib/logstash/util/retry_timer_task.rb
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'java'
+
+class RetryTimerTask < java.util.TimerTask
+   def initialize(retry_queue, event)
+      @retry_queue = retry_queue
+      # event style: [documents, http_headers, event_num, req_count]
+      @event = event
+      super()
+   end
+
+   def run
+      @retry_queue << @event
+   end
+end

--- a/extension/logstash/lib/logstash/util/retry_timer_task.rb
+++ b/extension/logstash/lib/logstash/util/retry_timer_task.rb
@@ -28,6 +28,6 @@ class RetryTimerTask < java.util.TimerTask
 
    def run
       @retry_queue << @event
-      @count_block_queue.pull
+      @count_block_queue.poll
    end
 end

--- a/extension/logstash/logstash-output-doris.gemspec
+++ b/extension/logstash/logstash-output-doris.gemspec
@@ -18,7 +18,7 @@ under the License.
 =end
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-doris'
-  s.version         = '1.0.1'
+  s.version         = '1.1.0'
   s.author          = 'Apache Doris'
   s.email           = 'dev@doris.apache.org'
   s.homepage        = 'http://doris.apache.org'


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The retry task enters the retry queue separately and no longer blocks the normal queue

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

