### PR TITLE
[fix](restore) Add restore_reset_index_id config

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1624,6 +1624,15 @@ public class Config extends ConfigBase {
     public static boolean enable_restore_snapshot_rpc_compression = true;
 
     /**
+     * A internal config, to indicate whether to reset the index id when restore olap table.
+     *
+     * The inverted index saves the index id in the file path/header, so the index id between
+     * two clusters must be the same.
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean restore_reset_index_id = true;
+
+    /**
      * Control the max num of tablets per backup job involved.
      */
     @ConfField(mutable = true, masterOnly = true, description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2733,6 +2733,12 @@ public class SchemaChangeHandler extends AlterHandler {
                         indexDef.getIndexType() + " index for columns (" + String.join(",", indexDef.getColumns())
                                 + " ) already exist.");
             }
+            // The restored olap table may not reset the index id, which comes from the upstream,
+            // so we need to check and reset the index id here, to avoid confliction.
+            // See OlapTable.resetIdsForRestore for details.
+            if (existedIdx.getIndexId() == alterIndex.getIndexId()) {
+                alterIndex.setIndexId(Env.getCurrentEnv().getNextId());
+            }
         }
         boolean disableInvertedIndexV1ForVariant = olapTable.getInvertedIndexFileStorageFormat()
                         == TInvertedIndexFileStorageFormat.V1 && ConnectContext.get().getSessionVariable()

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2717,6 +2717,7 @@ public class SchemaChangeHandler extends AlterHandler {
         IndexDef indexDef = alterClause.getIndexDef();
         Set<String> newColset = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         newColset.addAll(indexDef.getColumns());
+        Set<Long> existedIndexIdSet = Sets.newHashSet();
         for (Index existedIdx : existedIndexes) {
             if (existedIdx.getIndexName().equalsIgnoreCase(indexDef.getIndexName())) {
                 if (indexDef.isSetIfNotExists()) {
@@ -2733,13 +2734,16 @@ public class SchemaChangeHandler extends AlterHandler {
                         indexDef.getIndexType() + " index for columns (" + String.join(",", indexDef.getColumns())
                                 + " ) already exist.");
             }
-            // The restored olap table may not reset the index id, which comes from the upstream,
-            // so we need to check and reset the index id here, to avoid confliction.
-            // See OlapTable.resetIdsForRestore for details.
-            if (existedIdx.getIndexId() == alterIndex.getIndexId()) {
-                alterIndex.setIndexId(Env.getCurrentEnv().getNextId());
-            }
+            existedIndexIdSet.add(existedIdx.getIndexId());
         }
+
+        // The restored olap table may not reset the index id, which comes from the upstream,
+        // so we need to check and reset the index id here, to avoid confliction.
+        // See OlapTable.resetIdsForRestore for details.
+        while (existedIndexIdSet.contains(alterIndex.getIndexId())) {
+            alterIndex.setIndexId(Env.getCurrentEnv().getNextId());
+        }
+
         boolean disableInvertedIndexV1ForVariant = olapTable.getInvertedIndexFileStorageFormat()
                         == TInvertedIndexFileStorageFormat.V1 && ConnectContext.get().getSessionVariable()
                                                                         .getDisableInvertedIndexV1ForVaraint();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -885,9 +885,17 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         if (this.indexes != null) {
             List<Index> indexes = this.indexes.getIndexes();
             for (Index idx : indexes) {
-                long newIdxId = idx.getIndexId();
+                long newIdxId;
                 if (Config.restore_reset_index_id) {
                     newIdxId = env.getNextId();
+                } else {
+                    // The index id from the upstream is used, if restore_reset_index_id is not set.
+                    //
+                    // This is because the index id is used as a part of inverted file name/header
+                    // in BE. During restore, the inverted file is copied from the upstream to the
+                    // downstream. If the index id is changed, it might cause the BE to fail to find
+                    // the inverted files.
+                    newIdxId = idx.getIndexId();
                 }
                 idx.setIndexId(newIdxId);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -885,7 +885,11 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         if (this.indexes != null) {
             List<Index> indexes = this.indexes.getIndexes();
             for (Index idx : indexes) {
-                idx.setIndexId(env.getNextId());
+                long newIdxId = idx.getIndexId();
+                if (Config.restore_reset_index_id) {
+                    newIdxId = env.getNextId();
+                }
+                idx.setIndexId(newIdxId);
             }
             for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
                 entry.getValue().setIndexes(indexes);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -2082,15 +2082,11 @@ public class EditLog {
 
     public void logModifyTableAddOrDropInvertedIndices(TableAddOrDropInvertedIndicesInfo info) {
         long logId = logEdit(OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_INVERTED_INDICES, info);
-        LOG.info("walter log modify table add or drop inverted indices, infos: {}, json: {}",
-                info, info.toJson(), new RuntimeException("test"));
         Env.getCurrentEnv().getBinlogManager().addModifyTableAddOrDropInvertedIndices(info, logId);
     }
 
     public void logIndexChangeJob(IndexChangeJob indexChangeJob) {
         long logId = logEdit(OperationType.OP_INVERTED_INDEX_JOB, indexChangeJob);
-        LOG.info("walter log inverted index job, infos: {}, json: {}",
-                indexChangeJob, indexChangeJob.toJson(), new RuntimeException("test"));
         Env.getCurrentEnv().getBinlogManager().addIndexChangeJob(indexChangeJob, logId);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -2082,11 +2082,15 @@ public class EditLog {
 
     public void logModifyTableAddOrDropInvertedIndices(TableAddOrDropInvertedIndicesInfo info) {
         long logId = logEdit(OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_INVERTED_INDICES, info);
+        LOG.info("walter log modify table add or drop inverted indices, infos: {}, json: {}",
+                info, info.toJson(), new RuntimeException("test"));
         Env.getCurrentEnv().getBinlogManager().addModifyTableAddOrDropInvertedIndices(info, logId);
     }
 
     public void logIndexChangeJob(IndexChangeJob indexChangeJob) {
         long logId = logEdit(OperationType.OP_INVERTED_INDEX_JOB, indexChangeJob);
+        LOG.info("walter log inverted index job, infos: {}, json: {}",
+                indexChangeJob, indexChangeJob.toJson(), new RuntimeException("test"));
         Env.getCurrentEnv().getBinlogManager().addIndexChangeJob(indexChangeJob, logId);
     }
 

--- a/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_backup_restore_inverted_idx", "backup_restore") {
+    String suiteName = "test_backup_restore_inverted_idx"
+    String dbName = "${suiteName}_db"
+    String repoName = "repo_" + UUID.randomUUID().toString().replace("-", "")
+    String snapshotName = "${suiteName}_snapshot"
+    String tableName = "${suiteName}_table"
+
+    def syncer = getSyncer()
+    syncer.createS3Repository(repoName)
+    sql "CREATE DATABASE IF NOT EXISTS ${dbName}"
+
+    sql "DROP TABLE IF EXISTS ${dbName}.${tableName}"
+    sql """
+        CREATE TABLE ${dbName}.${tableName} (
+            `id` LARGEINT NOT NULL,
+            `value` STRING DEFAULT "",
+            `value1` STRING DEFAULT "",
+            INDEX `idx_value` (`value`) USING INVERTED PROPERTIES ("parser" = "english")
+        )
+        UNIQUE KEY(`id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("10"),
+            PARTITION p2 VALUES LESS THAN ("20"),
+            PARTITION p3 VALUES LESS THAN ("30"),
+            PARTITION p4 VALUES LESS THAN ("40"),
+            PARTITION p5 VALUES LESS THAN ("50"),
+            PARTITION p6 VALUES LESS THAN ("60"),
+            PARTITION p7 VALUES LESS THAN ("70")
+        )
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES
+        (
+            "replication_num" = "1"
+        )
+        """
+    List<String> values = []
+    int numRows = 6;
+    for (int j = 0; j <= numRows; ++j) {
+        values.add("(${j}1, \"${j} ${j*10} ${j*100}\", \"${j*11} ${j*12}\")")
+    }
+    sql "INSERT INTO ${dbName}.${tableName} VALUES ${values.join(",")}"
+
+    def indexes = sql_return_maparray "SHOW INDEX FROM ${dbName}.${tableName}"
+    logger.info("current indexes: ${indexes}")
+    assertTrue(indexes.any { it.Key_name == "idx_value" && it.Index_type == "INVERTED" })
+
+    def query_index_id = { indexName ->
+        def res = sql_return_maparray "SHOW TABLETS FROM ${dbName}.${tableName}"
+        def tabletId = res[0].TabletId
+        res = sql_return_maparray "SHOW TABLET ${tabletId}"
+        def dbId = res[0].DbId
+        def tableId = res[0].TableId
+        res = sql_return_maparray """ SHOW PROC "/dbs/${dbId}/${tableId}/indexes" """
+        for (def record in res) {
+            if (record.KeyName == indexName) {
+                return record.IndexId
+            }
+        }
+        throw new Exception("index ${indexName} is not exists")
+    }
+
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("restore_reset_index_id" = "false") """
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${snapshotName}
+            TO `${repoName}`
+            ON (`${tableName}`)
+        """
+
+        syncer.waitSnapshotFinish(dbName)
+
+        def snapshot = syncer.getSnapshotTimestamp(repoName, snapshotName)
+        assertTrue(snapshot != null)
+
+        def indexId = query_index_id("idx_value")
+        logger.info("the exists index id is ${indexId}")
+
+        sql "DROP TABLE ${dbName}.${tableName}"
+
+        sql """
+            RESTORE SNAPSHOT ${dbName}.${snapshotName}
+            FROM `${repoName}`
+            ON (`${tableName}`)
+            PROPERTIES
+            (
+                "backup_timestamp" = "${snapshot}",
+                "reserve_replica" = "true"
+            )
+        """
+
+        syncer.waitAllRestoreFinish(dbName)
+
+        indexes = sql_return_maparray "SHOW INDEX FROM ${dbName}.${tableName}"
+        logger.info("current indexes: ${indexes}")
+        assertTrue(indexes.any { it.Key_name == "idx_value" && it.Index_type == "INVERTED" })
+
+        def newIndexId = query_index_id("idx_value")
+        assertTrue(newIndexId == indexId, "old index id ${indexId}, new index id ${newIndexId}")
+
+        // 1. query with inverted index
+        sql """ set enable_match_without_inverted_index = false """
+        def res = sql """ SELECT * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "10" """
+        assertTrue(res.size() > 0)
+
+        // 2. add partition and query
+        sql """ ALTER TABLE ${dbName}.${tableName} ADD PARTITION p8 VALUES LESS THAN ("80") """
+        sql """ INSERT INTO ${dbName}.${tableName} VALUES (75, "75 750", "76 77") """
+        res = sql """ SELECT * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "75" """
+        assertTrue(res.size() > 0)
+
+        // 3. add new index
+        sql """ ALTER TABLE ${dbName}.${tableName}
+            ADD INDEX idx_value1(value1) USING INVERTED PROPERTIES("parser" = "english") """
+
+        indexes = sql_return_maparray """ SHOW INDEX FROM ${dbName}.${tableName} """
+        logger.info("current indexes: ${indexes}")
+        assertTrue(indexes.any { it.Key_name == "idx_value1" && it.Index_type == "INVERTED" })
+
+        // 4. drop old index
+        sql """ ALTER TABLE ${dbName}.${tableName} DROP INDEX idx_value"""
+        indexes = sql_return_maparray """ SHOW INDEX FROM ${dbName}.${tableName} """
+        logger.info("current indexes: ${indexes}")
+        assertFalse(indexes.any { it.Key_name == "idx_value" && it.Index_type == "INVERTED" })
+
+        // 5. query new index with inverted idx
+        sql """ INSERT INTO ${dbName}.${tableName} VALUES(76, "76 760", "12321 121") """
+        sql """ BUILD INDEX idx_value1 ON ${dbName}.${tableName} """
+        def build_index_finished = false
+        for (int i = 0; i < 100; i++) {
+            def build_status = sql_return_maparray """
+                SHOW BUILD INDEX FROM ${dbName} WHERE TableName = "${tableName}" """
+            if (!(build_status.any { it.State != 'FINISHED' })) {
+                build_index_finished = true
+                break
+            }
+            sleep(1000)
+        }
+        if (!build_index_finished) {
+            def build_status = sql_return_maparray """
+                SHOW BUILD INDEX FROM ${dbName} WHERE TableName = "${tableName}" """
+            logger.info("the build index status: ${build_status}")
+            assertTrue(false)
+        }
+        res = sql """ SELECT * FROM ${dbName}.${tableName} WHERE value1 MATCH_ANY "12321" """
+        assertTrue(res.size() > 0)
+
+    } finally {
+        sql """ set enable_match_without_inverted_index = true """
+        sql """ ADMIN SET FRONTEND CONFIG ("restore_reset_index_id" = "true") """
+    }
+
+    // sql "DROP TABLE ${dbName}.${tableName} FORCE"
+    // sql "DROP DATABASE ${dbName} FORCE"
+    // sql "DROP REPOSITORY `${repoName}`"
+}
+

--- a/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
@@ -167,8 +167,8 @@ suite("test_backup_restore_inverted_idx", "backup_restore") {
         sql """ ADMIN SET FRONTEND CONFIG ("restore_reset_index_id" = "true") """
     }
 
-    // sql "DROP TABLE ${dbName}.${tableName} FORCE"
-    // sql "DROP DATABASE ${dbName} FORCE"
-    // sql "DROP REPOSITORY `${repoName}`"
+    sql "DROP TABLE ${dbName}.${tableName} FORCE"
+    sql "DROP DATABASE ${dbName} FORCE"
+    sql "DROP REPOSITORY `${repoName}`"
 }
 

--- a/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
@@ -117,13 +117,13 @@ suite("test_backup_restore_inverted_idx", "backup_restore") {
 
         // 1. query with inverted index
         sql """ set enable_match_without_inverted_index = false """
-        def res = sql """ SELECT * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "10" """
+        def res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0) */ * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "10" """
         assertTrue(res.size() > 0)
 
         // 2. add partition and query
         sql """ ALTER TABLE ${dbName}.${tableName} ADD PARTITION p8 VALUES LESS THAN ("80") """
         sql """ INSERT INTO ${dbName}.${tableName} VALUES (75, "75 750", "76 77") """
-        res = sql """ SELECT * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "75" """
+        res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0) */ * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "75" """
         assertTrue(res.size() > 0)
 
         // 3. add new index
@@ -159,7 +159,7 @@ suite("test_backup_restore_inverted_idx", "backup_restore") {
             logger.info("the build index status: ${build_status}")
             assertTrue(false)
         }
-        res = sql """ SELECT * FROM ${dbName}.${tableName} WHERE value1 MATCH_ANY "12321" """
+        res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0) */ * FROM ${dbName}.${tableName} WHERE value1 MATCH_ANY "12321" """
         assertTrue(res.size() > 0)
 
     } finally {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The inverted index saves the index id in the file path/header, so the index id between two clusters must be the same when synced with the ccr-syncer.

This PR add new config `restore_reset_index_id` to indicate whether to reset the index ids.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

