### PR TITLE
[fix](catelog) Unifies partition items string

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6486,11 +6486,7 @@ public class Env {
                 long partitionId = partition.getId();
                 partitionMeta.setId(partitionId);
                 partitionMeta.setName(partition.getName());
-                String partitionRange = "";
-                if (tblPartitionInfo.getType() == PartitionType.RANGE
-                        || tblPartitionInfo.getType() == PartitionType.LIST) {
-                    partitionRange = tblPartitionInfo.getItem(partitionId).getItems().toString();
-                }
+                String partitionRange = tblPartitionInfo.getPartitionRangeString(partitionId);
                 partitionMeta.setRange(partitionRange);
                 partitionMeta.setVisibleVersion(partition.getVisibleVersion());
                 // partitionMeta.setTemp（partition.isTemp());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionItem.java
@@ -61,7 +61,12 @@ public class ListPartitionItem extends PartitionItem {
     }
 
     public String getItemsString() {
-        return toString();
+        // ATTN: DO NOT EDIT unless unless you explicitly guarantee compatibility
+        // between different versions.
+        //
+        // the ccr syncer depends on this string to identify partitions between two
+        // clusters (cluster versions may be different).
+        return getItems().toString();
     }
 
     public String getItemsSql() {
@@ -173,11 +178,6 @@ public class ListPartitionItem extends PartitionItem {
 
     @Override
     public String toString() {
-        // ATTN: DO NOT EDIT unless unless you explicitly guarantee compatibility
-        // between different versions.
-        //
-        // the ccr syncer depends on this string to identify partitions between two
-        // clusters (cluster versions may be different).
         StringBuilder builder = new StringBuilder();
         builder.append("partitionKeys: [");
         for (PartitionKey partitionKey : partitionKeys) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionItem.java
@@ -46,7 +46,12 @@ public class RangePartitionItem extends PartitionItem {
     }
 
     public String getItemsString() {
-        return toString();
+        // ATTN: DO NOT EDIT unless unless you explicitly guarantee compatibility
+        // between different versions.
+        //
+        // the ccr syncer depends on this string to identify partitions between two
+        // clusters (cluster versions may be different).
+        return partitionKeyRange.toString();
     }
 
     public String getItemsSql() {
@@ -125,11 +130,6 @@ public class RangePartitionItem extends PartitionItem {
 
     @Override
     public String toString() {
-        // ATTN: DO NOT EDIT unless unless you explicitly guarantee compatibility
-        // between different versions.
-        //
-        // the ccr syncer depends on this string to identify partitions between two
-        // clusters (cluster versions may be different).
         return partitionKeyRange.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/EsPartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/EsPartitionsProcDir.java
@@ -93,7 +93,7 @@ public class EsPartitionsProcDir implements ProcDirInterface {
                 }
                 partitionInfo.add(joiner.join(colNames));  // partition key
                 partitionInfo.add(
-                        rangePartitionInfo.getItem(esShardPartitions.getPartitionId()).getItems().toString()); // range
+                        rangePartitionInfo.getItem(esShardPartitions.getPartitionId()).getItemsString()); // range
                 partitionInfo.add("-");  // dis
                 partitionInfo.add(esShardPartitions.getShardRoutings().size());  // shards
                 partitionInfo.add(1);  //  replica num

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -323,7 +323,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                     String colNamesStr = joiner.join(colNames);
                     partitionInfo.add(colNamesStr);
                     trow.addToColumnValue(new TCell().setStringVal(colNamesStr));
-                    String itemStr = tblPartitionInfo.getItem(partitionId).getItems().toString();
+                    String itemStr = tblPartitionInfo.getPartitionRangeString(partitionId);
                     partitionInfo.add(itemStr);
                     trow.addToColumnValue(new TCell().setStringVal(itemStr));
                 } else {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

For range partitions, `getItems().toString()` is equal to `getItemsString`, but for list partitions, there has a `,` between each item.

The upsert record of binlog is generated via `getItemsString`, but the getMeta method fetches partition items string via `getItems().toString()`, which are different in the list partitions, and the ccr-syncer is unable to identify them.

This PR unifies all partition items string via `getItemsString`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

The test in the ccr part: https://github.com/selectdb/ccr-syncer/pull/339

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

