### PR TITLE
[fix](ip)fix default value for ip

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -651,6 +651,12 @@ public class ColumnDef {
             case BOOLEAN:
                 new BoolLiteral(defaultValue);
                 break;
+            case IPV4:
+                new IPv4Literal(defaultValue);
+                break;
+            case IPV6:
+                new IPv6Literal(defaultValue);
+                break;
             default:
                 throw new AnalysisException("Unsupported type: " + type);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv4Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv4Literal.java
@@ -89,7 +89,6 @@ public class IPv4Literal extends LiteralExpr {
 
     private static String parseLongToIPv4(long ipv4) {
         StringBuilder sb = new StringBuilder();
-        sb.append("\"");
         for (int i = 3; i >= 0; i--) {
             short octet = (short) ((ipv4 >> (i * 8)) & 0xFF);
             sb.append(octet);
@@ -97,7 +96,6 @@ public class IPv4Literal extends LiteralExpr {
                 sb.append(".");
             }
         }
-        sb.append("\"");
         return sb.toString();
     }
 
@@ -117,7 +115,7 @@ public class IPv4Literal extends LiteralExpr {
 
     @Override
     protected String toSqlImpl() {
-        return getStringValue();
+        return "\"" + getStringValue() + "\"";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv4Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv4Literal.java
@@ -89,6 +89,7 @@ public class IPv4Literal extends LiteralExpr {
 
     private static String parseLongToIPv4(long ipv4) {
         StringBuilder sb = new StringBuilder();
+        sb.append("\"");
         for (int i = 3; i >= 0; i--) {
             short octet = (short) ((ipv4 >> (i * 8)) & 0xFF);
             sb.append(octet);
@@ -96,6 +97,7 @@ public class IPv4Literal extends LiteralExpr {
                 sb.append(".");
             }
         }
+        sb.append("\"");
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv6Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv6Literal.java
@@ -75,7 +75,7 @@ public class IPv6Literal extends LiteralExpr {
 
     @Override
     protected String toSqlImpl() {
-        return getStringValue();
+        return "\"" + getStringValue() + "\"";
     }
 
     @Override
@@ -101,7 +101,7 @@ public class IPv6Literal extends LiteralExpr {
 
     @Override
     public String getStringValue() {
-        return "\"" + this.value + "\"";
+        return this.value;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv6Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IPv6Literal.java
@@ -101,7 +101,7 @@ public class IPv6Literal extends LiteralExpr {
 
     @Override
     public String getStringValue() {
-        return this.value;
+        return "\"" + this.value + "\"";
     }
 
     @Override

--- a/regression-test/data/datatype_p0/ip/test_ip_basic.out
+++ b/regression-test/data/datatype_p0/ip/test_ip_basic.out
@@ -377,3 +377,33 @@ ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff	4
 1	5be8:dde9:7f0b:d5a7:bd01:b3be:9c69:573b	0.0.0.1
 2	::	127.0.0.1
 
+-- !sql --
+table_ip_default	CREATE TABLE `table_ip_default` (\n  `col0` bigint NOT NULL,\n  `col4` ipv6 NULL DEFAULT "::",\n  `col24` ipv4 NULL DEFAULT "127.0.0.1"\n) ENGINE=OLAP\nUNIQUE KEY(`col0`)\nDISTRIBUTED BY HASH(`col0`) BUCKETS 4\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"min_load_replica_num" = "-1",\n"is_being_synced" = "false",\n"storage_medium" = "hdd",\n"storage_format" = "V2",\n"inverted_index_storage_format" = "V2",\n"enable_unique_key_merge_on_write" = "true",\n"light_schema_change" = "true",\n"disable_auto_compaction" = "false",\n"binlog.enable" = "false",\n"binlog.ttl_seconds" = "86400",\n"binlog.max_bytes" = "9223372036854775807",\n"binlog.max_history_nums" = "9223372036854775807",\n"enable_single_replica_compaction" = "false",\n"group_commit_interval_ms" = "10000",\n"group_commit_data_bytes" = "134217728",\n"enable_mow_light_delete" = "false"\n);
+
+-- !sql --
+col0	bigint	No	true	\N	
+col4	ipv6	Yes	false	::	NONE
+col24	ipv4	Yes	false	127.0.0.1	NONE
+
+-- !sql --
+col0	bigint	No	true	\N	
+col4	ipv6	Yes	false	::	NONE
+col24	ipv4	Yes	false	127.0.0.1	NONE
+
+-- !sql --
+2
+
+-- !sql --
+1	5be8:dde9:7f0b:d5a7:bd01:b3be:9c69:573b	0.0.0.1
+2	::	127.0.0.1
+
+-- !sql --
+0
+
+-- !sql --
+0
+
+-- !sql --
+1	5be8:dde9:7f0b:d5a7:bd01:b3be:9c69:573b	0.0.0.1	::	127.0.0.1
+2	::	127.0.0.1	::	127.0.0.1
+

--- a/regression-test/data/datatype_p0/ip/test_ip_basic.out
+++ b/regression-test/data/datatype_p0/ip/test_ip_basic.out
@@ -378,17 +378,14 @@ ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff	4
 2	::	127.0.0.1
 
 -- !sql --
-table_ip_default	CREATE TABLE `table_ip_default` (\n  `col0` bigint NOT NULL,\n  `col4` ipv6 NULL DEFAULT "::",\n  `col24` ipv4 NULL DEFAULT "127.0.0.1"\n) ENGINE=OLAP\nUNIQUE KEY(`col0`)\nDISTRIBUTED BY HASH(`col0`) BUCKETS 4\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"min_load_replica_num" = "-1",\n"is_being_synced" = "false",\n"storage_medium" = "hdd",\n"storage_format" = "V2",\n"inverted_index_storage_format" = "V2",\n"enable_unique_key_merge_on_write" = "true",\n"light_schema_change" = "true",\n"disable_auto_compaction" = "false",\n"binlog.enable" = "false",\n"binlog.ttl_seconds" = "86400",\n"binlog.max_bytes" = "9223372036854775807",\n"binlog.max_history_nums" = "9223372036854775807",\n"enable_single_replica_compaction" = "false",\n"group_commit_interval_ms" = "10000",\n"group_commit_data_bytes" = "134217728",\n"enable_mow_light_delete" = "false"\n);
+table_ip_default	UNIQUE_KEYS	col0	bigint	bigint	No	true	\N		true		
+		col4	ipv6	ipv6	Yes	false	::	NONE	true		
+		col24	ipv4	ipv4	Yes	false	127.0.0.1	NONE	true		
 
 -- !sql --
-col0	bigint	No	true	\N	
-col4	ipv6	Yes	false	::	NONE
-col24	ipv4	Yes	false	127.0.0.1	NONE
-
--- !sql --
-col0	bigint	No	true	\N	
-col4	ipv6	Yes	false	::	NONE
-col24	ipv4	Yes	false	127.0.0.1	NONE
+table_ip_default_like	UNIQUE_KEYS	col0	bigint	bigint	No	true	\N		true		
+		col4	ipv6	ipv6	Yes	false	::	NONE	true		
+		col24	ipv4	ipv4	Yes	false	127.0.0.1	NONE	true		
 
 -- !sql --
 2

--- a/regression-test/data/datatype_p0/ip/test_ip_basic.out
+++ b/regression-test/data/datatype_p0/ip/test_ip_basic.out
@@ -373,3 +373,7 @@ ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff	4
 -- !sql --
 1	false	127.0.0.1	ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 
+-- !sql --
+1	5be8:dde9:7f0b:d5a7:bd01:b3be:9c69:573b	0.0.0.1
+2	::	127.0.0.1
+

--- a/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
@@ -166,5 +166,21 @@ suite("test_ip_basic") {
     sql """ CREATE TABLE IF NOT EXISTS `table_ip_default` (`col0` bigint NOT NULL, `col4` ipv6 NULL DEFAULT "::",   `col24` ipv4 NULL DEFAULT "127.0.0.1") ENGINE=OLAP UNIQUE KEY(`col0`) DISTRIBUTED BY HASH(`col0`) BUCKETS 4 PROPERTIES ("replication_allocation" = "tag.location.default: 1") """
     sql """ insert into table_ip_default values (1, "5be8:dde9:7f0b:d5a7:bd01:b3be:9c69:573b", "0.0.0.1") """
     sql """ insert into table_ip_default(col0) values (2); """
-    qt_sql """ select * from table_ip_default order by col0""";
+    qt_sql """ select * from table_ip_default order by col0"""
+    // add cases for default value to make sure in all cases, the default value is not lost.
+    // show create table
+    // desc table
+    // create table like
+    // insert into table
+    // alter new ip column with default value
+    qt_sql """ show create table table_ip_default """
+    qt_sql """ desc table_ip_default """
+    sql """ DROP TABLE IF EXISTS table_ip_default_like """
+    sql """ create table table_ip_default_like like table_ip_default """
+    qt_sql """ desc table_ip_default_like"""
+    qt_sql """ insert into table_ip_default_like select * from table_ip_default """
+    qt_sql """ select * from table_ip_default_like order by col0 """
+    qt_sql """ alter table table_ip_default_like add column col25 ipv6 NULL DEFAULT "::" """
+    qt_sql """ alter table table_ip_default_like add column col26 ipv4 NULL DEFAULT "127.0.0.1" """
+    qt_sql """ select * from table_ip_default_like order by col0 """
 }

--- a/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
@@ -160,4 +160,11 @@ suite("test_ip_basic") {
     qt_sql """ select * from table_ip where col0 = 1"""
     sql """ Update table_ip set col25 = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' where col0 = 1 """
     qt_sql """ select * from table_ip where col0 = 1"""
+
+    // test ip with default value
+    sql """ DROP TABLE IF EXISTS table_ip_default """
+    sql """ CREATE TABLE IF NOT EXISTS `table_ip_default` (`col0` bigint NOT NULL, `col4` ipv6 NULL DEFAULT "::",   `col24` ipv4 NULL DEFAULT "127.0.0.1") ENGINE=OLAP UNIQUE KEY(`col0`) DISTRIBUTED BY HASH(`col0`) BUCKETS 4 PROPERTIES ("replication_allocation" = "tag.location.default: 1") """
+    sql """ insert into table_ip_default values (1, "5be8:dde9:7f0b:d5a7:bd01:b3be:9c69:573b", "0.0.0.1") """
+    sql """ insert into table_ip_default(col0) values (2); """
+    qt_sql """ select * from table_ip_default order by col0""";
 }

--- a/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_basic.groovy
@@ -173,11 +173,14 @@ suite("test_ip_basic") {
     // create table like
     // insert into table
     // alter new ip column with default value
-    qt_sql """ show create table table_ip_default """
-    qt_sql """ desc table_ip_default """
+    def result = sql """ show create table table_ip_default """
+    log.info("show result : ${result}")
+    assertTrue(result.toString().containsIgnoreCase("`col4` ipv6 NULL DEFAULT \"::\""))
+    assertTrue(result.toString().containsIgnoreCase("`col24` ipv4 NULL DEFAULT \"127.0.0.1\""))
+    qt_sql """ desc table_ip_default all"""
     sql """ DROP TABLE IF EXISTS table_ip_default_like """
     sql """ create table table_ip_default_like like table_ip_default """
-    qt_sql """ desc table_ip_default_like"""
+    qt_sql """ desc table_ip_default_like all"""
     qt_sql """ insert into table_ip_default_like select * from table_ip_default """
     qt_sql """ select * from table_ip_default_like order by col0 """
     qt_sql """ alter table table_ip_default_like add column col25 ipv6 NULL DEFAULT "::" """


### PR DESCRIPTION
### What problem does this PR solve?
before this pr: we do not support create table for IP type with default value 
like this:
```
mysql> CREATE TABLE table2
    -> (
    ->     col0 BIGINT  NOT NULL DEFAULT '1' ,
    ->     col24 IPV4  NULL DEFAULT '127.0.0.1'
    -> )
    -> DUPLICATE KEY(col0)
    -> DISTRIBUTED BY HASH(col0) BUCKETS 4
    -> PROPERTIES (
    ->     "replication_num" = "1"
    -> );
ERROR 1105 (HY000): errCode = 2, detailMessage = Unsupported type: ipv4
```
after this pr we deal with this problem
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

