### PR TITLE
[fix](cloud) fix abort transaction in runningTxns list when show routine load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -1211,6 +1211,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         if (txnCommitAttachment != null && txnCommitAttachment instanceof RLTaskTxnCommitAttachment) {
             RLTaskTxnCommitAttachment rlTaskTxnCommitAttachment = (RLTaskTxnCommitAttachment) txnCommitAttachment;
             callbackId = rlTaskTxnCommitAttachment.getJobId();
+            txnState.setTransactionId(transactionId);
         }
 
         cb = callbackFactory.getCallback(callbackId);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

There are some abort transaction in running transaction list when execute `Show routine load`:
```
statistic: {"receivedBytes":690347731,"runningTxns":[84983868539904,85435786230784,85005343163392,85437129268225,85454778056704,85435116123136,85025611246592,85437060583424,85434241746944,85415318736896,85465045433344,84985143969794,85004337471488,85415183878144,85415385197568,85424109151232,85004808868865,85005412474880,85025545732096,85414981022720,84984677082113,85436924459012],"errorRows":0,"committedTaskNum":211,"loadedRows":3612290,"loadRowsRate":195026,"abortedTaskNum":1,"errorRowsAfterResumed":0,"totalRows":3612290,"unselectedRows":0,"receivedBytesRate":37271770,"taskExecuteTimeMs":18522} 
```

When abort transaction to meta service, transaction info in `abortTxnResponse `would be default value when abort transaction failed.Then this logic will invalid for transaction id is default value:
```
this.jobStatistic.runningTxnIds.remove(txnState.getTransactionId());
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

