### PR TITLE
[Fix](Iceberg)Fix HDFS FileSystem Leak Caused by Frequent Refresh of Iceberg Catalog

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticator.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticator.java
@@ -35,10 +35,6 @@ public interface HadoopAuthenticator {
     }
 
     static HadoopAuthenticator getHadoopAuthenticator(AuthenticationConfig config) {
-        if (config instanceof KerberosAuthenticationConfig) {
-            return new HadoopKerberosAuthenticator((KerberosAuthenticationConfig) config);
-        } else {
-            return new HadoopSimpleAuthenticator((SimpleAuthenticationConfig) config);
-        }
+        return HadoopAuthenticatorManager.getAuthenticator(config);
     }
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticatorManager.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticatorManager.java
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.security.authentication;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * HadoopAuthenticatorManager is a centralized manager responsible for managing and reusing instances
+ * of {@link HadoopAuthenticator}. It ensures that authenticators are created and cached based on
+ * the given {@link AuthenticationConfig} to minimize redundant authenticator and resource creation.
+ *
+ * <p>Key Features:</p>
+ * <ul>
+ *   <li>Uses a {@link ConcurrentHashMap} to cache authenticators and avoid creating duplicates.</li>
+ *   <li>Supports different authentication mechanisms, such as Kerberos and Simple Authentication.</li>
+ *   <li>Provides a unified entry point to retrieve a {@link HadoopAuthenticator} instance
+ *       based on the given {@link AuthenticationConfig}.</li>
+ * </ul>
+ *
+ * <p>How It Works:</p>
+ * <ol>
+ *   <li>When a new {@link AuthenticationConfig} is passed to {@code getAuthenticator},
+ *       it checks if an existing authenticator is cached for the configuration.</li>
+ *   <li>If an authenticator exists, it is returned directly.</li>
+ *   <li>If not, a new authenticator is created using {@code createAuthenticator} and cached for future use.</li>
+ * </ol>
+ *
+ * <p>This design helps optimize resource usage, particularly when working with file systems
+ * that depend on authentication mechanisms (e.g., Hadoop's {@link org.apache.hadoop.security.UserGroupInformation}).
+ * </p>
+ *
+ * <p>Note:</p>
+ * <ul>
+ *   <li>Ensure that {@link AuthenticationConfig} implementations have properly implemented
+ *       {@code equals} and {@code hashCode} to guarantee correct caching behavior.</li>
+ *   <li>The class is thread-safe, leveraging the thread-safety guarantees of {@link ConcurrentHashMap}.</li>
+ * </ul>
+ *
+ * @see HadoopAuthenticator
+ * @see AuthenticationConfig
+ * @see KerberosAuthenticationConfig
+ * @see SimpleAuthenticationConfig
+ */
+public class HadoopAuthenticatorManager {
+    private static final Logger LOG = LogManager.getLogger(HadoopAuthenticatorManager.class);
+
+    private static final ConcurrentHashMap<AuthenticationConfig, HadoopAuthenticator> authenticatorMap =
+            new ConcurrentHashMap<>();
+
+    public static HadoopAuthenticator getAuthenticator(AuthenticationConfig config) {
+        return authenticatorMap.computeIfAbsent(config, HadoopAuthenticatorManager::createAuthenticator);
+    }
+
+    private static HadoopAuthenticator createAuthenticator(AuthenticationConfig config) {
+        LOG.info("Creating a new authenticator.");
+        if (config instanceof KerberosAuthenticationConfig) {
+            return new HadoopKerberosAuthenticator((KerberosAuthenticationConfig) config);
+        } else if (config instanceof SimpleAuthenticationConfig) {
+            return new HadoopSimpleAuthenticator((SimpleAuthenticationConfig) config);
+        } else {
+            throw new IllegalArgumentException("Unsupported AuthenticationConfig type: " + config.getClass().getName());
+        }
+    }
+}
+

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/KerberosAuthenticationConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/KerberosAuthenticationConfig.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
+import java.util.Objects;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class KerberosAuthenticationConfig extends AuthenticationConfig {
@@ -33,5 +35,24 @@ public class KerberosAuthenticationConfig extends AuthenticationConfig {
     @Override
     public boolean isValid() {
         return StringUtils.isNotEmpty(kerberosPrincipal) && StringUtils.isNotEmpty(kerberosKeytab);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KerberosAuthenticationConfig that = (KerberosAuthenticationConfig) o;
+        return printDebugLog == that.printDebugLog && Objects.equals(kerberosPrincipal, that.kerberosPrincipal)
+                && Objects.equals(kerberosKeytab, that.kerberosKeytab)
+                && Objects.equals(conf, that.conf);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kerberosPrincipal, kerberosKeytab, conf, printDebugLog);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/security/authentication/AuthenticationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/security/authentication/AuthenticationTest.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.security.authentication;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AuthenticationTest {
+
+    @Test
+    public void testAuthConf() {
+        Configuration conf = new Configuration();
+        AuthenticationConfig conf1 = AuthenticationConfig.getKerberosConfig(conf);
+        Assert.assertEquals(SimpleAuthenticationConfig.class, conf1.getClass());
+
+        conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+
+        AuthenticationConfig conf2 = AuthenticationConfig.getKerberosConfig(conf);
+        Assert.assertEquals(SimpleAuthenticationConfig.class, conf2.getClass());
+
+        conf.set(AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL, "principal");
+        conf.set(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB, "keytab");
+
+        AuthenticationConfig conf3 = AuthenticationConfig.getKerberosConfig(conf);
+        Assert.assertEquals(KerberosAuthenticationConfig.class, conf3.getClass());
+    }
+
+
+    @Test
+    public void testAuthConf2() {
+        Configuration conf1 = new Configuration();
+        conf1.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+        conf1.set(AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL, "principal");
+        conf1.set(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB, "keytab");
+        AuthenticationConfig authenticationConfig1 = AuthenticationConfig.getKerberosConfig(conf1);
+        AuthenticationConfig authenticationConfig2 = AuthenticationConfig.getKerberosConfig(conf1);
+        Assert.assertEquals(authenticationConfig1.equals(authenticationConfig2), true);
+        Assert.assertEquals(authenticationConfig1, authenticationConfig2);
+        HadoopAuthenticator authenticator1 = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig1);
+        HadoopAuthenticator authenticator2 = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig2);
+        Assert.assertEquals(authenticator1, authenticator2);
+        Configuration conf2 = new Configuration();
+        conf2.set(AuthenticationConfig.HADOOP_USER_NAME, "hadoop");
+        AuthenticationConfig authenticationConfig3 = AuthenticationConfig.getSimpleAuthenticationConfig(conf2);
+        AuthenticationConfig authenticationConfig4 = AuthenticationConfig.getSimpleAuthenticationConfig(conf2);
+        Assert.assertEquals(authenticationConfig3.getClass(), authenticationConfig4.getClass());
+        HadoopAuthenticator authenticator3 = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig3);
+        HadoopAuthenticator authenticator4 = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig4);
+        Assert.assertEquals(authenticator3, authenticator4);
+    }
+}


### PR DESCRIPTION


### Background
When using an HMS-based Iceberg Catalog, refreshing the Catalog frequently creates new HadoopAuthenticator instances. This leads to the following issues:

#### Frequent FileSystem Creation:
Iceberg uses Path.getFileSystem(Configuration) to obtain a FileSystem instance. Even though the Configuration remains unchanged, changes in the UserGroupInformation (UGI) cause new FileSystem instances to be created.

#### Resource Leakage:
```
Newly created FileSystem instances are not released, leading to increased resource consumption over time.

 198:          1978          72712  [Ljava.security.Principal;
 244:          2202          52848  javax.security.auth.kerberos.KerberosPrincipal
 418:           753          24096  sun.security.krb5.PrincipalName
 717:           391           9384  com.sun.security.auth.UnixNumericGroupPrincipal
 940:           382           6112  com.sun.security.auth.UnixNumericUserPrincipal
  64:          1158         240864  org.apache.hadoop.hdfs.client.impl.DfsClientConf
  99:          1155         147840  org.apache.hadoop.hdfs.DFSClient
 113:          1158         120432  org.apache.hadoop.hdfs.client.impl.DfsClientConf$ShortCircuitConf
 127:          3465         110880  org.apache.hadoop.hdfs.server.namenode.ha.AbstractNNFailoverProxyProvider$NNProxyInfo
 189:          1155          64680  org.apache.hadoop.hdfs.DistributedFileSystem
 204:           294          58800  org.apache.hadoop.hdfs.protocol.DatanodeInfoWithStorage
 215:          2310          55440  org.apache.hadoop.hdfs.server.datanode.CachingStrategy
```


#### Root Cause
Each Catalog refresh creates a new HadoopAuthenticator instance. Changes in the UGI contained in HadoopAuthenticator lead to the creation of new FileSystem instances, even when the Configuration is the same.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

