### PR TITLE
[enhance](auth)When authorization includes create, not check if resources exist

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -686,7 +686,7 @@ public class Auth implements Writable {
         writeLock();
         try {
             if (!isReplay) {
-                checkTablePatternExist(tblPattern);
+                checkTablePatternExist(tblPattern, privs);
             }
             if (role == null) {
                 if (!doesUserExist(userIdent)) {
@@ -706,8 +706,12 @@ public class Auth implements Writable {
         }
     }
 
-    private void checkTablePatternExist(TablePattern tablePattern) throws DdlException {
+    private void checkTablePatternExist(TablePattern tablePattern, PrivBitSet privs) throws DdlException {
         Objects.requireNonNull(tablePattern, "tablePattern can not be null");
+        Objects.requireNonNull(privs, "privs can not be null");
+        if (privs.containsPrivs(Privilege.CREATE_PRIV)) {
+            return;
+        }
         PrivLevel privLevel = tablePattern.getPrivLevel();
         if (privLevel == PrivLevel.GLOBAL) {
             return;

--- a/regression-test/suites/auth_p0/test_grant_nonexist_table.groovy
+++ b/regression-test/suites/auth_p0/test_grant_nonexist_table.groovy
@@ -39,7 +39,9 @@ suite("test_grant_nonexist_table","p0,auth") {
             sql """grant select_priv on internal.${dbName}.non_exist_table to ${user}"""
             exception "table"
         }
-
+    // contain create_triv should not check name, Same behavior as MySQL
+    sql """grant create_priv on internal.${dbName}.non_exist_table to ${user}"""
+    sql """grant create_priv,select_priv on internal.${dbName}.non_exist_table to ${user}"""
 
     try_sql("DROP USER ${user}")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #39597 

Problem Summary:
When authorization includes create, not check if resources exist
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

