### PR TITLE
[fix](external catalog) Fixed non-master FE log replay during refresh

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -723,7 +723,7 @@ public abstract class ExternalCatalog
 
     public void replayInitCatalog(InitCatalogLog log) {
         // If the remote name is missing during upgrade, all databases in the Map will be reinitialized.
-        if (log.getRemoteDbNames() == null || log.getRemoteDbNames().isEmpty()) {
+        if (log.getCreateCount() > 0 && (log.getRemoteDbNames() == null || log.getRemoteDbNames().isEmpty())) {
             dbNameToId = Maps.newConcurrentMap();
             idToDb = Maps.newConcurrentMap();
             lastUpdateTime = log.getLastUpdateTime();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -191,7 +191,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
 
     public void replayInitDb(InitDatabaseLog log, ExternalCatalog catalog) {
         // If the remote name is missing during upgrade, all tables in the Map will be reinitialized.
-        if (log.getRemoteTableNames() == null || log.getRemoteTableNames().isEmpty()) {
+        if (log.getCreateCount() > 0 && (log.getRemoteTableNames() == null || log.getRemoteTableNames().isEmpty())) {
             tableNameToId = Maps.newConcurrentMap();
             idToTbl = Maps.newConcurrentMap();
             lastUpdateTime = log.getLastUpdateTime();

--- a/regression-test/suites/external_table_p0/lower_case/test_conflict_name.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_conflict_name.groovy
@@ -18,11 +18,15 @@
 suite("test_conflict_name", "p0,external,doris,meta_names_mapping") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_conflict_name_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     sql """drop database if exists internal.external_conflict_name; """
     sql """drop database if exists internal.EXTERNAL_CONFLICT_NAME; """
@@ -91,4 +95,6 @@ suite("test_conflict_name", "p0,external,doris,meta_names_mapping") {
 
     sql """drop database if exists internal.external_conflict_name; """
     sql """drop database if exists internal.EXTERNAL_CONFLICT_NAME; """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_include.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_include.groovy
@@ -18,11 +18,15 @@
 suite("test_lower_case_meta_include", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_lower_include_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     String mapping_db = """
     {
@@ -155,4 +159,6 @@ suite("test_lower_case_meta_include", "p0,external,doris,external_docker,externa
     sql """drop catalog if exists test_lower_case_exclude """
     sql """drop database if exists internal.external_INCLUDE; """
     sql """drop database if exists internal.external_EXCLUDE; """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_show_and_select.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_show_and_select.groovy
@@ -18,11 +18,15 @@
 suite("test_lower_case_meta_show_and_select", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_lower_without_conf_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     sql """drop database if exists internal.external_test_lower; """
     sql """drop database if exists internal.external_test_UPPER; """
@@ -251,4 +255,6 @@ suite("test_lower_case_meta_show_and_select", "p0,external,doris,external_docker
 
     sql """drop database if exists internal.external_test_lower; """
     sql """drop database if exists internal.external_test_UPPER; """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_show_and_select.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_show_and_select.groovy
@@ -18,14 +18,17 @@
 suite("test_lower_case_meta_with_lower_table_conf_show_and_select", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_lower_with_conf"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
 
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
+
     sql """drop database if exists internal.external_test_lower_with_conf; """
-    sql """drop database if exists internal.external_test_UPPER_with_conf; """
     sql """create database if not exists internal.external_test_lower_with_conf; """
     sql """create table if not exists internal.external_test_lower_with_conf.lower_with_conf
          (id int, name varchar(20))
@@ -699,4 +702,6 @@ suite("test_lower_case_meta_with_lower_table_conf_show_and_select", "p0,external
     sql """drop catalog if exists test_cache_true_lower_true_with_conf0 """
 
     sql """drop database if exists internal.external_test_lower_with_conf; """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_mtmv.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_mtmv.groovy
@@ -18,11 +18,15 @@
 suite("test_lower_case_mtmv", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_lower_case_mtmv_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     sql """drop database if exists internal.EXTERNAL_LOWER_MTMV; """
     sql """create database if not exists internal.EXTERNAL_LOWER_MTMV;"""
@@ -61,4 +65,6 @@ suite("test_lower_case_mtmv", "p0,external,doris,external_docker,external_docker
 
     sql """drop catalog if exists test_lower_case_mtmv """
     sql """drop database if exists internal.EXTERNAL_LOWER_MTMV """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_meta_cache_select_without_refresh.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_meta_cache_select_without_refresh.groovy
@@ -18,11 +18,15 @@
 suite("test_meta_cache_select_without_refresh", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_meta_cache_select_without_refresh_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     sql """ drop database if exists internal.external_lower_select_without_refresh; """
     sql """create database if not exists internal.external_lower_select_without_refresh;"""
@@ -89,4 +93,6 @@ suite("test_meta_cache_select_without_refresh", "p0,external,doris,external_dock
     sql """drop catalog if exists test_meta_cache_lower_true_select_without_refresh """
     sql """drop catalog if exists test_meta_cache_lower_false_select_without_refresh """
     sql """drop database if exists internal.external_lower_select_without_refresh; """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_meta_names_mapping.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_meta_names_mapping.groovy
@@ -18,11 +18,15 @@
 suite("test_meta_names_mapping", "p0,external,doris,meta_names_mapping") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_meta_names_mapping_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     String validMetaNamesMapping = """
     {
@@ -286,4 +290,6 @@ suite("test_meta_names_mapping", "p0,external,doris,meta_names_mapping") {
 
     sql """drop database if exists internal.external_meta_names_mapping; """
     sql """drop database if exists internal.EXTERNAL_META_NAMES_MAPPING; """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/test_timing_refresh_catalog.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_timing_refresh_catalog.groovy
@@ -18,11 +18,15 @@
 suite("test_timing_refresh_catalog", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_timing_refresh_catalog_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     String mapping = """
     {
@@ -158,4 +162,6 @@ suite("test_timing_refresh_catalog", "p0,external,doris,external_docker,external
     sql """drop catalog if exists test_timing_refresh_catalog1 """
     sql """drop catalog if exists test_timing_refresh_catalog2 """
     sql """drop database if exists internal.external_timing_refresh_catalog """
+
+    try_sql """drop user ${jdbcUser}"""
 }

--- a/regression-test/suites/external_table_p0/lower_case/upgrade/load.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/upgrade/load.groovy
@@ -18,11 +18,15 @@
 suite("test_upgrade_lower_case_catalog_prepare", "p0,external,doris,external_docker,external_docker_doris") {
 
     String jdbcUrl = context.config.jdbcUrl
-    String jdbcUser = context.config.jdbcUser
-    String jdbcPassword = context.config.jdbcPassword
+    String jdbcUser = "test_upgrade_lower_case_catalog_user"
+    String jdbcPassword = "C123_567p"
     String s3_endpoint = getS3Endpoint()
     String bucket = getS3BucketName()
     String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.3.0.jar"
+
+    try_sql """drop user ${jdbcUser}"""
+    sql """create user ${jdbcUser} identified by '${jdbcPassword}'"""
+    sql """grant all on *.*.* to ${jdbcUser}"""
 
     sql """drop database if exists internal.upgrade_lower_case_catalog_lower; """
     sql """drop database if exists internal.upgrade_lower_case_catalog_UPPER; """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

In the case of multiple FEs, non-Master FEs create Catalogs by pulling master FE logs for replay. However, when refreshing, there is no need to determine the remote name to reset the meta information. It is only determined when creating.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

