### PR TITLE
[regression-test](fix) Fix the incorrect invocation of Awaitility.await.untilAsserted 

### DIFF
--- a/regression-test/plugins/cloud_compaction_plugin.groovy
+++ b/regression-test/plugins/cloud_compaction_plugin.groovy
@@ -75,6 +75,9 @@ Suite.metaClass.doCloudCompaction = { String tableName /* param */ ->
             //assertEquals("success", compactJson.status.toLowerCase())
         }
 
+        // waiting compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
             boolean running = true

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.awaitility.Awaitility
+
+Suite.metaClass.getComactionStatus = { String backendIP, String backendPort, String tabletID ->
+    def (code, out, err) = be_get_compaction_status(backendIP, backendPort, tabletID)
+    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
+    if (code != 0) {
+        throw new IllegalArgumentException("get compaction status failed, code = ${code}")
+    }
+        
+    def compactionStatus = parseJson(out.trim())
+    if ("success" == compactionStatus.status.toLowerCase()) {
+        return compactionStatus.run_status
+    } else {
+        return false
+    }
+}
+
+Suite.metaClass.assertCompactionStatus = { String backendIP, String backendPort, String tabletID ->
+    Awaitility.await().untilAsserted({
+        assert getComactionStatus(backendIP, backendPort, tabletID)
+    })
+}
+
+Suite.metaClass.assertCompactionStatusAtMost = { String backendIP, String backendPort, String tabletID, long t, TimeUnit tu ->
+    Awaitility.await().atMost(t, tu).untilAsserted({
+        assert getComactionStatus(backendIP, backendPort, tabletID)
+    })
+}

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -18,13 +18,13 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 import org.awaitility.Awaitility
 
-Suite.metaClass.getComactionStatus = { String backendIP, String backendPort, String tabletID ->
+Suite.metaClass.checkComactionStatus = { String backendIP, String backendPort, String tabletID ->
     def (code, out, err) = be_get_compaction_status(backendIP, backendPort, tabletID)
     logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
     if (code != 0) {
-        throw new IllegalArgumentException("get compaction status failed, code = ${code}")
+        return false
     }
-        
+
     def compactionStatus = parseJson(out.trim())
     if ("success" == compactionStatus.status.toLowerCase()) {
         return compactionStatus.run_status
@@ -35,12 +35,12 @@ Suite.metaClass.getComactionStatus = { String backendIP, String backendPort, Str
 
 Suite.metaClass.assertCompactionStatus = { String backendIP, String backendPort, String tabletID ->
     Awaitility.await().untilAsserted({
-        assert getComactionStatus(backendIP, backendPort, tabletID)
+        assert checkComactionStatus(backendIP, backendPort, tabletID)
     })
 }
 
 Suite.metaClass.assertCompactionStatusAtMost = { String backendIP, String backendPort, String tabletID, long t, TimeUnit tu ->
     Awaitility.await().atMost(t, tu).untilAsserted({
-        assert getComactionStatus(backendIP, backendPort, tabletID)
+        assert checkComactionStatus(backendIP, backendPort, tabletID)
     })
 }

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -34,13 +34,13 @@ Suite.metaClass.checkComactionStatus = { String backendIP, String backendPort, S
 }
 
 Suite.metaClass.assertCompactionStatus = { String backendIP, String backendPort, String tabletID ->
-    Awaitility.await().untilAsserted({
+    Awaitility.await().pollInterval(1, SECONDS).untilAsserted({
         assert checkComactionStatus(backendIP, backendPort, tabletID)
     })
 }
 
 Suite.metaClass.assertCompactionStatusAtMost = { String backendIP, String backendPort, String tabletID, long t, TimeUnit tu ->
-    Awaitility.await().atMost(t, tu).untilAsserted({
+    Awaitility.await().atMost(t, tu).pollInterval(1, SECONDS).untilAsserted({
         assert checkComactionStatus(backendIP, backendPort, tabletID)
     })
 }

--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -18,6 +18,9 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 import org.awaitility.Awaitility
 
+/*
+* make sure compactions are triggered and sleep a short time ( maybe 10 seconds ) waiting for compactions starting.
+*/
 Suite.metaClass.checkComactionStatus = { String backendIP, String backendPort, String tabletID ->
     def (code, out, err) = be_get_compaction_status(backendIP, backendPort, tabletID)
     logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
@@ -27,14 +30,16 @@ Suite.metaClass.checkComactionStatus = { String backendIP, String backendPort, S
 
     def compactionStatus = parseJson(out.trim())
     if ("success" == compactionStatus.status.toLowerCase()) {
-        return compactionStatus.run_status
+        // run_status == true means compactions are running
+        // run_status == false means compaction are finished
+        return !compactionStatus.run_status
     } else {
         return false
     }
 }
 
 Suite.metaClass.assertCompactionStatus = { String backendIP, String backendPort, String tabletID ->
-    Awaitility.await().pollInterval(1, SECONDS).untilAsserted({
+    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(1, SECONDS).untilAsserted({
         assert checkComactionStatus(backendIP, backendPort, tabletID)
     })
 }
@@ -44,3 +49,40 @@ Suite.metaClass.assertCompactionStatusAtMost = { String backendIP, String backen
         assert checkComactionStatus(backendIP, backendPort, tabletID)
     })
 }
+
+// let table do full compaction, and waiting for them done.
+// TODO: auto compaction what.
+Suite.metaClass.doCompactionWaitDone = { String tableName ->
+    // get table tablets.
+    def tablets = sql_return_maparray """ show tablets from ${tableName}; """
+
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+
+    // trigger compactions for all tablets in ${tableName}
+    for (def tablet in tablets) {
+        String tablet_id = tablet.TabletId
+        def backend_id = tablet.BackendId
+        def (code, out, err) = be_run_cumulative_compaction(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
+        logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
+        assertEquals(code, 0)
+        def compactJson = parseJson(out.trim())
+        if (compactJson.status.toLowerCase() == "fail") {
+            assertEquals(disableAutoCompaction, false)
+            logger.info("Compaction was done automatically!")
+        }
+        if (disableAutoCompaction) {
+            assertEquals("success", compactJson.status.toLowerCase())
+        }
+    }
+
+    // waiting compaction to start
+    Thread.sleep(10000)
+
+    // wait for all compactions done
+    for (def tablet in tablets) {
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
+    }
+}
+

--- a/regression-test/suites/cloud_p0/cache/compaction/test_stale_rowset.groovy
+++ b/regression-test/suites/cloud_p0/cache/compaction/test_stale_rowset.groovy
@@ -189,6 +189,9 @@ suite("test_stale_rowset") {
         }
     }
 
+    // waiting compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (String[] tablet in tablets) {
         boolean running = true

--- a/regression-test/suites/compaction/compaction_width_array_column.groovy
+++ b/regression-test/suites/compaction/compaction_width_array_column.groovy
@@ -98,6 +98,9 @@ suite('compaction_width_array_column', "p2") {
             assertEquals("success", compactJson.status.toLowerCase())
         }
 
+        // waiting compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_base_compaction.groovy
+++ b/regression-test/suites/compaction/test_base_compaction.groovy
@@ -146,6 +146,9 @@ suite("test_base_compaction", "p2") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
@@ -197,6 +200,9 @@ suite("test_base_compaction", "p2") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
@@ -216,6 +222,9 @@ suite("test_base_compaction", "p2") {
         def compactJson = parseJson(out.trim())
         assertEquals("success", compactJson.status.toLowerCase())
     }
+
+    // wait compaction to start
+    Thread.sleep(10000)
 
     // wait for all compactions done
     for (def tablet in tablets) {

--- a/regression-test/suites/compaction/test_base_compaction.groovy
+++ b/regression-test/suites/compaction/test_base_compaction.groovy
@@ -148,16 +148,7 @@ suite("test_base_compaction", "p2") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("success", compactionStatus.status.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
 
     streamLoad {
@@ -208,16 +199,7 @@ suite("test_base_compaction", "p2") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("success", compactionStatus.status.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
 
     qt_select_default """ SELECT count(*) FROM ${tableName} """
@@ -237,16 +219,7 @@ suite("test_base_compaction", "p2") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("success", compactionStatus.status.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
 
     def replicaNum = get_table_replica_num(tableName)

--- a/regression-test/suites/compaction/test_base_compaction_no_value.groovy
+++ b/regression-test/suites/compaction/test_base_compaction_no_value.groovy
@@ -145,6 +145,9 @@ suite("test_base_compaction_no_value", "p2") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
@@ -196,6 +199,9 @@ suite("test_base_compaction_no_value", "p2") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
@@ -215,6 +221,9 @@ suite("test_base_compaction_no_value", "p2") {
         def compactJson = parseJson(out.trim())
         assertEquals("success", compactJson.status.toLowerCase())
     }
+    
+    // wait compaction to start
+    Thread.sleep(10000)
 
     // wait for all compactions done
     for (def tablet in tablets) {

--- a/regression-test/suites/compaction/test_base_compaction_no_value.groovy
+++ b/regression-test/suites/compaction/test_base_compaction_no_value.groovy
@@ -16,7 +16,6 @@
 // under the License.
 
 import org.codehaus.groovy.runtime.IOGroovyMethods
-import org.awaitility.Awaitility
 
 suite("test_base_compaction_no_value", "p2") {
     def tableName = "base_compaction_uniq_keys_no_value"
@@ -148,16 +147,7 @@ suite("test_base_compaction_no_value", "p2") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("success", compactionStatus.status.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
 
     streamLoad {
@@ -208,16 +198,7 @@ suite("test_base_compaction_no_value", "p2") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("success", compactionStatus.status.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
 
     qt_select_default """ SELECT count(*) FROM ${tableName} """
@@ -237,16 +218,7 @@ suite("test_base_compaction_no_value", "p2") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("success", compactionStatus.status.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
 
     def replicaNum = get_table_replica_num(tableName)

--- a/regression-test/suites/compaction/test_compacation_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compacation_with_delete.groovy
@@ -114,6 +114,9 @@ suite("test_compaction_with_delete") {
                 assertEquals("success", compactJson.status.toLowerCase())
             }
         }
+        
+        // wait compaction to start
+        Thread.sleep(10000)
 
         // wait for all compactions done
         for (def tablet in tablets) {

--- a/regression-test/suites/compaction/test_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys.groovy
@@ -123,18 +123,7 @@ suite("test_compaction_agg_keys") {
 
         // wait for all compactions done
         for (def tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet.TabletId
-                backend_id = tablet.BackendId
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;                
-
-            });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
 
         def replicaNum = get_table_replica_num(tableName)

--- a/regression-test/suites/compaction/test_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys.groovy
@@ -121,6 +121,9 @@ suite("test_compaction_agg_keys") {
             }
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/compaction/test_compaction_agg_keys_with_array_map.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys_with_array_map.groovy
@@ -112,6 +112,8 @@ suite("test_compaction_agg_keys_with_array_map") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_agg_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_agg_keys_with_delete.groovy
@@ -131,6 +131,8 @@ suite("test_compaction_agg_keys_with_delete") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_dup_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_dup_keys.groovy
@@ -120,6 +120,8 @@ suite("test_compaction_dup_keys") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_dup_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_dup_keys_with_delete.groovy
@@ -132,6 +132,8 @@ suite("test_compaction_dup_keys_with_delete") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
@@ -120,6 +120,9 @@ suite("test_compaction_uniq_keys") {
             }
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys.groovy
@@ -122,16 +122,7 @@ suite("test_compaction_uniq_keys") {
 
         // wait for all compactions done
         for (def tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet.TabletId
-                backend_id = tablet.BackendId
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
 
         def replicaNum = get_table_replica_num(tableName)

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_ck.groovy
@@ -124,6 +124,8 @@ suite("test_compaction_uniq_keys_ck") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_row_store.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_row_store.groovy
@@ -201,6 +201,8 @@ suite("test_compaction_uniq_keys_row_store", "p0") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_row_store_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_row_store_ck.groovy
@@ -203,6 +203,8 @@ suite("test_compaction_uniq_keys_row_store_ck", "p0") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete.groovy
@@ -135,6 +135,8 @@ suite("test_compaction_uniq_keys_with_delete") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
+++ b/regression-test/suites/compaction/test_compaction_uniq_keys_with_delete_ck.groovy
@@ -152,6 +152,8 @@ suite("test_compaction_uniq_keys_with_delete_ck") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_compaction_with_visible_version.groovy
+++ b/regression-test/suites/compaction/test_compaction_with_visible_version.groovy
@@ -108,6 +108,8 @@ suite('test_compaction_with_visible_version', 'docker') {
                 triggerCompaction it, isCumuCompactSucc, 'cumulative'
             }
 
+            Thread.sleep(10000)
+
             if (isCumuCompactSucc) {
                 // wait compaction done
                 def startTs = System.currentTimeMillis()

--- a/regression-test/suites/compaction/test_full_compaction.groovy
+++ b/regression-test/suites/compaction/test_full_compaction.groovy
@@ -139,11 +139,12 @@ suite("test_full_compaction") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for full compaction done
         for (def tablet in tablets) {
             boolean running = true
             do {
-                Thread.sleep(1000)
                 String tablet_id = tablet.TabletId
                 backend_id = tablet.BackendId
                 (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)

--- a/regression-test/suites/compaction/test_full_compaction_by_table_id.groovy
+++ b/regression-test/suites/compaction/test_full_compaction_by_table_id.groovy
@@ -147,6 +147,8 @@ suite("test_full_compaction_by_table_id") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for full compaction done
         {
             for (def tablet : tablets) {

--- a/regression-test/suites/compaction/test_full_compaction_ck.groovy
+++ b/regression-test/suites/compaction/test_full_compaction_ck.groovy
@@ -140,6 +140,8 @@ suite("test_full_compaction_ck") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for full compaction done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_vertical_compaction_agg_keys.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_agg_keys.groovy
@@ -132,6 +132,8 @@ suite("test_vertical_compaction_agg_keys") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/compaction/test_vertical_compaction_agg_state.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_agg_state.groovy
@@ -93,6 +93,8 @@ suite("test_vertical_compaction_agg_state") {
             }
         }
 
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             boolean running = true

--- a/regression-test/suites/delete_p0/test_delete_sign_with_cumu_compaction.groovy
+++ b/regression-test/suites/delete_p0/test_delete_sign_with_cumu_compaction.groovy
@@ -68,7 +68,7 @@ suite('test_delete_sign_with_cumu_compaction') {
 
     def waitForCompaction = { be_host, be_http_port ->
         // wait for all compactions done
-        Awaitility.await().atMost(30, SECONDS).pollInterval(1, SECONDS).until {
+        Awaitility.await().atMost(30, SECONDS).pollDelay(10, TimeUnit.SECONDS).pollInterval(1, SECONDS).untilAsserted {
             String tablet_id = tablet[0]
             StringBuilder sb = new StringBuilder();
             sb.append("curl -X GET http://${be_host}:${be_http_port}")
@@ -85,7 +85,7 @@ suite('test_delete_sign_with_cumu_compaction') {
             def compactionStatus = parseJson(out.trim())
             assertEquals("success", compactionStatus.status.toLowerCase())
 
-            !compactionStatus.run_status
+            assert !compactionStatus.run_status
         }
     }
 

--- a/regression-test/suites/fault_injection_p0/cloud/test_cloud_mow_stale_resp_load_compaction_conflict.groovy
+++ b/regression-test/suites/fault_injection_p0/cloud/test_cloud_mow_stale_resp_load_compaction_conflict.groovy
@@ -92,7 +92,7 @@ suite("test_cloud_mow_stale_resp_load_compaction_conflict", "nonConcurrent") {
             Assert.assertEquals("success", compactJson.status.toLowerCase())
 
             // wait for full compaction to complete
-            Awaitility.await().atMost(3, TimeUnit.SECONDS).pollDelay(200, TimeUnit.MILLISECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+            Awaitility.await().atMost(30, TimeUnit.SECONDS).pollDelay(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(
                 {
                     (code, out, err) = be_get_compaction_status(tabletBackend.Host, tabletBackend.HttpPort, tabletId)
                     logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_compaction_with_higher_version.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_compaction_with_higher_version.groovy
@@ -172,7 +172,7 @@ suite("test_partial_update_compaction_with_higher_version", "nonConcurrent") {
         Assert.assertEquals("success", compactJson.status.toLowerCase())
 
         // wait for full compaction to complete
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).pollDelay(200, TimeUnit.MILLISECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollDelay(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(
             {
                 (code, out, err) = be_get_compaction_status(tabletBackend.Host, tabletBackend.HttpPort, tabletId)
                 logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_conflict_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_conflict_skip_compaction.groovy
@@ -155,7 +155,7 @@ suite("test_partial_update_conflict_skip_compaction", "nonConcurrent") {
         Assert.assertEquals("success", compactJson.status.toLowerCase())
 
         // wait for full compaction to complete
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).pollDelay(200, TimeUnit.MILLISECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollDelay(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(
             {
                 (code, out, err) = be_get_compaction_status(tabletBackend.Host, tabletBackend.HttpPort, tabletId)
                 logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_skip_compaction.groovy
@@ -144,7 +144,7 @@ suite("test_partial_update_skip_compaction", "nonConcurrent") {
         Assert.assertEquals("success", compactJson.status.toLowerCase())
 
         // wait for full compaction to complete
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).pollDelay(200, TimeUnit.MILLISECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollDelay(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(
             {
                 (code, out, err) = be_get_compaction_status(tabletBackend.Host, tabletBackend.HttpPort, tabletId)
                 logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)

--- a/regression-test/suites/fault_injection_p0/test_variant_bloom_filter.groovy
+++ b/regression-test/suites/fault_injection_p0/test_variant_bloom_filter.groovy
@@ -98,6 +98,9 @@ suite("test_variant_bloom_filter", "nonConcurrent") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 3, TimeUnit.MINUTES)

--- a/regression-test/suites/fault_injection_p0/test_variant_bloom_filter.groovy
+++ b/regression-test/suites/fault_injection_p0/test_variant_bloom_filter.groovy
@@ -100,16 +100,7 @@ suite("test_variant_bloom_filter", "nonConcurrent") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().atMost(3, TimeUnit.MINUTES).untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("compaction task for this tablet is not running", compactionStatus.msg.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 3, TimeUnit.MINUTES)
     }
 
     for (def tablet in tablets) {

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_empty_segments.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_empty_segments.groovy
@@ -70,16 +70,7 @@ suite("test_index_compaction_empty_segments", "p0, nonConcurrent") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().atMost(10, TimeUnit.MINUTES).untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("compaction task for this tablet is not running", compactionStatus.msg.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 10, TimeUnit.MINUTES)
     }
 
     

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_empty_segments.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_empty_segments.groovy
@@ -68,6 +68,9 @@ suite("test_index_compaction_empty_segments", "p0, nonConcurrent") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 10, TimeUnit.MINUTES)

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_p0.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_p0.groovy
@@ -116,6 +116,9 @@ suite("test_index_compaction_p0", "p0, nonConcurrent") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 1, TimeUnit.MINUTES)

--- a/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_p0.groovy
+++ b/regression-test/suites/inverted_index_p0/index_compaction/test_index_compaction_p0.groovy
@@ -118,16 +118,7 @@ suite("test_index_compaction_p0", "p0, nonConcurrent") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("compaction task for this tablet is not running", compactionStatus.msg.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 1, TimeUnit.MINUTES)
     }
 
     

--- a/regression-test/suites/inverted_index_p1/index_compaction/test_index_compaction_p1.groovy
+++ b/regression-test/suites/inverted_index_p1/index_compaction/test_index_compaction_p1.groovy
@@ -123,16 +123,7 @@ suite("test_index_compaction_p1", "p1, nonConcurrent") {
 
     // wait for all compactions done
     for (def tablet in tablets) {
-        Awaitility.await().atMost(10, TimeUnit.MINUTES).untilAsserted(() -> {
-            String tablet_id = tablet.TabletId
-            backend_id = tablet.BackendId
-            (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-            logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-            assertEquals(code, 0)
-            def compactionStatus = parseJson(out.trim())
-            assertEquals("compaction task for this tablet is not running", compactionStatus.msg.toLowerCase())
-            return compactionStatus.run_status;
-        });
+        assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 10, TimeUnit.MINUTES)
     }
 
     for (def tablet in tablets) {

--- a/regression-test/suites/inverted_index_p1/index_compaction/test_index_compaction_p1.groovy
+++ b/regression-test/suites/inverted_index_p1/index_compaction/test_index_compaction_p1.groovy
@@ -121,6 +121,9 @@ suite("test_index_compaction_p1", "p1, nonConcurrent") {
         assertEquals("success", compactJson.status.toLowerCase())
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (def tablet in tablets) {
         assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 10, TimeUnit.MINUTES)

--- a/regression-test/suites/inverted_index_p1/show_data/test_show_index_data.groovy
+++ b/regression-test/suites/inverted_index_p1/show_data/test_show_index_data.groovy
@@ -143,18 +143,11 @@ suite("test_show_index_data", "p1") {
             assertEquals("success", compactJson.status.toLowerCase())
         }
 
+        Thread.sleep(30000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
-            Awaitility.await().atMost(30, TimeUnit.MINUTES).untilAsserted(() -> {
-                Thread.sleep(30000)
-                String tablet_id = tablet.TabletId
-                backend_id = tablet.BackendId
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("compaction task for this tablet is not running", compactionStatus.msg.toLowerCase())
-            });
+            assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 30, TimeUnit.MINUTES)
         }
 
         

--- a/regression-test/suites/inverted_index_p1/show_data/test_show_index_data.groovy
+++ b/regression-test/suites/inverted_index_p1/show_data/test_show_index_data.groovy
@@ -237,10 +237,10 @@ suite("test_show_index_data", "p1") {
             }
         }
         sql """ alter table ${show_table_name} drop column clientip"""
-        Awaitility.await().atMost(30, TimeUnit.MINUTES).untilAsserted(() -> {
-            Thread.sleep(30000)
-            tablets = sql_return_maparray """ show tablets from ${show_table_name}; """
-            for (def tablet in tablets) {
+        Thread.sleep(30000)
+
+        for (def tablet in tablets) {
+            Awaititly.await().pollInterval(2, TimeUnit.SECONDS).atMost(30, TimeUnit.MINUTES).untilAsserted({
                 String tablet_id = tablet.TabletId
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -256,8 +256,8 @@ suite("test_show_index_data", "p1") {
                     logger.info("rowsetid: " + rowsetid)
                     assertTrue(!rowsetids.contains(rowsetid))
                 }
-            }
-        });
+            })
+        }
     }
 
     def build_index = {
@@ -285,10 +285,10 @@ suite("test_show_index_data", "p1") {
         if (!isCloudMode()) {
             sql """ build index status_idx on ${show_table_name}"""
         }
-        Awaitility.await().atMost(30, TimeUnit.MINUTES).untilAsserted(() -> {
-            Thread.sleep(30000)
-            tablets = sql_return_maparray """ show tablets from ${show_table_name}; """
-            for (def tablet in tablets) {
+        Thread.Sleep(10000)
+
+        for (def tablet in tablets) {
+            Awaititly.await().pollInterval(2, TimeUnit.SECONDS).atMost(30, TimeUnit.MINUTES).untilAsserted({
                 String tablet_id = tablet.TabletId
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -304,8 +304,8 @@ suite("test_show_index_data", "p1") {
                     logger.info("rowsetid: " + rowsetid)
                     assertTrue(!rowsetids.contains(rowsetid))
                 }
-            }
-        });
+            })
+        }
     }
 
     def drop_index = {
@@ -329,10 +329,10 @@ suite("test_show_index_data", "p1") {
             }
         }
         sql """ DROP INDEX status_idx on ${show_table_name}"""
-        Awaitility.await().atMost(30, TimeUnit.MINUTES).untilAsserted(() -> {
-            Thread.sleep(30000)
-            tablets = sql_return_maparray """ show tablets from ${show_table_name}; """
-            for (def tablet in tablets) {
+        Thread.sleep(30000)
+        
+        for (def tablet in tablets) {
+            Awaititly.await().pollInterval(2, TimeUnit.SECONDS).atMost(30, TimeUnit.MINUTES).untilAsserted({
                 String tablet_id = tablet.TabletId
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -348,8 +348,8 @@ suite("test_show_index_data", "p1") {
                     logger.info("rowsetid: " + rowsetid)
                     assertTrue(!rowsetids.contains(rowsetid))
                 }
-            }
-        });
+            })
+        }
     }
 
     // 1. load data

--- a/regression-test/suites/inverted_index_p2/show_data/test_show_index_data_p2.groovy
+++ b/regression-test/suites/inverted_index_p2/show_data/test_show_index_data_p2.groovy
@@ -243,10 +243,8 @@ suite("test_show_index_data_p2", "p2") {
             }
         }
         sql """ alter table ${show_table_name} drop column clientip"""
-        Awaitility.await().atMost(60, TimeUnit.MINUTES).untilAsserted(() -> {
-            Thread.sleep(30000)
-            tablets = sql_return_maparray """ show tablets from ${show_table_name}; """
-            for (def tablet in tablets) {
+        for (def tablet in tablets) {
+            Awaititly.await().pollInterval(2, TimeUnit.SECONDS).atMost(30, TimeUnit.MINUTES).untilAsserted({
                 String tablet_id = tablet.TabletId
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -262,8 +260,8 @@ suite("test_show_index_data_p2", "p2") {
                     logger.info("rowsetid: " + rowsetid)
                     assertTrue(!rowsetids.contains(rowsetid))
                 }
-            }
-        });
+            })
+        }
     }
 
     def build_index = {
@@ -290,10 +288,10 @@ suite("test_show_index_data_p2", "p2") {
         if (!isCloudMode()) {
             sql """ build index status_idx on ${show_table_name}"""
         }
-        Awaitility.await().atMost(60, TimeUnit.MINUTES).untilAsserted(() -> {
-            Thread.sleep(30000)
-            tablets = sql_return_maparray """ show tablets from ${show_table_name}; """
-            for (def tablet in tablets) {
+        Thread.sleep(30000)
+
+        for (def tablet in tablets) {
+            Awaititly.await().pollInterval(2, TimeUnit.SECONDS).atMost(30, TimeUnit.MINUTES).untilAsserted({
                 String tablet_id = tablet.TabletId
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -309,8 +307,8 @@ suite("test_show_index_data_p2", "p2") {
                     logger.info("rowsetid: " + rowsetid)
                     assertTrue(!rowsetids.contains(rowsetid))
                 }
-            }
-        });
+            })
+        }
     }
 
     def drop_index = {
@@ -334,10 +332,9 @@ suite("test_show_index_data_p2", "p2") {
             }
         }
         sql """ DROP INDEX status_idx on ${show_table_name}"""
-        Awaitility.await().atMost(60, TimeUnit.MINUTES).untilAsserted(() -> {
-            Thread.sleep(30000)
-            tablets = sql_return_maparray """ show tablets from ${show_table_name}; """
-            for (def tablet in tablets) {
+        Thread.sleep(30000)
+        for (def tablet in tablets) {
+            Awaititly.await().pollInterval(2, TimeUnit.SECONDS).atMost(30, TimeUnit.MINUTES).untilAsserted({
                 String tablet_id = tablet.TabletId
                 (code, out, err) = curl("GET", tablet.CompactionStatus)
                 logger.info("Show tablets status: code=" + code + ", out=" + out + ", err=" + err)
@@ -353,8 +350,8 @@ suite("test_show_index_data_p2", "p2") {
                     logger.info("rowsetid: " + rowsetid)
                     assertTrue(!rowsetids.contains(rowsetid))
                 }
-            }
-        });
+            })
+        }
     }
 
     // 1. load data

--- a/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_dup_key.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_dup_key.groovy
@@ -50,7 +50,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
         """
     int max_try_secs = 1200
     String res = "NOT_FINISHED"
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -66,7 +66,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
             ADD COLUMN value3 CHAR(100) DEFAULT 'A';
         """
     max_try_secs = 1200
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -113,7 +113,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
             ALTER TABLE ${tbName1} 
             DROP COLUMN value3;
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -128,7 +128,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
             ALTER TABLE ${tbName1} 
             ADD COLUMN value3 CHAR(100) DEFAULT 'A';
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -146,7 +146,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
             ALTER TABLE ${tbName1} 
             ADD COLUMN k2 CHAR(10) KEY DEFAULT 'A';
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -190,7 +190,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
             ALTER TABLE ${tbName1} 
             DROP COLUMN value3;
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -206,7 +206,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
             ADD COLUMN value3 CHAR(100) DEFAULT 'A';
         """
 
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)

--- a/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_unique_key.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_unique_key.groovy
@@ -52,7 +52,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
         """
     int max_try_secs = 1200
     String res = "NOT_FINISHED"
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -67,7 +67,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
             ALTER TABLE ${tbName1} 
             ADD COLUMN value3 CHAR(100) DEFAULT 'A';
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -115,7 +115,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
             ALTER TABLE ${tbName1} 
             DROP COLUMN k2;
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -130,7 +130,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
             ALTER TABLE ${tbName1} 
             ADD COLUMN value3 CHAR(100) DEFAULT 'A';
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)
@@ -148,7 +148,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
             ALTER TABLE ${tbName1} 
             ADD COLUMN k2 CHAR(10) KEY DEFAULT 'A';
         """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         res = getJobState(tbName1)
         if (res == "FINISHED" || res == "CANCELLED") {
             assertEquals("FINISHED", res)

--- a/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
@@ -51,16 +51,7 @@ suite("test_agg_keys_schema_change_datev2") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
-                String tablet_id = tablet[0]
-                backend_id = tablet[2]
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+            assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 20, TimeUnit.SECONDS)
         }
     }
 

--- a/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
@@ -85,7 +85,7 @@ suite("test_agg_keys_schema_change_datev2") {
 
     sql """ alter table ${tbName} add column `datev3` datev2 DEFAULT '2022-01-01' """
     int max_try_secs = 300
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -102,7 +102,7 @@ suite("test_agg_keys_schema_change_datev2") {
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
     sql """ alter table ${tbName} drop column `datev3` """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -125,7 +125,7 @@ suite("test_agg_keys_schema_change_datev2") {
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
     sql """ alter  table ${tbName} add column `datev3` datetimev2 DEFAULT '2022-01-01 11:11:11' """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -141,7 +141,7 @@ suite("test_agg_keys_schema_change_datev2") {
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
     sql """ alter table ${tbName} drop column `datev3` """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -165,7 +165,7 @@ suite("test_agg_keys_schema_change_datev2") {
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
     sql """ alter  table ${tbName} add column `datev3` datetimev2(3) DEFAULT '2022-01-01 11:11:11.111' """
  
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -191,7 +191,7 @@ suite("test_agg_keys_schema_change_datev2") {
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
     sql """ alter table ${tbName} drop column `datev3` """
 
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;

--- a/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
@@ -49,6 +49,9 @@ suite("test_agg_keys_schema_change_datev2") {
             logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
             assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 20, TimeUnit.SECONDS)

--- a/regression-test/suites/schema_change_p0/datev2/test_schema_change_varchar_to_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_schema_change_varchar_to_datev2.groovy
@@ -48,9 +48,13 @@ suite("test_schema_change_varchar_to_datev2") {
             logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
+        }
     }
     
     sql """ DROP TABLE IF EXISTS ${tbName} FORCE"""

--- a/regression-test/suites/schema_change_p0/datev2/test_schema_change_varchar_to_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_schema_change_varchar_to_datev2.groovy
@@ -50,17 +50,7 @@ suite("test_schema_change_varchar_to_datev2") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet[0]
-                backend_id = tablet[2]
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
-        }
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
     
     sql """ DROP TABLE IF EXISTS ${tbName} FORCE"""

--- a/regression-test/suites/schema_change_p0/datev2/test_schema_change_varchar_to_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_schema_change_varchar_to_datev2.groovy
@@ -75,7 +75,7 @@ suite("test_schema_change_varchar_to_datev2") {
 
     sql """ alter table ${tbName} modify column `k3` date; """
     int max_try_secs = 300
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;

--- a/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
@@ -90,7 +90,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     sql """ alter table ${tbName} add column `decimalv2v3` decimalv2(27,9) """
     int max_try_secs = 300
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -105,7 +105,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
     qt_sql3 """select * from ${tbName} ORDER BY 1,2,3,4;"""
 
     sql """ alter table ${tbName} drop column `decimalv2v3` """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -118,7 +118,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV2(21,3) -> decimalv3 OK
     sql """ alter table ${tbName} modify column decimalv2k2 DECIMALV3(21,3) key """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -131,7 +131,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV2(21,3) -> decimalv3 OK
     sql """ alter table ${tbName} modify column decimalv2k3 DECIMALV3(38,10) key """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -144,7 +144,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV2(27,9) -> decimalv3, round scale part, not overflow
     sql """ alter table ${tbName} modify column decimalv2v1 DECIMALV3(26,8) sum """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -158,7 +158,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV2(21,3) -> decimalv3,  round scale part, overflow
     sql """ alter table ${tbName} modify column decimalv2v2 DECIMALV3(20,2) sum """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "CANCELLED") {
             return true;
@@ -172,7 +172,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV2(21,3) -> decimalv3,  narrow integral, overflow
     sql """ alter table ${tbName} modify column decimalv2v2 DECIMALV3(20,3) sum """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "CANCELLED") {
             return true;
@@ -187,7 +187,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV3(21,3) -> decimalv2 OK
     sql """ alter table ${tbName} modify column decimalv2k2 DECIMALV2(21,3) key """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -201,7 +201,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV3(26,8) -> decimalv2
     sql """ alter table ${tbName} modify column decimalv2v1 DECIMALV2(25,7) sum """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -215,7 +215,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
     // DECIMALV3(26,8) -> decimalv2, narrow integer
     sql """ alter table ${tbName} modify column decimalv2v1 DECIMALV2(25,8) sum """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;

--- a/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
@@ -62,6 +62,9 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
             logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
@@ -64,16 +64,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet[0]
-                backend_id = tablet[2]
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
     }
 

--- a/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
@@ -74,7 +74,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
 
     sql """ alter table ${tbName} add column `decimalv3v3` DECIMALV3(38,4) """
     int max_try_secs = 300
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -88,7 +88,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `decimalv3k1`;"""
     sql """ alter table ${tbName} drop column `decimalv3v3` """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
             return true;
@@ -99,7 +99,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `decimalv3k1`;"""
     sql """ alter table ${tbName} modify column decimalv3k2 DECIMALV3(19,3) key """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "CANCELLED") {
             return true;
@@ -112,7 +112,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     qt_sql """select * from ${tbName} ORDER BY `decimalv3k1`;"""
 
     sql """ alter table ${tbName} modify column decimalv3k2 DECIMALV3(38,10) key """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "CANCELLED") {
             return true;
@@ -124,7 +124,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     qt_sql """select * from ${tbName} ORDER BY `decimalv3k1`;"""
 
     sql """ alter table ${tbName} modify column decimalv3k2 DECIMALV3(16,3) key """
-    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tbName)
         if (result == "CANCELLED") {
             return true;

--- a/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
@@ -49,9 +49,14 @@ suite("test_agg_keys_schema_change_decimalv3") {
             logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
         }
 
+        // wait compaction to start.
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
+            def tid = tablet[0]
+            def beid = tablet[2]
+            assertCompactionStatus(backendId_to_backendIP.get(beid), backendId_to_backendHttpPort.get(tablet[2]), tid)        
         }
     }
 

--- a/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
@@ -51,16 +51,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet[0]
-                backend_id = tablet[2]
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
     }
 

--- a/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
@@ -151,16 +151,7 @@ suite ("test_dup_keys_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-                Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    def backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 20, TimeUnit.SECONDS)
         }
 
         qt_sc """ select count(*) from ${tableName} """

--- a/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
@@ -101,7 +101,7 @@ suite ("test_dup_keys_schema_change") {
             ALTER TABLE ${tableName} DROP COLUMN sex
             """
         int max_try_time = 300
-        Awaitility.await().atMost(max_try_time, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+        Awaitility.await().atMost(max_try_time, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getJobState(tableName)
             if (result == "FINISHED") {
                 return true;

--- a/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
@@ -149,9 +149,14 @@ suite ("test_dup_keys_schema_change") {
                 //assertEquals(code, 0)
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 20, TimeUnit.SECONDS)
+            def tid = tablet[0]
+            def beid = tablet[2]
+            assertCompactionStatus(backendId_to_backendIP.get(beid), backendId_to_backendHttpPort.get(tablet[2]), tid)
         }
 
         qt_sc """ select count(*) from ${tableName} """

--- a/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
@@ -159,6 +159,9 @@ suite ("test_dup_mv_schema_change") {
                 //assertEquals(code, 0)
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
@@ -27,7 +27,7 @@ suite ("test_dup_mv_schema_change") {
     }
 
     def waitForJob =  (tbName, timeout) -> {
-       Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+       Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getJobState(tbName)
             if (result == "FINISHED") {
                 return true;

--- a/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
@@ -161,16 +161,7 @@ suite ("test_dup_mv_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-                Awaitility.await().untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
 
         qt_sc """ select count(*) from ${tableName} """

--- a/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
@@ -29,7 +29,7 @@ suite ("test_dup_rollup_schema_change") {
          return jobStateResult[0][9]
     }
     def waitForMVJob =  (tbName, timeout) -> {
-       Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+       Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getMVJobState(tbName)
             if (result == "FINISHED") {
                 return true;

--- a/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
@@ -177,6 +177,9 @@ suite ("test_dup_rollup_schema_change") {
                 //assertEquals(code, 0)
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
@@ -179,16 +179,7 @@ suite ("test_dup_rollup_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-           Awaitility.await().untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
 
         qt_sc """ select count(*) from ${tableName} """

--- a/regression-test/suites/schema_change_p0/test_dup_vals_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_vals_schema_change.groovy
@@ -137,9 +137,14 @@ suite ("test_dup_vals_schema_change") {
                 //assertEquals(code, 0)
         }
 
+        // wait compaction to start.
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
+            def tid = tablet[0]
+            def beid = tablet[2]
+            assertCompactionStatus(backendId_to_backendIP.get(beid), backendId_to_backendHttpPort.get(tablet[2]), tid)
         }
         qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_dup_vals_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_vals_schema_change.groovy
@@ -139,16 +139,7 @@ suite ("test_dup_vals_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
         qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
@@ -134,16 +134,7 @@ suite ("test_uniq_keys_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-                Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 20, TimeUnit.SECONDS)
         }
         qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
@@ -131,10 +131,15 @@ suite ("test_uniq_keys_schema_change") {
                 logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
                 //assertEquals(code, 0)
         }
+        
+        // waiting compaction to start.
+        Thread.sleep(10000)
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            assertCompactionStatusAtMost(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId, 20, TimeUnit.SECONDS)
+            def tid = tablet[0]
+            def beid = tablet[2]
+            assertCompactionStatus(backendId_to_backendIP.get(beid), backendId_to_backendHttpPort.get(tablet[2]), tid)
         }
         qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
@@ -26,7 +26,7 @@ suite ("test_uniq_mv_schema_change") {
          return jobStateResult[0][8]
     }
     def waitForJob =  (tbName, timeout) -> {
-       Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+       Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getMVJobState(tbName)
             if (result == "FINISHED") {
                 return true;

--- a/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
@@ -177,16 +177,7 @@ suite ("test_uniq_mv_schema_change") {
 
     // wait for all compactions done
     for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet[0]
-                backend_id = tablet[2]
-                def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
     qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
@@ -175,6 +175,9 @@ suite ("test_uniq_mv_schema_change") {
             //assertEquals(code, 0)
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (String[] tablet in tablets) {
         assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
@@ -180,16 +180,7 @@ suite ("test_uniq_rollup_schema_change") {
 
     // wait for all compactions done
     for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet[0]
-                backend_id = tablet[2]
-                def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+        assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
     }
     qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
@@ -30,7 +30,7 @@ suite ("test_uniq_rollup_schema_change") {
          return jobStateResult[0][9]
     }
     def waitForMVJob =  (tbName, timeout) -> {
-        Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+        Awaitility.await().atMost(timeout, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getMVJobState(tbName)
             if (result == "FINISHED") {
                 return true;
@@ -132,7 +132,7 @@ suite ("test_uniq_rollup_schema_change") {
           """
 
     def max_try_time = 300
-    Awaitility.await().atMost(max_try_time, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(max_try_time, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         String result = getJobState(tableName)
         if (result == "FINISHED") {
             return true;

--- a/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
@@ -178,6 +178,9 @@ suite ("test_uniq_rollup_schema_change") {
             //assertEquals(code, 0)
     }
 
+    // wait compaction to start
+    Thread.sleep(10000)
+
     // wait for all compactions done
     for (String[] tablet in tablets) {
         assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/schema_change_p0/test_uniq_vals_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_vals_schema_change.groovy
@@ -142,7 +142,7 @@ suite ("test_uniq_vals_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
+            assertCompactionStatus(backendId_to_backendIP.get(tablet[2]), backendId_to_backendHttpPort.get(tablet[2]), tablet[0])
         }
         qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_uniq_vals_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_vals_schema_change.groovy
@@ -142,16 +142,7 @@ suite ("test_uniq_vals_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
         qt_sc """ select count(*) from ${tableName} """
 

--- a/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
@@ -119,16 +119,7 @@ suite ("test_varchar_schema_change") {
 
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                    String tablet_id = tablet[0]
-                    backend_id = tablet[2]
-                    def (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
 
         qt_sc " select * from ${tableName} order by 1,2; "

--- a/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
@@ -117,9 +117,14 @@ suite ("test_varchar_schema_change") {
                 logger.info("Run compaction: code=" + code + ", out=" + out + ", err=" + err)
         }
 
+        // wait compaction to start.
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (String[] tablet in tablets) {
-            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
+            def tid = tablet[0]
+            def beid = tablet[2]
+            assertCompactionStatus(backendId_to_backendIP.get(beid), backendId_to_backendHttpPort.get(tablet[2]), tid)        
         }
 
         qt_sc " select * from ${tableName} order by 1,2; "

--- a/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
@@ -66,7 +66,7 @@ suite ("test_varchar_schema_change") {
 
         sql """ alter table ${tableName} modify column c2 varchar(30) """
         int max_try_secs = 300
-        Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+        Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getJobState(tableName)
             if (result == "FINISHED") {
                 return true;
@@ -89,7 +89,7 @@ suite ("test_varchar_schema_change") {
         sql """ insert into ${tableName} values(55,'2019-11-21',21474,'123aa') """
 
         sql """ alter table ${tableName} modify column c2 INT """
-        Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+        Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getJobState(tableName)
             if (result == "CANCELLED" || result == "FINISHED") {
                 assertEquals(result, "CANCELLED")
@@ -131,7 +131,7 @@ suite ("test_varchar_schema_change") {
         modify column c2 varchar(40), 
         modify column c3 varchar(6) DEFAULT '0'
         """
-        Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+        Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
             String result = getJobState(tableName)
             if (result == "FINISHED") {
                 return true;

--- a/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_insert_light_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_insert_light_schema_change.groovy
@@ -65,7 +65,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
             def try_times=1200
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -125,7 +125,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             // schema change
             sql " ALTER table ${tableName} DROP COLUMN c8 "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -205,7 +205,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             // schema change
             sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -243,7 +243,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             // schema change
             sql """ ALTER table ${tableName} ADD COLUMN c1 int key default "0"; """
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -254,7 +254,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
 
             sql " ALTER table ${tableName} ADD COLUMN c2 int null "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -265,7 +265,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
 
             sql " ALTER table ${tableName} ADD COLUMN c3 int null "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -321,7 +321,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             
             sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;

--- a/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_insert_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_insert_schema_change.groovy
@@ -57,7 +57,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     def try_times=1200
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -117,7 +117,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -196,7 +196,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -233,7 +233,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     // schema change
     sql """ ALTER table ${tableName} ADD COLUMN c1 int key default "0"; """
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -244,7 +244,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -255,7 +255,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c3 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -312,7 +312,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;

--- a/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_schema_change.groovy
@@ -79,7 +79,7 @@ suite("test_partial_update_schema_change", "p0") {
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     def try_times=1200
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -203,7 +203,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -327,7 +327,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -410,7 +410,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -420,7 +420,7 @@ suite("test_partial_update_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -512,7 +512,7 @@ suite("test_partial_update_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -689,7 +689,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -811,7 +811,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -928,7 +928,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1009,7 +1009,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1018,7 +1018,7 @@ suite("test_partial_update_schema_change", "p0") {
     });
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1105,7 +1105,7 @@ suite("test_partial_update_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;

--- a/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_schema_change_row_store.groovy
+++ b/regression-test/suites/unique_with_mow_c_p0/partial_update/test_partial_update_schema_change_row_store.groovy
@@ -80,7 +80,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     def try_times = 1200
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -206,7 +206,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -331,7 +331,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -414,7 +414,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -424,7 +424,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -517,7 +517,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -696,7 +696,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -820,7 +820,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -939,7 +939,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1022,7 +1022,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1031,7 +1031,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     });
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1119,7 +1119,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_light_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_light_schema_change.groovy
@@ -60,7 +60,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
             def try_times=1200
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -118,7 +118,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             // schema change
             sql " ALTER table ${tableName} DROP COLUMN c8 "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -194,7 +194,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             // schema change
             sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -232,7 +232,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             // schema change
             sql """ ALTER table ${tableName} ADD COLUMN c1 int key default "0"; """
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -243,7 +243,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
 
             sql " ALTER table ${tableName} ADD COLUMN c2 int null "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -254,7 +254,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
 
             sql " ALTER table ${tableName} ADD COLUMN c3 int null "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;
@@ -307,7 +307,7 @@ suite("test_partial_update_insert_light_schema_change", "p0") {
             
             sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
             // if timeout awaitility will raise exception
-            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+            Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
                 def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
                 if(res[0][9].toString() == "FINISHED"){
                     return true;

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_insert_schema_change.groovy
@@ -51,7 +51,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     def try_times=1200
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -108,7 +108,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -181,7 +181,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -217,7 +217,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     // schema change
     sql """ ALTER table ${tableName} ADD COLUMN c1 int key default "0"; """
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -228,7 +228,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -239,7 +239,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c3 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -292,7 +292,7 @@ suite("test_partial_update_insert_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
@@ -74,7 +74,7 @@ suite("test_partial_update_schema_change", "p0") {
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     def try_times=1200
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -194,7 +194,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -314,7 +314,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -396,7 +396,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -406,7 +406,7 @@ suite("test_partial_update_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -496,7 +496,7 @@ suite("test_partial_update_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -667,7 +667,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -785,7 +785,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -899,7 +899,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -979,7 +979,7 @@ suite("test_partial_update_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -988,7 +988,7 @@ suite("test_partial_update_schema_change", "p0") {
     });
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1073,7 +1073,7 @@ suite("test_partial_update_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change_row_store.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change_row_store.groovy
@@ -75,7 +75,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     def try_times = 1200
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -197,7 +197,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -318,7 +318,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -400,7 +400,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -410,7 +410,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
 
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -501,7 +501,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -674,7 +674,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -794,7 +794,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -910,7 +910,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -992,7 +992,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1001,7 +1001,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     });
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;
@@ -1087,7 +1087,7 @@ suite("test_partial_update_row_store_schema_change", "p0") {
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
     // if timeout awaitility will raise exception
-    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
+    Awaitility.await().atMost(try_times, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
         if(res[0][9].toString() == "FINISHED"){
             return true;

--- a/regression-test/suites/variant_p0/compaction/test_compaction.groovy
+++ b/regression-test/suites/variant_p0/compaction/test_compaction.groovy
@@ -105,6 +105,9 @@ suite("test_compaction_variant") {
                 }
             }
 
+            // wait compaction to start
+            Thread.sleep(10000)
+
             // wait for all compactions done
             for (def tablet in tablets) {
                 assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/variant_p0/compaction/test_compaction.groovy
+++ b/regression-test/suites/variant_p0/compaction/test_compaction.groovy
@@ -107,16 +107,7 @@ suite("test_compaction_variant") {
 
             // wait for all compactions done
             for (def tablet in tablets) {
-                Awaitility.await().untilAsserted(() -> {
-                    String tablet_id = tablet.TabletId
-                    backend_id = tablet.BackendId
-                    (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                    logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                    assertEquals(code, 0)
-                    def compactionStatus = parseJson(out.trim())
-                    assertEquals("success", compactionStatus.status.toLowerCase())
-                    return compactionStatus.run_status;
-                });
+                assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
             }
 
             int rowCount = 0

--- a/regression-test/suites/variant_p1/compaction/compaction_sparse_column.groovy
+++ b/regression-test/suites/variant_p1/compaction/compaction_sparse_column.groovy
@@ -124,6 +124,9 @@ suite("test_compaction_sparse_column", "p1,nonConcurrent") {
             }
         }
 
+        // wait compaction to start
+        Thread.sleep(10000)
+
         // wait for all compactions done
         for (def tablet in tablets) {
             assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)

--- a/regression-test/suites/variant_p1/compaction/compaction_sparse_column.groovy
+++ b/regression-test/suites/variant_p1/compaction/compaction_sparse_column.groovy
@@ -126,16 +126,7 @@ suite("test_compaction_sparse_column", "p1,nonConcurrent") {
 
         // wait for all compactions done
         for (def tablet in tablets) {
-            Awaitility.await().untilAsserted(() -> {
-                String tablet_id = tablet.TabletId
-                backend_id = tablet.BackendId
-                (code, out, err) = be_get_compaction_status(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), tablet_id)
-                logger.info("Get compaction status: code=" + code + ", out=" + out + ", err=" + err)
-                assertEquals(code, 0)
-                def compactionStatus = parseJson(out.trim())
-                assertEquals("success", compactionStatus.status.toLowerCase())
-                return compactionStatus.run_status;
-            });
+            assertCompactionStatus(backendId_to_backendIP.get(tablet.BackendId), backendId_to_backendHttpPort.get(tablet.BackendId), tablet.TabletId)
         }
 
         int rowCount = 0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx
#45591 

Related PR: #xxx
#38836 

Problem Summary:
Awaitility.await.untilAsserted  is used like
```
def booleanClosure = { ->
   ...
   return true or false
}

await().atMost(ofSeconds(5)).untilAsserted(() -> {
    assert booleanClosure()
});
```
"untilAsserted" has a feature that it stops executing the subsequent statements upon encountering the first false assertion. If no assertion is encountered, or all assertions are true, "await" exits. There is an issue with our usage in our test cases.
This pr fix this.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

