### PR TITLE
[fix](sql) enable_unique_key_skip_bitmap_column should be show correctly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3618,8 +3618,7 @@ public class Env {
         }
 
         // enable_unique_key_skip_bitmap, always print this property for merge-on-write unique table
-        if (olapTable.getKeysType() == KeysType.UNIQUE_KEYS && olapTable.getEnableUniqueKeyMergeOnWrite()
-                && olapTable.getEnableUniqueKeySkipBitmap()) {
+        if (olapTable.getKeysType() == KeysType.UNIQUE_KEYS) {
             sb.append(",\n\"").append(PropertyAnalyzer.ENABLE_UNIQUE_KEY_SKIP_BITMAP_COLUMN).append("\" = \"");
             sb.append(olapTable.getEnableUniqueKeySkipBitmap()).append("\"");
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowCreateTableStmtTest.java
@@ -32,14 +32,17 @@ public class ShowCreateTableStmtTest extends TestWithFeService {
         createDatabase("test");
         useDatabase("test");
         createTable("create table table1\n"
-                + "(k1 int comment 'test column k1', k2 int comment 'test column k2', `timestamp` DATE NOT NULL COMMENT '[''0000-01-01'', ''9999-12-31'']')  comment 'test table1' "
+                + "(k1 int comment 'test column k1', k2 int comment 'test column k2', `timestamp` DATE NOT NULL COMMENT '[''0000-01-01'', ''9999-12-31'']')\n"
+                + "UNIQUE KEY(`k1`)\n"
+                + "comment 'test table1'\n"
                 + "PARTITION BY RANGE(`k1`)\n"
                 + "(\n"
                 + "    PARTITION `p01` VALUES LESS THAN (\"10\"),\n"
                 + "    PARTITION `p02` VALUES LESS THAN (\"100\")\n"
                 + ") "
                 + "distributed by hash(k1) buckets 1\n"
-                + "properties(\"replication_num\" = \"1\");");
+                + "properties(\"replication_num\" = \"1\", \"enable_unique_key_skip_bitmap_column\" = \"false\", "
+                + "\"enable_unique_key_merge_on_write\" = \"true\");");
     }
 
 
@@ -70,4 +73,14 @@ public class ShowCreateTableStmtTest extends TestWithFeService {
         Assertions.assertTrue(!showSql.contains("PARTITION BY"));
         Assertions.assertTrue(!showSql.contains("PARTITION `p01`"));
     }
+
+    @Test
+    public void testProperty() throws Exception {
+        String sql = "show create table table1";
+        ShowResultSet showResultSet = showCreateTable(sql);
+        String showSql = showResultSet.getResultRows().get(0).get(1);
+        Assertions.assertTrue(showSql.contains("\"enable_unique_key_merge_on_write\" = \"true\""));
+        Assertions.assertTrue(showSql.contains("\"enable_unique_key_skip_bitmap_column\" = \"false\""));
+    }
+
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

