### PR TITLE
[enhance](mtmv)Change the way to verify the existence of partition names when refreshing MTMV

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/RefreshMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/RefreshMTMVInfo.java
@@ -34,8 +34,8 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
-import org.glassfish.jersey.internal.guava.Sets;
 
 import java.util.List;
 import java.util.Objects;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/RefreshMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/RefreshMTMVInfo.java
@@ -88,7 +88,8 @@ public class RefreshMTMVInfo {
         try {
             if (mtmv.getMvPartitionInfo().getPartitionType().equals(MTMVPartitionType.SELF_MANAGE)) {
                 throw new AnalysisException(
-                        "The partition method of this asynchronous materialized view does not support refreshing by partition");
+                        "The partition method of this asynchronous materialized view "
+                                + "does not support refreshing by partition");
             }
             List<AllPartitionDesc> partitionDescs = MTMVPartitionUtil.getPartitionDescsByRelatedTable(
                     mtmv.getTableProperty().getProperties(), mtmv.getMvPartitionInfo(), mtmv.getMvProperties());

--- a/regression-test/suites/mtmv_p0/test_refresh_partition_name_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_refresh_partition_name_mtmv.groovy
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Assert;
+
+suite("test_refresh_partition_name_mtmv","mtmv") {
+    String suiteName = "test_refresh_partition_name_mtmv"
+    String tableName = "${suiteName}_table"
+    String mvName = "${suiteName}_mv"
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+
+    sql """
+        CREATE TABLE ${tableName}
+        (
+            k2 TINYINT,
+            k3 INT not null
+        )
+        COMMENT "my first table"
+        PARTITION BY LIST(`k3`)
+        (
+            PARTITION `p1` VALUES IN ('1'),
+            PARTITION `p2` VALUES IN ('2'),
+            PARTITION `p3` VALUES IN ('3')
+        )
+        DISTRIBUTED BY HASH(k2) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+        """
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH AUTO ON MANUAL
+        partition by(`k3`)
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1',
+        'refresh_partition_num' = '2'
+        )
+        AS
+        SELECT * from ${tableName};
+        """
+
+    test {
+          sql """
+              REFRESH MATERIALIZED VIEW ${mvName} partitions(p_4)
+          """
+          exception "partition not exist"
+    }
+
+    sql """
+        alter table ${tableName} add PARTITION `p4` VALUES IN ('4')
+        """
+    sql """
+          REFRESH MATERIALIZED VIEW ${mvName} partitions(p_4)
+      """
+
+    waitingMTMVTaskFinishedByMvName(mvName)
+
+    sql """drop table if exists `${tableName}`"""
+    sql """drop materialized view if exists ${mvName};"""
+}


### PR DESCRIPTION
### What problem does this PR solve?

Previously, when refreshing the materialized view according to the partition name, the existing partition of the materialized view was used to verify whether the partition name existed
After the change, the partition that should be present after refreshing the materialized view is used for verification

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Change the way to verify the existence of partition names when refreshing MTMV
### Release note

Change the way to verify the existence of partition names when refreshing MTMV

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

