### PR TITLE
[fix](doris compose) fix wait master fe ip 10s for ls command

### DIFF
--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -23,7 +23,6 @@ import jsonpickle
 import os
 import os.path
 import utils
-import time
 
 DOCKER_DORIS_PATH = "/opt/apache-doris"
 LOCAL_DORIS_PATH = os.getenv("LOCAL_DORIS_PATH", "/tmp/doris")

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -140,12 +140,9 @@ def gen_subnet_prefix16():
 
 def get_master_fe_endpoint(cluster_name):
     master_fe_ip_file = get_cluster_path(cluster_name) + "/status/master_fe_ip"
-    max_retries = 10
-    for attempt in range(max_retries):
-        if os.path.exists(master_fe_ip_file):
-            with open(master_fe_ip_file, "r") as f:
-                return "{}:{}".format(f.read().strip(), FE_QUERY_PORT)
-        time.sleep(1)
+    if os.path.exists(master_fe_ip_file):
+        with open(master_fe_ip_file, "r") as f:
+            return "{}:{}".format(f.read().strip(), FE_QUERY_PORT)
     try:
         cluster = Cluster.load(cluster_name)
         LOG.info("master file not exist, master ip get from node 1")

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -23,6 +23,7 @@ import jsonpickle
 import os
 import os.path
 import utils
+import time
 
 DOCKER_DORIS_PATH = "/opt/apache-doris"
 LOCAL_DORIS_PATH = os.getenv("LOCAL_DORIS_PATH", "/tmp/doris")

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -138,14 +138,21 @@ def gen_subnet_prefix16():
     raise Exception("Failed to gen subnet")
 
 
-def get_master_fe_endpoint(cluster_name):
-    master_fe_ip_file = get_cluster_path(cluster_name) + "/status/master_fe_ip"
-    max_retries = 10
-    for attempt in range(max_retries):
-        if os.path.exists(master_fe_ip_file):
-            with open(master_fe_ip_file, "r") as f:
-                return "{}:{}".format(f.read().strip(), FE_QUERY_PORT)
-        time.sleep(1)
+def get_master_fe_endpoint(cluster_name, wait_master_fe_ip_file=False):
+    cluster_path = get_cluster_path(cluster_name)
+    if os.path.exists(cluster_path):
+        master_fe_ip_file = "{}/status/master_fe_ip".format(cluster_path)
+        max_retries = 10 if wait_master_fe_ip_file else 0
+        i = 0
+        while True:
+            if os.path.exists(master_fe_ip_file):
+                with open(master_fe_ip_file, "r") as f:
+                    return "{}:{}".format(f.read().strip(), FE_QUERY_PORT)
+            i += 1
+            if i < max_retries:
+                time.sleep(1)
+            else:
+                break
     try:
         cluster = Cluster.load(cluster_name)
         LOG.info("master file not exist, master ip get from node 1")

--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -139,9 +139,12 @@ def gen_subnet_prefix16():
 
 def get_master_fe_endpoint(cluster_name):
     master_fe_ip_file = get_cluster_path(cluster_name) + "/status/master_fe_ip"
-    if os.path.exists(master_fe_ip_file):
-        with open(master_fe_ip_file, "r") as f:
-            return "{}:{}".format(f.read().strip(), FE_QUERY_PORT)
+    max_retries = 10
+    for attempt in range(max_retries):
+        if os.path.exists(master_fe_ip_file):
+            with open(master_fe_ip_file, "r") as f:
+                return "{}:{}".format(f.read().strip(), FE_QUERY_PORT)
+        time.sleep(1)
     try:
         cluster = Cluster.load(cluster_name)
         LOG.info("master file not exist, master ip get from node 1")

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -626,7 +626,7 @@ class UpCommand(Command):
             if cluster.is_cloud and args.sql_mode_node_mgr:
                 db_mgr = database.get_db_mgr(args.NAME, False)
                 master_fe_endpoint = CLUSTER.get_master_fe_endpoint(
-                    cluster.name)
+                    cluster.name, True)
                 # Add FEs except master_fe
                 for fe in cluster.get_all_nodes(CLUSTER.Node.TYPE_FE):
                     fe_endpoint = f"{fe.get_ip()}:{CLUSTER.FE_EDITLOG_PORT}"
@@ -1071,7 +1071,8 @@ class ListCommand(Command):
                 if services is None:
                     return COMPOSE_BAD, {}
                 return COMPOSE_GOOD, {
-                    service: ComposeService(
+                    service:
+                    ComposeService(
                         service,
                         list(service_conf["networks"].values())[0]
                         ["ipv4_address"], service_conf["image"])

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -625,8 +625,13 @@ class UpCommand(Command):
             LOG.info("after Waiting for FE master to be elected...")
             if cluster.is_cloud and args.sql_mode_node_mgr:
                 db_mgr = database.get_db_mgr(args.NAME, False)
-                master_fe_endpoint = CLUSTER.get_master_fe_endpoint(
-                    cluster.name)
+                master_fe_endpoint = ""
+                for i in range(10):
+                    master_fe_endpoint = CLUSTER.get_master_fe_endpoint(
+                        cluster.name)
+                    if master_fe_endpoint:
+                        break
+                    time.sleep(1)
                 # Add FEs except master_fe
                 for fe in cluster.get_all_nodes(CLUSTER.Node.TYPE_FE):
                     fe_endpoint = f"{fe.get_ip()}:{CLUSTER.FE_EDITLOG_PORT}"
@@ -1071,7 +1076,8 @@ class ListCommand(Command):
                 if services is None:
                     return COMPOSE_BAD, {}
                 return COMPOSE_GOOD, {
-                    service: ComposeService(
+                    service:
+                    ComposeService(
                         service,
                         list(service_conf["networks"].values())[0]
                         ["ipv4_address"], service_conf["image"])

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -625,13 +625,8 @@ class UpCommand(Command):
             LOG.info("after Waiting for FE master to be elected...")
             if cluster.is_cloud and args.sql_mode_node_mgr:
                 db_mgr = database.get_db_mgr(args.NAME, False)
-                master_fe_endpoint = ""
-                for i in range(10):
-                    master_fe_endpoint = CLUSTER.get_master_fe_endpoint(
-                        cluster.name)
-                    if master_fe_endpoint:
-                        break
-                    time.sleep(1)
+                master_fe_endpoint = CLUSTER.get_master_fe_endpoint(
+                    cluster.name)
                 # Add FEs except master_fe
                 for fe in cluster.get_all_nodes(CLUSTER.Node.TYPE_FE):
                     fe_endpoint = f"{fe.get_ip()}:{CLUSTER.FE_EDITLOG_PORT}"
@@ -1076,8 +1071,7 @@ class ListCommand(Command):
                 if services is None:
                     return COMPOSE_BAD, {}
                 return COMPOSE_GOOD, {
-                    service:
-                    ComposeService(
+                    service: ComposeService(
                         service,
                         list(service_conf["networks"].values())[0]
                         ["ipv4_address"], service_conf["image"])

--- a/docker/runtime/doris-compose/database.py
+++ b/docker/runtime/doris-compose/database.py
@@ -233,11 +233,15 @@ class DBManager(object):
                     cursor.execute(sql)
                     fields = [field_md[0] for field_md in cursor.description
                               ] if cursor.description else []
-                    return [dict(zip(fields, row)) for row in cursor.fetchall()]
+                    return [
+                        dict(zip(fields, row)) for row in cursor.fetchall()
+                    ]
             except Exception as e:
                 LOG.warn(f"Error occurred: {e}")
                 if "timed out" in str(e).lower() and attempt < retries - 1:
-                    LOG.warn(f"Query timed out. Retrying {attempt + 1}/{retries}...")
+                    LOG.warn(
+                        f"Query timed out. Retrying {attempt + 1}/{retries}..."
+                    )
                     self._reset_conn()
                 else:
                     raise e

--- a/docker/runtime/doris-compose/database.py
+++ b/docker/runtime/doris-compose/database.py
@@ -233,15 +233,11 @@ class DBManager(object):
                     cursor.execute(sql)
                     fields = [field_md[0] for field_md in cursor.description
                               ] if cursor.description else []
-                    return [
-                        dict(zip(fields, row)) for row in cursor.fetchall()
-                    ]
+                    return [dict(zip(fields, row)) for row in cursor.fetchall()]
             except Exception as e:
                 LOG.warn(f"Error occurred: {e}")
                 if "timed out" in str(e).lower() and attempt < retries - 1:
-                    LOG.warn(
-                        f"Query timed out. Retrying {attempt + 1}/{retries}..."
-                    )
+                    LOG.warn(f"Query timed out. Retrying {attempt + 1}/{retries}...")
                     self._reset_conn()
                 else:
                     raise e


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

For ls command without a cluster name arg, it will list all clusters' information.  For each cluster, it will need to get the master fe ip.  And if the cluster path had been deleted or this cluster is not located in LOCAL_DORIS_PATH,  then it can't found the master_fe_ip  file,  then it will wait this cluster for 10s.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

