### PR TITLE
[Refactor](partition) Refine behaviors when use both auto&dynamic partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
@@ -55,16 +55,20 @@ public class DynamicPartitionProperty {
     public static final String STORAGE_POLICY = "dynamic_partition.storage_policy";
     public static final String STORAGE_MEDIUM = "dynamic_partition.storage_medium";
 
+    public static final String CREATE_METHOD = "dynamic_partition.create_method";
+
     public static final Set<String> DYNAMIC_PARTITION_PROPERTIES = new HashSet<>(
             Arrays.asList(TIME_UNIT, START, END, PREFIX, BUCKETS, ENABLE, START_DAY_OF_WEEK, START_DAY_OF_MONTH,
                     TIME_ZONE, REPLICATION_NUM, REPLICATION_ALLOCATION, CREATE_HISTORY_PARTITION, HISTORY_PARTITION_NUM,
-                    HOT_PARTITION_NUM, RESERVED_HISTORY_PERIODS, STORAGE_POLICY, STORAGE_MEDIUM));
+                    HOT_PARTITION_NUM, RESERVED_HISTORY_PERIODS, STORAGE_POLICY, STORAGE_MEDIUM, CREATE_METHOD));
 
     public static final int MIN_START_OFFSET = Integer.MIN_VALUE;
     public static final int MAX_END_OFFSET = Integer.MAX_VALUE;
     public static final int NOT_SET_REPLICATION_NUM = -1;
     public static final int NOT_SET_HISTORY_PARTITION_NUM = -1;
     public static final String NOT_SET_RESERVED_HISTORY_PERIODS = "NULL";
+    public static final String AUTO_METHOD = "AUTO";
+    public static final String SCHEDULE_METHOD = "SCHEDULE";
 
     private boolean exist;
 
@@ -87,6 +91,7 @@ public class DynamicPartitionProperty {
     private String reservedHistoryPeriods;
     private String storagePolicy;
     private String storageMedium; // ssd or hdd
+    private String createMethod;
 
     public DynamicPartitionProperty(Map<String, String> properties) {
         if (properties != null && !properties.isEmpty()) {
@@ -96,7 +101,7 @@ public class DynamicPartitionProperty {
             this.tz = TimeUtils.getOrSystemTimeZone(properties.get(TIME_ZONE));
             // In order to compatible dynamic add partition version
             this.start = Integer.parseInt(properties.getOrDefault(START, String.valueOf(MIN_START_OFFSET)));
-            this.end = Integer.parseInt(properties.get(END));
+            this.end = Integer.parseInt(properties.getOrDefault(END, String.valueOf(MAX_END_OFFSET)));
             this.prefix = properties.get(PREFIX);
             this.buckets = Integer.parseInt(properties.get(BUCKETS));
             this.replicaAlloc = analyzeReplicaAllocation(properties);
@@ -108,6 +113,7 @@ public class DynamicPartitionProperty {
                     RESERVED_HISTORY_PERIODS, NOT_SET_RESERVED_HISTORY_PERIODS);
             this.storagePolicy = properties.getOrDefault(STORAGE_POLICY, "");
             this.storageMedium = properties.getOrDefault(STORAGE_MEDIUM, "");
+            this.createMethod = properties.getOrDefault(CREATE_METHOD, "");
             createStartOfs(properties);
         } else {
             this.exist = false;
@@ -199,6 +205,10 @@ public class DynamicPartitionProperty {
         return storageMedium;
     }
 
+    public String getCreateMethod() {
+        return createMethod;
+    }
+
     public String getStartOfInfo() {
         if (getTimeUnit().equalsIgnoreCase(TimeUnit.WEEK.toString())) {
             return startOfWeek.toDisplayInfo();
@@ -251,6 +261,9 @@ public class DynamicPartitionProperty {
         addProperty.accept(STORAGE_POLICY, storagePolicy);
         if (!Strings.isNullOrEmpty(storageMedium)) {
             addProperty.accept(STORAGE_MEDIUM, storageMedium);
+        }
+        if (!Strings.isNullOrEmpty(createMethod)) {
+            addProperty.accept(STORAGE_MEDIUM, createMethod);
         }
         if (getTimeUnit().equalsIgnoreCase(TimeUnit.WEEK.toString())) {
             addProperty.accept(START_DAY_OF_WEEK, startOfWeek.dayOfWeek);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DynamicPartitionProperty.java
@@ -54,7 +54,6 @@ public class DynamicPartitionProperty {
     public static final String RESERVED_HISTORY_PERIODS = "dynamic_partition.reserved_history_periods";
     public static final String STORAGE_POLICY = "dynamic_partition.storage_policy";
     public static final String STORAGE_MEDIUM = "dynamic_partition.storage_medium";
-
     public static final String CREATE_METHOD = "dynamic_partition.create_method";
 
     public static final Set<String> DYNAMIC_PARTITION_PROPERTIES = new HashSet<>(
@@ -71,7 +70,6 @@ public class DynamicPartitionProperty {
     public static final String SCHEDULE_METHOD = "SCHEDULE";
 
     private boolean exist;
-
     private boolean enable;
     private String timeUnit;
     private int start;
@@ -263,7 +261,7 @@ public class DynamicPartitionProperty {
             addProperty.accept(STORAGE_MEDIUM, storageMedium);
         }
         if (!Strings.isNullOrEmpty(createMethod)) {
-            addProperty.accept(STORAGE_MEDIUM, createMethod);
+            addProperty.accept(CREATE_METHOD, createMethod);
         }
         if (getTimeUnit().equalsIgnoreCase(TimeUnit.WEEK.toString())) {
             addProperty.accept(START_DAY_OF_WEEK, startOfWeek.dayOfWeek);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -577,6 +577,13 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                     recordCreatePartitionFailedMsg(db.getFullName(), olapTable.getName(), errorMsg, olapTable.getId());
                     skipAddPartition = true;
                 }
+                // for auto+dynamic table, only support auto to create.
+                DynamicPartitionProperty dynamicPartitionProperty = olapTable.getTableProperty()
+                        .getDynamicPartitionProperty();
+                String createMethod = dynamicPartitionProperty.getCreateMethod();
+                if (createMethod.equalsIgnoreCase(DynamicPartitionProperty.AUTO_METHOD)) {
+                    skipAddPartition = true;
+                }
 
                 // Determine the partition column type
                 // if column type is Date, format partition name as yyyyMMdd

--- a/regression-test/suites/doc/table-design/data-partitioning/auto-partitioning.md.groovy
+++ b/regression-test/suites/doc/table-design/data-partitioning/auto-partitioning.md.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import org.junit.jupiter.api.Assertions;
-
 suite("docs/table-design/data-partitioning/auto-partitioning.md") {
     sql "drop table if exists `DAILY_TRADE_VALUE`"
     sql """
@@ -164,15 +162,15 @@ suite("docs/table-design/data-partitioning/auto-partitioning.md") {
         k0 datetime(6) NOT NULL
     )
     auto partition by range (date_trunc(k0, 'year'))
-    (
-    )
+    ()
     DISTRIBUTED BY HASH(`k0`) BUCKETS 2
     properties(
         "dynamic_partition.enable" = "true",
         "dynamic_partition.prefix" = "p",
         "dynamic_partition.start" = "-50",
-        "dynamic_partition.end" = "0", --- Dynamic Partition 不创建分区
+        "dynamic_partition.end" = "123", --- 将被忽略
         "dynamic_partition.time_unit" = "year",
+        "dynamic_partition.create_method" = "AUTO",
         "replication_num" = "1"
     );
     """

--- a/regression-test/suites/doc/table-design/data-partitioning/basic-concepts.md.groovy
+++ b/regression-test/suites/doc/table-design/data-partitioning/basic-concepts.md.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import org.junit.jupiter.api.Assertions;
-
 suite("docs/table-design/data-partitioning/basic-concepts.md") {
     sql "drop table if exists example_range_tbl"
     sql """
@@ -141,7 +139,8 @@ suite("docs/table-design/data-partitioning/basic-concepts.md") {
         "dynamic_partition.enable" = "true",
         "dynamic_partition.time_unit" = "month", --- 二者粒度必须相同
         "dynamic_partition.start" = "-2", --- 动态分区自动清理超过两周的历史分区
-        "dynamic_partition.end" = "0", --- 动态分区不创建未来分区，完全交给自动分区
+        "dynamic_partition.create_method" = "AUTO", --- 必需。分区创建完全由自动分区负责
+        "dynamic_partition.end" = "123", --- 将被忽略
         "dynamic_partition.prefix" = "p",
         "dynamic_partition.buckets" = "8"
     );


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Add property `create_method` for dynamic partition. Disable dynamic partition's creation when it's true. It can and only can be true when use both auto and dynamic partitiion.

when that, we must:
```sql
 create table auto_dynamic(
     k0 datetime(6) NOT NULL
 )
 auto partition by range (date_trunc(k0, 'year'))
 ()
 DISTRIBUTED BY HASH(`k0`) BUCKETS 2
 properties(
     "dynamic_partition.enable" = "true",
     "dynamic_partition.prefix" = "p",
     "dynamic_partition.start" = "-50",
     "dynamic_partition.end" = "123", --- ATTN, this is not useful.
     "dynamic_partition.time_unit" = "year",
     "dynamic_partition.create_method" = "AUTO", --- ATTN, this is required.
     "replication_num" = "1"
 );
 ```

### Release note

Add property `create_method` for dynamic partition. Disable dynamic partition's creation when enable both auto and dynamic partitiion.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/1535

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

