### PR TITLE
[enhance](nereids)rewrite aggregate to limit when all group by key is uniform and not null, and there is no aggregate functions

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKeyByUniformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKeyByUniformTest.java
@@ -108,9 +108,7 @@ public class EliminateGroupByKeyByUniformTest extends TestWithFeService implemen
                 .analyze("select  c2 from (select a c1,1 c2, 3 c3 from eli_gbk_by_uniform_t) t group by c2,c3 order by 1;")
                 .rewrite()
                 .printlnTree()
-                .matches(logicalAggregate().when(agg ->
-                        agg.getGroupByExpressions().size() == 1
-                                && agg.getGroupByExpressions().get(0).toSql().equals("c2")));
+                .nonMatch(logicalAggregate());
     }
 
     @Test
@@ -191,7 +189,7 @@ public class EliminateGroupByKeyByUniformTest extends TestWithFeService implemen
                 .analyze("select  t1.b from eli_gbk_by_uniform_t t1 left semi join eli_gbk_by_uniform_t t2 on t1.b=t2.b and t2.b=100 group by t1.b")
                 .rewrite()
                 .printlnTree()
-                .matches(logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 1));
+                .nonMatch(logicalAggregate());
     }
 
     @Test
@@ -209,7 +207,7 @@ public class EliminateGroupByKeyByUniformTest extends TestWithFeService implemen
                 .analyze("select  t2.b from eli_gbk_by_uniform_t t1 right semi join eli_gbk_by_uniform_t t2 on t1.b=t2.b and t2.b=100 group by t2.b")
                 .rewrite()
                 .printlnTree()
-                .matches(logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 1));
+                .nonMatch(logicalAggregate());
     }
 
     @Test

--- a/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.out
@@ -267,6 +267,7 @@ cherry	3
 
 -- !right_anti_right_side --
 
+
 -- !grouping --
 \N	\N
 \N	1
@@ -276,4 +277,57 @@ cherry	3
 1	1
 1	2
 1	3
+
+-- !to_limit_project_uniform --
+1
+
+-- !to_limit_predicate_uniform --
+1
+
+-- !to_limit_project_uniform_has_upper_ref --
+2
+
+-- !to_limit_predicate_uniform_has_upper_ref --
+2
+
+-- !to_limit_join_predicate --
+105
+
+-- !to_limit_join_project --
+1
+
+-- !to_limit_multi_group_by --
+1	1
+
+-- !to_limit_multi_group_by_one_col_in_project --
+2
+
+-- !to_limit_join_project_shape --
+PhysicalResultSink
+--PhysicalQuickSort[MERGE_SORT]
+----PhysicalQuickSort[LOCAL_SORT]
+------PhysicalLimit[GLOBAL]
+--------PhysicalDistribute[DistributionSpecGather]
+----------PhysicalProject
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((t1.a = t2.a)) otherCondition=() build RFs:RF0 a->[a];RF1 a->[a]
+--------------PhysicalProject
+----------------PhysicalOlapScan[test1] apply RFs: RF0 RF1
+--------------PhysicalProject
+----------------filter((test2.b = 105))
+------------------PhysicalOlapScan[test2]
+
+-- !to_limit_project_uniform_shape --
+PhysicalResultSink
+--PhysicalLimit[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------PhysicalProject
+--------PhysicalStorageLayerAggregate[eli_gbk_by_uniform_t]
+
+-- !to_limit_multi_group_by_shape --
+PhysicalResultSink
+--PhysicalLimit[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------PhysicalProject
+--------filter((eli_gbk_by_uniform_t.a = 1))
+----------PhysicalOlapScan[eli_gbk_by_uniform_t]
 

--- a/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.out
@@ -267,7 +267,6 @@ cherry	3
 
 -- !right_anti_right_side --
 
-
 -- !grouping --
 \N	\N
 \N	1

--- a/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.out
@@ -309,9 +309,9 @@ PhysicalResultSink
 ------PhysicalLimit[GLOBAL]
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((t1.a = t2.a)) otherCondition=() build RFs:RF0 a->[a];RF1 a->[a]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((t1.a = t2.a)) otherCondition=()
 --------------PhysicalProject
-----------------PhysicalOlapScan[test1] apply RFs: RF0 RF1
+----------------PhysicalOlapScan[test1]
 --------------PhysicalProject
 ----------------filter((test2.b = 105))
 ------------------PhysicalOlapScan[test2]

--- a/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.groovy
+++ b/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.groovy
@@ -16,6 +16,7 @@
 // under the License.
 suite("eliminate_group_by_key_by_uniform") {
     sql "set enable_nereids_rules = 'ELIMINATE_GROUP_BY_KEY_BY_UNIFORM'"
+    sql "set runtime_filter_mode=OFF"
     sql "drop table if exists eli_gbk_by_uniform_t"
     sql """create table eli_gbk_by_uniform_t(a int null, b int not null, c varchar(10) null, d date, dt datetime)
     distributed by hash(a) properties("replication_num"="1");

--- a/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.groovy
+++ b/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by_key_by_uniform.groovy
@@ -221,4 +221,18 @@ suite("eliminate_group_by_key_by_uniform") {
 
     //grouping
     qt_grouping "select k, k3 from (select 1 as k, a k3, sum(b) as sum_k1 from  test1  group by cube(k,a)) t group by k,k3 order by 1,2"
+
+    // test agg to limit
+    qt_to_limit_project_uniform "select 1 as c1 from eli_gbk_by_uniform_t group by c1"
+    qt_to_limit_predicate_uniform "select a from eli_gbk_by_uniform_t where a=1 group by a"
+    qt_to_limit_project_uniform_has_upper_ref "select c1+1 from (select 1 as c1 from eli_gbk_by_uniform_t group by c1) t"
+    qt_to_limit_predicate_uniform_has_upper_ref "select a+1 from (select a from eli_gbk_by_uniform_t where a=1 group by a) t"
+    qt_to_limit_join_predicate "select t2.b from test1 t1 inner join (select * from test2 where b=105)  t2 on t1.a=t2.a group by t2.b order by 1;"
+    qt_to_limit_join_project "select 1 as c1 from test1 t1 inner join (select * from test2 where b=105)  t2 on t1.a=t2.a group by c1 order by 1;"
+    qt_to_limit_multi_group_by "select 1 as c1,a from eli_gbk_by_uniform_t where a=1 group by c1,a"
+    qt_to_limit_multi_group_by_one_col_in_project "select 2 as c1 from eli_gbk_by_uniform_t where a=1 group by c1,a"
+
+    qt_to_limit_join_project_shape "explain shape plan select 1 as c1 from test1 t1 inner join (select * from test2 where b=105)  t2 on t1.a=t2.a group by c1 order by 1;"
+    qt_to_limit_project_uniform_shape "explain shape plan select 1 as c1 from eli_gbk_by_uniform_t group by c1"
+    qt_to_limit_multi_group_by_shape "explain shape plan select 2 as c1 from eli_gbk_by_uniform_t where a=1 group by c1,a"
 }

--- a/regression-test/suites/trino_p0/constant_group_key.groovy
+++ b/regression-test/suites/trino_p0/constant_group_key.groovy
@@ -26,7 +26,7 @@ suite("constant_group_key") {
     //reserve constant key in group by
     explain {
         sql("select 'oneline' from nation group by 'constant1'")
-        contains "group by: 'constant1'"
+        contains "limit: 1"
     }
 
     explain {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
select 1 c1 from test group by c; -> select 1 c1 from test limit 1;
c is uniform and aggregate can be eliminated
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

