### PR TITLE
[fix](parquet) parse dict page in ColumnChunkReader::init

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -220,7 +220,6 @@ private:
     size_t _decompress_buf_size = 0;
     Slice _v2_rep_levels;
     Slice _v2_def_levels;
-    bool _dict_checked = false;
     bool _has_dict = false;
     Decoder* _page_decoder = nullptr;
     // Map: encoding -> Decoder


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #45740 

Problem Summary:
This code can be removed after #45740 merged. Because now we can correctly determine whether the dictionary page exists.
``` c++
    if (!_dict_checked) {
        _dict_checked = true;
        const tparquet::PageHeader* header;
        RETURN_IF_ERROR(_page_reader->get_page_header(header));
        if (header->type == tparquet::PageType::DICTIONARY_PAGE) {
            // the first page maybe directory page even if _metadata.__isset.dictionary_page_offset == false,
            // so we should parse the directory page in next_page()
            RETURN_IF_ERROR(_decode_dict_page());
            // parse the real first data page
            return next_page();
        }
    }
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

