### PR TITLE
[fix](Planner) fix escape character when used in create view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -135,6 +135,9 @@ public class StringLiteral extends LiteralExpr {
 
     @Override
     public String toSqlImpl() {
+        if (value.equals("\\")) {
+            value = "\\\\";
+        }
         return "'" + value.replaceAll("'", "''") + "'";
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/QueryBuildersTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/QueryBuildersTest.java
@@ -100,6 +100,12 @@ public class QueryBuildersTest {
     }
 
     @Test
+    public void testStringLiteralToSql() {
+        Expr escape = new StringLiteral("\\");
+        Assertions.assertEquals("'\\\\'", escape.toSql());
+    }
+
+    @Test
     public void testCompoundPredicateConvertEsDsl() {
         SlotRef k1 = new SlotRef(null, "k1");
         IntLiteral intLiteral1 = new IntLiteral(3);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
when using escape character '\' in create view as select statement, it would failed because SelectStmt toSql implementation remove first escape character 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

