### PR TITLE
[fix](auth)Remove SerializedName tag of lock object in PasswordPolicy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PasswordPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PasswordPolicy.java
@@ -58,7 +58,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class PasswordPolicy implements Writable {
     private static final Logger LOG = LogManager.getLogger(PasswordPolicy.class);
 
-    @SerializedName(value = "lock")
     private ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     private static final String EXPIRATION_SECONDS = "password_policy.expiration_seconds";


### PR DESCRIPTION
### What problem does this PR solve?

lock object in PasswordPolicy is written to disk, when user upgrade from older version, this lock will be null, and cause user couldn't connect to Doris.

Code cause this issue in PasswordPolicy:

    @SerializedName(value = "lock")
    private ReentrantReadWriteLock lock = new ReentrantReadWriteLock();

Issue Number: close #xxx

Related PR: #44905

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

