### PR TITLE
[fix](hive) fix block decompressor bug

### DIFF
--- a/be/src/exec/decompressor.cpp
+++ b/be/src/exec/decompressor.cpp
@@ -492,14 +492,14 @@ Status Lz4BlockDecompressor::decompress(uint8_t* input, size_t input_len, size_t
     auto* output_ptr = output;
 
     while (input_len > 0) {
-        //if faild ,  fall back to large block begin
+        if (input_len < sizeof(uint32_t)) {
+            *more_input_bytes = sizeof(uint32_t) - input_len;
+            break;
+        }
+
+        //if faild, fall back to large block begin
         auto* large_block_input_ptr = input_ptr;
         auto* large_block_output_ptr = output_ptr;
-
-        if (input_len < sizeof(uint32_t)) {
-            return Status::InvalidArgument(strings::Substitute(
-                    "fail to do hadoop-lz4 decompress, input_len=$0", input_len));
-        }
 
         uint32_t remaining_decompressed_large_block_len = BigEndian::Load32(input_ptr);
 
@@ -609,14 +609,14 @@ Status SnappyBlockDecompressor::decompress(uint8_t* input, size_t input_len,
     auto* output_ptr = output;
 
     while (input_len > 0) {
-        //if faild ,  fall back to large block begin
+        if (input_len < sizeof(uint32_t)) {
+            *more_input_bytes = sizeof(uint32_t) - input_len;
+            break;
+        }
+
+        //if faild, fall back to large block begin
         auto* large_block_input_ptr = input_ptr;
         auto* large_block_output_ptr = output_ptr;
-
-        if (input_len < sizeof(uint32_t)) {
-            return Status::InvalidArgument(strings::Substitute(
-                    "fail to do hadoop-snappy decompress, input_len=$0", input_len));
-        }
 
         uint32_t remaining_decompressed_large_block_len = BigEndian::Load32(input_ptr);
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
In the block decompressor, when it is found that the input data is less than 4 bytes (the header size of the large block), should set more_input_bytes instead of reporting an error.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

