### PR TITLE
[Bug](auto-partition) fix auto partition could set storage_medium properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionExprUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionExprUtil.java
@@ -189,13 +189,9 @@ public class PartitionExprUtil {
 
             SinglePartitionDesc singleRangePartitionDesc = new SinglePartitionDesc(true, partitionName,
                     partitionKeyDesc, partitionProperties);
-            // as the auto partition table maybe no any partitions firstly, it's should same
-            // as table's storage medium rather than default storage medium
-            if (!olapTable.getStorageMedium()
-                    .equals(singleRangePartitionDesc.getPartitionDataProperty().getStorageMedium())) {
-                singleRangePartitionDesc.getPartitionDataProperty().setStorageMedium(olapTable.getStorageMedium());
-                singleRangePartitionDesc.getPartitionDataProperty().setStorageMediumSpecified(
-                        !olapTable.getStorageMedium().equals(DataProperty.DEFAULT_STORAGE_MEDIUM));
+            // iff table's storage medium is not equal default storage medium,
+            // should add storage medium in partition properties
+            if (!DataProperty.DEFAULT_STORAGE_MEDIUM.equals(olapTable.getStorageMedium())) {
                 partitionProperties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM,
                         olapTable.getStorageMedium().name());
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -55,7 +55,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -232,7 +232,8 @@ public class FrontendServiceImplTest {
         TGetDbsResult dbNames = impl.getDbNames(params);
 
         Assert.assertEquals(dbNames.getDbs().size(), 2);
-        Assert.assertEquals(dbNames.getDbs(), Arrays.asList("test", "test_"));
+        Assert.assertTrue(dbNames.getDbs().contains("test"));
+        Assert.assertTrue(dbNames.getDbs().contains("test_"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.ConfigBase;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
@@ -135,6 +136,7 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testCreatePartitionRangeMedium() throws Exception {
+        ConfigBase.setMutableConfig("disable_storage_medium_check", "true");
         String createOlapTblStmt = new String("CREATE TABLE test.partition_range2(\n"
                 + "    event_day DATETIME NOT NULL,\n"
                 + "    site_id INT DEFAULT '10',\n"

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_range_partition.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_range_partition.groovy
@@ -243,28 +243,4 @@ suite("test_auto_range_partition") {
         sql "insert into awh_test_range_auto values (1,'20201212')"
         exception "date_trunc function second param only support argument is"
     }
-
-    sql "drop table if exists DAILY_TRADE_VALUE"
-    sql """
-        CREATE TABLE `DAILY_TRADE_VALUE`
-        (
-            `TRADE_DATE`              datev2 NOT NULL COMMENT '交易日期',
-            `TRADE_ID`                varchar(40) NOT NULL COMMENT '交易编号'
-        )
-        UNIQUE KEY(`TRADE_DATE`, `TRADE_ID`)
-        AUTO PARTITION BY RANGE (date_trunc(`TRADE_DATE`, 'year'))
-        (
-        )
-        DISTRIBUTED BY HASH(`TRADE_DATE`) BUCKETS 10
-        PROPERTIES (
-        "storage_medium" = "ssd",
-        "replication_num" = "1"
-        );
-    """
-    sql " insert into DAILY_TRADE_VALUE values ('2022-02-02','asd'); "
-    result2 = sql "show partitions from DAILY_TRADE_VALUE"
-    logger.info("${result2}")
-    assertEquals(result2.size(), 1)
-    // check storage medium, and have check the pipeline P0 disk is all ssd
-    assertEquals(result2[0][10], "SSD")
 }

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_range_partition.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_range_partition.groovy
@@ -243,4 +243,28 @@ suite("test_auto_range_partition") {
         sql "insert into awh_test_range_auto values (1,'20201212')"
         exception "date_trunc function second param only support argument is"
     }
+
+    sql "drop table if exists DAILY_TRADE_VALUE"
+    sql """
+        CREATE TABLE `DAILY_TRADE_VALUE`
+        (
+            `TRADE_DATE`              datev2 NOT NULL COMMENT '交易日期',
+            `TRADE_ID`                varchar(40) NOT NULL COMMENT '交易编号'
+        )
+        UNIQUE KEY(`TRADE_DATE`, `TRADE_ID`)
+        AUTO PARTITION BY RANGE (date_trunc(`TRADE_DATE`, 'year'))
+        (
+        )
+        DISTRIBUTED BY HASH(`TRADE_DATE`) BUCKETS 10
+        PROPERTIES (
+        "storage_medium" = "ssd",
+        "replication_num" = "1"
+        );
+    """
+    sql " insert into DAILY_TRADE_VALUE values ('2022-02-02','asd'); "
+    result2 = sql "show partitions from DAILY_TRADE_VALUE"
+    logger.info("${result2}")
+    assertEquals(result2.size(), 1)
+    // check storage medium, and have check the pipeline P0 disk is all ssd
+    assertEquals(result2[0][10], "SSD")
 }


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
 as the auto partition table maybe no any partitions firstly, it's should same as table's storage medium rather than   default storage medium, maybe user have change different from default value.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

