### PR TITLE
[Improvement](scheduler) Use a separate eager queue to execute cancel…

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -227,6 +227,7 @@ private:
     OperatorPtr _root_op = nullptr;
     // this is a [n * m] matrix. n is parallelism of pipeline engine and m is the number of pipelines.
     std::vector<std::vector<std::unique_ptr<PipelineTask>>> _tasks;
+    std::vector<TaskHolderSPtr> _task_holders;
 
     // TODO: remove the _sink and _multi_cast_stream_sink_senders to set both
     // of it in pipeline task not the fragment_context

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -511,7 +511,7 @@ std::string PipelineTask::debug_string() {
                    (void*)this, _index, _opened, _eos, _finalized, _dry_run, elapsed,
                    _wake_up_early.load(),
                    cur_blocked_dep && !_finalized ? cur_blocked_dep->debug_string() : "NULL",
-                   is_running());
+                   _holder ? false : _holder->state.load() == TaskState::RUNNING);
     for (size_t i = 0; i < _operators.size(); i++) {
         fmt::format_to(debug_string_buffer, "\n{}",
                        _opened && !_finalized ? _operators[i]->debug_string(_state, i)

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -172,9 +172,6 @@ public:
 
     void pop_out_runnable_queue() { _wait_worker_watcher.stop(); }
 
-    bool is_running() { return _running.load(); }
-    void set_running(bool running) { _running = running; }
-
     bool is_exceed_debug_timeout() {
         if (_has_exceed_timeout) {
             return true;
@@ -297,7 +294,6 @@ private:
     std::atomic<bool> _finalized = false;
     std::mutex _dependency_lock;
 
-    std::atomic<bool> _running = false;
     std::atomic<bool> _eos = false;
     std::atomic<bool> _wake_up_early = false;
     std::shared_ptr<TaskHolder> _holder;

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -29,9 +29,7 @@
 namespace doris::pipeline {
 #include "common/compile_check_begin.h"
 
-TaskHolder::TaskHolder(PipelineTask* task_) : task(task_), state(TaskState::VALID) {
-    task_->set_holder(shared_from_this());
-}
+TaskHolder::TaskHolder(PipelineTask* task_) : task(task_), state(TaskState::VALID) {}
 
 TaskHolderSPtr SubTaskQueue::try_take(bool is_steal) {
     if (_queue.empty()) {

--- a/be/src/pipeline/task_queue.h
+++ b/be/src/pipeline/task_queue.h
@@ -42,7 +42,7 @@ enum class TaskState {
     INVALID = 2, // Invalid task which already de-constructed.
 };
 
-struct TaskHolder : public std::enable_shared_from_this<TaskHolder> {
+struct TaskHolder {
     PipelineTask* task;
     std::atomic<TaskState> state;
     TaskHolder(PipelineTask* task_);

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -97,7 +97,6 @@ void _close_task(TaskHolderSPtr holder, Status exec_status) {
         task->fragment_context()->cancel(status);
     }
     task->finalize();
-    task->set_running(false);
     {
         auto expected = TaskState::RUNNING;
         CHECK(holder->state.compare_exchange_strong(expected, TaskState::VALID));

--- a/be/src/pipeline/task_scheduler.h
+++ b/be/src/pipeline/task_scheduler.h
@@ -51,7 +51,7 @@ public:
 
     ~TaskScheduler();
 
-    Status schedule_task(PipelineTask* task);
+    Status schedule_task(TaskHolderSPtr task);
 
     Status start();
 


### PR DESCRIPTION
…ed tasks

### What problem does this PR solve?

Now, a pipeline task which is canceled will be put in runnable queue and release memory once it ran. However, a runnable queue may have too much tasks which leads to a unacceptable delay for this canceled task. So this PR use a separate queue to process all canceled tasks.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

