### PR TITLE
[fix](function) The parameters after the first of the mask function need to be restricted to constants

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -702,6 +702,8 @@ public:
 
     size_t get_number_of_arguments() const override { return 0; }
 
+    ColumnNumbers get_arguments_that_are_always_constant() const override { return {1, 2, 3}; }
+
     bool is_variadic() const override { return true; }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,

--- a/regression-test/suites/correctness_p0/test_mask_function.groovy
+++ b/regression-test/suites/correctness_p0/test_mask_function.groovy
@@ -77,6 +77,27 @@ suite("test_mask_function") {
     """
 
     test {
+        sql """
+            select mask('abcd', name) from table_mask_test order by id;
+        """
+        exception "Argument at index 1 for function mask must be constant"
+    }
+
+    test {
+        sql """
+            select mask('abcd', '>', name) from table_mask_test order by id;
+        """
+        exception "Argument at index 2 for function mask must be constant"
+    }
+
+    test {
+        sql """
+            select mask('abcd', '>', '<', `name`) from table_mask_test order by id;
+        """
+        exception "Argument at index 3 for function mask must be constant"
+    }
+
+    test {
         sql """ select mask_last_n("12345", -100); """
         exception "function mask_last_n only accept non-negative input for 2nd argument but got -100"
     }


### PR DESCRIPTION
### What problem does this PR solve?

```
*** Query id: 88218e14284c497a-b1a04172e7b896b6 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1733912200 (unix time) try "date -d @1733912200" if you are using GNU date ***
*** Current BE git commitID: 17bcc208e9 ***
*** SIGSEGV invalid permissions for mapped object (@0x7f04d94a0000) received by PID 6347 (TID 8285 OR 0x7f05c4996640) from PID 18446744073060089856; stack trace: ***
terminate called after throwing an instance of 'terminate called recursively
std::system_error'
  what():  Invalid argument
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F09BFC91520 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::vectorized::FunctionMask::vector_mask(doris::vectorized::ColumnStr<unsigned int> const&, doris::vectorized::ColumnStr<unsigned int>&, char, char, char) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function_string.h:986
 5# doris::vectorized::FunctionMask::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function.h:461
 7# doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function.cpp:122
 8# doris::vectorized::PreparedFunctionImpl::default_implementation_for_nulls(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool, bool*) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function.cpp:217
 9# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function.cpp:244
10# doris::vectorized::PreparedFunctionImpl::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function.cpp:250
11# doris::vectorized::IFunctionBase::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/functions/function.h:194
12# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector<unsigned long, std::allocator<unsigned long> >&) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
13# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exprs/vectorized_fn_call.cpp:196
14# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/exprs/vexpr_context.cpp:54
15# doris::pipeline::OperatorXBase::do_projections(doris::RuntimeState*, doris::vectorized::Block*, doris::vectorized::Block*) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/operator.cpp:259
16# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/operator.cpp:290
17# doris::pipeline::PipelineXTask::execute(bool*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:346
18# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:347
19# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
20# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:499
21# start_thread at ./nptl/pthread_create.c:442
22# 0x00007F09BFD75850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

