### PR TITLE
[fix](split)Fixed the bug that batch mode split could not query data in multiple be scenarios.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -340,7 +340,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
             totalFileSize = fileSplit.getLength() * selectedSplitNum;
             long maxWaitTime = ConnectContext.get().getSessionVariable().getFetchSplitsMaxWaitTime();
             // Not accurate, only used to estimate concurrency.
-            int numSplitsPerBE = numApproximateSplits() / backendPolicy.numBackends();
+            // Here, we must take the max of 1, because
+            // in the case of multiple BEs, `numApproximateSplits() / backendPolicy.numBackends()` may be 0,
+            // and finally numSplitsPerBE is 0, resulting in no data being queried.
+            int numSplitsPerBE = Math.max(numApproximateSplits() / backendPolicy.numBackends(), 1);
             for (Backend backend : backendPolicy.getBackends()) {
                 SplitSource splitSource = new SplitSource(backend, splitAssignment, maxWaitTime);
                 splitSources.add(splitSource);


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
In multiple be scenarios, batch mode split sometimes could not query data.

The reason is that the estimated `numApproximateSplits()` may be relatively small, and the value after dividing the current number of be may be 0. As a result, the split will not be distributed to be, and the query result will be empty.
We need to take the max of the value after division and 1.

Followup #45148

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

