### PR TITLE
[fix](expr) Fix the problem of concurrent execution in VExpr.

### DIFF
--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -78,7 +78,7 @@ doris::Status vectorized::VBitmapPredicate::open(doris::RuntimeState* state,
 
 doris::Status vectorized::VBitmapPredicate::execute(vectorized::VExprContext* context,
                                                     doris::vectorized::Block* block,
-                                                    int* result_column_id) {
+                                                    int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     doris::vectorized::ColumnNumbers arguments(_children.size());
     for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vbitmap_predicate.h
+++ b/be/src/vec/exprs/vbitmap_predicate.h
@@ -49,7 +49,7 @@ public:
 
     ~VBitmapPredicate() override = default;
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
 

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -72,7 +72,7 @@ void VBloomPredicate::close(VExprContext* context, FunctionContext::FunctionStat
     VExpr::close(context, scope);
 }
 
-Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     doris::vectorized::ColumnNumbers arguments(_children.size());
     for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vbloom_predicate.h
+++ b/be/src/vec/exprs/vbloom_predicate.h
@@ -43,7 +43,7 @@ class VBloomPredicate final : public VExpr {
 public:
     VBloomPredicate(const TExprNode& node);
     ~VBloomPredicate() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -96,7 +96,7 @@ void VCaseExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
     VExpr::close(context, scope);
 }
 
-Status VCaseExpr::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VCaseExpr::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         return get_result_from_const(block, _expr_name, result_column_id);
     }

--- a/be/src/vec/exprs/vcase_expr.h
+++ b/be/src/vec/exprs/vcase_expr.h
@@ -43,7 +43,7 @@ class VCaseExpr final : public VExpr {
 public:
     VCaseExpr(const TExprNode& node);
     ~VCaseExpr() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -101,7 +101,7 @@ void VCastExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
 }
 
 doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block* block,
-                                 int* result_column_id) {
+                                 int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col)
             << _open_finished << _getting_const_col << _expr_name;
     // for each child call execute

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -44,7 +44,7 @@ class VCastExpr final : public VExpr {
 public:
     VCastExpr(const TExprNode& node) : VExpr(node) {}
     ~VCastExpr() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vcolumn_ref.h
+++ b/be/src/vec/exprs/vcolumn_ref.h
@@ -57,7 +57,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         DCHECK(_open_finished || _getting_const_col);
         *result_column_id = _column_id + _gap;
         return Status::OK();

--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -57,7 +57,8 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
-    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override {
+    Status evaluate_inverted_index(VExprContext* context,
+                                   uint32_t segment_num_rows) const override {
         segment_v2::InvertedIndexResultBitmap res;
         bool all_pass = true;
 
@@ -148,14 +149,14 @@ public:
 
         if (all_pass && !res.is_empty()) {
             // set fast_execute when expr evaluated by inverted index correctly
-            _can_fast_execute = true;
+            context->can_fast_execute = true;
             context->get_inverted_index_context()->set_inverted_index_result_for_expr(this, res);
         }
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
-        if (_can_fast_execute && fast_execute(context, block, result_column_id)) {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
+        if (context->can_fast_execute && fast_execute(context, block, result_column_id)) {
             return Status::OK();
         }
         if (get_num_children() == 1 || !_all_child_is_compound_and_not_const()) {

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -47,14 +47,14 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         ColumnNumbers arguments;
         return _do_execute(context, block, result_column_id, arguments);
     }
 
     Status execute_runtime_fitler(doris::vectorized::VExprContext* context,
                                   doris::vectorized::Block* block, int* result_column_id,
-                                  ColumnNumbers& args) override {
+                                  ColumnNumbers& args) const override {
         return _do_execute(context, block, result_column_id, args);
     }
 
@@ -64,7 +64,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, Block* block, int* result_column_id,
-                       ColumnNumbers& arguments) {
+                       ColumnNumbers& arguments) const {
         DCHECK(_open_finished || _getting_const_col);
         arguments.resize(_children.size());
         for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -138,18 +138,19 @@ void VectorizedFnCall::close(VExprContext* context, FunctionContext::FunctionSta
     VExpr::close(context, scope);
 }
 
-Status VectorizedFnCall::evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) {
+Status VectorizedFnCall::evaluate_inverted_index(VExprContext* context,
+                                                 uint32_t segment_num_rows) const {
     DCHECK_GE(get_num_children(), 1);
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
 Status VectorizedFnCall::_do_execute(doris::vectorized::VExprContext* context,
                                      doris::vectorized::Block* block, int* result_column_id,
-                                     ColumnNumbers& args) {
+                                     ColumnNumbers& args) const {
     if (is_const_and_have_executed()) { // const have executed in open function
         return get_result_from_const(block, _expr_name, result_column_id);
     }
-    if (_can_fast_execute && fast_execute(context, block, result_column_id)) {
+    if (context->can_fast_execute && fast_execute(context, block, result_column_id)) {
         return Status::OK();
     }
     DBUG_EXECUTE_IF("VectorizedFnCall.must_in_slow_path", {
@@ -192,12 +193,12 @@ Status VectorizedFnCall::_do_execute(doris::vectorized::VExprContext* context,
 
 Status VectorizedFnCall::execute_runtime_fitler(doris::vectorized::VExprContext* context,
                                                 doris::vectorized::Block* block,
-                                                int* result_column_id, ColumnNumbers& args) {
+                                                int* result_column_id, ColumnNumbers& args) const {
     return _do_execute(context, block, result_column_id, args);
 }
 
 Status VectorizedFnCall::execute(VExprContext* context, vectorized::Block* block,
-                                 int* result_column_id) {
+                                 int* result_column_id) const {
     ColumnNumbers arguments;
     return _do_execute(context, block, result_column_id, arguments);
 }

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -46,11 +46,11 @@ class VectorizedFnCall : public VExpr {
 
 public:
     VectorizedFnCall(const TExprNode& node);
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status execute_runtime_fitler(doris::vectorized::VExprContext* context,
                                   doris::vectorized::Block* block, int* result_column_id,
-                                  ColumnNumbers& args) override;
-    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
+                                  ColumnNumbers& args) const override;
+    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -77,7 +77,7 @@ protected:
 
 private:
     Status _do_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,
-                       int* result_column_id, ColumnNumbers& args);
+                       int* result_column_id, ColumnNumbers& args) const;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -614,7 +614,7 @@ Status VExpr::check_constant(const Block& block, ColumnNumbers arguments) const 
 }
 
 Status VExpr::get_result_from_const(vectorized::Block* block, const std::string& expr_name,
-                                    int* result_column_id) {
+                                    int* result_column_id) const {
     *result_column_id = block->columns();
     auto column = ColumnConst::create(_constant_col->column_ptr, block->rows());
     block->insert({std::move(column), _data_type, expr_name});
@@ -622,7 +622,7 @@ Status VExpr::get_result_from_const(vectorized::Block* block, const std::string&
 }
 
 Status VExpr::_evaluate_inverted_index(VExprContext* context, const FunctionBasePtr& function,
-                                       uint32_t segment_num_rows) {
+                                       uint32_t segment_num_rows) const {
     // Pre-allocate vectors based on an estimated or known size
     std::vector<segment_v2::InvertedIndexIterator*> iterators;
     std::vector<vectorized::IndexFieldNameAndTypePair> data_type_with_names;
@@ -736,13 +736,13 @@ Status VExpr::_evaluate_inverted_index(VExprContext* context, const FunctionBase
             index_context->set_true_for_inverted_index_status(this, column_id);
         }
         // set fast_execute when expr evaluated by inverted index correctly
-        _can_fast_execute = true;
+        context->can_fast_execute = true;
     }
     return Status::OK();
 }
 
 bool VExpr::fast_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,
-                         int* result_column_id) {
+                         int* result_column_id) const {
     if (context->get_inverted_index_context() &&
         context->get_inverted_index_context()->get_inverted_index_result_column().contains(this)) {
         uint32_t num_columns_without_result = block->columns();

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -119,20 +119,20 @@ public:
         return Status::InternalError(expr_name() + " is not ready when execute");
     }
 
-    virtual Status execute(VExprContext* context, Block* block, int* result_column_id) = 0;
+    virtual Status execute(VExprContext* context, Block* block, int* result_column_id) const = 0;
 
     // execute current expr with inverted index to filter block. Given a roaring bitmap of match rows
-    virtual Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) {
+    virtual Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) const {
         return Status::OK();
     }
 
     Status _evaluate_inverted_index(VExprContext* context, const FunctionBasePtr& function,
-                                    uint32_t segment_num_rows);
+                                    uint32_t segment_num_rows) const;
 
     // Only the 4th parameter is used in the runtime filter. In and MinMax need overwrite the
     // interface
     virtual Status execute_runtime_fitler(VExprContext* context, Block* block,
-                                          int* result_column_id, ColumnNumbers& args) {
+                                          int* result_column_id, ColumnNumbers& args) const {
         return execute(context, block, result_column_id);
     };
 
@@ -253,7 +253,7 @@ public:
 
     // fast_execute can direct copy expr filter result which build by apply index in segment_iterator
     bool fast_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,
-                      int* result_column_id);
+                      int* result_column_id) const;
 
     virtual bool can_push_down_to_index() const { return false; }
     virtual bool equals(const VExpr& other);
@@ -279,10 +279,12 @@ protected:
         return res;
     }
 
-    bool is_const_and_have_executed() { return (is_constant() && (_constant_col != nullptr)); }
+    bool is_const_and_have_executed() const {
+        return (is_constant() && (_constant_col != nullptr));
+    }
 
     Status get_result_from_const(vectorized::Block* block, const std::string& expr_name,
-                                 int* result_column_id);
+                                 int* result_column_id) const;
 
     Status check_constant(const Block& block, ColumnNumbers arguments) const;
 
@@ -328,7 +330,6 @@ protected:
 
     // ensuring uniqueness during index traversal
     uint32_t _index_unique_id = 0;
-    bool _can_fast_execute = false;
     bool _enable_inverted_index_query = true;
 };
 

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -271,6 +271,8 @@ public:
         return *this;
     }
 
+    bool can_fast_execute = false;
+
 private:
     // Close method is called in vexpr context dector, not need call expicility
     void close();

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -42,7 +42,7 @@ class VInPredicate final : public VExpr {
 public:
     VInPredicate(const TExprNode& node);
     ~VInPredicate() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -51,12 +51,12 @@ public:
 
     std::string debug_string() const override;
 
-    size_t skip_constant_args_size() const;
+    size_t skip_constant_args_size(VExprContext* context) const;
 
     const FunctionBasePtr function() { return _function; }
 
     bool is_not_in() const { return _is_not_in; };
-    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
+    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) const override;
 
 private:
     FunctionBasePtr _function;

--- a/be/src/vec/exprs/vinfo_func.cpp
+++ b/be/src/vec/exprs/vinfo_func.cpp
@@ -55,7 +55,8 @@ VInfoFunc::VInfoFunc(const TExprNode& node) : VExpr(node) {
     this->_column_ptr = _data_type->create_column_const(1, field);
 }
 
-Status VInfoFunc::execute(VExprContext* context, vectorized::Block* block, int* result_column_id) {
+Status VInfoFunc::execute(VExprContext* context, vectorized::Block* block,
+                          int* result_column_id) const {
     // Info function should return least one row, e.g. select current_user().
     size_t row_size = std::max(block->rows(), 1UL);
     *result_column_id = VExpr::insert_param(block, {_column_ptr, _data_type, _expr_name}, row_size);

--- a/be/src/vec/exprs/vinfo_func.h
+++ b/be/src/vec/exprs/vinfo_func.h
@@ -39,7 +39,7 @@ public:
     ~VInfoFunc() override = default;
 
     const std::string& expr_name() const override { return _expr_name; }
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
 private:
     const std::string _expr_name = "vinfofunc expr";

--- a/be/src/vec/exprs/vlambda_function_call_expr.h
+++ b/be/src/vec/exprs/vlambda_function_call_expr.h
@@ -63,7 +63,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         DCHECK(_open_finished || _getting_const_col);
         return _lambda_function->execute(context, block, result_column_id, _data_type, _children);
     }

--- a/be/src/vec/exprs/vlambda_function_expr.h
+++ b/be/src/vec/exprs/vlambda_function_expr.h
@@ -42,7 +42,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         DCHECK(_open_finished || _getting_const_col);
         return get_child(0)->execute(context, block, result_column_id);
     }

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -49,7 +49,8 @@ Status VLiteral::prepare(RuntimeState* state, const RowDescriptor& desc, VExprCo
     return Status::OK();
 }
 
-Status VLiteral::execute(VExprContext* context, vectorized::Block* block, int* result_column_id) {
+Status VLiteral::execute(VExprContext* context, vectorized::Block* block,
+                         int* result_column_id) const {
     // Literal expr should return least one row.
     // sometimes we just use a VLiteral without open or prepare. so can't check it at this moment
     size_t row_size = std::max(block->rows(), _column_ptr->size());

--- a/be/src/vec/exprs/vliteral.h
+++ b/be/src/vec/exprs/vliteral.h
@@ -44,7 +44,7 @@ public:
     }
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     const std::string& expr_name() const override { return _expr_name; }
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -129,14 +129,15 @@ void VMatchPredicate::close(VExprContext* context, FunctionContext::FunctionStat
     VExpr::close(context, scope);
 }
 
-Status VMatchPredicate::evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) {
+Status VMatchPredicate::evaluate_inverted_index(VExprContext* context,
+                                                uint32_t segment_num_rows) const {
     DCHECK_EQ(get_num_children(), 2);
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
-    if (_can_fast_execute && fast_execute(context, block, result_column_id)) {
+    if (context->can_fast_execute && fast_execute(context, block, result_column_id)) {
         return Status::OK();
     }
     DBUG_EXECUTE_IF("VMatchPredicate.execute", {

--- a/be/src/vec/exprs/vmatch_predicate.h
+++ b/be/src/vec/exprs/vmatch_predicate.h
@@ -49,12 +49,12 @@ class VMatchPredicate final : public VExpr {
 public:
     VMatchPredicate(const TExprNode& node);
     ~VMatchPredicate() override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
     void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
-    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
+    Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) const override;
     const std::string& expr_name() const override;
     const std::string& function_name() const;
 

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -85,7 +85,8 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
     _impl->close(context, scope);
 }
 
-Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block,
+                                      int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     DCHECK(_expr_filtered_rows_counter && _expr_input_rows_counter && _always_true_counter)
             << "rf counter must be initialized";

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -50,7 +50,7 @@ public:
     VRuntimeFilterWrapper(const TExprNode& node, VExprSPtr impl, double ignore_thredhold,
                           bool null_aware = false);
     ~VRuntimeFilterWrapper() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -95,7 +95,7 @@ public:
     }
 
 private:
-    void reset_judge_selectivity() {
+    void reset_judge_selectivity() const {
         _always_true = false;
         _judge_counter = config::runtime_filter_sampling_frequency;
         _judge_input_rows = 0;
@@ -111,10 +111,10 @@ private:
     // is evaluated as true, the logic for always_true is applied for the rest of that period
     // without recalculating. At the beginning of the next period,
     // reset_judge_selectivity is used to reset these variables.
-    std::atomic_int _judge_counter = 0;
-    std::atomic_uint64_t _judge_input_rows = 0;
-    std::atomic_uint64_t _judge_filter_rows = 0;
-    std::atomic_int _always_true = false;
+    mutable std::atomic_int _judge_counter = 0;
+    mutable std::atomic_uint64_t _judge_input_rows = 0;
+    mutable std::atomic_uint64_t _judge_filter_rows = 0;
+    mutable std::atomic_int _always_true = false;
 
     RuntimeProfile::Counter* _expr_filtered_rows_counter = nullptr;
     RuntimeProfile::Counter* _expr_input_rows_counter = nullptr;

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -90,7 +90,7 @@ Status VSlotRef::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -41,7 +41,7 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     const std::string& expr_name() const override;
     std::string expr_label() override;

--- a/be/src/vec/exprs/vtopn_pred.h
+++ b/be/src/vec/exprs/vtopn_pred.h
@@ -79,7 +79,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         if (!_predicate->has_value()) {
             block->insert({create_always_true_column(block->rows(), _data_type->is_nullable()),
                            _data_type, _expr_name});

--- a/be/src/vec/exprs/vtuple_is_null_predicate.cpp
+++ b/be/src/vec/exprs/vtuple_is_null_predicate.cpp
@@ -60,7 +60,8 @@ Status VTupleIsNullPredicate::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-Status VTupleIsNullPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VTupleIsNullPredicate::execute(VExprContext* context, Block* block,
+                                      int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     *result_column_id = _column_to_check;
     return Status::OK();

--- a/be/src/vec/exprs/vtuple_is_null_predicate.h
+++ b/be/src/vec/exprs/vtuple_is_null_predicate.h
@@ -45,7 +45,7 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     [[nodiscard]] bool is_constant() const override { return false; }
 

--- a/be/test/exprs/mock_vexpr.h
+++ b/be/test/exprs/mock_vexpr.h
@@ -29,8 +29,8 @@ class MockVExpr : public VExpr {
 public:
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     MOCK_CONST_METHOD0(expr_name, const std::string&());
-    MOCK_METHOD3(execute,
-                 Status(VExprContext* context, vectorized::Block* block, int* result_column_id));
+    MOCK_CONST_METHOD3(execute, Status(VExprContext* context, vectorized::Block* block,
+                                 int* result_column_id));
 }; // class MockVExpr
 
 } // namespace vectorized

--- a/be/test/exprs/mock_vexpr.h
+++ b/be/test/exprs/mock_vexpr.h
@@ -30,7 +30,7 @@ public:
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     MOCK_CONST_METHOD0(expr_name, const std::string&());
     MOCK_CONST_METHOD3(execute, Status(VExprContext* context, vectorized::Block* block,
-                                 int* result_column_id));
+                                       int* result_column_id));
 }; // class MockVExpr
 
 } // namespace vectorized


### PR DESCRIPTION
### What problem does this PR solve?

In the past, a _can_fast_execute flag was maintained in VExpr. 
However, since exec executes concurrently, errors would occur when using the _can_fast_execute judgment.
The correct approach is to put _can_fast_execute into VExprContext.

In addition, to prevent similar problems from occurring in the future, const has been added to all relevant execution functions.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

