### PR TITLE
[chore](script) fix `start_fe.sh --version` not work and MetaService scripts occur error in Debian GNU/Linux 11 (bullseye)

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -258,6 +258,12 @@ if [[ "${HELPER}" != "" ]]; then
     HELPER="-helper ${HELPER}"
 fi
 
+if [[ "$OPT_VERSION" != "" ]]; then
+    export DORIS_LOG_TO_STDERR=1
+    ${LIMIT:+${LIMIT}} "${JAVA}" org.apache.doris.DorisFE --version
+    exit 0
+fi
+
 if [[ "${IMAGE_TOOL}" -eq 1 ]]; then
     if [[ -n "${IMAGE_PATH}" ]]; then
         ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE -i "${IMAGE_PATH}"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -258,7 +258,7 @@ if [[ "${HELPER}" != "" ]]; then
     HELPER="-helper ${HELPER}"
 fi
 
-if [[ "$OPT_VERSION" != "" ]]; then
+if [[ "${OPT_VERSION}" != "" ]]; then
     export DORIS_LOG_TO_STDERR=1
     ${LIMIT:+${LIMIT}} "${JAVA}" org.apache.doris.DorisFE --version
     exit 0

--- a/cloud/script/start.sh
+++ b/cloud/script/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/cloud/script/stop.sh
+++ b/cloud/script/stop.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -35,7 +35,7 @@ build_version_hotfix=0
 build_version_rc_version=""
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
-if [[ ${build_version_hotfix} > 0 ]]; then
+if [[ ${build_version_hotfix} -gt 0 ]]; then
     build_version+=".${build_version_hotfix}"
 fi
 build_version+="-${build_version_rc_version}"
@@ -225,7 +225,7 @@ fi
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 
-if [[ ${build_version_hotfix} > 0 ]]; then
+if [[ ${build_version_hotfix} -gt 0 ]]; then
     build_version+=".${build_version_hotfix}"
 fi
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

1. fix `start_fe.sh --version` not work
2. fix `ms/bin/start.sh` could not work in Debian GNU/Linux 11 (bullseye)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

