### PR TITLE
[Improvement](local shuffle) Reduce locking scope in local exchanger

### DIFF
--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -47,7 +47,7 @@ void Exchanger<BlockType>::_enqueue_data_and_set_ready(int channel_id,
         block->ref(1);
         allocated_bytes = block->data_block.allocated_bytes();
     }
-    std::unique_lock l(_m);
+    std::unique_lock l(*_m[channel_id]);
     local_state->_shared_state->add_mem_usage(channel_id, allocated_bytes,
                                               !std::is_same_v<PartitionedBlock, BlockType> &&
                                                       !std::is_same_v<BroadcastBlock, BlockType>);
@@ -95,7 +95,7 @@ bool Exchanger<BlockType>::_dequeue_data(LocalExchangeSourceLocalState* local_st
     } else if (all_finished) {
         *eos = true;
     } else {
-        std::unique_lock l(_m);
+        std::shared_lock l(*_m[channel_id]);
         if (_data_queue[channel_id].try_dequeue(block)) {
             if constexpr (std::is_same_v<PartitionedBlock, BlockType> ||
                           std::is_same_v<BroadcastBlock, BlockType>) {

--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -95,7 +95,7 @@ bool Exchanger<BlockType>::_dequeue_data(LocalExchangeSourceLocalState* local_st
     } else if (all_finished) {
         *eos = true;
     } else {
-        std::shared_lock l(*_m[channel_id]);
+        std::unique_lock l(*_m[channel_id]);
         if (_data_queue[channel_id].try_dequeue(block)) {
             if constexpr (std::is_same_v<PartitionedBlock, BlockType> ||
                           std::is_same_v<BroadcastBlock, BlockType>) {

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -167,7 +167,7 @@ public:
         _data_queue.resize(num_partitions);
         _m.resize(num_partitions);
         for (size_t i = 0; i < num_partitions; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
+            _m[i] = std::make_unique<std::mutex>();
         }
     }
     Exchanger(int running_sink_operators, int num_sources, int num_partitions, int free_block_limit)

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -248,7 +248,6 @@ public:
                                           free_block_limit) {
         DCHECK_GT(num_partitions, 0);
         DCHECK_GT(num_sources, 0);
-        DCHECK_GE(num_partitions, num_sources);
         _partition_rows_histogram.resize(running_sink_operators);
     }
     ~ShuffleExchanger() override = default;

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -163,9 +163,20 @@ template <typename BlockType>
 class Exchanger : public ExchangerBase {
 public:
     Exchanger(int running_sink_operators, int num_partitions, int free_block_limit)
-            : ExchangerBase(running_sink_operators, num_partitions, free_block_limit) {}
+            : ExchangerBase(running_sink_operators, num_partitions, free_block_limit) {
+        _data_queue.resize(num_partitions);
+        _m.resize(num_partitions);
+        for (size_t i = 0; i < num_partitions; i++) {
+            _m[i] = std::make_unique<std::shared_mutex>();
+        }
+    }
     Exchanger(int running_sink_operators, int num_sources, int num_partitions, int free_block_limit)
             : ExchangerBase(running_sink_operators, num_sources, num_partitions, free_block_limit) {
+        _data_queue.resize(num_sources);
+        _m.resize(num_sources);
+        for (size_t i = 0; i < num_sources; i++) {
+            _m[i] = std::make_unique<std::shared_mutex>();
+        }
     }
     ~Exchanger() override = default;
     std::string data_queue_debug_string(int i) override {
@@ -237,12 +248,8 @@ public:
                                           free_block_limit) {
         DCHECK_GT(num_partitions, 0);
         DCHECK_GT(num_sources, 0);
-        _data_queue.resize(num_sources);
+        DCHECK_GE(num_partitions, num_sources);
         _partition_rows_histogram.resize(running_sink_operators);
-        _m.resize(num_sources);
-        for (size_t i = 0; i < num_sources; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
-        }
     }
     ~ShuffleExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
@@ -267,9 +274,7 @@ class BucketShuffleExchanger final : public ShuffleExchanger {
     BucketShuffleExchanger(int running_sink_operators, int num_sources, int num_partitions,
                            int free_block_limit)
             : ShuffleExchanger(running_sink_operators, num_sources, num_partitions,
-                               free_block_limit) {
-        DCHECK_GT(num_partitions, 0);
-    }
+                               free_block_limit) {}
     ~BucketShuffleExchanger() override = default;
     ExchangeType get_type() const override { return ExchangeType::BUCKET_HASH_SHUFFLE; }
 };
@@ -279,13 +284,7 @@ public:
     ENABLE_FACTORY_CREATOR(PassthroughExchanger);
     PassthroughExchanger(int running_sink_operators, int num_partitions, int free_block_limit)
             : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions,
-                                          free_block_limit) {
-        _data_queue.resize(num_partitions);
-        _m.resize(num_partitions);
-        for (size_t i = 0; i < num_partitions; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
-        }
-    }
+                                          free_block_limit) {}
     ~PassthroughExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;
@@ -301,13 +300,7 @@ public:
     ENABLE_FACTORY_CREATOR(PassToOneExchanger);
     PassToOneExchanger(int running_sink_operators, int num_partitions, int free_block_limit)
             : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions,
-                                          free_block_limit) {
-        _data_queue.resize(num_partitions);
-        _m.resize(num_partitions);
-        for (size_t i = 0; i < num_partitions; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
-        }
-    }
+                                          free_block_limit) {}
     ~PassToOneExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;
@@ -324,13 +317,7 @@ public:
     LocalMergeSortExchanger(std::shared_ptr<SortSourceOperatorX> sort_source,
                             int running_sink_operators, int num_partitions, int free_block_limit)
             : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions, free_block_limit),
-              _sort_source(std::move(sort_source)) {
-        _data_queue.resize(num_partitions);
-        _m.resize(num_partitions);
-        for (size_t i = 0; i < num_partitions; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
-        }
-    }
+              _sort_source(std::move(sort_source)) {}
     ~LocalMergeSortExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;
@@ -354,13 +341,7 @@ class BroadcastExchanger final : public Exchanger<BroadcastBlock> {
 public:
     ENABLE_FACTORY_CREATOR(BroadcastExchanger);
     BroadcastExchanger(int running_sink_operators, int num_partitions, int free_block_limit)
-            : Exchanger<BroadcastBlock>(running_sink_operators, num_partitions, free_block_limit) {
-        _data_queue.resize(num_partitions);
-        _m.resize(num_partitions);
-        for (size_t i = 0; i < num_partitions; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
-        }
-    }
+            : Exchanger<BroadcastBlock>(running_sink_operators, num_partitions, free_block_limit) {}
     ~BroadcastExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;
@@ -380,12 +361,7 @@ public:
                                  int free_block_limit)
             : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions,
                                           free_block_limit) {
-        _data_queue.resize(num_partitions);
         _partition_rows_histogram.resize(running_sink_operators);
-        _m.resize(num_partitions);
-        for (size_t i = 0; i < num_partitions; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
-        }
     }
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -175,7 +175,7 @@ public:
         _data_queue.resize(num_sources);
         _m.resize(num_sources);
         for (size_t i = 0; i < num_sources; i++) {
-            _m[i] = std::make_unique<std::shared_mutex>();
+            _m[i] = std::make_unique<std::mutex>();
         }
     }
     ~Exchanger() override = default;
@@ -194,7 +194,7 @@ protected:
     void _enqueue_data_and_set_ready(int channel_id, BlockType&& block);
     bool _dequeue_data(BlockType& block, bool* eos, vectorized::Block* data_block, int channel_id);
     std::vector<BlockQueue<BlockType>> _data_queue;
-    std::vector<std::unique_ptr<std::shared_mutex>> _m;
+    std::vector<std::unique_ptr<std::mutex>> _m;
 };
 
 class LocalExchangeSourceLocalState;


### PR DESCRIPTION
### What problem does this PR solve?

Reduce lock scope from global level to data queue level.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

