### PR TITLE
[opt](iceberg)support iceberg in batch mode

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -293,7 +293,7 @@ DEFINE_Validator(doris_scanner_thread_pool_thread_num, [](const int config) -> b
     return true;
 });
 DEFINE_Int32(doris_scanner_min_thread_pool_thread_num, "8");
-DEFINE_Int32(remote_split_source_batch_size, "10240");
+DEFINE_Int32(remote_split_source_batch_size, "1000");
 DEFINE_Int32(doris_max_remote_scanner_thread_pool_thread_num, "-1");
 // number of olap scanner thread pool queue size
 DEFINE_Int32(doris_scanner_thread_pool_queue_size, "102400");

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticator.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticator.java
@@ -20,6 +20,7 @@ package org.apache.doris.common.security.authentication;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.security.PrivilegedExceptionAction;
 
 public interface HadoopAuthenticator {
@@ -31,6 +32,12 @@ public interface HadoopAuthenticator {
             return getUGI().doAs(action);
         } catch (InterruptedException e) {
             throw new IOException(e);
+        } catch (UndeclaredThrowableException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
         }
     }
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/PreExecutionAuthenticator.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/PreExecutionAuthenticator.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.common.security.authentication;
 
-import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.Callable;
 
 /**
@@ -54,11 +53,23 @@ public class PreExecutionAuthenticator {
     public <T> T execute(Callable<T> task) throws Exception {
         if (hadoopAuthenticator != null) {
             // Adapts Callable to PrivilegedExceptionAction for use with Hadoop authentication
-            PrivilegedExceptionAction<T> action = new CallableToPrivilegedExceptionActionAdapter<>(task);
-            return hadoopAuthenticator.doAs(action);
+            return hadoopAuthenticator.doAs(task::call);
         } else {
             // Executes the task directly if no authentication is needed
             return task.call();
+        }
+    }
+
+    public void execute(Runnable task) throws Exception {
+        if (hadoopAuthenticator != null) {
+            // Adapts Runnable to PrivilegedExceptionAction for use with Hadoop authentication
+            hadoopAuthenticator.doAs(() -> {
+                task.run();
+                return null;
+            });
+        } else {
+            // Executes the task directly if no authentication is needed
+            task.run();
         }
     }
 
@@ -81,36 +92,5 @@ public class PreExecutionAuthenticator {
      */
     public void setHadoopAuthenticator(HadoopAuthenticator hadoopAuthenticator) {
         this.hadoopAuthenticator = hadoopAuthenticator;
-    }
-
-    /**
-     * Adapter class to convert a Callable into a PrivilegedExceptionAction.
-     * <p>This is necessary to run the task within a privileged context,
-     * particularly for Hadoop operations with Kerberos.
-     *
-     * @param <T> The type of result returned by the action
-     */
-    public class CallableToPrivilegedExceptionActionAdapter<T> implements PrivilegedExceptionAction<T> {
-        private final Callable<T> callable;
-
-        /**
-         * Constructs an adapter that wraps a Callable into a PrivilegedExceptionAction.
-         *
-         * @param callable The Callable to be adapted
-         */
-        public CallableToPrivilegedExceptionActionAdapter(Callable<T> callable) {
-            this.callable = callable;
-        }
-
-        /**
-         * Executes the wrapped Callable as a PrivilegedExceptionAction.
-         *
-         * @return The result of the callable's call method
-         * @throws Exception If an exception occurs during callable execution
-         */
-        @Override
-        public T run() throws Exception {
-            return callable.call();
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common;
 
 
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
 import org.apache.doris.metric.Metric;
 import org.apache.doris.metric.Metric.MetricUnit;
 import org.apache.doris.metric.MetricLabel;
@@ -33,6 +34,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -69,6 +71,7 @@ import java.util.function.Supplier;
 
 public class ThreadPoolManager {
 
+    private static final Logger LOG = LogManager.getLogger(ThreadPoolManager.class);
     private static Map<String, ThreadPoolExecutor> nameToThreadPoolMap = Maps.newConcurrentMap();
 
     private static String[] poolMetricTypes = {"pool_size", "active_thread_num", "task_in_queue"};
@@ -138,6 +141,17 @@ public class ThreadPoolManager {
         return newDaemonThreadPool(numThread, numThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(queueSize), new BlockedPolicy(poolName, 60),
                 poolName, needRegisterMetric);
+    }
+
+    public static ThreadPoolExecutor newDaemonFixedThreadPoolWithPreAuth(
+            int numThread,
+            int queueSize,
+            String poolName,
+            boolean needRegisterMetric,
+            PreExecutionAuthenticator preAuth) {
+        return newDaemonThreadPoolWithPreAuth(numThread, numThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(queueSize), new BlockedPolicy(poolName, 60),
+            poolName, needRegisterMetric, preAuth);
     }
 
     public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread, int queueSize,
@@ -227,6 +241,40 @@ public class ThreadPoolManager {
      */
     private static ThreadFactory namedThreadFactory(String poolName) {
         return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(poolName + "-%d").build();
+    }
+
+
+    public static ThreadPoolExecutor newDaemonThreadPoolWithPreAuth(
+            int corePoolSize,
+            int maximumPoolSize,
+            long keepAliveTime,
+            TimeUnit unit,
+            BlockingQueue<Runnable> workQueue,
+            RejectedExecutionHandler handler,
+            String poolName,
+            boolean needRegisterMetric,
+            PreExecutionAuthenticator preAuth) {
+        ThreadFactory threadFactory = namedThreadFactoryWithPreAuth(poolName, preAuth);
+        ThreadPoolExecutor threadPool = new ThreadPoolExecutor(corePoolSize, maximumPoolSize,
+                keepAliveTime, unit, workQueue, threadFactory, handler);
+        if (needRegisterMetric) {
+            nameToThreadPoolMap.put(poolName, threadPool);
+        }
+        return threadPool;
+    }
+
+    private static ThreadFactory namedThreadFactoryWithPreAuth(String poolName, PreExecutionAuthenticator preAuth) {
+        return new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat(poolName + "-%d")
+            .setThreadFactory(runnable -> new Thread(() -> {
+                try {
+                    preAuth.execute(runnable);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }))
+            .build();
     }
 
     private static class PriorityThreadPoolExecutor<T> extends ThreadPoolExecutor {
@@ -382,6 +430,27 @@ public class ThreadPoolManager {
                 LOG.warn("Task: {} submit to {}, and discard the oldest task:{}", task, threadPoolName, discardTask);
                 executor.execute(task);
             }
+        }
+    }
+
+    public static void shutdownExecutorService(ExecutorService executorService) {
+        // Disable new tasks from being submitted
+        executorService.shutdown();
+        try {
+            // Wait a while for existing tasks to terminate
+            if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                // Cancel currently executing tasks
+                executorService.shutdownNow();
+                // Wait a while for tasks to respond to being cancelled
+                if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                    LOG.warn("ExecutorService did not terminate");
+                }
+            }
+        } catch (InterruptedException e) {
+            // (Re-)Cancel if current thread also interrupted
+            executorService.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -35,6 +35,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.io.Text;
@@ -92,6 +93,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 /**
@@ -158,6 +160,7 @@ public abstract class ExternalCatalog
     protected Optional<Boolean> useMetaCache = Optional.empty();
     protected MetaCache<ExternalDatabase<? extends ExternalTable>> metaCache;
     protected PreExecutionAuthenticator preExecutionAuthenticator;
+    protected ThreadPoolExecutor threadPool;
 
     private volatile Configuration cachedConf = null;
     private byte[] confLock = new byte[0];
@@ -716,6 +719,9 @@ public abstract class ExternalCatalog
     @Override
     public void onClose() {
         removeAccessController();
+        if (threadPool != null) {
+            ThreadPoolManager.shutdownExecutorService(threadPool);
+        }
         CatalogIf.super.onClose();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -160,7 +160,7 @@ public abstract class ExternalCatalog
     protected Optional<Boolean> useMetaCache = Optional.empty();
     protected MetaCache<ExternalDatabase<? extends ExternalTable>> metaCache;
     protected PreExecutionAuthenticator preExecutionAuthenticator;
-    protected ThreadPoolExecutor threadPool;
+    protected ThreadPoolExecutor threadPoolWithPreAuth;
 
     private volatile Configuration cachedConf = null;
     private byte[] confLock = new byte[0];
@@ -719,8 +719,8 @@ public abstract class ExternalCatalog
     @Override
     public void onClose() {
         removeAccessController();
-        if (threadPool != null) {
-            ThreadPoolManager.shutdownExecutorService(threadPool);
+        if (threadPoolWithPreAuth != null) {
+            ThreadPoolManager.shutdownExecutorService(threadPoolWithPreAuth);
         }
         CatalogIf.super.onClose();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -54,7 +54,7 @@ public class SplitAssignment {
     private final List<String> pathPartitionKeys;
     private final Object assignLock = new Object();
     private Split sampleSplit = null;
-    private final AtomicBoolean isStop = new AtomicBoolean(false);
+    private final AtomicBoolean isStopped = new AtomicBoolean(false);
     private final AtomicBoolean scheduleFinished = new AtomicBoolean(false);
 
     private UserException exception = null;
@@ -90,7 +90,7 @@ public class SplitAssignment {
     }
 
     private boolean waitFirstSplit() {
-        return !scheduleFinished.get() && !isStop.get() && exception == null;
+        return !scheduleFinished.get() && !isStopped.get() && exception == null;
     }
 
     private void appendBatch(Multimap<Backend, Split> batch) throws UserException {
@@ -155,7 +155,7 @@ public class SplitAssignment {
         }
         BlockingQueue<Collection<TScanRangeLocations>> splits = assignment.computeIfAbsent(backend,
                 be -> new LinkedBlockingQueue<>());
-        if (scheduleFinished.get() && splits.isEmpty() || isStop.get()) {
+        if (scheduleFinished.get() && splits.isEmpty() || isStopped.get()) {
             return null;
         }
         return splits;
@@ -175,7 +175,7 @@ public class SplitAssignment {
         if (isStop()) {
             return;
         }
-        isStop.set(true);
+        isStopped.set(true);
         closeableResources.forEach((closeable) -> {
             try {
                 closeable.close();
@@ -188,7 +188,7 @@ public class SplitAssignment {
     }
 
     public boolean isStop() {
-        return isStop.get();
+        return isStopped.get();
     }
 
     public void addCloseable(Closeable resource) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitGenerator.java
@@ -52,7 +52,7 @@ public interface SplitGenerator {
         return -1;
     }
 
-    default void startSplit(int numBackends) {
+    default void startSplit(int numBackends) throws UserException {
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.datasource.iceberg;
 
+import org.apache.doris.common.ThreadPoolManager;
+import org.apache.doris.common.security.authentication.AuthenticationConfig;
+import org.apache.doris.common.security.authentication.HadoopAuthenticator;
 import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
@@ -43,6 +46,7 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
     public static final String EXTERNAL_CATALOG_NAME = "external_catalog.name";
     protected String icebergCatalogType;
     protected Catalog catalog;
+    private static final int ICEBERG_CATALOG_EXECUTOR_THREAD_NUM = 16;
 
     public IcebergExternalCatalog(long catalogId, String name, String comment) {
         super(catalogId, name, InitCatalogLog.Type.ICEBERG, comment);
@@ -54,9 +58,20 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
     @Override
     protected void initLocalObjectsImpl() {
         preExecutionAuthenticator = new PreExecutionAuthenticator();
+        // TODO If the storage environment does not support Kerberos (such as s3),
+        //      there is no need to generate a simple authentication information anymore.
+        AuthenticationConfig config = AuthenticationConfig.getKerberosConfig(getConfiguration());
+        HadoopAuthenticator authenticator = HadoopAuthenticator.getHadoopAuthenticator(config);
+        preExecutionAuthenticator.setHadoopAuthenticator(authenticator);
         initCatalog();
         IcebergMetadataOps ops = ExternalMetadataOperations.newIcebergMetadataOps(this, catalog);
         transactionManager = TransactionManagerFactory.createIcebergTransactionManager(ops);
+        threadPool = ThreadPoolManager.newDaemonFixedThreadPoolWithPreAuth(
+            ICEBERG_CATALOG_EXECUTOR_THREAD_NUM,
+            Integer.MAX_VALUE,
+            String.format("iceberg_catalog_%s_executor_pool", name),
+            true,
+            preExecutionAuthenticator);
         metadataOps = ops;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
@@ -66,7 +66,7 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
         initCatalog();
         IcebergMetadataOps ops = ExternalMetadataOperations.newIcebergMetadataOps(this, catalog);
         transactionManager = TransactionManagerFactory.createIcebergTransactionManager(ops);
-        threadPool = ThreadPoolManager.newDaemonFixedThreadPoolWithPreAuth(
+        threadPoolWithPreAuth = ThreadPoolManager.newDaemonFixedThreadPoolWithPreAuth(
             ICEBERG_CATALOG_EXECUTOR_THREAD_NUM,
             Integer.MAX_VALUE,
             String.format("iceberg_catalog_%s_executor_pool", name),

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
@@ -323,7 +323,7 @@ public class IcebergExternalTable extends ExternalTable implements MTMVRelatedTa
     public IcebergPartitionInfo loadPartitionInfo(long snapshotId) throws AnalysisException {
         // snapshotId == UNKNOWN_SNAPSHOT_ID means this is an empty table, haven't contained any snapshot yet.
         if (!isValidRelatedTable() || snapshotId == IcebergUtils.UNKNOWN_SNAPSHOT_ID) {
-            return new IcebergPartitionInfo();
+            return IcebergPartitionInfo.empty();
         }
         List<IcebergPartition> icebergPartitions = loadIcebergPartition(snapshotId);
         Map<String, IcebergPartition> nameToPartition = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHMSExternalCatalog.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.datasource.iceberg;
 
-import org.apache.doris.common.security.authentication.AuthenticationConfig;
-import org.apache.doris.common.security.authentication.HadoopAuthenticator;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.property.PropertyConverter;
 
@@ -37,11 +35,6 @@ public class IcebergHMSExternalCatalog extends IcebergExternalCatalog {
     protected void initCatalog() {
         icebergCatalogType = ICEBERG_HMS;
         catalog = IcebergUtils.createIcebergHiveCatalog(this, getName());
-        if (preExecutionAuthenticator.getHadoopAuthenticator() == null) {
-            AuthenticationConfig config = AuthenticationConfig.getKerberosConfig(getConfiguration());
-            HadoopAuthenticator authenticator = HadoopAuthenticator.getHadoopAuthenticator(config);
-            preExecutionAuthenticator.setHadoopAuthenticator(authenticator);
-        }
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -91,11 +91,19 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
 
     @Override
     public boolean tableExist(String dbName, String tblName) {
-        return catalog.tableExists(getTableIdentifier(dbName, tblName));
+        try {
+            return preExecutionAuthenticator.execute(() -> catalog.tableExists(getTableIdentifier(dbName, tblName)));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to check table exist, error message is:" + e.getMessage(), e);
+        }
     }
 
     public boolean databaseExist(String dbName) {
-        return nsCatalog.namespaceExists(getNamespace(dbName));
+        try {
+            return preExecutionAuthenticator.execute(() -> nsCatalog.namespaceExists(getNamespace(dbName)));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to check database exist, error message is:" + e.getMessage(), e);
+        }
     }
 
     public List<String> listDatabaseNames() {
@@ -112,8 +120,14 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
 
     @Override
     public List<String> listTableNames(String dbName) {
-        List<TableIdentifier> tableIdentifiers = catalog.listTables(getNamespace(dbName));
-        return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toList());
+        try {
+            return preExecutionAuthenticator.execute(() -> {
+                List<TableIdentifier> tableIdentifiers = catalog.listTables(getNamespace(dbName));
+                return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toList());
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to list table names, error message is:" + e.getMessage(), e);
+        }
     }
 
     @Override
@@ -275,7 +289,11 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
 
     @Override
     public Table loadTable(String dbName, String tblName) {
-        return catalog.loadTable(getTableIdentifier(dbName, tblName));
+        try {
+            return preExecutionAuthenticator.execute(() -> catalog.loadTable(getTableIdentifier(dbName, tblName)));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load table, error message is:" + e.getMessage(), e);
+        }
     }
 
     private TableIdentifier getTableIdentifier(String dbName, String tblName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergPartitionInfo.java
@@ -29,18 +29,24 @@ public class IcebergPartitionInfo {
     private final Map<String, IcebergPartition> nameToIcebergPartition;
     private final Map<String, Set<String>> nameToIcebergPartitionNames;
 
-    public IcebergPartitionInfo() {
+    private static final IcebergPartitionInfo EMPTY = new IcebergPartitionInfo();
+
+    private IcebergPartitionInfo() {
         this.nameToPartitionItem = Maps.newHashMap();
         this.nameToIcebergPartition = Maps.newHashMap();
         this.nameToIcebergPartitionNames = Maps.newHashMap();
     }
 
     public IcebergPartitionInfo(Map<String, PartitionItem> nameToPartitionItem,
-                               Map<String, IcebergPartition> nameToIcebergPartition,
+                                Map<String, IcebergPartition> nameToIcebergPartition,
                                 Map<String, Set<String>> nameToIcebergPartitionNames) {
         this.nameToPartitionItem = nameToPartitionItem;
         this.nameToIcebergPartition = nameToIcebergPartition;
         this.nameToIcebergPartitionNames = nameToIcebergPartitionNames;
+    }
+
+    static IcebergPartitionInfo empty() {
+        return EMPTY;
     }
 
     public Map<String, PartitionItem> getNameToPartitionItem() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -368,7 +368,8 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public boolean isBatchMode() {
-        return sessionVariable.getNumPartitionsInBatchMode() > 0;
+        // TODO Use a better judgment method to decide whether to use batch mode.
+        return sessionVariable.getNumPartitionsInBatchMode() > SessionVariable.NUM_PARTITIONS_IN_BATCH_MODE_DEFAULT;
     }
 
     public Long getSpecifiedSnapshot() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -369,7 +369,7 @@ public class IcebergScanNode extends FileQueryScanNode {
     @Override
     public boolean isBatchMode() {
         // TODO Use a better judgment method to decide whether to use batch mode.
-        return sessionVariable.getNumPartitionsInBatchMode() > SessionVariable.NUM_PARTITIONS_IN_BATCH_MODE_DEFAULT;
+        return sessionVariable.getNumPartitionsInBatchMode() > 1024;
     }
 
     public Long getSpecifiedSnapshot() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.ExternalTable;
@@ -52,7 +53,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
@@ -72,11 +72,12 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class IcebergScanNode extends FileQueryScanNode {
 
@@ -94,6 +95,11 @@ public class IcebergScanNode extends FileQueryScanNode {
     // And for split level count push down opt, the flag is set in each split.
     private boolean tableLevelPushDownCount = false;
     private static final long COUNT_WITH_PARALLEL_SPLITS = 10000;
+    private long targetSplitSize;
+    private ConcurrentHashMap.KeySetView<Object, Boolean> partitionPathSet;
+    private boolean isPartitionedTable;
+    private int formatVersion;
+    private PreExecutionAuthenticator preExecutionAuthenticator;
 
     /**
      * External file scan node for Query iceberg table
@@ -128,6 +134,11 @@ public class IcebergScanNode extends FileQueryScanNode {
     @Override
     protected void doInitialize() throws UserException {
         icebergTable = source.getIcebergTable();
+        targetSplitSize = getRealFileSplitSize(0);
+        partitionPathSet = ConcurrentHashMap.newKeySet();
+        isPartitionedTable = icebergTable.spec().isPartitioned();
+        formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
+        preExecutionAuthenticator = source.getCatalog().getPreExecutionAuthenticator();
         super.doInitialize();
     }
 
@@ -142,7 +153,6 @@ public class IcebergScanNode extends FileQueryScanNode {
         TTableFormatFileDesc tableFormatFileDesc = new TTableFormatFileDesc();
         tableFormatFileDesc.setTableFormatType(icebergSplit.getTableFormatType().value());
         TIcebergFileDesc fileDesc = new TIcebergFileDesc();
-        int formatVersion = icebergSplit.getFormatVersion();
         fileDesc.setFormatVersion(formatVersion);
         fileDesc.setOriginalFilePath(icebergSplit.getOriginalPath());
         if (tableLevelPushDownCount) {
@@ -184,14 +194,45 @@ public class IcebergScanNode extends FileQueryScanNode {
     @Override
     public List<Split> getSplits(int numBackends) throws UserException {
         try {
-            return source.getCatalog().getPreExecutionAuthenticator().execute(() -> doGetSplits(numBackends));
+            return preExecutionAuthenticator.execute(() -> doGetSplits(numBackends));
         } catch (Exception e) {
             throw new RuntimeException(ExceptionUtils.getRootCauseMessage(e), e);
         }
-
     }
 
-    private List<Split> doGetSplits(int numBackends) throws UserException {
+    @Override
+    public void startSplit(int numBackends) throws UserException {
+        try {
+            preExecutionAuthenticator.execute(() -> {
+                doStartSplit();
+                return null;
+            });
+        } catch (Exception e) {
+            throw new UserException(e.getMessage(), e);
+        }
+    }
+
+    public void doStartSplit() throws UserException {
+        TableScan scan = createTableScan();
+        CompletableFuture.runAsync(() -> {
+            try {
+                CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan);
+                // 1. this task should stop when all splits are assigned
+                // 2. if we want to stop this plan, we can close the fileScanTasks to stop
+                splitAssignment.addCloseable(fileScanTasks);
+
+                fileScanTasks.forEach(fileScanTask -> {
+                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(fileScanTask)));
+                });
+
+                splitAssignment.finishSchedule();
+            } catch (Exception e) {
+                splitAssignment.setException(new UserException(e.getMessage(), e));
+            }
+        });
+    }
+
+    private TableScan createTableScan() throws UserException {
         TableScan scan = icebergTable.newScan();
 
         // set snapshot
@@ -213,16 +254,16 @@ public class IcebergScanNode extends FileQueryScanNode {
             this.pushdownIcebergPredicates.add(predicate.toString());
         }
 
-        // get splits
-        List<Split> splits = new ArrayList<>();
-        int formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
-        HashSet<String> partitionPathSet = new HashSet<>();
-        boolean isPartitionedTable = icebergTable.spec().isPartitioned();
+        scan = scan.planWith(source.getCatalog().getThreadPool());
 
-        long realFileSplitSize = getRealFileSplitSize(0);
-        CloseableIterable<FileScanTask> fileScanTasks = null;
+        return scan;
+    }
+
+    public CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {
+        long targetSplitSize = getRealFileSplitSize(0);
+        CloseableIterable<FileScanTask> splitFiles;
         try {
-            fileScanTasks = TableScanUtil.splitFiles(scan.planFiles(), realFileSplitSize);
+            splitFiles = TableScanUtil.splitFiles(scan.planFiles(), targetSplitSize);
         } catch (NullPointerException e) {
             /*
         Caused by: java.lang.NullPointerException: Type cannot be null
@@ -253,33 +294,45 @@ public class IcebergScanNode extends FileQueryScanNode {
             LOG.warn("Iceberg TableScanUtil.splitFiles throw NullPointerException. Cause : ", e);
             throw new NotSupportedException("Unable to read Iceberg table with dropped old partition column.");
         }
-        try (CloseableIterable<CombinedScanTask> combinedScanTasks =
-                     TableScanUtil.planTasks(fileScanTasks, realFileSplitSize, 1, 0)) {
-            combinedScanTasks.forEach(taskGrp -> taskGrp.files().forEach(splitTask -> {
-                if (isPartitionedTable) {
-                    StructLike structLike = splitTask.file().partition();
-                    // Counts the number of partitions read
-                    partitionPathSet.add(structLike.toString());
-                }
-                String originalPath = splitTask.file().path().toString();
-                LocationPath locationPath = new LocationPath(originalPath, source.getCatalog().getProperties());
-                IcebergSplit split = new IcebergSplit(
-                        locationPath,
-                        splitTask.start(),
-                        splitTask.length(),
-                        splitTask.file().fileSizeInBytes(),
-                        new String[0],
-                        formatVersion,
-                        source.getCatalog().getProperties(),
-                        new ArrayList<>(),
-                        originalPath);
-                split.setTargetSplitSize(realFileSplitSize);
-                if (formatVersion >= MIN_DELETE_FILE_SUPPORT_VERSION) {
-                    split.setDeleteFileFilters(getDeleteFileFilters(splitTask));
-                }
-                split.setTableFormatType(TableFormatType.ICEBERG);
+        return splitFiles;
+    }
+
+    private Split createIcebergSplit(FileScanTask fileScanTask) {
+        if (isPartitionedTable) {
+            StructLike structLike = fileScanTask.file().partition();
+            // Counts the number of partitions read
+            partitionPathSet.add(structLike.toString());
+        }
+        String originalPath = fileScanTask.file().path().toString();
+        LocationPath locationPath = new LocationPath(originalPath, source.getCatalog().getProperties());
+        IcebergSplit split = new IcebergSplit(
+                locationPath,
+                fileScanTask.start(),
+                fileScanTask.length(),
+                fileScanTask.file().fileSizeInBytes(),
+                new String[0],
+                formatVersion,
+                source.getCatalog().getProperties(),
+                new ArrayList<>(),
+                originalPath);
+        if (!fileScanTask.deletes().isEmpty()) {
+            split.setDeleteFileFilters(getDeleteFileFilters(fileScanTask));
+        }
+        split.setTableFormatType(TableFormatType.ICEBERG);
+        split.setTargetSplitSize(targetSplitSize);
+        return split;
+    }
+
+    private List<Split> doGetSplits(int numBackends) throws UserException {
+
+        TableScan scan = createTableScan();
+        List<Split> splits = new ArrayList<>();
+
+        try (CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan)) {
+            fileScanTasks.forEach(taskGrp ->  {
+                Split split = createIcebergSplit(taskGrp);
                 splits.add(split);
-            }));
+            });
         } catch (IOException e) {
             throw new UserException(e.getMessage(), e.getCause());
         }
@@ -306,6 +359,11 @@ public class IcebergScanNode extends FileQueryScanNode {
         }
         selectedPartitionNum = partitionPathSet.size();
         return splits;
+    }
+
+    @Override
+    public boolean isBatchMode() {
+        return sessionVariable.getNumPartitionsInBatchMode() > 0;
     }
 
     public Long getSpecifiedSnapshot() throws UserException {
@@ -459,5 +517,10 @@ public class IcebergScanNode extends FileQueryScanNode {
             ((IcebergSplit) splits.get(i)).setTableLevelRowCount(countPerSplit);
         }
         ((IcebergSplit) splits.get(size - 1)).setTableLevelRowCount(countPerSplit + totalCount % size);
+    }
+
+    @Override
+    public int numApproximateSplits() {
+        return NUM_SPLITS_PER_PARTITION * partitionPathSet.size() > 0 ? partitionPathSet.size() : 1;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -259,7 +259,7 @@ public class IcebergScanNode extends FileQueryScanNode {
             this.pushdownIcebergPredicates.add(predicate.toString());
         }
 
-        scan = scan.planWith(source.getCatalog().getThreadPool());
+        scan = scan.planWith(source.getCatalog().getThreadPoolWithPreAuth());
 
         return scan;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSplit.java
@@ -22,6 +22,7 @@ import org.apache.doris.datasource.FileSplit;
 
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public class IcebergSplit extends FileSplit {
     // but the original datafile path must be used.
     private final String originalPath;
     private Integer formatVersion;
-    private List<IcebergDeleteFileFilter> deleteFileFilters;
+    private List<IcebergDeleteFileFilter> deleteFileFilters = new ArrayList<>();
     private Map<String, String> config;
     // tableLevelRowCount will be set only table-level count push down opt is available.
     private long tableLevelRowCount = -1;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -101,7 +101,7 @@ public abstract class ScanNode extends PlanNode implements SplitGenerator {
     protected SplitAssignment splitAssignment = null;
 
     protected long selectedPartitionNum = 0;
-    protected long selectedSplitNum = 0;
+    protected int selectedSplitNum = 0;
 
     // create a mapping between output slot's id and project expr
     Map<SlotId, Expr> outputSlotToProjectExpr = new HashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1763,7 +1763,7 @@ public class SessionVariable implements Serializable, Writable {
             description = {"batch方式中BE获取splits的最大等待时间",
                     "The max wait time of getting splits in batch mode."},
             needForward = true)
-    public long fetchSplitsMaxWaitTime = 4000;
+    public long fetchSplitsMaxWaitTime = 1000;
 
     @VariableMgr.VarAttr(
             name = ENABLE_PARQUET_LAZY_MAT,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1756,8 +1756,7 @@ public class SessionVariable implements Serializable, Writable {
             description = {"如果分区数量超过阈值，BE将通过batch方式获取scan ranges",
                     "If the number of partitions exceeds the threshold, scan ranges will be got through batch mode."},
             needForward = true)
-    public static final int NUM_PARTITIONS_IN_BATCH_MODE_DEFAULT = 1024;
-    public int numPartitionsInBatchMode = NUM_PARTITIONS_IN_BATCH_MODE_DEFAULT;
+    public int numPartitionsInBatchMode = 1024;
 
     @VariableMgr.VarAttr(
             name = FETCH_SPLITS_MAX_WAIT_TIME,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1756,7 +1756,8 @@ public class SessionVariable implements Serializable, Writable {
             description = {"如果分区数量超过阈值，BE将通过batch方式获取scan ranges",
                     "If the number of partitions exceeds the threshold, scan ranges will be got through batch mode."},
             needForward = true)
-    public int numPartitionsInBatchMode = 1024;
+    public static final int NUM_PARTITIONS_IN_BATCH_MODE_DEFAULT = 1024;
+    public int numPartitionsInBatchMode = NUM_PARTITIONS_IN_BATCH_MODE_DEFAULT;
 
     @VariableMgr.VarAttr(
             name = FETCH_SPLITS_MAX_WAIT_TIME,

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_filter.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_filter.groovy
@@ -19,6 +19,7 @@ suite("test_iceberg_filter", "p0,external,doris,external_docker,external_docker_
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {
+            sql """set num_partitions_in_batch_mode=0"""
             String rest_port = context.config.otherConfigs.get("iceberg_rest_uri_port")
             String minio_port = context.config.otherConfigs.get("iceberg_minio_port")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
@@ -91,6 +92,7 @@ suite("test_iceberg_filter", "p0,external,doris,external_docker,external_docker_
             }
 
         } finally {
+            sql """set num_partitions_in_batch_mode=1024"""
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

1. use thread pool in planFiles.
2. support batch mode.
3. When executing `doAs`, if the exception type is `UndeclaredThrowableException`, we should get the specific cause inside. Because the message of UndeclaredThrowableException is null, the message will not be obtained if the exception is captured externally
4. Modify the default configuration:
     fetch_splits_max_wait_time_ms: from 4000 to 1000
     remote_split_source_batch_size: from 10240 to 1000

ATTN：
There is a cache client pool in BE to obtain splits from FE. 
When FE restarts, the clients will report errors due to invalidation.
 This will cause an error when querying data in batch mode for the first time:  
> Failed to get batch of split source:  No more data to read

Don't worry, just query again. 

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

