### PR TITLE
[fix](nereids) not rewrite first_value when first_value ignore nulls

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.trees.expressions.functions.window.Ntile;
 import org.apache.doris.nereids.trees.expressions.functions.window.PercentRank;
 import org.apache.doris.nereids.trees.expressions.functions.window.Rank;
 import org.apache.doris.nereids.trees.expressions.functions.window.RowNumber;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
@@ -315,6 +316,9 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
      */
     @Override
     public FirstOrLastValue visitFirstValue(FirstValue firstValue, Void ctx) {
+        if (firstValue.arity() == 2 && firstValue.child(1).equals(BooleanLiteral.TRUE)) {
+            return firstValue;
+        }
         Optional<WindowFrame> windowFrame = windowExpression.getWindowFrame();
         if (windowFrame.isPresent()) {
             WindowFrame wf = windowFrame.get();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
@@ -316,6 +316,7 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
      */
     @Override
     public FirstOrLastValue visitFirstValue(FirstValue firstValue, Void ctx) {
+        FirstOrLastValue.checkSecondParameter(firstValue);
         if (2 == firstValue.arity() && firstValue.child(1).equals(BooleanLiteral.TRUE)) {
             return firstValue;
         }
@@ -341,6 +342,12 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
                 FrameBoundary.newPrecedingBoundary(), FrameBoundary.newCurrentRowBoundary()));
         }
         return firstValue;
+    }
+
+    @Override
+    public FirstOrLastValue visitLastValue(LastValue lastValue, Void ctx) {
+        FirstOrLastValue.checkSecondParameter(lastValue);
+        return lastValue;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
@@ -316,13 +316,8 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
      */
     @Override
     public FirstOrLastValue visitFirstValue(FirstValue firstValue, Void ctx) {
-        if (2 == firstValue.arity()) {
-            if (!firstValue.child(1).isConstant()) {
-                throw new AnalysisException("The second parameter of first_value must be constant");
-            }
-            if (firstValue.child(1).equals(BooleanLiteral.TRUE)) {
-                return firstValue;
-            }
+        if (2 == firstValue.arity() && firstValue.child(1).equals(BooleanLiteral.TRUE)) {
+            return firstValue;
         }
         Optional<WindowFrame> windowFrame = windowExpression.getWindowFrame();
         if (windowFrame.isPresent()) {
@@ -346,14 +341,6 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
                 FrameBoundary.newPrecedingBoundary(), FrameBoundary.newCurrentRowBoundary()));
         }
         return firstValue;
-    }
-
-    @Override
-    public FirstOrLastValue visitLastValue(LastValue lastValue, Void ctx) {
-        if (2 == lastValue.arity() && !lastValue.child(1).isConstant()) {
-            throw new AnalysisException("The second parameter of last_value must be constant");
-        }
-        return lastValue;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
@@ -316,8 +316,13 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
      */
     @Override
     public FirstOrLastValue visitFirstValue(FirstValue firstValue, Void ctx) {
-        if (firstValue.arity() == 2 && firstValue.child(1).equals(BooleanLiteral.TRUE)) {
-            return firstValue;
+        if (2 == firstValue.arity()) {
+            if (!firstValue.child(1).isConstant()) {
+                throw new AnalysisException("The second parameter of first_value must be constant");
+            }
+            if (firstValue.child(1).equals(BooleanLiteral.TRUE)) {
+                return firstValue;
+            }
         }
         Optional<WindowFrame> windowFrame = windowExpression.getWindowFrame();
         if (windowFrame.isPresent()) {
@@ -341,6 +346,14 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
                 FrameBoundary.newPrecedingBoundary(), FrameBoundary.newCurrentRowBoundary()));
         }
         return firstValue;
+    }
+
+    @Override
+    public FirstOrLastValue visitLastValue(LastValue lastValue, Void ctx) {
+        if (2 == lastValue.arity() && !lastValue.child(1).isConstant()) {
+            throw new AnalysisException("The second parameter of lasst_value must be constant");
+        }
+        return lastValue;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
@@ -351,7 +351,7 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
     @Override
     public FirstOrLastValue visitLastValue(LastValue lastValue, Void ctx) {
         if (2 == lastValue.arity() && !lastValue.child(1).isConstant()) {
-            throw new AnalysisException("The second parameter of lasst_value must be constant");
+            throw new AnalysisException("The second parameter of last_value must be constant");
         }
         return lastValue;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/FirstOrLastValue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/FirstOrLastValue.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions.window;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
@@ -62,5 +63,12 @@ public abstract class FirstOrLastValue extends WindowFunction
     @Override
     public List<FunctionSignature> getSignatures() {
         return SIGNATURES;
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        if (2 == arity() && !child(1).isConstant()) {
+            throw new AnalysisException("The second parameter of " + getName() + " must be constant");
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/FirstOrLastValue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/FirstOrLastValue.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
 
@@ -65,10 +66,16 @@ public abstract class FirstOrLastValue extends WindowFunction
         return SIGNATURES;
     }
 
-    @Override
-    public void checkLegalityBeforeTypeCoercion() {
-        if (2 == arity() && !child(1).isConstant()) {
-            throw new AnalysisException("The second parameter of " + getName() + " must be constant");
+    /**check the second parameter must be true or false*/
+    public static void checkSecondParameter(FirstOrLastValue firstOrLastValue) {
+        if (1 == firstOrLastValue.arity()) {
+            return;
+        }
+        if (!BooleanLiteral.TRUE.equals(firstOrLastValue.child(1))
+                && !BooleanLiteral.FALSE.equals(firstOrLastValue.child(1))) {
+            throw new AnalysisException("The second parameter of " + firstOrLastValue.getName()
+                    + " must be a constant or a constant expression, and the result of "
+                    + "the calculated constant or constant expression must be true or false.");
         }
     }
 }

--- a/regression-test/suites/nereids_syntax_p0/window_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/window_function.groovy
@@ -279,4 +279,15 @@ suite("window_function") {
                 )t
             )a where rn=1
     """
+
+    // test first value second param is not constant
+    test {
+        sql "select first_value(c1,c1) over() from window_test"
+        exception "The second parameter of first_value must be constant"
+    }
+
+    test {
+        sql "select last_value(c1,c1) over() from window_test"
+        exception "The second parameter of first_value must be constant"
+    }
 }

--- a/regression-test/suites/nereids_syntax_p0/window_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/window_function.groovy
@@ -283,11 +283,35 @@ suite("window_function") {
     // test first value second param is not constant
     test {
         sql "select first_value(c1,c1) over() from window_test"
-        exception "The second parameter of first_value must be constant"
+        exception "The second parameter of first_value must be a constant or a constant expression, and the result of the calculated constant or constant expression must be true or false."
     }
 
     test {
         sql "select last_value(c1,c1) over() from window_test"
-        exception "The second parameter of last_value must be constant"
+        exception "The second parameter of last_value must be a constant or a constant expression, and the result of the calculated constant or constant expression must be true or false."
     }
+
+    test {
+        sql "select first_value(c1,cast('abc' as boolean)) over() from window_test"
+        exception "The second parameter of first_value must be a constant or a constant expression, and the result of the calculated constant or constant expression must be true or false."
+    }
+    test {
+        sql "select first_value(c1,'') over() from window_test"
+        exception "The second parameter of first_value must be a constant or a constant expression, and the result of the calculated constant or constant expression must be true or false."
+    }
+    test {
+        sql "select last_value(c1,'345_a') over() from window_test"
+        exception "The second parameter of last_value must be a constant or a constant expression, and the result of the calculated constant or constant expression must be true or false."
+    }
+    sql "select last_value(c1,cast('67' as boolean)) over() from window_test"
+    sql "select first_value(c1,cast(56 as boolean)) over() from window_test"
+    sql "select last_value(c1,cast(56 as boolean)) over() from window_test"
+    sql "select first_value(c1,cast('true' as boolean)) over() from window_test"
+    sql "select last_value(c1,cast('false' as boolean)) over() from window_test"
+    sql "select first_value(c1,cast('1' as boolean)) over() from window_test"
+    sql "select last_value(c1,cast('0' as boolean)) over() from window_test"
+    sql "select first_value(c1,true) over() from window_test"
+    sql "select last_value(c1,false) over() from window_test"
+    sql "select first_value(c1,1) over() from window_test"
+    sql "select last_value(c1,0) over() from window_test"
 }

--- a/regression-test/suites/nereids_syntax_p0/window_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/window_function.groovy
@@ -288,6 +288,6 @@ suite("window_function") {
 
     test {
         sql "select last_value(c1,c1) over() from window_test"
-        exception "The second parameter of first_value must be constant"
+        exception "The second parameter of last_value must be constant"
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
this pr fix 2 things:
1.when first_value/last_value second parameter is true, which means ignore nulls, fe should not do some rewrite.
2.adding check that first_value/last_value second parameter must be true or false.

Issue Number: close #xxx

Related PR: #44996 #27623

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

