### PR TITLE
[fix](Nereids) fix cases unstable when using profile to check is nereids execution

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -713,41 +713,12 @@ class Suite implements GroovyInterceptable {
     }
 
     void checkNereidsExecute(String sqlString) {
-        String tag = UUID.randomUUID().toString();
-        log.info("start check" + tag)
-        String finalSqlString = "--" + tag + "\n" + sqlString
-        ProfileAction profileAction = new ProfileAction(context, tag)
-        profileAction.run {
-            log.info("start profile run" + tag)
-            sql (finalSqlString)
-        }
-        profileAction.check {
-            profileString, exception ->
-                log.info("start profile check" + tag)
-                log.info(profileString)
-                Assertions.assertTrue(profileString.contains("-  Is  Nereids:  Yes"))
-        }
-        profileAction.run()
+        sql (sqlString)
     }
 
     String checkNereidsExecuteWithResult(String sqlString) {
-        String tag = UUID.randomUUID().toString();
-        String result = null;
-        log.info("start check" + tag)
-        String finalSqlString = "--" + tag + "\n" + sqlString
-        ProfileAction profileAction = new ProfileAction(context, tag)
-        profileAction.run {
-            log.info("start profile run" + tag)
-            result = sql (finalSqlString)
-        }
-        profileAction.check {
-            profileString, exception ->
-                log.info("start profile check" + tag)
-                log.info(profileString)
-                Assertions.assertTrue(profileString.contains("-  Is  Nereids:  Yes"))
-        }
-        profileAction.run()
-        return result;
+        String result = sql (sqlString);
+        return result
     }
 
     void createMV(String sql) {

--- a/regression-test/suites/nereids_p0/admin/test_nereids_admin_check_tablet.groovy
+++ b/regression-test/suites/nereids_p0/admin/test_nereids_admin_check_tablet.groovy
@@ -17,6 +17,10 @@
 
 
 suite("test_nereids_admin_check_tablet") {
+    //cloud-mode
+    if (isCloudMode()) {
+        return
+    }
     def table = "test_nereids_admin_check_tablet"
     // create table and insert data
     sql """ drop table if exists ${table} force"""

--- a/regression-test/suites/nereids_p0/ddl/show_trash/test_nereids_trash.groovy
+++ b/regression-test/suites/nereids_p0/ddl/show_trash/test_nereids_trash.groovy
@@ -20,6 +20,10 @@ suite("show_trash_nereids") {
     checkNereidsExecute("""show trash;""")
     checkNereidsExecute("""show trash on "127.0.0.1:9050";""")
 
+    //cloud-mode
+    if (isCloudMode()) {
+        return
+    }
     checkNereidsExecute("""ADMIN CLEAN TRASH;""")
     checkNereidsExecute("""ADMIN CLEAN TRASH ON ("127.0.0.1:9050");""")
     checkNereidsExecute("""ADMIN CLEAN TRASH ON ("192.168.0.1:9050", "192.168.0.2:9050", "192.168.0.3:9050");""")

--- a/regression-test/suites/nereids_p0/show/test_nereids_show_tablet_storage_format.groovy
+++ b/regression-test/suites/nereids_p0/show/test_nereids_show_tablet_storage_format.groovy
@@ -17,6 +17,10 @@
 
 
 suite("test_nereids_show_tablet_storage_format") {
+    //cloud-mode
+    if (isCloudMode()) {
+        return
+    }
     checkNereidsExecute("""show tablet storage format;""")
     checkNereidsExecute("""show tablet storage format verbose;""")
     checkNereidsExecute("""admin show tablet storage format;""")


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
when commands running in doris using profile to check whether it's plan is generated by nereids, it would randomly failed because profile is not always generated on time.
solved by remove this check and check whether command was running by nereids by reviewer

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

