### PR TITLE
[fix](nereids)EliminateGroupBy rule should keep output's datatype unchanged

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
@@ -30,7 +30,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
-import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.PlanUtils;
@@ -84,12 +84,8 @@ public class EliminateGroupBy extends OneRewriteRuleFactory {
                                         .castIfNotSameType(f.child(0), f.getDataType()), ne.getName()));
                             } else if (f instanceof Count) {
                                 newOutput.add((NamedExpression) ne.withChildren(
-                                        new If(
-                                            new IsNull(f.child(0)),
-                                            Literal.of(0),
-                                            Literal.of(1)
-                                        )
-                                ));
+                                        new If(new IsNull(f.child(0)), new BigIntLiteral(0),
+                                                new BigIntLiteral(1))));
                             } else {
                                 throw new IllegalStateException("Unexpected aggregate function: " + f);
                             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByTest.java
@@ -94,6 +94,7 @@ class EliminateGroupByTest extends TestWithFeService implements MemoPatternMatch
                         logicalEmptyRelation().when(p -> p.getProjects().get(0).toSql().equals("id")
                                 && p.getProjects().get(1).toSql()
                                 .equals("if(age IS NULL, 0, 1) AS `if(age IS NULL, 0, 1)`")
+                                && p.getProjects().get(1).getDataType().isBigIntType()
                         )
                 );
     }


### PR DESCRIPTION
`select id, count(age) from t group by id`
consider t is unique table and it's unique key is id. The sql will be convert to:
`select id, if(age is null, 0, 1) from t;`
count(age) is replaced by if(age is null, 0, 1). And we should keep if(age is null, 0, 1)'s datatype same as count(age) which is bigint.

Issue Number: close #xxx

Related PR: [28615](https://github.com/apache/doris/pull/28615) 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

