### PR TITLE
[Job](Fix)Improve Event Publishing with Timeout

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/ExecuteTaskEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/ExecuteTaskEvent.java
@@ -34,4 +34,9 @@ public class ExecuteTaskEvent<T extends AbstractTask> {
         return ExecuteTaskEvent::new;
     }
 
+    public void clear() {
+        this.task = null;
+        this.jobConfig = null;
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -104,7 +104,7 @@ public class TaskDisruptor<T> {
 
             // Timeout reached without publishing the event
             LOG.warn("Failed to publish event within the specified timeout (1 second)."
-                            + "Queue may be full. the remaining buffer size is  {}",
+                            + "Queue may be full. the remaining buffer size is {}",
                     disruptor.getRingBuffer().remainingCapacity());
         } catch (Exception e) {
             // Catching general exceptions to handle unexpected errors

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -19,7 +19,6 @@ package org.apache.doris.job.disruptor;
 
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventTranslatorVararg;
-import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.WorkHandler;
 import com.lmax.disruptor.dsl.Disruptor;
@@ -28,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utility class for creating and managing a Disruptor instance.
@@ -73,20 +73,37 @@ public class TaskDisruptor<T> {
      */
     public boolean publishEvent(Object... args) {
         try {
-            RingBuffer<T> ringBuffer = disruptor.getRingBuffer();
-            // Check if the RingBuffer has enough capacity to reserve 10 slots for tasks
-            // If there is insufficient capacity (less than 10 slots available)
-            // log a warning and drop the current task
-            if (!ringBuffer.hasAvailableCapacity(10)) {
-                LOG.warn("ring buffer has no available capacity,task will be dropped,"
-                        + "please check the task queue size.");
-                return false;
+            // Set the timeout to 1 second, converted to nanoseconds for precision
+            long timeoutInNanos = TimeUnit.SECONDS.toNanos(1);  // Timeout set to 1 second
+            long startTime = System.nanoTime();  // Record the start time
+
+            // Loop until the timeout is reached
+            while (System.nanoTime() - startTime < timeoutInNanos) {
+                // Check if there is enough remaining capacity in the ring buffer
+                // Adjusting to check if the required capacity is available (instead of hardcoding 1)
+                if (disruptor.getRingBuffer().remainingCapacity() > 1) {
+                    // Publish the event if there is enough capacity
+                    disruptor.getRingBuffer().publishEvent(eventTranslator, args);
+                    return true;
+                }
+
+                // Wait for a short period before retrying
+                try {
+                    Thread.sleep(10);  // Adjust the wait time as needed (maybe increase if not high-frequency)
+                } catch (InterruptedException e) {
+                    // Log the exception and return false if interrupted
+                    Thread.currentThread().interrupt();  // Restore interrupt status
+                    LOG.warn("Thread interrupted while waiting to publish event", e);
+                    return false;
+                }
             }
-            ringBuffer.publishEvent(eventTranslator, args);
-            return true;
+
+            // Timeout reached without publishing the event
+            LOG.warn("Failed to publish event within the specified timeout (1 second)."
+                    + "Queue may be full. size is {}", disruptor.getRingBuffer().remainingCapacity());
         } catch (Exception e) {
-            LOG.warn("Failed to publish event", e);
-            // Handle the exception, e.g., retry or alert
+            // Catching general exceptions to handle unexpected errors
+            LOG.warn("Failed to publish event due to an unexpected error", e);
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -84,6 +84,10 @@ public class TaskDisruptor<T> {
                 if (disruptor.getRingBuffer().remainingCapacity() > 1) {
                     // Publish the event if there is enough capacity
                     disruptor.getRingBuffer().publishEvent(eventTranslator, args);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("publishEvent success,the remaining buffer size is {}",
+                                disruptor.getRingBuffer().remainingCapacity());
+                    }
                     return true;
                 }
 
@@ -100,7 +104,7 @@ public class TaskDisruptor<T> {
 
             // Timeout reached without publishing the event
             LOG.warn("Failed to publish event within the specified timeout (1 second)."
-                    + "Queue may be full. the remaining buffer size is  {}",
+                            + "Queue may be full. the remaining buffer size is  {}",
                     disruptor.getRingBuffer().remainingCapacity());
         } catch (Exception e) {
             // Catching general exceptions to handle unexpected errors

--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -100,7 +100,8 @@ public class TaskDisruptor<T> {
 
             // Timeout reached without publishing the event
             LOG.warn("Failed to publish event within the specified timeout (1 second)."
-                    + "Queue may be full. size is {}", disruptor.getRingBuffer().remainingCapacity());
+                    + "Queue may be full. the remaining buffer size is  {}",
+                    disruptor.getRingBuffer().remainingCapacity());
         } catch (Exception e) {
             // Catching general exceptions to handle unexpected errors
             LOG.warn("Failed to publish event due to an unexpected error", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/DefaultTaskExecutorHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/DefaultTaskExecutorHandler.java
@@ -36,35 +36,23 @@ public class DefaultTaskExecutorHandler<T extends AbstractTask> implements WorkH
 
     @Override
     public void onEvent(ExecuteTaskEvent<T> executeTaskEvent) {
-        T task = executeTaskEvent.getTask();
-        if (null == task) {
-            log.warn("task is null, ignore,maybe task has been canceled");
-            return;
-        }
-        if (task.isCancelled()) {
-            log.info("task is canceled, ignore. task id is {}", task.getTaskId());
-            return;
-        }
-        log.info("start to execute task, task id is {}", task.getTaskId());
         try {
+            T task = executeTaskEvent.getTask();
+            if (null == task) {
+                log.warn("task is null, ignore,maybe task has been canceled");
+                return;
+            }
+            if (task.isCancelled()) {
+                log.info("task is canceled, ignore. task id is {}", task.getTaskId());
+                return;
+            }
+            log.info("start to execute task, task id is {}", task.getTaskId());
             task.runTask();
         } catch (Exception e) {
-            //if task.onFail() throw exception, we will catch it here
-            log.warn("task before error, task id is {}", task.getTaskId(), e);
-        }
-        //todo we need discuss whether we need to use semaphore to control the concurrent task num
-        /* Semaphore semaphore = null;
-        // get token
-        try {
-            int maxConcurrentTaskNum = executeTaskEvent.getJobConfig().getMaxConcurrentTaskNum();
-            semaphore = TaskTokenManager.tryAcquire(task.getJobId(), maxConcurrentTaskNum);
-            task.runTask();
-        } catch (Exception e) {
-            task.onFail();
-            log.error("execute task error, task id is {}", task.getTaskId(), e);
+            log.error("execute task error, task id is {}", executeTaskEvent.getTask().getTaskId(), e);
         } finally {
-            if (null != semaphore) {
-                semaphore.release();
-            }*/
+            executeTaskEvent.clear();
+        }
+
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/DispatchTaskHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/DispatchTaskHandler.java
@@ -21,7 +21,6 @@ import org.apache.doris.job.base.AbstractJob;
 import org.apache.doris.job.common.JobStatus;
 import org.apache.doris.job.common.JobType;
 import org.apache.doris.job.common.TaskType;
-import org.apache.doris.job.disruptor.TaskDisruptor;
 import org.apache.doris.job.disruptor.TimerJobEvent;
 import org.apache.doris.job.task.AbstractTask;
 
@@ -40,9 +39,9 @@ import java.util.Map;
 @Log4j2
 public class DispatchTaskHandler<T extends AbstractJob> implements WorkHandler<TimerJobEvent<T>> {
 
-    private final Map<JobType, TaskDisruptor<T>> disruptorMap;
+    private final Map<JobType, TaskProcessor> disruptorMap;
 
-    public DispatchTaskHandler(Map<JobType, TaskDisruptor<T>> disruptorMap) {
+    public DispatchTaskHandler(Map<JobType, TaskProcessor> disruptorMap) {
         this.disruptorMap = disruptorMap;
     }
 
@@ -66,7 +65,7 @@ public class DispatchTaskHandler<T extends AbstractJob> implements WorkHandler<T
                 }
                 JobType jobType = event.getJob().getJobType();
                 for (AbstractTask task : tasks) {
-                    if (!disruptorMap.get(jobType).publishEvent(task, event.getJob().getJobConfig())) {
+                    if (!disruptorMap.get(jobType).addTask(task)) {
                         task.cancel();
                         continue;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/TaskProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/TaskProcessor.java
@@ -45,7 +45,7 @@ public class TaskProcessor {
 
     public boolean addTask(AbstractTask task) {
         try {
-            executor.execute(() -> runTask(task)); // 直接提交任务
+            executor.execute(() -> runTask(task));
             log.info("Add task to executor, task id: {}", task.getTaskId());
             return true;
         } catch (RejectedExecutionException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/TaskProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/TaskProcessor.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.job.executor;
+
+import org.apache.doris.job.task.AbstractTask;
+
+import lombok.extern.log4j.Log4j2;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+@Log4j2
+public class TaskProcessor {
+    private ExecutorService executor;
+
+    public  TaskProcessor(int numberOfThreads, int queueSize, ThreadFactory threadFactory) {
+        this.executor = new ThreadPoolExecutor(
+                numberOfThreads,
+                numberOfThreads,
+                0L, TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(queueSize),
+                threadFactory,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+    }
+
+    public boolean addTask(AbstractTask task) {
+        try {
+            executor.execute(() -> runTask(task)); // 直接提交任务
+            log.info("Add task to executor, task id: {}", task.getTaskId());
+            return true;
+        } catch (RejectedExecutionException e) {
+            log.warn("Failed to add task to executor, task id: {}", task.getTaskId(), e);
+            return false;
+        }
+    }
+
+    public void shutdown() {
+        log.info("Shutting down executor service...");
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        log.info("Executor service shut down successfully.");
+    }
+
+    private void runTask(AbstractTask task) {
+        try {
+            if (task == null) {
+                log.warn("Task is null, ignore. Maybe it has been canceled.");
+                return;
+            }
+            if (task.isCancelled()) {
+                log.info("Task is canceled, ignore. Task id: {}", task.getTaskId());
+                return;
+            }
+            log.info("Start to execute task, task id: {}", task.getTaskId());
+            task.runTask();
+        } catch (Exception e) {
+            log.warn("Execute task error, task id: {}", task.getTaskId(), e);
+        }
+    }
+}


### PR DESCRIPTION
### Summary:
This PR refines the publishEvent method to improve event publishing reliability by introducing a timeout mechanism and enhanced logging. The changes allow for a more responsive system when attempting to publish events to the disruptor, especially in cases where the ring buffer may not have sufficient capacity at the time.

#### Timeout Implementation:

A 1-second timeout (in nanoseconds) is set, after which the event publishing attempt will stop if the required capacity is not available. The timeout is tracked using System.nanoTime() for precise elapsed time measurement. 

#### Remaining Capacity Check:

The method checks if the remainingCapacity() of the ring buffer is greater than 1 (this can be adjusted based on your capacity requirements). If enough capacity is available, the event is published; otherwise, it waits and retries.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

