### PR TITLE
[fix](regression)turn runtime filter off in invalid_stats case

### DIFF
--- a/regression-test/suites/nereids_p0/stats/invalid_stats/invalid_stats.groovy
+++ b/regression-test/suites/nereids_p0/stats/invalid_stats/invalid_stats.groovy
@@ -17,11 +17,11 @@
 
 suite("invalid_stats") {
     multi_sql """
-        set global enable_auto_analyze=false;
         SET enable_nereids_planner=true;
         SET enable_fallback_to_original_planner=false;
         set disable_nereids_rules=PRUNE_EMPTY_PARTITION;
         set ignore_shape_nodes=PhysicalProject;
+        set runtime_filter_mode=off;
         
         drop table if exists region;
         CREATE TABLE region  (


### PR DESCRIPTION
### What problem does this PR solve?
set "runtime_filter_mode=off" to avoid interference of runtime filter in the case "invalid_stats.groovy"  

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

