### PR TITLE
[fix](nereids) fix compare with date like literal

### DIFF
--- a/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_literal.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_literal.out
@@ -1528,7 +1528,7 @@ PhysicalResultSink
 ----------PhysicalProject
 ------------PhysicalStorageLayerAggregate[test_pull_up_predicate_literal]
 ------PhysicalProject
---------filter((cast(d_date as DATETIMEV2(0)) = '2024-08-02 10:10:00'))
+--------filter((t2.d_date = '2024-08-02'))
 ----------PhysicalOlapScan[test_types]
 
 -- !const_value_and_join_column_type170 --

--- a/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_literal.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_literal.groovy
@@ -997,7 +997,7 @@ select c1 from (select
     qt_const_value_and_join_column_type169 """
 explain shape plan
 select c1 from (select 
-'2024-08-02 10:10:00.123332' as c1 from test_pull_up_predicate_literal limit 10) t inner join test_types t2 on d_date=t.c1"""
+'2024-08-02 00:00:00.000000' as c1 from test_pull_up_predicate_literal limit 10) t inner join test_types t2 on d_date=t.c1"""
 
     qt_const_value_and_join_column_type170 """
 explain shape plan


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

when compare with date like literal,  the literal may be wrong cut.

for example:

if a is datetimev1,   then:

 `a = '2020-01-01 00:00:00.12'`   should opt as `FALSE`,  but it opt as `a = '2020-01-01 00:00:00`;
 `a >= '2020-01-01 00:00:00.12'`   should opt as `a >= '2020-01-01 00:00:01`,  but it opt as `a >= '2020-01-01 00:00:00`;

if a is date / datev2, then:
 `a = '2020-01-01 00:00:12'`   should opt as `FALSE`,  but it don't opt it;


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

