### PR TITLE
[opt](nereids) range inference convert isnull to EmptyValue 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
@@ -326,7 +326,10 @@ public class AddMinMax implements ExpressionPatternRuleFactory {
         for (int i = 1; i < sourceValues.size(); i++) {
             // process in sourceValues[i]
             Map<Expression, MinMaxValue> minMaxValues = getExprMinMaxValues(sourceValues.get(i));
-            for (Map.Entry<Expression, MinMaxValue> entry : minMaxValues.entrySet()) {
+            List<Map.Entry<Expression, MinMaxValue>> minMaxValueList = minMaxValues.entrySet().stream()
+                    .sorted((a, b) -> Integer.compare(a.getValue().exprOrderIndex, b.getValue().exprOrderIndex))
+                    .collect(Collectors.toList());
+            for (Map.Entry<Expression, MinMaxValue> entry : minMaxValueList) {
                 Expression expr = entry.getKey();
                 MinMaxValue value = result.get(expr);
                 MinMaxValue otherValue = entry.getValue();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
@@ -326,6 +326,13 @@ public class AddMinMax implements ExpressionPatternRuleFactory {
         for (int i = 1; i < sourceValues.size(); i++) {
             // process in sourceValues[i]
             Map<Expression, MinMaxValue> minMaxValues = getExprMinMaxValues(sourceValues.get(i));
+            // merge values of sourceValues[i] into result.
+            // also keep the value's relative order in sourceValues[i].
+            // for example, if a and b in sourceValues[i], but not in result, then during merging,
+            // a and b will assign a new exprOrderIndex (using nextExprOrderIndex).
+            // if in sourceValues[i], a's exprOrderIndex < b's exprOrderIndex,
+            // then make sure in result, a's new exprOrderIndex < b's new exprOrderIndex.
+            // so that their relative order can preserve.
             List<Map.Entry<Expression, MinMaxValue>> minMaxValueList = minMaxValues.entrySet().stream()
                     .sorted((a, b) -> Integer.compare(a.getValue().exprOrderIndex, b.getValue().exprOrderIndex))
                     .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -133,22 +133,16 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             BinaryOperator<ValueDesc> op, boolean isAnd) {
 
         boolean convertIsNullToEmptyValue = isAnd && predicates.stream().anyMatch(expr -> expr instanceof NullLiteral);
-        boolean hadNullLiteral = false;
-
         Multimap<Expression, ValueDesc> groupByReference
                 = Multimaps.newListMultimap(new LinkedHashMap<>(), ArrayList::new);
         for (Expression predicate : predicates) {
             ValueDesc valueDesc = null;
             if (convertIsNullToEmptyValue) {
                 if (predicate instanceof NullLiteral) {
-                    if (hadNullLiteral) {
-                        continue;
-                    }
-                    hadNullLiteral = true;
                     valueDesc = new UnknownValue(context, predicate);
                 } else if (predicate instanceof IsNull) {
                     Expression reference = ((IsNull) predicate).child();
-                    valueDesc = new EmptyValue(context, reference, ExpressionUtils.falseOrNull(reference));
+                    valueDesc = new EmptyValue(context, reference, predicate);
                 } else {
                     valueDesc = predicate.accept(this, context);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -475,6 +475,8 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
 
         @Override
         public ValueDesc union(ValueDesc other) {
+            // for RangeValue/DiscreteValue/UnknownValue, when union with EmptyValue,
+            // call EmptyValue.union(this) => this
             if (other instanceof EmptyValue) {
                 return other.union(this);
             }
@@ -486,6 +488,8 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
 
         @Override
         public ValueDesc intersect(ValueDesc other) {
+            // for RangeValue/DiscreteValue/UnknownValue, when intersect with EmptyValue,
+            // call EmptyValue.intersect(this) => EmptyValue
             if (other instanceof EmptyValue) {
                 return other.intersect(this);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -25,22 +25,16 @@ import org.apache.doris.nereids.rules.expression.rules.RangeInference.EmptyValue
 import org.apache.doris.nereids.rules.expression.rules.RangeInference.RangeValue;
 import org.apache.doris.nereids.rules.expression.rules.RangeInference.UnknownValue;
 import org.apache.doris.nereids.rules.expression.rules.RangeInference.ValueDesc;
-import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
 import org.apache.doris.nereids.trees.expressions.InPredicate;
-import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
-import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.Or;
-import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
-import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
-import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.BoundType;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -108,11 +108,7 @@ public class SimplifyRange implements ExpressionPatternRuleFactory {
 
     private Expression getExpression(EmptyValue value) {
         Expression reference = value.getReference();
-        if (reference.nullable()) {
-            return new And(new IsNull(reference), new NullLiteral(BooleanType.INSTANCE));
-        } else {
-            return BooleanLiteral.FALSE;
-        }
+        return ExpressionUtils.falseOrNull(reference);
     }
 
     private Expression getExpression(RangeValue value) {
@@ -136,11 +132,7 @@ public class SimplifyRange implements ExpressionPatternRuleFactory {
         if (!result.isEmpty()) {
             return ExpressionUtils.and(result);
         } else {
-            if (reference.nullable()) {
-                return new Or(new Not(new IsNull(reference)), new NullLiteral(BooleanType.INSTANCE));
-            } else {
-                return BooleanLiteral.TRUE;
-            }
+            return ExpressionUtils.trueOrNull(reference);
         }
     }
 
@@ -167,8 +159,15 @@ public class SimplifyRange implements ExpressionPatternRuleFactory {
         if (sourceValues.isEmpty()) {
             return originExpr;
         }
-        List<Expression> sourceExprs = sourceValues.stream().map(sourceValue -> getExpression(sourceValue))
-                .collect(Collectors.toList());
+        List<Expression> sourceExprs = Lists.newArrayListWithExpectedSize(sourceValues.size());
+        for (ValueDesc sourceValue : sourceValues) {
+            Expression expr = getExpression(sourceValue);
+            if (value.isAnd()) {
+                sourceExprs.addAll(ExpressionUtils.extractConjunction(expr));
+            } else {
+                sourceExprs.addAll(ExpressionUtils.extractDisjunction(expr));
+            }
+        }
         Expression result = value.isAnd() ? ExpressionUtils.and(sourceExprs) : ExpressionUtils.or(sourceExprs);
         result = FoldConstantRuleOnFE.evaluate(result, value.getExpressionRewriteContext());
         // ATTN: we must return original expr, because OrToIn is implemented with MutableState,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -46,7 +46,6 @@ import org.apache.commons.lang3.NotImplementedException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This class implements the function to simplify expression range.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -260,6 +260,22 @@ public class ExpressionUtils {
         }
     }
 
+    public static Expression falseOrNull(Expression expression) {
+        if (expression.nullable()) {
+            return new And(new IsNull(expression), new NullLiteral(BooleanType.INSTANCE));
+        } else {
+            return BooleanLiteral.FALSE;
+        }
+    }
+
+    public static Expression trueOrNull(Expression expression) {
+        if (expression.nullable()) {
+            return new Or(new Not(new IsNull(expression)), new NullLiteral(BooleanType.INSTANCE));
+        } else {
+            return BooleanLiteral.TRUE;
+        }
+    }
+
     /**
      * Use AND/OR to combine expressions together.
      */

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -348,6 +348,10 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
 
         assertRewriteAfterTypeCoercion("TA between 10 and 20 or TA between 30 and 40 or TA between 60 and 50",
                 "(TA <= 20 or TA >= 30 or TA is null and null) and TA >= 10 and TA <= 40");
+        assertRewriteAfterTypeCoercion("ISNULL(TB) and (TA between 10 and 20 or TA between 30 and 40 or TA between 60 and 50)",
+                "ISNULL(TB) and ((TA <= 20 or TA >= 30 or TA is null and null) and TA >= 10 and TA <= 40)");
+        assertRewriteAfterTypeCoercion("TB between 20 and 10 and (TA between 10 and 20 or TA between 30 and 40 or TA between 60 and 50)",
+                "TB IS NULL AND NULL and (TA <= 20 or TA >= 30 or TA is null and null) and TA >= 10 and TA <= 40");
         assertRewriteAfterTypeCoercion("TA between 10 and 20 and TB between 10 and 20 or TA between 30 and 40 and TB between 30 and 40 or TA between 60 and 50 and TB between 60 and 50",
                 "(TA <= 20 and TB <= 20 or TA >= 30 and TB >= 30 or TA is null and null and TB is null) and TA >= 10 and TA <= 40 and TB >= 10 and TB <= 40");
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -340,12 +340,11 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
     @Test
     void testSimplifyRangeAndAddMinMax() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
-            bottomUp(
-                SimplifyRange.INSTANCE,
-                AddMinMax.INSTANCE
-            )
+                bottomUp(
+                        SimplifyRange.INSTANCE,
+                        AddMinMax.INSTANCE
+                )
         ));
-
 
         assertRewriteAfterTypeCoercion("ISNULL(TA)", "ISNULL(TA)");
         assertRewriteAfterTypeCoercion("ISNULL(TA) and null", "ISNULL(TA) and null");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -346,12 +346,34 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
             )
         ));
 
+
+        assertRewriteAfterTypeCoercion("ISNULL(TA)", "ISNULL(TA)");
+        assertRewriteAfterTypeCoercion("ISNULL(TA) and null", "ISNULL(TA) and null");
+        assertRewriteAfterTypeCoercion("ISNULL(TA) and ISNULL(TA)", "ISNULL(TA)");
+        assertRewriteAfterTypeCoercion("ISNULL(TA) or ISNULL(TA)", "ISNULL(TA)");
+        assertRewriteAfterTypeCoercion("ISNULL(TA) and TA between 20 and 10", "ISNULL(TA) and null");
+        // assertRewriteAfterTypeCoercion("ISNULL(TA) and TA > 10", "ISNULL(TA) and null"); // should be, but not support now
+        assertRewriteAfterTypeCoercion("ISNULL(TA) and TA > 10 and null", "ISNULL(TA) and null");
+        assertRewriteAfterTypeCoercion("ISNULL(TA) or TA > 10", "ISNULL(TA) or TA > 10");
+        // assertRewriteAfterTypeCoercion("(TA < 30 or TA > 40) and TA between 20 and 10", "TA IS NULL AND NULL"); // should be, but not support because flatten and
+        assertRewriteAfterTypeCoercion("(TA < 30 or TA > 40) and TA is null and null", "TA IS NULL AND NULL");
+        assertRewriteAfterTypeCoercion("(TA < 30 or TA > 40) or TA between 20 and 10", "TA < 30 or TA > 40");
+
         assertRewriteAfterTypeCoercion("TA between 10 and 20 or TA between 30 and 40 or TA between 60 and 50",
+                "(TA <= 20 or TA >= 30) and TA >= 10 and TA <= 40");
+        // should be, but not support yet, because 'TA is null and null' => UnknownValue(EmptyValue(TA) and null)
+        //assertRewriteAfterTypeCoercion("TA between 10 and 20 or TA between 30 and 40 or TA is null and null",
+        //        "(TA <= 20 or TA >= 30) and TA >= 10 and TA <= 40");
+        assertRewriteAfterTypeCoercion("TA between 10 and 20 or TA between 30 and 40 or TA is null and null",
                 "(TA <= 20 or TA >= 30 or TA is null and null) and TA >= 10 and TA <= 40");
+        assertRewriteAfterTypeCoercion("TA between 10 and 20 or TA between 30 and 40 or TA is null",
+                "TA >= 10 and TA <= 20 or TA >= 30 and TA <= 40 or TA is null");
         assertRewriteAfterTypeCoercion("ISNULL(TB) and (TA between 10 and 20 or TA between 30 and 40 or TA between 60 and 50)",
-                "ISNULL(TB) and ((TA <= 20 or TA >= 30 or TA is null and null) and TA >= 10 and TA <= 40)");
+                "ISNULL(TB) and ((TA <= 20 or TA >= 30) and TA >= 10 and TA <= 40)");
+        assertRewriteAfterTypeCoercion("ISNULL(TB) and (TA between 10 and 20 or TA between 30 and 40 or TA is null)",
+                "ISNULL(TB) and (TA >= 10 and TA <= 20 or TA >= 30 and TA <= 40 or TA is null)");
         assertRewriteAfterTypeCoercion("TB between 20 and 10 and (TA between 10 and 20 or TA between 30 and 40 or TA between 60 and 50)",
-                "TB IS NULL AND NULL and (TA <= 20 or TA >= 30 or TA is null and null) and TA >= 10 and TA <= 40");
+                "TB IS NULL AND NULL and (TA <= 20 or TA >= 30) and TA >= 10 and TA <= 40");
         assertRewriteAfterTypeCoercion("TA between 10 and 20 and TB between 10 and 20 or TA between 30 and 40 and TB between 30 and 40 or TA between 60 and 50 and TB between 60 and 50",
                 "(TA <= 20 and TB <= 20 or TA >= 30 and TB >= 30 or TA is null and null and TB is null) and TA >= 10 and TA <= 40 and TB >= 10 and TB <= 40");
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

for sql 

```
a > 10 and a < 20 or a > 30 and a < 40 or  a > 60 and a < 50
```

AddMinMax should opt it as: 

```
(a < 20 or a > 30 or a is null and null) and a > 10 and a < 40
```

But it fail, because the SimplifyRange will opt it as 

```
a > 10 and a < 20 or a > 30 and a < 40 or  a is null and null
```

since the 3rd is `a is null and null`,  it couldn't get a's range and suppose a's range is [-00, +00], then the whole expression,  it will get a's range is [-00, +00], to fix this problem,  RangeInference need to convert `a is null and null` to EmptyValue instead of UnknownValue.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

