### PR TITLE
[fix](variant) disable column name with dot character for variant type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -325,6 +325,11 @@ public class CreateTableStmt extends DdlStmt implements NotFallbackInParser {
                 throw new AnalysisException(
                         "Disable to create table column with name start with __DORIS_: " + columnNameUpperCase);
             }
+            if (Objects.equals(columnDef.getType(), Type.VARIANT) && columnNameUpperCase.indexOf('.') != -1) {
+                throw new AnalysisException(
+                        "Disable to create table of `VARIANT` type column named with a `.` character: "
+                                + columnNameUpperCase);
+            }
             if (Objects.equals(columnDef.getType(), Type.DATE) && Config.disable_datev1) {
                 throw new AnalysisException("Disable to create table with `DATE` type columns, please use `DATEV2`.");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
@@ -313,6 +313,11 @@ public class CreateTableInfo {
                 throw new AnalysisException(
                         "Disable to create table column with name start with __DORIS_: " + columnNameUpperCase);
             }
+            if (columnDef.getType().isVariantType() && columnNameUpperCase.indexOf('.') != -1) {
+                throw new AnalysisException(
+                        "Disable to create table of `VARIANT` type column named with a `.` character: "
+                                + columnNameUpperCase);
+            }
             if (columnDef.getType().isDateType() && Config.disable_datev1) {
                 throw new AnalysisException(
                         "Disable to create table with `DATE` type columns, please use `DATEV2`.");

--- a/regression-test/suites/ddl_p0/test_create_table.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table.groovy
@@ -46,6 +46,21 @@ suite("sql_create_time_range_table") {
 	);
 		"""
 
+    // variant type column named with '.' character is disabled
+    sql "DROP TABLE IF EXISTS disable_variant_column_with_dot"
+    test {
+        sql """
+            CREATE TABLE disable_variant_column_with_dot (
+                k int,
+                `v1.v2` variant
+            )
+            DUPLICATE KEY (`k`)
+            DISTRIBUTED BY HASH(`k`) BUCKETS 1
+            PROPERTIES ( "replication_num" = "1");
+        """
+        exception "Disable to create table"
+    }
+
     // DDL/DML return 1 row and 1 column, the only value is update row count
     assertTrue(result1.size() == 1)
     assertTrue(result1[0].size() == 1)
@@ -58,4 +73,19 @@ suite("sql_create_time_range_table") {
     def res_show = sql "show create table varchar_0_char_0"
     mustContain(res_show[0][1], "varchar(65533)")
     mustContain(res_show[0][1], "char(1)")
+
+    // variant type column named with '.' character is disabled
+    sql "DROP TABLE IF EXISTS disable_variant_column_with_dot"
+    test {
+        sql """
+            CREATE TABLE disable_variant_column_with_dot (
+                k int,
+                `v1.v2` variant
+            )
+            DUPLICATE KEY (`k`)
+            DISTRIBUTED BY HASH(`k`) BUCKETS 1
+            PROPERTIES ( "replication_num" = "1");
+        """
+        exception "Disable to create table"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/apache/doris/issues/44882

Variant type column named with '.' character make be crashed, here disable it temporarily.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

