### PR TITLE
[Fix](recycler) Fix potential data leak when a partial update load which has publish conflict fails

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1522,8 +1522,8 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
             index_ids = std::move(index_info.second);
         }
         if (rs.rowset_state() == RowsetStatePB::BEGIN_PARTIAL_UPDATE) {
-            // if rowset state is RowsetStatePB::BEGIN_PARTIAL_UPDATE, the num of segments may be bigger than num_segments
-            // so we need to delete the rowset's data by prefix
+            // if rowset state is RowsetStatePB::BEGIN_PARTIAL_UPDATE, the number of segments data
+            // may be larger than num_segments field in RowsetMeta, so we need to delete the rowset's data by prefix
             rowsets_delete_by_prefix.emplace_back(rs.resource_id(), tablet_id, rs.rowset_id_v2());
             continue;
         }

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1551,13 +1551,12 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
         });
     }
     for (const auto& [resource_id, tablet_id, rowset_id] : rowsets_delete_by_prefix) {
+        LOG_INFO(
+                "delete rowset {} by prefix because it's in BEGIN_PARTIAL_UPDATE state, "
+                "resource_id={}, tablet_id={}, instance_id={}",
+                rowset_id, resource_id, tablet_id, instance_id_);
         concurrent_delete_executor.add(
                 [&]() -> int { return delete_rowset_data(resource_id, tablet_id, rowset_id); });
-    }
-    if (!rowsets_delete_by_prefix.empty()) {
-        LOG_INFO("delete {} rowsets by prefix because they are in BEGIN_PARTIAL_UPDATE state",
-                 rowsets_delete_by_prefix.size())
-                .tag("instance_id", instance_id_);
     }
     bool finished = true;
     std::vector<int> rets = concurrent_delete_executor.when_all(&finished);

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1554,6 +1554,11 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
         concurrent_delete_executor.add(
                 [&]() -> int { return delete_rowset_data(resource_id, tablet_id, rowset_id); });
     }
+    if (!rowsets_delete_by_prefix.empty()) {
+        LOG_INFO("delete {} rowsets by prefix because they are in BEGIN_PARTIAL_UPDATE state",
+                 rowsets_delete_by_prefix.size())
+                .tag("instance_id", instance_id_);
+    }
     bool finished = true;
     std::vector<int> rets = concurrent_delete_executor.when_all(&finished);
     for (int r : rets) {

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1449,8 +1449,6 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
     int ret = 0;
     // resource_id -> file_paths
     std::map<std::string, std::vector<std::string>> resource_file_paths;
-    // (resource_id, tablet_id, rowset_id)
-    std::vector<std::tuple<std::string, int64_t, std::string>> rowsets_delete_by_prefix;
 
     for (const auto& rs : rowsets) {
         {
@@ -1521,12 +1519,6 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
             index_format = index_info.first;
             index_ids = std::move(index_info.second);
         }
-        if (rs.rowset_state() == RowsetStatePB::BEGIN_PARTIAL_UPDATE) {
-            // if rowset state is RowsetStatePB::BEGIN_PARTIAL_UPDATE, the num of segments may be bigger than num_segments
-            // so we need to delete the rowset's data by prefix
-            rowsets_delete_by_prefix.emplace_back(rs.resource_id(), tablet_id, rs.rowset_id_v2());
-            continue;
-        }
         for (int64_t i = 0; i < num_segments; ++i) {
             file_paths.push_back(segment_path(tablet_id, rowset_id, i));
             if (index_format == InvertedIndexStorageFormatPB::V1) {
@@ -1549,10 +1541,6 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
             DCHECK(accessor);
             return accessor->delete_files(*paths);
         });
-    }
-    for (const auto& [resource_id, tablet_id, rowset_id] : rowsets_delete_by_prefix) {
-        concurrent_delete_executor.add(
-                [&]() -> int { return delete_rowset_data(resource_id, tablet_id, rowset_id); });
     }
     bool finished = true;
     std::vector<int> rets = concurrent_delete_executor.when_all(&finished);


### PR DESCRIPTION
### What problem does this PR solve?

when recycling tmp rowsets, if rowset's state is `RowsetStatePB::BEGIN_PARTIAL_UPDATE`, the `num_segments` field in `RowsetMetaCloudPB` may not reflect the actual segments num(This may happen if partial update load writes a new segment to an existing tmp rowset in publish phase due to conflict and fails before it updates segments num in `RowsetMetaCloudPB` in MS successfully). So we need to delete the rowsets by prefix rather than delete by path in this case.

related case: https://github.com/apache/doris/pull/45795

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

