### PR TITLE
[fix](nereids) fix ExtractAndNormalizeWindowExpression bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.NullableAggregateFunction;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalWindow;
@@ -117,7 +118,7 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
         // we need replace alias's child expr with corresponding alias's slot in output
         // so create a customNormalizeMap alias's child -> alias.toSlot to do it
         Map<Expression, Slot> customNormalizeMap = toBePushedDown.stream()
-                .filter(expr -> expr instanceof Alias)
+                .filter(expr -> expr instanceof Alias && !(expr.child(0) instanceof Literal))
                 .collect(Collectors.toMap(expr -> ((Alias) expr).child(), expr -> ((Alias) expr).toSlot(),
                         (oldExpr, newExpr) -> oldExpr));
 

--- a/regression-test/data/nereids_rules_p0/normalize_window/normalize_window_nullable_agg_test.out
+++ b/regression-test/data/nereids_rules_p0/normalize_window/normalize_window_nullable_agg_test.out
@@ -291,3 +291,7 @@ false
 false
 false
 
+-- !fold_window --
+0	false	0	be
+9999-12-31 23:59:59	false	9999-12-31 23:59:59	b
+

--- a/regression-test/suites/nereids_rules_p0/normalize_window/normalize_window_nullable_agg_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/normalize_window/normalize_window_nullable_agg_test.groovy
@@ -72,4 +72,61 @@ suite("normalize_window_nullable_agg") {
         sql "select group_concat(xwho order by xwhat) over(partition by xwhen) from windowfunnel_test_normalize_window;"
         exception "order by is not supported"
     }
+
+    sql "set enable_fold_constant_by_be = 1;"
+    sql "drop table if exists fold_window1"
+    sql """create table fold_window1 (
+            pk int,
+                    col_char_255__undef_signed char(255)  null  ,
+            col_char_100__undef_signed char(100)  null  ,
+            col_varchar_255__undef_signed varchar(255)  null  ,
+            col_char_255__undef_signed_not_null char(255)  not null  ,
+                    col_char_100__undef_signed_not_null char(100)  not null  ,
+            col_varchar_255__undef_signed_not_null varchar(255)  not null  ,
+            col_varchar_1000__undef_signed varchar(1000)  null  ,
+            col_varchar_1000__undef_signed_not_null varchar(1000)  not null  ,
+                    col_varchar_1001__undef_signed varchar(1001)  null  ,
+            col_varchar_1001__undef_signed_not_null varchar(1001)  not null  ,
+                    col_string_undef_signed string  null  ,
+                    col_string_undef_signed_not_null string  not null
+    ) engine=olap
+    DUPLICATE KEY(pk, col_char_255__undef_signed, col_char_100__undef_signed, col_varchar_255__undef_signed)
+    distributed by hash(pk) buckets 10
+    properties("bloom_filter_columns" = "col_char_255__undef_signed, col_char_100__undef_signed, col_varchar_255__undef_signed ", "replication_num" = "1");"""
+    sql """insert into fold_window1(pk,col_char_255__undef_signed,col_char_255__undef_signed_not_null,col_char_100__undef_signed
+    ,col_char_100__undef_signed_not_null,col_varchar_255__undef_signed,col_varchar_255__undef_signed_not_null,col_varchar_1000__undef_signed,col_varchar_1000__undef_signed_not_null
+    ,col_varchar_1001__undef_signed,col_varchar_1001__undef_signed_not_null,col_string_undef_signed,col_string_undef_signed_not_null)
+     values (0,'like','9999-12-31 23:59:59','9999-12-31 23:59:59','c','20240803','2024-08-03 13:08:30','300.343','2024-07-01','that''s','9999-12-31 23:59:59','s','b'),
+     (1,'be','g','f','not','20240803','20240803','2024-08-03 13:08:30','g','20240803','0','2024-07-01','be')"""
+
+    sql "drop table if exists fold_window2"
+    sql """create table fold_window2 (
+            pk int,
+                    col_char_255__undef_signed char(255)  null  ,
+            col_char_255__undef_signed_not_null char(255)  not null  ,
+                    col_char_100__undef_signed char(100)  null  ,
+            col_char_100__undef_signed_not_null char(100)  not null  ,
+                    col_varchar_255__undef_signed varchar(255)  null  ,
+            col_varchar_255__undef_signed_not_null varchar(255)  not null  ,
+                    col_varchar_1000__undef_signed varchar(1000)  null  ,
+            col_varchar_1000__undef_signed_not_null varchar(1000)  not null  ,
+                    col_varchar_1001__undef_signed varchar(1001)  null  ,
+            col_varchar_1001__undef_signed_not_null varchar(1001)  not null  ,
+                    col_string_undef_signed string  null  ,
+                    col_string_undef_signed_not_null string  not null
+    ) engine=olap
+    DUPLICATE KEY(pk)
+    distributed by hash(pk) buckets 10
+    properties ("bloom_filter_columns" = "col_char_255__undef_signed, col_char_100__undef_signed, col_varchar_255__undef_signed ", "replication_num" = "1");"""
+    sql """insert into fold_window2(pk,col_char_255__undef_signed,col_char_255__undef_signed_not_null,col_char_100__undef_signed
+    ,col_char_100__undef_signed_not_null,col_varchar_255__undef_signed,col_varchar_255__undef_signed_not_null,col_varchar_1000__undef_signed
+    ,col_varchar_1000__undef_signed_not_null,col_varchar_1001__undef_signed,col_varchar_1001__undef_signed_not_null,col_string_undef_signed,col_string_undef_signed_not_null)
+    values (0,'some','2024-07-01','9999-12-31 23:59:59','9999-12-31 23:59:59','9999-12-31 23:59:59','300.343','2024-07-01','1','1','2024-07-01','2024-08-03 13:08:30','2024-08-03 13:08:30');"""
+
+    qt_fold_window """
+    select initcap(col_varchar_1001__undef_signed_not_null)  col_alias97650 , starts_with('ourBZbRijD', "e")  AS col_alias97651 ,
+    col_varchar_1001__undef_signed_not_null  AS col_alias97652 , LAST_VALUE(col_string_undef_signed_not_null , false) over ( order by pk ) 
+     AS col_alias97653  from fold_window1 where 'DCOFMrybqf' <> (select min (  col_char_255__undef_signed ) 
+     from fold_window2)  ORDER BY col_alias97650,col_alias97651,col_alias97652,col_alias97653 ;
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
In ExtractAndNormalizeWindowExpression, some expressions are pushed down and output by the bottom LogicalProject. If a window expression depends on these pushed-down expressions, those parts should be replaced accordingly. However, when a Literal is pushed down, it should not be used as a replacement.

Example:
For the window expression:
last_value(c1, false) over()

If the expression false is pushed down as alias1, the window expression would incorrectly be replaced as:
last_value(c1, alias1) over()

This PR fixes the issue by ensuring Literals are not replaced when pushed down.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

