### PR TITLE
[fix](nereids) Create Runtime filter even if equal.right is not in aliasTransferMap (branch-2.1)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -274,11 +274,6 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                     continue;
                 }
                 long buildSideNdv = getBuildSideNdv(join, equalTo);
-                Pair<PhysicalRelation, Slot> pair = ctx.getAliasTransferMap().get(equalTo.right());
-                // CteConsumer is not allowed to generate RF in order to avoid RF cycle.
-                if (pair == null) {
-                    continue;
-                }
                 if (equalTo.left().getInputSlots().size() == 1) {
                     RuntimeFilterPushDownVisitor.PushDownContext pushDownContext =
                             RuntimeFilterPushDownVisitor.PushDownContext.createPushDownContextForHashJoin(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

