### PR TITLE
[fix](export) Make enable_outfile_to_local available for export command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -47,6 +47,7 @@ import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -145,6 +146,11 @@ public class ExportStmt extends StatementBase implements NotFallbackInParser {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
+
+        if (!Config.enable_outfile_to_local && Objects.requireNonNull(path)
+                .startsWith(OutFileClause.LOCAL_FILE_PREFIX)) {
+            throw new AnalysisException("`enable_outfile_to_local` = false, exporting file to local fs is disabled.");
+        }
 
         tableRef = analyzer.resolveTableRef(tableRef);
         Preconditions.checkNotNull(tableRef);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExportCommand.java
@@ -140,6 +140,10 @@ public class ExportCommand extends Command implements ForwardWithSync {
                     tblName.getDb() + ": " + tblName.getTbl());
         }
 
+        if (!Config.enable_outfile_to_local && path.startsWith(OutFileClause.LOCAL_FILE_PREFIX)) {
+            throw new AnalysisException("`enable_outfile_to_local` = false, exporting file to local fs is disabled.");
+        }
+
         // check phases
         checkAllParameters(ctx, tblName, fileProperties);
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`enable_outfile_to_local` previously not work to control export command.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
       ```
        2024-12-10 16:34:34.298 ERROR [suite-thread-1] (ScriptContext.groovy:122) - Run test_export_basic in /mnt/disk1/tangsiyang/src/doris/regression-test/suites/export_p0/test_export_basic.groovy failed
java.sql.SQLException: errCode = 2, detailMessage = `enable_outfile_to_local` = false, exporting file to local fs is disabled.
       ```
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

