### PR TITLE
[fix](suites) Enable common expr pushdown in the restore inverted idx case

### DIFF
--- a/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_inverted_idx.groovy
@@ -117,13 +117,13 @@ suite("test_backup_restore_inverted_idx", "backup_restore") {
 
         // 1. query with inverted index
         sql """ set enable_match_without_inverted_index = false """
-        def res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0) */ * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "10" """
+        def res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0, enable_common_expr_pushdown = true) */ * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "10" """
         assertTrue(res.size() > 0)
 
         // 2. add partition and query
         sql """ ALTER TABLE ${dbName}.${tableName} ADD PARTITION p8 VALUES LESS THAN ("80") """
         sql """ INSERT INTO ${dbName}.${tableName} VALUES (75, "75 750", "76 77") """
-        res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0) */ * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "75" """
+        res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0, enable_common_expr_pushdown = true) */ * FROM ${dbName}.${tableName} WHERE value MATCH_ANY "75" """
         assertTrue(res.size() > 0)
 
         // 3. add new index
@@ -159,7 +159,7 @@ suite("test_backup_restore_inverted_idx", "backup_restore") {
             logger.info("the build index status: ${build_status}")
             assertTrue(false)
         }
-        res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0) */ * FROM ${dbName}.${tableName} WHERE value1 MATCH_ANY "12321" """
+        res = sql """ SELECT /*+ SET_VAR(inverted_index_skip_threshold = 0, enable_common_expr_pushdown = true) */ * FROM ${dbName}.${tableName} WHERE value1 MATCH_ANY "12321" """
         assertTrue(res.size() > 0)
 
     } finally {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #45283

Problem Summary:

`set enable_common_expr_pushdown = false` will affect the execution of match_any

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

