### PR TITLE
[Improve](nereids) use hash set replace three set in DiscreteValue to improve in predicate performance (#45181)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyRange.java
@@ -408,7 +408,7 @@ public class SimplifyRange implements ExpressionPatternRuleFactory {
         public DiscreteValue(ExpressionRewriteContext context,
                 Expression reference, Expression toExpr, Collection<Literal> values) {
             super(context, reference, toExpr);
-            this.values = Sets.newTreeSet(values);
+            this.values = Sets.newHashSet(values);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InPredicate.java
@@ -27,6 +27,8 @@ import org.apache.doris.nereids.types.DataType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.util.Collection;
 import java.util.List;
@@ -164,5 +166,14 @@ public class InPredicate extends Expression {
             }
         }
         return true;
+    }
+
+    //use for ut
+    public Expression sortOptions() {
+        if (isLiteralChildren()) {
+            List<Literal> values = options.stream().map(e -> (Literal) e).collect(Collectors.toList());
+            return new InPredicate(compareExpr, Lists.newArrayList(Sets.newTreeSet(values)));
+        }
+        return this;
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

cp #45181

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

