### PR TITLE
[fix](catalog) Fix mark handling for failed tasks to maintain getLeftMarks

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -497,7 +497,7 @@ Status DataDir::load() {
     }
     if (rowset_partition_id_eq_0_num > config::ignore_invalid_partition_id_rowset_num) {
         throw Exception(Status::FatalError(
-                "roswet partition id eq 0 is {} bigger than config {}, be exit, plz check be.INFO",
+                "rowset partition id eq 0 is {} bigger than config {}, be exit, plz check be.INFO",
                 rowset_partition_id_eq_0_num, config::ignore_invalid_partition_id_rowset_num));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -663,7 +663,7 @@ public class MasterImpl {
         }
 
         AlterInvertedIndexTask alterInvertedIndexTask = (AlterInvertedIndexTask) task;
-        LOG.info("beigin finish AlterInvertedIndexTask: {}, tablet: {}, toString: {}",
+        LOG.info("begin finish AlterInvertedIndexTask: {}, tablet: {}, toString: {}",
                 alterInvertedIndexTask.getSignature(),
                 alterInvertedIndexTask.getTabletId(),
                 alterInvertedIndexTask.toString());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Many pieces of code use `getLeftMarks` to check whether a task is finished. Therefore, when a task fails, its mark should not be deleted directly. For example, when creating a tablet, the left marks are used to track how many replicas were successfully created. If the number of successful replicas exceeds the quorum, the tablet is considered successfully created. However, if the mark is deleted due to failure, it could lead to a situation where the majority of replicas fail to be created, but the tablet is still mistakenly considered as successfully created.

This PR addresses the issue by saving the mark of the failed task in a separate map while maintaining the method's idempotency.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

