### PR TITLE
[fix](nereids) fix comparison with date like

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
@@ -182,7 +182,7 @@ public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule i
                     DateTimeLiteral dateTimeLiteral = (DateTimeLiteral) right;
                     right = migrateToDateV2(dateTimeLiteral);
                     if (dateTimeLiteral.getHour() != 0 || dateTimeLiteral.getMinute() != 0
-                            || dateTimeLiteral.getSecond() != 0) {
+                            || dateTimeLiteral.getSecond() != 0 || dateTimeLiteral.getMicroSecond() != 0) {
                         if (cp instanceof EqualTo) {
                             return ExpressionUtils.falseOrNull(cast.child());
                         } else if (cp instanceof NullSafeEqual) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
@@ -166,6 +166,18 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
                 new LessThan(date, new DateV2Literal("2020-01-02")));
         assertRewrite(new LessThanEqual(new Cast(date, DateTimeType.INSTANCE), new DateTimeLiteral("2020-01-01 00:00:01")),
                 new LessThanEqual(date, new DateV2Literal("2020-01-01")));
+        assertRewrite(new EqualTo(new Cast(date, DateTimeV2Type.SYSTEM_DEFAULT), new DateTimeV2Literal("2020-01-01 00:00:00")),
+                new EqualTo(date, new DateV2Literal("2020-01-01")));
+        assertRewrite(new EqualTo(new Cast(date, DateTimeV2Type.SYSTEM_DEFAULT), new DateTimeV2Literal("2020-01-01 00:00:01")),
+                ExpressionUtils.falseOrNull(date));
+        assertRewrite(new EqualTo(new Cast(date, DateTimeV2Type.of(2)), new DateTimeV2Literal("2020-01-01 00:00:00.01")),
+                ExpressionUtils.falseOrNull(date));
+        assertRewrite(new NullSafeEqual(new Cast(date, DateTimeV2Type.of(2)), new DateTimeV2Literal("2020-01-01 00:00:00.01")),
+                BooleanLiteral.FALSE);
+        assertRewrite(new GreaterThanEqual(new Cast(date, DateTimeV2Type.SYSTEM_DEFAULT), new DateTimeV2Literal("2020-01-01 00:00:01")),
+                new GreaterThanEqual(date, new DateV2Literal("2020-01-02")));
+        assertRewrite(new GreaterThanEqual(new Cast(date, DateTimeV2Type.of(2)), new DateTimeV2Literal("2020-01-01 00:00:00.01")),
+                new GreaterThanEqual(date, new DateV2Literal("2020-01-02")));
         // cast (date as datev1) = datev1-literal
         // assertRewrite(new EqualTo(new Cast(date, DateType.INSTANCE), new DateLiteral("2020-01-01")),
         //        new EqualTo(date, new DateV2Literal("2020-01-01")));
@@ -191,6 +203,18 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
                 new EqualTo(datev1, new DateLiteral("2020-01-01")));
         assertRewrite(new GreaterThan(new Cast(datev1, DateV2Type.INSTANCE), new DateV2Literal("2020-01-01")),
                 new GreaterThan(datev1, new DateLiteral("2020-01-01")));
+        assertRewrite(new EqualTo(new Cast(datev1, DateTimeV2Type.SYSTEM_DEFAULT), new DateTimeV2Literal("2020-01-01 00:00:00")),
+                new EqualTo(datev1, new DateLiteral("2020-01-01")));
+        assertRewrite(new EqualTo(new Cast(datev1, DateTimeV2Type.SYSTEM_DEFAULT), new DateTimeV2Literal("2020-01-01 00:00:01")),
+                ExpressionUtils.falseOrNull(datev1));
+        assertRewrite(new EqualTo(new Cast(datev1, DateTimeV2Type.of(2)), new DateTimeV2Literal("2020-01-01 00:00:00.01")),
+                ExpressionUtils.falseOrNull(datev1));
+        assertRewrite(new NullSafeEqual(new Cast(datev1, DateTimeV2Type.of(2)), new DateTimeV2Literal("2020-01-01 00:00:00.01")),
+                BooleanLiteral.FALSE);
+        assertRewrite(new GreaterThanEqual(new Cast(datev1, DateTimeV2Type.SYSTEM_DEFAULT), new DateTimeV2Literal("2020-01-01 00:00:01")),
+                new GreaterThanEqual(datev1, new DateLiteral("2020-01-02")));
+        assertRewrite(new GreaterThanEqual(new Cast(datev1, DateTimeV2Type.of(2)), new DateTimeV2Literal("2020-01-01 00:00:00.01")),
+                new GreaterThanEqual(datev1, new DateLiteral("2020-01-02")));
 
         // cast (datetimev1 as datetime) cmp datetime
         assertRewrite(new EqualTo(new Cast(datetimev1, DateTimeV2Type.of(0)), new DateTimeV2Literal("2020-01-01 00:00:00")),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #45382

Problem Summary:

#45382 had fix compare date/datev1 with datetime literal wrong cutting.  but it not fix completely. 

```
if (right instanceof DateTimeLiteral) {
                    DateTimeLiteral dateTimeLiteral = (DateTimeLiteral) right;
                    right = migrateToDateV2(dateTimeLiteral);
                    if (dateTimeLiteral.getHour() != 0 || dateTimeLiteral.getMinute() != 0
                            || dateTimeLiteral.getSecond() != 0) {
                            ...
                    }
}
```


For the above code, if check right is date time literal,  but notice that datetimev2 literal is datetime literal's child class.  so datetimev2 literal will also run the above code. And datetimev2 literal should check its microseconds not equals to 0.

for example:   `date_a  =  '2020-01-01 00:00:00.01'` should opt as `FALSE`, but not `date_a = '2020-01-01'`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

