### PR TITLE
[opt](explain) wrap the expr list in explain string to make output pretty

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -98,8 +98,8 @@ public abstract class FileScanNode extends ExternalScanNode {
                     .append(getExplainString(conjuncts, prefix)).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
-            output.append(prefix).append("runtime filters: ");
-            output.append(getRuntimeFilterExplainString(false));
+            output.append(prefix).append("runtime filters:\n");
+            output.append(getRuntimeFilterExplainString(false, prefix));
         }
 
         output.append(prefix);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileScanNode.java
@@ -94,7 +94,8 @@ public abstract class FileScanNode extends ExternalScanNode {
         StringBuilder output = new StringBuilder();
         output.append(prefix).append("table: ").append(desc.getTable().getName()).append("\n");
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
             output.append(prefix).append("runtime filters: ");

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/source/EsScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/source/EsScanNode.java
@@ -327,20 +327,21 @@ public class EsScanNode extends ExternalScanNode {
     @Override
     public String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
-        output.append(prefix).append("TABLE: ").append(table.getName()).append("\n");
+        output.append(prefix).append("table: ").append(table.getName()).append("\n");
 
         if (detailLevel == TExplainLevel.BRIEF) {
             return output.toString();
         }
 
         if (null != sortColumn) {
-            output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");
+            output.append(prefix).append("sort column: ").append(sortColumn).append("\n");
         }
 
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("LOCAL_PREDICATES: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("local predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
-        output.append(prefix).append("REMOTE_PREDICATES: ").append(queryBuilder.toJson()).append("\n");
+        output.append(prefix).append("remote predicates: ").append(queryBuilder.toJson()).append("\n");
         String indexName = table.getIndexName();
         String typeName = table.getMappingType();
         output.append(prefix).append(String.format("ES index/type: %s/%s", indexName, typeName)).append("\n");
@@ -348,7 +349,7 @@ public class EsScanNode extends ExternalScanNode {
             String topnFilterSources = String.join(",",
                     topnFilterSortNodes.stream()
                             .map(node -> node.getId().asInt() + "").collect(Collectors.toList()));
-            output.append(prefix).append("TOPN OPT:").append(topnFilterSources).append("\n");
+            output.append(prefix).append("topn opt:").append(topnFilterSources).append("\n");
         }
         return output.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -398,19 +398,21 @@ public class AggregationNode extends PlanNode {
         if (aggInfo.getAggregateExprs() != null && aggInfo.getMaterializedAggregateExprs().size() > 0) {
             List<String> labels = aggInfo.getMaterializedAggregateExprLabels();
             if (labels.isEmpty()) {
-                output.append(detailPrefix).append("output: ")
-                        .append(getExplainString(aggInfo.getMaterializedAggregateExprs())).append("\n");
+                output.append(detailPrefix).append("output:\n")
+                        .append(getExplainString(aggInfo.getMaterializedAggregateExprs(),
+                                detailPrefix)).append("\n");
             } else {
                 output.append(detailPrefix).append("output: ")
                         .append(StringUtils.join(labels, ", ")).append("\n");
             }
         }
         // TODO: group by can be very long. Break it into multiple lines
-        output.append(detailPrefix).append("group by: ")
-                .append(getExplainString(aggInfo.getGroupingExprs()))
+        output.append(detailPrefix).append("group by:\n")
+                .append(getExplainString(aggInfo.getGroupingExprs(), detailPrefix))
                 .append("\n");
         if (!conjuncts.isEmpty()) {
-            output.append(detailPrefix).append("having: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(detailPrefix).append("having:\n")
+                    .append(getExplainString(conjuncts, detailPrefix)).append("\n");
         }
         output.append(detailPrefix).append("sortByGroupKey:").append(sortByGroupKey != null).append("\n");
         output.append(detailPrefix).append(String.format(

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
@@ -291,7 +291,7 @@ public class AnalyticEvalNode extends PlanNode {
         }
 
         if (!conjuncts.isEmpty()) {
-            output.append(prefix + "predicates: " + getExplainString(conjuncts) + "\n");
+            output.append(prefix + "predicates:\n" + getExplainString(conjuncts, prefix) + "\n");
         }
 
         return output.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
@@ -96,7 +96,8 @@ public class AssertNumRowsNode extends PlanNode {
                 .append(assertion).append(" ").append(desiredNumOfRows).append("\n");
 
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
 
         return output.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DataGenScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DataGenScanNode.java
@@ -143,7 +143,8 @@ public class DataGenScanNode extends ExternalScanNode {
         StringBuilder output = new StringBuilder();
 
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
         output.append(prefix).append("table value function: ").append(tvf.getDataGenFunctionName()).append("\n");
         if (useTopnFilter()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DataStreamSink.java
@@ -157,23 +157,23 @@ public class DataStreamSink extends DataSink {
     @Override
     public String getExplainString(String prefix, TExplainLevel explainLevel) {
         StringBuilder strBuilder = new StringBuilder();
-        strBuilder.append(prefix).append("STREAM DATA SINK\n");
-        strBuilder.append(prefix).append("  EXCHANGE ID: ").append(exchNodeId);
+        strBuilder.append(prefix).append("stream data sink\n");
+        strBuilder.append(prefix).append("  exchange id: ").append(exchNodeId);
         if (outputPartition != null) {
             strBuilder.append("\n").append(prefix).append("  ").append(outputPartition.getExplainString(explainLevel));
         }
         if (!conjuncts.isEmpty()) {
             Expr expr = PlanNode.convertConjunctsToAndCompoundPredicate(conjuncts);
-            strBuilder.append(prefix).append("  CONJUNCTS: ").append(expr.toSql()).append("\n");
+            strBuilder.append(prefix).append("  conjuncts: ").append(expr.toSql()).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
             strBuilder.append(prefix).append("  runtime filters: ");
             strBuilder.append(getRuntimeFilterExplainString(false, false));
         }
         if (!CollectionUtils.isEmpty(projections)) {
-            strBuilder.append(prefix).append("  PROJECTIONS: ")
-                    .append(PlanNode.getExplainString(projections)).append("\n");
-            strBuilder.append(prefix).append("  PROJECTION TUPLE: ").append(outputTupleDesc.getId());
+            strBuilder.append(prefix).append("  projections:\n")
+                    .append(PlanNode.getExplainString(projections, prefix)).append("\n");
+            strBuilder.append(prefix).append("  projection tuple: ").append(outputTupleDesc.getId());
             strBuilder.append("\n");
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DataStreamSink.java
@@ -157,7 +157,7 @@ public class DataStreamSink extends DataSink {
     @Override
     public String getExplainString(String prefix, TExplainLevel explainLevel) {
         StringBuilder strBuilder = new StringBuilder();
-        strBuilder.append(prefix).append("stream data sink\n");
+        strBuilder.append(prefix).append("STREAM_DATA_SINK\n");
         strBuilder.append(prefix).append("  exchange id: ").append(exchNodeId);
         if (outputPartition != null) {
             strBuilder.append("\n").append(prefix).append("  ").append(outputPartition.getExplainString(explainLevel));

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -845,15 +845,16 @@ public class HashJoinNode extends JoinNodeBase {
             output.append(detailPrefix).append("equal join conjunct: ").append(eqJoinPredicate.toSql()).append("\n");
         }
         if (!otherJoinConjuncts.isEmpty()) {
-            output.append(detailPrefix).append("other join predicates: ")
-                    .append(getExplainString(otherJoinConjuncts)).append("\n");
+            output.append(detailPrefix).append("other join predicates:\n")
+                    .append(getExplainString(otherJoinConjuncts, detailPrefix)).append("\n");
         }
         if (markJoinConjuncts != null && !markJoinConjuncts.isEmpty()) {
-            output.append(detailPrefix).append("mark join predicates: ")
-                    .append(getExplainString(markJoinConjuncts)).append("\n");
+            output.append(detailPrefix).append("mark join predicates:\n")
+                    .append(getExplainString(markJoinConjuncts, detailPrefix)).append("\n");
         }
         if (!conjuncts.isEmpty()) {
-            output.append(detailPrefix).append("other predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(detailPrefix).append("other predicates:\n")
+                    .append(getExplainString(conjuncts, detailPrefix)).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
             output.append(detailPrefix).append("runtime filters: ");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -835,8 +835,8 @@ public class HashJoinNode extends JoinNodeBase {
             output.append(detailPrefix).append(
                     String.format("cardinality=%,d", cardinality)).append("\n");
             if (!runtimeFilters.isEmpty()) {
-                output.append(detailPrefix).append("runtime filters: ");
-                output.append(getRuntimeFilterExplainString(true, true));
+                output.append(detailPrefix).append("runtime filters:\n");
+                output.append(getRuntimeFilterExplainString(true, true, detailPrefix));
             }
             return output.toString();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -857,8 +857,8 @@ public class HashJoinNode extends JoinNodeBase {
                     .append(getExplainString(conjuncts, detailPrefix)).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
-            output.append(detailPrefix).append("runtime filters: ");
-            output.append(getRuntimeFilterExplainString(true));
+            output.append(detailPrefix).append("runtime filters:\n");
+            output.append(getRuntimeFilterExplainString(true, detailPrefix));
         }
         output.append(detailPrefix).append(String.format("cardinality=%,d", cardinality)).append("\n");
         if (outputTupleDesc != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
@@ -244,16 +244,18 @@ public class NestedLoopJoinNode extends JoinNodeBase {
         }
 
         if (!joinConjuncts.isEmpty()) {
-            output.append(detailPrefix).append("join conjuncts: ").append(getExplainString(joinConjuncts)).append("\n");
+            output.append(detailPrefix).append("join conjuncts:\n")
+                    .append(getExplainString(joinConjuncts, detailPrefix)).append("\n");
         }
 
         if (markJoinConjuncts != null && !markJoinConjuncts.isEmpty()) {
-            output.append(detailPrefix).append("mark join predicates: ")
-                    .append(getExplainString(markJoinConjuncts)).append("\n");
+            output.append(detailPrefix).append("mark join predicates:\n")
+                    .append(getExplainString(markJoinConjuncts, detailPrefix)).append("\n");
         }
 
         if (!conjuncts.isEmpty()) {
-            output.append(detailPrefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(detailPrefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, detailPrefix)).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
             output.append(detailPrefix).append("runtime filters: ");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
@@ -259,7 +259,7 @@ public class NestedLoopJoinNode extends JoinNodeBase {
         }
         if (!runtimeFilters.isEmpty()) {
             output.append(detailPrefix).append("runtime filters: ");
-            output.append(getRuntimeFilterExplainString(true));
+            output.append(getRuntimeFilterExplainString(true, detailPrefix));
         }
         output.append(detailPrefix).append("is output left side only: ").append(isOutputLeftSideOnly).append("\n");
         output.append(detailPrefix).append(String.format("cardinality=%,d", cardinality)).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1374,8 +1374,8 @@ public class OlapScanNode extends ScanNode {
             output.append(prefix).append("PREDICATES: ").append(expr.toSql()).append("\n");
         }
         if (!runtimeFilters.isEmpty()) {
-            output.append(prefix).append("runtime filters: ");
-            output.append(getRuntimeFilterExplainString(false));
+            output.append(prefix).append("runtime filters:\n");
+            output.append(getRuntimeFilterExplainString(false, prefix));
         }
 
         String selectedPartitions = getSelectedPartitionIds().stream().sorted()

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1404,8 +1404,8 @@ public class OlapScanNode extends ScanNode {
         }
 
         if (!CollectionUtils.isEmpty(rewrittenProjectList)) {
-            output.append(prefix).append("rewrittenProjectList: ").append(
-                    getExplainString(rewrittenProjectList)).append("\n");
+            output.append(prefix).append("rewrittenProjectList:\n").append(
+                    getExplainString(rewrittenProjectList, prefix)).append("\n");
         }
 
         return output.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1335,8 +1335,8 @@ public class OlapScanNode extends ScanNode {
                 output.append("\n").append(prefix).append(String.format("afterFilter=%,d", cardinalityAfterFilter));
             }
             if (!runtimeFilters.isEmpty()) {
-                output.append("\n").append(prefix).append("Apply RFs: ");
-                output.append(getRuntimeFilterExplainString(false, true));
+                output.append("\n").append(prefix).append("Apply RFs:\n");
+                output.append(getRuntimeFilterExplainString(false, true, prefix));
             }
             if (!conjuncts.isEmpty()) {
                 output.append("\n").append(prefix).append("PREDICATES: ").append(conjuncts.size()).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionSortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionSortNode.java
@@ -121,7 +121,8 @@ public class PartitionSortNode extends PlanNode {
         output.append("\n");
 
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
 
         // Add the limit information;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -998,7 +998,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         // [prefix  ]expr1,
         // [prefix  ]expr2,
         // [prefix  ]expr3
-        return Joiner.on(",\n").join(exprs.stream()
+        return Joiner.on("\n").join(exprs.stream()
                 .map(expr -> prefix + "  " + expr.toSql()).collect(Collectors.toList()));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -1206,19 +1206,24 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         runtimeFilters.clear();
     }
 
-    protected String getRuntimeFilterExplainString(boolean isBuildNode, boolean isBrief) {
+    protected String getRuntimeFilterExplainString(boolean isBuildNode, boolean isBrief, String prefix) {
         if (runtimeFilters.isEmpty()) {
             return "";
         }
         List<String> filtersStr = new ArrayList<>();
         for (RuntimeFilter filter : runtimeFilters) {
-            filtersStr.add(filter.getExplainString(isBuildNode, isBrief, getId()));
+            filtersStr.add(prefix + "  " + filter.getExplainString(isBuildNode, isBrief, getId()));
         }
-        return Joiner.on(", ").join(filtersStr) + "\n";
+        return Joiner.on("\n").join(filtersStr) + "\n";
     }
 
+    protected String getRuntimeFilterExplainString(boolean isBuildNode, String prefix) {
+        return getRuntimeFilterExplainString(isBuildNode, false, prefix);
+    }
+
+    // For test only
     protected String getRuntimeFilterExplainString(boolean isBuildNode) {
-        return getRuntimeFilterExplainString(isBuildNode, false);
+        return getRuntimeFilterExplainString(isBuildNode, false, "");
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -599,7 +599,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         return expBuilder.toString();
     }
 
-    private String getplanNodeExplainString(String prefix, TExplainLevel detailLevel) {
+    private String getPlanNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder expBuilder = new StringBuilder();
         expBuilder.append(getNodeExplainString(prefix, detailLevel));
         if (limit != -1) {
@@ -615,7 +615,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
     }
 
     public void getExplainStringMap(TExplainLevel detailLevel, Map<Integer, String> planNodeMap) {
-        planNodeMap.put(id.asInt(), getplanNodeExplainString("", detailLevel));
+        planNodeMap.put(id.asInt(), getPlanNodeExplainString("", detailLevel));
         for (int i = 0; i < children.size(); ++i) {
             children.get(i).getExplainStringMap(detailLevel, planNodeMap);
         }
@@ -995,10 +995,11 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         }
         // expr1, expr2, expr3
         // ==>
-        // [prefix]expr1,
-        // [prefix]expr2,
-        // [prefix]expr3
-        return Joiner.on(",\n").join(exprs.stream().map(expr -> prefix + expr.toSql()).collect(Collectors.toList()));
+        // [prefix  ]expr1,
+        // [prefix  ]expr2,
+        // [prefix  ]expr3
+        return Joiner.on(",\n").join(exprs.stream()
+                .map(expr -> prefix + "  " + expr.toSql()).collect(Collectors.toList()));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -551,24 +551,25 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
             expBuilder.append(detailPrefix + "limit: " + limit + "\n");
         }
         if (!CollectionUtils.isEmpty(projectList)) {
-            expBuilder.append(detailPrefix).append("final projections: ")
-                .append(getExplainString(projectList)).append("\n");
+            expBuilder.append(detailPrefix).append("final projections:\n")
+                .append(getExplainString(projectList, detailPrefix)).append("\n");
             expBuilder.append(detailPrefix).append("final project output tuple id: ")
                     .append(outputTupleDesc.getId().asInt()).append("\n");
         }
         if (!intermediateProjectListList.isEmpty()) {
             int layers = intermediateProjectListList.size();
             for (int i = layers - 1; i >= 0; i--) {
-                expBuilder.append(detailPrefix).append("intermediate projections: ")
-                        .append(getExplainString(intermediateProjectListList.get(i))).append("\n");
+                expBuilder.append(detailPrefix).append("intermediate projections:\n")
+                        .append(getExplainString(intermediateProjectListList.get(i),
+                                detailPrefix)).append("\n");
                 expBuilder.append(detailPrefix).append("intermediate tuple id: ")
                         .append(intermediateOutputTupleDescList.get(i).getId().asInt()).append("\n");
             }
         }
         if (!CollectionUtils.isEmpty(childrenDistributeExprLists)) {
             for (List<Expr> distributeExprList : childrenDistributeExprLists) {
-                expBuilder.append(detailPrefix).append("distribute expr lists: ")
-                    .append(getExplainString(distributeExprList)).append("\n");
+                expBuilder.append(detailPrefix).append("distribute expr lists:\n")
+                    .append(getExplainString(distributeExprList, detailPrefix + detailPrefix)).append("\n");
             }
         }
         // Output Tuple Ids only when explain plan level is set to verbose
@@ -605,7 +606,8 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
             expBuilder.append(prefix + "limit: " + limit + "\n");
         }
         if (!CollectionUtils.isEmpty(projectList)) {
-            expBuilder.append(prefix).append("projections: ").append(getExplainString(projectList)).append("\n");
+            expBuilder.append(prefix).append("projections:\n")
+                    .append(getExplainString(projectList, prefix)).append("\n");
             expBuilder.append(prefix).append("project output tuple id: ")
                     .append(outputTupleDesc.getId().asInt()).append("\n");
         }
@@ -987,18 +989,16 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         return output.toString();
     }
 
-    public static String getExplainString(List<? extends Expr> exprs) {
+    public static String getExplainString(List<? extends Expr> exprs, String prefix) {
         if (exprs == null) {
             return "";
         }
-        StringBuilder output = new StringBuilder();
-        for (int i = 0; i < exprs.size(); ++i) {
-            if (i > 0) {
-                output.append(", ");
-            }
-            output.append(exprs.get(i).toSql());
-        }
-        return output.toString();
+        // expr1, expr2, expr3
+        // ==>
+        // [prefix]expr1,
+        // [prefix]expr2,
+        // [prefix]expr3
+        return Joiner.on(",\n").join(exprs.stream().map(expr -> prefix + expr.toSql()).collect(Collectors.toList()));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RepeatNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RepeatNode.java
@@ -191,7 +191,8 @@ public class RepeatNode extends PlanNode {
         output.append(repeatSlotIdList.size() - 1);
         output.append(" lines ");
         output.append(repeatSlotIdList).append("\n");
-        output.append(detailPrefix).append("exprs: ").append(getExplainString(groupingInfo.getPreRepeatExprs()));
+        output.append(detailPrefix).append("exprs:\n")
+                .append(getExplainString(groupingInfo.getPreRepeatExprs(), detailPrefix));
         output.append("\n");
         if (CollectionUtils.isNotEmpty(outputTupleDesc.getSlots())) {
             output.append(detailPrefix + "output slots: ");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
@@ -105,7 +105,8 @@ public class SelectNode extends PlanNode {
         }
         StringBuilder output = new StringBuilder();
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
         return output.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SetOperationNode.java
@@ -426,7 +426,8 @@ public abstract class SetOperationNode extends PlanNode {
         // A SetOperationNode may have predicates if a union is set operation inside an inline view,
         // and the enclosing select stmt has predicates referring to the inline view.
         if (CollectionUtils.isNotEmpty(conjuncts)) {
-            output.append(prefix).append("predicates: ").append(getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n")
+                    .append(getExplainString(conjuncts, prefix)).append("\n");
         }
         if (CollectionUtils.isNotEmpty(constExprLists)) {
             output.append(prefix).append("constant exprs: ").append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -215,8 +215,8 @@ public class TableFunctionNode extends PlanNode {
         output.append("\n");
 
         if (!conjuncts.isEmpty()) {
-            output.append(prefix).append("PREDICATES: ").append(
-                    getExplainString(conjuncts)).append("\n");
+            output.append(prefix).append("predicates:\n").append(
+                    getExplainString(conjuncts, prefix)).append("\n");
         }
         output.append(prefix).append(String.format("cardinality=%,d", cardinality)).append("\n");
         return output.toString();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RuntimeFilterGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RuntimeFilterGeneratorTest.java
@@ -262,11 +262,11 @@ public class RuntimeFilterGeneratorTest {
         };
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         Assert.assertEquals(hashJoinNode.getRuntimeFilterExplainString(true),
-                        "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n",
+                        "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n",
                         hashJoinNode.getRuntimeFilterExplainString(true));
         Assert.assertEquals(lhsScanNode.getRuntimeFilterExplainString(false),
                         lhsScanNode.getRuntimeFilterExplainString(false),
-                        "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
+                        "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 1);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 1);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 1);
@@ -282,9 +282,9 @@ public class RuntimeFilterGeneratorTest {
         };
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         Assert.assertEquals(hashJoinNode.getRuntimeFilterExplainString(true),
-                "RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n");
+                "  RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n");
         Assert.assertEquals(lhsScanNode.getRuntimeFilterExplainString(false),
-                "RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
+                "  RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 1);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 1);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 1);
@@ -301,14 +301,14 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         String rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString, rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString, rfString.contains(
-                "RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString, rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString, rfString.contains(
-                "RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 2);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 2);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 2);
@@ -324,9 +324,9 @@ public class RuntimeFilterGeneratorTest {
         };
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         Assert.assertEquals(hashJoinNode.getRuntimeFilterExplainString(true),
-                "RF000[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n");
+                "  RF000[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n");
         Assert.assertEquals(lhsScanNode.getRuntimeFilterExplainString(false),
-                "RF000[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
+                "  RF000[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 1);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 1);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 1);
@@ -343,14 +343,14 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 2);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 2);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 2);
@@ -367,15 +367,15 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
 
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 2);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 2);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 2);
@@ -392,18 +392,18 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF002[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF002[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF002[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF002[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 3);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 3);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 3);
@@ -419,9 +419,9 @@ public class RuntimeFilterGeneratorTest {
         };
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         Assert.assertEquals(hashJoinNode.getRuntimeFilterExplainString(true),
-                "RF000[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n");
+                "  RF000[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)(-1/0/2097152)\n");
         Assert.assertEquals(lhsScanNode.getRuntimeFilterExplainString(false),
-                "RF000[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
+                "  RF000[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`\n");
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 1);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 1);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 1);
@@ -438,15 +438,15 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
 
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 2);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 2);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 2);
@@ -463,14 +463,14 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 2);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 2);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 2);
@@ -487,18 +487,18 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF002[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF002[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF002[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF002[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 3);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 3);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 3);
@@ -515,14 +515,14 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                        "RF001[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                        "  RF001[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 2);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 2);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 2);
@@ -539,18 +539,18 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                        "RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                        "  RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                        "RF002[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                        "  RF002[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                        "RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                        "  RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                        "RF002[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                        "  RF002[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 3);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 3);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 3);
@@ -568,18 +568,18 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                "RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF001[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                        "RF002[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                        "  RF002[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                        "RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                        "  RF001[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                        "RF002[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                        "  RF002[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 3);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 3);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 3);
@@ -596,22 +596,22 @@ public class RuntimeFilterGeneratorTest {
         RuntimeFilterGenerator.generateRuntimeFilters(analyzer, hashJoinNode);
         rfString = hashJoinNode.getRuntimeFilterExplainString(true);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                "  RF000[in] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                        "RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                        "  RF001[bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                        "RF002[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                        "  RF002[min_max] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         Assert.assertTrue(rfString.contains(
-                        "RF003[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
+                        "  RF003[in_or_bloom] <- CAST(`test_db`.`test_rhs_tbl`.`test_rhs_col` AS bigint)"));
         rfString = lhsScanNode.getRuntimeFilterExplainString(false);
         Assert.assertTrue(rfString.contains(
-                "RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF000[in] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF001[bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                "RF002[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                "  RF002[min_max] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertTrue(rfString.contains(
-                        "RF003[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
+                        "  RF003[in_or_bloom] -> `test_db`.`test_lhs_tbl`.`test_lhs_col`"));
         Assert.assertEquals(testPlanFragment.getTargetRuntimeFilterIds().size(), 4);
         Assert.assertEquals(testPlanFragment.getBuilderRuntimeFilterIds().size(), 4);
         Assert.assertEquals(analyzer.getAssignedRuntimeFilter().size(), 4);

--- a/regression-test/suites/nereids_p0/compress_materialize/compress_materialize.groovy
+++ b/regression-test/suites/nereids_p0/compress_materialize/compress_materialize.groovy
@@ -73,12 +73,12 @@ suite("compress_materialize") {
 
     explain {
         sql("select sum(v) from compress group by substring(k, 1, 3);")
-        contains("group by: encode_as_int(substring(k, 1, 3))")
+        contains("encode_as_int(substring(k, 1, 3))")
     }
 
     explain {
         sql("select sum(v) from compress group by substring(k, 1, 4);")
-        contains("group by: encode_as_bigint(substring(k, 1, 4))")
+        contains("encode_as_bigint(substring(k, 1, 4))")
     }
 
     order_qt_encodeexpr "select sum(v) from compress group by substring(k, 1, 3);"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Optimize the format of explain string:
Before:
```
final projections: c_custkey[#17], c_name[#18], c_address[#19], c_nationkey[#20], c_phone[#21], c_acctbal[#22], c_comment[#24]
```
If there are too many project columns, the line is too long and not friendly for command line tools.

After:
```
final projections: 
  c_custkey[#17]
  c_name[#18]
  c_address[#19]
  c_nationkey[#20]
  c_phone[#21]
  c_acctbal[#22]
  c_comment[#24]
```
wrap each column to make line short.

Same format for `runtime filter list` and other lists in explain result

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

