### PR TITLE
[opt](iceberg) opt the error msg when create db which already exists

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.DorisTypeVisitor;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
@@ -125,7 +126,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
             });
         } catch (Exception e) {
             throw new DdlException("Failed to create database: "
-                    + stmt.getFullDbName() + ", error message is:" + e.getMessage(), e);
+                    + stmt.getFullDbName() + ": " + Util.getRootCauseMessage(e), e);
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

before:
```
mysql> create database cmytest;
ERROR 1105 (HY000): errCode = 2, detailMessage = Failed to create database: cmytest, error message is:null
```

after:
```
mysql> create database cmytest;
ERROR 1105 (HY000): errCode = 2, detailMessage = Failed to create database: cmytest: org.apache.doris.common.DdlException: errCode = 2, detailMessage = Can't create database 'cmytest'; database exists
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

