### PR TITLE
[branch-2.1](ORC) fix predicate filter failed when use hive 1.x version

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -724,6 +724,11 @@ bool OrcReader::_init_search_argument(
     if (predicates.empty()) {
         return false;
     }
+
+    if (_is_hive1_orc_or_use_idx) {
+        for (OrcPredicate& it : predicates) it.col_name = _col_name_to_file_col_name[it.col_name];
+    }
+
     std::unique_ptr<orc::SearchArgumentBuilder> builder = orc::SearchArgumentFactory::newBuilder();
     if (build_search_argument(predicates, 0, builder)) {
         std::unique_ptr<orc::SearchArgument> sargs = builder->build();

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -726,7 +726,10 @@ bool OrcReader::_init_search_argument(
     }
 
     if (_is_hive1_orc_or_use_idx) {
-        for (OrcPredicate& it : predicates) it.col_name = _col_name_to_file_col_name[it.col_name];
+        // use hive 1.x version orc file, need to convert column name to internal column name
+        for (OrcPredicate& it : predicates) {
+            it.col_name = _col_name_to_file_col_name[it.col_name];
+        }
     }
 
     std::unique_ptr<orc::SearchArgumentBuilder> builder = orc::SearchArgumentFactory::newBuilder();

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -732,6 +732,11 @@ bool OrcReader::_init_search_argument(
         }
     }
 
+    // check if all column names in predicates are same as orc file
+    DCHECK(std::all_of(predicates.begin(), predicates.end(), [&](const OrcPredicate& predicate) {
+        return type_map.contains(predicate.col_name);
+    }));
+
     std::unique_ptr<orc::SearchArgumentBuilder> builder = orc::SearchArgumentFactory::newBuilder();
     if (build_search_argument(predicates, 0, builder)) {
         std::unique_ptr<orc::SearchArgument> sargs = builder->build();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #43185 

Pick the pr https://github.com/apache/doris/pull/43185 to branch-2.1 to fix predicate filter failed when use hive 1.x version

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

