### PR TITLE
[Fix]Fix query token  not release in NereidsCoordinator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -477,8 +477,8 @@ public class NereidsCoordinator extends Coordinator {
                     }
                     QueueToken queueToken = queryQueue.getToken();
                     int queryTimeout = coordinatorContext.queryOptions.getExecutionTimeout() * 1000;
-                    queueToken.get(DebugUtil.printId(coordinatorContext.queryId), queryTimeout);
                     coordinatorContext.setQueueInfo(queryQueue, queueToken);
+                    queueToken.get(DebugUtil.printId(coordinatorContext.queryId), queryTimeout);
                 }
             } else {
                 context.setWorkloadGroupName("");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
queueToken and queryQueue should set to coordinatorContext before query begins wait, or when query wait timeout, exception throws, coordinatorContext's queueToken and queryQueue is empty.
So queueToken can not be released correctly, this could cause query queue is always full and even no quey running, finally new queries can not be accessed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

