### PR TITLE
[feature](meta-service) Support dynamic configuration for meta service

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -54,6 +54,10 @@ CONF_Int32(log_verbose_level, "5");
 // Only works when starting Cloud with --console.
 CONF_Bool(enable_file_logger, "true");
 
+// Custom conf path is default the same as conf path, and configs will be append to it.
+// Otherwise, will a new custom conf file will be created.
+CONF_String(custom_conf_path, "./conf/doris_cloud.conf");
+
 // recycler config
 CONF_mInt64(recycle_interval_seconds, "3600");
 CONF_mInt64(retention_seconds, "259200"); // 72h, global retention time

--- a/cloud/src/common/configbase.h
+++ b/cloud/src/common/configbase.h
@@ -26,6 +26,8 @@
 
 namespace doris::cloud::config {
 
+extern std::string g_conf_path;
+
 class Register {
 public:
     struct Field {
@@ -170,4 +172,5 @@ extern std::map<std::string, std::string>* full_conf_map;
 bool init(const char* conf_file, bool fill_conf_map = false, bool must_exist = true,
           bool set_to_default = true);
 
+bool set_config(const std::string& field, const std::string& value, bool need_persist = false);
 } // namespace doris::cloud::config

--- a/cloud/src/common/configbase.h
+++ b/cloud/src/common/configbase.h
@@ -26,8 +26,6 @@
 
 namespace doris::cloud::config {
 
-extern std::string g_conf_path;
-
 class Register {
 public:
     struct Field {
@@ -172,5 +170,6 @@ extern std::map<std::string, std::string>* full_conf_map;
 bool init(const char* conf_file, bool fill_conf_map = false, bool must_exist = true,
           bool set_to_default = true);
 
-bool set_config(const std::string& field, const std::string& value, bool need_persist = false);
+bool set_config(const std::string& field, const std::string& value, bool need_persist,
+                const std::string& custom_conf_path);
 } // namespace doris::cloud::config

--- a/cloud/src/common/configbase.h
+++ b/cloud/src/common/configbase.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace doris::cloud::config {
@@ -152,7 +153,11 @@ public:
 
     void set_force(const std::string& key, const std::string& val);
 
-    // dump props to conf file
+    // Dump props to conf file if conffile exists, will append to it
+    // else will dump to a new conffile.
+    //
+    // This Function will generate a tmp file for modification and rename it
+    // to subtitute the original one if modication success.
     bool dump(const std::string& conffile);
 
 private:
@@ -170,6 +175,7 @@ extern std::map<std::string, std::string>* full_conf_map;
 bool init(const char* conf_file, bool fill_conf_map = false, bool must_exist = true,
           bool set_to_default = true);
 
-bool set_config(const std::string& field, const std::string& value, bool need_persist,
-                const std::string& custom_conf_path);
+std::pair<bool, std::string> set_config(std::unordered_map<std::string, std::string> field_map,
+                                        bool need_persist, const std::string& custom_conf_path);
+
 } // namespace doris::cloud::config

--- a/cloud/src/main.cpp
+++ b/cloud/src/main.cpp
@@ -33,6 +33,7 @@
 
 #include "common/arg_parser.h"
 #include "common/config.h"
+#include "common/configbase.h"
 #include "common/encryption_util.h"
 #include "common/logging.h"
 #include "meta-service/mem_txn_kv.h"
@@ -193,9 +194,9 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    auto conf_file = args.get<std::string>(ARG_CONF);
-    if (!config::init(conf_file.c_str(), true)) {
-        std::cerr << "failed to init config file, conf=" << conf_file << std::endl;
+    config::g_conf_path = args.get<std::string>(ARG_CONF);
+    if (!config::init(config::g_conf_path.data(), true)) {
+        std::cerr << "failed to init config file, conf=" << config::g_conf_path << std::endl;
         return -1;
     }
 

--- a/cloud/src/main.cpp
+++ b/cloud/src/main.cpp
@@ -194,9 +194,15 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    config::g_conf_path = args.get<std::string>(ARG_CONF);
-    if (!config::init(config::g_conf_path.data(), true)) {
-        std::cerr << "failed to init config file, conf=" << config::g_conf_path << std::endl;
+    auto conf_file = args.get<std::string>(ARG_CONF);
+    if (!config::init(conf_file.c_str(), true)) {
+        std::cerr << "failed to init config file, conf=" << conf_file << std::endl;
+        return -1;
+    }
+    if (!std::filesystem::equivalent(conf_file, config::custom_conf_path) &&
+        !config::init(config::custom_conf_path.c_str(), false)) {
+        std::cerr << "failed to init custom config file, conf=" << config::custom_conf_path
+                  << std::endl;
         return -1;
     }
 

--- a/cloud/src/meta-service/meta_service_http.cpp
+++ b/cloud/src/meta-service/meta_service_http.cpp
@@ -20,6 +20,7 @@
 #include <brpc/controller.h>
 #include <brpc/http_status_code.h>
 #include <brpc/uri.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
 #include <gen_cpp/cloud.pb.h>
 #include <glog/logging.h>
@@ -44,7 +45,9 @@
 #include <vector>
 
 #include "common/config.h"
+#include "common/configbase.h"
 #include "common/logging.h"
+#include "common/string_util.h"
 #include "meta-service/keys.h"
 #include "meta-service/txn_kv.h"
 #include "meta-service/txn_kv_error.h"
@@ -448,6 +451,31 @@ static HttpResponse process_query_rate_limit(MetaServiceImpl* service, brpc::Con
     return http_json_reply(MetaServiceCode::OK, "", sb.GetString());
 }
 
+static HttpResponse process_update_config(MetaServiceImpl* service, brpc::Controller* cntl) {
+    const auto& uri = cntl->http_request().uri();
+    bool persist = (http_query(uri, "persist") == "true");
+    auto configs = std::string {http_query(uri, "configs")};
+    if (configs.empty()) [[unlikely]] {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
+                               "query param `config` should not be empty");
+    }
+    auto conf_list = split(configs, ',');
+    for (const auto& conf : conf_list) {
+        auto conf_pair = split(conf, '=');
+        if (conf_pair.size() != 2) [[unlikely]] {
+            return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
+                                   fmt::format("config {} is invalid", configs));
+        }
+        trim(conf_pair[0]);
+        trim(conf_pair[1]);
+        if (!config::set_config(conf_pair[0], conf_pair[1], persist)) {
+            return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
+                                   fmt::format("set {}={} failed", conf_pair[0], conf_pair[1]));
+        }
+    }
+    return http_json_reply(MetaServiceCode::OK, "");
+}
+
 static HttpResponse process_decode_key(MetaServiceImpl*, brpc::Controller* ctrl) {
     auto& uri = ctrl->http_request().uri();
     std::string_view key = http_query(uri, "key");
@@ -732,12 +760,14 @@ void MetaServiceImpl::http(::google::protobuf::RpcController* controller,
             {"alter_iam", process_alter_iam},
             {"adjust_rate_limit", process_adjust_rate_limit},
             {"list_rate_limit", process_query_rate_limit},
+            {"update_config", process_update_config},
             {"v1/abort_txn", process_abort_txn},
             {"v1/abort_tablet_job", process_abort_tablet_job},
             {"v1/alter_ram_user", process_alter_ram_user},
             {"v1/alter_iam", process_alter_iam},
             {"v1/adjust_rate_limit", process_adjust_rate_limit},
             {"v1/list_rate_limit", process_query_rate_limit},
+            {"v1/update_config", process_update_config},
     };
 
     auto* cntl = static_cast<brpc::Controller*>(controller);

--- a/cloud/src/meta-service/meta_service_http.cpp
+++ b/cloud/src/meta-service/meta_service_http.cpp
@@ -468,7 +468,7 @@ static HttpResponse process_update_config(MetaServiceImpl* service, brpc::Contro
         }
         trim(conf_pair[0]);
         trim(conf_pair[1]);
-        if (!config::set_config(conf_pair[0], conf_pair[1], persist)) {
+        if (!config::set_config(conf_pair[0], conf_pair[1], persist, config::custom_conf_path)) {
             return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
                                    fmt::format("set {}={} failed", conf_pair[0], conf_pair[1]));
         }

--- a/cloud/test/meta_service_http_test.cpp
+++ b/cloud/test/meta_service_http_test.cpp
@@ -1663,7 +1663,8 @@ TEST(MetaServiceHttpTest, UpdateConfig) {
         ASSERT_EQ(config::recycle_interval_seconds, 3601);
     }
     {
-        config::g_conf_path = "./doris_cloud.conf";
+        auto original_conf_path = config::custom_conf_path;
+        config::custom_conf_path = "./doris_cloud.conf";
         auto [status_code, content] = ctx.query<std::string>(
                 "update_config",
                 "configs=recycle_interval_seconds=3659,retention_seconds=259219&persist=true");
@@ -1671,7 +1672,7 @@ TEST(MetaServiceHttpTest, UpdateConfig) {
         ASSERT_EQ(config::recycle_interval_seconds, 3659);
         ASSERT_EQ(config::retention_seconds, 259219);
         config::Properties props;
-        ASSERT_TRUE(props.load(config::g_conf_path.data(), true));
+        ASSERT_TRUE(props.load(config::custom_conf_path.c_str(), true));
         {
             bool new_val_set = false;
             int64_t recycle_interval_s = 0;
@@ -1688,7 +1689,8 @@ TEST(MetaServiceHttpTest, UpdateConfig) {
             ASSERT_TRUE(new_val_set);
             ASSERT_EQ(retention_s, 259219);
         }
-        std::filesystem::remove(config::g_conf_path);
+        std::filesystem::remove(config::custom_conf_path);
+        config::custom_conf_path = original_conf_path;
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Provide an http interface to change metaservice's mutable configuration.
```
curl http://ms_ip:ms_port/MetaService/http/v1/update_config?configs=${configs}&persist=${boolean}
```

For example:
```
curl http://ms_ip:ms_port/MetaService/http/v1/update_config?configs=recycle_interval_seconds=3601,retention_seconds=259201
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

