### PR TITLE
[typo](docker) Adjust the indentation format of the init_be and entry_point scripts, as well as the duration of loop execution(Merge-2.1). 

### DIFF
--- a/docker/runtime/be/resource/entry_point.sh
+++ b/docker/runtime/be/resource/entry_point.sh
@@ -61,95 +61,95 @@ docker_setup_env() {
 
 # Check the variables required for startup
 docker_required_variables_env() {
-  declare -g RUN_TYPE
-  if [[ -n "$FE_SERVERS" && -n "$BE_ADDR" ]]; then
-      RUN_TYPE="ELECTION"
-      if [[ $FE_SERVERS =~ ^.+:[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}:[1-6]{0,1}[0-9]{1,4}(,.+:[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}:[1-6]{0,1}[0-9]{1,4})*$ || $FE_SERVERS =~ ^.+:([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:)$ ]]; then
-          doris_warn "FE_SERVERS" $FE_SERVERS
-      else
-          doris_error "FE_SERVERS rule error！example: \$FE_NAME:\$FE_HOST_IP:\$FE_EDIT_LOG_PORT[,\$FE_NAME:\$FE_HOST_IP:\$FE_EDIT_LOG_PORT]..."
-      fi
-      if [[ $BE_ADDR =~ ^[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}:[1-6]{0,1}[0-9]{1,4}$ || $BE_ADDR =~ ^([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:):[1-6]{0,1}[0-9]{1,4}$ ]]; then
-        doris_warn "BE_ADDR" $BE_ADDR
-      else
-        doris_error "BE_ADDR rule error！example: \$BE_IP:\$HEARTBEAT_SERVICE_PORT"
-      fi
-      export RUN_TYPE=${RUN_TYPE}
-      return
-  fi
+    declare -g RUN_TYPE
+    if [[ -n "$FE_SERVERS" && -n "$BE_ADDR" ]]; then
+        RUN_TYPE="ELECTION"
+        if [[ $FE_SERVERS =~ ^.+:[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}:[1-6]{0,1}[0-9]{1,4}(,.+:[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}:[1-6]{0,1}[0-9]{1,4})*$ || $FE_SERVERS =~ ^.+:([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:)$ ]]; then
+            doris_warn "FE_SERVERS" $FE_SERVERS
+        else
+            doris_error "FE_SERVERS rule error！example: \$FE_NAME:\$FE_HOST_IP:\$FE_EDIT_LOG_PORT[,\$FE_NAME:\$FE_HOST_IP:\$FE_EDIT_LOG_PORT]..."
+        fi
+        if [[ $BE_ADDR =~ ^[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}:[1-6]{0,1}[0-9]{1,4}$ || $BE_ADDR =~ ^([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:):[1-6]{0,1}[0-9]{1,4}$ ]]; then
+            doris_warn "BE_ADDR" $BE_ADDR
+        else
+            doris_error "BE_ADDR rule error！example: \$BE_IP:\$HEARTBEAT_SERVICE_PORT"
+        fi
+        export RUN_TYPE=${RUN_TYPE}
+        return
+    fi
 
-  if [[ -n "$FE_MASTER_IP"  && -n "$BE_IP" && -n "$BE_PORT" ]]; then
-      RUN_TYPE="ASSIGN"
-      if [[ $FE_MASTER_IP =~ ^[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}$ || $FE_MASTER_IP =~ ^([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:)$ ]]; then
-          doris_warn "FE_MASTER_IP" $FE_MASTER_IP
-      else
-          doris_error "FE_MASTER_IP rule error！example: \$FE_MASTER_IP"
-      fi
-      if [[ $BE_IP =~ ^[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}$ || $BE_IP =~ ^([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:)$ ]]; then
-          doris_warn "BE_IP" $BE_IP
-      else
-          doris_error "BE_IP rule error！example: \$BE_IP"
-      fi
-      if [[ $BE_PORT =~ ^[1-6]{0,1}[0-9]{1,4}$ ]]; then
-          doris_warn "BE_PORT" $BE_PORT
-      else
-          doris_error "BE_PORT rule error！example: \$BE_PORT."
-      fi
-      export RUN_TYPE=${RUN_TYPE}
-      return
-  fi
+    if [[ -n "$FE_MASTER_IP"  && -n "$BE_IP" && -n "$BE_PORT" ]]; then
+        RUN_TYPE="ASSIGN"
+        if [[ $FE_MASTER_IP =~ ^[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}$ || $FE_MASTER_IP =~ ^([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:)$ ]]; then
+            doris_warn "FE_MASTER_IP" $FE_MASTER_IP
+        else
+            doris_error "FE_MASTER_IP rule error！example: \$FE_MASTER_IP"
+        fi
+        if [[ $BE_IP =~ ^[1-2]{0,1}[0-9]{0,1}[0-9]{1}(\.[1-2]{0,1}[0-9]{0,1}[0-9]{1}){3}$ || $BE_IP =~ ^([0-9a-fA-F]{1,4}:){7,7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,6}(:[0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,5}((:[0-9a-fA-F]{1,4}){1,2}|:)|([0-9a-fA-F]{1,4}:){1,4}((:[0-9a-fA-F]{1,4}){1,3}|:)|([0-9a-fA-F]{1,4}:){1,3}((:[0-9a-fA-F]{1,4}){1,4}|:)|([0-9a-fA-F]{1,4}:){1,2}((:[0-9a-fA-F]{1,4}){1,5}|:)|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}|:)|:((:[0-9a-fA-F]{1,4}){1,7}|:)$ ]]; then
+            doris_warn "BE_IP" $BE_IP
+        else
+            doris_error "BE_IP rule error！example: \$BE_IP"
+        fi
+        if [[ $BE_PORT =~ ^[1-6]{0,1}[0-9]{1,4}$ ]]; then
+            doris_warn "BE_PORT" $BE_PORT
+        else
+            doris_error "BE_PORT rule error！example: \$BE_PORT."
+        fi
+        export RUN_TYPE=${RUN_TYPE}
+        return
+    fi
 
-  doris_error EOF "
-               Note that you did not configure the required parameters!
-               plan 1:
-               FE_SERVERS & BE_ADDR
-               plan 2:
-               FE_MASTER_IP & FE_MASTER_PORT & BE_IP & BE_PORT"
-              EOF
+    doris_error EOF "
+                 Note that you did not configure the required parameters!
+                 plan 1:
+                 FE_SERVERS & BE_ADDR
+                 plan 2:
+                 FE_MASTER_IP & FE_MASTER_PORT & BE_IP & BE_PORT"
+                EOF
 }
 
 get_doris_args() {
-  declare -g MASTER_FE_IP CURRENT_BE_IP CURRENT_BE_PORT PRIORITY_NETWORKS
-  if [ $RUN_TYPE == "ELECTION" ]; then
-      local feServerArray=($(echo "${FE_SERVERS}" | awk '{gsub (/,/," "); print $0}'))
-      for i in "${feServerArray[@]}"; do
-        val=${i}
-        val=${val// /}
-        tmpFeName=$(echo "${val}" | awk -F ':' '{ sub(/fe/, ""); sub(/ /, ""); print$1}')
-        tmpFeIp=$(echo "${val}" | awk -F ':' '{ sub(/ /, ""); print$2}')
-        tmpFeEditLogPort=$(echo "${val}" | awk -F ':' '{ sub(/ /, ""); print$3}')
-        check_arg "TMP_FE_NAME" $tmpFeName
-        feIpArray[$tmpFeName]=${tmpFeIp}
-      done
+    declare -g MASTER_FE_IP CURRENT_BE_IP CURRENT_BE_PORT PRIORITY_NETWORKS
+    if [ $RUN_TYPE == "ELECTION" ]; then
+        local feServerArray=($(echo "${FE_SERVERS}" | awk '{gsub (/,/," "); print $0}'))
+        for i in "${feServerArray[@]}"; do
+            val=${i}
+            val=${val// /}
+            tmpFeName=$(echo "${val}" | awk -F ':' '{ sub(/fe/, ""); sub(/ /, ""); print$1}')
+            tmpFeIp=$(echo "${val}" | awk -F ':' '{ sub(/ /, ""); print$2}')
+            tmpFeEditLogPort=$(echo "${val}" | awk -F ':' '{ sub(/ /, ""); print$3}')
+            check_arg "TMP_FE_NAME" $tmpFeName
+            feIpArray[$tmpFeName]=${tmpFeIp}
+        done
 
-      FE_MASTER_IP=${feIpArray[1]}
-      check_arg "FE_MASTER_IP" $FE_MASTER_IP
-      BE_IP=$(echo "${BE_ADDR}" | awk -F ':' '{ sub(/ /, ""); print$1}')
-      check_arg "BE_IP" $BE_IP
-      BE_PORT=$(echo "${BE_ADDR}" | awk -F ':' '{ sub(/ /, ""); print$2}')
-      check_arg "BE_PORT" $BE_PORT
+        FE_MASTER_IP=${feIpArray[1]}
+        check_arg "FE_MASTER_IP" $FE_MASTER_IP
+        BE_IP=$(echo "${BE_ADDR}" | awk -F ':' '{ sub(/ /, ""); print$1}')
+        check_arg "BE_IP" $BE_IP
+        BE_PORT=$(echo "${BE_ADDR}" | awk -F ':' '{ sub(/ /, ""); print$2}')
+        check_arg "BE_PORT" $BE_PORT
 
-  elif [ $RUN_TYPE == "ASSIGN" ]; then
-      check_arg "FE_MASTER_IP" $FE_MASTER_IP
-      check_arg "BE_IP" $BE_IP
-      check_arg "BE_PORT" $BE_PORT
-  fi
+    elif [ $RUN_TYPE == "ASSIGN" ]; then
+        check_arg "FE_MASTER_IP" $FE_MASTER_IP
+        check_arg "BE_IP" $BE_IP
+        check_arg "BE_PORT" $BE_PORT
+    fi
 
-  PRIORITY_NETWORKS=$(echo "${BE_IP}" | awk -F '.' '{print$1"."$2"."$3".0/24"}')
-  check_arg "PRIORITY_NETWORKS" $PRIORITY_NETWORKS
+    PRIORITY_NETWORKS=$(echo "${BE_IP}" | awk -F '.' '{print$1"."$2"."$3".0/24"}')
+    check_arg "PRIORITY_NETWORKS" $PRIORITY_NETWORKS
 
-  # export be args
-  export MASTER_FE_IP=${FE_MASTER_IP}
-  export CURRENT_BE_IP=${BE_IP}
-  export CURRENT_BE_PORT=${BE_PORT}
-  export PRIORITY_NETWORKS=${PRIORITY_NETWORKS}
+    # export be args
+    export MASTER_FE_IP=${FE_MASTER_IP}
+    export CURRENT_BE_IP=${BE_IP}
+    export CURRENT_BE_PORT=${BE_PORT}
+    export PRIORITY_NETWORKS=${PRIORITY_NETWORKS}
 
-  doris_note "MASTER_FE_IP ${MASTER_FE_IP}"
-  doris_note "CURRENT_BE_IP ${CURRENT_BE_IP}"
-  doris_note "CURRENT_BE_PORT ${CURRENT_BE_PORT}"
-  doris_note "PRIORITY_NETWORKS ${PRIORITY_NETWORKS}"
+    doris_note "MASTER_FE_IP ${MASTER_FE_IP}"
+    doris_note "CURRENT_BE_IP ${CURRENT_BE_IP}"
+    doris_note "CURRENT_BE_PORT ${CURRENT_BE_PORT}"
+    doris_note "PRIORITY_NETWORKS ${PRIORITY_NETWORKS}"
 
-  check_be_status true
+    check_be_status true
 }
 
 # Execute sql script, passed via stdin
@@ -162,32 +162,32 @@ docker_process_sql() {
 }
 
 check_be_status() {
-  set +e
-  for i in {1..300}; do
-    if [[ $1 == true ]]; then
-      docker_process_sql <<<"show frontends" | grep "[[:space:]]${MASTER_FE_IP}[[:space:]]"
-    else
-      docker_process_sql <<<"show backends" | grep "[[:space:]]${CURRENT_BE_IP}[[:space:]]" | grep "[[:space:]]${CURRENT_BE_PORT}[[:space:]]" | grep "[[:space:]]true[[:space:]]"
-    fi
-    be_join_status=$?
-    if [[ "${be_join_status}" == 0 ]]; then
-      if [[ $1 == true ]]; then
-        doris_note "MASTER FE is started!"
-      else
-        doris_note "EntryPoint Check - Verify that BE is registered to FE successfully"
-        BE_ALREADY_EXISTS=true
-      fi
-      return
-    fi
-    if [[ $(( $i % 20 )) == 1 ]]; then
-      if [[ $1 == true ]]; then
-        doris_note "MASTER FE is not started. retry."
-      else
-        doris_note "BE is not register. retry."
-      fi
-    fi
-    sleep 1
-  done
+    set +e
+    for i in {1..30}; do
+        if [[ $1 == true ]]; then
+            docker_process_sql <<<"show frontends" | grep "[[:space:]]${MASTER_FE_IP}[[:space:]]"
+        else
+            docker_process_sql <<<"show backends" | grep "[[:space:]]${CURRENT_BE_IP}[[:space:]]" | grep "[[:space:]]${CURRENT_BE_PORT}[[:space:]]" | grep "[[:space:]]true[[:space:]]"
+        fi
+        be_join_status=$?
+        if [[ "${be_join_status}" == 0 ]]; then
+            if [[ $1 == true ]]; then
+                doris_note "MASTER FE is started!"
+            else
+                doris_note "EntryPoint Check - Verify that BE is registered to FE successfully"
+                BE_ALREADY_EXISTS=true
+            fi
+            return
+        fi
+        if [[ $(( $i % 15 )) == 1 ]]; then
+            if [[ $1 == true ]]; then
+                doris_note "MASTER FE is not started. retry."
+            else
+                doris_note "BE is not register. retry."
+            fi
+        fi
+        sleep 1
+    done
 }
 
 # usage: docker_process_init_files [file [file [...]]]
@@ -240,9 +240,9 @@ docker_process_init_files() {
 # Check whether the passed parameters are empty to avoid subsequent task execution failures. At the same time,
 # enumeration checks can be added, such as checking whether a certain parameter appears repeatedly, etc.
 check_arg() {
-  if [ -z $2 ]; then
-    doris_error "$1 is null!"
-  fi
+    if [ -z $2 ]; then
+        doris_error "$1 is null!"
+    fi
 }
 
 _main() {

--- a/docker/runtime/be/resource/init_be.sh
+++ b/docker/runtime/be/resource/init_be.sh
@@ -28,67 +28,67 @@ DORIS_HOME="/opt/apache-doris"
 #    ie: doris_warn "task may be risky!"
 #   out: 2023-01-08T19:08:16+08:00 [Warn] [Entrypoint]: task may be risky!
 doris_log() {
-  local type="$1"
-  shift
-  # accept argument string or stdin
-  local text="$*"
-  if [ "$#" -eq 0 ]; then text="$(cat)"; fi
-  local dt="$(date -Iseconds)"
-  printf '%s [%s] [Entrypoint]: %s\n' "$dt" "$type" "$text"
+    local type="$1"
+    shift
+    # accept argument string or stdin
+    local text="$*"
+    if [ "$#" -eq 0 ]; then text="$(cat)"; fi
+    local dt="$(date -Iseconds)"
+    printf '%s [%s] [Entrypoint]: %s\n' "$dt" "$type" "$text"
 }
 doris_note() {
-  doris_log Note "$@"
+    doris_log Note "$@"
 }
 doris_warn() {
-  doris_log Warn "$@" >&2
+    doris_log Warn "$@" >&2
 }
 doris_error() {
-  doris_log ERROR "$@" >&2
-  exit 1
+    doris_log ERROR "$@" >&2
+    exit 1
 }
 
 # check to see if this file is being run or sourced from another script
 _is_sourced() {
-  [ "${#FUNCNAME[@]}" -ge 2 ] &&
+    [ "${#FUNCNAME[@]}" -ge 2 ] &&
     [ "${FUNCNAME[0]}" = '_is_sourced' ] &&
     [ "${FUNCNAME[1]}" = 'source' ]
 }
 
 docker_setup_env() {
-  declare -g DATABASE_ALREADY_EXISTS
-  if [ -d "${DORIS_HOME}/be/storage/data" ]; then
-    DATABASE_ALREADY_EXISTS='true'
-  fi
+    declare -g DATABASE_ALREADY_EXISTS
+    if [ -d "${DORIS_HOME}/be/storage/data" ]; then
+        DATABASE_ALREADY_EXISTS='true'
+    fi
 }
 
 add_priority_networks() {
-  doris_note "add priority_networks ${1} to ${DORIS_HOME}/be/conf/be.conf"
-  echo "priority_networks = ${1}" >>${DORIS_HOME}/be/conf/be.conf
+    doris_note "add priority_networks ${1} to ${DORIS_HOME}/be/conf/be.conf"
+    echo "priority_networks = ${1}" >>${DORIS_HOME}/be/conf/be.conf
 }
 
 show_be_args(){
-  doris_note "============= init args ================"
-  doris_note "MASTER_FE_IP " ${MASTER_FE_IP}
-  doris_note "CURRENT_BE_IP " ${CURRENT_BE_IP}
-  doris_note "CURRENT_BE_PORT " ${CURRENT_BE_PORT}
-  doris_note "RUN_TYPE " ${RUN_TYPE}
-  doris_note "PRIORITY_NETWORKS " ${PRIORITY_NETWORKS}
+    doris_note "============= init args ================"
+    doris_note "MASTER_FE_IP " ${MASTER_FE_IP}
+    doris_note "CURRENT_BE_IP " ${CURRENT_BE_IP}
+    doris_note "CURRENT_BE_PORT " ${CURRENT_BE_PORT}
+    doris_note "RUN_TYPE " ${RUN_TYPE}
+    doris_note "PRIORITY_NETWORKS " ${PRIORITY_NETWORKS}
 }
 
 # Execute sql script, passed via stdin
 # usage: docker_process_sql sql_script
 docker_process_sql() {
-  set +e
-  mysql -uroot -P9030 -h${MASTER_FE_IP} --comments "$@" 2>/dev/null
+    set +e
+    mysql -uroot -P9030 -h${MASTER_FE_IP} --comments "$@" 2>/dev/null
 }
 
 node_role_conf(){
-  if [[ ${NODE_ROLE} == 'computation' ]]; then
-    doris_note "this node role is computation"
-    echo "be_node_role=computation" >>${DORIS_HOME}/be/conf/be.conf
-  else
-    doris_note "this node role is mix"
-  fi
+    if [[ ${NODE_ROLE} == 'computation' ]]; then
+        doris_note "this node role is computation"
+        echo "be_node_role=computation" >>${DORIS_HOME}/be/conf/be.conf
+    else
+        doris_note "this node role is mix"
+    fi
 }
 
 register_be_to_fe() {
@@ -96,49 +96,49 @@ register_be_to_fe() {
     # check fe status
     local is_fe_start=false
     if [ -n "$DATABASE_ALREADY_EXISTS" ]; then
-      check_be_status
-      if [ -n "$BE_ALREADY_EXISTS" ]; then
-        doris_warn "Same backend already exists! No need to register again！"
-        return
-      fi
+        check_be_status
+        if [ -n "$BE_ALREADY_EXISTS" ]; then
+            doris_warn "Same backend already exists! No need to register again！"
+            return
+        fi
     fi
-    for i in {1..300}; do
-      docker_process_sql <<<"alter system add backend '${CURRENT_BE_IP}:${CURRENT_BE_PORT}'"
-      register_be_status=$?
-      if [[ $register_be_status == 0 ]]; then
-        doris_note "BE successfully registered to FE！"
-        is_fe_start=true
-        return
-      fi
-      if [[ $(( $i % 20 )) == 1 ]]; then
-        doris_note "Register BE to FE is failed. retry."
-      fi
-      sleep 1
+    for i in {1..30}; do
+        docker_process_sql <<<"alter system add backend '${CURRENT_BE_IP}:${CURRENT_BE_PORT}'"
+        register_be_status=$?
+        if [[ $register_be_status == 0 ]]; then
+            doris_note "BE successfully registered to FE！"
+            is_fe_start=true
+            return
+        fi
+        if [[ $(( $i % 15 )) == 1 ]]; then
+            doris_note "Register BE to FE is failed. retry."
+        fi
+        sleep 1
     done
     if ! [[ $is_fe_start ]]; then
-      doris_error "Failed to register BE to FE！Tried 30 times！Maybe FE Start Failed！"
+        doris_error "Failed to register BE to FE！Tried 30 times！Maybe FE Start Failed！"
     fi
 }
 
 check_be_status() {
     set +e
     local is_fe_start=false
-    for i in {1..300}; do
-      if [[ $(($i % 20)) == 1 ]]; then
-        doris_warn "start check be register status~"
-      fi
-      docker_process_sql <<<"show backends;" | grep "[[:space:]]${CURRENT_BE_IP}[[:space:]]" | grep "[[:space:]]${CURRENT_BE_PORT}[[:space:]]"
-      be_join_status=$?
-      if [[ "${be_join_status}" == 0 ]]; then
-        doris_note "Verify that BE is registered to FE successfully"
-        is_fe_start=true
-        return
-      else
-      if [[ $(($i % 20)) == 1 ]]; then
-        doris_note "register is failed, wait next~"
-      fi
-      fi
-      sleep 1
+    for i in {1..30}; do
+        if [[ $(($i % 15)) == 1 ]]; then
+            doris_warn "start check be register status~"
+        fi
+        docker_process_sql <<<"show backends;" | grep "[[:space:]]${CURRENT_BE_IP}[[:space:]]" | grep "[[:space:]]${CURRENT_BE_PORT}[[:space:]]"
+        be_join_status=$?
+        if [[ "${be_join_status}" == 0 ]]; then
+            doris_note "Verify that BE is registered to FE successfully"
+            is_fe_start=true
+            return
+        else
+            if [[ $(($i % 15)) == 1 ]]; then
+                doris_note "register is failed, wait next~"
+            fi
+        fi
+        sleep 1
     done
     if [[ ! $is_fe_start ]]; then
         doris_error "Failed to register BE to FE！Tried 30 times！Maybe FE Start Failed！"
@@ -154,10 +154,10 @@ _main() {
     trap 'cleanup' SIGTERM SIGINT
     docker_setup_env
     if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
-      add_priority_networks $PRIORITY_NETWORKS
-      node_role_conf
-      show_be_args
-      register_be_to_fe
+        add_priority_networks $PRIORITY_NETWORKS
+        node_role_conf
+        show_be_args
+        register_be_to_fe
     fi
     check_be_status
     doris_note "Ready to start BE！"
@@ -168,5 +168,5 @@ _main() {
 }
 
 if ! _is_sourced; then
-  _main "$@"
+    _main "$@"
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Master PR: #45308 

Problem Summary:

Adjust the indentation format of the `init_be` and `entry_point` scripts, as well as the duration of loop execution.
Adjust the smallest unit of all indentations to a single tab character, and modify the loop duration when checking the BE startup status, changing both from 300 seconds to 30 seconds to speed up the overall Docker startup time.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

