### PR TITLE
[fix](cloud) fix routine load loss data when fe master node restart

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaRoutineLoadJob.java
@@ -367,6 +367,11 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     @Override
     protected void unprotectUpdateProgress() throws UserException {
+        // For cloud mode, should update cloud progress from meta service,
+        // then update progress with default offset from Kafka if necessary.
+        if (Config.isCloudMode()) {
+            updateCloudProgress();
+        }
         updateNewPartitionProgress();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadScheduler.java
@@ -18,7 +18,6 @@
 package org.apache.doris.load.routineload;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
@@ -79,10 +78,6 @@ public class RoutineLoadScheduler extends MasterDaemon {
             RoutineLoadJob.JobState errorJobState = null;
             UserException userException = null;
             try {
-                if (Config.isCloudMode()) {
-                    routineLoadJob.updateCloudProgress();
-                }
-
                 routineLoadJob.prepare();
                 // judge nums of tasks more than max concurrent tasks of cluster
                 int desiredConcurrentTaskNum = routineLoadJob.calculateCurrentConcurrentTaskNum();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In cloud mode, routine load loss data when fe master node restart.

When updating progress, in order to avoid small values covering large values, we introduced pr https://github.com/apache/doris/pull/39313, Due to the pr that the routine load replays progress metadata by first obtaining the set default offset and then pulling metadata from meta service to update the local value, if the metadata pulled from meta service is not larger than the set default offset, the correct value cannot be assigned to memory.

To solve this problem,  pulling metadata from meta service when restart, determine whether to obtain default offset from Kafka based on the pulled value. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

