### PR TITLE
[fix](editlog) Fix replay BatchDropInfo

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/BatchDropInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/BatchDropInfo.java
@@ -86,6 +86,10 @@ public class BatchDropInfo implements Writable {
         return indexIdSet;
     }
 
+    public boolean hasIndexNameMap() {
+        return indexNameMap != null;
+    }
+
     public Map<Long, String> getIndexNameMap() {
         return indexNameMap;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
@@ -52,7 +52,7 @@ public class DropInfo implements Writable {
 
     public DropInfo(long dbId, long tableId, String tableName, boolean isView, boolean forceDrop,
             long recycleTime) {
-        this(dbId, tableId, tableName, -1, "", isView, forceDrop, recycleTime);
+        this(dbId, tableId, tableName, -1L, "", isView, forceDrop, recycleTime);
     }
 
     public DropInfo(long dbId, long tableId, String tableName, long indexId, String indexName, boolean isView,

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -347,13 +347,21 @@ public class EditLog {
                 }
                 case OperationType.OP_BATCH_DROP_ROLLUP: {
                     BatchDropInfo batchDropInfo = (BatchDropInfo) journal.getData();
-                    for (Map.Entry<Long, String> entry : batchDropInfo.getIndexNameMap().entrySet()) {
-                        long indexId = entry.getKey();
-                        String indexName = entry.getValue();
-                        DropInfo info = new DropInfo(batchDropInfo.getDbId(), batchDropInfo.getTableId(),
-                                        batchDropInfo.getTableName(), indexId, indexName, false, false, 0);
-                        env.getMaterializedViewHandler().replayDropRollup(info, env);
-                        env.getBinlogManager().addDropRollup(info, logId);
+                    if (batchDropInfo.hasIndexNameMap()) {
+                        for (Map.Entry<Long, String> entry : batchDropInfo.getIndexNameMap().entrySet()) {
+                            long indexId = entry.getKey();
+                            String indexName = entry.getValue();
+                            DropInfo info = new DropInfo(batchDropInfo.getDbId(), batchDropInfo.getTableId(),
+                                            batchDropInfo.getTableName(), indexId, indexName, false, false, 0);
+                            env.getMaterializedViewHandler().replayDropRollup(info, env);
+                            env.getBinlogManager().addDropRollup(info, logId);
+                        }
+                    } else {
+                        for (Long indexId : batchDropInfo.getIndexIdSet()) {
+                            DropInfo info = new DropInfo(batchDropInfo.getDbId(), batchDropInfo.getTableId(),
+                                    batchDropInfo.getTableName(), indexId, "", false, false, 0);
+                            env.getMaterializedViewHandler().replayDropRollup(info, env);
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: introduced by #44677

Problem Summary:

The new field `indexNameMap` does not exist in the former version of the persisted metadata, and should be skipped during replaying.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

