### PR TITLE
[refactor](partition) refactor partition sort node about control data to output 

### DIFF
--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -17,6 +17,8 @@
 
 #include "partition_sort_sink_operator.h"
 
+#include <glog/logging.h>
+
 #include <cstdint>
 
 #include "common/status.h"
@@ -142,8 +144,11 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                     std::move(_value_place->_partition_topn_sorter));
         }
         // notice: need split two for loop, as maybe need check sorter early
+        DCHECK_EQ(local_state._value_places.size(),
+                  local_state._shared_state->partition_sorts.size());
         for (int i = 0; i < local_state._value_places.size(); ++i) {
             auto& sorter = local_state._shared_state->partition_sorts[i];
+            DCHECK(sorter != nullptr);
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -145,7 +145,7 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         }
         // notice: need split two for loop, as maybe need check sorter early
         CHECK_EQ(local_state._value_places.size(),
-                  local_state._shared_state->partition_sorts.size());
+                 local_state._shared_state->partition_sorts.size());
         for (int i = 0; i < local_state._value_places.size(); ++i) {
             auto& sorter = local_state._shared_state->partition_sorts[i];
             CHECK(sorter != nullptr) << i;

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -152,6 +152,7 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
             local_state._value_places[i]->_blocks.clear();
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
+            std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
             local_state._dependency->set_ready_to_read();
         }
 

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -138,8 +138,8 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         SCOPED_TIMER(local_state._sorted_data_timer);
         for (auto& _value_place : local_state._value_places) {
             _value_place->create_or_reset_sorter_state();
-            auto sorter = std::move(_value_place->_partition_topn_sorter);
-            local_state._shared_state->partition_sorts.push_back(std::move(sorter));
+            local_state._shared_state->partition_sorts.emplace_back(
+                    _value_place->_partition_topn_sorter);
         }
         // notice: need split two for loop, as maybe need check sorter early
         for (int i = 0; i < local_state._value_places.size(); ++i) {
@@ -147,6 +147,7 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
+            local_state._value_places[i]->_blocks.clear();
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
             local_state._dependency->set_ready_to_read();

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -139,7 +139,7 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         for (auto& _value_place : local_state._value_places) {
             _value_place->create_or_reset_sorter_state();
             local_state._shared_state->partition_sorts.emplace_back(
-                    _value_place->_partition_topn_sorter);
+                    std::move(_value_place->_partition_topn_sorter));
         }
         // notice: need split two for loop, as maybe need check sorter early
         for (int i = 0; i < local_state._value_places.size(); ++i) {

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -150,9 +150,9 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
             local_state._value_places[i]->_blocks.clear();
-            std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
+            std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
             local_state._dependency->set_ready_to_read();
         }
 

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -141,17 +141,15 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
             auto sorter = std::move(_value_place->_partition_topn_sorter);
             local_state._shared_state->partition_sorts.push_back(std::move(sorter));
         }
-        // notice: need split two for loop
+        // notice: need split two for loop, as maybe need check sorter early
         for (int i = 0; i < local_state._value_places.size(); ++i) {
             auto& sorter = local_state._shared_state->partition_sorts[i];
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
             RETURN_IF_ERROR(sorter->prepare_for_read());
-            if (i == 0) {
-                // iff one sorter have data, then could set source ready to read
-                local_state._dependency->set_ready_to_read();
-            }
+            // iff one sorter have data, then could set source ready to read
+            local_state._dependency->set_ready_to_read();
         }
 
         COUNTER_SET(local_state._hash_table_size_counter, int64_t(local_state._num_partition));

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -144,16 +144,12 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                     std::move(_value_place->_partition_topn_sorter));
         }
         // notice: need split two for loop, as maybe need check sorter early
-        CHECK_EQ(local_state._value_places.size(),
-                 local_state._shared_state->partition_sorts.size());
         for (int i = 0; i < local_state._value_places.size(); ++i) {
             auto& sorter = local_state._shared_state->partition_sorts[i];
-            CHECK(sorter != nullptr) << i;
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
             local_state._value_places[i]->_blocks.clear();
-            CHECK(sorter != nullptr) << i;
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
             local_state._dependency->set_ready_to_read();

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -150,9 +150,9 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
             local_state._value_places[i]->_blocks.clear();
+            std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
-            std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
             local_state._dependency->set_ready_to_read();
         }
 

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -148,12 +148,12 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                   local_state._shared_state->partition_sorts.size());
         for (int i = 0; i < local_state._value_places.size(); ++i) {
             auto& sorter = local_state._shared_state->partition_sorts[i];
-            CHECK(sorter != nullptr);
+            CHECK(sorter != nullptr) << i;
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
             local_state._value_places[i]->_blocks.clear();
-            CHECK(sorter != nullptr);
+            CHECK(sorter != nullptr) << i;
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
             local_state._dependency->set_ready_to_read();

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -144,15 +144,16 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
                     std::move(_value_place->_partition_topn_sorter));
         }
         // notice: need split two for loop, as maybe need check sorter early
-        DCHECK_EQ(local_state._value_places.size(),
+        CHECK_EQ(local_state._value_places.size(),
                   local_state._shared_state->partition_sorts.size());
         for (int i = 0; i < local_state._value_places.size(); ++i) {
             auto& sorter = local_state._shared_state->partition_sorts[i];
-            DCHECK(sorter != nullptr);
+            CHECK(sorter != nullptr);
             for (const auto& block : local_state._value_places[i]->_blocks) {
                 RETURN_IF_ERROR(sorter->append_block(block.get()));
             }
             local_state._value_places[i]->_blocks.clear();
+            CHECK(sorter != nullptr);
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
             local_state._dependency->set_ready_to_read();

--- a/be/src/pipeline/exec/partition_sort_sink_operator.h
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.h
@@ -58,6 +58,7 @@ private:
     RuntimeProfile::Counter* _build_timer = nullptr;
     RuntimeProfile::Counter* _emplace_key_timer = nullptr;
     RuntimeProfile::Counter* _selector_block_timer = nullptr;
+    RuntimeProfile::Counter* _sorted_data_timer = nullptr;
     RuntimeProfile::Counter* _hash_table_size_counter = nullptr;
     RuntimeProfile::Counter* _passthrough_rows_counter = nullptr;
     RuntimeProfile::Counter* _sorted_partition_input_rows_counter = nullptr;

--- a/be/src/pipeline/exec/partition_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_source_operator.cpp
@@ -97,6 +97,7 @@ Status PartitionSortSourceOperatorX::get_sorted_block(RuntimeState* state,
     if (current_eos) {
         // current sort have eos, so get next idx
         sorters[local_state._sort_idx].reset(nullptr);
+        LOG(INFO)<<"asd reset sorter "<<local_state._sort_idx;
         local_state._sort_idx++;
         if (local_state._sort_idx < sorter_size &&
             !sorters[local_state._sort_idx]->prepared_finish()) {

--- a/be/src/pipeline/exec/partition_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_source_operator.cpp
@@ -97,6 +97,7 @@ Status PartitionSortSourceOperatorX::get_sorted_block(RuntimeState* state,
         // current sort have eos, so get next idx
         sorters[local_state._sort_idx].reset(nullptr);
         local_state._sort_idx++;
+        std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
         if (local_state._sort_idx < sorter_size &&
             !sorters[local_state._sort_idx]->prepared_finish()) {
             local_state._dependency->block();

--- a/be/src/pipeline/exec/partition_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_source_operator.cpp
@@ -89,7 +89,7 @@ Status PartitionSortSourceOperatorX::get_sorted_block(RuntimeState* state,
     bool current_eos = false;
     auto& sorters = local_state._shared_state->partition_sorts;
     auto sorter_size = sorters.size();
-    if (local_state._sort_idx < sorter_size) {
+    if (local_state._sort_idx < sorter_size && sorters[local_state._sort_idx]->prepared_finish()) {
         RETURN_IF_ERROR(
                 sorters[local_state._sort_idx]->get_next(state, output_block, &current_eos));
         COUNTER_UPDATE(local_state._sorted_partition_output_rows_counter, output_block->rows());
@@ -97,7 +97,7 @@ Status PartitionSortSourceOperatorX::get_sorted_block(RuntimeState* state,
     if (current_eos) {
         // current sort have eos, so get next idx
         sorters[local_state._sort_idx].reset(nullptr);
-        LOG(INFO)<<"asd reset sorter "<<local_state._sort_idx;
+        LOG(INFO) << "asd reset sorter " << local_state._sort_idx;
         local_state._sort_idx++;
         if (local_state._sort_idx < sorter_size &&
             !sorters[local_state._sort_idx]->prepared_finish()) {

--- a/be/src/pipeline/exec/partition_sort_source_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_source_operator.cpp
@@ -92,7 +92,8 @@ Status PartitionSortSourceOperatorX::get_sorted_block(RuntimeState* state,
     SCOPED_TIMER(local_state._get_sorted_timer);
     //sorter output data one by one
     bool current_eos = false;
-    if (local_state._sort_idx < local_state._shared_state->partition_sorts.size()) {
+    if (local_state._sort_idx < local_state._shared_state->partition_sorts.size() &&
+        local_state._shared_state->partition_sorts[local_state._sort_idx]->prepared_finish()) {
         RETURN_IF_ERROR(local_state._shared_state->partition_sorts[local_state._sort_idx]->get_next(
                 state, output_block, &current_eos));
         COUNTER_UPDATE(local_state._sorted_partition_output_rows_counter, output_block->rows());

--- a/be/src/vec/common/sort/partition_sorter.cpp
+++ b/be/src/vec/common/sort/partition_sorter.cpp
@@ -69,6 +69,7 @@ Status PartitionSorter::prepare_for_read() {
         priority_queue.emplace(MergeSortCursorImpl::create_shared(block, _sort_description));
     }
     blocks.clear();
+    _prepared_finish = true;
     return Status::OK();
 }
 

--- a/be/src/vec/common/sort/partition_sorter.cpp
+++ b/be/src/vec/common/sort/partition_sorter.cpp
@@ -86,6 +86,7 @@ void PartitionSorter::reset_sorter_state(RuntimeState* runtime_state) {
     }
     _output_total_rows = 0;
     _output_distinct_rows = 0;
+    _prepared_finish = false;
 }
 
 Status PartitionSorter::get_next(RuntimeState* state, Block* block, bool* eos) {

--- a/be/src/vec/common/sort/partition_sorter.h
+++ b/be/src/vec/common/sort/partition_sorter.h
@@ -95,7 +95,7 @@ public:
     Status partition_sort_read(Block* block, bool* eos, int batch_size);
     int64 get_output_rows() const { return _output_total_rows; }
     void reset_sorter_state(RuntimeState* runtime_state);
-    auto prepared_finish() { return _prepared_finish.load(); }
+    bool prepared_finish() { return _prepared_finish; }
 
 private:
     std::unique_ptr<MergeSorterState> _state;

--- a/be/src/vec/common/sort/partition_sorter.h
+++ b/be/src/vec/common/sort/partition_sorter.h
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -94,6 +95,7 @@ public:
     Status partition_sort_read(Block* block, bool* eos, int batch_size);
     int64 get_output_rows() const { return _output_total_rows; }
     void reset_sorter_state(RuntimeState* runtime_state);
+    auto prepared_finish() { return _prepared_finish.load(); }
 
 private:
     std::unique_ptr<MergeSorterState> _state;
@@ -104,6 +106,7 @@ private:
     int _partition_inner_limit = 0;
     TopNAlgorithm::type _top_n_algorithm = TopNAlgorithm::type::ROW_NUMBER;
     SortCursorCmp* _previous_row = nullptr;
+    std::atomic_bool _prepared_finish = false;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

before when the partition sort sink operator all of sorters have been sorted data
then set source operator decency ready.
but the sorted data maybe need more time, so we could notice source operator after the first sorter have done.



None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

