### PR TITLE
[fix](nereids)fix bug of PushDownFilterThroughSetOperation

### DIFF
--- a/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.out
@@ -564,29 +564,5 @@ abbbb
 -- !intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform --
 1	d2
 
--- !intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform_shape --
-PhysicalResultSink
---PhysicalQuickSort[MERGE_SORT]
-----PhysicalQuickSort[LOCAL_SORT]
-------hashJoin[INNER_JOIN] hashCondition=((t3.a = t.a) and (t3.b = t.b)) otherCondition=()
---------PhysicalIntersect
-----------filter((a = 1))
-------------hashAgg[GLOBAL]
---------------hashAgg[LOCAL]
-----------------filter((test_pull_up_predicate_set_op1.b > 'ab'))
-------------------PhysicalOlapScan[test_pull_up_predicate_set_op1]
-----------filter((test_pull_up_predicate_set_op2.a = 1))
-------------hashAgg[GLOBAL]
---------------hashAgg[LOCAL]
-----------------filter((test_pull_up_predicate_set_op2.a = 1) and (test_pull_up_predicate_set_op2.b > 'ab'))
-------------------PhysicalOlapScan[test_pull_up_predicate_set_op2]
---------filter((t3.a = 1) and (t3.b > 'ab'))
-----------PhysicalOlapScan[test_pull_up_predicate_set_op3]
-
-Hint log:
-Used: use_INFER_SET_OPERATOR_DISTINCT
-UnUsed:
-SyntaxError:
-
 -- !test --
 

--- a/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.out
@@ -561,5 +561,32 @@ abbbb
 -- !union_child_and_const_exprs_orpredicates_res --
 1	d2
 
+-- !intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform --
+1	d2
+
+-- !intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform_shape --
+PhysicalResultSink
+--PhysicalQuickSort[MERGE_SORT]
+----PhysicalQuickSort[LOCAL_SORT]
+------hashJoin[INNER_JOIN] hashCondition=((t3.a = t.a) and (t3.b = t.b)) otherCondition=()
+--------PhysicalIntersect
+----------filter((a = 1))
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------filter((test_pull_up_predicate_set_op1.b > 'ab'))
+------------------PhysicalOlapScan[test_pull_up_predicate_set_op1]
+----------filter((test_pull_up_predicate_set_op2.a = 1))
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------filter((test_pull_up_predicate_set_op2.a = 1) and (test_pull_up_predicate_set_op2.b > 'ab'))
+------------------PhysicalOlapScan[test_pull_up_predicate_set_op2]
+--------filter((t3.a = 1) and (t3.b > 'ab'))
+----------PhysicalOlapScan[test_pull_up_predicate_set_op3]
+
+Hint log:
+Used: use_INFER_SET_OPERATOR_DISTINCT
+UnUsed:
+SyntaxError:
+
 -- !test --
 

--- a/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.groovy
@@ -471,10 +471,6 @@ suite("pull_up_predicate_set_op") {
     select /*+use_cbo_rule(INFER_SET_OPERATOR_DISTINCT)*/ t.a,t3.b from (select 1 as a,b from test_pull_up_predicate_set_op1 intersect select a,b from test_pull_up_predicate_set_op2 where b>'ab') t inner join test_pull_up_predicate_set_op3 t3 
     on t3.a=t.a and t3.b=t.b order by 1,2; 
     """
-    qt_intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform_shape """
-    explain shape plan select /*+use_cbo_rule(INFER_SET_OPERATOR_DISTINCT)*/ t.a,t3.b from (select 1 as a,b from test_pull_up_predicate_set_op1 intersect select a,b from test_pull_up_predicate_set_op2 where b>'ab') t inner join test_pull_up_predicate_set_op3 t3 
-    on t3.a=t.a and t3.b=t.b order by 1,2; 
-    """
 
     sql """
         drop table if exists table_1_undef_partitions2_keys3_properties4_distributed_by52;

--- a/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.groovy
@@ -467,6 +467,14 @@ suite("pull_up_predicate_set_op") {
     select t.a,t3.b from      (select a,b from test_pull_up_predicate_set_op1 where a in (1,2) or b in ('2d','3') union select 2,'2d' union select 2,'3') t inner join test_pull_up_predicate_set_op3 t3
     on t3.a=t.a and t3.b=t.b order by 1,2;"""
 
+    qt_intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform """
+    select /*+use_cbo_rule(INFER_SET_OPERATOR_DISTINCT)*/ t.a,t3.b from (select 1 as a,b from test_pull_up_predicate_set_op1 intersect select a,b from test_pull_up_predicate_set_op2 where b>'ab') t inner join test_pull_up_predicate_set_op3 t3 
+    on t3.a=t.a and t3.b=t.b order by 1,2; 
+    """
+    qt_intersect_with_hint_infer_set_operator_distinct_and_do_eliminate_gby_key_by_uniform_shape """
+    explain shape plan select /*+use_cbo_rule(INFER_SET_OPERATOR_DISTINCT)*/ t.a,t3.b from (select 1 as a,b from test_pull_up_predicate_set_op1 intersect select a,b from test_pull_up_predicate_set_op2 where b>'ab') t inner join test_pull_up_predicate_set_op3 t3 
+    on t3.a=t.a and t3.b=t.b order by 1,2; 
+    """
 
     sql """
         drop table if exists table_1_undef_partitions2_keys3_properties4_distributed_by52;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
LogicalSetOperation child outputs order may changed by transformation rules. When pushing down predicates, setOperation.getRegularChildOutput should be used to create a map representing the correspondence between the output of LogicalSetOperation and the output of its children.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

