### PR TITLE
[fix](olap) Set the original tablet state to TABLET_SHUTDOWN

### DIFF
--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -549,4 +549,55 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
     ASSERT_TRUE(trash_st.ok()) << trash_st;
 }
 
+TEST_F(TabletMgrTest, LoadTabletFromMeta) {
+    TTabletId tablet_id = 111;
+    TSchemaHash schema_hash = 3333;
+    auto create_tablet = [&]() -> TabletSharedPtr {
+        TColumnType col_type;
+        col_type.__set_type(TPrimitiveType::SMALLINT);
+        TColumn col1;
+        col1.__set_column_name("col1");
+        col1.__set_column_type(col_type);
+        col1.__set_is_key(true);
+        std::vector<TColumn> cols;
+        cols.push_back(col1);
+        TTabletSchema tablet_schema;
+        tablet_schema.__set_short_key_column_count(1);
+        tablet_schema.__set_schema_hash(3333);
+        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+        tablet_schema.__set_storage_type(TStorageType::COLUMN);
+        tablet_schema.__set_columns(cols);
+        TCreateTabletReq create_tablet_req;
+        create_tablet_req.__set_tablet_schema(tablet_schema);
+        create_tablet_req.__set_tablet_id(111);
+        create_tablet_req.__set_version(2);
+        std::vector<DataDir*> data_dirs;
+        data_dirs.push_back(_data_dir);
+        RuntimeProfile profile("CreateTablet");
+        Status create_st =
+                k_engine->tablet_manager()->create_tablet(create_tablet_req, data_dirs, &profile);
+        EXPECT_TRUE(create_st == Status::OK());
+        TabletSharedPtr tablet = k_engine->tablet_manager()->get_tablet(111);
+        EXPECT_TRUE(tablet != nullptr);
+        return tablet;
+    };
+
+    TabletSharedPtr tablet = add_tablet();
+    EXPECT_TRUE(tablet != nullptr);
+
+    std::string serialized_tablet_meta;
+    tablet->tablet_meta()->serialize(&serialized_tablet_meta);
+    bool update_meta = true;
+    bool force = true;
+    bool restore = false;
+    bool check_path = true;
+    Status st = _tablet_mgr->load_tablet_from_meta(_data_dir, tablet_id, schema_hash,
+                                                   serialized_tablet_meta, update_meta, force,
+                                                   restore, check_path);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // After reload, the original tablet should not be allowed to save meta.
+    ASSERT_FALSE(tablet->do_tablet_meta_checkpoint());
+}
+
 } // namespace doris

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -552,37 +552,31 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
 TEST_F(TabletMgrTest, LoadTabletFromMeta) {
     TTabletId tablet_id = 111;
     TSchemaHash schema_hash = 3333;
-    auto create_tablet = [&]() -> TabletSharedPtr {
-        TColumnType col_type;
-        col_type.__set_type(TPrimitiveType::SMALLINT);
-        TColumn col1;
-        col1.__set_column_name("col1");
-        col1.__set_column_type(col_type);
-        col1.__set_is_key(true);
-        std::vector<TColumn> cols;
-        cols.push_back(col1);
-        TTabletSchema tablet_schema;
-        tablet_schema.__set_short_key_column_count(1);
-        tablet_schema.__set_schema_hash(3333);
-        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
-        tablet_schema.__set_storage_type(TStorageType::COLUMN);
-        tablet_schema.__set_columns(cols);
-        TCreateTabletReq create_tablet_req;
-        create_tablet_req.__set_tablet_schema(tablet_schema);
-        create_tablet_req.__set_tablet_id(111);
-        create_tablet_req.__set_version(2);
-        std::vector<DataDir*> data_dirs;
-        data_dirs.push_back(_data_dir);
-        RuntimeProfile profile("CreateTablet");
-        Status create_st =
-                k_engine->tablet_manager()->create_tablet(create_tablet_req, data_dirs, &profile);
-        EXPECT_TRUE(create_st == Status::OK());
-        TabletSharedPtr tablet = k_engine->tablet_manager()->get_tablet(111);
-        EXPECT_TRUE(tablet != nullptr);
-        return tablet;
-    };
-
-    TabletSharedPtr tablet = add_tablet();
+    TColumnType col_type;
+    col_type.__set_type(TPrimitiveType::SMALLINT);
+    TColumn col1;
+    col1.__set_column_name("col1");
+    col1.__set_column_type(col_type);
+    col1.__set_is_key(true);
+    std::vector<TColumn> cols;
+    cols.push_back(col1);
+    TTabletSchema tablet_schema;
+    tablet_schema.__set_short_key_column_count(1);
+    tablet_schema.__set_schema_hash(3333);
+    tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+    tablet_schema.__set_storage_type(TStorageType::COLUMN);
+    tablet_schema.__set_columns(cols);
+    TCreateTabletReq create_tablet_req;
+    create_tablet_req.__set_tablet_schema(tablet_schema);
+    create_tablet_req.__set_tablet_id(111);
+    create_tablet_req.__set_version(2);
+    std::vector<DataDir*> data_dirs;
+    data_dirs.push_back(_data_dir);
+    RuntimeProfile profile("CreateTablet");
+    Status create_st =
+            k_engine->tablet_manager()->create_tablet(create_tablet_req, data_dirs, &profile);
+    EXPECT_TRUE(create_st == Status::OK());
+    TabletSharedPtr tablet = k_engine->tablet_manager()->get_tablet(111);
     EXPECT_TRUE(tablet != nullptr);
 
     std::string serialized_tablet_meta;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Set the original tablet state to TABLET_SHUTDOWN when loading a new tablet from the disk during the restore job. Otherwise, the other thread may hold the old tablet object, and save meta too.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

