### PR TITLE
[branch-2.1](regression) disable hudi p2 jni reader  test for branch-2.1

### DIFF
--- a/regression-test/suites/external_table_p2/hudi/test_hudi_incremental.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_incremental.groovy
@@ -107,12 +107,14 @@ suite("test_hudi_incremental", "p2,external,hudi,external_remote,external_remote
     test_hudi_incremental_querys("user_activity_log_cow_partition", timestamps_cow_partition)
     test_hudi_incremental_querys("user_activity_log_mor_non_partition", timestamps_mor_non_partition)
     test_hudi_incremental_querys("user_activity_log_mor_partition", timestamps_mor_partition)
-    sql """set force_jni_scanner=true;"""
+
+    // disable jni scanner because the old hudi jni reader based on spark can't read the emr hudi data
+    // sql """set force_jni_scanner=true;"""
     // don't support incremental query for cow table by jni reader
     // test_hudi_incremental_querys("user_activity_log_cow_non_partition", timestamps_cow_non_partition)
     // test_hudi_incremental_querys("user_activity_log_cow_partition", timestamps_cow_partition)
-    test_hudi_incremental_querys("user_activity_log_mor_non_partition", timestamps_mor_non_partition)
-    test_hudi_incremental_querys("user_activity_log_mor_partition", timestamps_mor_partition)
+    // test_hudi_incremental_querys("user_activity_log_mor_non_partition", timestamps_mor_non_partition)
+    // test_hudi_incremental_querys("user_activity_log_mor_partition", timestamps_mor_partition)
     // sql """set force_jni_scanner=false;"""
 
     sql """drop catalog if exists ${catalog_name};"""

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_schema_evolution.groovy
@@ -44,17 +44,18 @@ suite("test_hudi_schema_evolution", "p2,external,hudi,external_remote,external_r
     // qt_deleting_complex_columns_table """ select * from deleting_complex_columns_table order by id """
     // qt_renaming_complex_columns_table """ select * from renaming_complex_columns_table order by id """
     
-    sql """set force_jni_scanner = true;"""
-    qt_adding_simple_columns_table """ select * from adding_simple_columns_table order by id """
-    qt_altering_simple_columns_table """ select * from altering_simple_columns_table order by id """
+    // disable jni scanner because the old hudi jni reader based on spark can't read the emr hudi data
+    // sql """set force_jni_scanner = true;"""
+    // qt_adding_simple_columns_table """ select * from adding_simple_columns_table order by id """
+    // qt_altering_simple_columns_table """ select * from altering_simple_columns_table order by id """
     // qt_deleting_simple_columns_table """ select * from deleting_simple_columns_table order by id """
     // qt_renaming_simple_columns_table """ select * from renaming_simple_columns_table order by id """
 
-    qt_adding_complex_columns_table """ select * from adding_complex_columns_table order by id """
-    qt_altering_complex_columns_table """ select * from altering_complex_columns_table order by id """
+    // qt_adding_complex_columns_table """ select * from adding_complex_columns_table order by id """
+    // qt_altering_complex_columns_table """ select * from altering_complex_columns_table order by id """
     // qt_deleting_complex_columns_table """ select * from deleting_complex_columns_table order by id """
     // qt_renaming_complex_columns_table """ select * from renaming_complex_columns_table order by id """
-    sql """set force_jni_scanner = false;"""
+    // sql """set force_jni_scanner = false;"""
 
     sql """drop catalog if exists ${catalog_name};"""
 }

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_snapshot.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_snapshot.groovy
@@ -87,12 +87,13 @@ suite("test_hudi_snapshot", "p2,external,hudi,external_remote,external_remote_hu
     test_hudi_snapshot_querys("user_activity_log_cow_non_partition")
     test_hudi_snapshot_querys("user_activity_log_cow_partition")
 
-    sql """set force_jni_scanner=true;"""
-    test_hudi_snapshot_querys("user_activity_log_mor_non_partition")
-    test_hudi_snapshot_querys("user_activity_log_mor_partition")
-    test_hudi_snapshot_querys("user_activity_log_cow_non_partition")
-    test_hudi_snapshot_querys("user_activity_log_cow_partition")
-    sql """set force_jni_scanner=false;"""
+    // disable jni scanner because the old hudi jni reader based on spark can't read the emr hudi data
+    // sql """set force_jni_scanner=true;"""
+    // test_hudi_snapshot_querys("user_activity_log_mor_non_partition")
+    // test_hudi_snapshot_querys("user_activity_log_mor_partition")
+    // test_hudi_snapshot_querys("user_activity_log_cow_non_partition")
+    // test_hudi_snapshot_querys("user_activity_log_cow_partition")
+    // sql """set force_jni_scanner=false;"""
 
     sql """drop catalog if exists ${catalog_name};"""
 }

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_timestamp.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_timestamp.groovy
@@ -45,10 +45,12 @@ suite("test_hudi_timestamp", "p2,external,hudi,external_remote,external_remote_h
 
     // test native reader
     test_timestamp_different_timezones()
-    sql """ set force_jni_scanner = true; """
+
+    // disable jni scanner because the old hudi jni reader based on spark can't read the emr hudi data
+    // sql """ set force_jni_scanner = true; """
     // test jni reader
-    test_timestamp_different_timezones()
-    sql """ set force_jni_scanner = false; """
+    // test_timestamp_different_timezones()
+    // sql """ set force_jni_scanner = false; """
 
 
     sql """drop catalog if exists ${catalog_name};"""

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_timetravel.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_timetravel.groovy
@@ -101,12 +101,14 @@ suite("test_hudi_timetravel", "p2,external,hudi,external_remote,external_remote_
     test_hudi_timetravel_querys("user_activity_log_cow_partition", timestamps_cow_partition)
     test_hudi_timetravel_querys("user_activity_log_mor_non_partition", timestamps_mor_non_partition)
     test_hudi_timetravel_querys("user_activity_log_mor_partition", timestamps_mor_partition)
-    sql """set force_jni_scanner=true;"""
-    test_hudi_timetravel_querys("user_activity_log_cow_non_partition", timestamps_cow_non_partition)
-    test_hudi_timetravel_querys("user_activity_log_cow_partition", timestamps_cow_partition)
-    test_hudi_timetravel_querys("user_activity_log_mor_non_partition", timestamps_mor_non_partition)
-    test_hudi_timetravel_querys("user_activity_log_mor_partition", timestamps_mor_partition)
-    sql """set force_jni_scanner=false;"""
+
+    // disable jni scanner because the old hudi jni reader based on spark can't read the emr hudi data
+    // sql """set force_jni_scanner=true;"""
+    // test_hudi_timetravel_querys("user_activity_log_cow_non_partition", timestamps_cow_non_partition)
+    // test_hudi_timetravel_querys("user_activity_log_cow_partition", timestamps_cow_partition)
+    // test_hudi_timetravel_querys("user_activity_log_mor_non_partition", timestamps_mor_non_partition)
+    // test_hudi_timetravel_querys("user_activity_log_mor_partition", timestamps_mor_partition)
+    // sql """set force_jni_scanner=false;"""
 
     sql """drop catalog if exists ${catalog_name};"""
 }


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
disable hudi p2 jni reader test because the old hudi jni reader based on spark can't read the emr hudi data

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

