### PR TITLE
[opt](nereids) simplify arithmethic handle with mix add/sub/multiply/divide

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticRule.java
@@ -133,12 +133,15 @@ public class SimplifyArithmeticRule implements ExpressionPatternRuleFactory {
         }
     }
 
+    // isAddOrSub: true for extract only "+" or "-" sub expressions, false for extract only "*" or "/" sub expressions
     private static List<Operand> flatten(Expression expr, boolean isAddOrSub) {
         List<Operand> result = Lists.newArrayList();
         doFlatten(true, expr, isAddOrSub, result, Optional.empty());
         return result;
     }
 
+    // flag: true for '+' or '*', false for '-' or '/'
+    // isAddOrSub: true for extract only "+" or "-" sub expressions, false for extract only "*" or "/" sub expressions
     private static void doFlatten(boolean flag, Expression expr, boolean isAddOrSub, List<Operand> result,
             Optional<DataType> castType) {
         // cast (a * 10 as double)  *  (cast 20 as double)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticRule.java
@@ -168,8 +168,8 @@ public class SimplifyArithmeticRule implements ExpressionPatternRuleFactory {
                 doFlatten(!isNegativeArithmetic.test(arithmetic), arithmetic.right(), isAddOrSub, result, castType);
             }
         } else {
-            if (castType.isPresent() && !(expr.getDataType().equals(castType.get()))) {
-                result.add(Operand.of(flag, new Cast(expr, castType.get())));
+            if (castType.isPresent()) {
+                result.add(Operand.of(flag, TypeCoercionUtils.castIfNotSameType(expr, castType.get())));
             } else {
                 result.add(Operand.of(flag, expr));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticRule.java
@@ -21,10 +21,12 @@ import org.apache.doris.nereids.rules.expression.ExpressionPatternMatcher;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
 import org.apache.doris.nereids.trees.expressions.Add;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
+import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Divide;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Multiply;
 import org.apache.doris.nereids.trees.expressions.Subtract;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 import org.apache.doris.nereids.util.TypeUtils;
 import org.apache.doris.nereids.util.Utils;
@@ -34,6 +36,7 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Simplify arithmetic rule.
@@ -89,6 +92,9 @@ public class SimplifyArithmeticRule implements ExpressionPatternRuleFactory {
         }
         // 2. move variables to left side and move constants to right sid.
         for (Operand operand : flattedExpressions) {
+            if (operand.expression instanceof BinaryArithmetic) {
+                operand.expression = simplify((BinaryArithmetic) operand.expression);
+            }
             if (operand.expression.isConstant()) {
                 constants.add(operand);
             } else {
@@ -129,43 +135,68 @@ public class SimplifyArithmeticRule implements ExpressionPatternRuleFactory {
 
     private static List<Operand> flatten(Expression expr, boolean isAddOrSub) {
         List<Operand> result = Lists.newArrayList();
-        if (isAddOrSub) {
-            flattenAddSubtract(true, expr, result);
-        } else {
-            flattenMultiplyDivide(true, expr, result);
-        }
+        doFlatten(true, expr, isAddOrSub, result, Optional.empty());
         return result;
     }
 
-    private static void flattenAddSubtract(boolean flag, Expression expr, List<Operand> result) {
-        if (TypeUtils.isAddOrSubtract(expr)) {
-            BinaryArithmetic arithmetic = (BinaryArithmetic) expr;
-            flattenAddSubtract(flag, arithmetic.left(), result);
-            if (TypeUtils.isSubtract(expr) && !flag) {
-                flattenAddSubtract(true, arithmetic.right(), result);
-            } else if (TypeUtils.isAdd(expr) && !flag) {
-                flattenAddSubtract(false, arithmetic.right(), result);
+    private static void doFlatten(boolean flag, Expression expr, boolean isAddOrSub, List<Operand> result,
+            Optional<DataType> castType) {
+        // cast (a * 10 as double)  *  (cast 20 as double)
+        // => cast(a as double) * (cast 10 as double) * (cast 20 as double)
+        BinaryArithmetic arithmetic = null;
+        Predicate<Expression> isPositiveArithmetic = isAddOrSub
+                ? TypeUtils::isAdd : TypeUtils::isMultiply;
+        Predicate<Expression> isNegativeArithmetic = isAddOrSub
+                ? TypeUtils::isSubtract : TypeUtils::isDivide;
+        Predicate<Expression> isPosNegArithmetic = isPositiveArithmetic.or(isNegativeArithmetic);
+        if (isPosNegArithmetic.test(expr)) {
+            arithmetic = (BinaryArithmetic) expr;
+        } else if (expr instanceof Cast && hasConstantOperand(expr, isAddOrSub)) {
+            Cast cast = (Cast) expr;
+            if (isPosNegArithmetic.test(cast.child())) {
+                arithmetic = (BinaryArithmetic) cast.child();
+                castType = Optional.of(cast.getDataType());
+            }
+        }
+        if (arithmetic != null) {
+            doFlatten(flag, arithmetic.left(), isAddOrSub, result, castType);
+            if (isNegativeArithmetic.test(arithmetic) && !flag) {
+                doFlatten(true, arithmetic.right(), isAddOrSub, result, castType);
+            } else if (isPositiveArithmetic.test(arithmetic) && !flag) {
+                doFlatten(false, arithmetic.right(), isAddOrSub, result, castType);
             } else {
-                flattenAddSubtract(!TypeUtils.isSubtract(expr), arithmetic.right(), result);
+                doFlatten(!isNegativeArithmetic.test(arithmetic), arithmetic.right(), isAddOrSub, result, castType);
             }
         } else {
-            result.add(Operand.of(flag, expr));
+            if (castType.isPresent() && !(expr.getDataType().equals(castType.get()))) {
+                result.add(Operand.of(flag, new Cast(expr, castType.get())));
+            } else {
+                result.add(Operand.of(flag, expr));
+            }
         }
     }
 
-    private static void flattenMultiplyDivide(boolean flag, Expression expr, List<Operand> result) {
-        if (TypeUtils.isMultiplyOrDivide(expr)) {
-            BinaryArithmetic arithmetic = (BinaryArithmetic) expr;
-            flattenMultiplyDivide(flag, arithmetic.left(), result);
-            if (TypeUtils.isDivide(expr) && !flag) {
-                flattenMultiplyDivide(true, arithmetic.right(), result);
-            } else if (TypeUtils.isMultiply(expr) && !flag) {
-                flattenMultiplyDivide(false, arithmetic.right(), result);
-            } else {
-                flattenMultiplyDivide(!TypeUtils.isDivide(expr), arithmetic.right(), result);
+    private static boolean hasConstantOperand(Expression expr, boolean isAddOrSub) {
+        if (expr.isConstant()) {
+            return true;
+        }
+
+        Predicate<Expression> checkArithmetic = isAddOrSub
+                ? TypeUtils::isAddOrSubtract : TypeUtils::isMultiplyOrDivide;
+        BinaryArithmetic arithmetic = null;
+        if (checkArithmetic.test(expr)) {
+            arithmetic = (BinaryArithmetic) expr;
+        } else if (expr instanceof Cast) {
+            Cast cast = (Cast) expr;
+            if (checkArithmetic.test(cast.child())) {
+                arithmetic = (BinaryArithmetic) cast.child();
             }
+        }
+        if (arithmetic != null) {
+            return hasConstantOperand(arithmetic.left(), isAddOrSub)
+                    || hasConstantOperand(arithmetic.right(), isAddOrSub);
         } else {
-            result.add(Operand.of(flag, expr));
+            return false;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Two optimizations:

1. handle mix add / sub / multiply / divide
 
SimplifyArithmeticRule only handle add-sub,  or multiply-divide,  but not both of them.

for example, if the expression root is add, then only simplify add-sub, but not simplify multiply-divide.

for expr ` a + 10 + (b * 2 * 3 *  (c + 4 + 5)) + 20`,  after fold const and this rule, it will opt as `a + (b * (c + 4 + 5) * 2 * 3) + 30`,  but after this pr  it will opt as `a + (b * (c+9) * 6) + 30`

2. handle cast

SimplifyArithmeticRule not handle with cast.

for example,  for expr `cast ( a * 2 * 30 as double) /  (cast 10 as double)` ,  after fold const and this rule,  it will opt as `cast (a * 60 as double) / 10.0`, but after this pr it will opt as `cast (a as double) * 6.0`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

