### PR TITLE
[chore](conf) Set enable_advance_next_id=true by default (#44790)

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2872,7 +2872,7 @@ public class Config extends ConfigBase {
             "Whether to advance the ID generator after becoming Master to ensure that the id "
                     + "generator will not be rolled back even when metadata is rolled back."
     })
-    public static boolean enable_advance_next_id = false;
+    public static boolean enable_advance_next_id = true;
 
     // The count threshold to do manual GC when doing checkpoint but not enough memory.
     // Set zero to disable it.

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExportToOutfileLogicalPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExportToOutfileLogicalPlanTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.load.ExportJob;
@@ -47,6 +48,12 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
     private String dbName = "testDb";
     private String tblName = "table1";
 
+    private final boolean defaultEnableAdvanceNextId = Config.enable_advance_next_id; // backup
+
+    {
+        enableAdvanceNextId = false;
+    }
+
     /**
      * create a database and a table
      *
@@ -65,6 +72,7 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
                 + "PARTITION p4 VALUES LESS THAN (\"50\")\n" + ")\n"
                 + " distributed by hash(k1) buckets 10\n"
                 + "properties(\"replication_num\" = \"1\");");
+        Config.enable_advance_next_id = defaultEnableAdvanceNextId; // restore
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexesProcNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexesProcNodeTest.java
@@ -96,7 +96,7 @@ public class IndexesProcNodeTest {
         Assert.assertEquals(procResult.getRows().get(3).get(5), "col_4");
         Assert.assertEquals(procResult.getRows().get(3).get(11), "NGRAM_BF");
         Assert.assertEquals(procResult.getRows().get(3).get(12), "ngram_bf index on col_4");
-        Assert.assertEquals(procResult.getRows().get(3).get(13), "(\"gram_size\" = \"3\", \"bf_size\" = \"256\")");
+        Assert.assertEquals(procResult.getRows().get(3).get(13), "(\"bf_size\" = \"256\", \"gram_size\" = \"3\")");
 
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -185,7 +185,10 @@ public class FrontendServiceImplTest {
         TGetDbsResult dbNames = impl.getDbNames(params);
 
         Assert.assertEquals(dbNames.getDbs().size(), 2);
-        Assert.assertEquals(dbNames.getDbs(), Arrays.asList("test", "test_"));
+        List<String> expected = Arrays.asList("test", "test_");
+        dbNames.getDbs().sort(String::compareTo);
+        expected.sort(String::compareTo);
+        Assert.assertEquals(dbNames.getDbs(), expected);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -140,6 +140,8 @@ public abstract class TestWithFeService {
     protected ConnectContext connectContext;
     protected boolean needCleanDir = true;
     protected int lastFeRpcPort = 0;
+    // make it default to enable_advance_next_id
+    protected boolean enableAdvanceNextId = Config.enable_advance_next_id;
 
     protected static final String DEFAULT_CLUSTER_PREFIX = "";
 
@@ -152,6 +154,8 @@ public abstract class TestWithFeService {
 
     @BeforeAll
     public final void beforeAll() throws Exception {
+        // this.enableAdvanceNextId may be reset by children classes
+        Config.enable_advance_next_id = this.enableAdvanceNextId;
         FeConstants.enableInternalSchemaDb = false;
         beforeCreatingConnectContext();
         connectContext = createDefaultCtx();


### PR DESCRIPTION
pick #44790

Bind the generation of next_id to physical time to ensure its generation is monotonically increasing, even if we directly overwrite the FE metadata and then restart. This way, it supports a lossy cluster rollback in scenarios where major version upgrades are incompatible.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

