### PR TITLE
[Enchancement](join) do not build non-output column on join probe

### DIFF
--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -73,8 +73,7 @@ public:
         return _shared_state->build_block;
     }
     bool empty_right_table_shortcut() const {
-        // !Base::_projections.empty() means nereids planner
-        return _shared_state->empty_right_table_need_probe_dispose && !Base::_projections.empty();
+        return _shared_state->empty_right_table_need_probe_dispose;
     }
     std::string debug_string(int indentation_level) const override;
 

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -126,7 +126,9 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
             } else if (i + _right_col_idx == _parent->_mark_column_id) {
                 mcol[i + _right_col_idx]->resize(size);
             } else {
-                mcol[i + _right_col_idx] = MutableColumnPtr();
+                mcol[i + _right_col_idx]->insert_default();
+                mcol[i + _right_col_idx] =
+                        vectorized::ColumnConst::create(std::move(mcol[i + _right_col_idx]), size);
             }
         }
     }
@@ -148,7 +150,8 @@ void ProcessHashTableProbe<JoinOpType>::probe_side_output_column(
                                              _probe_indexs.data() + size);
             }
         } else {
-            mcol[i] = MutableColumnPtr();
+            mcol[i]->insert_default();
+            mcol[i] = vectorized::ColumnConst::create(std::move(mcol[i]), size);
         }
     }
 

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -129,10 +129,10 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
                         assert_cast<vectorized::ColumnNullable&>(*mcol[i + _right_col_idx]);
                 mark_column.resize(size);
                 auto* null_map = mark_column.get_null_map_column().get_data().data();
-                memset(null_map, 0, size);
                 auto* data = assert_cast<vectorized::ColumnUInt8&>(mark_column.get_nested_column())
                                      .get_data()
                                      .data();
+                std::fill(null_map, null_map + size, 0);
                 std::fill(data, data + size, 1);
             } else {
                 mcol[i + _right_col_idx]->insert_default();

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -124,7 +124,7 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
                                                                   _build_indexs.data() + size);
                 }
             } else {
-                mcol[i + _right_col_idx]->insert_many_defaults(size);
+                mcol[i + _right_col_idx] = MutableColumnPtr();
             }
         }
     }
@@ -146,7 +146,7 @@ void ProcessHashTableProbe<JoinOpType>::probe_side_output_column(
                                              _probe_indexs.data() + size);
             }
         } else {
-            mcol[i]->insert_many_defaults(size);
+            mcol[i] = MutableColumnPtr();
         }
     }
 

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -112,7 +112,7 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
             }
         }
 
-        for (int i = 0; i < _right_col_len; i++) {
+        for (size_t i = 0; i < _right_col_len; i++) {
             const auto& column = *_build_block->safe_get_by_position(i).column;
             if (output_slot_flags[i]) {
                 if (!build_index_has_zero && _build_column_has_null[i]) {
@@ -123,7 +123,7 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
                     mcol[i + _right_col_idx]->insert_indices_from(column, _build_indexs.data(),
                                                                   _build_indexs.data() + size);
                 }
-            } else {
+            } else if (i + _right_col_idx != _parent->_mark_column_id) {
                 mcol[i + _right_col_idx] = MutableColumnPtr();
             }
         }

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -123,7 +123,9 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
                     mcol[i + _right_col_idx]->insert_indices_from(column, _build_indexs.data(),
                                                                   _build_indexs.data() + size);
                 }
-            } else if (i + _right_col_idx != _parent->_mark_column_id) {
+            } else if (i + _right_col_idx == _parent->_mark_column_id) {
+                mcol[i + _right_col_idx]->resize(size);
+            } else {
                 mcol[i + _right_col_idx] = MutableColumnPtr();
             }
         }

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -127,7 +127,7 @@ void ProcessHashTableProbe<JoinOpType>::build_side_output_column(
                                  .data();
             std::fill(null_map, null_map + size, 0);
             std::fill(data, data + size, 1);
-        } else {
+        } else if (mcol[i + _right_col_idx]) {
             mcol[i + _right_col_idx]->insert_default();
             mcol[i + _right_col_idx] =
                     vectorized::ColumnConst::create(std::move(mcol[i + _right_col_idx]), size);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -631,7 +631,7 @@ void PInternalService::cancel_plan_fragment(google::protobuf::RpcController* /*c
         // Convert PPlanFragmentCancelReason to Status
         if (has_cancel_status) {
             // If fe set cancel status, then it is new FE now, should use cancel status.
-            actual_cancel_status = Status::create(request->cancel_status());
+            actual_cancel_status = Status::create<false>(request->cancel_status());
         } else if (has_cancel_reason) {
             // If fe not set cancel status, but set cancel reason, should convert cancel reason
             // to cancel status here.

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -804,7 +804,7 @@ void Block::filter_block_internal(Block* block, const std::vector<uint32_t>& col
     size_t count = filter.size() - simd::count_zero_num((int8_t*)filter.data(), filter.size());
     for (const auto& col : columns_to_filter) {
         auto& column = block->get_by_position(col).column;
-        if (!column || column->size() == count) {
+        if (column->size() == count) {
             continue;
         }
         if (count == 0) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -802,26 +802,25 @@ void Block::update_hash(SipHash& hash) const {
 void Block::filter_block_internal(Block* block, const std::vector<uint32_t>& columns_to_filter,
                                   const IColumn::Filter& filter) {
     size_t count = filter.size() - simd::count_zero_num((int8_t*)filter.data(), filter.size());
-    if (count == 0) {
-        for (const auto& col : columns_to_filter) {
-            std::move(*block->get_by_position(col).column).assume_mutable()->clear();
+    for (const auto& col : columns_to_filter) {
+        auto& column = block->get_by_position(col).column;
+        if (!column || column->size() == count) {
+            continue;
         }
-    } else {
-        for (const auto& col : columns_to_filter) {
-            auto& column = block->get_by_position(col).column;
-            if (column->size() != count) {
-                if (column->is_exclusive()) {
-                    const auto result_size = column->assume_mutable()->filter(filter);
-                    if (result_size != count) [[unlikely]] {
-                        throw Exception(ErrorCode::INTERNAL_ERROR,
-                                        "result_size not equal with filter_size, result_size={}, "
-                                        "filter_size={}",
-                                        result_size, count);
-                    }
-                } else {
-                    column = column->filter(filter, count);
-                }
+        if (count == 0) {
+            block->get_by_position(col).column->assume_mutable()->clear();
+            continue;
+        }
+        if (column->is_exclusive()) {
+            const auto result_size = column->assume_mutable()->filter(filter);
+            if (result_size != count) [[unlikely]] {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "result_size not equal with filter_size, result_size={}, "
+                                "filter_size={}",
+                                result_size, count);
             }
+        } else {
+            column = column->filter(filter, count);
         }
     }
 }

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -276,6 +276,10 @@ Status VExprContext::execute_conjuncts(const VExprContextSPtrs& conjuncts, Block
     if (rows == 0) {
         return Status::OK();
     }
+    if (null_map.size() != rows) {
+        return Status::InternalError("null_map.size() != rows, null_map.size()={}, rows={}",
+                                     null_map.size(), rows);
+    }
 
     auto* final_null_map = null_map.get_data().data();
     auto* final_filter_ptr = filter.data();

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -277,10 +277,7 @@ Status VExprContext::execute_conjuncts(const VExprContextSPtrs& conjuncts, Block
         return Status::OK();
     }
 
-    null_map.resize(rows);
     auto* final_null_map = null_map.get_data().data();
-    memset(final_null_map, 0, rows);
-    filter.resize_fill(rows, 1);
     auto* final_filter_ptr = filter.data();
 
     for (const auto& conjunct : conjuncts) {

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -326,8 +326,11 @@ Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs&
             execute_conjuncts(ctxs, nullptr, false, block, &result_filter, &can_filter_all));
     if (can_filter_all) {
         for (auto& col : columns_to_filter) {
-            // NOLINTNEXTLINE(performance-move-const-arg)
-            std::move(*block->get_by_position(col).column).assume_mutable()->clear();
+            auto& column = block->get_by_position(col).column;
+            if (!column || column->empty()) {
+                continue;
+            }
+            column->assume_mutable()->clear();
         }
     } else {
         try {

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -326,11 +326,7 @@ Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs&
             execute_conjuncts(ctxs, nullptr, false, block, &result_filter, &can_filter_all));
     if (can_filter_all) {
         for (auto& col : columns_to_filter) {
-            auto& column = block->get_by_position(col).column;
-            if (!column || column->empty()) {
-                continue;
-            }
-            column->assume_mutable()->clear();
+            block->get_by_position(col).column->assume_mutable()->clear();
         }
     } else {
         try {


### PR DESCRIPTION
### What problem does this PR solve?
1. do not build non-output column on join probe
2. remove some unused code on `JoinProbeLocalState<SharedStateArg, Derived>::_build_output_block`
3. do not print stack on `PInternalService::cancel_plan_fragment`
Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

