### PR TITLE
[refactor](sync job) disable sync job by default

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2974,6 +2974,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_checkpoint = true;
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+            "是否开启 sync job 功能。默认关闭。该功能将在3.1版本中移除。",
+            "Whether to enable the sync job feature. It is disabled by default and will be removed in version 3.1."
+    })
+    public static boolean enable_feature_data_sync_job = false;
+
     //==========================================================================
     //                    begin of cloud config
     //==========================================================================

--- a/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/sync/SyncJobManager.java
@@ -69,6 +69,11 @@ public class SyncJobManager implements Writable {
     }
 
     public void addDataSyncJob(CreateDataSyncJobStmt stmt) throws DdlException {
+        if (!Config.enable_feature_data_sync_job) {
+            throw new DdlException("Data sync job is deprecated and disabled by default. You can enable it by setting "
+                    + "'enable_feature_data_sync_job=true' in fe.conf. "
+                    + "But it's not recommended to use it in production.");
+        }
         long jobId = Env.getCurrentEnv().getNextId();
         SyncJob syncJob = SyncJob.fromStmt(jobId, stmt);
         writeLock();

--- a/fe/fe-core/src/test/java/org/apache/doris/load/sync/SyncJobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/sync/SyncJobManagerTest.java
@@ -70,6 +70,7 @@ public class SyncJobManagerTest {
 
     @Before
     public void setUp() throws DdlException {
+        Config.enable_feature_data_sync_job = true;
         new Expectations() {
             {
                 env.getEditLog();

--- a/regression-test/suites/nereids_p0/show/test_show_sync_job_command.groovy
+++ b/regression-test/suites/nereids_p0/show/test_show_sync_job_command.groovy
@@ -16,6 +16,11 @@
 // under the License.
 
 suite("test_show_sync_job_command", "query,sync_job") {
+    boolean enabled = false;
+    if (!enabled) {
+        //sync job is deprecated
+        return;
+    }
     try {
         sql """CREATE DATABASE IF NOT EXISTS test_db_sync_job;"""
         


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`create sync job` feature is no longer maintained, deprecated it by default and remove it in version 3.1.
And a new FE config `enable_feature_data_sync_job`

### Release note

[refactor](sync job) disable sync job by default

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

