### PR TITLE
[opt](catalog) use table in db object return get db

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -110,7 +110,7 @@ public abstract class ExternalCatalog
     public static final String CREATE_TIME = "create_time";
     public static final boolean DEFAULT_USE_META_CACHE = true;
 
-    public static final String FOUND_CONFLICTING  = "Found conflicting";
+    public static final String FOUND_CONFLICTING = "Found conflicting";
     public static final String ONLY_TEST_LOWER_CASE_TABLE_NAMES = "only_test_lower_case_table_names";
 
     // Properties that should not be shown in the `show create catalog` result
@@ -746,6 +746,7 @@ public abstract class ExternalCatalog
             Preconditions.checkNotNull(db.get());
             tmpDbNameToId.put(db.get().getFullName(), db.get().getId());
             tmpIdToDb.put(db.get().getId(), db.get());
+            LOG.info("Synchronized database (refresh): [Name: {}, ID: {}]", db.get().getFullName(), db.get().getId());
         }
         for (int i = 0; i < log.getCreateCount(); i++) {
             ExternalDatabase<? extends ExternalTable> db =
@@ -754,6 +755,8 @@ public abstract class ExternalCatalog
             if (db != null) {
                 tmpDbNameToId.put(db.getFullName(), db.getId());
                 tmpIdToDb.put(db.getId(), db);
+                LOG.info("Synchronized database (create): [Name: {}, ID: {}, Remote Name: {}]",
+                        db.getFullName(), db.getId(), log.getRemoteDbNames().get(i));
             }
         }
         dbNameToId = tmpDbNameToId;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -211,6 +211,13 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             if (table.isPresent()) {
                 tmpTableNameToId.put(table.get().getName(), table.get().getId());
                 tmpIdToTbl.put(table.get().getId(), table.get());
+
+                // Add logic to set the database if missing
+                if (table.get().getDb() == null) {
+                    table.get().setDb(this);
+                }
+                LOG.info("Synchronized table (refresh): [Name: {}, ID: {}]", table.get().getName(),
+                        table.get().getId());
             }
         }
         for (int i = 0; i < log.getCreateCount(); i++) {
@@ -219,6 +226,13 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                             log.getCreateTableIds().get(i), catalog, this, false);
             tmpTableNameToId.put(table.getName(), table.getId());
             tmpIdToTbl.put(table.getId(), table);
+
+            // Add logic to set the database if missing
+            if (table.getDb() == null) {
+                table.setDb(this);
+            }
+            LOG.info("Synchronized table (create): [Name: {}, ID: {}, Remote Name: {}]",
+                    table.getName(), table.getId(), log.getRemoteTableNames().get(i));
         }
         tableNameToId = tmpTableNameToId;
         idToTbl = tmpIdToTbl;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -308,7 +308,7 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
 
     @Override
     public DatabaseIf getDatabase() {
-        return catalog.getDbNullable(dbName);
+        return this.db;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalTable.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
 public class JdbcExternalTable extends ExternalTable {
     private static final Logger LOG = LogManager.getLogger(JdbcExternalTable.class);
 
-    public static final String MYSQL_ROW_COUNT_SQL = "SELECT max(row_count) as rows FROM ("
+    public static final String MYSQL_ROW_COUNT_SQL = "SELECT max(row_count) as `rows` FROM ("
             + "(SELECT TABLE_ROWS AS row_count FROM INFORMATION_SCHEMA.TABLES "
             + "WHERE TABLE_SCHEMA = '${dbName}' AND TABLE_NAME = '${tblName}' "
             + "AND TABLE_TYPE = 'BASE TABLE') "

--- a/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
@@ -34,6 +34,8 @@ p1=part1
 p1=part2
 
 -- !sql10 --
+test_use_meta_cache_partitioned_tbl_hive
+test_use_meta_cache_tbl_hive
 
 -- !sql11 --
 
@@ -123,6 +125,8 @@ p1=part1
 p1=part2
 
 -- !sql10 --
+test_use_meta_cache_partitioned_tbl_hive
+test_use_meta_cache_tbl_hive
 
 -- !sql11 --
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy
@@ -186,7 +186,8 @@ suite("test_hive_parquet", "p0,external,hive,external_docker,external_docker_hiv
                 "type"="hms",
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
             );"""
-            sql """use `${catalog_name}`.`default`"""
+            sql """switch ${catalog_name}"""
+            sql """use `default`"""
 
             sql """set enable_fallback_to_original_planner=false;"""
 

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_snapshot.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_snapshot.groovy
@@ -34,7 +34,6 @@ suite("test_hudi_snapshot", "p2,external,hudi,external_remote,external_remote_hu
     sql """ use regression_hudi;""" 
     sql """ set enable_fallback_to_original_planner=false """
 
-    // 创建groovy函数，接收table_name为参数
     def test_hudi_snapshot_querys = { table_name ->
         // Query users by event_time in descending order and limit output
         qt_q01 """SELECT * FROM ${table_name} ORDER BY event_time DESC LIMIT 10;"""
@@ -49,7 +48,7 @@ suite("test_hudi_snapshot", "p2,external,hudi,external_remote,external_remote_hu
         qt_q04 """SELECT * FROM ${table_name} WHERE event_time BETWEEN '2024-01-01 00:00:00' AND '2024-12-31 23:59:59' ORDER BY event_time LIMIT 10;"""
 
         // Count users by age group and limit output
-        qt_q05 """SELECT age, COUNT(*) AS user_count FROM ${table_name} GROUP BY age ORDER BY user_count DESC LIMIT 5;"""
+        qt_q05 """SELECT age, COUNT(*) AS user_count FROM ${table_name} GROUP BY age ORDER BY user_count, age DESC LIMIT 5;"""
 
         // Query users with purchase records and limit output
         qt_q06 """SELECT user_id, purchases FROM ${table_name} WHERE array_size(purchases) > 0 ORDER BY user_id LIMIT 5;"""


### PR DESCRIPTION
### What problem does this PR solve?

This pull request includes several changes across multiple files to improve logging, add missing logic, and correct SQL syntax. The most important changes include adding logging for synchronization actions, setting the database if missing, and correcting SQL syntax for MySQL queries.

#### Logging Improvements:
* [`fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java`](diffhunk://#diff-50477c5ff1b42452704e942fe5fc738563dc64182690f378925fbc2401be5d48R749): Added logging for synchronized databases during refresh and create actions in the `replayInitCatalog` method. [[1]](diffhunk://#diff-50477c5ff1b42452704e942fe5fc738563dc64182690f378925fbc2401be5d48R749) [[2]](diffhunk://#diff-50477c5ff1b42452704e942fe5fc738563dc64182690f378925fbc2401be5d48R758-R759)
* [`fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java`](diffhunk://#diff-7b2044ac22da12680de78fbe8fface00accf1f915f74473696a78d8ad1e780c6R214-R220): Added logging for synchronized tables during refresh and create actions in the `replayInitDb` method. [[1]](diffhunk://#diff-7b2044ac22da12680de78fbe8fface00accf1f915f74473696a78d8ad1e780c6R214-R220) [[2]](diffhunk://#diff-7b2044ac22da12680de78fbe8fface00accf1f915f74473696a78d8ad1e780c6R229-R235)

#### Logic Enhancements:
* [`fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java`](diffhunk://#diff-7b2044ac22da12680de78fbe8fface00accf1f915f74473696a78d8ad1e780c6R214-R220): Added logic to set the database for tables if it is missing in the `replayInitDb` method. [[1]](diffhunk://#diff-7b2044ac22da12680de78fbe8fface00accf1f915f74473696a78d8ad1e780c6R214-R220) [[2]](diffhunk://#diff-7b2044ac22da12680de78fbe8fface00accf1f915f74473696a78d8ad1e780c6R229-R235)

#### SQL Syntax Correction:
* [`fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalTable.java`](diffhunk://#diff-1dc9bf9b52cfa9a96fd6aaed8060578b07dc9ecdefbaa9f3a2c69f9e69e63ce3L54-R54): Corrected SQL syntax by adding backticks around the `rows` alias in the `MYSQL_ROW_COUNT_SQL` query.

#### Test Data Adjustments:
* [`regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out`](diffhunk://#diff-995a65142428f1d804967ee6169b21e5409187a5f5e139d6d413a994bd8944c7R37-R38): Added missing test cases for Hive meta cache. [[1]](diffhunk://#diff-995a65142428f1d804967ee6169b21e5409187a5f5e139d6d413a994bd8944c7R37-R38) [[2]](diffhunk://#diff-995a65142428f1d804967ee6169b21e5409187a5f5e139d6d413a994bd8944c7R128-R129)

#### Test Suite Modifications:
* [`regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy`](diffhunk://#diff-e16bd2abd096731e6e3c735e31d39210a256a9a2a63a736355877b5e7f441c83L189-R190): Modified the test suite to switch catalogs correctly before using the default database.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

