### PR TITLE
[fix](fe) Disable releases for Apache snapshots repo

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1745,6 +1745,9 @@ under the License.
             <id>snapshots</id>
             <name>apache snapshots maven repo https</name>
             <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <snapshots>
                 <updatePolicy>always</updatePolicy>
             </snapshots>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -399,6 +399,9 @@ under the License.
                     <id>snapshots</id>
                     <name>apache snapshots maven repo https</name>
                     <url>https://repository.apache.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
                 </repository>
                 <!-- for java-cup -->
                 <!-- https://docs.cloudera.com/documentation/enterprise/release-notes/topics/cdh_vd_cdh5_maven_repo.html -->

--- a/fe_plugins/pom.xml
+++ b/fe_plugins/pom.xml
@@ -113,6 +113,9 @@ under the License.
                     <id>snapshots</id>
                     <name>apache snapshots maven repo https</name>
                     <url>https://repository.apache.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
                 </repository>
                 <repository>
                     <id>cloudera-public</id>


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: while building `fe`, Maven looks for release artifacts in `snapshots` repo (and gets HTTP 404).

Repro:

```
$ mvn -DskipTests clean package
...
Downloading from snapshots: https://repository.apache.org/content/repositories/snapshots/com/google/cloud/first-party-dependencies/3.19.0/first-party-dependencies-3.19.0.pom
Downloading from cloudera: https://repository.cloudera.com/repository/libs-release-local/com/google/cloud/first-party-dependencies/3.19.0/first-party-dependencies-3.19.0.pom
Downloading from central: https://repo.maven.apache.org/maven2/com/google/cloud/first-party-dependencies/3.19.0/first-party-dependencies-3.19.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/cloud/first-party-dependencies/3.19.0/first-party-dependencies-3.19.0.pom (3.2 kB at 269 kB/s)
Downloading from snapshots: https://repository.apache.org/content/repositories/snapshots/com/google/cloud/google-cloud-shared-config/1.6.1/google-cloud-shared-config-1.6.1.pom
Downloading from cloudera: https://repository.cloudera.com/repository/libs-release-local/com/google/cloud/google-cloud-shared-config/1.6.1/google-cloud-shared-config-1.6.1.pom
Downloading from central: https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-shared-config/1.6.1/google-cloud-shared-config-1.6.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-shared-config/1.6.1/google-cloud-shared-config-1.6.1.pom (30 kB at 2.7 MB/s)
...
```

Repository list shows `snapshots` is configured for `releases+snapshots`:

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ fe ---
[INFO] Remote repositories used by project org.apache.doris:fe:pom:1.2-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * snapshots (https://repository.apache.org/content/repositories/snapshots/, default, releases+snapshots)
[INFO]    First introduced on root
[INFO]  * cloudera (https://repository.cloudera.com/repository/libs-release-local/, default, releases+snapshots)
[INFO]    First introduced on root
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, snapshots)
[INFO]    First introduced on root
[INFO]  * sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots, default, snapshots)
[INFO]    First introduced on org.awaitility:awaitility:jar:4.2.0 (compile)
```

Excerpt from same list with the fix:

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO]  * snapshots (https://repository.apache.org/content/repositories/snapshots/, default, snapshots)
...
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

