### PR TITLE
[fix](external)fix split and get the schema

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
@@ -90,7 +90,7 @@ public class LocationPath {
     private LocationPath(String originLocation, Map<String, String> props, boolean convertPath) {
         isBindBroker = props.containsKey(HMSExternalCatalog.BIND_BROKER_NAME);
         String tmpLocation = originLocation;
-        if (!originLocation.contains(SCHEME_DELIM)) {
+        if (!(originLocation.contains(SCHEME_DELIM) || originLocation.contains(NONSTANDARD_SCHEME_DELIM))) {
             // Sometimes the file path does not contain scheme, need to add default fs
             // eg, /path/to/file.parquet -> hdfs://nn/path/to/file.parquet
             // the default fs is from the catalog properties

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
@@ -205,4 +205,16 @@ public class LocationPathTest {
         String beLocation = locationPath.toStorageLocation().toString();
         Assertions.assertTrue(beLocation.equalsIgnoreCase("/path/to/local"));
     }
+
+    @Test
+    public void testLocalFileSystem() {
+        HashMap<String, String> props = new HashMap<>();
+        props.put("fs.defaultFS", "hdfs:///xyz");
+        LocationPath p1 = new LocationPath("file:///abc/def", props);
+        Assertions.assertEquals(Scheme.LOCAL, p1.getScheme());
+        LocationPath p2 = new LocationPath("file:/abc/def", props);
+        Assertions.assertEquals(Scheme.LOCAL, p2.getScheme());
+        LocationPath p3 = new LocationPath("file://authority/abc/def", props);
+        Assertions.assertEquals(Scheme.LOCAL, p3.getScheme());
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #39116

Problem Summary:

Split and get the schema according to `://` and `:/`.
Like `file://ab/c`, `file:/ab/c`

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

