### PR TITLE
[Bug](runtime-filter) avoid missing eos make rf process meet error

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -92,11 +92,10 @@ std::string Dependency::debug_string(int indentation_level) {
 
 std::string CountedFinishDependency::debug_string(int indentation_level) {
     fmt::memory_buffer debug_string_buffer;
-    fmt::format_to(
-            debug_string_buffer,
-            "{}{}: id={}, block_task={}, ready={}, _always_ready={}, count={}, _stack_set_ready={}",
-            std::string(indentation_level * 2, ' '), _name, _node_id, _blocked_task.size(), _ready,
-            _always_ready, _counter, _stack_set_ready);
+    fmt::format_to(debug_string_buffer,
+                   "{}{}: id={}, block_task={}, ready={}, _always_ready={}, count={}",
+                   std::string(indentation_level * 2, ' '), _name, _node_id, _blocked_task.size(),
+                   _ready, _always_ready, _counter);
     return fmt::to_string(debug_string_buffer);
 }
 

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -173,26 +173,11 @@ struct FakeSharedState final : public BasicSharedState {
     ENABLE_FACTORY_CREATOR(FakeSharedState)
 };
 
-class DependencyWithStack : public Dependency {
-public:
-    using SharedState = FakeSharedState;
-    DependencyWithStack(int id, int node_id, std::string name, bool ready = false)
-            : Dependency(id, node_id, name, ready) {}
-
-    void set_ready() override {
-        _stack_set_ready = get_stack_trace();
-        Dependency::set_ready();
-    }
-
-protected:
-    std::string _stack_set_ready;
-};
-
-class CountedFinishDependency final : public DependencyWithStack {
+class CountedFinishDependency final : public Dependency {
 public:
     using SharedState = FakeSharedState;
     CountedFinishDependency(int id, int node_id, std::string name)
-            : DependencyWithStack(id, node_id, name, true) {}
+            : Dependency(id, node_id, name, true) {}
 
     void add() {
         std::unique_lock<std::mutex> l(_mtx);

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -171,8 +171,8 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
                     !p._shared_hash_table_context->complete_build_stage)) {
             throw Exception(ErrorCode::INTERNAL_ERROR, "build_sink::close meet error state");
         } else {
-            RETURN_IF_ERROR(local_state._runtime_filter_slots->copy_from_shared_context(
-                    _shared_hash_table_context));
+            RETURN_IF_ERROR(
+                    _runtime_filter_slots->copy_from_shared_context(p._shared_hash_table_context));
         }
 
         SCOPED_TIMER(_publish_runtime_filter_timer);

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -170,6 +170,9 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
                    (p._shared_hash_table_context &&
                     !p._shared_hash_table_context->complete_build_stage)) {
             throw Exception(ErrorCode::INTERNAL_ERROR, "build_sink::close meet error state");
+        } else {
+            RETURN_IF_ERROR(local_state._runtime_filter_slots->copy_from_shared_context(
+                    _shared_hash_table_context));
         }
 
         SCOPED_TIMER(_publish_runtime_filter_timer);
@@ -552,9 +555,6 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         if (!_shared_hash_table_context->status.ok()) {
             return _shared_hash_table_context->status;
         }
-
-        RETURN_IF_ERROR(local_state._runtime_filter_slots->copy_from_shared_context(
-                _shared_hash_table_context));
 
         local_state.profile()->add_info_string(
                 "SharedHashTableFrom",


### PR DESCRIPTION
### What problem does this PR solve?
a instance may closed early coz sink is finished, then this instance will missing eos.
shared hash table join build sink will copy rf from other instance when sink meet eos, then use those rf on close() method.
for avoid rf process meet error,  this pr move copy rf logic to close() method.

![图片](https://github.com/user-attachments/assets/f80aee0b-4b23-4095-b49b-68f6e2e56f25)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

