### PR TITLE
[Fix](recycler) Fix recycler Hdfs accessor list all bug

### DIFF
--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -20,8 +20,6 @@
 #include <bvar/latency_recorder.h>
 #include <gen_cpp/cloud.pb.h>
 
-#include <regex>
-
 #include "common/stopwatch.h"
 #include "recycler/util.h"
 

--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -368,14 +368,14 @@ int HdfsAccessor::init() {
     return 0;
 }
 
-    // Currently, the hdfs accessor deletes files on hdfs through a prefix parameter.
-    // The format of the prefix parameter is data/{tablet id}/{rowset_prefix}, 
-    // for example: data/492211/02000000008a012957476a3e174dfdaa71ee5f80a3abafa3_.
-    // Since the hdfs cpp sdk doesn't provide an interface for deleting by prefix,
-    // we need to extract the tablet id path from the given prefix, 
-    // traverse all files in the tablet id path, and delete the files that match the prefix.
-    // This implementation is not ideal because the hdfs accessor needs to be aware of the path structure.
-    // We will optimize this in the future.
+// Currently, the hdfs accessor deletes files on hdfs through a prefix parameter.
+// The format of the prefix parameter is data/{tablet id}/{rowset_prefix},
+// for example: data/492211/02000000008a012957476a3e174dfdaa71ee5f80a3abafa3_.
+// Since the hdfs cpp sdk doesn't provide an interface for deleting by prefix,
+// we need to extract the tablet id path from the given prefix,
+// traverse all files in the tablet id path, and delete the files that match the prefix.
+// This implementation is not ideal because the hdfs accessor needs to be aware of the path structure.
+// We will optimize this in the future.
 int HdfsAccessor::delete_prefix(const std::string& path_prefix, int64_t expiration_time) {
     auto uri = to_uri(path_prefix);
     LOG(INFO) << "delete prefix, uri=" << uri;

--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -368,6 +368,14 @@ int HdfsAccessor::init() {
     return 0;
 }
 
+    // Currently, the hdfs accessor deletes files on hdfs through a prefix parameter.
+    // The format of the prefix parameter is data/{tablet id}/{rowset_prefix}, 
+    // for example: data/492211/02000000008a012957476a3e174dfdaa71ee5f80a3abafa3_.
+    // Since the hdfs cpp sdk doesn't provide an interface for deleting by prefix,
+    // we need to extract the tablet id path from the given prefix, 
+    // traverse all files in the tablet id path, and delete the files that match the prefix.
+    // This implementation is not ideal because the hdfs accessor needs to be aware of the path structure.
+    // We will optimize this in the future.
 int HdfsAccessor::delete_prefix(const std::string& path_prefix, int64_t expiration_time) {
     auto uri = to_uri(path_prefix);
     LOG(INFO) << "delete prefix, uri=" << uri;

--- a/cloud/src/recycler/hdfs_accessor.cpp
+++ b/cloud/src/recycler/hdfs_accessor.cpp
@@ -371,13 +371,18 @@ int HdfsAccessor::delete_prefix(const std::string& path_prefix, int64_t expirati
     LOG(INFO) << "delete prefix, uri=" << uri;
     // If path prefix exists, assume it is a dir or a file.
     if (exists(path_prefix) == 0) {
-        // try to delete path prefix as a dir or a file.
+        // If it exists, then it is a dir or a file.
+        // delete_directory func can delete a dir or a file.
         if (delete_directory(path_prefix) == 0) {
             LOG(INFO) << "delete prefix succ"
                       << ", is dir or file = true"
                       << ", uri=" << uri;
             return 0;
         }
+        // delete failed, return err
+        LOG_WARNING("delete prefix failed, this is a dir or a file")
+                .tag("path prefix", path_prefix);
+        return -1;
     }
     // If path prefix is not a dir or a file,
     // for example: data/492211/02000000008a012957476a3e174dfdaa71ee5f80a3abafa3_.

--- a/cloud/test/hdfs_accessor_test.cpp
+++ b/cloud/test/hdfs_accessor_test.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <vector>
 
 #include "common/config.h"
 #include "common/logging.h"
@@ -59,20 +60,20 @@ TEST(HdfsAccessorTest, normal) {
 
     HdfsAccessor accessor(info);
     int ret = accessor.init();
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
 
     std::string file1 = "data/10000/1_0.dat";
 
     ret = accessor.delete_directory("");
-    ASSERT_NE(ret, 0);
+    EXPECT_NE(ret, 0);
     ret = accessor.delete_all();
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
 
     ret = accessor.put_file(file1, "");
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
 
     ret = accessor.exists(file1);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
 
     auto* sp = SyncPoint::get_instance();
     sp->enable_processing();
@@ -90,46 +91,46 @@ TEST(HdfsAccessorTest, normal) {
 
     std::unique_ptr<ListIterator> iter;
     ret = accessor.list_directory("data", &iter);
-    ASSERT_EQ(ret, 0);
-    ASSERT_TRUE(iter);
-    ASSERT_TRUE(iter->is_valid());
-    ASSERT_TRUE(iter->has_next());
-    ASSERT_EQ(iter->next()->path, file1);
-    ASSERT_FALSE(iter->has_next());
+    EXPECT_EQ(ret, 0);
+    EXPECT_TRUE(iter);
+    EXPECT_TRUE(iter->is_valid());
+    EXPECT_TRUE(iter->has_next());
+    EXPECT_EQ(iter->next()->path, file1);
+    EXPECT_FALSE(iter->has_next());
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
+    EXPECT_EQ(alloc_entries, 0);
 
     ret = accessor.list_directory("data/", &iter);
-    ASSERT_EQ(ret, 0);
-    ASSERT_TRUE(iter->is_valid());
-    ASSERT_TRUE(iter->has_next());
-    ASSERT_EQ(iter->next()->path, file1);
-    ASSERT_FALSE(iter->has_next());
-    ASSERT_FALSE(iter->next());
+    EXPECT_EQ(ret, 0);
+    EXPECT_TRUE(iter->is_valid());
+    EXPECT_TRUE(iter->has_next());
+    EXPECT_EQ(iter->next()->path, file1);
+    EXPECT_FALSE(iter->has_next());
+    EXPECT_FALSE(iter->next());
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
+    EXPECT_EQ(alloc_entries, 0);
 
     ret = accessor.list_directory("data/100", &iter);
-    ASSERT_EQ(ret, 0);
-    ASSERT_FALSE(iter->has_next());
-    ASSERT_FALSE(iter->next());
+    EXPECT_EQ(ret, 0);
+    EXPECT_FALSE(iter->has_next());
+    EXPECT_FALSE(iter->next());
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
+    EXPECT_EQ(alloc_entries, 0);
 
     ret = accessor.delete_file(file1);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     ret = accessor.exists(file1);
-    ASSERT_EQ(ret, 1);
+    EXPECT_EQ(ret, 1);
     ret = accessor.list_directory("", &iter);
-    ASSERT_NE(ret, 0);
+    EXPECT_NE(ret, 0);
     ret = accessor.list_all(&iter);
-    ASSERT_EQ(ret, 0);
-    ASSERT_FALSE(iter->has_next());
-    ASSERT_FALSE(iter->next());
+    EXPECT_EQ(ret, 0);
+    EXPECT_FALSE(iter->has_next());
+    EXPECT_FALSE(iter->next());
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
+    EXPECT_EQ(alloc_entries, 0);
     ret = accessor.delete_file(file1);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
 
     std::vector<std::string> files;
     for (int dir = 10000; dir < 10005; ++dir) {
@@ -140,18 +141,18 @@ TEST(HdfsAccessorTest, normal) {
 
     for (auto&& file : files) {
         ret = accessor.put_file(file, "");
-        ASSERT_EQ(ret, 0);
+        EXPECT_EQ(ret, 0);
     }
 
     std::unordered_set<std::string> list_files;
     ret = accessor.list_all(&iter);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     for (auto file = iter->next(); file.has_value(); file = iter->next()) {
         list_files.insert(std::move(file->path));
     }
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
-    ASSERT_EQ(list_files.size(), files.size());
+    EXPECT_EQ(alloc_entries, 0);
+    EXPECT_EQ(list_files.size(), files.size());
     for (auto&& file : files) {
         EXPECT_TRUE(list_files.contains(file));
     }
@@ -163,69 +164,139 @@ TEST(HdfsAccessorTest, normal) {
         files.pop_back();
     }
     ret = accessor.delete_files(to_delete_files);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
 
     ret = accessor.list_all(&iter);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     list_files.clear();
     for (auto file = iter->next(); file.has_value(); file = iter->next()) {
         list_files.insert(std::move(file->path));
     }
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
-    ASSERT_EQ(list_files.size(), files.size());
+    EXPECT_EQ(alloc_entries, 0);
+    EXPECT_EQ(list_files.size(), files.size());
     for (auto&& file : files) {
         EXPECT_TRUE(list_files.contains(file));
     }
 
     std::string to_delete_dir = "data/10001";
     ret = accessor.delete_directory(to_delete_dir);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     ret = accessor.list_directory(to_delete_dir, &iter);
-    ASSERT_EQ(ret, 0);
-    ASSERT_FALSE(iter->has_next());
+    EXPECT_EQ(ret, 0);
+    EXPECT_FALSE(iter->has_next());
 
     files.erase(std::remove_if(files.begin(), files.end(),
                                [&](auto&& file) { return file.starts_with(to_delete_dir); }),
                 files.end());
     ret = accessor.list_all(&iter);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     list_files.clear();
     for (auto file = iter->next(); file.has_value(); file = iter->next()) {
         list_files.insert(std::move(file->path));
     }
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
-    ASSERT_EQ(list_files.size(), files.size());
+    EXPECT_EQ(alloc_entries, 0);
+    EXPECT_EQ(list_files.size(), files.size());
     for (auto&& file : files) {
         EXPECT_TRUE(list_files.contains(file));
     }
 
     std::string to_delete_prefix = "data/10003/";
     ret = accessor.delete_directory(to_delete_prefix);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     files.erase(std::remove_if(files.begin(), files.end(),
                                [&](auto&& file) { return file.starts_with(to_delete_prefix); }),
                 files.end());
     ret = accessor.list_all(&iter);
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     list_files.clear();
     for (auto file = iter->next(); file.has_value(); file = iter->next()) {
         list_files.insert(std::move(file->path));
     }
     iter.reset();
-    ASSERT_EQ(alloc_entries, 0);
-    ASSERT_EQ(list_files.size(), files.size());
+    EXPECT_EQ(alloc_entries, 0);
+    EXPECT_EQ(list_files.size(), files.size());
     for (auto&& file : files) {
         EXPECT_TRUE(list_files.contains(file));
     }
 
     ret = accessor.delete_all();
-    ASSERT_EQ(ret, 0);
+    EXPECT_EQ(ret, 0);
     ret = accessor.list_all(&iter);
-    ASSERT_EQ(ret, 0);
-    ASSERT_FALSE(iter->has_next());
-    ASSERT_FALSE(iter->next());
+    EXPECT_EQ(ret, 0);
+    EXPECT_FALSE(iter->has_next());
+    EXPECT_FALSE(iter->next());
+}
+
+TEST(HdfsAccessorTest, delete_prefix) {
+    HdfsVaultInfo info;
+    info.set_prefix(config::test_hdfs_prefix + "/HdfsAccessorTest/" + butil::GenerateGUID());
+    auto* conf = info.mutable_build_conf();
+    conf->set_fs_name(config::test_hdfs_fs_name);
+
+    HdfsAccessor accessor(info);
+    int ret = accessor.init();
+    EXPECT_EQ(ret, 0);
+
+    auto put_and_verify = [&accessor](const std::string& file) {
+        int ret = accessor.put_file(file, "");
+        EXPECT_EQ(ret, 0);
+        ret = accessor.exists(file);
+        EXPECT_EQ(ret, 0);
+    };
+
+    ret = accessor.delete_directory("");
+    EXPECT_NE(ret, 0);
+    ret = accessor.delete_all();
+    EXPECT_EQ(ret, 0);
+
+    put_and_verify("data/10000/1_0.dat");
+    put_and_verify("data/10000/2_0.dat");
+    put_and_verify("data/10000/20000/1_0.dat");
+    put_and_verify("data/10000/20000/30000/1_0.dat");
+    put_and_verify("data/20000/1_0.dat");
+    put_and_verify("data111/10000/1_0.dat");
+
+    ret = accessor.delete_prefix("data/10000/1_");
+    EXPECT_EQ(ret, 0);
+    ret = accessor.delete_prefix("data/10000/2_");
+    EXPECT_EQ(ret, 0);
+
+    std::unordered_set<std::string> list_files;
+    std::unique_ptr<ListIterator> iter;
+    ret = accessor.list_all(&iter);
+    EXPECT_EQ(ret, 0);
+    list_files.clear();
+    for (auto file = iter->next(); file.has_value(); file = iter->next()) {
+        list_files.insert(std::move(file->path));
+    }
+    EXPECT_EQ(list_files.size(), 4);
+    EXPECT_TRUE(list_files.contains("data/10000/20000/1_0.dat"));
+    EXPECT_TRUE(list_files.contains("data/10000/20000/30000/1_0.dat"));
+    EXPECT_TRUE(list_files.contains("data/20000/1_0.dat"));
+    EXPECT_TRUE(list_files.contains("data111/10000/1_0.dat"));
+
+    ret = accessor.delete_prefix("data/10000");
+    EXPECT_EQ(ret, -1);
+    ret = accessor.delete_prefix("data111/10000");
+    EXPECT_EQ(ret, -1);
+    ret = accessor.delete_prefix("data/20000/1_");
+    EXPECT_EQ(ret, 0);
+    ret = accessor.delete_prefix("data/10000/1");
+    EXPECT_EQ(ret, -1);
+
+    iter.reset();
+    ret = accessor.list_all(&iter);
+    EXPECT_EQ(ret, 0);
+    list_files.clear();
+    for (auto file = iter->next(); file.has_value(); file = iter->next()) {
+        list_files.insert(std::move(file->path));
+    }
+    EXPECT_EQ(list_files.size(), 3);
+    EXPECT_TRUE(list_files.contains("data/10000/20000/1_0.dat"));
+    EXPECT_TRUE(list_files.contains("data/10000/20000/30000/1_0.dat"));
+    EXPECT_TRUE(list_files.contains("data111/10000/1_0.dat"));
 }
 
 } // namespace doris::cloud

--- a/cloud/test/hdfs_accessor_test.cpp
+++ b/cloud/test/hdfs_accessor_test.cpp
@@ -295,6 +295,31 @@ TEST(HdfsAccessorTest, delete_prefix) {
     EXPECT_TRUE(list_files.contains("data/10000/20000/30000/1_0.dat"));
     EXPECT_TRUE(list_files.contains("data/10000/20000/1_0.dat"));
     EXPECT_TRUE(list_files.contains("data111/10000/1_0.dat"));
+
+    ret = accessor.delete_prefix("data/10000/20000");
+    EXPECT_EQ(ret, 0);
+
+    iter.reset();
+    ret = accessor.list_all(&iter);
+    EXPECT_EQ(ret, 0);
+    list_files.clear();
+    for (auto file = iter->next(); file.has_value(); file = iter->next()) {
+        list_files.insert(std::move(file->path));
+    }
+    EXPECT_EQ(list_files.size(), 1);
+    EXPECT_TRUE(list_files.contains("data111/10000/1_0.dat"));
+
+    ret = accessor.delete_prefix("data111/10000/1_0.dat");
+    EXPECT_EQ(ret, 0);
+
+    iter.reset();
+    ret = accessor.list_all(&iter);
+    EXPECT_EQ(ret, 0);
+    list_files.clear();
+    for (auto file = iter->next(); file.has_value(); file = iter->next()) {
+        list_files.insert(std::move(file->path));
+    }
+    EXPECT_EQ(list_files.size(), 0);
 }
 
 } // namespace doris::cloud

--- a/cloud/test/hdfs_accessor_test.cpp
+++ b/cloud/test/hdfs_accessor_test.cpp
@@ -277,14 +277,12 @@ TEST(HdfsAccessorTest, delete_prefix) {
     EXPECT_TRUE(list_files.contains("data/20000/1_0.dat"));
     EXPECT_TRUE(list_files.contains("data111/10000/1_0.dat"));
 
-    ret = accessor.delete_prefix("data/10000");
-    EXPECT_EQ(ret, -1);
-    ret = accessor.delete_prefix("data111/10000");
-    EXPECT_EQ(ret, -1);
+    ret = accessor.delete_prefix("data/10000/1_");
+    EXPECT_EQ(ret, 0);
+    ret = accessor.delete_prefix("data/10000/2_");
+    EXPECT_EQ(ret, 0);
     ret = accessor.delete_prefix("data/20000/1_");
     EXPECT_EQ(ret, 0);
-    ret = accessor.delete_prefix("data/10000/1");
-    EXPECT_EQ(ret, -1);
 
     iter.reset();
     ret = accessor.list_all(&iter);
@@ -294,8 +292,8 @@ TEST(HdfsAccessorTest, delete_prefix) {
         list_files.insert(std::move(file->path));
     }
     EXPECT_EQ(list_files.size(), 3);
-    EXPECT_TRUE(list_files.contains("data/10000/20000/1_0.dat"));
     EXPECT_TRUE(list_files.contains("data/10000/20000/30000/1_0.dat"));
+    EXPECT_TRUE(list_files.contains("data/10000/20000/1_0.dat"));
     EXPECT_TRUE(list_files.contains("data111/10000/1_0.dat"));
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The HDFS accessor in the recycler currently lists all files from the root directory when deleting by prefix, and then matches and deletes files based on the prefix. This approach wastes significant time processing unrelated tablets. This PR fixes the issue by only listing files under the relevant tablet directories first, then matching them against the prefix for deletion.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

