### PR TITLE
[Opt](function) Speed up function string and add regression

### DIFF
--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -888,16 +888,17 @@ struct StringSpace {
                          ColumnString::Offsets& res_offsets) {
         res_offsets.resize(data.size());
         size_t input_size = res_offsets.size();
-        std::vector<char, Allocator_<char>> buffer;
+        // sample to get approximate best reserve size
+        if (input_size > 4) {
+            res_data.reserve(((data[0] + data[input_size >> 1] + data[input_size >> 2] +
+                               data[input_size - 1]) >>
+                              2) *
+                             input_size);
+        }
         for (size_t i = 0; i < input_size; ++i) {
-            buffer.clear();
-            if (data[i] > 0) {
-                buffer.resize(data[i]);
-                for (size_t j = 0; j < data[i]; ++j) {
-                    buffer[j] = ' ';
-                }
-                StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i,
-                                            res_data, res_offsets);
+            if (data[i] > 0) [[likely]] {
+                res_data.resize_fill(res_data.size() + data[i], ' ');
+                res_offsets[i] = res_data.size();
             } else {
                 StringOP::push_empty_string(i, res_data, res_offsets);
             }

--- a/regression-test/suites/nereids_function_p0/scalar_function/S.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/S.groovy
@@ -126,6 +126,7 @@ suite("nereids_scalar_fn_S") {
 
 	sql "select space(10) from fn_test order by kint"
 	sql "select space(10) from fn_test_not_nullable order by kint"
+	sql """select k from (select length(space(number)) k from numbers("number" = "10"))t;""" // before #44919 will crash
 	qt_sql_split_part_Varchar_Varchar_Integer "select split_part(kvchrs1, ' ', 1) from fn_test order by kvchrs1"
 	qt_sql_split_part_Varchar_Varchar_Integer_notnull "select split_part(kvchrs1, ' ', 1) from fn_test_not_nullable order by kvchrs1"
 	qt_sql_split_part_String_String_Integer "select split_part(kstr, ' ', 1) from fn_test order by kstr"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/44919

Problem Summary:

Add the missing testcase for the bug which was fixed in the PR mentioned above. and optimized its performance

before:
```sql
mysql> select count(space(100000000)) from double_ranges;
+-------------------------+
| count(space(100000000)) |
+-------------------------+
|                50000000 |
+-------------------------+
1 row in set (0.88 sec)
```

now:
```sql
mysql> select count(space(100000000)) from double_ranges;
+-------------------------+
| count(space(100000000)) |
+-------------------------+
|                50000000 |
+-------------------------+
1 row in set (0.66 sec)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

