### PR TITLE
[fix](hive) sync DDL command to other FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4176,7 +4176,8 @@ public class Env {
     }
 
     public void replayCreateTable(CreateTableInfo info) throws MetaNotFoundException {
-        if (Strings.isNullOrEmpty(info.getCtlName())) {
+        if (Strings.isNullOrEmpty(info.getCtlName()) || info.getCtlName()
+                .equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
             getInternalCatalog().replayCreateTable(info.getDbName(), info.getTable());
         } else {
             ExternalCatalog externalCatalog = (ExternalCatalog) catalogMgr.getCatalog(info.getCtlName());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -5866,9 +5866,11 @@ public class Env {
 
     public void replayTruncateTable(TruncateTableInfo info) throws MetaNotFoundException {
         if (Strings.isNullOrEmpty(info.getCtl())) {
+            // In previous versions(before 2.1.8), there is no catalog info in TruncateTableInfo,
+            // So if the catalog info is empty, we assume it's internal table.
             getInternalCatalog().replayTruncateTable(info);
         } else {
-            ExternalCatalog ctl = catalogMgr.getCatalog(info.getCtl());
+            ExternalCatalog ctl = (ExternalCatalog) catalogMgr.getCatalog(info.getCtl());
             if (ctl != null) {
                 ctl.replayTruncateTable(info);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3262,8 +3262,15 @@ public class Env {
         getInternalCatalog().unprotectCreateDb(db);
     }
 
-    public void replayCreateDb(Database db) {
-        getInternalCatalog().replayCreateDb(db, "");
+    public void replayCreateDb(CreateDbInfo dbInfo) {
+        if (dbInfo.getInternalDb() != null) {
+            getInternalCatalog().replayCreateDb(dbInfo.getInternalDb(), "");
+        } else {
+            ExternalCatalog externalCatalog = (ExternalCatalog) catalogMgr.getCatalog(dbInfo.getCtlName());
+            if (externalCatalog != null) {
+                externalCatalog.replayCreateDb(dbInfo.getDbName());
+            }
+        }
     }
 
     public void replayNewCreateDb(CreateDbInfo info) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -5865,7 +5865,14 @@ public class Env {
     }
 
     public void replayTruncateTable(TruncateTableInfo info) throws MetaNotFoundException {
-        getInternalCatalog().replayTruncateTable(info);
+        if (Strings.isNullOrEmpty(info.getCtl())) {
+            getInternalCatalog().replayTruncateTable(info);
+        } else {
+            ExternalCatalog ctl = catalogMgr.getCatalog(info.getCtl());
+            if (ctl != null) {
+                ctl.replayTruncateTable(info);
+            }
+        }
     }
 
     public void createFunction(CreateFunctionStmt stmt) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3273,17 +3273,6 @@ public class Env {
         }
     }
 
-    public void replayNewCreateDb(CreateDbInfo info) {
-        if (info.getCtlName().equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
-            getInternalCatalog().replayCreateDb(info.getInternalDb(), "");
-        } else {
-            ExternalCatalog externalCatalog = (ExternalCatalog) catalogMgr.getCatalog(info.getCtlName());
-            if (externalCatalog != null) {
-                externalCatalog.replayCreateDb(info.getDbName());
-            }
-        }
-    }
-
     public void dropDb(DropDbStmt stmt) throws DdlException {
         dropDb(stmt.getCtlName(), stmt.getDbName(), stmt.isSetIfExists(), stmt.isForceDrop());
     }
@@ -3299,7 +3288,8 @@ public class Env {
     }
 
     public void replayDropDb(DropDbInfo info) throws DdlException {
-        if (Strings.isNullOrEmpty(info.getCtlName())) {
+        if (Strings.isNullOrEmpty(info.getCtlName()) || info.getCtlName()
+                .equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
             getInternalCatalog().replayDropDb(info.getDbName(), info.isForceDrop(), info.getRecycleTime());
         } else {
             ExternalCatalog externalCatalog = (ExternalCatalog) catalogMgr.getCatalog(info.getCtlName());
@@ -5900,7 +5890,7 @@ public class Env {
     }
 
     public void replayTruncateTable(TruncateTableInfo info) throws MetaNotFoundException {
-        if (Strings.isNullOrEmpty(info.getCtl())) {
+        if (Strings.isNullOrEmpty(info.getCtl()) || info.getCtl().equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
             // In previous versions(before 2.1.8), there is no catalog info in TruncateTableInfo,
             // So if the catalog info is empty, we assume it's internal table.
             getInternalCatalog().replayTruncateTable(info);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogIf.java
@@ -189,7 +189,9 @@ public interface CatalogIf<T extends DatabaseIf> {
 
     void createDb(CreateDbStmt stmt) throws DdlException;
 
-    void dropDb(DropDbStmt stmt) throws DdlException;
+    default void dropDb(DropDbStmt stmt) throws DdlException {
+        dropDb(stmt.getDbName(), stmt.isSetIfExists(), stmt.isForceDrop());
+    }
 
     void dropDb(String dbName, boolean ifExists, boolean force) throws DdlException;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -19,7 +19,6 @@ package org.apache.doris.datasource;
 
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
-import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.analysis.TableRef;
@@ -961,11 +960,11 @@ public abstract class ExternalCatalog
             return;
         }
         try {
-            metadataOps.dropDb(dbName, ifExists, force);
+            metadataOps.dropDb(getName(), dbName, ifExists, force);
             DropDbInfo info = new DropDbInfo(getName(), dbName);
             Env.getCurrentEnv().getEditLog().logDropDb(info);
         } catch (Exception e) {
-            LOG.warn("Failed to drop database {} in catalog {}", stmt.getDbName(), getName(), e);
+            LOG.warn("Failed to drop database {} in catalog {}", dbName, getName(), e);
             throw e;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -940,7 +940,7 @@ public abstract class ExternalCatalog
         try {
             metadataOps.createDb(stmt);
             CreateDbInfo info = new CreateDbInfo(getName(), stmt.getFullDbName(), null);
-            Env.getCurrentEnv().getEditLog().logNewCreateDb(info);
+            Env.getCurrentEnv().getEditLog().logCreateDb(info);
         } catch (Exception e) {
             LOG.warn("Failed to create database {} in catalog {}.", stmt.getFullDbName(), getName(), e);
             throw e;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -1090,7 +1090,7 @@ public abstract class ExternalCatalog
             }
             metadataOps.truncateTable(tableName.getDb(), tableName.getTbl(), partitions, false);
         } catch (Exception e) {
-            LOG.warn("Failed to truncate table {}.{} in catlaog {}", stmt.getTblRef().getName().getDb(),
+            LOG.warn("Failed to truncate table {}.{} in catalog {}", stmt.getTblRef().getName().getDb(),
                     stmt.getTblRef().getName().getTbl(), getName(), e);
             throw e;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -1124,6 +1124,9 @@ public abstract class ExternalCatalog
                 partitions = tableRef.getPartitionNames().getPartitionNames();
             }
             metadataOps.truncateTable(tableName.getDb(), tableName.getTbl(), partitions);
+            TruncateTableInfo info = new TruncateTableInfo(getName(), tableName.getDb(), tableName.getTbl(),
+                    partitions);
+            Env.getCurrentEnv().getEditLog().logTruncateTable(info);
         } catch (Exception e) {
             LOG.warn("Failed to truncate table {}.{} in catalog {}", stmt.getTblRef().getName().getDb(),
                     stmt.getTblRef().getName().getTbl(), getName(), e);
@@ -1133,12 +1136,7 @@ public abstract class ExternalCatalog
 
     public void replayTruncateTable(TruncateTableInfo info) {
         if (metadataOps != null) {
-            try {
-                metadataOps.truncateTable(info.getDb(), info.getTable(), info.getExtPartNames());
-            } catch (DdlException e) {
-                LOG.warn("Failed to replay truncate table {}.{} in catalog {}", info.getDb(), info.getTable(),
-                        getName(), e);
-            }
+            metadataOps.afterTruncateTable(info.getDb(), info.getTable());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -486,10 +486,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         }
     }
 
-    public void dropDb(DropDbStmt stmt) throws DdlException {
-        dropDb(stmt.getDbName(), stmt.isSetIfExists(), stmt.isForceDrop());
-    }
-
+    @Override
     public void dropDb(String dbName, boolean ifExists, boolean force) throws DdlException {
         LOG.info("begin drop database[{}], is force : {}", dbName, force);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -33,7 +33,6 @@ import org.apache.doris.analysis.CreateTableLikeStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DataSortInfo;
 import org.apache.doris.analysis.DistributionDesc;
-import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropPartitionClause;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.Expr;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -151,6 +151,7 @@ import org.apache.doris.nereids.trees.plans.commands.info.TableNameInfo;
 import org.apache.doris.persist.AlterDatabasePropertyInfo;
 import org.apache.doris.persist.AutoIncrementIdUpdateLog;
 import org.apache.doris.persist.ColocatePersistInfo;
+import org.apache.doris.persist.CreateDbInfo;
 import org.apache.doris.persist.DatabaseInfo;
 import org.apache.doris.persist.DropDbInfo;
 import org.apache.doris.persist.DropInfo;
@@ -447,7 +448,8 @@ public class InternalCatalog implements CatalogIf<Database> {
                 }
                 try {
                     unprotectCreateDb(db);
-                    Env.getCurrentEnv().getEditLog().logCreateDb(db);
+                    CreateDbInfo dbInfo = new CreateDbInfo(InternalCatalog.INTERNAL_CATALOG_NAME, db.getName(), db);
+                    Env.getCurrentEnv().getEditLog().logCreateDb(dbInfo);
                 } finally {
                     db.writeUnlock();
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -20,7 +20,6 @@ package org.apache.doris.datasource.hive;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DistributionDesc;
-import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.HashDistributionDesc;
 import org.apache.doris.analysis.PartitionDesc;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -108,7 +108,7 @@ public class HiveMetadataOps implements ExternalMetadataOps {
     }
 
     @Override
-    public void createDb(CreateDbStmt stmt) throws DdlException {
+    public void createDbImpl(CreateDbStmt stmt) throws DdlException {
         String fullDbName = stmt.getFullDbName();
         Map<String, String> properties = stmt.getProperties();
         long dbId = Env.getCurrentEnv().getNextId();
@@ -131,7 +131,6 @@ public class HiveMetadataOps implements ExternalMetadataOps {
             catalogDatabase.setProperties(properties);
             catalogDatabase.setComment(properties.getOrDefault("comment", ""));
             client.createDatabase(catalogDatabase);
-            catalog.onRefreshCache(true);
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -139,12 +138,12 @@ public class HiveMetadataOps implements ExternalMetadataOps {
     }
 
     @Override
-    public void dropDb(DropDbStmt stmt) throws DdlException {
-        dropDb(stmt.getDbName(), stmt.isSetIfExists(), stmt.isForceDrop());
+    public void afterCreateDb(String dbName) {
+        catalog.onRefreshCache(true);
     }
 
     @Override
-    public void dropDb(String dbName, boolean ifExists, boolean force) throws DdlException {
+    public void dropDbImpl(String dbName, boolean ifExists, boolean force) throws DdlException {
         if (!databaseExist(dbName)) {
             if (ifExists) {
                 LOG.info("drop database[{}] which does not exist", dbName);
@@ -155,14 +154,18 @@ public class HiveMetadataOps implements ExternalMetadataOps {
         }
         try {
             client.dropDatabase(dbName);
-            catalog.onRefreshCache(true);
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws UserException {
+    public void afterDropDb(String dbName) {
+        catalog.onRefreshCache(true);
+    }
+
+    @Override
+    public boolean createTableImpl(CreateTableStmt stmt) throws UserException {
         String dbName = stmt.getDbName();
         String tblName = stmt.getTableName();
         ExternalDatabase<?> db = catalog.getDbNullable(dbName);
@@ -270,7 +273,6 @@ public class HiveMetadataOps implements ExternalMetadataOps {
                         comment);
             }
             client.createTable(hiveTableMeta, stmt.isSetIfNotExists());
-            db.setUnInitialized(true);
         } catch (Exception e) {
             throw new UserException(e.getMessage(), e);
         }
@@ -278,7 +280,15 @@ public class HiveMetadataOps implements ExternalMetadataOps {
     }
 
     @Override
-    public void dropTable(DropTableStmt stmt) throws DdlException {
+    public void afterCreateTable(String dbName, String tblName) {
+        ExternalDatabase<?> db = catalog.getDbNullable(dbName);
+        if (db != null) {
+            db.setUnInitialized(true);
+        }
+    }
+
+    @Override
+    public void dropTableImpl(DropTableStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tblName = stmt.getTableName();
         ExternalDatabase<?> db = catalog.getDbNullable(stmt.getDbName());
@@ -304,39 +314,44 @@ public class HiveMetadataOps implements ExternalMetadataOps {
 
         try {
             client.dropTable(dbName, tblName);
-            db.setUnInitialized(true);
         } catch (Exception e) {
             throw new DdlException(e.getMessage(), e);
         }
     }
 
     @Override
-    public void truncateTable(String dbName, String tblName, List<String> partitions, boolean isReplay)
+    public void afterDropTable(String dbName, String tblName) {
+        ExternalDatabase<?> db = catalog.getDbNullable(dbName);
+        if (db != null) {
+            db.setUnInitialized(true);
+        }
+    }
+
+    @Override
+    public void truncateTableImpl(String dbName, String tblName, List<String> partitions)
             throws DdlException {
         ExternalDatabase<?> db = catalog.getDbNullable(dbName);
         if (db == null) {
-            if (!isReplay) {
-                throw new DdlException("Failed to get database: '" + dbName + "' in catalog: " + catalog.getName());
-            } else {
-                LOG.warn("Failed to get database: '{}' in catalog: {} when replaying truncate table", dbName,
-                        catalog.getName());
-                return;
-            }
+            throw new DdlException("Failed to get database: '" + dbName + "' in catalog: " + catalog.getName());
         }
-        if (!isReplay) {
-            try {
-                client.truncateTable(dbName, tblName, partitions);
-            } catch (Exception e) {
-                throw new DdlException(e.getMessage(), e);
-            }
-            TruncateTableInfo info = new TruncateTableInfo(catalog.getName(), dbName, tblName, partitions);
-            Env.getCurrentEnv().getEditLog().logTruncateTable(info);
+        try {
+            client.truncateTable(dbName, tblName, partitions);
+        } catch (Exception e) {
+            throw new DdlException(e.getMessage(), e);
         }
+        TruncateTableInfo info = new TruncateTableInfo(catalog.getName(), dbName, tblName, partitions);
+        Env.getCurrentEnv().getEditLog().logTruncateTable(info);
+    }
 
+    @Override
+    public void afterTruncateTable(String dbName, String tblName) {
         // Invalidate cache.
         Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(catalog.getId(), dbName, tblName);
-        db.setLastUpdateTime(System.currentTimeMillis());
-        db.setUnInitialized(true);
+        ExternalDatabase<?> db = catalog.getDbNullable(dbName);
+        if (db != null) {
+            db.setLastUpdateTime(System.currentTimeMillis());
+            db.setUnInitialized(true);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -40,7 +40,6 @@ import org.apache.doris.datasource.jdbc.client.JdbcClient;
 import org.apache.doris.datasource.jdbc.client.JdbcClientConfig;
 import org.apache.doris.datasource.operations.ExternalMetadataOps;
 import org.apache.doris.datasource.property.constants.HMSProperties;
-import org.apache.doris.persist.TruncateTableInfo;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -339,8 +338,6 @@ public class HiveMetadataOps implements ExternalMetadataOps {
         } catch (Exception e) {
             throw new DdlException(e.getMessage(), e);
         }
-        TruncateTableInfo info = new TruncateTableInfo(catalog.getName(), dbName, tblName, partitions);
-        Env.getCurrentEnv().getEditLog().logTruncateTable(info);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -19,7 +19,6 @@ package org.apache.doris.datasource.iceberg;
 
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
-import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.StructField;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -279,7 +279,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
     }
 
     @Override
-    public void truncateTable(String dbName, String tblName, List<String> partitions) {
+    public void truncateTable(String dbName, String tblName, List<String> partitions, boolean isReplay) {
         throw new UnsupportedOperationException("Truncate Iceberg table is not supported.");
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
@@ -75,7 +75,7 @@ public interface ExternalMetadataOps {
      * @param tblName
      * @param partitions
      */
-    void truncateTable(String dbName, String tblName, List<String> partitions) throws DdlException;
+    void truncateTable(String dbName, String tblName, List<String> partitions, boolean isReplay) throws DdlException;
 
     /**
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
@@ -56,6 +56,11 @@ public interface ExternalMetadataOps {
         afterDropDb(stmt.getCtlName());
     }
 
+    default void dropDb(String ctlName, String dbName, boolean ifExists, boolean force) throws DdlException {
+        dropDbImpl(dbName, ifExists, force);
+        afterDropDb(ctlName);
+    }
+
     /**
      * drop db in external metastore for nereids
      * @param dbName

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/operations/ExternalMetadataOps.java
@@ -36,14 +36,25 @@ public interface ExternalMetadataOps {
      * @param stmt
      * @throws DdlException
      */
-    void createDb(CreateDbStmt stmt) throws DdlException;
+    default void createDb(CreateDbStmt stmt) throws DdlException {
+        createDbImpl(stmt);
+        afterCreateDb(stmt.getFullDbName());
+    }
+
+    void createDbImpl(CreateDbStmt stmt) throws DdlException;
+
+    default void afterCreateDb(String dbName) {
+    }
 
     /**
      * drop db in external metastore
      * @param stmt
      * @throws DdlException
      */
-    void dropDb(DropDbStmt stmt) throws DdlException;
+    default void dropDb(DropDbStmt stmt) throws DdlException {
+        dropDbImpl(stmt.getDbName(), stmt.isSetIfExists(), stmt.isForceDrop());
+        afterDropDb(stmt.getCtlName());
+    }
 
     /**
      * drop db in external metastore for nereids
@@ -52,7 +63,9 @@ public interface ExternalMetadataOps {
      * @param force
      * @throws DdlException
      */
-    void dropDb(String dbName, boolean ifExists, boolean force) throws DdlException;
+    void dropDbImpl(String dbName, boolean ifExists, boolean force) throws DdlException;
+
+    void afterDropDb(String dbName);
 
     /**
      *
@@ -60,14 +73,33 @@ public interface ExternalMetadataOps {
      * @return if set isExists is true, return true if table exists, otherwise return false
      * @throws UserException
      */
-    boolean createTable(CreateTableStmt stmt) throws UserException;
+    default boolean createTable(CreateTableStmt stmt) throws UserException {
+        boolean res = createTableImpl(stmt);
+        if (!res) {
+            afterCreateTable(stmt.getDbName(), stmt.getTableName());
+        }
+        return res;
+    }
+
+    boolean createTableImpl(CreateTableStmt stmt) throws UserException;
+
+    default void afterCreateTable(String dbName, String tblName) {
+    }
 
     /**
      *
      * @param stmt
      * @throws DdlException
      */
-    void dropTable(DropTableStmt stmt) throws DdlException;
+    default void dropTable(DropTableStmt stmt) throws DdlException {
+        dropTableImpl(stmt);
+        afterDropTable(stmt.getDbName(), stmt.getTableName());
+    }
+
+    void dropTableImpl(DropTableStmt stmt) throws DdlException;
+
+    default void afterDropTable(String dbName, String tblName) {
+    }
 
     /**
      *
@@ -75,7 +107,15 @@ public interface ExternalMetadataOps {
      * @param tblName
      * @param partitions
      */
-    void truncateTable(String dbName, String tblName, List<String> partitions, boolean isReplay) throws DdlException;
+    default void truncateTable(String dbName, String tblName, List<String> partitions) throws DdlException {
+        truncateTableImpl(dbName, tblName, partitions);
+        afterTruncateTable(dbName, tblName);
+    }
+
+    void truncateTableImpl(String dbName, String tblName, List<String> partitions) throws DdlException;
+
+    default void afterTruncateTable(String dbName, String tblName) {
+    }
 
     /**
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -81,6 +81,7 @@ import org.apache.doris.persist.CleanLabelOperationLog;
 import org.apache.doris.persist.CleanQueryStatsInfo;
 import org.apache.doris.persist.ColocatePersistInfo;
 import org.apache.doris.persist.ConsistencyCheckInfo;
+import org.apache.doris.persist.CreateDbInfo;
 import org.apache.doris.persist.CreateTableInfo;
 import org.apache.doris.persist.DatabaseInfo;
 import org.apache.doris.persist.DropDbInfo;
@@ -214,6 +215,11 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_CREATE_DB: {
                 data = Database.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_NEW_CREATE_DB: {
+                data = CreateDbInfo.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/CreateDbInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/CreateDbInfo.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class CreateDbInfo implements Writable {
+
+    @SerializedName("ctl")
+    private String ctlName;
+    @SerializedName("db")
+    private String dbName;
+    @SerializedName("idb")
+    private Database internalDb;
+
+    public CreateDbInfo() {
+        this.ctlName = "";
+        this.dbName = "";
+    }
+
+    public CreateDbInfo(String ctlName, String dbName, Database internalDb) {
+        this.ctlName = ctlName;
+        this.dbName = dbName;
+        this.internalDb = internalDb;
+    }
+
+    public String getCtlName() {
+        return ctlName;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public Database getInternalDb() {
+        return internalDb;
+    }
+
+    public static CreateDbInfo read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, CreateDbInfo.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/CreateTableInfo.java
@@ -23,9 +23,11 @@ import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +55,7 @@ public class CreateTableInfo implements Writable, GsonPostProcessable {
 
     // for internal table
     public CreateTableInfo(String dbName, Table table) {
+        this.ctlName = InternalCatalog.INTERNAL_CATALOG_NAME;
         this.dbName = dbName;
         this.tblName = table.getName();
         this.table = table;
@@ -127,7 +130,11 @@ public class CreateTableInfo implements Writable, GsonPostProcessable {
 
     @Override
     public String toString() {
-        return toJson();
+        // In previous versions, ctlName and tblName is not set, so it may be null.
+        return String.format("%s.%s.%s",
+                Strings.isNullOrEmpty(ctlName) ? InternalCatalog.INTERNAL_CATALOG_NAME : ctlName,
+                dbName,
+                Strings.isNullOrEmpty(tblName) ? table.getName() : tblName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/CreateTableInfo.java
@@ -38,8 +38,12 @@ import java.util.Objects;
 public class CreateTableInfo implements Writable, GsonPostProcessable {
     public static final Logger LOG = LoggerFactory.getLogger(CreateTableInfo.class);
 
+    @SerializedName(value = "ctl")
+    private String ctlName;
     @SerializedName(value = "dbName")
     private String dbName;
+    @SerializedName(value = "tbl")
+    private String tblName;
     @SerializedName(value = "table")
     private Table table;
 
@@ -47,13 +51,30 @@ public class CreateTableInfo implements Writable, GsonPostProcessable {
         // for persist
     }
 
+    // for internal table
     public CreateTableInfo(String dbName, Table table) {
         this.dbName = dbName;
+        this.tblName = table.getName();
         this.table = table;
+    }
+
+    // for external table
+    public CreateTableInfo(String ctlName, String dbName, String tblName) {
+        this.ctlName = ctlName;
+        this.dbName = dbName;
+        this.tblName = tblName;
+    }
+
+    public String getCtlName() {
+        return ctlName;
     }
 
     public String getDbName() {
         return dbName;
+    }
+
+    public String getTblName() {
+        return tblName;
     }
 
     public Table getTable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropDbInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropDbInfo.java
@@ -30,6 +30,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class DropDbInfo implements Writable, GsonPostProcessable {
+    @SerializedName(value = "ctl")
+    private String ctlName;
     @SerializedName(value = "dbName")
     private String dbName;
     @SerializedName(value = "forceDrop")
@@ -41,10 +43,21 @@ public class DropDbInfo implements Writable, GsonPostProcessable {
         this("", false, 0);
     }
 
+    // for external table
+    public DropDbInfo(String ctlName, String dbName) {
+        this.ctlName = ctlName;
+        this.dbName = dbName;
+    }
+
+    // for internal table
     public DropDbInfo(String dbName, boolean forceDrop, long recycleTime) {
         this.dbName = dbName;
         this.forceDrop = forceDrop;
         this.recycleTime = recycleTime;
+    }
+
+    public String getCtlName() {
+        return ctlName;
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
@@ -30,6 +30,10 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class DropInfo implements Writable {
+    @SerializedName(value = "ctl")
+    private String ctl;
+    @SerializedName(value = "db")
+    private String db;
     @SerializedName(value = "dbId")
     private long dbId;
     @SerializedName(value = "tableId")
@@ -50,6 +54,13 @@ public class DropInfo implements Writable {
     public DropInfo() {
     }
 
+    // for external table
+    public DropInfo(String ctl, String db, String tbl) {
+        this.ctl = ctl;
+        this.db = db;
+        this.tableName = tbl;
+    }
+
     public DropInfo(long dbId, long tableId, String tableName, boolean isView, boolean forceDrop,
             long recycleTime) {
         this(dbId, tableId, tableName, -1L, "", isView, forceDrop, recycleTime);
@@ -65,6 +76,14 @@ public class DropInfo implements Writable {
         this.isView = isView;
         this.forceDrop = forceDrop;
         this.recycleTime = recycleTime;
+    }
+
+    public String getCtl() {
+        return ctl;
+    }
+
+    public String getDb() {
+        return db;
     }
 
     public long getDbId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
@@ -21,8 +21,10 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
@@ -61,13 +63,16 @@ public class DropInfo implements Writable {
         this.tableName = tbl;
     }
 
+    // for internal table
     public DropInfo(long dbId, long tableId, String tableName, boolean isView, boolean forceDrop,
             long recycleTime) {
         this(dbId, tableId, tableName, -1L, "", isView, forceDrop, recycleTime);
     }
 
+    // for internal table
     public DropInfo(long dbId, long tableId, String tableName, long indexId, String indexName, boolean isView,
             boolean forceDrop, long recycleTime) {
+        this.ctl = InternalCatalog.INTERNAL_CATALOG_NAME;
         this.dbId = dbId;
         this.tableId = tableId;
         this.tableName = tableName;
@@ -167,5 +172,14 @@ public class DropInfo implements Writable {
 
     public static DropInfo fromJson(String json) {
         return GsonUtils.GSON.fromJson(json, DropInfo.class);
+    }
+
+    @Override
+    public String toString() {
+        // In previous versions, ctl and db are not set, so they may be null.
+        return String.format("%s.%s.%s",
+                Strings.isNullOrEmpty(ctl) ? InternalCatalog.INTERNAL_CATALOG_NAME : ctl,
+                Strings.isNullOrEmpty(db) ? dbId : db,
+                tableName);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -193,7 +193,8 @@ public class EditLog {
                 }
                 case OperationType.OP_CREATE_DB: {
                     Database db = (Database) journal.getData();
-                    env.replayCreateDb(db);
+                    CreateDbInfo info = new CreateDbInfo(db.getCatalog().getName(), db.getName(), db);
+                    env.replayCreateDb(info);
                     break;
                 }
                 case OperationType.OP_NEW_CREATE_DB: {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -51,6 +51,7 @@ import org.apache.doris.cooldown.CooldownConfHandler;
 import org.apache.doris.cooldown.CooldownConfList;
 import org.apache.doris.cooldown.CooldownDelete;
 import org.apache.doris.datasource.CatalogLog;
+import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalObjectLog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.InitDatabaseLog;
@@ -100,6 +101,7 @@ import org.apache.doris.system.Frontend;
 import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
 
+import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -194,9 +196,14 @@ public class EditLog {
                     env.replayCreateDb(db);
                     break;
                 }
+                case OperationType.OP_NEW_CREATE_DB: {
+                    CreateDbInfo info = (CreateDbInfo) journal.getData();
+                    env.replayCreateDb(info);
+                    break;
+                }
                 case OperationType.OP_DROP_DB: {
                     DropDbInfo dropDbInfo = (DropDbInfo) journal.getData();
-                    env.replayDropDb(dropDbInfo.getDbName(), dropDbInfo.isForceDrop(), dropDbInfo.getRecycleTime());
+                    env.replayDropDb(dropDbInfo);
                     break;
                 }
                 case OperationType.OP_ALTER_DB: {
@@ -227,9 +234,11 @@ public class EditLog {
                     CreateTableInfo info = (CreateTableInfo) journal.getData();
                     LOG.info("Begin to unprotect create table. db = " + info.getDbName() + " table = " + info.getTable()
                             .getId());
-                    CreateTableRecord record = new CreateTableRecord(logId, info);
-                    env.replayCreateTable(info.getDbName(), info.getTable());
-                    env.getBinlogManager().addCreateTableRecord(record);
+                    env.replayCreateTable(info);
+                    if (Strings.isNullOrEmpty(info.getCtlName())) {
+                        CreateTableRecord record = new CreateTableRecord(logId, info);
+                        env.getBinlogManager().addCreateTableRecord(record);
+                    }
                     break;
                 }
                 case OperationType.OP_ALTER_EXTERNAL_TABLE_SCHEMA: {
@@ -241,12 +250,20 @@ public class EditLog {
                 }
                 case OperationType.OP_DROP_TABLE: {
                     DropInfo info = (DropInfo) journal.getData();
-                    Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(info.getDbId());
-                    LOG.info("Begin to unprotect drop table. db = " + db.getFullName() + " table = "
-                            + info.getTableId());
-                    DropTableRecord record = new DropTableRecord(logId, info);
-                    env.replayDropTable(db, info.getTableId(), info.isForceDrop(), info.getRecycleTime());
-                    env.getBinlogManager().addDropTableRecord(record);
+                    if (Strings.isNullOrEmpty(info.getCtl())) {
+                        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(info.getDbId());
+                        LOG.info("Begin to unprotect drop table. db = " + db.getFullName() + " table = "
+                                + info.getTableId());
+                        env.replayDropTable(db, info.getTableId(), info.isForceDrop(), info.getRecycleTime());
+                        DropTableRecord record = new DropTableRecord(logId, info);
+                        env.getBinlogManager().addDropTableRecord(record);
+                    } else {
+                        ExternalCatalog ctl = (ExternalCatalog) Env.getCurrentEnv().getCatalogMgr()
+                                .getCatalog(info.getCtl());
+                        if (ctl != null) {
+                            ctl.replayDropTable(info.getDb(), info.getTableName());
+                        }
+                    }
                     break;
                 }
                 case OperationType.OP_ADD_PARTITION: {
@@ -1410,6 +1427,10 @@ public class EditLog {
         logEdit(OperationType.OP_CREATE_DB, db);
     }
 
+    public void logNewCreateDb(CreateDbInfo info) {
+        logEdit(OperationType.OP_NEW_CREATE_DB, info);
+    }
+
     public void logDropDb(DropDbInfo dropDbInfo) {
         logEdit(OperationType.OP_DROP_DB, dropDbInfo);
     }
@@ -1428,8 +1449,10 @@ public class EditLog {
 
     public void logCreateTable(CreateTableInfo info) {
         long logId = logEdit(OperationType.OP_CREATE_TABLE, info);
-        CreateTableRecord record = new CreateTableRecord(logId, info);
-        Env.getCurrentEnv().getBinlogManager().addCreateTableRecord(record);
+        if (Strings.isNullOrEmpty(info.getCtlName())) {
+            CreateTableRecord record = new CreateTableRecord(logId, info);
+            Env.getCurrentEnv().getBinlogManager().addCreateTableRecord(record);
+        }
     }
 
     public void logRefreshExternalTableSchema(RefreshExternalTableInfo info) {
@@ -1473,8 +1496,10 @@ public class EditLog {
 
     public void logDropTable(DropInfo info) {
         long logId = logEdit(OperationType.OP_DROP_TABLE, info);
-        DropTableRecord record = new DropTableRecord(logId, info);
-        Env.getCurrentEnv().getBinlogManager().addDropTableRecord(record);
+        if (Strings.isNullOrEmpty(info.getCtl())) {
+            DropTableRecord record = new DropTableRecord(logId, info);
+            Env.getCurrentEnv().getBinlogManager().addDropTableRecord(record);
+        }
     }
 
     public void logEraseTable(long tableId) {
@@ -1712,7 +1737,9 @@ public class EditLog {
     public void logTruncateTable(TruncateTableInfo info) {
         long logId = logEdit(OperationType.OP_TRUNCATE_TABLE, info);
         LOG.info("log truncate table, logId:{}, infos: {}", logId, info);
-        Env.getCurrentEnv().getBinlogManager().addTruncateTable(info, logId);
+        if (Strings.isNullOrEmpty(info.getCtl())) {
+            Env.getCurrentEnv().getBinlogManager().addTruncateTable(info, logId);
+        }
     }
 
     public void logColocateModifyRepliaAlloc(ColocatePersistInfo info) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -234,8 +234,7 @@ public class EditLog {
                 }
                 case OperationType.OP_CREATE_TABLE: {
                     CreateTableInfo info = (CreateTableInfo) journal.getData();
-                    LOG.info("Begin to unprotect create table. db = " + info.getDbName() + " table = " + info.getTable()
-                            .getId());
+                    LOG.info("Begin to unprotect create table. {}", info);
                     env.replayCreateTable(info);
                     if (Strings.isNullOrEmpty(info.getCtlName()) || info.getCtlName().equals(
                             InternalCatalog.INTERNAL_CATALOG_NAME)) {
@@ -253,11 +252,10 @@ public class EditLog {
                 }
                 case OperationType.OP_DROP_TABLE: {
                     DropInfo info = (DropInfo) journal.getData();
+                    LOG.info("Begin to unprotect drop table: {}", info);
                     if (Strings.isNullOrEmpty(info.getCtl()) || info.getCtl().equals(
                             InternalCatalog.INTERNAL_CATALOG_NAME)) {
                         Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(info.getDbId());
-                        LOG.info("Begin to unprotect drop table. db = {} table = {}", db.getFullName(),
-                                info.getTableId());
                         env.replayDropTable(db, info.getTableId(), info.isForceDrop(), info.getRecycleTime());
                         DropTableRecord record = new DropTableRecord(logId, info);
                         env.getBinlogManager().addDropTableRecord(record);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1427,11 +1427,7 @@ public class EditLog {
         logEdit(OperationType.OP_SAVE_TRANSACTION_ID, new Text(Long.toString(transactionId)));
     }
 
-    public void logCreateDb(Database db) {
-        logEdit(OperationType.OP_CREATE_DB, db);
-    }
-
-    public void logNewCreateDb(CreateDbInfo info) {
+    public void logCreateDb(CreateDbInfo info) {
         logEdit(OperationType.OP_NEW_CREATE_DB, info);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -27,7 +27,8 @@ public class OperationType {
     // OP_LOCAL_EOF is only for local edit log, to indicate the end of a edit log run.
     public static final short OP_LOCAL_EOF = -1;
     public static final short OP_SAVE_NEXTID = 0;
-    public static final short OP_CREATE_DB = 1;
+    @Deprecated
+    public static final short OP_CREATE_DB = 1; // deprecated, use OP_NEW_CREATE_DB instead
     public static final short OP_DROP_DB = 2;
     public static final short OP_ALTER_DB = 3;
     public static final short OP_ERASE_DB = 4;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -33,6 +33,7 @@ public class OperationType {
     public static final short OP_ERASE_DB = 4;
     public static final short OP_RECOVER_DB = 5;
     public static final short OP_RENAME_DB = 6;
+    public static final short OP_NEW_CREATE_DB = 7;
 
     // 10~19 110~119 210~219 ...
     public static final short OP_CREATE_TABLE = 10;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TruncateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TruncateTableInfo.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TruncateTableInfo implements Writable {
-    @SerializedName(value = "dbId")
+    @SerializedName(value = "ctl")
     private String ctl;
     @SerializedName(value = "dbId")
     private long dbId;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TruncateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TruncateTableInfo.java
@@ -34,6 +34,8 @@ import java.util.Map;
 
 public class TruncateTableInfo implements Writable {
     @SerializedName(value = "dbId")
+    private String ctl;
+    @SerializedName(value = "dbId")
     private long dbId;
     @SerializedName(value = "db")
     private String db;
@@ -43,6 +45,9 @@ public class TruncateTableInfo implements Writable {
     private String table;
     @SerializedName(value = "partitions")
     private List<Partition> partitions = Lists.newArrayList();
+    // Only for external table
+    @SerializedName(value = "extParts")
+    private List<String> extPartNames = Lists.newArrayList();
     @SerializedName(value = "isEntireTable")
     private boolean isEntireTable = false;
     @SerializedName(value = "rawSql")
@@ -56,6 +61,7 @@ public class TruncateTableInfo implements Writable {
 
     }
 
+    // for internal table
     public TruncateTableInfo(long dbId, String db, long tblId, String table, List<Partition> partitions,
             boolean isEntireTable, String rawSql, List<Partition> oldPartitions, boolean force) {
         this.dbId = dbId;
@@ -69,6 +75,18 @@ public class TruncateTableInfo implements Writable {
             this.oldPartitions.put(partition.getId(), partition.getName());
         }
         this.force = force;
+    }
+
+    // for external table
+    public TruncateTableInfo(String ctl, String db, String table, List<String> partNames) {
+        this.ctl = ctl;
+        this.db = db;
+        this.table = table;
+        this.extPartNames = partNames;
+    }
+
+    public String getCtl() {
+        return ctl;
     }
 
     public long getDbId() {
@@ -91,6 +109,10 @@ public class TruncateTableInfo implements Writable {
         return partitions;
     }
 
+    public List<String> getExtPartNames() {
+        return extPartNames;
+    }
+
     public Map<Long, String> getOldPartitions() {
         return oldPartitions == null ? new HashMap<>() : oldPartitions;
     }
@@ -102,7 +124,6 @@ public class TruncateTableInfo implements Writable {
     public boolean getForce() {
         return force;
     }
-
 
     public String getRawSql() {
         return rawSql;
@@ -126,13 +147,15 @@ public class TruncateTableInfo implements Writable {
     @Override
     public String toString() {
         return "TruncateTableInfo{"
+                + "ctl=" + ctl
                 + "dbId=" + dbId
                 + ", db='" + db + '\''
                 + ", tblId=" + tblId
                 + ", table='" + table + '\''
                 + ", isEntireTable=" + isEntireTable
                 + ", rawSql='" + rawSql + '\''
-                + ", partitions_size=" + partitions.size()
+                + ", partitions_size=" + (partitions == null ? "0" : partitions.size())
+                + ", extPartNames_size=" + (extPartNames == null ? "0" : extPartNames.size())
                 + '}';
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/CreateDbInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/CreateDbInfoTest.java
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.meta.MetaContext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.nio.file.Files;
+
+public class CreateDbInfoTest {
+    @Test
+    public void testSerialization() throws Exception {
+        MetaContext metaContext = new MetaContext();
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_CURRENT);
+        metaContext.setThreadLocalInfo();
+
+        // 1. Write objects to file
+        File file = new File("./createDbInfo");
+        file.createNewFile();
+        DataOutputStream dos = new DataOutputStream(Files.newOutputStream(file.toPath()));
+
+        Database db = new Database(10000, "db1");
+        CreateDbInfo info1 = new CreateDbInfo(InternalCatalog.INTERNAL_CATALOG_NAME, db.getName(), db);
+        info1.write(dos);
+
+        CreateDbInfo info2 = new CreateDbInfo("external_catalog", "external_db", null);
+        info2.write(dos);
+
+        dos.flush();
+        dos.close();
+
+        // 2. Read objects from file
+        DataInputStream dis = new DataInputStream(Files.newInputStream(file.toPath()));
+
+        CreateDbInfo rInfo1 = CreateDbInfo.read(dis);
+        Assert.assertEquals(info1.getCtlName(), rInfo1.getCtlName());
+        Assert.assertEquals(info1.getDbName(), rInfo1.getDbName());
+        Assert.assertEquals(info1.getInternalDb().getId(), rInfo1.getInternalDb().getId());
+
+        CreateDbInfo rInfo2 = CreateDbInfo.read(dis);
+        Assert.assertEquals(info2.getCtlName(), rInfo2.getCtlName());
+        Assert.assertEquals(info2.getDbName(), rInfo2.getDbName());
+        Assert.assertNull(rInfo2.getInternalDb());
+
+        // 3. delete files
+        dis.close();
+        file.delete();
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

When executing DDL on a hive table, the DDL command should be synced to other FE,
so that other FE can invalidate the cache of that table or db.
Otherwise, after executing the DDL on a hive table on non-master FE and then query that table,
we can still access to the cached files.

Modify the following ddl:
1. create db/table
2. drop db/table
3. truncate table

For these operations, I saved the info like dbname, tablename, and sync them to other FE,
so that other FE can refresh these objects to get latest metadata info

### Release Note

This PR add a new edit log type: `OperationType.OP_NEW_CREATE_DB`.
So that it can't downgrade

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

