### PR TITLE
[enhancement](blacklist) ignore shutdown message to avoid add the backend to blacklist

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiver.java
@@ -179,7 +179,10 @@ public class ResultReceiver {
                 status.updateStatus(TStatusCode.TIMEOUT, e.getMessage());
             } else {
                 status.updateStatus(TStatusCode.THRIFT_RPC_ERROR, e.getMessage());
-                SimpleScheduler.addToBlacklist(backendId, e.getMessage());
+                // Shutdown maybe called by other request, should ignore this case.
+                if (!e.getMessage().contains("shutdown")) {
+                    SimpleScheduler.addToBlacklist(backendId, e.getMessage());
+                }
             }
         } catch (TimeoutException e) {
             LOG.warn("fetch result timeout, finstId={}", DebugUtil.printId(finstId), e);


### PR DESCRIPTION
### What problem does this PR solve?

1. If one request failed to send fragment to BE then it will call removeProxy;
2. removeProxy will call shutdown and shutdown will cancel all requests related with this client.
3. Other request will get exception when receive data from be and will add this be to blacklist.

Should avoid this scenario.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

