### PR TITLE
[enchement](mc)opt maxcompute read arrow skip repeated check of isNull

### DIFF
--- a/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
+++ b/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
@@ -52,8 +52,14 @@ import java.util.Objects;
  * MaxComputeJ JniScanner. BE will read data from the scanner object.
  */
 public class MaxComputeJniScanner extends JniScanner {
-    private static final Logger LOG = Logger.getLogger(MaxComputeJniScanner.class);
+    static {
+        //Set `NullCheckingForGet.NULL_CHECKING_ENABLED` false.
+        //We will call isNull() before calling getXXX(), so we can set this parameter
+        // to skip the repeated check of isNull().
+        System.setProperty("arrow.enable_null_check_for_get", "false");
+    }
 
+    private static final Logger LOG = Logger.getLogger(MaxComputeJniScanner.class);
 
     private static final String ACCESS_KEY = "access_key";
     private static final String SECRET_KEY = "secret_key";


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
Set MaxCompute Arrow `NullCheckingForGet.NULL_CHECKING_ENABLED` false.We will call isNull() before calling getXXX(), so we can set this parameter to skip the repeated check of isNull().

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

