### PR TITLE
[fix](ranger) make RangerDorisAccessController as singleton to avoid more and more ranger policy refresher

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerCacheDorisAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerCacheDorisAccessController.java
@@ -28,7 +28,8 @@ public class RangerCacheDorisAccessController extends CatalogCacheAccessControll
 
     public RangerCacheDorisAccessController(String serviceName) {
         this.cache = new RangerCache();
-        this.proxyController = new RangerDorisAccessController(serviceName, new RangerCacheInvalidateListener(cache));
+        this.proxyController = RangerDorisAccessController.getInstance(serviceName,
+            new RangerCacheInvalidateListener(cache));
         this.cache.init(proxyController);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerDorisAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/ranger/doris/RangerDorisAccessController.java
@@ -45,19 +45,34 @@ import java.util.stream.Collectors;
 public class RangerDorisAccessController extends RangerAccessController {
     private static final Logger LOG = LogManager.getLogger(RangerDorisAccessController.class);
     private RangerBasePlugin dorisPlugin;
+
+    private static RangerDorisAccessController instance;
+
     // private static ScheduledThreadPoolExecutor logFlushTimer = ThreadPoolManager.newDaemonScheduledThreadPool(1,
     //        "ranger-doris-audit-log-flusher-timer", true);
     // private RangerHiveAuditHandler auditHandler;
 
-    public RangerDorisAccessController(String serviceName) {
+    private RangerDorisAccessController(String serviceName) {
         this(serviceName, null);
     }
 
-    public RangerDorisAccessController(String serviceName, RangerAuthContextListener rangerAuthContextListener) {
+    private RangerDorisAccessController(String serviceName, RangerAuthContextListener rangerAuthContextListener) {
         dorisPlugin = new RangerDorisPlugin(serviceName, rangerAuthContextListener);
         // auditHandler = new RangerHiveAuditHandler(dorisPlugin.getConfig());
         // start a timed log flusher
         // logFlushTimer.scheduleAtFixedRate(new RangerHiveAuditLogFlusher(auditHandler), 10, 20L, TimeUnit.SECONDS);
+    }
+
+    public static RangerDorisAccessController getInstance(String serviceName) {
+        return getInstance(serviceName, null);
+    }
+
+    public static synchronized RangerDorisAccessController getInstance(String serviceName,
+            RangerAuthContextListener rangerAuthContextListener) {
+        if (instance == null) {
+            instance = new RangerDorisAccessController(serviceName, rangerAuthContextListener);
+        }
+        return instance;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #45641

Problem Summary:
doris create new RangerDorisAccessController twice when do every checkpoint, and the new RangerDorisAccessController instance create a new ranger policy refresher. Too many policy refreshers will cause ranger admin overload

before fix:
![image](https://github.com/user-attachments/assets/d8b5a92d-6441-4793-9653-f93ded5bfbf8)


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

