### PR TITLE
[fix](routine load) ensure compatibility of replaying edit log during upgrade

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/RoutineLoadOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/RoutineLoadOperation.java
@@ -83,6 +83,13 @@ public class RoutineLoadOperation implements Writable {
     @Deprecated
     public void readFields(DataInput in) throws IOException {
         id = in.readLong();
-        jobState = JobState.valueOf(Text.readString(in));
+        // for https://github.com/apache/doris/pull/45035,
+        // we should update read fields logic
+        // to ensure compatibility of replaying edit log during upgrade from 2.1
+        String[] stateWithReason = Text.readString(in).split("\\|", 2);
+        jobState = JobState.valueOf(stateWithReason[0]);
+        if (stateWithReason.length == 2) {
+            reason = GsonUtils.GSON.fromJson(stateWithReason[1], ErrorReason.class);
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

For https://github.com/apache/doris/pull/45035, we should update read fields logic to ensure compatibility of replaying edit log during upgrade from 2.1.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

