### PR TITLE
[fix](report) report queue size based on the number of Bes and config

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -232,11 +232,13 @@ public class ReportHandler extends Daemon {
 
     private void putToQueue(ReportTask reportTask) throws Exception {
         int currentSize = reportQueue.size();
-        if (currentSize > Config.report_queue_size) {
-            LOG.warn("the report queue size exceeds the limit: {}. current: {}", Config.report_queue_size, currentSize);
+        int maxReportQueueSize = Math.max(Config.report_queue_size,
+                10 * Env.getCurrentSystemInfo().getAllBackendIds().size());
+        if (currentSize > maxReportQueueSize) {
+            LOG.warn("the report queue size exceeds the limit: {}. current: {}", maxReportQueueSize, currentSize);
             throw new Exception(
                     "the report queue size exceeds the limit: "
-                            + Config.report_queue_size + ". current: " + currentSize);
+                            + maxReportQueueSize + ". current: " + currentSize);
         }
 
         BackendReportType backendReportType = new BackendReportType(reportTask.beId, reportTask.reportType);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

A large cluster has many BE nodes, and the report occasionally encounters a "queue full" error. The report queue size will be modified based on the number of BE instances.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

