### PR TITLE
[Fix](Job)Fix redundant job scheduling by preventing same state transitions (e.g., RUNNING → RUNNING)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -206,7 +206,7 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
                     }
                     alterJobStatus(a.getJobId(), jobStatus);
                 } catch (JobException e) {
-                    throw new JobException("Alter job status error, jobName is %cds, errorMsg is %s",
+                    throw new JobException("Alter job status error, jobName is %s, errorMsg is %s",
                             jobName, e.getMessage());
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -548,8 +548,8 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
             }
             // check state here
             unfinishedLoadJob =
-                    matchLoadJobs.stream().filter(InsertJob::isRunning)
-                            .collect(Collectors.toList());
+                matchLoadJobs.stream().filter(InsertJob::isRunning)
+                    .collect(Collectors.toList());
             if (unfinishedLoadJob.isEmpty()) {
                 throw new JobException("There is no uncompleted job");
             }
@@ -560,7 +560,7 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
         if (unfinishedLoadJob.size() > 1 || unfinishedLoadJob.get(0).getTableNames().isEmpty()) {
             if (Env.getCurrentEnv().getAccessManager()
                     .checkDbPriv(ConnectContext.get(), InternalCatalog.INTERNAL_CATALOG_NAME, dbName,
-                            PrivPredicate.LOAD)) {
+                    PrivPredicate.LOAD)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_DBACCESS_DENIED_ERROR, "LOAD",
                         ConnectContext.get().getQualifiedUser(),
                         ConnectContext.get().getRemoteIP(), dbName);
@@ -569,8 +569,8 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
             for (String tableName : unfinishedLoadJob.get(0).getTableNames()) {
                 if (Env.getCurrentEnv().getAccessManager()
                         .checkTblPriv(ConnectContext.get(), InternalCatalog.INTERNAL_CATALOG_NAME, dbName,
-                                tableName,
-                                PrivPredicate.LOAD)) {
+                        tableName,
+                        PrivPredicate.LOAD)) {
                     ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
                             ConnectContext.get().getQualifiedUser(),
                             ConnectContext.get().getRemoteIP(), dbName + ":" + tableName);
@@ -595,26 +595,26 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
                 CaseSensibility.LABEL.getCaseSensibility());
         matchLoadJobs.addAll(
                 loadJobs.stream()
-                        .filter(job -> !job.isCancelled())
-                        .filter(job -> {
-                            if (operator != null) {
-                                // compound
-                                boolean labelFilter =
-                                        label.contains("%") ? matcher.match(job.getLabelName())
-                                                : job.getLabelName().equalsIgnoreCase(label);
-                                boolean stateFilter = job.getJobStatus().name().equalsIgnoreCase(state);
-                                return operator instanceof And ? labelFilter && stateFilter :
-                                        labelFilter || stateFilter;
-                            }
-                            if (StringUtils.isNotEmpty(label)) {
-                                return label.contains("%") ? matcher.match(job.getLabelName())
-                                        : job.getLabelName().equalsIgnoreCase(label);
-                            }
-                            if (StringUtils.isNotEmpty(state)) {
-                                return job.getJobStatus().name().equalsIgnoreCase(state);
-                            }
-                            return false;
-                        }).collect(Collectors.toList())
+                .filter(job -> !job.isCancelled())
+                .filter(job -> {
+                    if (operator != null) {
+                        // compound
+                        boolean labelFilter =
+                                label.contains("%") ? matcher.match(job.getLabelName())
+                                : job.getLabelName().equalsIgnoreCase(label);
+                        boolean stateFilter = job.getJobStatus().name().equalsIgnoreCase(state);
+                        return operator instanceof And ? labelFilter && stateFilter :
+                            labelFilter || stateFilter;
+                    }
+                    if (StringUtils.isNotEmpty(label)) {
+                        return label.contains("%") ? matcher.match(job.getLabelName())
+                            : job.getLabelName().equalsIgnoreCase(label);
+                    }
+                    if (StringUtils.isNotEmpty(state)) {
+                        return job.getJobStatus().name().equalsIgnoreCase(state);
+                    }
+                    return false;
+                }).collect(Collectors.toList())
         );
     }
 }

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -304,12 +304,10 @@ suite("test_base_insert_job") {
         assert e.getMessage().contains("Invalid interval time unit: years")
     }
     // assert interval time unit is -1
-    try {
+    assertThrows(Exception) {
         sql """
             CREATE JOB test_error_starts  ON SCHEDULE every -1 second    comment 'test' DO insert into ${tableName} (timestamp, type, user_id) values ('2023-03-18','1','12213');
         """
-    } catch (Exception e) {
-        assert e.getMessage().contains("expecting INTEGER_VALUE")
     }
 
     // test keyword as job name

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -190,6 +190,11 @@ suite("test_base_insert_job") {
         // check job status and succeed task count is 1
         pressJob.size() == 1 && '1' == onceJob.get(0).get(0)
     })
+    assertThrows(Exception) {
+        sql """
+        RESUME JOB where jobName='press'
+    """
+    }
 
     sql """
         DROP JOB IF EXISTS where jobname =  'past_start_time'


### PR DESCRIPTION
### What problem does this PR solve?


In the current job scheduling logic, invalid state transitions (e.g., RUNNING to RUNNING) are not filtered, which causes redundant scheduling during resume operations. This PR adds a check to ensure that jobs cannot transition to the same state, preventing duplicate scheduling triggers and improving state consistency.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

