### PR TITLE
[Enhancement](compaction)Optimize compaction task permit allocation

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -453,7 +453,7 @@ DEFINE_mInt32(cumulative_compaction_max_deltas_factor, "10");
 DEFINE_mInt32(multi_get_max_threads, "10");
 
 // The upper limit of "permits" held by all compaction tasks. This config can be set to limit memory consumption for compaction.
-DEFINE_mInt64(total_permits_for_compaction_score, "10000");
+DEFINE_mInt64(total_permits_for_compaction_score, "1000000");
 
 // sleep interval in ms after generated compaction tasks
 DEFINE_mInt32(generate_compaction_tasks_interval_ms, "100");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

## Problem

The current implementation of compaction task submission reserves permits before task execution, which can lead to inefficient resource utilization. Tasks waiting in the thread pool queue may hold permits, potentially blocking other tasks from being executed.

## Solution

Change total_permits_for_compaction_score to 1,000,000, which will effectively remove the limit on total permits. The original purpose of total permits was to control the memory of compaction tasks, but currently, memory is controlled by individual compaction tasks, so total permits are no longer serving any purpose. If no memory issues arise in the next two versions after making this change, we will remove the permits mechanism.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

