### PR TITLE
[fix](cancel) Fix `BufferControlBlock` cancel msg

### DIFF
--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -170,10 +170,10 @@ BufferControlBlock::BufferControlBlock(TUniqueId id, int buffer_size, RuntimeSta
 }
 
 BufferControlBlock::~BufferControlBlock() {
-    cancel(Status::Cancelled(fmt::format(
+    cancel(Status::Cancelled(
             "BufferControlBlock is destructed, this is not the expected path, the correct path is "
             "ResultBufferMgr::cancel before the destructor, fragmentId: {}",
-            print_id(_fragment_id))));
+            print_id(_fragment_id)));
 }
 
 Status BufferControlBlock::init() {

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -170,7 +170,10 @@ BufferControlBlock::BufferControlBlock(TUniqueId id, int buffer_size, RuntimeSta
 }
 
 BufferControlBlock::~BufferControlBlock() {
-    cancel(Status::Cancelled("Cancelled"));
+    cancel(Status::Cancelled(fmt::format(
+            "BufferControlBlock is destructed, this is not the expected path, the correct path is "
+            "ResultBufferMgr::cancel before the destructor, fragmentId: {}",
+            print_id(_fragment_id))));
 }
 
 Status BufferControlBlock::init() {

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -463,7 +463,7 @@ void BufferControlBlock::cancel(const Status& reason) {
     }
     _waiting_rpc.clear();
     for (auto& ctx : _waiting_arrow_result_batch_rpc) {
-        ctx->on_failure(Status::Cancelled("Cancelled"));
+        ctx->on_failure(reason);
     }
     _waiting_arrow_result_batch_rpc.clear();
     _update_dependency();

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -211,7 +211,8 @@ void ResultBufferMgr::cancel_thread() {
 
         // cancel query
         for (const auto& id : query_to_cancel) {
-            cancel(id, Status::TimedOut("Query tiemout"));
+            cancel(id, Status::Cancelled(fmt::format(
+                               "Clean up expired BufferControlBlock, queryId: {}", print_id(id))));
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(1)));
 

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -211,8 +211,8 @@ void ResultBufferMgr::cancel_thread() {
 
         // cancel query
         for (const auto& id : query_to_cancel) {
-            cancel(id, Status::Cancelled(fmt::format(
-                               "Clean up expired BufferControlBlock, queryId: {}", print_id(id))));
+            cancel(id, Status::Cancelled("Clean up expired BufferControlBlock, queryId: {}",
+                                         print_id(id)));
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(1)));
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Clean up expired BufferControlBlock
2. BufferControlBlock is destructed, this is not the expected path, the correct path is ResultBufferMgr::cancel before the destructor.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

