### PR TITLE
[fix](azure) let backup to azure work and use https for azure

### DIFF
--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -254,8 +254,8 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
             std::make_shared<Azure::Storage::StorageSharedKeyCredential>(s3_conf.ak, s3_conf.sk);
 
     const std::string container_name = s3_conf.bucket;
-    const std::string uri = fmt::format("{}://{}.blob.core.windows.net/{}",
-                                        "https", s3_conf.ak, container_name);
+    const std::string uri =
+            fmt::format("{}://{}.blob.core.windows.net/{}", "https", s3_conf.ak, container_name);
 
     auto containerClient = std::make_shared<Azure::Storage::Blobs::BlobContainerClient>(uri, cred);
     LOG_INFO("create one azure client with {}", s3_conf.to_string());

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -255,7 +255,7 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
 
     const std::string container_name = s3_conf.bucket;
     const std::string uri = fmt::format("{}://{}.blob.core.windows.net/{}",
-                                        config::s3_client_http_scheme, s3_conf.ak, container_name);
+                                        "https", s3_conf.ak, container_name);
 
     auto containerClient = std::make_shared<Azure::Storage::Blobs::BlobContainerClient>(uri, cred);
     LOG_INFO("create one azure client with {}", s3_conf.to_string());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StorageBackend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StorageBackend.java
@@ -152,6 +152,7 @@ public class StorageBackend implements ParseNode {
         GFS("Tencent Goose File System"),
         JFS("Juicefs"),
         STREAM("Stream load pipe"),
+        // decrepated
         AZURE("MicroSoft Azure Blob");
 
         @SerializedName("desc")

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -787,6 +787,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                         brokers.get(0),
                         S3ClientBEProperties.getBeFSProperties(repo.getRemoteFileSystem().getProperties()),
                         repo.getRemoteFileSystem().getStorageType(), repo.getLocation());
+                LOG.info("Remote file system properties: {}", repo.getRemoteFileSystem().getProperties());
                 batchTask.addTask(task);
                 unfinishedTaskIds.put(signature, beId);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -787,7 +787,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                         brokers.get(0),
                         S3ClientBEProperties.getBeFSProperties(repo.getRemoteFileSystem().getProperties()),
                         repo.getRemoteFileSystem().getStorageType(), repo.getLocation());
-                LOG.info("Remote file system properties: {}", repo.getRemoteFileSystem().getProperties());
                 batchTask.addTask(task);
                 unfinishedTaskIds.put(signature, beId);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -448,7 +448,8 @@ public class Repository implements Writable, GsonPostProcessable {
                 LOG.debug("get remote file: {} {}", remoteFile.getName(), listPathPrefix);
             }
             if (index == -1) {
-                LOG.info("glob list wrong results, prefix {}, file name {}", listPathPrefix, remoteFile.getName());
+                LOG.info("glob list wrong results, prefix {}, file name {}, full path is expected",
+                        listPathPrefix, remoteFile.getName());
                 continue;
             }
             String snapshotName = remoteFile.getName().substring(index + snapshotNameOffset + 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -453,13 +453,21 @@ public class Repository implements Writable, GsonPostProcessable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("get remote file: {} {}", remoteFilePath, listPathPrefix);
             }
-            if (index == -1) {
+            if (index == -1 || index == remoteFilePath.length() - 1) {
                 LOG.info("glob list wrong results, prefix {}, file name {}, full path is expected",
                         listPathPrefix, remoteFilePath);
                 continue;
             }
+
             String snapshotName = remoteFilePath.substring(index + snapshotNameOffset + 1);
             snapshotName = disjoinPrefix(PREFIX_SNAPSHOT_DIR, snapshotName);
+
+            // _ss_/a
+            int delimiterCount = snapshotName.length() - snapshotName.replace(PATH_DELIMITER, "").length();
+            if (delimiterCount != 1) {
+                LOG.info("Invalid snapshot name format, expected 1 PATH_DELIMITER, got {}", delimiterCount);
+                continue;
+            }
             index = snapshotName.indexOf(PATH_DELIMITER);
             if (index != -1) {
                 snapshotName = snapshotName.substring(0, index);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -88,7 +88,7 @@ public class BrokerUtil {
         try {
             RemoteFileSystem fileSystem = FileSystemFactory.get(
                     brokerDesc.getName(), brokerDesc.getStorageType(), brokerDesc.getProperties());
-            Status st = fileSystem.globList(path, rfiles, false);
+            Status st = fileSystem.globList(path, rfiles);
             if (!st.ok()) {
                 throw new UserException(st.getErrMsg());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/PropertyConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/PropertyConverter.java
@@ -265,7 +265,7 @@ public class PropertyConverter {
         }
         if (Strings.isNullOrEmpty(region)) {
             String errorMsg = String.format("No '%s' info found, using SDK default region: us-east-1", regionKey);
-            LOG.warn(errorMsg);
+            LOG.info(errorMsg);
             return "us-east-1";
         }
         return region;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/S3ClientBEProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/S3ClientBEProperties.java
@@ -85,6 +85,10 @@ public class S3ClientBEProperties {
         if (properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
             beProperties.put(PropertyConverter.USE_PATH_STYLE, properties.get(PropertyConverter.USE_PATH_STYLE));
         }
+        if (properties.containsKey(S3Properties.PROVIDER)) {
+            beProperties.put(S3Properties.PROVIDER, properties.get(S3Properties.PROVIDER));
+        }
+
         return beProperties;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
@@ -72,24 +72,11 @@ public interface FileSystem {
 
     /**
      * List files in remotePath by wildcard <br/>
-     * The {@link RemoteFile}'name will only contain file name (Not full path)
      * @param remotePath remote path
      * @param result All eligible files under the path
      * @return
      */
-    default Status globList(String remotePath, List<RemoteFile> result) {
-        return globList(remotePath, result, true);
-    }
-
-    /**
-     * List files in remotePath by wildcard <br/>
-     * @param remotePath remote path
-     * @param result All eligible files under the path
-     * @param fileNameOnly for {@link RemoteFile}'name: whether the full path is included.<br/>
-     *                     true: only contains file name, false: contains full path<br/>
-     * @return
-     */
-    Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly);
+    Status globList(String remotePath, List<RemoteFile> result);
 
     default Status listDirectories(String remotePath, Set<String> result) {
         throw new UnsupportedOperationException("Unsupported operation list directories on current file system.");

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/LocalDfsFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/LocalDfsFileSystem.java
@@ -134,7 +134,7 @@ public class LocalDfsFileSystem implements FileSystem {
     }
 
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+    public Status globList(String remotePath, List<RemoteFile> result) {
         try {
             FileStatus[] locatedFileStatusRemoteIterator = fs.globStatus(new Path(remotePath));
             if (locatedFileStatusRemoteIterator == null) {
@@ -142,7 +142,7 @@ public class LocalDfsFileSystem implements FileSystem {
             }
             for (FileStatus fileStatus : locatedFileStatusRemoteIterator) {
                 RemoteFile remoteFile = new RemoteFile(
-                        fileNameOnly ? fileStatus.getPath().getName() : fileStatus.getPath().toString(),
+                        fileStatus.getPath().toString(),
                         !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen(),
                         fileStatus.getBlockSize(), fileStatus.getModificationTime());
                 result.add(remoteFile);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -379,6 +379,7 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
         }
         return st;
     }
+
     public PagedResponse<BlobItem> getPagedBlobItems(BlobContainerClient client, ListBlobsOptions options,
                                                      String newContinuationToken) {
         PagedIterable<BlobItem> pagedBlobs = client.listBlobs(options, newContinuationToken, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -319,24 +319,12 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
         return globPattern.substring(0, earliestSpecialCharIndex);
     }
 
-    class MatcherContext {
-        public long elementCnt = 0;
-        public long matchCnt = 0;
-        public List<RemoteFile> result;
-        public boolean fileNameOnly;
-        public PathMatcher matcher;
-
-        public MatcherContext(List<RemoteFile> result, boolean fileNameOnly) {
-            this.result = result;
-            this.fileNameOnly = fileNameOnly;
-        }
-    }
-
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+    public Status globList(String remotePath, List<RemoteFile> result) {
+        long roundCnt = 0;
+        long elementCnt = 0;
+        long matchCnt = 0;
         long startTime = System.nanoTime();
         Status st = Status.OK;
-        MatcherContext matchContext = new MatcherContext(result, fileNameOnly);
-
         try {
             S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
             String globPath = uri.getKey();
@@ -347,11 +335,34 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
             LOG.info("path pattern {}", pathPattern.toString());
             PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pathPattern.toString());
 
-            matchContext.matcher = matcher;
             String listPrefix = getLongestPrefix(globPath);
             LOG.info("azure glob list prefix is {}", listPrefix);
+            ListBlobsOptions options = new ListBlobsOptions().setPrefix(listPrefix);
+            String newContinuationToken = null;
+            do {
+                roundCnt++;
+                PagedIterable<BlobItem> pagedBlobs = client.listBlobs(options, newContinuationToken, null);
+                PagedResponse<BlobItem> pagedResponse = pagedBlobs.iterableByPage().iterator().next();
 
-            listBlobsHierarchicalListing(client, listPrefix, matchContext);
+                for (BlobItem blobItem : pagedResponse.getElements()) {
+                    elementCnt++;
+                    java.nio.file.Path blobPath = Paths.get(blobItem.getName());
+
+                    if (!matcher.matches(blobPath)) {
+                        continue;
+                    }
+                    matchCnt++;
+                    RemoteFile remoteFile = new RemoteFile(
+                            constructS3Path(blobPath.toString(), uri.getBucket()),
+                            !blobItem.isPrefix(),
+                            blobItem.isPrefix() ? -1 : blobItem.getProperties().getContentLength(),
+                            blobItem.getProperties().getContentLength(),
+                            blobItem.getProperties().getLastModified().getSecond());
+                    result.add(remoteFile);
+                }
+                newContinuationToken = pagedResponse.getContinuationToken();
+            } while (newContinuationToken != null);
+
         } catch (BlobStorageException e) {
             LOG.warn("glob file " + remotePath + " failed because azure error: " + e.getMessage());
             st = new Status(Status.ErrCode.COMMON_ERROR, "glob file " + remotePath
@@ -362,12 +373,12 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
         } finally {
             long endTime = System.nanoTime();
             long duration = endTime - startTime;
-            LOG.info("process {} elements under prefix {}, match {} elements, take {} micro second",
-                    remotePath, matchContext.elementCnt, matchContext.matchCnt, duration / 1000);
+            LOG.info("process {} elements under prefix {} for {} round, match {} elements, result {} take {} "
+                    + "micro second",
+                    remotePath, elementCnt, roundCnt, matchCnt, result.size(), duration / 1000);
         }
         return st;
     }
-
     public PagedResponse<BlobItem> getPagedBlobItems(BlobContainerClient client, ListBlobsOptions options,
                                                      String newContinuationToken) {
         PagedIterable<BlobItem> pagedBlobs = client.listBlobs(options, newContinuationToken, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -341,8 +341,7 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
             String newContinuationToken = null;
             do {
                 roundCnt++;
-                PagedIterable<BlobItem> pagedBlobs = client.listBlobs(options, newContinuationToken, null);
-                PagedResponse<BlobItem> pagedResponse = pagedBlobs.iterableByPage().iterator().next();
+                PagedResponse<BlobItem> pagedResponse = getPagedBlobItems(client, options, newContinuationToken);
 
                 for (BlobItem blobItem : pagedResponse.getElements()) {
                     elementCnt++;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -103,10 +103,9 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         forceParsingByStandardUri = this.properties.getOrDefault(PropertyConverter.FORCE_PARSING_BY_STANDARD_URI,
                 "false").equalsIgnoreCase("true");
 
-        String endpoint = properties.get(S3Properties.ENDPOINT);
-        String region = properties.get(S3Properties.REGION);
-        LOG.info("Endpoint: " + endpoint);
-        LOG.info("Region: " + region);
+        String endpoint = this.properties.get(S3Properties.ENDPOINT);
+        String region = this.properties.get(S3Properties.REGION);
+
         this.properties.put(S3Properties.REGION, PropertyConverter.checkRegion(endpoint, region, S3Properties.REGION));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -102,6 +102,10 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                 .equalsIgnoreCase("true");
         forceParsingByStandardUri = this.properties.getOrDefault(PropertyConverter.FORCE_PARSING_BY_STANDARD_URI,
                 "false").equalsIgnoreCase("true");
+
+        String endpoint = properties.get(S3Properties.ENDPOINT);
+        String region = properties.get(S3Properties.REGION);
+        this.properties.put(S3Properties.REGION, PropertyConverter.checkRegion(endpoint, region, S3Properties.REGION));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -105,6 +105,8 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
 
         String endpoint = properties.get(S3Properties.ENDPOINT);
         String region = properties.get(S3Properties.REGION);
+        LOG.info("Endpoint: " + endpoint);
+        LOG.info("Region: " + region);
         this.properties.put(S3Properties.REGION, PropertyConverter.checkRegion(endpoint, region, S3Properties.REGION));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
@@ -54,8 +54,8 @@ public class AzureFileSystem extends ObjFileSystem {
     }
 
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+    public Status globList(String remotePath, List<RemoteFile> result) {
         AzureObjStorage azureObjStorage = (AzureObjStorage) getObjStorage();
-        return azureObjStorage.globList(remotePath, result, fileNameOnly);
+        return azureObjStorage.globList(remotePath, result);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.fs.remote;
 
-import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.analysis.StorageBackend.StorageType;
 import org.apache.doris.backup.Status;
 import org.apache.doris.common.UserException;
@@ -35,13 +34,13 @@ public class AzureFileSystem extends ObjFileSystem {
     private static final Logger LOG = LogManager.getLogger(AzureFileSystem.class);
 
     public AzureFileSystem(Map<String, String> properties) {
-        super(StorageType.AZURE.name(), StorageType.AZURE, new AzureObjStorage(properties));
+        super(StorageType.AZURE.name(), StorageType.S3, new AzureObjStorage(properties));
         initFsProperties();
     }
 
     @VisibleForTesting
     public AzureFileSystem(AzureObjStorage storage) {
-        super(StorageBackend.StorageType.AZURE.name(), StorageBackend.StorageType.AZURE, storage);
+        super(StorageType.AZURE.name(), StorageType.S3, storage);
         initFsProperties();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/BrokerFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/BrokerFileSystem.java
@@ -649,7 +649,7 @@ public class BrokerFileSystem extends RemoteFileSystem {
 
     // List files in remotePath
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+    public Status globList(String remotePath, List<RemoteFile> result) {
         // get a proper broker
         Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
         if (pair == null) {
@@ -663,7 +663,7 @@ public class BrokerFileSystem extends RemoteFileSystem {
         try {
             TBrokerListPathRequest req = new TBrokerListPathRequest(TBrokerVersion.VERSION_ONE, remotePath,
                     false /* not recursive */, properties);
-            req.setFileNameOnly(fileNameOnly);
+            req.setFileNameOnly(false);
             TBrokerListResponse rep = client.listPath(req);
             TBrokerOperationStatus opst = rep.getOpStatus();
             if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -103,7 +103,7 @@ public class S3FileSystem extends ObjFileSystem {
 
     // broker file pattern glob is too complex, so we use hadoop directly
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+    public Status globList(String remotePath, List<RemoteFile> result) {
         try {
             FileSystem s3AFileSystem = nativeFileSystem(remotePath);
             Path pathPattern = new Path(remotePath);
@@ -113,7 +113,7 @@ public class S3FileSystem extends ObjFileSystem {
             }
             for (FileStatus fileStatus : files) {
                 RemoteFile remoteFile = new RemoteFile(
-                        fileNameOnly ? fileStatus.getPath().getName() : fileStatus.getPath().toString(),
+                        fileStatus.getPath().toString(),
                         !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen(),
                         fileStatus.getBlockSize(), fileStatus.getModificationTime());
                 result.add(remoteFile);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/SwitchingFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/SwitchingFileSystem.java
@@ -113,11 +113,6 @@ public class SwitchingFileSystem implements FileSystem {
     }
 
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
-        return fileSystem(remotePath).globList(remotePath, result, fileNameOnly);
-    }
-
-    @Override
     public Status listDirectories(String remotePath, Set<String> result) {
         return fileSystem(remotePath).listDirectories(remotePath, result);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -447,7 +447,7 @@ public class DFSFileSystem extends RemoteFileSystem {
      * @return Status.OK if success.
      */
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+    public Status globList(String remotePath, List<RemoteFile> result) {
         try {
             URI pathUri = URI.create(remotePath);
             FileSystem fileSystem = nativeFileSystem(remotePath);
@@ -459,7 +459,7 @@ public class DFSFileSystem extends RemoteFileSystem {
             }
             for (FileStatus fileStatus : files) {
                 RemoteFile remoteFile = new RemoteFile(
-                        fileNameOnly ? fileStatus.getPath().getName() : fileStatus.getPath().toString(),
+                        fileStatus.getPath().toString(),
                         !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen(),
                         fileStatus.getBlockSize(), fileStatus.getModificationTime());
                 result.add(remoteFile);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -172,6 +172,7 @@ import org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalCatalog;
 import org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalDatabase;
 import org.apache.doris.datasource.trinoconnector.TrinoConnectorExternalTable;
 import org.apache.doris.fs.PersistentFileSystem;
+import org.apache.doris.fs.remote.AzureFileSystem;
 import org.apache.doris.fs.remote.BrokerFileSystem;
 import org.apache.doris.fs.remote.ObjFileSystem;
 import org.apache.doris.fs.remote.S3FileSystem;
@@ -570,7 +571,8 @@ public class GsonUtils {
             .registerSubtype(JFSFileSystem.class, JFSFileSystem.class.getSimpleName())
             .registerSubtype(OFSFileSystem.class, OFSFileSystem.class.getSimpleName())
             .registerSubtype(ObjFileSystem.class, ObjFileSystem.class.getSimpleName())
-            .registerSubtype(S3FileSystem.class, S3FileSystem.class.getSimpleName());
+            .registerSubtype(S3FileSystem.class, S3FileSystem.class.getSimpleName())
+            .registerSubtype(AzureFileSystem.class, AzureFileSystem.class.getSimpleName());
 
     private static RuntimeTypeAdapterFactory<org.apache.doris.backup.AbstractJob>
             jobBackupTypeAdapterFactory

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -184,9 +184,10 @@ public class RepositoryTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
-                        result.add(new RemoteFile(location + "/" + Repository.PREFIX_SNAPSHOT_DIR + "a",
-                                false, 100, 0));
-                        result.add(new RemoteFile(location + "/" + "_ss_b", true, 100, 0));
+                        result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + "/"
+                                + Repository.PREFIX_SNAPSHOT_DIR + "/" + "a", false, 100, 0));
+                        result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + "/"
+                                + Repository.PREFIX_SNAPSHOT_DIR + "/" + "_ss_b", true, 100, 0));
                         return Status.OK;
                     }
                 };
@@ -284,6 +285,8 @@ public class RepositoryTest {
 
     @Test
     public void testGetSnapshotInfo() {
+        String repoName = "repo";
+
         new Expectations() {
             {
                 fileSystem.globList(anyString, (List<RemoteFile>) any);
@@ -296,10 +299,10 @@ public class RepositoryTest {
                                     100,
                                     0));
                         } else {
-                            result.add(new RemoteFile(location + "//" + Repository.PREFIX_SNAPSHOT_DIR + "s1",
-                                    false, 100, 0));
-                            result.add(new RemoteFile(location + "/" + Repository.PREFIX_SNAPSHOT_DIR + "s2",
-                                    false, 100, 0));
+                            result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + repoName + "//"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
+                            result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + repoName + "//"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
                         }
                         return Status.OK;
                     }
@@ -307,7 +310,7 @@ public class RepositoryTest {
             }
         };
 
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, repoName, false, location, fileSystem);
         String snapshotName = "";
         String timestamp = "";
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -184,8 +184,9 @@ public class RepositoryTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
-                        result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "a", false, 100, 0));
-                        result.add(new RemoteFile("_ss_b", true, 100, 0));
+                        result.add(new RemoteFile(location + "/" + Repository.PREFIX_SNAPSHOT_DIR + "a",
+                                false, 100, 0));
+                        result.add(new RemoteFile(location + "/" + "_ss_b", true, 100, 0));
                         return Status.OK;
                     }
                 };
@@ -295,8 +296,10 @@ public class RepositoryTest {
                                     100,
                                     0));
                         } else {
-                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
-                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
+                            result.add(new RemoteFile(location + "//" + Repository.PREFIX_SNAPSHOT_DIR + "s1",
+                                    false, 100, 0));
+                            result.add(new RemoteFile(location + "/" + Repository.PREFIX_SNAPSHOT_DIR + "s2",
+                                    false, 100, 0));
                         }
                         return Status.OK;
                     }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -184,7 +184,7 @@ public class RepositoryTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
-                        result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + name + "/"
+                        result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + name + "/"
                                 + Repository.PREFIX_SNAPSHOT_DIR + "/" + "a", false, 100, 0));
                         result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name + "/"
                                 + Repository.PREFIX_SNAPSHOT_DIR + "/" + "_ss_b", true, 100, 0));
@@ -285,8 +285,6 @@ public class RepositoryTest {
 
     @Test
     public void testGetSnapshotInfo() {
-        String name = "repo";
-
         new Expectations() {
             {
                 fileSystem.globList(anyString, (List<RemoteFile>) any);
@@ -299,7 +297,7 @@ public class RepositoryTest {
                                     100,
                                     0));
                         } else {
-                            result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + name + "/"
+                            result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + name + "//"
                                     + Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
                             result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name + "/"
                                     + Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -184,9 +184,9 @@ public class RepositoryTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
-                        result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + "/"
+                        result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + name + "/"
                                 + Repository.PREFIX_SNAPSHOT_DIR + "/" + "a", false, 100, 0));
-                        result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + "/"
+                        result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name + "/"
                                 + Repository.PREFIX_SNAPSHOT_DIR + "/" + "_ss_b", true, 100, 0));
                         return Status.OK;
                     }
@@ -194,7 +194,7 @@ public class RepositoryTest {
             }
         };
 
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, name, false, location, fileSystem);
         List<String> snapshotNames = Lists.newArrayList();
         Status st = repo.listSnapshots(snapshotNames);
         Assert.assertTrue(st.ok());
@@ -285,7 +285,7 @@ public class RepositoryTest {
 
     @Test
     public void testGetSnapshotInfo() {
-        String repoName = "repo";
+        String name = "repo";
 
         new Expectations() {
             {
@@ -299,9 +299,9 @@ public class RepositoryTest {
                                     100,
                                     0));
                         } else {
-                            result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + repoName + "/"
+                            result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + name + "/"
                                     + Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
-                            result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + repoName + "/"
+                            result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name + "/"
                                     + Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
                         }
                         return Status.OK;
@@ -310,7 +310,7 @@ public class RepositoryTest {
             }
         };
 
-        repo = new Repository(10000, repoName, false, location, fileSystem);
+        repo = new Repository(10000, name, false, location, fileSystem);
         String snapshotName = "";
         String timestamp = "";
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -185,9 +185,11 @@ public class RepositoryTest {
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
                         result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + name + "/"
-                                + Repository.PREFIX_SNAPSHOT_DIR + "/" + "a", false, 100, 0));
-                        result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name + "/"
-                                + Repository.PREFIX_SNAPSHOT_DIR + "/" + "_ss_b", true, 100, 0));
+                                + Repository.PREFIX_SNAPSHOT_DIR + "a/__info_", false, 100, 0));
+                        result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + name + "/"
+                                + Repository.PREFIX_SNAPSHOT_DIR + "/" + "a/__info_", false, 100, 0));
+                        result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name
+                                + "/_ss_b/__info_", true, 100, 0));
                         return Status.OK;
                     }
                 };
@@ -197,6 +199,7 @@ public class RepositoryTest {
         repo = new Repository(10000, name, false, location, fileSystem);
         List<String> snapshotNames = Lists.newArrayList();
         Status st = repo.listSnapshots(snapshotNames);
+        System.out.println(snapshotNames);
         Assert.assertTrue(st.ok());
         Assert.assertEquals(1, snapshotNames.size());
         Assert.assertEquals("a", snapshotNames.get(0));
@@ -291,16 +294,20 @@ public class RepositoryTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
+                        String metaFilePath1 = location + "//" + Repository.PREFIX_REPO + name + "//"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "s1//"
+                                    + "__info_2018-04-18-20-11-00.12345678123456781234567812345678";
+                        String metaFilePath2 = location + "//" + Repository.PREFIX_REPO + name + "//"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "s2//"
+                                    + "__info_2018-04-18-20-11-00.12345678123456781234567812345678";
                         if (remotePath.contains(Repository.PREFIX_JOB_INFO)) {
-                            result.add(new RemoteFile(" __info_2018-04-18-20-11-00.12345678123456781234567812345678",
+                            result.add(new RemoteFile(metaFilePath1,
                                     true,
                                     100,
                                     0));
                         } else {
-                            result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + name + "//"
-                                    + Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
-                            result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + name + "/"
-                                    + Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
+                            result.add(new RemoteFile(metaFilePath1, true, 100, 0));
+                            result.add(new RemoteFile(metaFilePath2, true, 100, 0));
                         }
                         return Status.OK;
                     }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -299,9 +299,9 @@ public class RepositoryTest {
                                     100,
                                     0));
                         } else {
-                            result.add(new RemoteFile(location + "//" + Repository.PREFIX_REPO + repoName + "//"
+                            result.add(new RemoteFile(location + "/" + Repository.PREFIX_REPO + repoName + "/"
                                     + Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
-                            result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + repoName + "//"
+                            result.add(new RemoteFile(location + "/"  + Repository.PREFIX_REPO + repoName + "/"
                                     + Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
                         }
                         return Status.OK;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/PropertyConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/PropertyConverterTest.java
@@ -179,7 +179,7 @@ public class PropertyConverterTest extends TestWithFeService {
                 + "    'AWS_REGION' = 'us-east-1'\n"
                 + ");";
         CreateRepositoryStmt analyzedStmt = createStmt(s3Repo);
-        Assertions.assertEquals(analyzedStmt.getProperties().size(), 4);
+        Assertions.assertEquals(analyzedStmt.getProperties().size(), 5);
         Repository repository = getRepository(analyzedStmt, "s3_repo");
         Assertions.assertEquals(9, repository.getRemoteFileSystem().getProperties().size());
 
@@ -195,7 +195,7 @@ public class PropertyConverterTest extends TestWithFeService {
         CreateRepositoryStmt analyzedStmtNew = createStmt(s3RepoNew);
         Assertions.assertEquals(analyzedStmtNew.getProperties().size(), 3);
         Repository repositoryNew = getRepository(analyzedStmtNew, "s3_repo_new");
-        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 4);
+        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 5);
     }
 
     private static Repository getRepository(CreateRepositoryStmt analyzedStmt, String name) throws DdlException {
@@ -223,7 +223,7 @@ public class PropertyConverterTest extends TestWithFeService {
         Env.getCurrentEnv().getBrokerMgr().addBrokers("bos_broker", brokers);
 
         Repository repositoryNew = getRepository(analyzedStmt, "bos_broker_repo");
-        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 4);
+        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 5);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/PropertyConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/PropertyConverterTest.java
@@ -179,7 +179,7 @@ public class PropertyConverterTest extends TestWithFeService {
                 + "    'AWS_REGION' = 'us-east-1'\n"
                 + ");";
         CreateRepositoryStmt analyzedStmt = createStmt(s3Repo);
-        Assertions.assertEquals(analyzedStmt.getProperties().size(), 5);
+        Assertions.assertEquals(analyzedStmt.getProperties().size(), 4);
         Repository repository = getRepository(analyzedStmt, "s3_repo");
         Assertions.assertEquals(9, repository.getRemoteFileSystem().getProperties().size());
 
@@ -223,7 +223,7 @@ public class PropertyConverterTest extends TestWithFeService {
         Env.getCurrentEnv().getBrokerMgr().addBrokers("bos_broker", brokers);
 
         Repository repositoryNew = getRepository(analyzedStmt, "bos_broker_repo");
-        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 5);
+        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 4);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/AzureObjStorageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/AzureObjStorageTest.java
@@ -97,9 +97,8 @@ public class AzureObjStorageTest {
         inputs.stream().forEach(i -> {
             AzureObjStorage azs = new AzureObjStorage(props);
             List<RemoteFile> result = new ArrayList<RemoteFile>();
-            boolean fileNameOnly = false;
             // FIXME(gavin): Mock the result returned from azure blob to make this UT work when no aksk and network
-            Status st = azs.globList(i.pattern, result, fileNameOnly);
+            Status st = azs.globList(i.pattern, result);
             Assertions.assertTrue(st.ok());
             Assertions.assertEquals(i.expectedMatchSize, result.size());
         });
@@ -117,9 +116,8 @@ public class AzureObjStorageTest {
         inputs.stream().forEach(i -> {
             AzureObjStorage azs = genMockedAzureObjStorage(4/*numBatches, numContinuations*/);
             List<RemoteFile> result = new ArrayList<RemoteFile>();
-            boolean fileNameOnly = false;
             // FIXME(gavin): Mock the result returned from azure blob to make this UT work when no aksk and network
-            Status st = azs.globList(i.pattern, result, fileNameOnly);
+            Status st = azs.globList(i.pattern, result);
             Assertions.assertTrue(st.ok());
             Assertions.assertEquals(i.expectedMatchSize, result.size());
             for (int j = 0; j < result.size() && j < 10; ++j) {
@@ -169,8 +167,7 @@ public class AzureObjStorageTest {
     public void testMockObj() {
         AzureObjStorage azs = genMockedAzureObjStorage(2);
         List<RemoteFile> result = new ArrayList<RemoteFile>();
-        boolean fileNameOnly = false;
-        Status st = azs.globList("s3://gavin-test-jp/azure-test/1/*", result, fileNameOnly);
+        Status st = azs.globList("s3://gavin-test-jp/azure-test/1/*", result);
         Assertions.assertTrue(st.ok());
         // for (RemoteFile i : result) {
         //     System.out.println(i.getName());

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3FileSystemTest.java
@@ -108,7 +108,7 @@ public class S3FileSystemTest {
             fileSystem = new S3FileSystem(mockedStorage);
             new MockUp<S3FileSystem>(S3FileSystem.class) {
                 @Mock
-                public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+                public Status globList(String remotePath, List<RemoteFile> result) {
                     try {
                         S3URI uri = S3URI.create(remotePath, false);
                         ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder().bucket(uri.getBucket());


### PR DESCRIPTION
### What problem does this PR solve?

1. use https for azure
2. region is unnecessary for gcp.
3. fe pass provider to be
4. be listblob endless loop
5. fe globlist use hierarchy api
6. azure type should be s3 in fe
7. add azure file system adaptor in gson

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

