### PR TITLE
[fix](HMSExternalTable) refactor HMSExternalTable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalDatabase.java
@@ -18,6 +18,7 @@
 package org.apache.doris.datasource.hive;
 
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.InitDatabaseLog;
@@ -45,9 +46,11 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
             ExternalDatabase db) {
         HMSExternalTable hmsExternalTable = new HMSExternalTable(tblId, localTableName, remoteTableName,
                 (HMSExternalCatalog) extCatalog, (HMSExternalDatabase) db);
-        if (hmsExternalTable.getDlaType() == DLAType.HIVE) {
-            return new HiveExternalTable(tblId, localTableName, remoteTableName,
-                    (HMSExternalCatalog) extCatalog, (HMSExternalDatabase) db);
+        if (!FeConstants.runningUnitTest) {
+            if (hmsExternalTable.getDlaType() == DLAType.HIVE) {
+                return new HiveExternalTable(tblId, localTableName, remoteTableName,
+                        (HMSExternalCatalog) extCatalog, (HMSExternalDatabase) db);
+            }
         }
         return hmsExternalTable;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalDatabase.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.InitDatabaseLog;
+import org.apache.doris.datasource.hive.HMSExternalTable.DLAType;
 
 /**
  * Hive metastore external database.
@@ -42,8 +43,13 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
     public HMSExternalTable buildTableInternal(String remoteTableName, String localTableName, long tblId,
             ExternalCatalog catalog,
             ExternalDatabase db) {
-        return new HMSExternalTable(tblId, localTableName, remoteTableName, (HMSExternalCatalog) extCatalog,
-                (HMSExternalDatabase) db);
+        HMSExternalTable hmsExternalTable = new HMSExternalTable(tblId, localTableName, remoteTableName,
+                (HMSExternalCatalog) extCatalog, (HMSExternalDatabase) db);
+        if (hmsExternalTable.getDlaType() == DLAType.HIVE) {
+            return new HiveExternalTable(tblId, localTableName, remoteTableName,
+                    (HMSExternalCatalog) extCatalog, (HMSExternalDatabase) db);
+        }
+        return hmsExternalTable;
     }
 
     public void addTableForTest(HMSExternalTable tbl) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalTable.java
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.PartitionItem;
+import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.datasource.mvcc.MvccSnapshot;
+import org.apache.doris.mtmv.MTMVBaseTableIf;
+import org.apache.doris.mtmv.MTMVMaxTimestampSnapshot;
+import org.apache.doris.mtmv.MTMVRefreshContext;
+import org.apache.doris.mtmv.MTMVRelatedTableIf;
+import org.apache.doris.mtmv.MTMVSnapshotIf;
+import org.apache.doris.mtmv.MTMVTimestampSnapshot;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class HiveExternalTable extends HMSExternalTable implements MTMVRelatedTableIf, MTMVBaseTableIf {
+
+    public HiveExternalTable(long id, String name, String remoteName, HMSExternalCatalog catalog,
+            HMSExternalDatabase db) {
+        super(id, name, remoteName, catalog, db);
+    }
+
+    @Override
+    public PartitionType getPartitionType(Optional<MvccSnapshot> snapshot) {
+        return getPartitionType();
+    }
+
+    @Override
+    public Set<String> getPartitionColumnNames(Optional<MvccSnapshot> snapshot) {
+        return getPartitionColumnNames();
+    }
+
+    @Override
+    public List<Column> getPartitionColumns(Optional<MvccSnapshot> snapshot) {
+        return getPartitionColumns();
+    }
+
+    @Override
+    public Map<String, PartitionItem> getAndCopyPartitionItems(Optional<MvccSnapshot> snapshot) {
+        return getNameToPartitionItems();
+    }
+
+    @Override
+    public MTMVSnapshotIf getPartitionSnapshot(String partitionName, MTMVRefreshContext context,
+            Optional<MvccSnapshot> snapshot) throws AnalysisException {
+        HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
+                .getMetaStoreCache((HMSExternalCatalog) getCatalog());
+        HiveMetaStoreCache.HivePartitionValues hivePartitionValues = cache.getPartitionValues(
+                getDbName(), getName(), getPartitionColumnTypes());
+        Long partitionId = getPartitionIdByNameOrAnalysisException(partitionName, hivePartitionValues);
+        HivePartition hivePartition = getHivePartitionByIdOrAnalysisException(partitionId,
+                hivePartitionValues, cache);
+        return new MTMVTimestampSnapshot(hivePartition.getLastModifiedTime());
+    }
+
+    @Override
+    public MTMVSnapshotIf getTableSnapshot(MTMVRefreshContext context, Optional<MvccSnapshot> snapshot)
+            throws AnalysisException {
+        if (getPartitionType() == PartitionType.UNPARTITIONED) {
+            return new MTMVMaxTimestampSnapshot(getName(), getLastDdlTime());
+        }
+        HivePartition maxPartition = null;
+        long maxVersionTime = 0L;
+        long visibleVersionTime;
+        HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
+                .getMetaStoreCache((HMSExternalCatalog) getCatalog());
+        HiveMetaStoreCache.HivePartitionValues hivePartitionValues = cache.getPartitionValues(
+                getDbName(), getName(), getPartitionColumnTypes());
+        List<HivePartition> partitionList = cache.getAllPartitionsWithCache(getDbName(), getName(),
+                Lists.newArrayList(hivePartitionValues.getPartitionValuesMap().values()));
+        if (CollectionUtils.isEmpty(partitionList)) {
+            throw new AnalysisException("partitionList is empty, table name: " + getName());
+        }
+        for (HivePartition hivePartition : partitionList) {
+            visibleVersionTime = hivePartition.getLastModifiedTime();
+            if (visibleVersionTime > maxVersionTime) {
+                maxVersionTime = visibleVersionTime;
+                maxPartition = hivePartition;
+            }
+        }
+        return new MTMVMaxTimestampSnapshot(maxPartition.getPartitionName(getPartitionColumns()), maxVersionTime);
+    }
+
+    private Long getPartitionIdByNameOrAnalysisException(String partitionName,
+            HiveMetaStoreCache.HivePartitionValues hivePartitionValues)
+            throws AnalysisException {
+        Long partitionId = hivePartitionValues.getPartitionNameToIdMap().get(partitionName);
+        if (partitionId == null) {
+            throw new AnalysisException("can not find partition: " + partitionName);
+        }
+        return partitionId;
+    }
+
+    private HivePartition getHivePartitionByIdOrAnalysisException(Long partitionId,
+            HiveMetaStoreCache.HivePartitionValues hivePartitionValues,
+            HiveMetaStoreCache cache) throws AnalysisException {
+        List<String> partitionValues = hivePartitionValues.getPartitionValuesMap().get(partitionId);
+        if (CollectionUtils.isEmpty(partitionValues)) {
+            throw new AnalysisException("can not find partitionValues: " + partitionId);
+        }
+        HivePartition partition = cache.getHivePartition(getDbName(), getName(), partitionValues);
+        if (partition == null) {
+            throw new AnalysisException("can not find partition: " + partitionId);
+        }
+        return partition;
+    }
+
+    @Override
+    public boolean isPartitionColumnAllowNull() {
+        return true;
+    }
+
+    @Override
+    public void beforeMTMVRefresh(MTMV mtmv) throws DdlException {
+        Env.getCurrentEnv().getRefreshManager()
+                .refreshTable(getCatalog().getName(), getDbName(), getName(), true);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionCheckUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionCheckUtilTest.java
@@ -30,7 +30,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.DynamicPartitionUtil;
 import org.apache.doris.common.util.DynamicPartitionUtil.StartOfDate;
-import org.apache.doris.datasource.hive.HMSExternalTable;
+import org.apache.doris.datasource.hive.HiveExternalTable;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
@@ -43,7 +43,7 @@ import java.util.ArrayList;
 
 public class MTMVPartitionCheckUtilTest {
     @Mocked
-    private HMSExternalTable hmsExternalTable;
+    private HiveExternalTable hiveExternalTable;
     @Mocked
     private OlapTable originalTable;
     @Mocked
@@ -138,7 +138,7 @@ public class MTMVPartitionCheckUtilTest {
     @Test
     public void testCheckIfAllowMultiTablePartitionRefreshNotOlapTable() {
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.checkIfAllowMultiTablePartitionRefresh(
-                hmsExternalTable);
+                hiveExternalTable);
         Assert.assertFalse(res.first);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

This pull request focuses on the handling of Hive metastore external tables.
The changes introduce a new `HiveExternalTable` class and refactor the existing `HMSExternalTable` class to accommodate this new structure.

As before, both the `Hive External Table` and the `Hudi External Table` utilize `HMSExternalTable`. The `HMSExternalTable` implements the `MTMVRelatedTableIf` and `MTMVBaseTableIf` interfaces, which enables it to support the partition refresh functionality for the Hive External Table.

Nevertheless, in order to implement partition refresh for the Hudi External Table, we have to split the `HMSExternalTable` into two separate, independent classes so that partition refresh can be supported independently. 

#### Introduction of `HiveExternalTable` class:
* [`fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalTable.java`](diffhunk://#diff-beb3e99a3ae1a47dfcf42043421ce82563f3fa5fa28eb46001c36c393f7b1496R1-R145): Created a new `HiveExternalTable` class that extends `HMSExternalTable` and implements `MTMVRelatedTableIf` and `MTMVBaseTableIf`. This class includes methods for partition handling and MTMV snapshot management.

#### Modifications to `HMSExternalTable` class:
* [`fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java`](diffhunk://#diff-58d2a4c3d0790e5da0a40e448187185b7772252c1ee14392cfc0126e21e4db6dL24-L32): Removed the implementation of `MTMVRelatedTableIf` and `MTMVBaseTableIf` interfaces and their associated methods, which are now handled by the new `HiveExternalTable` class. [[1]](diffhunk://#diff-58d2a4c3d0790e5da0a40e448187185b7772252c1ee14392cfc0126e21e4db6dL24-L32) [[2]](diffhunk://#diff-58d2a4c3d0790e5da0a40e448187185b7772252c1ee14392cfc0126e21e4db6dL42-L47) [[3]](diffhunk://#diff-58d2a4c3d0790e5da0a40e448187185b7772252c1ee14392cfc0126e21e4db6dL100-R91) [[4]](diffhunk://#diff-58d2a4c3d0790e5da0a40e448187185b7772252c1ee14392cfc0126e21e4db6dL801-L894) [[5]](diffhunk://#diff-58d2a4c3d0790e5da0a40e448187185b7772252c1ee14392cfc0126e21e4db6dL1025-L1030)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

