### PR TITLE
[opt](cloud) Make get tablet stats and update delete bitmap update lock be able to be in different fdb txns

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2217,8 +2217,8 @@ void MetaServiceImpl::get_delete_bitmap_update_lock(google::protobuf::RpcControl
                 }
                 internal_get_tablet_stats(code, msg, txn.get(), instance_id, idx, tablet_stat,
                                           false);
-                LOG(INFO) << "retry get tablet stats, tablet=" << idx.tablet_id()
-                          << ", retry=" << retry;
+                LOG(INFO) << "retry get tablet stats, instance_id=" << instance_id
+                          << ", tablet=" << idx.tablet_id() << ", retry=" << retry;
             }
             if (code != MetaServiceCode::OK) {
                 response->clear_base_compaction_cnts();

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1701,6 +1701,7 @@ static bool check_delete_bitmap_lock(MetaServiceCode& code, std::string& msg, st
         msg = "failed to parse DeleteBitmapUpdateLockPB";
         return false;
     }
+    TEST_SYNC_POINT_CALLBACK("check_delete_bitmap_lock.set_lock_info", &lock_info);
     if (lock_info.lock_id() != lock_id) {
         ss << "lock id not match, locked by lock_id=" << lock_info.lock_id();
         msg = ss.str();

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1685,6 +1685,7 @@ static bool check_delete_bitmap_lock(MetaServiceCode& code, std::string& msg, st
     std::string lock_val;
     DeleteBitmapUpdateLockPB lock_info;
     auto err = txn->get(lock_key, &lock_val);
+    TEST_SYNC_POINT_CALLBACK("check_delete_bitmap_lock.inject_get_lock_key_err", &err);
     if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
         msg = "lock id key not found";
         code = MetaServiceCode::LOCK_EXPIRED;

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2209,7 +2209,8 @@ void MetaServiceImpl::get_delete_bitmap_update_lock(google::protobuf::RpcControl
                                   tablet_idx.partition_id(), tablet_idx.tablet_id()});
         std::string stats_val;
         TxnErrorCode err = txn->get(stats_key, &stats_val);
-        TEST_SYNC_POINT_CALLBACK("get_delete_bitmap_update_lock.get_compaction_cnts_inject_error", &err);
+        TEST_SYNC_POINT_CALLBACK("get_delete_bitmap_update_lock.get_compaction_cnts_inject_error",
+                                 &err);
         if (err == TxnErrorCode::TXN_TOO_OLD) {
             code = MetaServiceCode::OK;
             err = txn_kv_->create_txn(&txn);

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2209,6 +2209,7 @@ void MetaServiceImpl::get_delete_bitmap_update_lock(google::protobuf::RpcControl
                                   tablet_idx.partition_id(), tablet_idx.tablet_id()});
         std::string stats_val;
         TxnErrorCode err = txn->get(stats_key, &stats_val);
+        TEST_SYNC_POINT_CALLBACK("get_delete_bitmap_update_lock.get_compaction_cnts_inject_error", &err);
         if (err == TxnErrorCode::TXN_TOO_OLD) {
             code = MetaServiceCode::OK;
             err = txn_kv_->create_txn(&txn);
@@ -2244,7 +2245,8 @@ void MetaServiceImpl::get_delete_bitmap_update_lock(google::protobuf::RpcControl
                                   request->initiator())) {
         LOG(WARNING) << "failed to check delete bitmap lock after get tablet stats, table_id="
                      << table_id << " request lock_id=" << request->lock_id()
-                     << " request initiator=" << request->initiator() << " msg " << msg;
+                     << " request initiator=" << request->initiator() << " code=" << code
+                     << " msg=" << msg;
     }
 }
 

--- a/cloud/src/meta-service/meta_service_tablet_stats.cpp
+++ b/cloud/src/meta-service/meta_service_tablet_stats.cpp
@@ -169,7 +169,6 @@ void internal_get_tablet_stats(MetaServiceCode& code, std::string& msg, Transact
                                TabletStatsPB& stats, bool snapshot) {
     TabletStats detached_stats;
     internal_get_tablet_stats(code, msg, txn, instance_id, idx, stats, detached_stats, snapshot);
-    TEST_SYNC_POINT_CALLBACK("internal_get_tablet_stats.inject_error", &code, &msg);
     merge_tablet_stats(stats, detached_stats);
 }
 

--- a/cloud/src/meta-service/meta_service_tablet_stats.cpp
+++ b/cloud/src/meta-service/meta_service_tablet_stats.cpp
@@ -169,6 +169,7 @@ void internal_get_tablet_stats(MetaServiceCode& code, std::string& msg, Transact
                                TabletStatsPB& stats, bool snapshot) {
     TabletStats detached_stats;
     internal_get_tablet_stats(code, msg, txn, instance_id, idx, stats, detached_stats, snapshot);
+    TEST_SYNC_POINT_CALLBACK("internal_get_tablet_stats.inject_error", &code, &msg);
     merge_tablet_stats(stats, detached_stats);
 }
 

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -4675,6 +4675,65 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::LOCK_EXPIRED);
     }
+
+    {
+        // 2.2 abnormal path, lock has been taken by another load/compaction and been released during
+        // the reading of tablet stats
+        std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal2";
+        [[maybe_unused]] auto* sp = SyncPoint::get_instance();
+        std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
+            SyncPoint::get_instance()->disable_processing();
+            SyncPoint::get_instance()->clear_all_call_backs();
+        });
+        sp->set_call_back("get_instance_id", [&](auto&& args) {
+            auto* ret = try_any_cast_ret<std::string>(args);
+            ret->first = instance_id;
+            ret->second = true;
+        });
+        sp->set_call_back("check_delete_bitmap_lock.inject_get_lock_key_err", [&](auto&& args) {
+            auto* err = try_any_cast<TxnErrorCode*>(args[0]);
+            // the lock has been taken by another load and been released,
+            // so the delete bitmap update lock KV will be removed
+            *err = TxnErrorCode::TXN_KEY_NOT_FOUND;
+        });
+
+        sp->enable_processing();
+
+        // store tablet stats
+        int64_t db_id = 1000;
+        int64_t table_id = 2001;
+        int64_t index_id = 3001;
+        // [(partition_id, tablet_id)]
+        std::vector<std::array<int64_t, 2>> tablet_idxes {
+                {70001, 12345}, {80001, 3456}, {90001, 6789}};
+
+        add_tablet_stats(meta_service.get(), instance_id, table_id, index_id, tablet_idxes);
+
+        brpc::Controller cntl;
+        GetDeleteBitmapUpdateLockRequest req;
+        GetDeleteBitmapUpdateLockResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_table_id(table_id);
+        for (const auto& [partition_id, _] : tablet_idxes) {
+            req.add_partition_ids(partition_id);
+        }
+        req.set_expiration(0);
+        req.set_lock_id(999999);
+        req.set_initiator(-1);
+        req.set_require_compaction_stats(true);
+        for (const auto& [partition_id, tablet_id] : tablet_idxes) {
+            TabletIndexPB* idx = req.add_tablet_indexes();
+            idx->set_db_id(db_id);
+            idx->set_table_id(table_id);
+            idx->set_index_id(index_id);
+            idx->set_partition_id(partition_id);
+            idx->set_tablet_id(tablet_id);
+        }
+
+        meta_service->get_delete_bitmap_update_lock(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::LOCK_EXPIRED);
+    }
 }
 
 static std::string generate_random_string(int length) {

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -4702,9 +4702,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
         get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
                                       tablet_idxes, 5, 999999, -1, true);
         ASSERT_EQ(res.status().code(), MetaServiceCode::LOCK_EXPIRED);
-        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
-        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
-        ASSERT_EQ(res.cumulative_points().size(), 0);
     }
 }
 
@@ -4747,9 +4744,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
         get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
                                       tablet_idxes, 5, 999999, -1, true);
         ASSERT_EQ(res.status().code(), MetaServiceCode::KV_TXN_GET_ERR);
-        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
-        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
-        ASSERT_EQ(res.cumulative_points().size(), 0);
     }
 
     {

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -4755,7 +4755,7 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
 
     {
         // 2.4 abnormal path, meeting TXN_TOO_OLD error when reading tablets' stats,
-        // this should not fail if lock is not expired
+        // this should not fail if lock is not expired and total retry times doesn't exceeds limit
         std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal4";
         [[maybe_unused]] auto* sp = SyncPoint::get_instance();
         std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
@@ -4813,7 +4813,7 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
 
     {
         // 2.5 abnormal path, meeting TXN_TOO_OLD error when reading tablets' stats and the retry times exceeds limit
-        std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal4";
+        std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal5";
         [[maybe_unused]] auto* sp = SyncPoint::get_instance();
         std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
             SyncPoint::get_instance()->disable_processing();
@@ -4840,6 +4840,54 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
         // [(partition_id, tablet_id)]
         std::vector<std::array<int64_t, 2>> tablet_idxes;
         for (int i = 0; i < 20; i++) {
+            int64_t partition_id = 70000 + i;
+            int64_t tablet_id = 80000 + i;
+            tablet_idxes.push_back({partition_id, tablet_id});
+        }
+
+        add_tablet_stats(meta_service.get(), instance_id, table_id, index_id, tablet_idxes);
+
+        GetDeleteBitmapUpdateLockResponse res;
+        get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
+                                      tablet_idxes, 5, 999999, -1, true);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::KV_TXN_TOO_OLD);
+        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_points().size(), 0);
+    }
+
+    {
+        // 2.6 abnormal path, meeting TXN_TOO_OLD error when reading tablets' stats and the total retry times exceeds limit
+        std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal6";
+        [[maybe_unused]] auto* sp = SyncPoint::get_instance();
+        std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
+            SyncPoint::get_instance()->disable_processing();
+            SyncPoint::get_instance()->clear_all_call_backs();
+        });
+        sp->set_call_back("get_instance_id", [&](auto&& args) {
+            auto* ret = try_any_cast_ret<std::string>(args);
+            ret->first = instance_id;
+            ret->second = true;
+        });
+
+        int counter = 0;
+        sp->set_call_back("internal_get_tablet_stats.inject_error", [&](auto&& args) {
+            if (counter++ % 3 == 0) {
+                auto* code = try_any_cast<MetaServiceCode*>(args[0]);
+                auto* msg = try_any_cast<std::string*>(args[1]);
+                *code = MetaServiceCode::KV_TXN_TOO_OLD;
+                *msg = "injected KV_TXN_TOO_OLD error";
+            }
+        });
+
+        sp->enable_processing();
+
+        int64_t db_id = 1000;
+        int64_t table_id = 2001;
+        int64_t index_id = 3001;
+        // [(partition_id, tablet_id)]
+        std::vector<std::array<int64_t, 2>> tablet_idxes;
+        for (int i = 0; i < 1000; i++) {
             int64_t partition_id = 70000 + i;
             int64_t tablet_id = 80000 + i;
             tablet_idxes.push_back({partition_id, tablet_id});

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -4550,12 +4550,77 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockNoReadStats) {
     ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
 }
 
-TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStats) {
+TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsNormal) {
+    auto meta_service = get_meta_service();
+
+    std::string instance_id = "test_get_delete_bitmap_update_lock_normal";
+    [[maybe_unused]] auto* sp = SyncPoint::get_instance();
+    std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
+        SyncPoint::get_instance()->disable_processing();
+        SyncPoint::get_instance()->clear_all_call_backs();
+    });
+    sp->set_call_back("get_instance_id", [&](auto&& args) {
+        auto* ret = try_any_cast_ret<std::string>(args);
+        ret->first = instance_id;
+        ret->second = true;
+    });
+    sp->enable_processing();
+
+    // store tablet stats
+    int64_t db_id = 1000;
+    int64_t table_id = 2001;
+    int64_t index_id = 3001;
+    // [(partition_id, tablet_id)]
+    std::vector<std::array<int64_t, 2>> tablet_idxes {{70001, 12345}, {80001, 3456}, {90001, 6789}};
+
+    add_tablet_stats(meta_service.get(), instance_id, table_id, index_id, tablet_idxes);
+
+    brpc::Controller cntl;
+    GetDeleteBitmapUpdateLockRequest req;
+    GetDeleteBitmapUpdateLockResponse res;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    req.set_table_id(table_id);
+    for (const auto& [partition_id, _] : tablet_idxes) {
+        req.add_partition_ids(partition_id);
+    }
+    req.set_expiration(5);
+    req.set_lock_id(999999);
+    req.set_initiator(-1);
+    req.set_require_compaction_stats(true);
+    for (const auto& [partition_id, tablet_id] : tablet_idxes) {
+        TabletIndexPB* idx = req.add_tablet_indexes();
+        idx->set_db_id(db_id);
+        idx->set_table_id(table_id);
+        idx->set_index_id(index_id);
+        idx->set_partition_id(partition_id);
+        idx->set_tablet_id(tablet_id);
+    }
+
+    meta_service->get_delete_bitmap_update_lock(
+            reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+    ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+
+    ASSERT_EQ(res.base_compaction_cnts().size(), tablet_idxes.size());
+    for (const auto& base_compaction_cnt : res.base_compaction_cnts()) {
+        ASSERT_EQ(base_compaction_cnt, 10);
+    }
+    ASSERT_EQ(res.cumulative_compaction_cnts().size(), tablet_idxes.size());
+    for (const auto& cumu_compaction_cnt : res.cumulative_compaction_cnts()) {
+        ASSERT_EQ(cumu_compaction_cnt, 20);
+    }
+    ASSERT_EQ(res.cumulative_points().size(), tablet_idxes.size());
+    for (const auto& cumulative_point : res.cumulative_points()) {
+        ASSERT_EQ(cumulative_point, 30);
+    }
+}
+
+TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
     auto meta_service = get_meta_service();
 
     {
-        // 1. normal path
-        std::string instance_id = "test_get_delete_bitmap_update_lock_normal";
+        // 2.1 abnormal path, lock has been expired and taken by another load/compaction during
+        // the reading of tablet stats
+        std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal1";
         [[maybe_unused]] auto* sp = SyncPoint::get_instance();
         std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
             SyncPoint::get_instance()->disable_processing();
@@ -4566,6 +4631,13 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStats) {
             ret->first = instance_id;
             ret->second = true;
         });
+        sp->set_call_back("check_delete_bitmap_lock.set_lock_info", [&](auto&& args) {
+            auto* lock_info = try_any_cast<DeleteBitmapUpdateLockPB*>(args[0]);
+            // simulate that lock_id has been modified by another load
+            lock_info->set_lock_id(345);
+            LOG(INFO) << "change lock_info.lock_id to 345, lock_info=" << lock_info->DebugString();
+        });
+
         sp->enable_processing();
 
         // store tablet stats
@@ -4586,7 +4658,7 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStats) {
         for (const auto& [partition_id, _] : tablet_idxes) {
             req.add_partition_ids(partition_id);
         }
-        req.set_expiration(5);
+        req.set_expiration(0);
         req.set_lock_id(999999);
         req.set_initiator(-1);
         req.set_require_compaction_stats(true);
@@ -4601,25 +4673,7 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStats) {
 
         meta_service->get_delete_bitmap_update_lock(
                 reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
-        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
-
-        ASSERT_EQ(res.base_compaction_cnts().size(), tablet_idxes.size());
-        for (const auto& base_compaction_cnt : res.base_compaction_cnts()) {
-            ASSERT_EQ(base_compaction_cnt, 10);
-        }
-        ASSERT_EQ(res.cumulative_compaction_cnts().size(), tablet_idxes.size());
-        for (const auto& cumu_compaction_cnt : res.cumulative_compaction_cnts()) {
-            ASSERT_EQ(cumu_compaction_cnt, 20);
-        }
-        ASSERT_EQ(res.cumulative_points().size(), tablet_idxes.size());
-        for (const auto& cumulative_point : res.cumulative_points()) {
-            ASSERT_EQ(cumulative_point, 30);
-        }
-    }
-
-    {
-        ;
-        ;
+        ASSERT_EQ(res.status().code(), MetaServiceCode::LOCK_EXPIRED);
     }
 }
 

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -4595,7 +4595,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsNormal) {
     });
     sp->enable_processing();
 
-    // store tablet stats
     int64_t db_id = 1000;
     int64_t table_id = 2001;
     int64_t index_id = 3001;
@@ -4649,7 +4648,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
 
         sp->enable_processing();
 
-        // store tablet stats
         int64_t db_id = 1000;
         int64_t table_id = 2001;
         int64_t index_id = 3001;
@@ -4663,6 +4661,9 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
         get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
                                       tablet_idxes, 5, 999999, -1, true);
         ASSERT_EQ(res.status().code(), MetaServiceCode::LOCK_EXPIRED);
+        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_points().size(), 0);
     }
 
     {
@@ -4688,7 +4689,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
 
         sp->enable_processing();
 
-        // store tablet stats
         int64_t db_id = 1000;
         int64_t table_id = 2001;
         int64_t index_id = 3001;
@@ -4702,6 +4702,9 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsLockExpired) {
         get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
                                       tablet_idxes, 5, 999999, -1, true);
         ASSERT_EQ(res.status().code(), MetaServiceCode::LOCK_EXPIRED);
+        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_points().size(), 0);
     }
 }
 
@@ -4732,7 +4735,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
 
         sp->enable_processing();
 
-        // store tablet stats
         int64_t db_id = 1000;
         int64_t table_id = 2001;
         int64_t index_id = 3001;
@@ -4746,10 +4748,13 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
         get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
                                       tablet_idxes, 5, 999999, -1, true);
         ASSERT_EQ(res.status().code(), injected_error_code);
+        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_points().size(), 0);
     }
 
     {
-        // 2.4 abnormal path, meeting TXN_TOO_OLD error when reading tablets' stats
+        // 2.4 abnormal path, meeting TXN_TOO_OLD error when reading tablets' stats,
         // this should not fail if lock is not expired
         std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal4";
         [[maybe_unused]] auto* sp = SyncPoint::get_instance();
@@ -4775,7 +4780,6 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
 
         sp->enable_processing();
 
-        // store tablet stats
         int64_t db_id = 1000;
         int64_t table_id = 2001;
         int64_t index_id = 3001;
@@ -4793,6 +4797,63 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStatsError) {
         get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
                                       tablet_idxes, 5, 999999, -1, true);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        ASSERT_EQ(res.base_compaction_cnts().size(), tablet_idxes.size());
+        for (const auto& base_compaction_cnt : res.base_compaction_cnts()) {
+            ASSERT_EQ(base_compaction_cnt, 10);
+        }
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), tablet_idxes.size());
+        for (const auto& cumu_compaction_cnt : res.cumulative_compaction_cnts()) {
+            ASSERT_EQ(cumu_compaction_cnt, 20);
+        }
+        ASSERT_EQ(res.cumulative_points().size(), tablet_idxes.size());
+        for (const auto& cumulative_point : res.cumulative_points()) {
+            ASSERT_EQ(cumulative_point, 30);
+        }
+    }
+
+    {
+        // 2.5 abnormal path, meeting TXN_TOO_OLD error when reading tablets' stats and the retry times exceeds limit
+        std::string instance_id = "test_get_delete_bitmap_update_lock_abnormal4";
+        [[maybe_unused]] auto* sp = SyncPoint::get_instance();
+        std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
+            SyncPoint::get_instance()->disable_processing();
+            SyncPoint::get_instance()->clear_all_call_backs();
+        });
+        sp->set_call_back("get_instance_id", [&](auto&& args) {
+            auto* ret = try_any_cast_ret<std::string>(args);
+            ret->first = instance_id;
+            ret->second = true;
+        });
+
+        sp->set_call_back("internal_get_tablet_stats.inject_error", [&](auto&& args) {
+            auto* code = try_any_cast<MetaServiceCode*>(args[0]);
+            auto* msg = try_any_cast<std::string*>(args[1]);
+            *code = MetaServiceCode::KV_TXN_TOO_OLD;
+            *msg = "injected KV_TXN_TOO_OLD error";
+        });
+
+        sp->enable_processing();
+
+        int64_t db_id = 1000;
+        int64_t table_id = 2001;
+        int64_t index_id = 3001;
+        // [(partition_id, tablet_id)]
+        std::vector<std::array<int64_t, 2>> tablet_idxes;
+        for (int i = 0; i < 20; i++) {
+            int64_t partition_id = 70000 + i;
+            int64_t tablet_id = 80000 + i;
+            tablet_idxes.push_back({partition_id, tablet_id});
+        }
+
+        add_tablet_stats(meta_service.get(), instance_id, table_id, index_id, tablet_idxes);
+
+        GetDeleteBitmapUpdateLockResponse res;
+        get_delete_bitmap_update_lock(meta_service.get(), res, db_id, table_id, index_id,
+                                      tablet_idxes, 5, 999999, -1, true);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::KV_TXN_TOO_OLD);
+        ASSERT_EQ(res.base_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), 0);
+        ASSERT_EQ(res.cumulative_points().size(), 0);
     }
 }
 

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -230,6 +230,26 @@ static void insert_rowset(MetaServiceProxy* meta_service, int64_t db_id, const s
     commit_txn(meta_service, db_id, txn_id, label);
 }
 
+static void add_tablet_stats(MetaServiceProxy* meta_service, std::string instance_id,
+                             int64_t table_id, int64_t index_id,
+                             const std::vector<std::array<int64_t, 2>>& tablet_idxes) {
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+
+    for (const auto& idx : tablet_idxes) {
+        int64_t partition_id = idx[0];
+        int64_t tablet_id = idx[1];
+        std::string stats_key =
+                stats_tablet_key({instance_id, table_id, index_id, partition_id, tablet_id});
+        TabletStatsPB stats;
+        stats.set_base_compaction_cnt(10);
+        stats.set_cumulative_compaction_cnt(20);
+        stats.set_cumulative_point(30);
+        txn->put(stats_key, stats.SerializeAsString());
+    }
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+}
+
 TEST(MetaServiceTest, GetInstanceIdTest) {
     extern std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
                                        const std::string& cloud_unique_id);
@@ -4488,7 +4508,7 @@ TEST(MetaServiceTest, GetTabletStatsTest) {
     EXPECT_EQ(res.tablet_stats(0).segment_size(), 40000);
 }
 
-TEST(MetaServiceTest, GetDeleteBitmapUpdateLock) {
+TEST(MetaServiceTest, GetDeleteBitmapUpdateLockNoReadStats) {
     auto meta_service = get_meta_service();
 
     brpc::Controller cntl;
@@ -4528,6 +4548,79 @@ TEST(MetaServiceTest, GetDeleteBitmapUpdateLock) {
     meta_service->get_delete_bitmap_update_lock(
             reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
     ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+}
+
+TEST(MetaServiceTest, GetDeleteBitmapUpdateLockTabletStats) {
+    auto meta_service = get_meta_service();
+
+    {
+        // 1. normal path
+        std::string instance_id = "test_get_delete_bitmap_update_lock_normal";
+        [[maybe_unused]] auto* sp = SyncPoint::get_instance();
+        std::unique_ptr<int, std::function<void(int*)>> defer((int*)0x01, [](int*) {
+            SyncPoint::get_instance()->disable_processing();
+            SyncPoint::get_instance()->clear_all_call_backs();
+        });
+        sp->set_call_back("get_instance_id", [&](auto&& args) {
+            auto* ret = try_any_cast_ret<std::string>(args);
+            ret->first = instance_id;
+            ret->second = true;
+        });
+        sp->enable_processing();
+
+        // store tablet stats
+        int64_t db_id = 1000;
+        int64_t table_id = 2001;
+        int64_t index_id = 3001;
+        // [(partition_id, tablet_id)]
+        std::vector<std::array<int64_t, 2>> tablet_idxes {
+                {70001, 12345}, {80001, 3456}, {90001, 6789}};
+
+        add_tablet_stats(meta_service.get(), instance_id, table_id, index_id, tablet_idxes);
+
+        brpc::Controller cntl;
+        GetDeleteBitmapUpdateLockRequest req;
+        GetDeleteBitmapUpdateLockResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_table_id(table_id);
+        for (const auto& [partition_id, _] : tablet_idxes) {
+            req.add_partition_ids(partition_id);
+        }
+        req.set_expiration(5);
+        req.set_lock_id(999999);
+        req.set_initiator(-1);
+        req.set_require_compaction_stats(true);
+        for (const auto& [partition_id, tablet_id] : tablet_idxes) {
+            TabletIndexPB* idx = req.add_tablet_indexes();
+            idx->set_db_id(db_id);
+            idx->set_table_id(table_id);
+            idx->set_index_id(index_id);
+            idx->set_partition_id(partition_id);
+            idx->set_tablet_id(tablet_id);
+        }
+
+        meta_service->get_delete_bitmap_update_lock(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+
+        ASSERT_EQ(res.base_compaction_cnts().size(), tablet_idxes.size());
+        for (const auto& base_compaction_cnt : res.base_compaction_cnts()) {
+            ASSERT_EQ(base_compaction_cnt, 10);
+        }
+        ASSERT_EQ(res.cumulative_compaction_cnts().size(), tablet_idxes.size());
+        for (const auto& cumu_compaction_cnt : res.cumulative_compaction_cnts()) {
+            ASSERT_EQ(cumu_compaction_cnt, 20);
+        }
+        ASSERT_EQ(res.cumulative_points().size(), tablet_idxes.size());
+        for (const auto& cumulative_point : res.cumulative_points()) {
+            ASSERT_EQ(cumulative_point, 30);
+        }
+    }
+
+    {
+        ;
+        ;
+    }
 }
 
 static std::string generate_random_string(int length) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -922,14 +922,20 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
             List<Long> respBaseCompactionCnts = response.getBaseCompactionCntsList();
             List<Long> respCumulativeCompactionCnts = response.getCumulativeCompactionCntsList();
             List<Long> respCumulativePoints = response.getCumulativePointsList();
-            if (!respBaseCompactionCnts.isEmpty() && !respCumulativeCompactionCnts.isEmpty()
-                    && !respCumulativePoints.isEmpty()) {
-                for (int i = 0; i < tabletList.size(); i++) {
-                    long tabletId = tabletList.get(i);
-                    baseCompactionCnts.put(tabletId, respBaseCompactionCnts.get(i));
-                    cumulativeCompactionCnts.put(tabletId, respCumulativeCompactionCnts.get(i));
-                    cumulativePoints.put(tabletId, respCumulativePoints.get(i));
-                }
+            int size1 = respBaseCompactionCnts.size();
+            int size2 = respCumulativeCompactionCnts.size();
+            int size3 = respCumulativePoints.size();
+            if (size1 != tabletList.size() || size2 != tabletList.size() || size3 != tabletList.size()) {
+                throw new UserException("The size of returned compaction cnts can't match the size of tabletList, "
+                        + "tabletList.size()=" + tabletList.size() + ", respBaseCompactionCnts.size()=" + size1
+                                + ", respCumulativeCompactionCnts.size()=" + size2 + ", respCumulativePoints.size()="
+                                        + size3);
+            }
+            for (int i = 0; i < tabletList.size(); i++) {
+                long tabletId = tabletList.get(i);
+                baseCompactionCnts.put(tabletId, respBaseCompactionCnts.get(i));
+                cumulativeCompactionCnts.put(tabletId, respCumulativeCompactionCnts.get(i));
+                cumulativePoints.put(tabletId, respCumulativePoints.get(i));
             }
             totalRetryTime += retryTime;
         }


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/apache/doris/pull/37670 let the meta service return the tablet compaction stats along with the `getDeleteBitmapUpdateLockResponse` to FE to let the BE know whether it should `sync_rowsets()` due to successful compaction on other BEs on the same tablet. That PR makes the process of reading tablets' stats and writing the delete bitmap update lock KV in one fdb txn to achieve the atomic sematic. However, when a load involves a large number of tablets, the process of reading tablets' stats may take longer than fdb txn's 5 seconds limitation and cause `TXN_TOO_OLD` error.
This PR re-arrange the process so that the read of tablet stats can be not necessarily in the same fdb txn with the txn which update the lock_info.lock_id. In detail, we do as the following:
1. gain the delete bitmap update lock in MS (write delete bitmap update lock KV)
2. read tablets' stats to get the compaction counts.
3. check if the delete bitmap update lock is still held by the current load.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

