### PR TITLE
[fix](TrinoConnector) fix the error message when querying a not-existent table with TrinoConnector

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorExternalTable.java
@@ -108,7 +108,8 @@ public class TrinoConnectorExternalTable extends ExternalTable {
                     qualifiedTable.asSchemaTableName(), Optional.empty(), Optional.empty()));
         }
         if (!connectorTableHandle.isPresent()) {
-            throw new RuntimeException(String.format("Table does not exist: %s.%s.%s", qualifiedTable));
+            throw new RuntimeException(String.format("Table does not exist: %s.%s.%s", trinoConnectorCatalog.getName(),
+                    dbName, name));
         }
 
         // 4. Get ColumnHandle


### PR DESCRIPTION
Problem Summary:
fix the error message when querying a not-existent table with TrinoConnector


- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

