### PR TITLE
[fix](memory) Process available memory to increase the Jemalloc cache

### DIFF
--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -76,7 +76,7 @@ public:
     static inline int64_t sys_mem_available() {
         return MemInfo::_s_sys_mem_available.load(std::memory_order_relaxed) -
                refresh_interval_memory_growth.load(std::memory_order_relaxed) -
-               process_reserved_memory();
+               process_reserved_memory() + static_cast<int64_t>(MemInfo::allocator_cache_mem());
     }
 
     static inline std::string sys_mem_available_str() {
@@ -91,12 +91,14 @@ public:
     static inline std::string sys_mem_available_details_str() {
         auto msg = fmt::format(
                 "sys available memory {}(= {}[proc/available] - {}[reserved] - "
-                "{}B[waiting_refresh])",
+                "{}B[waiting_refresh] + {}[tc/jemalloc_cache])",
                 PrettyPrinter::print(sys_mem_available(), TUnit::BYTES),
                 PrettyPrinter::print(MemInfo::_s_sys_mem_available.load(std::memory_order_relaxed),
                                      TUnit::BYTES),
                 PrettyPrinter::print(process_reserved_memory(), TUnit::BYTES),
-                refresh_interval_memory_growth);
+                refresh_interval_memory_growth,
+                PrettyPrinter::print(static_cast<uint64_t>(MemInfo::allocator_cache_mem()),
+                                     TUnit::BYTES));
 #ifdef ADDRESS_SANITIZER
         msg = "[ASAN]" + msg;
 #endif


### PR DESCRIPTION
### What problem does this PR solve?

Currently, when the Doris BE process exceed memory limit, Jemalloc cache will be manually released. 
Add the Jemalloc cache to the available memory of the BE process is expected to have little impact on the risk of the process OOM killer. the process memory used has already subtracted the Jemalloc cache.

Not merge to 2.1 because 2.1 is stable now

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

