### PR TITLE
[fix](catalog) fix npe after replaying the external catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -154,7 +154,7 @@ public abstract class ExternalCatalog
     protected PreExecutionAuthenticator preExecutionAuthenticator;
 
     private volatile Configuration cachedConf = null;
-    private final byte[] confLock = new byte[0];
+    private byte[] confLock = new byte[0];
 
     public ExternalCatalog() {
     }
@@ -784,6 +784,7 @@ public abstract class ExternalCatalog
             }
         }
         this.propLock = new byte[0];
+        this.confLock = new byte[0];
         this.initialized = false;
         setDefaultPropsIfMissing(true);
         if (tableAutoAnalyzePolicy == null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -22,9 +22,10 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalCatalog;
-import org.apache.doris.mysql.privilege.Auth;
+import org.apache.doris.meta.MetaContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.StmtExecutor;
@@ -32,16 +33,20 @@ import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ExternalCatalogTest extends TestWithFeService {
-    private static Auth auth;
-    private static Env env;
+    private Env env;
     private CatalogMgr mgr;
     private ConnectContext rootCtx;
 
@@ -51,7 +56,6 @@ public class ExternalCatalogTest extends TestWithFeService {
         mgr = Env.getCurrentEnv().getCatalogMgr();
         rootCtx = createDefaultCtx();
         env = Env.getCurrentEnv();
-        auth = env.getAuth();
         // 1. create test catalog
         CreateCatalogStmt testCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
                 "create catalog test1 properties(\n"
@@ -243,5 +247,33 @@ public class ExternalCatalogTest extends TestWithFeService {
         public Map<String, Map<String, List<Column>>> getMetadata() {
             return MOCKED_META;
         }
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        MetaContext metaContext = new MetaContext();
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_CURRENT);
+        metaContext.setThreadLocalInfo();
+
+        // 1. Write objects to file
+        File file = new File("./external_catalog_persist_test.dat");
+        file.createNewFile();
+        DataOutputStream dos = new DataOutputStream(Files.newOutputStream(file.toPath()));
+
+        TestExternalCatalog ctl = (TestExternalCatalog) mgr.getCatalog("test1");
+        ctl.write(dos);
+        dos.flush();
+        dos.close();
+
+        // 2. Read objects from file
+        DataInputStream dis = new DataInputStream(Files.newInputStream(file.toPath()));
+
+        TestExternalCatalog ctl2 = (TestExternalCatalog) ExternalCatalog.read(dis);
+        Configuration conf = ctl2.getConfiguration();
+        Assertions.assertNotNull(conf);
+
+        // 3. delete files
+        dis.close();
+        file.delete();
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #45433

Problem Summary:
the `confLock` should be created after replaying in `gsonPostProcess()` of `ExternalCatalog`,
or it will be null.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

