### PR TITLE
[enhance](mtmv)When drop MTMV, no longer wait for task cancel to complete

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/Job.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/Job.java
@@ -101,7 +101,7 @@ public interface Job<T extends AbstractTask, C> {
      * Cancels all running tasks of this job.
      * @throws JobException If cancelling a running task fails.
      */
-    void cancelAllTasks() throws JobException;
+    void cancelAllTasks(boolean needWaitCancelComplete) throws JobException;
 
     /**
      * register job

--- a/fe/fe-core/src/main/java/org/apache/doris/job/executor/DispatchTaskHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/executor/DispatchTaskHandler.java
@@ -66,7 +66,7 @@ public class DispatchTaskHandler<T extends AbstractJob> implements WorkHandler<T
                 JobType jobType = event.getJob().getJobType();
                 for (AbstractTask task : tasks) {
                     if (!disruptorMap.get(jobType).addTask(task)) {
-                        task.cancel();
+                        task.cancel(true);
                         continue;
                     }
                     log.info("dispatch timer job success, job id is {},  task id is {}",

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -297,12 +297,12 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
     }
 
     @Override
-    public void cancelAllTasks() throws JobException {
+    public void cancelAllTasks(boolean needWaitCancelComplete) throws JobException {
         try {
             if (getJobConfig().getExecuteType().equals(JobExecuteType.INSTANT)) {
                 checkAuth("CANCEL LOAD");
             }
-            super.cancelAllTasks();
+            super.cancelAllTasks(needWaitCancelComplete);
             this.failMsg = new FailMsg(FailMsg.CancelType.USER_CANCEL, "user cancel");
         } catch (DdlException e) {
             throw new JobException(e);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -223,7 +223,7 @@ public class InsertTask extends AbstractTask {
     }
 
     @Override
-    protected void executeCancelLogic() {
+    protected void executeCancelLogic(boolean needWaitCancelComplete) {
         if (isFinished.get() || isCanceled.get()) {
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -300,10 +300,10 @@ public class MTMVTask extends AbstractTask {
     }
 
     @Override
-    protected synchronized void executeCancelLogic() {
+    protected synchronized void executeCancelLogic(boolean needWaitCancelComplete) {
         LOG.info("mtmv task cancel, taskId: {}", super.getTaskId());
         if (executor != null) {
-            executor.cancel(new Status(TStatusCode.CANCELLED, "mtmv task cancelled"));
+            executor.cancel(new Status(TStatusCode.CANCELLED, "mtmv task cancelled"), needWaitCancelComplete);
         }
         after();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/AbstractTask.java
@@ -129,16 +129,16 @@ public abstract class AbstractTask implements Task {
     /**
      * Cancels the ongoing task, updating its status to {@link TaskStatus#CANCELED} and releasing associated resources.
      * This method encapsulates the core cancellation logic, calling the abstract method
-     * {@link #executeCancelLogic()} for task-specific actions.
+     * {@link #executeCancelLogic(boolean)} for task-specific actions.
      *
      * @throws JobException If an error occurs during the cancellation process, a new JobException is thrown wrapping
      *                      the original exception.
      */
     @Override
-    public void cancel() throws JobException {
+    public void cancel(boolean needWaitCancelComplete) throws JobException {
         try {
             status = TaskStatus.CANCELED;
-            executeCancelLogic();
+            executeCancelLogic(needWaitCancelComplete);
         } catch (Exception e) {
             log.warn("cancel task failed, job id is {}, task id is {}", jobId, taskId, e);
             throw new JobException(e);
@@ -153,7 +153,7 @@ public abstract class AbstractTask implements Task {
      *
      * @throws Exception Any exception that might occur during the cancellation process in the subclass.
      */
-    protected abstract void executeCancelLogic() throws Exception;
+    protected abstract void executeCancelLogic(boolean needWaitCancelComplete) throws Exception;
 
     @Override
     public void before() throws JobException {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/task/Task.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/task/Task.java
@@ -63,8 +63,10 @@ public interface Task {
     /**
      * This method is called to cancel the execution of the task.
      * Implementations should define the necessary steps to cancel the task.
+     *
+     * @param needWaitCancelComplete Do we need to wait for the cancellation to be completed.
      */
-    void cancel() throws JobException;
+    void cancel(boolean needWaitCancelComplete) throws JobException;
 
     /**
      * get info for tvf `tasks`

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1586,7 +1586,7 @@ public class StmtExecutor {
     }
 
     // Because this is called by other thread
-    public void cancel(Status cancelReason) {
+    public void cancel(Status cancelReason, boolean needWaitCancelComplete) {
         if (masterOpExecutor != null) {
             try {
                 masterOpExecutor.cancel();
@@ -1610,10 +1610,14 @@ public class StmtExecutor {
         if (parsedStmt instanceof AnalyzeTblStmt || parsedStmt instanceof AnalyzeDBStmt) {
             Env.getCurrentEnv().getAnalysisManager().cancelSyncTask(context);
         }
-        if (insertOverwriteTableCommand.isPresent()) {
+        if (insertOverwriteTableCommand.isPresent() && needWaitCancelComplete) {
             // Wait for the command to run or cancel completion
             insertOverwriteTableCommand.get().waitNotRunning();
         }
+    }
+
+    public void cancel(Status cancelReason) {
+        cancel(cancelReason, true);
     }
 
     private Optional<InsertOverwriteTableCommand> getInsertOverwriteTableCommand() {


### PR DESCRIPTION
### What problem does this PR solve?

problem:
- when drop db, will hold write lock of catalog, and drop all MTMV 
- when drop MTMV, will drop Job, 
- when drop Job, will cancel all tasks in this Job
- when cancel task, if task is running insert overwrite, will wait for a long time

fix:
when drop job, not wait task cacncelled complete

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

