### PR TITLE
[test](p0) force replica = 1 in p0 regression tests

### DIFF
--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -83,3 +83,5 @@ enable_advance_next_id = true
 # enable deadlock detection
 enable_deadlock_detection = true
 max_lock_hold_threshold_seconds = 1
+
+force_olap_table_replication_allocation=tag.location.default:1

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition.groovy
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 suite("test_dynamic_partition") {
+    def config_row = sql """ ADMIN SHOW FRONTEND CONFIG LIKE 'force_olap_table_replication_allocation'; """
+    String old_conf_value = config_row[0][1]
+    sql """ ADMIN SET FRONTEND CONFIG ("force_olap_table_replication_allocation" = ""); """
+
     // todo: test dynamic partition
     sql "drop table if exists dy_par"
     sql """
@@ -158,4 +162,7 @@ suite("test_dynamic_partition") {
     }
     }
     sql "drop table if exists dy_par_bad"
+
+    // restore force_olap_table_replication_allocation to old_value
+    sql """ ADMIN SET FRONTEND CONFIG ("force_olap_table_replication_allocation" = "${old_conf_value}"); """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Some tests in p0 does not set replica = 1, and will fail when BE number is not enough.

This PR fixed this problem by set `force_olap_table_replication_allocation` in p0 fe.conf 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

