### PR TITLE
[test](index compaction)Fix unstable index compaction fault injection case

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_index_compaction_exception_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_index_compaction_exception_fault_injection.groovy
@@ -26,8 +26,6 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
 
     def changed_variables = sql "show variables where Changed = 1"
     logger.info("changed variables: " + changed_variables.toString())
-    // sql "UNSET GLOBAL VARIABLE ALL;"
-    sql "SET global enable_match_without_inverted_index = false"
 
     boolean disableAutoCompaction = false
   
@@ -120,7 +118,7 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
     }
 
     def run_sql = { -> 
-        def result = sql_return_maparray "SELECT * FROM ${tableName} WHERE name MATCH 'bason'"
+        def result = sql_return_maparray "SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_common_expr_pushdown = true) */ * FROM ${tableName} WHERE name MATCH 'bason'"
         assertEquals(3, result.size())
         assertEquals(1, result[0]['id'])
         assertEquals("bason", result[0]['name'])
@@ -129,7 +127,7 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
         assertEquals(3, result[2]['id'])
         assertEquals("bason", result[2]['name'])
 
-        result = sql_return_maparray "SELECT * FROM ${tableName} WHERE age = 11"
+        result = sql_return_maparray "SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_common_expr_pushdown = true) */ * FROM ${tableName} WHERE age = 11"
         assertEquals(3, result.size())
         assertEquals(1, result[0]['id'])
         assertEquals("bason", result[0]['name'])
@@ -138,7 +136,7 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
         assertEquals(3, result[2]['id'])
         assertEquals("bason", result[2]['name'])
 
-        result = sql_return_maparray "SELECT * FROM ${tableName} WHERE description MATCH 'singing'"
+        result = sql_return_maparray "SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_common_expr_pushdown = true) */ * FROM ${tableName} WHERE description MATCH 'singing'"
         assertEquals(3, result.size())
         assertEquals("bason", result[0]['name'])
         assertEquals("bason is good at singing", result[0]['description'])
@@ -147,7 +145,7 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
         assertEquals("bason", result[2]['name'])
         assertEquals("bason is good at singing", result[2]['description'])
 
-        result = sql_return_maparray "SELECT * FROM ${tableName} WHERE array_contains(scores, 79)"
+        result = sql_return_maparray "SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_common_expr_pushdown = true) */ * FROM ${tableName} WHERE array_contains(scores, 79)"
         assertEquals(3, result.size())
         assertEquals("bason", result[0]['name'])
         assertEquals("[79, 85, 97]", result[0]['scores'])
@@ -156,7 +154,7 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
         assertEquals("bason", result[2]['name'])
         assertEquals("[79, 85, 97]", result[2]['scores'])
 
-        result = sql_return_maparray "SELECT * FROM ${tableName} WHERE array_contains(hobbies, 'dancing')"
+        result = sql_return_maparray "SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_common_expr_pushdown = true) */ * FROM ${tableName} WHERE array_contains(hobbies, 'dancing')"
         assertEquals(3, result.size())
         assertEquals("bason", result[0]['name'])
         assertEquals('["singing", "dancing"]', result[0]['hobbies'])
@@ -165,7 +163,7 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
         assertEquals("bason", result[2]['name'])
         assertEquals('["singing", "dancing"]', result[2]['hobbies'])
 
-        result = sql_return_maparray "SELECT * FROM ${tableName} WHERE array_contains(evaluation, 'bason is very clever')"
+        result = sql_return_maparray "SELECT /*+ SET_VAR(enable_match_without_inverted_index = false, enable_common_expr_pushdown = true) */ * FROM ${tableName} WHERE array_contains(evaluation, 'bason is very clever')"
         assertEquals(3, result.size())
         assertEquals("bason", result[0]['name'])
         assertEquals('["bason is very clever", "bason is very healthy"]', result[0]['evaluation'])
@@ -338,7 +336,5 @@ suite("test_index_compaction_exception_fault_injection", "nonConcurrent") {
         if (has_update_be_config) {
             set_be_config.call("inverted_index_compaction_enable", invertedIndexCompactionEnable.toString())
         }
-        sql "SET global enable_match_without_inverted_index = true"
     }
-
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Related PR: #45127

When set `enable_match_without_inverted_index` to `false`, `enable_common_expr_pushdown` must be `true`,  if not, it will throw `[E-6001]match_any not support execute_match` error.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

