### PR TITLE
[Refactor](function) make all Datetime arithmetic operation overflow lead to exception in BE

### DIFF
--- a/be/src/util/datetype_cast.hpp
+++ b/be/src/util/datetype_cast.hpp
@@ -29,8 +29,10 @@
 /*
  * We use these function family to clarify our types of datelike type. for example:
  *      DataTypeDate -------------------> ColumnDate -----------------------> Int64
- *           |          TypeToColumn                    ValueTypeOfColumn
- *           | TypeToValueType
+ *           |   |      TypeToColumn                    ValueTypeOfColumn       |
+ *           |   ↘--------------------------------------------------------------↗
+ *           |                           ::FieldType
+ *           ↓ TypeToValueType
  *      VecDateTimeValue
  */
 namespace doris::date_cast {
@@ -102,6 +104,7 @@ constexpr bool IsV1() {
                              std::is_same_v<Type, vectorized::Int64>);
 }
 
+// only for datelike types.
 template <typename Type>
 constexpr bool IsV2() {
     return !IsV1<Type>();

--- a/be/src/vec/common/typeid_cast.h
+++ b/be/src/vec/common/typeid_cast.h
@@ -20,14 +20,11 @@
 
 #pragma once
 
-#include <string>
 #include <type_traits>
-#include <typeindex>
 #include <typeinfo>
 
 #include "common/exception.h"
 #include "common/status.h"
-#include "vec/common/demangle.h"
 
 /** Checks type by comparing typeid.
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.

--- a/be/src/vec/functions/array/function_array_range.cpp
+++ b/be/src/vec/functions/array/function_array_range.cpp
@@ -16,10 +16,10 @@
 // under the License.
 
 #include <glog/logging.h>
-#include <stddef.h>
 
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
+#include <cstddef>
 #include <memory>
 #include <utility>
 
@@ -41,11 +41,11 @@
 #include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_time_v2.h"
 #include "vec/functions/function.h"
 #include "vec/functions/function_date_or_datetime_computation.h"
 #include "vec/functions/simple_function_factory.h"
 #include "vec/runtime/vdatetime_value.h"
-#include "vec/utils/util.hpp"
 
 namespace doris {
 class FunctionContext;
@@ -229,10 +229,9 @@ private:
                         dest_nested_null_map.push_back(0);
                         offset++;
                         move++;
-                        idx = doris::vectorized::date_time_add<
-                                UNIT::value, DateV2Value<DateTimeV2ValueType>,
-                                DateV2Value<DateTimeV2ValueType>, DateTimeV2>(idx, step_row,
-                                                                              is_null);
+                        idx = doris::vectorized::date_time_add<UNIT::value, DataTypeDateTimeV2,
+                                                               DataTypeDateTimeV2>(idx, step_row,
+                                                                                   is_null);
                     }
                     dest_offsets.push_back(offset);
                 }

--- a/be/src/vec/functions/function_date_or_datetime_computation.cpp
+++ b/be/src/vec/functions/function_date_or_datetime_computation.cpp
@@ -55,7 +55,7 @@ using FunctionWeeksDiff =
 using FunctionHoursDiff =
         FunctionDateOrDateTimeComputation<HoursDiffImpl<DataTypeDateTime, DataTypeDateTime>>;
 using FunctionMinutesDiff =
-        FunctionDateOrDateTimeComputation<MintueSDiffImpl<DataTypeDateTime, DataTypeDateTime>>;
+        FunctionDateOrDateTimeComputation<MintuesDiffImpl<DataTypeDateTime, DataTypeDateTime>>;
 using FunctionSecondsDiff =
         FunctionDateOrDateTimeComputation<SecondsDiffImpl<DataTypeDateTime, DataTypeDateTime>>;
 
@@ -68,6 +68,7 @@ struct NowFunctionName {
     static constexpr auto name = "now";
 };
 
+//TODO: remove the inter-layer CurrentDateTimeImpl
 using FunctionNow = FunctionCurrentDateOrDateTime<CurrentDateTimeImpl<NowFunctionName, false>>;
 
 using FunctionNowWithPrecision =

--- a/be/src/vec/functions/function_date_or_datetime_computation_v2.cpp
+++ b/be/src/vec/functions/function_date_or_datetime_computation_v2.cpp
@@ -95,14 +95,14 @@ using FunctionDatetimeV2SubYears =
     FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, DataTypeDateTimeV2, DataTypeDateV2)     \
     FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, DataTypeDateV2, DataTypeDateTimeV2)     \
     FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, DataTypeDateV2, DataTypeDateV2)
-
+// these diff functions accept all v2 types. but for v1 only datetime.
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2DateDiff, DateDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2TimeDiff, TimeDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2YearsDiff, YearsDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MonthsDiff, MonthsDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2WeeksDiff, WeeksDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2HoursDiff, HoursDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MinutesDiff, MintueSDiffImpl)
+ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MinutesDiff, MintuesDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2SecondsDiff, SecondsDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2DaysDiff, DaysDiffImpl)
 ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MilliSecondsDiff, MilliSecondsDiffImpl)

--- a/be/src/vec/functions/function_helpers.h
+++ b/be/src/vec/functions/function_helpers.h
@@ -20,10 +20,8 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <tuple>
-#include <type_traits>
 
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
@@ -53,11 +51,15 @@ const Type* check_and_get_data_type(const IDataType* data_type) {
 
 template <typename Type>
 const ColumnConst* check_and_get_column_const(const IColumn* column) {
-    if (!column || !is_column_const(*column)) return {};
+    if (!column || !is_column_const(*column)) {
+        return nullptr;
+    }
 
-    const ColumnConst* res = assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(column);
+    const auto* res = assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(column);
 
-    if (!check_column<Type>(&res->get_data_column())) return {};
+    if (!check_column<Type>(&res->get_data_column())) {
+        return nullptr;
+    }
 
     return res;
 }
@@ -66,7 +68,9 @@ template <typename Type>
 const Type* check_and_get_column_constData(const IColumn* column) {
     const ColumnConst* res = check_and_get_column_const<Type>(column);
 
-    if (!res) return {};
+    if (!res) {
+        return nullptr;
+    }
 
     return static_cast<const Type*>(&res->get_data_column());
 }

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -69,7 +69,7 @@ using Row = std::pair<CellSet, Expect>;
 using DataSet = std::vector<Row>;
 using InputTypeSet = std::vector<AnyType>;
 
-// FIXME: should use exception or expected to deal null value.w
+// FIXME: should use exception or expected to deal null value.
 int64_t str_to_date_time(std::string datetime_str, bool data_time = true);
 uint32_t str_to_date_v2(std::string datetime_str, std::string datetime_format);
 uint64_t str_to_datetime_v2(std::string datetime_str, std::string datetime_format);

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iomanip>
@@ -299,14 +300,22 @@ TEST(VTimestampFunctionsTest, years_add_test) {
 
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
-    DataSet data_set = {
-            {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2025-05-23 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2015-05-23 00:00:00")},
-            {{std::string(""), 5}, Null()},
-            {{std::string("2020-05-23 00:00:00"), 8000}, Null()},
-            {{Null(), 5}, Null()}};
+    {
+        DataSet data_set = {
+                {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2025-05-23 00:00:00")},
+                {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2015-05-23 00:00:00")},
+                {{std::string(""), 5}, Null()},
+                {{Null(), 5}, Null()}};
 
-    static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+
+    {
+        DataSet data_set = {{{std::string("2020-05-23 00:00:00"), 8000}, Null()}};
+
+        EXPECT_ANY_THROW(static_cast<void>(
+                check_function<DataTypeDateTime, true>(func_name, input_types, data_set)));
+    }
 }
 
 TEST(VTimestampFunctionsTest, years_sub_test) {
@@ -314,14 +323,22 @@ TEST(VTimestampFunctionsTest, years_sub_test) {
 
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
-    DataSet data_set = {
-            {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2015-05-23 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2025-05-23 00:00:00")},
-            {{std::string(""), 5}, Null()},
-            {{std::string("2020-05-23 00:00:00"), 3000}, Null()},
-            {{Null(), 5}, Null()}};
+    {
+        DataSet data_set = {
+                {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2015-05-23 00:00:00")},
+                {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2025-05-23 00:00:00")},
+                {{std::string(""), 5}, Null()},
+                {{Null(), 5}, Null()}};
 
-    static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+
+    {
+        DataSet data_set = {{{std::string("2020-05-23 00:00:00"), 3000}, Null()}};
+
+        EXPECT_ANY_THROW(static_cast<void>(
+                check_function<DataTypeDateTime, true>(func_name, input_types, data_set)));
+    }
 }
 
 TEST(VTimestampFunctionsTest, months_add_test) {
@@ -1043,10 +1060,17 @@ TEST(VTimestampFunctionsTest, years_add_v2_test) {
                 {{std::string("2020-05-23"), 5}, str_to_date_v2("2025-05-23", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -5}, str_to_date_v2("2015-05-23", "%Y-%m-%d")},
                 {{std::string(""), 5}, Null()},
-                {{std::string("2020-05-23"), 8000}, Null()},
                 {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
+
+        DataSet data_set = {{{std::string("2020-05-23"), 8000}, Null()}};
+
+        EXPECT_ANY_THROW(static_cast<void>(
+                check_function<DataTypeDateV2, true>(func_name, input_types, data_set)));
     }
 
     {
@@ -1057,11 +1081,18 @@ TEST(VTimestampFunctionsTest, years_add_v2_test) {
                             {{std::string("2020-05-23 00:00:11.123"), -5},
                              str_to_datetime_v2("2015-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string(""), 5}, Null()},
-                            {{std::string("2020-05-23 00:00:11.123"), 8000}, Null()},
                             {{Null(), 5}, Null()}};
 
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
+
+        DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 8000}, Null()}};
+
+        EXPECT_ANY_THROW(static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set)));
     }
 }
 
@@ -1075,11 +1106,19 @@ TEST(VTimestampFunctionsTest, years_sub_v2_test) {
                 {{std::string("2020-05-23"), 5}, str_to_date_v2("2015-05-23", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -5}, str_to_date_v2("2025-05-23", "%Y-%m-%d")},
                 {{std::string(""), 5}, Null()},
-                {{std::string("2020-05-23"), 3000}, Null()},
                 {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
+    {
+        InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
+
+        DataSet data_set = {{{std::string("2020-05-23"), 3000}, Null()}};
+
+        EXPECT_ANY_THROW(static_cast<void>(
+                check_function<DataTypeDateV2, true>(func_name, input_types, data_set)));
+    }
+
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
@@ -1088,11 +1127,18 @@ TEST(VTimestampFunctionsTest, years_sub_v2_test) {
                             {{std::string("2020-05-23 00:00:11.123"), -5},
                              str_to_datetime_v2("2025-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string(""), 5}, Null()},
-                            {{std::string("2020-05-23 00:00:11.123"), 3000}, Null()},
                             {{Null(), 5}, Null()}};
 
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
+
+        DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 3000}, Null()}};
+
+        EXPECT_ANY_THROW(static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set)));
     }
 }
 

--- a/regression-test/suites/correctness/test_date_function_const.groovy
+++ b/regression-test/suites/correctness/test_date_function_const.groovy
@@ -61,6 +61,6 @@ suite("test_date_function_const") {
 
     test {
         sql """select date_add("1900-01-01 12:00:00.123456", interval 10000000000 month);"""
-        exception "Operation months_add 133705200962757184 1410065408 out of range"
+        exception "Operation months_add of 133705200962757184 1410065408 out of range"
     }
 }

--- a/regression-test/suites/correctness/test_date_function_const.groovy
+++ b/regression-test/suites/correctness/test_date_function_const.groovy
@@ -61,6 +61,6 @@ suite("test_date_function_const") {
 
     test {
         sql """select date_add("1900-01-01 12:00:00.123456", interval 10000000000 month);"""
-        exception "Operation months_add of 133705200962757184 1410065408 out of range"
+        exception "Operation months_add of 1900-01-01 12:00:00.123456, 1410065408 out of range"
     }
 }

--- a/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_or_datetime_computation_negative.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_or_datetime_computation_negative.groovy
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 suite("test_date_or_datetime_computation_negative") {
     sql """ CREATE TABLE IF NOT EXISTS test_date_or_datetime_computation_negative (
                 `row_id` LARGEINT NOT NULL,
@@ -50,8 +51,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_sub(datetime, interval 1 year) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+
+        sql """SELECT date_sub(date_null, interval 1 year), date_sub(dateV2_null, interval 1 year), date_sub(datetime_null, interval 1 year) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_1 """SELECT date_sub(date_null, interval 1 year), date_sub(dateV2_null, interval 1 year), date_sub(datetime_null, interval 1 year) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_sub(date, interval 1 month) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
@@ -65,8 +69,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_sub(datetime, interval 1 month) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+
+        sql """SELECT date_sub(date_null, interval 1 month), date_sub(dateV2_null, interval 1 month), date_sub(datetime_null, interval 1 month) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_2 """SELECT date_sub(date_null, interval 1 month), date_sub(dateV2_null, interval 1 month), date_sub(datetime_null, interval 1 month) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """ SELECT date_sub(date, interval 1 week) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
@@ -80,9 +87,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """ SELECT date_sub(datetime, interval 1 week) FROM test_date_or_datetime_computation_negative WHERE row_id=1; """
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_sub(date_null, interval 1 week), date_sub(dateV2_null, interval 1 week), date_sub(datetime_null, interval 1 week) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-
-    qt_select_nullable_3 """SELECT date_sub(date_null, interval 1 week), date_sub(dateV2_null, interval 1 week), date_sub(datetime_null, interval 1 week) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_sub(date, interval 1 day) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
@@ -96,9 +105,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_sub(datetime, interval 1 day) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_sub(date_null, interval 1 day), date_sub(dateV2_null, interval 1 day), date_sub(datetime_null, interval 1 day) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-
-    qt_select_nullable_4 """SELECT date_sub(date_null, interval 1 day), date_sub(dateV2_null, interval 1 day), date_sub(datetime_null, interval 1 day) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_sub(date, interval 1 hour) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
@@ -112,8 +123,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_sub(datetime, interval 1 hour) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """ SELECT date_sub(date_null, interval 1 hour), date_sub(dateV2_null, interval 1 hour), date_sub(datetime_null, interval 1 hour) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_5 """ SELECT date_sub(date_null, interval 1 hour), date_sub(dateV2_null, interval 1 hour), date_sub(datetime_null, interval 1 hour) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_sub(date, interval 1 minute) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
@@ -127,8 +141,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_sub(datetime, interval 1 minute) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_sub(date_null, interval 1 minute), date_sub(dateV2_null, interval 1 minute), date_sub(datetime_null, interval 1 minute) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_6 """SELECT date_sub(date_null, interval 1 minute), date_sub(dateV2_null, interval 1 minute), date_sub(datetime_null, interval 1 minute) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_sub(date, interval 1 second) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
@@ -142,8 +159,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_sub(datetime, interval 1 second) FROM test_date_or_datetime_computation_negative WHERE row_id=1;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_sub(date_null, interval 1 second), date_sub(dateV2_null, interval 1 second), date_sub(datetime_null, interval 1 second) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_7 """SELECT date_sub(date_null, interval 1 second), date_sub(dateV2_null, interval 1 second), date_sub(datetime_null, interval 1 second) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
 
     test {
@@ -158,8 +178,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_add(datetime, interval 1 year) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_add(date_null, interval 1 year), date_add(dateV2_null, interval 1 year), date_add(datetime_null, interval 1 year) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_8 """SELECT date_add(date_null, interval 1 year), date_add(dateV2_null, interval 1 year), date_add(datetime_null, interval 1 year) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_add(date, interval 1 month) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
@@ -173,8 +196,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_add(datetime, interval 1 month) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_add(date_null, interval 1 month), date_add(dateV2_null, interval 1 month), date_add(datetime_null, interval 1 month) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_9 """SELECT date_add(date_null, interval 1 month), date_add(dateV2_null, interval 1 month), date_add(datetime_null, interval 1 month) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """ SELECT date_add(date, interval 1 week) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
@@ -188,9 +214,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """ SELECT date_add(datetime, interval 1 week) FROM test_date_or_datetime_computation_negative WHERE row_id=3; """
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_add(date_null, interval 1 week), date_add(dateV2_null, interval 1 week), date_add(datetime_null, interval 1 week) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-
-    qt_select_nullable_10 """SELECT date_add(date_null, interval 1 week), date_add(dateV2_null, interval 1 week), date_add(datetime_null, interval 1 week) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_add(date, interval 1 day) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
@@ -204,9 +232,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_add(datetime, interval 1 day) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_add(date_null, interval 1 day), date_add(dateV2_null, interval 1 day), date_add(datetime_null, interval 1 day) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-
-    qt_select_nullable_11 """SELECT date_add(date_null, interval 1 day), date_add(dateV2_null, interval 1 day), date_add(datetime_null, interval 1 day) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_add(date, interval 1 hour) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
@@ -220,8 +250,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_add(datetime, interval 1 hour) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """ SELECT date_add(date_null, interval 1 hour), date_add(dateV2_null, interval 1 hour), date_add(datetime_null, interval 1 hour) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_12 """ SELECT date_add(date_null, interval 1 hour), date_add(dateV2_null, interval 1 hour), date_add(datetime_null, interval 1 hour) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_add(date, interval 1 minute) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
@@ -235,8 +268,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_add(datetime, interval 1 minute) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_add(date_null, interval 1 minute), date_add(dateV2_null, interval 1 minute), date_add(datetime_null, interval 1 minute) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_13 """SELECT date_add(date_null, interval 1 minute), date_add(dateV2_null, interval 1 minute), date_add(datetime_null, interval 1 minute) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     test {
         sql """SELECT date_add(date, interval 1 second) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
@@ -250,8 +286,11 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT date_add(datetime, interval 1 second) FROM test_date_or_datetime_computation_negative WHERE row_id=3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT date_add(date_null, interval 1 second), date_add(dateV2_null, interval 1 second), date_add(datetime_null, interval 1 second) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_14 """SELECT date_add(date_null, interval 1 second), date_add(dateV2_null, interval 1 second), date_add(datetime_null, interval 1 second) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
 
     // TODO:
     // nagetive test for microseconds_add/milliseconds_add/seconds_add/minutes_add/hours_add/days_add/weeks_add/months_add/years_add
@@ -268,8 +307,9 @@ suite("test_date_or_datetime_computation_negative") {
         sql """SELECT hours_add(datetime, 24) FROM test_date_or_datetime_computation_negative WHERE row_id = 3;"""
         check {result, exception, startTime, endTime ->
                 assertTrue (exception != null)}
+    
+        sql """SELECT hours_add(date_null, 24), hours_add(dateV2_null, 24), hours_add(datetime_null, 24) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
+        check {result, exception, startTime, endTime ->
+                assertTrue (exception != null)}
     }
-    qt_select_nullable_15 """SELECT hours_add(date_null, 24), hours_add(dateV2_null, 24), hours_add(datetime_null, 24) FROM test_date_or_datetime_computation_negative ORDER BY row_id;"""
-
-    sql "DROP TABLE test_date_or_datetime_computation_negative"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

1. totally refactored `FunctionDateOrDateTimeComputation`. removed some unnecessary function and template. simplified some template calculations.
2. All Datetime arithmetic operation overflow will lead to exception now. before for nullable input it will get `NULL` result
see: 
```sql
mysql> select date_add('5000-10-10', interval 10000 year);
+------------------------------------------------+
| years_add(cast('5000-10-10' as DATEV2), 10000) |
+------------------------------------------------+
| NULL                                           |
+------------------------------------------------+
1 row in set (0.10 sec)
```
now:
```sql
ERROR 1105 (HY000): errCode = 2, detailMessage = (xxx)[E-218][E-218] Operation years_add of 5000-10-10, 10000 out of range
```

### Release note

All Datetime arithmetic operation overflow will lead to exception now.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/2176

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

