### PR TITLE
[refine](Column)Disallow implicit conversion of ColumnPtr to IColumn*

### DIFF
--- a/be/src/exec/table_connector.cpp
+++ b/be/src/exec/table_connector.cpp
@@ -118,16 +118,17 @@ Status TableConnector::convert_column_data(const vectorized::ColumnPtr& column_p
             fmt::format_to(_insert_stmt_buffer, "\"{}\"", str);
         }
     };
-    const vectorized::IColumn* column = column_ptr;
+    const vectorized::IColumn* column = column_ptr.get();
     if (type_ptr->is_nullable()) {
-        auto nullable_column = assert_cast<const vectorized::ColumnNullable*>(column_ptr.get());
+        const auto* nullable_column =
+                assert_cast<const vectorized::ColumnNullable*>(column_ptr.get());
         if (nullable_column->is_null_at(row)) {
             fmt::format_to(_insert_stmt_buffer, "{}", "NULL");
             return Status::OK();
         }
         column = nullable_column->get_nested_column_ptr().get();
     } else {
-        column = column_ptr;
+        column = column_ptr.get();
     }
     auto [item, size] = column->get_data_at(row);
     switch (type.type) {

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -518,7 +518,7 @@ Status PushBrokerReader::_convert_to_output_block(vectorized::Block* block) {
         column_ptr = _src_block.get_by_position(result_column_id).column;
         // column_ptr maybe a ColumnConst, convert it to a normal column
         column_ptr = column_ptr->convert_to_full_column_if_const();
-        DCHECK(column_ptr != nullptr);
+        DCHECK(column_ptr);
 
         // because of src_slot_desc is always be nullable, so the column_ptr after do dest_expr
         // is likely to be nullable

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -1257,8 +1257,8 @@ Status FileColumnIterator::next_batch(size_t* n, vectorized::MutableColumnPtr& d
                     DCHECK_EQ(this_run, num_rows);
                 } else {
                     *has_null = true;
-                    auto* null_col =
-                            vectorized::check_and_get_column<vectorized::ColumnNullable>(dst);
+                    const auto* null_col =
+                            vectorized::check_and_get_column<vectorized::ColumnNullable>(dst.get());
                     if (null_col != nullptr) {
                         const_cast<vectorized::ColumnNullable*>(null_col)->insert_null_elements(
                                 this_run);
@@ -1318,8 +1318,9 @@ Status FileColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t co
                 auto origin_index = _page.data_decoder->current_index();
                 if (this_read_count > 0) {
                     if (is_null) {
-                        auto* null_col =
-                                vectorized::check_and_get_column<vectorized::ColumnNullable>(dst);
+                        const auto* null_col =
+                                vectorized::check_and_get_column<vectorized::ColumnNullable>(
+                                        dst.get());
                         if (UNLIKELY(null_col == nullptr)) {
                             return Status::InternalError("unexpected column type in column reader");
                         }
@@ -1700,9 +1701,9 @@ Status DefaultNestedColumnIterator::next_batch(size_t* n, vectorized::MutableCol
 static void fill_nested_with_defaults(vectorized::MutableColumnPtr& dst,
                                       vectorized::MutableColumnPtr& sibling_column, size_t nrows) {
     const auto* sibling_array = vectorized::check_and_get_column<vectorized::ColumnArray>(
-            remove_nullable(sibling_column->get_ptr()));
+            remove_nullable(sibling_column->get_ptr()).get());
     const auto* dst_array = vectorized::check_and_get_column<vectorized::ColumnArray>(
-            remove_nullable(dst->get_ptr()));
+            remove_nullable(dst->get_ptr()).get());
     if (!dst_array || !sibling_array) {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR,
                                "Expected array column, but met %s and %s", dst->get_name(),

--- a/be/src/olap/rowset/segment_v2/hierarchical_data_reader.h
+++ b/be/src/olap/rowset/segment_v2/hierarchical_data_reader.h
@@ -165,8 +165,8 @@ private:
         // will type the type of ColumnObject::NESTED_TYPE, whih is Nullable<ColumnArray<NULLABLE(ColumnObject)>>.
         for (auto& entry : nested_subcolumns) {
             MutableColumnPtr nested_object = ColumnObject::create(true, false);
-            const auto* base_array =
-                    check_and_get_column<ColumnArray>(remove_nullable(entry.second[0].column));
+            const auto* base_array = check_and_get_column<ColumnArray>(
+                    remove_nullable(entry.second[0].column).get());
             MutableColumnPtr offset = base_array->get_offsets_ptr()->assume_mutable();
             auto* nested_object_ptr = assert_cast<ColumnObject*>(nested_object.get());
             // flatten nested arrays

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1951,8 +1951,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
 
 Status SegmentIterator::_convert_to_expected_type(const std::vector<ColumnId>& col_ids) {
     for (ColumnId i : col_ids) {
-        if (_current_return_columns[i] == nullptr || _converted_column_ids[i] ||
-            _is_pred_column[i]) {
+        if (!_current_return_columns[i] || _converted_column_ids[i] || _is_pred_column[i]) {
             continue;
         }
         if (!_segment->same_with_storage_type(
@@ -1995,7 +1994,7 @@ Status SegmentIterator::copy_column_data_by_selector(vectorized::IColumn* input_
         return Status::RuntimeError("copy_column_data_by_selector nullable mismatch");
     }
 
-    return input_col_ptr->filter_by_selector(sel_rowid_idx, select_size, output_col);
+    return input_col_ptr->filter_by_selector(sel_rowid_idx, select_size, output_col.get());
 }
 
 void SegmentIterator::_clear_iterators() {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -337,7 +337,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
             int result_tmp_column_idx = -1;
             RETURN_IF_ERROR(ctx->execute(ref_block, &result_tmp_column_idx));
             auto& result_tmp_column_def = ref_block->get_by_position(result_tmp_column_idx);
-            if (result_tmp_column_def.column == nullptr) {
+            if (!result_tmp_column_def.column) {
                 return Status::Error<ErrorCode::INTERNAL_ERROR>(
                         "result column={} is nullptr, input expr={}", result_tmp_column_def.name,
                         apache::thrift::ThriftDebugString(*expr));
@@ -430,7 +430,7 @@ Status BlockChanger::_check_cast_valid(vectorized::ColumnPtr input_column,
     if (input_column->is_nullable() != output_column->is_nullable()) {
         if (input_column->is_nullable()) {
             const auto* ref_null_map =
-                    vectorized::check_and_get_column<vectorized::ColumnNullable>(input_column)
+                    vectorized::check_and_get_column<vectorized::ColumnNullable>(input_column.get())
                             ->get_null_map_column()
                             .get_data()
                             .data();
@@ -446,10 +446,12 @@ Status BlockChanger::_check_cast_valid(vectorized::ColumnPtr input_column,
             }
         } else {
             const auto& null_map_column =
-                    vectorized::check_and_get_column<vectorized::ColumnNullable>(output_column)
+                    vectorized::check_and_get_column<vectorized::ColumnNullable>(
+                            output_column.get())
                             ->get_null_map_column();
             const auto& nested_column =
-                    vectorized::check_and_get_column<vectorized::ColumnNullable>(output_column)
+                    vectorized::check_and_get_column<vectorized::ColumnNullable>(
+                            output_column.get())
                             ->get_nested_column();
             const auto* new_null_map = null_map_column.get_data().data();
 
@@ -481,12 +483,12 @@ Status BlockChanger::_check_cast_valid(vectorized::ColumnPtr input_column,
 
     if (input_column->is_nullable() && output_column->is_nullable()) {
         const auto* ref_null_map =
-                vectorized::check_and_get_column<vectorized::ColumnNullable>(input_column)
+                vectorized::check_and_get_column<vectorized::ColumnNullable>(input_column.get())
                         ->get_null_map_column()
                         .get_data()
                         .data();
         const auto* new_null_map =
-                vectorized::check_and_get_column<vectorized::ColumnNullable>(output_column)
+                vectorized::check_and_get_column<vectorized::ColumnNullable>(output_column.get())
                         ->get_null_map_column()
                         .get_data()
                         .data();

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -254,7 +254,7 @@ Status HashJoinBuildSinkLocalState::_extract_join_column(
             // update nulllmap and split nested out of ColumnNullable when serialize_null_into_key is false and column is nullable
             const auto& col_nested = nullable->get_nested_column();
             const auto& col_nullmap = nullable->get_null_map_data();
-            DCHECK(null_map != nullptr);
+            DCHECK(null_map);
             vectorized::VectorizedUtils::update_null_map(null_map->get_data(), col_nullmap);
             raw_ptrs[i] = &col_nested;
         } else {

--- a/be/src/pipeline/exec/hashjoin_probe_operator.cpp
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.cpp
@@ -371,7 +371,7 @@ Status HashJoinProbeLocalState::_extract_join_column(vectorized::Block& block,
         _need_null_map_for_probe = _need_probe_null_map(block, res_col_ids);
     }
     if (_need_null_map_for_probe) {
-        if (_null_map_column == nullptr) {
+        if (!_null_map_column) {
             _null_map_column = vectorized::ColumnUInt8::create();
         }
         _null_map_column->get_data().assign(block.rows(), (uint8_t)0);
@@ -389,7 +389,7 @@ Status HashJoinProbeLocalState::_extract_join_column(vectorized::Block& block,
             // update nulllmap and split nested out of ColumnNullable when serialize_null_into_key is false and column is nullable
             const auto& col_nested = nullable->get_nested_column();
             const auto& col_nullmap = nullable->get_null_map_data();
-            DCHECK(_null_map_column != nullptr);
+            DCHECK(_null_map_column);
             vectorized::VectorizedUtils::update_null_map(_null_map_column->get_data(), col_nullmap);
             _probe_columns[i] = &col_nested;
         } else {

--- a/be/src/pipeline/exec/join_probe_operator.cpp
+++ b/be/src/pipeline/exec/join_probe_operator.cpp
@@ -150,7 +150,7 @@ Status JoinProbeLocalState<SharedStateArg, Derived>::_build_output_block(
                 /// TODO: maybe need a method to check if a column need to be converted to full
                 /// column.
                 if (is_column_const(*origin_column) ||
-                    check_column<vectorized::ColumnArray>(origin_column)) {
+                    check_column<vectorized::ColumnArray>(origin_column.get())) {
                     auto column_ptr = origin_column->convert_to_full_column_if_const();
                     insert_column_datas(mutable_columns[i], column_ptr, rows);
                 } else {

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -205,9 +205,8 @@ Status OlapScanLocalState::_should_push_down_function_filter(vectorized::Vectori
             DCHECK(children[1 - i]->type().is_string_type());
             std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
             RETURN_IF_ERROR(children[1 - i]->get_const_col(expr_ctx, &const_col_wrapper));
-            if (const vectorized::ColumnConst* const_column =
-                        check_and_get_column<vectorized::ColumnConst>(
-                                const_col_wrapper->column_ptr)) {
+            if (const auto* const_column = check_and_get_column<vectorized::ColumnConst>(
+                        const_col_wrapper->column_ptr.get())) {
                 *constant_str = const_column->get_data_at(0);
             } else {
                 pdt = PushDownType::UNACCEPTABLE;

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -520,8 +520,8 @@ Status ScanLocalState<Derived>::_eval_const_conjuncts(vectorized::VExpr* vexpr,
     if (vexpr->is_constant()) {
         std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
         RETURN_IF_ERROR(vexpr->get_const_col(expr_ctx, &const_col_wrapper));
-        if (const auto* const_column =
-                    check_and_get_column<vectorized::ColumnConst>(const_col_wrapper->column_ptr)) {
+        if (const auto* const_column = check_and_get_column<vectorized::ColumnConst>(
+                    const_col_wrapper->column_ptr.get())) {
             constant_val = const_cast<char*>(const_column->get_data_at(0).data);
             if (constant_val == nullptr || !*reinterpret_cast<bool*>(constant_val)) {
                 *pdt = PushDownType::ACCEPTABLE;
@@ -530,7 +530,7 @@ Status ScanLocalState<Derived>::_eval_const_conjuncts(vectorized::VExpr* vexpr,
             }
         } else if (const auto* bool_column =
                            check_and_get_column<vectorized::ColumnVector<vectorized::UInt8>>(
-                                   const_col_wrapper->column_ptr)) {
+                                   const_col_wrapper->column_ptr.get())) {
             // TODO: If `vexpr->is_constant()` is true, a const column is expected here.
             //  But now we still don't cover all predicates for const expression.
             //  For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`,
@@ -690,7 +690,7 @@ Status ScanLocalState<Derived>::_should_push_down_binary_predicate(
             std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
             RETURN_IF_ERROR(children[1 - i]->get_const_col(expr_ctx, &const_col_wrapper));
             if (const auto* const_column = check_and_get_column<vectorized::ColumnConst>(
-                        const_col_wrapper->column_ptr)) {
+                        const_col_wrapper->column_ptr.get())) {
                 *slot_ref_child = i;
                 *constant_val = const_column->get_data_at(0);
             } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -402,7 +402,7 @@ public:
                 if (nullable_column->is_null_at(0)) {
                     _default_value.reset();
                 } else {
-                    _default_value.set_value(nullable_column->get_nested_column_ptr(), 0);
+                    _default_value.set_value(nullable_column->get_nested_column_ptr().get(), 0);
                 }
             } else {
                 _default_value.set_value(column, 0);

--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -1484,7 +1484,7 @@ Status ColumnObject::serialize_one_row_to_json_format(size_t row, rapidjson::Str
 #endif
     for (const auto& subcolumn : subcolumns) {
         RETURN_IF_ERROR(find_and_set_leave_value(
-                subcolumn->data.get_finalized_column_ptr(), subcolumn->path,
+                subcolumn->data.get_finalized_column_ptr().get(), subcolumn->path,
                 subcolumn->data.get_least_common_type_serde(),
                 subcolumn->data.get_least_common_type(),
                 subcolumn->data.least_common_type.get_base_type_id(), root,
@@ -1558,7 +1558,7 @@ Status ColumnObject::merge_sparse_to_root_column() {
                 continue;
             }
             bool succ = find_and_set_leave_value(
-                    column, subcolumn->path, subcolumn->data.get_least_common_type_serde(),
+                    column.get(), subcolumn->path, subcolumn->data.get_least_common_type_serde(),
                     subcolumn->data.get_least_common_type(),
                     subcolumn->data.least_common_type.get_base_type_id(), root,
                     doc_structure->GetAllocator(), mem_pool, i);
@@ -1705,7 +1705,7 @@ bool ColumnObject::empty() const {
 }
 
 ColumnPtr get_base_column_of_array(const ColumnPtr& column) {
-    if (const auto* column_array = check_and_get_column<ColumnArray>(column)) {
+    if (const auto* column_array = check_and_get_column<ColumnArray>(column.get())) {
         return column_array->get_data_ptr();
     }
     return column;

--- a/be/src/vec/common/cow.h
+++ b/be/src/vec/common/cow.h
@@ -203,7 +203,6 @@ protected:
 
         operator bool() const { return t != nullptr; }
 
-        operator T*() const { return t; }
 
     private:
         T* t = nullptr;
@@ -346,8 +345,8 @@ protected:
         operator const immutable_ptr<T>&() const { return value; }
         operator immutable_ptr<T>&() { return value; }
 
-        operator bool() const { return value != nullptr; }
-        bool operator!() const { return value == nullptr; }
+        operator bool() const { return value.get() != nullptr; }
+        bool operator!() const { return value.get() == nullptr; }
 
         bool operator==(const chameleon_ptr& rhs) const { return value == rhs.value; }
         bool operator!=(const chameleon_ptr& rhs) const { return value != rhs.value; }

--- a/be/src/vec/common/cow.h
+++ b/be/src/vec/common/cow.h
@@ -203,7 +203,6 @@ protected:
 
         operator bool() const { return t != nullptr; }
 
-
     private:
         T* t = nullptr;
     };

--- a/be/src/vec/exec/format/column_type_convert.cpp
+++ b/be/src/vec/exec/format/column_type_convert.cpp
@@ -99,7 +99,7 @@ ColumnPtr ColumnTypeConverter::get_column(const TypeDescriptor& src_type, Column
         return dst_column;
     }
 
-    if (_cached_src_column == nullptr) {
+    if (!_cached_src_column) {
         _cached_src_type =
                 DataTypeFactory::instance().create_data_type(src_type, dst_type->is_nullable());
         _cached_src_column =

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -657,7 +657,7 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
                 col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
         Slice slice {value.data, value.size};
 
-        IColumn* col_ptr = columns[i];
+        IColumn* col_ptr = columns[i].get();
         if (!_is_load) {
             col_ptr = const_cast<IColumn*>(
                     block->get_by_position(_file_slot_idx_map[i]).column.get());
@@ -700,7 +700,7 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
 Status CsvReader::_fill_empty_line(Block* block, std::vector<MutableColumnPtr>& columns,
                                    size_t* rows) {
     for (int i = 0; i < _file_slot_descs.size(); ++i) {
-        IColumn* col_ptr = columns[i];
+        IColumn* col_ptr = columns[i].get();
         if (!_is_load) {
             col_ptr = const_cast<IColumn*>(
                     block->get_by_position(_file_slot_idx_map[i]).column.get());

--- a/be/src/vec/exec/format/parquet/parquet_column_convert.cpp
+++ b/be/src/vec/exec/format/parquet/parquet_column_convert.cpp
@@ -79,7 +79,7 @@ ColumnPtr PhysicalToLogicalConverter::get_physical_column(tparquet::Type::type s
         return dst_logical_column;
     }
 
-    if (_cached_src_physical_column == nullptr) {
+    if (!_cached_src_physical_column) {
         switch (src_physical_type) {
         case tparquet::Type::type::BOOLEAN:
             _cached_src_physical_type = std::make_shared<DataTypeUInt8>();

--- a/be/src/vec/exec/format/wal/wal_reader.cpp
+++ b/be/src/vec/exec/format/wal/wal_reader.cpp
@@ -92,7 +92,7 @@ Status WalReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
                                          pos, src_block.columns());
         }
         vectorized::ColumnPtr column_ptr = src_block.get_by_position(pos).column;
-        if (column_ptr != nullptr && slot_desc->is_nullable()) {
+        if (!column_ptr && slot_desc->is_nullable()) {
             column_ptr = make_nullable(column_ptr);
         }
         dst_block.insert(index, vectorized::ColumnWithTypeAndName(

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -241,7 +241,7 @@ Status JniConnector::fill_block(Block* block, const ColumnNumbers& arguments, lo
     TableMetaAddress table_meta(table_address);
     long num_rows = table_meta.next_meta_as_long();
     for (size_t i : arguments) {
-        if (block->get_by_position(i).column == nullptr) {
+        if (block->get_by_position(i).column.get() == nullptr) {
             auto return_type = block->get_data_type(i);
             bool result_nullable = return_type->is_nullable();
             ColumnUInt8::MutablePtr null_col = nullptr;

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -596,7 +596,7 @@ Status VFileScanner::_convert_to_output_block(Block* block) {
         column_ptr = _src_block_ptr->get_by_position(result_column_id).column;
         // column_ptr maybe a ColumnConst, convert it to a normal column
         column_ptr = column_ptr->convert_to_full_column_if_const();
-        DCHECK(column_ptr != nullptr);
+        DCHECK(column_ptr);
 
         // because of src_slot_desc is always be nullable, so the column_ptr after do dest_expr
         // is likely to be nullable

--- a/be/src/vec/exec/scan/vmeta_scanner.cpp
+++ b/be/src/vec/exec/scan/vmeta_scanner.cpp
@@ -148,7 +148,7 @@ Status VMetaScanner::_fill_block_with_remote_data(const std::vector<MutableColum
                 if (slot_desc->is_nullable()) {
                     auto& null_col = reinterpret_cast<ColumnNullable&>(*col_ptr);
                     null_col.get_null_map_data().push_back(0);
-                    col_ptr = null_col.get_nested_column_ptr();
+                    col_ptr = null_col.get_nested_column_ptr().get();
                 }
                 switch (slot_desc->type().type) {
                 case TYPE_BOOLEAN: {

--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -272,8 +272,10 @@ public:
             auto col_res = ColumnUInt8::create(size);
             auto col_nulls = ColumnUInt8::create(size);
 
-            auto* __restrict res_datas = assert_cast<ColumnUInt8*>(col_res)->get_data().data();
-            auto* __restrict res_nulls = assert_cast<ColumnUInt8*>(col_nulls)->get_data().data();
+            auto* __restrict res_datas =
+                    assert_cast<ColumnUInt8*>(col_res.get())->get_data().data();
+            auto* __restrict res_nulls =
+                    assert_cast<ColumnUInt8*>(col_nulls.get())->get_data().data();
             ColumnPtr temp_null_map = nullptr;
             // maybe both children are nullable / or one of children is nullable
             auto* __restrict lhs_null_map_tmp = create_null_map_column(temp_null_map, lhs_null_map);

--- a/be/src/vec/functions/array/function_array_cum_sum.cpp
+++ b/be/src/vec/functions/array/function_array_cum_sum.cpp
@@ -118,7 +118,7 @@ public:
         // get null map
         const ColumnNullable* src_nested_nullable_col =
                 check_and_get_column<ColumnNullable>(*src_nested_column);
-        src_nested_column = src_nested_nullable_col->get_nested_column_ptr();
+        src_nested_column = src_nested_nullable_col->get_nested_column_ptr().get();
         const NullMapType& src_null_map = src_nested_nullable_col->get_null_map_column().get_data();
 
         ColumnPtr res_nested_ptr;

--- a/be/src/vec/functions/array/function_array_distinct.h
+++ b/be/src/vec/functions/array/function_array_distinct.h
@@ -102,14 +102,14 @@ public:
         if (src_nested_column->is_nullable()) {
             const auto* src_nested_nullable_col =
                     check_and_get_column<ColumnNullable>(*src_nested_column);
-            src_nested_column = src_nested_nullable_col->get_nested_column_ptr();
+            src_nested_column = src_nested_nullable_col->get_nested_column_ptr().get();
             src_null_map = &src_nested_nullable_col->get_null_map_column().get_data();
         }
 
         NullMapType* dest_null_map = nullptr;
         if (dest_nested_column->is_nullable()) {
             auto* dest_nested_nullable_col = reinterpret_cast<ColumnNullable*>(dest_nested_column);
-            dest_nested_column = dest_nested_nullable_col->get_nested_column_ptr();
+            dest_nested_column = dest_nested_nullable_col->get_nested_column_ptr().get();
             dest_null_map = &dest_nested_nullable_col->get_null_map_column().get_data();
         }
 

--- a/be/src/vec/functions/array/function_array_enumerate.cpp
+++ b/be/src/vec/functions/array/function_array_enumerate.cpp
@@ -83,7 +83,7 @@ public:
         auto left_column =
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
         const ColumnArray* array =
-                check_and_get_column<ColumnArray>(remove_nullable(left_column->get_ptr()));
+                check_and_get_column<ColumnArray>(remove_nullable(left_column->get_ptr()).get());
         if (!array) {
             return Status::RuntimeError(
                     fmt::format("Illegal column {}, of first argument of function {}",
@@ -107,7 +107,8 @@ public:
         ColumnPtr res_column =
                 ColumnArray::create(std::move(nested_column), array->get_offsets_ptr());
         if (block.get_by_position(arguments[0]).column->is_nullable()) {
-            const ColumnNullable* nullable = check_and_get_column<ColumnNullable>(left_column);
+            const ColumnNullable* nullable =
+                    check_and_get_column<ColumnNullable>(left_column.get());
             res_column = ColumnNullable::create(
                     res_column, nullable->get_null_map_column().clone_resized(nullable->size()));
         }

--- a/be/src/vec/functions/array/function_array_enumerate_uniq.cpp
+++ b/be/src/vec/functions/array/function_array_enumerate_uniq.cpp
@@ -128,7 +128,7 @@ public:
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const());
             ColumnPtr& cur_column = src_columns[i];
             const ColumnArray* array =
-                    check_and_get_column<ColumnArray>(remove_nullable(cur_column->get_ptr()));
+                    check_and_get_column<ColumnArray>(remove_nullable(cur_column->get_ptr()).get());
             if (!array) {
                 return Status::RuntimeError(
                         fmt::format("Illegal column {}, of first argument of function {}",
@@ -151,7 +151,7 @@ public:
         const NullMapType* null_map = nullptr;
         if (arguments.size() == 1 && data_columns[0]->is_nullable()) {
             const ColumnNullable* nullable = check_and_get_column<ColumnNullable>(*data_columns[0]);
-            data_columns[0] = nullable->get_nested_column_ptr();
+            data_columns[0] = nullable->get_nested_column_ptr().get();
             null_map = &nullable->get_null_map_column().get_data();
         }
 
@@ -219,7 +219,8 @@ public:
         if (arguments.size() == 1 && block.get_by_position(arguments[0]).column->is_nullable()) {
             auto left_column =
                     block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-            const ColumnNullable* nullable = check_and_get_column<ColumnNullable>(left_column);
+            const ColumnNullable* nullable =
+                    check_and_get_column<ColumnNullable>(left_column.get());
             res_column = ColumnNullable::create(
                     res_column, nullable->get_null_map_column().clone_resized(nullable->size()));
         }

--- a/be/src/vec/functions/array/function_array_join.h
+++ b/be/src/vec/functions/array/function_array_join.h
@@ -78,10 +78,11 @@ public:
 
         auto nested_type = data_type_array->get_nested_type();
         auto dest_column_ptr = ColumnString::create();
-        DCHECK(dest_column_ptr != nullptr);
+        DCHECK(dest_column_ptr);
 
-        auto res_val = _execute_by_type(*src.nested_col, *src.offsets_ptr, src.nested_nullmap_data,
-                                        sep_str, null_replace_str, nested_type, dest_column_ptr);
+        auto res_val =
+                _execute_by_type(*src.nested_col, *src.offsets_ptr, src.nested_nullmap_data,
+                                 sep_str, null_replace_str, nested_type, dest_column_ptr.get());
         if (!res_val) {
             return Status::RuntimeError(fmt::format(
                     "execute failed or unsupported types for function {}({},{},{})", "array_join",

--- a/be/src/vec/functions/array/function_array_map.h
+++ b/be/src/vec/functions/array/function_array_map.h
@@ -165,7 +165,7 @@ public:
     static Status execute(ColumnPtr& res_ptr, ColumnArrayExecutionDatas datas,
                           std::vector<bool>& col_const, size_t start_row, size_t end_row) {
         ColumnArrayMutableData dst =
-                create_mutable_data(datas[0].nested_col, datas[0].nested_nullmap_data);
+                create_mutable_data(datas[0].nested_col.get(), datas[0].nested_nullmap_data);
         if (_execute_internal<ALL_COLUMNS_SIMPLE>(dst, datas, col_const, start_row, end_row)) {
             res_ptr = assemble_column_array(dst);
             return Status::OK();

--- a/be/src/vec/functions/array/function_array_pop.cpp
+++ b/be/src/vec/functions/array/function_array_pop.cpp
@@ -75,7 +75,7 @@ public:
         }
         // prepare dst array column
         bool is_nullable = src.nested_nullmap_data != nullptr;
-        ColumnArrayMutableData dst = create_mutable_data(src.nested_col, is_nullable);
+        ColumnArrayMutableData dst = create_mutable_data(src.nested_col.get(), is_nullable);
         dst.offsets_ptr->reserve(input_rows_count);
         // start from index depending on the PopType::start_offset
         auto offset_column = ColumnInt64::create(array_column->size(), PopType::start_offset);

--- a/be/src/vec/functions/array/function_array_range.cpp
+++ b/be/src/vec/functions/array/function_array_range.cpp
@@ -137,7 +137,7 @@ struct RangeImplUtil {
         IColumn* dest_nested_column = &dest_array_column_ptr->get_data();
         ColumnNullable* dest_nested_nullable_col =
                 reinterpret_cast<ColumnNullable*>(dest_nested_column);
-        dest_nested_column = dest_nested_nullable_col->get_nested_column_ptr();
+        dest_nested_column = dest_nested_nullable_col->get_nested_column_ptr().get();
         auto& dest_nested_null_map = dest_nested_nullable_col->get_null_map_column().get_data();
 
         auto args_null_map = ColumnUInt8::create(input_rows_count, 0);

--- a/be/src/vec/functions/array/function_array_remove.h
+++ b/be/src/vec/functions/array/function_array_remove.h
@@ -107,13 +107,13 @@ private:
             auto dst_nested_column =
                     ColumnNullable::create(nested_column.clone_empty(), ColumnUInt8::create());
             array_nested_column = dst_nested_column->get_ptr();
-            dst_column = dst_nested_column->get_nested_column_ptr();
+            dst_column = dst_nested_column->get_nested_column_ptr().get();
             dst_null_map = &dst_nested_column->get_null_map_data();
             dst_null_map->reserve(offsets.back());
         } else {
             auto dst_nested_column = nested_column.clone_empty();
             array_nested_column = dst_nested_column->get_ptr();
-            dst_column = dst_nested_column;
+            dst_column = dst_nested_column.get();
         }
 
         auto& dst_data = reinterpret_cast<NestedColumnType&>(*dst_column).get_data();
@@ -179,13 +179,13 @@ private:
             auto dst_nested_column =
                     ColumnNullable::create(nested_column.clone_empty(), ColumnUInt8::create());
             array_nested_column = dst_nested_column->get_ptr();
-            dst_column = dst_nested_column->get_nested_column_ptr();
+            dst_column = dst_nested_column->get_nested_column_ptr().get();
             dst_null_map = &dst_nested_column->get_null_map_data();
             dst_null_map->reserve(offsets.back());
         } else {
             auto dst_nested_column = nested_column.clone_empty();
             array_nested_column = dst_nested_column->get_ptr();
-            dst_column = dst_nested_column;
+            dst_column = dst_nested_column.get();
         }
 
         auto& dst_offs = reinterpret_cast<ColumnString&>(*dst_column).get_offsets();

--- a/be/src/vec/functions/array/function_array_reverse.h
+++ b/be/src/vec/functions/array/function_array_reverse.h
@@ -40,7 +40,7 @@ struct ArrayReverseImpl {
         }
 
         bool is_nullable = src.nested_nullmap_data ? true : false;
-        ColumnArrayMutableData dst = create_mutable_data(src.nested_col, is_nullable);
+        ColumnArrayMutableData dst = create_mutable_data(src.nested_col.get(), is_nullable);
         dst.offsets_ptr->reserve(input_rows_count);
 
         auto res_val = _execute_internal(*src.nested_col, *src.offsets_ptr, *dst.nested_col,

--- a/be/src/vec/functions/array/function_array_set.h
+++ b/be/src/vec/functions/array/function_array_set.h
@@ -142,9 +142,9 @@ public:
                           bool right_const) {
         ColumnArrayMutableData dst;
         if (left_data.nested_nullmap_data || right_data.nested_nullmap_data) {
-            dst = create_mutable_data(left_data.nested_col, true);
+            dst = create_mutable_data(left_data.nested_col.get(), true);
         } else {
-            dst = create_mutable_data(left_data.nested_col, false);
+            dst = create_mutable_data(left_data.nested_col.get(), false);
         }
         ColumnPtr res_column;
         if (left_const) {

--- a/be/src/vec/functions/array/function_array_slice.h
+++ b/be/src/vec/functions/array/function_array_slice.h
@@ -89,7 +89,7 @@ public:
         }
         // prepare dst array column
         bool is_nullable = src.nested_nullmap_data ? true : false;
-        ColumnArrayMutableData dst = create_mutable_data(src.nested_col, is_nullable);
+        ColumnArrayMutableData dst = create_mutable_data(src.nested_col.get(), is_nullable);
         dst.offsets_ptr->reserve(input_rows_count);
         // execute
         slice_array(dst, src, *offset_column, length_column.get());

--- a/be/src/vec/functions/array/function_array_sortby.cpp
+++ b/be/src/vec/functions/array/function_array_sortby.cpp
@@ -95,13 +95,13 @@ public:
                 src_column_array.get_offsets_column().clone_resized(input_rows_count);
         MutableColumnPtr result_nullmap = nullptr;
         const ColumnUInt8::Container* src_null_map_data = nullptr;
-        if (argument_nullmap[0] != nullptr) {
+        if (argument_nullmap[0]) {
             const auto& src_column_nullmap = assert_cast<const ColumnUInt8&>(*argument_nullmap[0]);
             result_nullmap = src_column_nullmap.clone_resized(input_rows_count);
             src_null_map_data = &(src_column_nullmap.get_data());
         }
         const ColumnUInt8::Container* key_null_map_data = nullptr;
-        if (argument_nullmap[1] != nullptr) {
+        if (argument_nullmap[1]) {
             const auto& key_column_nullmap = assert_cast<const ColumnUInt8&>(*argument_nullmap[1]);
             key_null_map_data = &(key_column_nullmap.get_data());
         }
@@ -149,7 +149,7 @@ public:
             }
         }
         src_nested_nullable_column.append_data_by_selector(result_data_column, src_selector);
-        if (result_nullmap != nullptr) {
+        if (result_nullmap) {
             block.replace_by_position(
                     result,
                     ColumnNullable::create(ColumnArray::create(std::move(result_data_column),

--- a/be/src/vec/functions/array/function_arrays_overlap.h
+++ b/be/src/vec/functions/array/function_arrays_overlap.h
@@ -370,11 +370,11 @@ private:
 
             ExecutorImpl impl;
             if (right_size < left_size) {
-                impl.insert_array(right_data.nested_col, right_start, right_size);
-                dst_data[row] = impl.find_any(left_data.nested_col, left_start, left_size);
+                impl.insert_array(right_data.nested_col.get(), right_start, right_size);
+                dst_data[row] = impl.find_any(left_data.nested_col.get(), left_start, left_size);
             } else {
-                impl.insert_array(left_data.nested_col, left_start, left_size);
-                dst_data[row] = impl.find_any(right_data.nested_col, right_start, right_size);
+                impl.insert_array(left_data.nested_col.get(), left_start, left_size);
+                dst_data[row] = impl.find_any(right_data.nested_col.get(), right_start, right_size);
             }
         }
         return Status::OK();

--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -139,18 +139,20 @@ public:
             left_column = check_and_get_column<const ColumnNullable>(
                     assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(
                             col_left.column.get())
-                            ->get_data_column_ptr());
+                            ->get_data_column_ptr()
+                            .get());
         } else {
-            left_column = check_and_get_column<const ColumnNullable>(col_left.column);
+            left_column = check_and_get_column<const ColumnNullable>(col_left.column.get());
         }
 
         if (right_const) {
             right_column = check_and_get_column<const ColumnNullable>(
                     assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(
                             col_right.column.get())
-                            ->get_data_column_ptr());
+                            ->get_data_column_ptr()
+                            .get());
         } else {
-            right_column = check_and_get_column<const ColumnNullable>(col_right.column);
+            right_column = check_and_get_column<const ColumnNullable>(col_right.column.get());
         }
 
         bool left_nullable = left_column != nullptr;

--- a/be/src/vec/functions/function_agg_state.h
+++ b/be/src/vec/functions/function_agg_state.h
@@ -82,7 +82,7 @@ public:
                 save_columns.push_back(column);
             }
 
-            agg_columns.push_back(column);
+            agg_columns.push_back(column.get());
         }
         _agg_function->streaming_agg_serialize_to_column(agg_columns.data(), col, input_rows_count,
                                                          &(context->get_arena()));

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -165,7 +165,7 @@ struct BinaryOperationImpl {
 
     static ColumnPtr adapt_normal_vector_constant(ColumnPtr column_left, B b) {
         auto column_left_ptr =
-                check_and_get_column<typename Base::Traits::ColumnVectorA>(column_left);
+                check_and_get_column<typename Base::Traits::ColumnVectorA>(column_left.get());
         auto column_result = Base::ColumnVectorResult::create(column_left->size());
         DCHECK(column_left_ptr != nullptr);
 
@@ -182,7 +182,7 @@ struct BinaryOperationImpl {
 
     static ColumnPtr adapt_normal_constant_vector(A a, ColumnPtr column_right) {
         auto column_right_ptr =
-                check_and_get_column<typename Base::Traits::ColumnVectorB>(column_right);
+                check_and_get_column<typename Base::Traits::ColumnVectorB>(column_right.get());
         auto column_result = Base::ColumnVectorResult::create(column_right->size());
         DCHECK(column_right_ptr != nullptr);
 
@@ -199,9 +199,9 @@ struct BinaryOperationImpl {
 
     static ColumnPtr adapt_normal_vector_vector(ColumnPtr column_left, ColumnPtr column_right) {
         auto column_left_ptr =
-                check_and_get_column<typename Base::Traits::ColumnVectorA>(column_left);
+                check_and_get_column<typename Base::Traits::ColumnVectorA>(column_left.get());
         auto column_right_ptr =
-                check_and_get_column<typename Base::Traits::ColumnVectorB>(column_right);
+                check_and_get_column<typename Base::Traits::ColumnVectorB>(column_right.get());
 
         auto column_result = Base::ColumnVectorResult::create(column_left->size());
         DCHECK(column_left_ptr != nullptr && column_right_ptr != nullptr);
@@ -447,7 +447,8 @@ public:
         auto type_result =
                 assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
                         *res_data_type);
-        auto column_left_ptr = check_and_get_column<typename Traits::ColumnVectorA>(column_left);
+        auto column_left_ptr =
+                check_and_get_column<typename Traits::ColumnVectorA>(column_left.get());
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_left->size(),
                 assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
@@ -482,7 +483,8 @@ public:
         auto type_result =
                 assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
                         *res_data_type);
-        auto column_right_ptr = check_and_get_column<typename Traits::ColumnVectorB>(column_right);
+        auto column_right_ptr =
+                check_and_get_column<typename Traits::ColumnVectorB>(column_right.get());
         auto column_result = ColumnDecimal<ResultType>::create(
                 column_right->size(),
                 assert_cast<const DataTypeDecimal<ResultType>&, TypeCheckOnRelease::DISABLE>(
@@ -515,8 +517,10 @@ public:
                                                  const ResultType& max_result_number,
                                                  const ResultType& scale_diff_multiplier,
                                                  DataTypePtr res_data_type) {
-        auto column_left_ptr = check_and_get_column<typename Traits::ColumnVectorA>(column_left);
-        auto column_right_ptr = check_and_get_column<typename Traits::ColumnVectorB>(column_right);
+        auto column_left_ptr =
+                check_and_get_column<typename Traits::ColumnVectorA>(column_left.get());
+        auto column_right_ptr =
+                check_and_get_column<typename Traits::ColumnVectorB>(column_right.get());
 
         const auto& type_result = assert_cast<const DataTypeDecimal<ResultType>&>(*res_data_type);
         auto column_result =
@@ -847,8 +851,8 @@ private:
     static ColumnPtr constant_constant(ColumnPtr column_left, ColumnPtr column_right,
                                        const LeftDataType& type_left,
                                        const RightDataType& type_right, DataTypePtr res_data_type) {
-        auto column_left_ptr = check_and_get_column<ColumnConst>(column_left);
-        auto column_right_ptr = check_and_get_column<ColumnConst>(column_right);
+        const auto* column_left_ptr = check_and_get_column<ColumnConst>(column_left.get());
+        const auto* column_right_ptr = check_and_get_column<ColumnConst>(column_right.get());
         DCHECK(column_left_ptr != nullptr && column_right_ptr != nullptr);
 
         ColumnPtr column_result = nullptr;
@@ -875,7 +879,7 @@ private:
     static ColumnPtr vector_constant(ColumnPtr column_left, ColumnPtr column_right,
                                      const LeftDataType& type_left, const RightDataType& type_right,
                                      DataTypePtr res_data_type) {
-        auto column_right_ptr = check_and_get_column<ColumnConst>(column_right);
+        const auto* column_right_ptr = check_and_get_column<ColumnConst>(column_right.get());
         DCHECK(column_right_ptr != nullptr);
 
         if constexpr (result_is_decimal) {
@@ -894,7 +898,7 @@ private:
     static ColumnPtr constant_vector(ColumnPtr column_left, ColumnPtr column_right,
                                      const LeftDataType& type_left, const RightDataType& type_right,
                                      DataTypePtr res_data_type) {
-        auto column_left_ptr = check_and_get_column<ColumnConst>(column_left);
+        const auto* column_left_ptr = check_and_get_column<ColumnConst>(column_left.get());
         DCHECK(column_left_ptr != nullptr);
 
         if constexpr (result_is_decimal) {

--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -1211,7 +1211,7 @@ public:
         IColumn* dest_nested_column = &dest_array_column_ptr->get_data();
         ColumnNullable* dest_nested_nullable_col =
                 reinterpret_cast<ColumnNullable*>(dest_nested_column);
-        dest_nested_column = dest_nested_nullable_col->get_nested_column_ptr();
+        dest_nested_column = dest_nested_nullable_col->get_nested_column_ptr().get();
         auto& dest_nested_null_map = dest_nested_nullable_col->get_null_map_column().get_data();
 
         auto& arg_col = block.get_by_position(arguments[0]).column;

--- a/be/src/vec/functions/function_bitmap_variadic.cpp
+++ b/be/src/vec/functions/function_bitmap_variadic.cpp
@@ -247,7 +247,7 @@ public:
         vec_res.resize(input_rows_count);
 
         RETURN_IF_ERROR(Impl::vector_vector(argument_columns.data(), argument_size,
-                                            input_rows_count, vec_res, col_res_nulls));
+                                            input_rows_count, vec_res, col_res_nulls.get()));
         if (!use_default_implementation_for_nulls() && result_info.type->is_nullable()) {
             block.replace_by_position(
                     result, ColumnNullable::create(std::move(col_res), std::move(col_res_nulls)));

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -318,7 +318,7 @@ public:
                                  const uint8* __restrict then_idx,
                                  CaseWhenColumnHolder& column_holder) const {
         for (auto& then_ptr : column_holder.then_ptrs) {
-            then_ptr->reset(then_ptr.value()->convert_to_full_column_if_const());
+            then_ptr->reset(then_ptr.value()->convert_to_full_column_if_const().get());
         }
 
         size_t rows_count = column_holder.rows_count;

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -763,7 +763,7 @@ struct ConvertImplGenericFromJsonb {
                     continue;
                 }
                 ReadBuffer read_buffer((char*)(input_str.data()), input_str.size());
-                Status st = data_type_to->from_string(read_buffer, col_to);
+                Status st = data_type_to->from_string(read_buffer, col_to.get());
                 // if parsing failed, will return null
                 (*vec_null_map_to)[i] = !st.ok();
                 if (!st.ok()) {

--- a/be/src/vec/functions/function_collection_in.h
+++ b/be/src/vec/functions/function_collection_in.h
@@ -117,7 +117,8 @@ public:
             DCHECK(const_column_ptr != nullptr);
             const auto& [col, _] = unpack_if_const(const_column_ptr->column_ptr);
             if (col->is_nullable()) {
-                auto* null_col = vectorized::check_and_get_column<vectorized::ColumnNullable>(col);
+                const auto* null_col =
+                        vectorized::check_and_get_column<vectorized::ColumnNullable>(col.get());
                 if (null_col->has_null()) {
                     state->null_in_set = true;
                 } else {
@@ -161,7 +162,7 @@ public:
         if (materialized_column_not_null->is_nullable()) {
             materialized_column_not_null = assert_cast<ColumnPtr>(
                     vectorized::check_and_get_column<vectorized::ColumnNullable>(
-                            materialized_column_not_null)
+                            materialized_column_not_null.get())
                             ->get_nested_column_ptr());
         }
 

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -878,7 +878,7 @@ struct CurrentDateTimeImpl {
         bool use_const;
         if constexpr (WithPrecision) {
             if (const auto* const_column = check_and_get_column<ColumnConst>(
-                        block.get_by_position(arguments[0]).column)) {
+                        block.get_by_position(arguments[0]).column.get())) {
                 int64_t scale = const_column->get_int(0);
                 dtv.from_unixtime(context->state()->timestamp_ms() / 1000,
                                   context->state()->nano_seconds(),
@@ -892,7 +892,7 @@ struct CurrentDateTimeImpl {
 
                 use_const = true;
             } else if (const auto* nullable_column = check_and_get_column<ColumnNullable>(
-                               block.get_by_position(arguments[0]).column)) {
+                               block.get_by_position(arguments[0]).column.get())) {
                 const auto& null_map = nullable_column->get_null_map_data();
                 const auto& nested_column = assert_cast<const ColumnInt32*>(
                         nullable_column->get_nested_column_ptr().get());

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -763,11 +763,13 @@ public:
         if (is_ipv4(addr_column_with_type_and_name.type)) {
             execute_impl_with_ip<PrimitiveType::TYPE_IPV4, ColumnIPv4>(
                     input_rows_count, addr_const, cidr_const,
-                    assert_cast<const ColumnString*>(cidr_column.get()), addr_column, col_res);
+                    assert_cast<const ColumnString*>(cidr_column.get()), addr_column,
+                    col_res.get());
         } else if (is_ipv6(addr_column_with_type_and_name.type)) {
             execute_impl_with_ip<PrimitiveType::TYPE_IPV6, ColumnIPv6>(
                     input_rows_count, addr_const, cidr_const,
-                    assert_cast<const ColumnString*>(cidr_column.get()), addr_column, col_res);
+                    assert_cast<const ColumnString*>(cidr_column.get()), addr_column,
+                    col_res.get());
         } else {
             const auto* str_addr_column = assert_cast<const ColumnString*>(addr_column.get());
             const auto* str_cidr_column = assert_cast<const ColumnString*>(cidr_column.get());

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -459,11 +459,12 @@ public:
         // prepare jsonb data column
         jsonb_data_column = unpack_if_const(block.get_by_position(arguments[0]).column).first;
         if (block.get_by_position(arguments[0]).column->is_nullable()) {
-            const auto* nullable = check_and_get_column<ColumnNullable>(jsonb_data_column);
+            const auto* nullable = check_and_get_column<ColumnNullable>(jsonb_data_column.get());
             jsonb_data_column = nullable->get_nested_column_ptr();
             data_null_map = &nullable->get_null_map_data();
         }
-        const ColumnString* col_from_string = check_and_get_column<ColumnString>(jsonb_data_column);
+        const ColumnString* col_from_string =
+                check_and_get_column<ColumnString>(jsonb_data_column.get());
 
         // prepare parse path column prepare, maybe we do not have path column
         ColumnPtr jsonb_path_column = nullptr;
@@ -475,11 +476,12 @@ public:
             std::tie(jsonb_path_column, path_const) =
                     unpack_if_const(block.get_by_position(arguments[1]).column);
             if (block.get_by_position(arguments[1]).column->is_nullable()) {
-                const auto* nullable = check_and_get_column<ColumnNullable>(jsonb_path_column);
+                const auto* nullable =
+                        check_and_get_column<ColumnNullable>(jsonb_path_column.get());
                 jsonb_path_column = nullable->get_nested_column_ptr();
                 path_null_map = &nullable->get_null_map_data();
             }
-            jsonb_path_col = check_and_get_column<ColumnString>(jsonb_path_column);
+            jsonb_path_col = check_and_get_column<ColumnString>(jsonb_path_column.get());
         }
 
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
@@ -1844,9 +1846,10 @@ public:
         // prepare jsonb data column
         std::tie(col_json, json_is_const) =
                 unpack_if_const(block.get_by_position(arguments[0]).column);
-        const ColumnString* col_json_string = check_and_get_column<ColumnString>(col_json);
-        if (auto* nullable = check_and_get_column<ColumnNullable>(col_json)) {
-            col_json_string = check_and_get_column<ColumnString>(nullable->get_nested_column_ptr());
+        const ColumnString* col_json_string = check_and_get_column<ColumnString>(col_json.get());
+        if (auto* nullable = check_and_get_column<ColumnNullable>(col_json.get())) {
+            col_json_string =
+                    check_and_get_column<ColumnString>(nullable->get_nested_column_ptr().get());
         }
 
         if (!col_json_string) {
@@ -1873,8 +1876,8 @@ public:
         // prepare jsonb data column
         std::tie(col_one, one_is_const) =
                 unpack_if_const(block.get_by_position(arguments[1]).column);
-        const ColumnString* col_one_string = check_and_get_column<ColumnString>(col_one);
-        if (auto* nullable = check_and_get_column<ColumnNullable>(col_one)) {
+        const ColumnString* col_one_string = check_and_get_column<ColumnString>(col_one.get());
+        if (auto* nullable = check_and_get_column<ColumnNullable>(col_one.get())) {
             col_one_string = check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
         }
         if (!col_one_string) {
@@ -1921,8 +1924,9 @@ public:
         std::tie(col_search, search_is_const) =
                 unpack_if_const(block.get_by_position(arguments[2]).column);
 
-        const ColumnString* col_search_string = check_and_get_column<ColumnString>(col_search);
-        if (auto* nullable = check_and_get_column<ColumnNullable>(col_search)) {
+        const ColumnString* col_search_string =
+                check_and_get_column<ColumnString>(col_search.get());
+        if (auto* nullable = check_and_get_column<ColumnNullable>(col_search.get())) {
             col_search_string =
                     check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
         }

--- a/be/src/vec/functions/function_nullables.cpp
+++ b/be/src/vec/functions/function_nullables.cpp
@@ -54,7 +54,8 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         ColumnPtr& col = block.get_by_position(arguments[0]).column;
-        if (const auto* col_null = check_and_get_column<ColumnNullable>(col); col_null == nullptr) {
+        if (const auto* col_null = check_and_get_column<ColumnNullable>(col.get());
+            col_null == nullptr) {
             // not null
             block.replace_by_position(
                     result, ColumnNullable::create(col, ColumnBool::create(input_rows_count, 0)));
@@ -85,7 +86,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto& data = block.get_by_position(arguments[0]);
-        if (const auto* col_null = check_and_get_column<ColumnNullable>(data.column);
+        if (const auto* col_null = check_and_get_column<ColumnNullable>(data.column.get());
             col_null == nullptr) // raise error if input is not nullable.
         {
             return Status::InvalidArgument(

--- a/be/src/vec/functions/function_quantile_state.cpp
+++ b/be/src/vec/functions/function_quantile_state.cpp
@@ -130,7 +130,7 @@ public:
         const ColumnPtr& column = block.get_by_position(arguments[0]).column;
         const DataTypePtr& data_type = block.get_by_position(arguments[0]).type;
         auto compression_arg = check_and_get_column_const<ColumnFloat32>(
-                block.get_by_position(arguments.back()).column);
+                block.get_by_position(arguments.back()).column.get());
         float compression = 2048;
         if (compression_arg) {
             auto compression_arg_val = compression_arg->get_value<Float32>();
@@ -189,7 +189,7 @@ public:
         auto str_col = assert_cast<const ColumnQuantileState*>(column.get());
         auto& col_data = str_col->get_data();
         auto percent_arg = check_and_get_column_const<ColumnFloat32>(
-                block.get_by_position(arguments.back()).column);
+                block.get_by_position(arguments.back()).column.get());
 
         if (!percent_arg) {
             return Status::InternalError(

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -2142,7 +2142,7 @@ public:
 
         NullMapType* dest_nested_null_map = nullptr;
         auto* dest_nullable_col = reinterpret_cast<ColumnNullable*>(dest_nested_column);
-        dest_nested_column = dest_nullable_col->get_nested_column_ptr();
+        dest_nested_column = dest_nullable_col->get_nested_column_ptr().get();
         dest_nested_null_map = &dest_nullable_col->get_null_map_column().get_data();
 
         const auto* col_left = check_and_get_column<ColumnString>(src_column.get());
@@ -4436,7 +4436,7 @@ public:
         } else if (is_ascii) {
             impl_vectors = impl_vectors_ascii<false>;
         }
-        impl_vectors(col_source, col_from, col_to, col_res);
+        impl_vectors(col_source, col_from, col_to, col_res.get());
         block.get_by_position(result).column = std::move(col_res);
         return Status::OK();
     }

--- a/be/src/vec/functions/function_tokenize.cpp
+++ b/be/src/vec/functions/function_tokenize.cpp
@@ -129,7 +129,7 @@ Status FunctionTokenize::execute_impl(FunctionContext* /*context*/, Block& block
 
     NullMapType* dest_nested_null_map = nullptr;
     ColumnNullable* dest_nullable_col = reinterpret_cast<ColumnNullable*>(dest_nested_column);
-    dest_nested_column = dest_nullable_col->get_nested_column_ptr();
+    dest_nested_column = dest_nullable_col->get_nested_column_ptr().get();
     dest_nested_null_map = &dest_nullable_col->get_null_map_column().get_data();
 
     if (auto col_left = check_and_get_column<ColumnString>(src_column.get())) {

--- a/be/src/vec/functions/functions_geo.cpp
+++ b/be/src/vec/functions/functions_geo.cpp
@@ -258,10 +258,10 @@ struct StDistanceSphere {
         ColumnPtr y_lat_origin =
                 block.get_by_position(arguments[3]).column->convert_to_full_column_if_const();
 
-        const auto* x_lng = check_and_get_column<ColumnFloat64>(x_lng_origin);
-        const auto* x_lat = check_and_get_column<ColumnFloat64>(x_lat_origin);
-        const auto* y_lng = check_and_get_column<ColumnFloat64>(y_lng_origin);
-        const auto* y_lat = check_and_get_column<ColumnFloat64>(y_lat_origin);
+        const auto* x_lng = check_and_get_column<ColumnFloat64>(x_lng_origin.get());
+        const auto* x_lat = check_and_get_column<ColumnFloat64>(x_lat_origin.get());
+        const auto* y_lng = check_and_get_column<ColumnFloat64>(y_lng_origin.get());
+        const auto* y_lat = check_and_get_column<ColumnFloat64>(y_lat_origin.get());
         CHECK(x_lng && x_lat && y_lng && y_lat);
 
         const auto size = x_lng->size();
@@ -305,10 +305,10 @@ struct StAngleSphere {
         ColumnPtr y_lat_origin =
                 block.get_by_position(arguments[3]).column->convert_to_full_column_if_const();
 
-        const auto* x_lng = check_and_get_column<ColumnFloat64>(x_lng_origin);
-        const auto* x_lat = check_and_get_column<ColumnFloat64>(x_lat_origin);
-        const auto* y_lng = check_and_get_column<ColumnFloat64>(y_lng_origin);
-        const auto* y_lat = check_and_get_column<ColumnFloat64>(y_lat_origin);
+        const auto* x_lng = check_and_get_column<ColumnFloat64>(x_lng_origin.get());
+        const auto* x_lat = check_and_get_column<ColumnFloat64>(x_lat_origin.get());
+        const auto* y_lng = check_and_get_column<ColumnFloat64>(y_lng_origin.get());
+        const auto* y_lat = check_and_get_column<ColumnFloat64>(y_lat_origin.get());
         CHECK(x_lng && x_lat && y_lng && y_lat);
 
         const auto size = x_lng->size();

--- a/be/src/vec/functions/functions_logical.cpp
+++ b/be/src/vec/functions/functions_logical.cpp
@@ -141,11 +141,11 @@ void basic_execute_impl(ColumnRawPtrs arguments, ColumnWithTypeAndName& result_i
                         size_t input_rows_count) {
     auto col_res = ColumnUInt8::create(input_rows_count);
     if (auto l = check_and_get_column<ColumnConst>(arguments[0])) {
-        vector_const<Op>(arguments[1], l, col_res, input_rows_count);
+        vector_const<Op>(arguments[1], l, col_res.get(), input_rows_count);
     } else if (auto r = check_and_get_column<ColumnConst>(arguments[1])) {
-        vector_const<Op>(arguments[0], r, col_res, input_rows_count);
+        vector_const<Op>(arguments[0], r, col_res.get(), input_rows_count);
     } else {
-        vector_vector<Op>(arguments[0], arguments[1], col_res, input_rows_count);
+        vector_vector<Op>(arguments[0], arguments[1], col_res.get(), input_rows_count);
     }
     result_info.column = std::move(col_res);
 }
@@ -156,11 +156,12 @@ void null_execute_impl(ColumnRawPtrs arguments, ColumnWithTypeAndName& result_in
     auto col_nulls = ColumnUInt8::create(input_rows_count);
     auto col_res = ColumnUInt8::create(input_rows_count);
     if (auto l = check_and_get_column<ColumnConst>(arguments[0])) {
-        vector_const_null<Op>(arguments[1], l, col_res, col_nulls, input_rows_count);
+        vector_const_null<Op>(arguments[1], l, col_res.get(), col_nulls.get(), input_rows_count);
     } else if (auto r = check_and_get_column<ColumnConst>(arguments[1])) {
-        vector_const_null<Op>(arguments[0], r, col_res, col_nulls, input_rows_count);
+        vector_const_null<Op>(arguments[0], r, col_res.get(), col_nulls.get(), input_rows_count);
     } else {
-        vector_vector_null<Op>(arguments[0], arguments[1], col_res, col_nulls, input_rows_count);
+        vector_vector_null<Op>(arguments[0], arguments[1], col_res.get(), col_nulls.get(),
+                               input_rows_count);
     }
     result_info.column = ColumnNullable::create(std::move(col_res), std::move(col_nulls));
 }

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -216,7 +216,7 @@ public:
             if (materialized_column->is_nullable()) {
                 const auto* null_col_ptr =
                         vectorized::check_and_get_column<vectorized::ColumnNullable>(
-                                materialized_column);
+                                materialized_column.get());
                 const auto& null_map = assert_cast<const vectorized::ColumnUInt8&>(
                                                null_col_ptr->get_null_map_column())
                                                .get_data();

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -173,7 +173,7 @@ struct FunctionFieldImpl {
                              size_t input_rows_count) {
         const auto& data_type = block.get_by_position(arguments[0]).type;
         auto result_column = ColumnInt32::create(input_rows_count, 0);
-        auto& res_data = static_cast<ColumnInt32*>(result_column)->get_data();
+        auto& res_data = static_cast<ColumnInt32*>(result_column.get())->get_data();
 
         const auto& column_size = arguments.size();
         std::vector<ColumnPtr> argument_columns(column_size);

--- a/be/src/vec/functions/round.h
+++ b/be/src/vec/functions/round.h
@@ -731,6 +731,7 @@ public:
         const auto* col_general = is_col_general_const
                                           ? assert_cast<const ColumnConst&>(*column_general.column)
                                                     .get_data_column_ptr()
+                                                    .get()
                                           : column_general.column.get();
         ColumnPtr res;
 

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -506,7 +506,8 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
     vectorized::ColumnInt64::Container& dst_values = dst_column->get_data();
 
     vectorized::ColumnPtr src_column_ptr = block->get_by_position(idx).column;
-    if (const auto* const_column = check_and_get_column<vectorized::ColumnConst>(src_column_ptr)) {
+    if (const auto* const_column =
+                check_and_get_column<vectorized::ColumnConst>(src_column_ptr.get())) {
         // for insert stmt like "insert into tbl1 select null,col1,col2,... from tbl2" or
         // "insert into tbl1 select 1,col1,col2,... from tbl2", the type of literal's column
         // will be `ColumnConst`
@@ -530,7 +531,7 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
             dst_values.resize_fill(rows, value);
         }
     } else if (const auto* src_nullable_column =
-                       check_and_get_column<vectorized::ColumnNullable>(src_column_ptr)) {
+                       check_and_get_column<vectorized::ColumnNullable>(src_column_ptr.get())) {
         auto src_nested_column_ptr = src_nullable_column->get_nested_column_ptr();
         const auto& null_map_data = src_nullable_column->get_null_map_data();
         dst_values.reserve(rows);

--- a/be/src/vec/sink/writer/iceberg/partition_transformers.h
+++ b/be/src/vec/sink/writer/iceberg/partition_transformers.h
@@ -153,8 +153,8 @@ public:
         ColumnPtr string_column_ptr;
         ColumnPtr null_map_column_ptr;
         bool is_nullable = false;
-        if (auto* nullable_column =
-                    check_and_get_column<ColumnNullable>(column_with_type_and_name.column)) {
+        if (const auto* nullable_column =
+                    check_and_get_column<ColumnNullable>(column_with_type_and_name.column.get())) {
             null_map_column_ptr = nullable_column->get_null_map_column_ptr();
             string_column_ptr = nullable_column->get_nested_column_ptr();
             is_nullable = true;
@@ -211,7 +211,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -270,7 +270,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -332,8 +332,8 @@ public:
         ColumnPtr column_ptr;
         ColumnPtr null_map_column_ptr;
         bool is_nullable = false;
-        if (auto* nullable_column =
-                    check_and_get_column<ColumnNullable>(column_with_type_and_name.column)) {
+        if (const auto* nullable_column =
+                    check_and_get_column<ColumnNullable>(column_with_type_and_name.column.get())) {
             null_map_column_ptr = nullable_column->get_null_map_column_ptr();
             column_ptr = nullable_column->get_nested_column_ptr();
             is_nullable = true;
@@ -342,7 +342,7 @@ public:
             is_nullable = false;
         }
 
-        const auto* const decimal_col = check_and_get_column<ColumnDecimal<T>>(column_ptr);
+        const auto* const decimal_col = check_and_get_column<ColumnDecimal<T>>(column_ptr.get());
         const auto& vec_src = decimal_col->get_data();
 
         auto col_res = ColumnDecimal<T>::create(vec_src.size(), decimal_col->get_scale());
@@ -391,7 +391,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -454,7 +454,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -518,7 +518,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -597,7 +597,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -665,7 +665,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -746,7 +746,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -811,7 +811,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -883,7 +883,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -955,7 +955,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -1027,7 +1027,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -1099,7 +1099,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -1177,7 +1177,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -1254,7 +1254,7 @@ public:
         //1) get the target column ptr
         const ColumnWithTypeAndName& column_with_type_and_name = block.get_by_position(column_pos);
         ColumnPtr column_ptr = column_with_type_and_name.column->convert_to_full_column_if_const();
-        CHECK(column_ptr != nullptr);
+        CHECK(column_ptr);
 
         //2) get the input data from block
         ColumnPtr null_map_column_ptr;
@@ -1328,7 +1328,7 @@ public:
         ColumnPtr column_ptr;
         ColumnPtr null_map_column_ptr;
         if (auto* nullable_column =
-                    check_and_get_column<ColumnNullable>(column_with_type_and_name.column)) {
+                    check_and_get_column<ColumnNullable>(column_with_type_and_name.column.get())) {
             null_map_column_ptr = nullable_column->get_null_map_column_ptr();
             column_ptr = nullable_column->get_nested_column_ptr();
         } else {

--- a/be/src/vec/sink/writer/iceberg/viceberg_table_writer.cpp
+++ b/be/src/vec/sink/writer/iceberg/viceberg_table_writer.cpp
@@ -410,7 +410,7 @@ std::any VIcebergTableWriter::_get_iceberg_partition_value(
         int position) {
     //1) get the partition column ptr
     ColumnPtr col_ptr = partition_column.column->convert_to_full_column_if_const();
-    CHECK(col_ptr != nullptr);
+    CHECK(col_ptr);
     if (col_ptr->is_nullable()) {
         const ColumnNullable* nullable_column =
                 reinterpret_cast<const vectorized::ColumnNullable*>(col_ptr.get());

--- a/be/src/vec/utils/util.hpp
+++ b/be/src/vec/utils/util.hpp
@@ -197,7 +197,7 @@ inline void change_null_to_true(ColumnPtr column, ColumnPtr argument = nullptr) 
             data[i] |= null_map[i];
         }
         memset(null_map, 0, rows);
-    } else if (argument != nullptr && argument->has_null()) {
+    } else if (argument && argument->has_null()) {
         const auto* __restrict null_map =
                 assert_cast<const ColumnNullable*>(argument.get())->get_null_map_data().data();
         auto* __restrict data =

--- a/be/test/vec/columns/common_column_test.h
+++ b/be/test/vec/columns/common_column_test.h
@@ -989,7 +989,7 @@ public:
                 // check size
                 EXPECT_EQ(ptr->size(), *cl);
                 // check ptr is not the same
-                EXPECT_NE(ptr.get(), source_column);
+                EXPECT_NE(ptr.get(), source_column.get());
 
                 // check after clone_resized with assert_res
                 auto ser_col = ColumnString::create();
@@ -1042,7 +1042,7 @@ public:
                 // check size
                 EXPECT_EQ(ptr->size(), insert_size);
                 // check ptr is not the same
-                EXPECT_NE(ptr.get(), source_column);
+                EXPECT_NE(ptr.get(), source_column.get());
                 // check after cut with assert_res
                 auto ser_col = ColumnString::create();
                 ser_col->reserve(ptr->size());
@@ -1095,7 +1095,7 @@ public:
                 // check size
                 EXPECT_EQ(ptr->size(), insert_size);
                 // check ptr is not the same
-                EXPECT_NE(ptr.get(), source_column);
+                EXPECT_NE(ptr.get(), source_column.get());
                 // check after cut with assert_res
                 auto ser_col = ColumnString::create();
                 ser_col->reserve(ptr->size());

--- a/be/test/vec/data_types/from_string_test.cpp
+++ b/be/test/vec/data_types/from_string_test.cpp
@@ -203,7 +203,7 @@ TEST(FromStringTest, ScalaWrapperFieldVsDataType) {
                 string test_str = std::get<1>(type_pair)[i];
                 // data_type from_string
                 ReadBuffer rb_test(test_str.data(), test_str.size());
-                Status st = data_type_ptr->from_string(rb_test, col);
+                Status st = data_type_ptr->from_string(rb_test, col.get());
                 if (std::get<3>(type_pair)[i].empty()) {
                     EXPECT_EQ(st.ok(), false);
                     std::cout << "deserialize failed: " << st.to_json() << std::endl;
@@ -256,11 +256,11 @@ TEST(FromStringTest, ScalaWrapperFieldVsDataType) {
             ReadBuffer rand_rb(rand_date.data(), rand_date.size());
 
             auto col = data_type_ptr->create_column();
-            Status st = data_type_ptr->from_string(min_rb, col);
+            Status st = data_type_ptr->from_string(min_rb, col.get());
             EXPECT_EQ(st.ok(), true);
-            st = data_type_ptr->from_string(max_rb, col);
+            st = data_type_ptr->from_string(max_rb, col.get());
             EXPECT_EQ(st.ok(), true);
-            st = data_type_ptr->from_string(rand_rb, col);
+            st = data_type_ptr->from_string(rand_rb, col.get());
             EXPECT_EQ(st.ok(), true);
 
             string min_s_d = data_type_ptr->to_string(*col, 0);
@@ -319,7 +319,7 @@ TEST(FromStringTest, ScalaWrapperFieldVsDataType) {
             string rand_ip = rand_wf->to_string();
             ReadBuffer rand_rb(rand_ip.data(), rand_ip.size());
             auto col = data_type_ptr->create_column();
-            st = data_type_ptr->from_string(rand_rb, col);
+            st = data_type_ptr->from_string(rand_rb, col.get());
             EXPECT_EQ(st.ok(), true);
             string rand_s_d = data_type_ptr->to_string(*col, 0);
             rtrim(rand_ip);
@@ -336,7 +336,7 @@ TEST(FromStringTest, ScalaWrapperFieldVsDataType) {
             EXPECT_EQ(st.ok(), false);
             ReadBuffer rand_rb(pair.second.data(), pair.second.size());
             auto col = data_type_ptr->create_column();
-            st = data_type_ptr->from_string(rand_rb, col);
+            st = data_type_ptr->from_string(rand_rb, col.get());
             EXPECT_EQ(st.ok(), false);
         }
     }

--- a/be/test/vec/data_types/serde/data_type_serde_text_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_text_test.cpp
@@ -510,7 +510,7 @@ TEST(TextSerde, ComplexTypeSerdeTextTest) {
                 {
                     // from_string
                     ReadBuffer rb(rand_str.data(), rand_str.size());
-                    Status status = array_data_type_ptr->from_string(rb, col2);
+                    Status status = array_data_type_ptr->from_string(rb, col2.get());
                     EXPECT_EQ(status.ok(), true);
                     auto ser_col = ColumnString::create();
                     ser_col->reserve(1);
@@ -661,7 +661,7 @@ TEST(TextSerde, ComplexTypeSerdeTextTest) {
                 {
                     ReadBuffer rb(rand_str.data(), rand_str.size());
                     std::cout << "from string rb: " << rb.to_string() << std::endl;
-                    Status stat = map_data_type_ptr->from_string(rb, col2);
+                    Status stat = map_data_type_ptr->from_string(rb, col2.get());
                     std::cout << stat.to_json() << std::endl;
                     auto ser_col = ColumnString::create();
                     ser_col->reserve(1);
@@ -840,7 +840,7 @@ TEST(TextSerde, ComplexTypeWithNestedSerdeTextTest) {
                     // from_string
                     ReadBuffer rb(rand_str.data(), rand_str.size());
                     auto col2 = array_data_type_ptr->create_column();
-                    Status status = array_data_type_ptr->from_string(rb, col2);
+                    Status status = array_data_type_ptr->from_string(rb, col2.get());
                     if (expect_from_string_str == "") {
                         EXPECT_EQ(status.ok(), false);
                         std::cout << "test from_string: " << status.to_json() << std::endl;
@@ -995,7 +995,7 @@ TEST(TextSerde, ComplexTypeWithNestedSerdeTextTest) {
                     // from_string
                     ReadBuffer rb(rand_str.data(), rand_str.size());
                     auto col2 = array_data_type_ptr->create_column();
-                    Status status = array_data_type_ptr->from_string(rb, col2);
+                    Status status = array_data_type_ptr->from_string(rb, col2.get());
                     if (expect_from_string_str == "") {
                         EXPECT_EQ(status.ok(), false);
                         std::cout << "test from_string: " << status.to_json() << std::endl;
@@ -1213,7 +1213,7 @@ TEST(TextSerde, ComplexTypeWithNestedSerdeTextTest) {
                     // from_string
                     ReadBuffer rb(rand_str.data(), rand_str.size());
                     auto col2 = map_data_type_ptr->create_column();
-                    Status status = map_data_type_ptr->from_string(rb, col2);
+                    Status status = map_data_type_ptr->from_string(rb, col2.get());
                     if (expect_from_string_str == "") {
                         EXPECT_EQ(status.ok(), false);
                         std::cout << "test from_string: " << status.to_json() << std::endl;
@@ -1354,7 +1354,7 @@ TEST(TextSerde, ComplexTypeWithNestedSerdeTextTest) {
                     // from_string
                     ReadBuffer rb(rand_str.data(), rand_str.size());
                     auto col2 = array_data_type_ptr->create_column();
-                    Status status = array_data_type_ptr->from_string(rb, col2);
+                    Status status = array_data_type_ptr->from_string(rb, col2.get());
                     if (expect_from_string_str == "") {
                         EXPECT_EQ(status.ok(), false);
                         std::cout << "test from_string: " << status.to_json() << std::endl;

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -315,7 +315,7 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
 
     // 3. check the result of function
     ColumnPtr column = block.get_columns()[result];
-    EXPECT_TRUE(column != nullptr);
+    EXPECT_TRUE(column);
 
     for (int i = 0; i < row_size; ++i) {
         // update current line

--- a/be/test/vec/olap/char_type_padding_test.cpp
+++ b/be/test/vec/olap/char_type_padding_test.cpp
@@ -40,10 +40,10 @@ TEST(CharTypePaddingTest, CharTypePaddingFullTest) {
     for (size_t i = 0; i < rows; i++) {
         input->insert_data(str.data(), str.length());
     }
-    EXPECT_FALSE(ConvertorChar::should_padding(input, str.length()));
+    EXPECT_FALSE(ConvertorChar::should_padding(input.get(), str.length()));
 
     input->insert_data(str.data(), str.length() - 1);
-    EXPECT_TRUE(ConvertorChar::should_padding(input, str.length()));
+    EXPECT_TRUE(ConvertorChar::should_padding(input.get(), str.length()));
 }
 
 TEST(CharTypePaddingTest, CharTypePaddingDataTest) {
@@ -56,7 +56,7 @@ TEST(CharTypePaddingTest, CharTypePaddingDataTest) {
         input->insert_data(str.data(), str.length() - i);
     }
 
-    auto output = ConvertorChar::clone_and_padding(input, str.length());
+    auto output = ConvertorChar::clone_and_padding(input.get(), str.length());
 
     for (int i = 0; i < rows; i++) {
         auto cell = output->get_data_at(i).to_string();


### PR DESCRIPTION
### What problem does this PR solve?

Previously, we allowed ColumnPtr to be directly converted to Column*:  
```C++
    ColumnPtr column;  
    const IColumn* ptr = column;  
```
This can easily cause confusion.  
For example, in the following code: 
```C++
    ColumnPtr column;  
    const auto& const_column = check_and_get_column<ColumnConst>(column);  
```
The matched function is:  
```C++
template <>  
const doris::vectorized::ColumnConst* check_and_get_column<doris::vectorized::ColumnConst>(  
        const IColumn* column)  
```
However, the actual type of const_column is:  
```C++
const doris::vectorized::ColumnConst* const&
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

