### PR TITLE
[fix](macOS) Fix build scripts for macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -148,7 +148,14 @@ fi
 
 eval set -- "${OPTS}"
 
-PARALLEL="$(($(nproc) / 4 + 1))"
+NUM_CORES=0
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    NUM_CORES=$(sysctl -n hw.logicalcpu)
+else
+    NUM_CORES=$(nproc)
+fi
+
+PARALLEL="$((${NUM_CORES} / 4 + 1))"
 BUILD_FE=0
 BUILD_BE=0
 BUILD_CLOUD=0

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -54,9 +54,11 @@ SPEC_ARCHIVES=(
 )
 while [[ $# -gt 0 ]]; do
     GIVEN_LIB=$1
+    GIVEN_LIB_LOWER="$(echo ${GIVEN_LIB} | awk '{print tolower($0)}')"
     SPEC_LIB=
     for TP_ARCH in "${TP_ARCHIVES[@]}"; do
-        if [[ "${GIVEN_LIB,,}" = "${TP_ARCH,,}" ]]; then
+        TP_ARCH_LOWER="$(echo ${TP_ARCH} | awk '{print tolower($0)}')"
+        if [[ "${GIVEN_LIB_LOWER}" = "${TP_ARCH_LOWER}" ]]; then
             SPEC_LIB=${TP_ARCH}
             break
         fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #45750

Related PR: None

Problem Summary: Build scripts do not work on macOS

### Release note

- Replaced `nproc` with `sysctl -n hw.logicalcpu` to get CPU count on macOS.
- Avoided lowercase parameter expansion due to macOS default Bash version (3.2).

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

