### PR TITLE
[fix](regression-test) Increase timeout for compaction tasks in some sc cases

### DIFF
--- a/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
@@ -51,7 +51,7 @@ suite("test_agg_keys_schema_change_datev2") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
+            Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
                 String tablet_id = tablet[0]
                 backend_id = tablet[2]
                 (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)

--- a/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
@@ -151,7 +151,7 @@ suite ("test_dup_keys_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-                Awaitility.await().untilAsserted(() -> {
+                Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
                     String tablet_id = tablet[0]
                     backend_id = tablet[2]
                     (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)

--- a/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
@@ -134,7 +134,7 @@ suite ("test_uniq_keys_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-                Awaitility.await().untilAsserted(() -> {
+                Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
                     String tablet_id = tablet[0]
                     backend_id = tablet[2]
                     (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Awaitility default timeout: 10s may be not enough for some compaction tasks in some schema change test cases.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

