### PR TITLE
[fix](auth)Fix the compatibility issue with show_view_priv when replaying editLog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -658,17 +658,19 @@ public class Auth implements Writable {
 
     public void replayGrant(PrivInfo privInfo) {
         try {
+            PrivBitSet privs = privInfo.getPrivs();
+            Role.compatibilityAuthIndexChange(privs);
             if (privInfo.getTblPattern() != null) {
                 grantInternal(privInfo.getUserIdent(), privInfo.getRole(),
-                        privInfo.getTblPattern(), privInfo.getPrivs(), privInfo.getColPrivileges(),
+                        privInfo.getTblPattern(), privs, privInfo.getColPrivileges(),
                         true /* err on non exist */, true /* is replay */);
             } else if (privInfo.getResourcePattern() != null) {
                 grantInternal(privInfo.getUserIdent(), privInfo.getRole(),
-                        privInfo.getResourcePattern(), privInfo.getPrivs(),
+                        privInfo.getResourcePattern(), privs,
                         true /* err on non exist */, true /* is replay */);
             } else if (privInfo.getWorkloadGroupPattern() != null) {
                 grantInternal(privInfo.getUserIdent(), privInfo.getRole(),
-                        privInfo.getWorkloadGroupPattern(), privInfo.getPrivs(),
+                        privInfo.getWorkloadGroupPattern(), privs,
                         true /* err on non exist */, true /* is replay */);
             } else {
                 grantInternal(privInfo.getUserIdent(), privInfo.getRoles(), true);
@@ -843,14 +845,16 @@ public class Auth implements Writable {
 
     public void replayRevoke(PrivInfo info) {
         try {
+            PrivBitSet privs = info.getPrivs();
+            Role.compatibilityAuthIndexChange(privs);
             if (info.getTblPattern() != null) {
-                revokeInternal(info.getUserIdent(), info.getRole(), info.getTblPattern(), info.getPrivs(),
+                revokeInternal(info.getUserIdent(), info.getRole(), info.getTblPattern(), privs,
                         info.getColPrivileges(), true /* err on non exist */, true /* is replay */);
             } else if (info.getResourcePattern() != null) {
-                revokeInternal(info.getUserIdent(), info.getRole(), info.getResourcePattern(), info.getPrivs(),
+                revokeInternal(info.getUserIdent(), info.getRole(), info.getResourcePattern(), privs,
                         true /* err on non exist */, true /* is replay */);
             } else if (info.getWorkloadGroupPattern() != null) {
-                revokeInternal(info.getUserIdent(), info.getRole(), info.getWorkloadGroupPattern(), info.getPrivs(),
+                revokeInternal(info.getUserIdent(), info.getRole(), info.getWorkloadGroupPattern(), privs,
                         true /* err on non exist */, true /* is replay */);
             } else {
                 revokeInternal(info.getUserIdent(), info.getRoles(), true /* is replay */);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -1128,6 +1128,9 @@ public class Role implements Writable, GsonPostProcessable {
     }
 
     public static void compatibilityAuthIndexChange(PrivBitSet privBitSet) {
+        if (privBitSet == null) {
+            return;
+        }
         int currentVersion = Env.getCurrentEnvJournalVersion();
         // not cloud mode,
         // For versions greater than VERSION_123,

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -1111,50 +1111,64 @@ public class Role implements Writable, GsonPostProcessable {
 
         LOG.info("auth into compatibility logic, currentVersion={}", currentVersion);
         if (Config.isNotCloudMode() && currentVersion >= FeMetaVersion.VERSION_129) {
-            // not cloud mode,
-            // For versions greater than VERSION_123,
-            // the community requires versions above VERSION_129 to follow compatibility logic.
-
-            // SHOW_VIEW_PRIV_DEPRECATED -> SHOW_VIEW_PRIV (9 -> 14)
             tblPatternToPrivs.values().forEach(privBitSet -> {
-                if (privBitSet.containsPrivs(Privilege.SHOW_VIEW_PRIV_DEPRECATED)) {
-                    // remove SHOW_VIEW_PRIV_DEPRECATED
-                    privBitSet.unset(Privilege.SHOW_VIEW_PRIV_DEPRECATED.getIdx());
-                    // add SHOW_VIEW_PRIV
-                    privBitSet.set(Privilege.SHOW_VIEW_PRIV.getIdx());
-                }
+                compatibilityAuthIndexChange(privBitSet);
             });
+        } else if (Config.isCloudMode()) {
+            clusterPatternToPrivs.values().forEach(privBitSet -> {
+                compatibilityAuthIndexChange(privBitSet);
+            });
+            stagePatternToPrivs.values().forEach(privBitSet -> {
+                compatibilityAuthIndexChange(privBitSet);
+            });
+            tblPatternToPrivs.values().forEach(privBitSet -> {
+                compatibilityAuthIndexChange(privBitSet);
+            });
+        }
+    }
+
+    public static void compatibilityAuthIndexChange(PrivBitSet privBitSet) {
+        int currentVersion = Env.getCurrentEnvJournalVersion();
+        // not cloud mode,
+        // For versions greater than VERSION_123,
+        // the community requires versions above VERSION_129 to follow compatibility logic.
+
+        // SHOW_VIEW_PRIV_DEPRECATED -> SHOW_VIEW_PRIV (9 -> 14)
+        if (Config.isNotCloudMode() && currentVersion >= FeMetaVersion.VERSION_129) {
+            if (privBitSet.containsPrivs(Privilege.SHOW_VIEW_PRIV_DEPRECATED)) {
+                // remove SHOW_VIEW_PRIV_DEPRECATED
+                privBitSet.unset(Privilege.SHOW_VIEW_PRIV_DEPRECATED.getIdx());
+                // add SHOW_VIEW_PRIV
+                privBitSet.set(Privilege.SHOW_VIEW_PRIV.getIdx());
+            }
         } else if (Config.isCloudMode()) {
             // cloud mode
             // For versions greater than VERSION_123, the cloud requires compatibility logic.
 
             // CLUSTER_USAGE_PRIV_DEPRECATED -> CLUSTER_USAGE_PRIV (9 -> 12)
-            clusterPatternToPrivs.values().forEach(privBitSet -> {
-                if (privBitSet.containsPrivs(Privilege.CLUSTER_USAGE_PRIV_DEPRECATED)) {
-                    // remove CLUSTER_USAGE_PRIV_DEPRECATED
-                    privBitSet.unset(Privilege.CLUSTER_USAGE_PRIV_DEPRECATED.getIdx());
-                    // add CLUSTER_USAGE_PRIV
-                    privBitSet.set(Privilege.CLUSTER_USAGE_PRIV.getIdx());
-                }
-            });
+
+            if (privBitSet.containsPrivs(Privilege.CLUSTER_USAGE_PRIV_DEPRECATED)) {
+                // remove CLUSTER_USAGE_PRIV_DEPRECATED
+                privBitSet.unset(Privilege.CLUSTER_USAGE_PRIV_DEPRECATED.getIdx());
+                // add CLUSTER_USAGE_PRIV
+                privBitSet.set(Privilege.CLUSTER_USAGE_PRIV.getIdx());
+            }
+
             // STAGE_USAGE_PRIV_DEPRECATED -> STAGE_USAGE_PRIV (10 -> 13)
-            stagePatternToPrivs.values().forEach(privBitSet -> {
-                if (privBitSet.containsPrivs(Privilege.STAGE_USAGE_PRIV_DEPRECATED)) {
-                    // remove CLUSTER_USAGE_PRIV_DEPRECATED
-                    privBitSet.unset(Privilege.STAGE_USAGE_PRIV_DEPRECATED.getIdx());
-                    // add CLUSTER_USAGE_PRIV
-                    privBitSet.set(Privilege.STAGE_USAGE_PRIV.getIdx());
-                }
-            });
+            if (privBitSet.containsPrivs(Privilege.STAGE_USAGE_PRIV_DEPRECATED)) {
+                // remove CLUSTER_USAGE_PRIV_DEPRECATED
+                privBitSet.unset(Privilege.STAGE_USAGE_PRIV_DEPRECATED.getIdx());
+                // add CLUSTER_USAGE_PRIV
+                privBitSet.set(Privilege.STAGE_USAGE_PRIV.getIdx());
+            }
+
             // SHOW_VIEW_PRIV_CLOUD_DEPRECATED -> SHOW_VIEW_PRIV (11 -> 14)
-            tblPatternToPrivs.values().forEach(privBitSet -> {
-                if (privBitSet.containsPrivs(Privilege.SHOW_VIEW_PRIV_CLOUD_DEPRECATED)) {
-                    // remove SHOW_VIEW_PRIV_CLOUD_DEPRECATED
-                    privBitSet.unset(Privilege.SHOW_VIEW_PRIV_CLOUD_DEPRECATED.getIdx());
-                    // add SHOW_VIEW_PRIV
-                    privBitSet.set(Privilege.SHOW_VIEW_PRIV.getIdx());
-                }
-            });
+            if (privBitSet.containsPrivs(Privilege.SHOW_VIEW_PRIV_CLOUD_DEPRECATED)) {
+                // remove SHOW_VIEW_PRIV_CLOUD_DEPRECATED
+                privBitSet.unset(Privilege.SHOW_VIEW_PRIV_CLOUD_DEPRECATED.getIdx());
+                // add SHOW_VIEW_PRIV
+                privBitSet.set(Privilege.SHOW_VIEW_PRIV.getIdx());
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

The previous version showed an index of 9 for show_view_priv, while the new version has an index of 14
The previous logic was only compatible with the playback logic of images, not with the playback logic of editLog


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fix the compatibility issue with show_view_priv when replaying editLog
### Release note
Fix the compatibility issue with show_view_priv when replaying editLog

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
           - use doris2.1 create user and grant show_view_priv on xx.xx to userxxx;
           - use doris master revoke show_view_priv on xx.xx from userxxx;
           - show grants for userxxx; show_view_priv has been disappear
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

