### PR TITLE
[fix](statistics)Fix sample all tablets scale factor incorrect bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -95,8 +95,8 @@ public abstract class BaseAnalysisTask {
             + "SUBSTRING(CAST(${min} AS STRING), 1, 1024) AS `min`, "
             + "SUBSTRING(CAST(${max} AS STRING), 1, 1024) AS `max`, "
             + "${dataSizeFunction} * ${scaleFactor} AS `data_size`, "
-            + "NOW() "
-            + "FROM `${catalogName}`.`${dbName}`.`${tblName}` ${index} ${sampleHints} ${limit}";
+            + "NOW() FROM ( "
+            + "SELECT * FROM `${catalogName}`.`${dbName}`.`${tblName}` ${index} ${sampleHints} ${limit})  as t";
 
     protected static final String DUJ1_ANALYZE_TEMPLATE = "SELECT "
             + "CONCAT('${tblId}', '-', '${idxId}', '-', '${colId}') AS `id`, "

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -308,7 +308,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             // Skip partitions with row count < row count / 2 expected to be sampled per partition.
             // It can be expected to sample a smaller number of partitions to avoid uneven distribution
             // of sampling results.
-            if (materializedIndex.getRowCount() < (avgRowsPerPartition / 2)) {
+            if (materializedIndex.getRowCount() < (avgRowsPerPartition / 2) && !forPartitionColumn) {
                 continue;
             }
             long avgRowsPerTablet = Math.max(materializedIndex.getRowCount() / ids.size(), 1);
@@ -339,8 +339,10 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         if (totalRows < sampleRows) {
             // can't fill full sample rows
             sampleTabletIds.clear();
+            actualSampledRowCount = 0;
         } else if (sampleTabletIds.size() == totalTablet && !enough) {
             sampleTabletIds.clear();
+            actualSampledRowCount = 0;
         }
         return Pair.of(sampleTabletIds, actualSampledRowCount);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -215,7 +215,7 @@ public class OlapAnalysisTaskTest {
                         + "AS `null_count`, SUBSTRING(CAST('1' AS STRING), 1, 1024) AS `min`, "
                         + "SUBSTRING(CAST('2' AS STRING), 1, 1024) AS `max`, "
                         + "SUM(LENGTH(`null`)) * 5.0 AS `data_size`, NOW() "
-                        + "FROM `catalogName`.`${dbName}`.`null`   limit 100", sql);
+                        + "FROM ( SELECT * FROM `catalogName`.`${dbName}`.`null`   limit 100)  as t", sql);
                 return;
             }
         };


### PR DESCRIPTION
### What problem does this PR solve?

Fix sample all tablets scale factor incorrect bug. When sampled rows is more than table row count, set scale factor to 1.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

