### PR TITLE
[fix](metrics) Fix negative scanner cnt

### DIFF
--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -40,6 +40,7 @@ VScanner::VScanner(RuntimeState* state, VScanNode* parent, int64_t limit, Runtim
           _output_tuple_desc(parent->output_tuple_desc()),
           _output_row_descriptor(_parent->_output_row_descriptor.get()) {
     _total_rf_num = _parent->runtime_filter_num();
+    DorisMetrics::instance()->scanner_cnt->increment(1);
 }
 
 VScanner::VScanner(RuntimeState* state, pipeline::ScanLocalStateBase* local_state, int64_t limit,

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -70,6 +70,9 @@ public:
         _common_expr_ctxs_push_down.clear();
         _stale_expr_ctxs.clear();
         DorisMetrics::instance()->scanner_cnt->increment(-1);
+        DCHECK(DorisMetrics::instance()->scanner_cnt->value() >= 0) << fmt::format(
+                "Meets negative scanner count: {}, current query {}",
+                DorisMetrics::instance()->scanner_cnt->value(), print_id(_state->query_id()));
     }
 
     virtual Status init() { return Status::OK(); }


### PR DESCRIPTION
### What problem does this PR solve?
Fix 
![image](https://github.com/user-attachments/assets/c78e4978-2292-46c2-8cc1-59da4c05cf41)

Related PR: https://github.com/apache/doris/pull/41314

Scanner has two constructor function on branch-2.1, but on master it just has one, so cherrypick introduced bug.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

