### PR TITLE
[opt](jni) Modify Exception Cause Formatting in JniUtil for Better Readability

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JniUtil.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JniUtil.java
@@ -72,7 +72,7 @@ public class JniUtil {
         // Follow the chain of exception causes and print them as well.
         Throwable cause = t;
         while ((cause = cause.getCause()) != null) {
-            output.write(String.format("\nCAUSED BY: %s: %s",
+            output.write(String.format(" | CAUSED BY: %s: %s",
                     cause.getClass().getSimpleName(), cause.getMessage()));
         }
         return output.toString();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This PR modifies the formatting of exception causes in the JniUtil class. Previously, the causes were separated by a newline (\n). Now, they are separated by | for better readability and consistent log formatting.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

