### PR TITLE
Fix threadpool blocked when create thread failed in init()

### DIFF
--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -273,19 +273,29 @@ ThreadPool::~ThreadPool() {
     shutdown();
 }
 
+Status ThreadPool::try_create_thread(int thread_num) {
+    for (int i = 0; i < thread_num; i++) {
+        Status status = create_thread();
+        if (status.ok()) {
+            _num_threads_pending_start++;
+        } else {
+            LOG(WARNING) << "Thread pool " << _name << " failed to create thread: " << status;
+            return status;
+        }
+    }
+    return Status::OK();
+}
+
 Status ThreadPool::init() {
     if (!_pool_status.is<UNINITIALIZED>()) {
         return Status::NotSupported("The thread pool {} is already initialized", _name);
     }
     _pool_status = Status::OK();
-    _num_threads_pending_start = _min_threads;
-    for (int i = 0; i < _min_threads; i++) {
-        Status status = create_thread();
-        if (!status.ok()) {
-            shutdown();
-            return status;
-        }
-    }
+
+    // create thread failed should not cause threadpool init failed,
+    // because thread can be created later such as when submit a task.
+    static_cast<void>(try_create_thread(_min_threads));
+
     // _id of thread pool is used to make sure when we create thread pool with same name, we can
     // get different _metric_entity
     // If not, we will have problem when we deregister entity and register hook.
@@ -688,16 +698,7 @@ Status ThreadPool::set_min_threads(int min_threads) {
     _min_threads = min_threads;
     if (min_threads > _num_threads + _num_threads_pending_start) {
         int addition_threads = min_threads - _num_threads - _num_threads_pending_start;
-        _num_threads_pending_start += addition_threads;
-        for (int i = 0; i < addition_threads; i++) {
-            Status status = create_thread();
-            if (!status.ok()) {
-                _num_threads_pending_start--;
-                LOG(WARNING) << "Thread pool " << _name
-                             << " failed to create thread: " << status.to_string();
-                return status;
-            }
-        }
+        RETURN_IF_ERROR(try_create_thread(addition_threads));
     }
     return Status::OK();
 }
@@ -713,16 +714,7 @@ Status ThreadPool::set_max_threads(int max_threads) {
     if (_max_threads > _num_threads + _num_threads_pending_start) {
         int addition_threads = _max_threads - _num_threads - _num_threads_pending_start;
         addition_threads = std::min(addition_threads, _total_queued_tasks);
-        _num_threads_pending_start += addition_threads;
-        for (int i = 0; i < addition_threads; i++) {
-            Status status = create_thread();
-            if (!status.ok()) {
-                _num_threads_pending_start--;
-                LOG(WARNING) << "Thread pool " << _name
-                             << " failed to create thread: " << status.to_string();
-                return status;
-            }
-        }
+        RETURN_IF_ERROR(try_create_thread(addition_threads));
     }
     return Status::OK();
 }

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -292,9 +292,12 @@ Status ThreadPool::init() {
     }
     _pool_status = Status::OK();
 
-    // create thread failed should not cause threadpool init failed,
-    // because thread can be created later such as when submit a task.
-    static_cast<void>(try_create_thread(_min_threads));
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        // create thread failed should not cause threadpool init failed,
+        // because thread can be created later such as when submit a task.
+        static_cast<void>(try_create_thread(_min_threads));
+    }
 
     // _id of thread pool is used to make sure when we create thread pool with same name, we can
     // get different _metric_entity

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -318,6 +318,9 @@ private:
     // Releases token 't' and invalidates it.
     void release_token(ThreadPoolToken* t);
 
+    //NOTE: not thread safe
+    Status try_create_thread(int thread_num);
+
     const std::string _name;
     const std::string _workload_group;
     int _min_threads;

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -318,8 +318,8 @@ private:
     // Releases token 't' and invalidates it.
     void release_token(ThreadPoolToken* t);
 
-    //NOTE: not thread safe
-    Status try_create_thread(int thread_num);
+    //NOTE: not thread safe, caller should keep it thread-safe by using lock
+    Status try_create_thread(int thread_num, std::lock_guard<std::mutex>&);
 
     const std::string _name;
     const std::string _workload_group;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Threadpool's ```_num_threads_pending_start``` field means a thread is created successfully, but has not begin executing, it increments when create thread succ, and then decrements when the thread begin runs.
Currently ```init``` and ```set_min/max_threads``` method create threads and increment ```_num_threads_pending_start```,   but not decrement it if some threads create failed.
This means ```_num_threads_pending_start``` can not be zero even all threads finish, then calling threadpool.shutdown could be blocked.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

