### PR TITLE
[opt](nereids) compare literal not convert to legacy literal and fix ip literal compareTo always equals  0

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -156,6 +156,12 @@ under the License.
             <artifactId>guava-testlib</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.googlecode.java-ipv6/java-ipv6 -->
+        <dependency>
+            <groupId>com.googlecode.java-ipv6</groupId>
+            <artifactId>java-ipv6</artifactId>
+            <version>0.17</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -670,7 +670,7 @@ public class DateLiteral extends LiteralExpr {
             return diff < 0 ? -1 : (diff == 0 ? 0 : 1);
         }
         // date time will not overflow when doing addition and subtraction
-        return getStringValue().compareTo(expr.getStringValue());
+        return Integer.signum(getStringValue().compareTo(expr.getStringValue()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -249,6 +249,9 @@ public class DecimalLiteral extends NumericLiteralExpr {
         if (expr instanceof NullLiteral) {
             return 1;
         }
+        if (expr == MaxLiteral.MAX_VALUE) {
+            return -1;
+        }
         if (expr instanceof DecimalLiteral) {
             return this.value.compareTo(((DecimalLiteral) expr).value);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FloatLiteral.java
@@ -126,6 +126,9 @@ public class FloatLiteral extends NumericLiteralExpr {
         if (expr instanceof NullLiteral) {
             return 1;
         }
+        if (expr == MaxLiteral.MAX_VALUE) {
+            return -1;
+        }
         return Double.compare(value, expr.getDoubleValue());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IntLiteral.java
@@ -261,17 +261,13 @@ public class IntLiteral extends NumericLiteralExpr {
         if (expr instanceof NullLiteral) {
             return 1;
         }
-        if (expr instanceof StringLiteral) {
-            return ((StringLiteral) expr).compareLiteral(this);
-        }
         if (expr == MaxLiteral.MAX_VALUE) {
             return -1;
         }
-        if (value == expr.getLongValue()) {
-            return 0;
-        } else {
-            return value > expr.getLongValue() ? 1 : -1;
+        if (expr instanceof StringLiteral) {
+            return - ((StringLiteral) expr).compareLiteral(this);
         }
+        return Long.compare(value, expr.getLongValue());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/ColumnBound.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/ColumnBound.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.rules.expression.rules;
 
 import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 
 import com.google.common.base.MoreObjects;
@@ -36,7 +37,13 @@ public class ColumnBound implements Comparable<ColumnBound> {
 
     @Override
     public int compareTo(ColumnBound o) {
-        return value.toLegacyLiteral().compareTo(o.value.toLegacyLiteral());
+        if (!(value instanceof ComparableLiteral)) {
+            throw new RuntimeException("'" + value + "' (" + value.getDataType() + ") is not comparable");
+        }
+        if (!(o.value instanceof ComparableLiteral)) {
+            throw new RuntimeException("'" + o.value + "' (" + o.value.getDataType() + ") is not comparable");
+        }
+        return ((ComparableLiteral) value).compareTo((ComparableLiteral) o.value);
     }
 
     public static ColumnBound of(Literal expr) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -80,6 +80,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Version;
 import org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
@@ -266,7 +267,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((Literal) equalTo.left()).compareTo((Literal) equalTo.right()) == 0);
+        try {
+            return BooleanLiteral.of(((ComparableLiteral) equalTo.left())
+                    .compareTo((ComparableLiteral) equalTo.right()) == 0);
+        } catch (Exception e) {
+            // left and right maybe not comparable
+            return BooleanLiteral.of(equalTo.left().equals(equalTo.right()));
+        }
     }
 
     @Override
@@ -276,7 +283,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((Literal) greaterThan.left()).compareTo((Literal) greaterThan.right()) > 0);
+        try {
+            return BooleanLiteral.of(((ComparableLiteral) greaterThan.left())
+                    .compareTo((ComparableLiteral) greaterThan.right()) > 0);
+        } catch (Exception e) {
+            // left and right maybe not comparable
+            return greaterThan;
+        }
     }
 
     @Override
@@ -286,8 +299,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((Literal) greaterThanEqual.left())
-                .compareTo((Literal) greaterThanEqual.right()) >= 0);
+        try {
+            return BooleanLiteral.of(((ComparableLiteral) greaterThanEqual.left())
+                    .compareTo((ComparableLiteral) greaterThanEqual.right()) >= 0);
+        } catch (Exception e) {
+            // left and right maybe not comparable
+            return greaterThanEqual;
+        }
     }
 
     @Override
@@ -297,7 +315,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((Literal) lessThan.left()).compareTo((Literal) lessThan.right()) < 0);
+        try {
+            return BooleanLiteral.of(((ComparableLiteral) lessThan.left())
+                    .compareTo((ComparableLiteral) lessThan.right()) < 0);
+        } catch (Exception e) {
+            // left and right maybe not comparable
+            return lessThan;
+        }
     }
 
     @Override
@@ -307,7 +331,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((Literal) lessThanEqual.left()).compareTo((Literal) lessThanEqual.right()) <= 0);
+        try {
+            return BooleanLiteral.of(((ComparableLiteral) lessThanEqual.left())
+                    .compareTo((ComparableLiteral) lessThanEqual.right()) <= 0);
+        } catch (Exception e) {
+            // left and right maybe not comparable
+            return lessThanEqual;
+        }
     }
 
     @Override
@@ -322,7 +352,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (l.isNullLiteral() && r.isNullLiteral()) {
             return BooleanLiteral.TRUE;
         } else if (!l.isNullLiteral() && !r.isNullLiteral()) {
-            return BooleanLiteral.of(l.compareTo(r) == 0);
+            try {
+                return BooleanLiteral.of(((ComparableLiteral) nullSafeEqual.left())
+                        .compareTo((ComparableLiteral) nullSafeEqual.right()) == 0);
+            } catch (Exception e) {
+                // left and right maybe not comparable
+                return BooleanLiteral.of(l.equals(r));
+            }
         } else {
             return BooleanLiteral.FALSE;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -267,11 +267,10 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        try {
+        if (equalTo.left() instanceof ComparableLiteral && equalTo.right() instanceof ComparableLiteral) {
             return BooleanLiteral.of(((ComparableLiteral) equalTo.left())
                     .compareTo((ComparableLiteral) equalTo.right()) == 0);
-        } catch (Exception e) {
-            // left and right maybe not comparable
+        } else {
             return BooleanLiteral.of(equalTo.left().equals(equalTo.right()));
         }
     }
@@ -283,13 +282,8 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        try {
-            return BooleanLiteral.of(((ComparableLiteral) greaterThan.left())
-                    .compareTo((ComparableLiteral) greaterThan.right()) > 0);
-        } catch (Exception e) {
-            // left and right maybe not comparable
-            return greaterThan;
-        }
+        return BooleanLiteral.of(((ComparableLiteral) greaterThan.left())
+                .compareTo((ComparableLiteral) greaterThan.right()) > 0);
     }
 
     @Override
@@ -299,13 +293,8 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        try {
-            return BooleanLiteral.of(((ComparableLiteral) greaterThanEqual.left())
-                    .compareTo((ComparableLiteral) greaterThanEqual.right()) >= 0);
-        } catch (Exception e) {
-            // left and right maybe not comparable
-            return greaterThanEqual;
-        }
+        return BooleanLiteral.of(((ComparableLiteral) greaterThanEqual.left())
+                .compareTo((ComparableLiteral) greaterThanEqual.right()) >= 0);
     }
 
     @Override
@@ -315,13 +304,8 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        try {
-            return BooleanLiteral.of(((ComparableLiteral) lessThan.left())
-                    .compareTo((ComparableLiteral) lessThan.right()) < 0);
-        } catch (Exception e) {
-            // left and right maybe not comparable
-            return lessThan;
-        }
+        return BooleanLiteral.of(((ComparableLiteral) lessThan.left())
+                .compareTo((ComparableLiteral) lessThan.right()) < 0);
     }
 
     @Override
@@ -331,13 +315,8 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        try {
-            return BooleanLiteral.of(((ComparableLiteral) lessThanEqual.left())
-                    .compareTo((ComparableLiteral) lessThanEqual.right()) <= 0);
-        } catch (Exception e) {
-            // left and right maybe not comparable
-            return lessThanEqual;
-        }
+        return BooleanLiteral.of(((ComparableLiteral) lessThanEqual.left())
+                .compareTo((ComparableLiteral) lessThanEqual.right()) <= 0);
     }
 
     @Override
@@ -352,11 +331,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (l.isNullLiteral() && r.isNullLiteral()) {
             return BooleanLiteral.TRUE;
         } else if (!l.isNullLiteral() && !r.isNullLiteral()) {
-            try {
+            if (nullSafeEqual.left() instanceof ComparableLiteral
+                    && nullSafeEqual.right() instanceof ComparableLiteral) {
                 return BooleanLiteral.of(((ComparableLiteral) nullSafeEqual.left())
                         .compareTo((ComparableLiteral) nullSafeEqual.right()) == 0);
-            } catch (Exception e) {
-                // left and right maybe not comparable
+            } else {
                 return BooleanLiteral.of(l.equals(r));
             }
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -29,7 +29,7 @@ import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
-import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.util.ExpressionUtils;
@@ -76,7 +76,8 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             return new UnknownValue(context, predicate);
         }
         // only handle `NumericType` and `DateLikeType`
-        if (right.isLiteral() && (right.getDataType().isNumericType() || right.getDataType().isDateLikeType())) {
+        if (right instanceof ComparableLiteral
+                && (right.getDataType().isNumericType() || right.getDataType().isDateLikeType())) {
             return ValueDesc.range(context, predicate);
         }
         return new UnknownValue(context, predicate);
@@ -111,7 +112,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
     public ValueDesc visitInPredicate(InPredicate inPredicate, ExpressionRewriteContext context) {
         // only handle `NumericType` and `DateLikeType`
         if (inPredicate.getOptions().size() <= InPredicateDedup.REWRITE_OPTIONS_MAX_SIZE
-                && ExpressionUtils.isAllNonNullLiteral(inPredicate.getOptions())
+                && ExpressionUtils.isAllNonNullComparableLiteral(inPredicate.getOptions())
                 && (ExpressionUtils.matchNumericType(inPredicate.getOptions())
                 || ExpressionUtils.matchDateLikeType(inPredicate.getOptions()))) {
             return ValueDesc.discrete(context, inPredicate);
@@ -216,7 +217,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         /** merge discrete and ranges only, no merge other value desc */
         public static List<ValueDesc> unionDiscreteAndRange(ExpressionRewriteContext context,
                 Expression reference, List<ValueDesc> valueDescs) {
-            Set<Literal> discreteValues = Sets.newHashSet();
+            Set<ComparableLiteral> discreteValues = Sets.newHashSet();
             for (ValueDesc valueDesc : valueDescs) {
                 if (valueDesc instanceof DiscreteValue) {
                     discreteValues.addAll(((DiscreteValue) valueDesc).getValues());
@@ -224,10 +225,10 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             }
 
             // for 'a > 8 or a = 8', then range (8, +00) can convert to [8, +00)
-            RangeSet<Literal> rangeSet = TreeRangeSet.create();
+            RangeSet<ComparableLiteral> rangeSet = TreeRangeSet.create();
             for (ValueDesc valueDesc : valueDescs) {
                 if (valueDesc instanceof RangeValue) {
-                    Range<Literal> range = ((RangeValue) valueDesc).range;
+                    Range<ComparableLiteral> range = ((RangeValue) valueDesc).range;
                     rangeSet.add(range);
                     if (range.hasLowerBound()
                             && range.lowerBoundType() == BoundType.OPEN
@@ -250,7 +251,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             if (!discreteValues.isEmpty()) {
                 result.add(new DiscreteValue(context, reference, discreteValues));
             }
-            for (Range<Literal> range : rangeSet.asRanges()) {
+            for (Range<ComparableLiteral> range : rangeSet.asRanges()) {
                 result.add(new RangeValue(context, reference, range));
             }
             for (ValueDesc valueDesc : valueDescs) {
@@ -267,7 +268,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
 
         /** intersect */
         public static ValueDesc intersect(ExpressionRewriteContext context, RangeValue range, DiscreteValue discrete) {
-            Set<Literal> newValues = discrete.values.stream().filter(x -> range.range.contains(x))
+            Set<ComparableLiteral> newValues = discrete.values.stream().filter(x -> range.range.contains(x))
                     .collect(Collectors.toSet());
             if (newValues.isEmpty()) {
                 return new EmptyValue(context, range.reference);
@@ -277,11 +278,11 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         }
 
         private static ValueDesc range(ExpressionRewriteContext context, ComparisonPredicate predicate) {
-            Literal value = (Literal) predicate.right();
+            ComparableLiteral value = (ComparableLiteral) predicate.right();
             if (predicate instanceof EqualTo) {
                 return new DiscreteValue(context, predicate.left(), Sets.newHashSet(value));
             }
-            Range<Literal> range = null;
+            Range<ComparableLiteral> range = null;
             if (predicate instanceof GreaterThanEqual) {
                 range = Range.atLeast(value);
             } else if (predicate instanceof GreaterThan) {
@@ -296,8 +297,9 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         }
 
         public static ValueDesc discrete(ExpressionRewriteContext context, InPredicate in) {
-            // Set<Literal> literals = (Set) Utils.fastToImmutableSet(in.getOptions());
-            Set<Literal> literals = in.getOptions().stream().map(Literal.class::cast).collect(Collectors.toSet());
+            // Set<ComparableLiteral> literals = (Set) Utils.fastToImmutableSet(in.getOptions());
+            Set<ComparableLiteral> literals = in.getOptions().stream()
+                    .map(ComparableLiteral.class::cast).collect(Collectors.toSet());
             return new DiscreteValue(context, in.getCompareExpr(), literals);
         }
     }
@@ -328,14 +330,14 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
      * a > 1 => (1...+∞)
      */
     public static class RangeValue extends ValueDesc {
-        Range<Literal> range;
+        Range<ComparableLiteral> range;
 
-        public RangeValue(ExpressionRewriteContext context, Expression reference, Range<Literal> range) {
+        public RangeValue(ExpressionRewriteContext context, Expression reference, Range<ComparableLiteral> range) {
             super(context, reference);
             this.range = range;
         }
 
-        public Range<Literal> getRange() {
+        public Range<ComparableLiteral> getRange() {
             return range;
         }
 
@@ -387,15 +389,15 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
      * a in (1,2,3) => [1,2,3]
      */
     public static class DiscreteValue extends ValueDesc {
-        final Set<Literal> values;
+        final Set<ComparableLiteral> values;
 
         public DiscreteValue(ExpressionRewriteContext context,
-                Expression reference, Set<Literal> values) {
+                Expression reference, Set<ComparableLiteral> values) {
             super(context, reference);
             this.values = values;
         }
 
-        public Set<Literal> getValues() {
+        public Set<ComparableLiteral> getValues() {
             return values;
         }
 
@@ -405,7 +407,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
                 return other.union(this);
             }
             if (other instanceof DiscreteValue) {
-                Set<Literal> newValues = Sets.newHashSet();
+                Set<ComparableLiteral> newValues = Sets.newHashSet();
                 newValues.addAll(((DiscreteValue) other).values);
                 newValues.addAll(this.values);
                 return new DiscreteValue(context, reference, newValues);
@@ -422,7 +424,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
                 return other.intersect(this);
             }
             if (other instanceof DiscreteValue) {
-                Set<Literal> newValues = Sets.newHashSet();
+                Set<ComparableLiteral> newValues = Sets.newHashSet();
                 newValues.addAll(((DiscreteValue) other).values);
                 newValues.retainAll(this.values);
                 if (newValues.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyArithmeticComparisonRule.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.SecondsAdd;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.SecondsSub;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeeksAdd;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeeksSub;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
@@ -124,7 +125,7 @@ public class SimplifyArithmeticComparisonRule implements ExpressionPatternRuleFa
         if (!left.child(1).isConstant()) {
             throw new RuntimeException(String.format("Expected literal when arranging children for Expr %s", left));
         }
-        Literal leftLiteral = (Literal) FoldConstantRule.evaluate(left.child(1), context);
+        ComparableLiteral leftLiteral = (ComparableLiteral) FoldConstantRule.evaluate(left.child(1), context);
         Expression leftExpr = left.child(0);
 
         Class<? extends Expression> oppositeOperator = REARRANGEMENT_MAP.get(left.getClass());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ComparisonPredicate.java
@@ -64,6 +64,8 @@ public abstract class ComparisonPredicate extends BinaryOperator {
         for (Expression c : children) {
             if (c.getDataType().isComplexType() && !c.getDataType().isArrayType()) {
                 throw new AnalysisException("comparison predicate could not contains complex type: " + this.toSql());
+            } else if (c.getDataType().isJsonType()) {
+                throw new AnalysisException("comparison predicate could not contains json type: " + this.toSql());
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UnixTimestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UnixTimestamp.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.Monotonic;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
@@ -176,7 +177,8 @@ public class UnixTimestamp extends ScalarFunction implements ExplicitlyCastableS
         if (null == upper) {
             upper = DateTimeLiteral.MAX_DATETIME;
         }
-        if (lower.compareTo(MAX) <= 0 && upper.compareTo(MAX) > 0) {
+        if (((ComparableLiteral) lower).compareTo(MAX) <= 0
+                && ((ComparableLiteral) upper).compareTo(MAX) > 0) {
             return false;
         } else {
             return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/ArrayLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/ArrayLiteral.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 /**
  * ArrayLiteral
  */
-public class ArrayLiteral extends Literal {
+public class ArrayLiteral extends Literal implements ComparableLiteral {
 
     private final List<Literal> items;
 
@@ -68,6 +68,39 @@ public class ArrayLiteral extends Literal {
                 .map(Literal::toLegacyLiteral)
                 .toArray(LiteralExpr[]::new);
         return new org.apache.doris.analysis.ArrayLiteral(getDataType().toCatalogDataType(), itemExprs);
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof ArrayLiteral) {
+            ArrayLiteral otherArray = (ArrayLiteral) other;
+            int size = Math.min(otherArray.items.size(), this.items.size());
+            for (int i = 0; i < size; i++) {
+                Literal thisItem = items.get(i);
+                Literal otherItem = otherArray.items.get(i);
+                if (!(thisItem instanceof ComparableLiteral)) {
+                    throw new RuntimeException(
+                            "array item '" + thisItem + "' (" + thisItem.dataType + ") is not comparable");
+                }
+                if (!(otherItem instanceof ComparableLiteral)) {
+                    throw new RuntimeException(
+                            "array item '" + otherItem + "' (" + otherItem.dataType + ") is not comparable");
+                }
+                int cmp = ((ComparableLiteral) thisItem).compareTo((ComparableLiteral) otherItem);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return Integer.compare(this.items.size(), otherArray.items.size());
+        }
+        if (other instanceof NullLiteral) {
+            return 1;
+        }
+        if (other instanceof MaxLiteral) {
+            return -1;
+        }
+        throw new RuntimeException("Cannot compare two values with different data types: "
+                + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/BooleanLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/BooleanLiteral.java
@@ -25,7 +25,7 @@ import org.apache.doris.nereids.types.BooleanType;
 /**
  * Represents Boolean literal
  */
-public class BooleanLiteral extends Literal {
+public class BooleanLiteral extends Literal implements ComparableLiteral {
 
     public static final BooleanLiteral TRUE = new BooleanLiteral(true);
     public static final BooleanLiteral FALSE = new BooleanLiteral(false);
@@ -67,6 +67,21 @@ public class BooleanLiteral extends Literal {
     @Override
     public LiteralExpr toLegacyLiteral() {
         return new BoolLiteral(value);
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof BooleanLiteral) {
+            return Boolean.compare(value, ((BooleanLiteral) other).value);
+        }
+        if (other instanceof NullLiteral) {
+            return 1;
+        }
+        if (other instanceof MaxLiteral) {
+            return -1;
+        }
+        throw new RuntimeException("Cannot compare two values with different data types: "
+                + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/ComparableLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/ComparableLiteral.java
@@ -17,20 +17,8 @@
 
 package org.apache.doris.nereids.trees.expressions.literal;
 
-import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
-import org.apache.doris.nereids.types.CharType;
-
 /**
- * char type literal
+ * comparable literal
  */
-public class CharLiteral extends StringLikeLiteral {
-
-    public CharLiteral(String value, int len) {
-        super(len >= 0 ? value.substring(0, Math.min(value.length(), len)) : value, CharType.createCharType(len));
-    }
-
-    @Override
-    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
-        return visitor.visitCharLiteral(this, context);
-    }
+public interface ComparableLiteral extends Comparable<ComparableLiteral> {
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
@@ -52,6 +52,11 @@ public class DecimalLiteral extends FractionalLiteral {
     }
 
     @Override
+    protected BigDecimal getBigDecimalValue() {
+        return value;
+    }
+
+    @Override
     public BigDecimal getValue() {
         return value;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
@@ -77,6 +77,11 @@ public class DecimalV3Literal extends FractionalLiteral {
         return value.doubleValue();
     }
 
+    @Override
+    protected BigDecimal getBigDecimalValue() {
+        return value;
+    }
+
     /**
      * get ceiling of a decimal v3 literal
      * @param newScale scale we want to cast to

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
@@ -23,6 +23,8 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DoubleType;
 
+import java.math.BigDecimal;
+
 /**
  * Double literal
  */
@@ -33,6 +35,11 @@ public class DoubleLiteral extends FractionalLiteral {
     public DoubleLiteral(double value) {
         super(DoubleType.INSTANCE);
         this.value = value;
+    }
+
+    @Override
+    protected BigDecimal getBigDecimalValue() {
+        return new BigDecimal(String.valueOf(value));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FloatLiteral.java
@@ -22,6 +22,8 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.FloatType;
 
+import java.math.BigDecimal;
+
 /**
  * float type literal
  */
@@ -32,6 +34,11 @@ public class FloatLiteral extends FractionalLiteral {
     public FloatLiteral(float value) {
         super(FloatType.INSTANCE);
         this.value = value;
+    }
+
+    @Override
+    protected BigDecimal getBigDecimalValue() {
+        return new BigDecimal(String.valueOf(value));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv4Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv4Literal.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 /**
  * Represents IPv4 literal
  */
-public class IPv4Literal extends Literal {
+public class IPv4Literal extends Literal implements ComparableLiteral {
 
     private static final Pattern IPV4_STD_REGEX =
             Pattern.compile("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
@@ -57,6 +57,21 @@ public class IPv4Literal extends Literal {
     @Override
     public LiteralExpr toLegacyLiteral() {
         return new org.apache.doris.analysis.IPv4Literal(value);
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof IPv4Literal) {
+            return Long.compare(value, ((IPv4Literal) other).value);
+        }
+        if (other instanceof NullLiteral) {
+            return 1;
+        }
+        if (other instanceof MaxLiteral) {
+            return -1;
+        }
+        throw new RuntimeException("Cannot compare two values with different data types: "
+                + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
     }
 
     void init(String ipv4) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv6Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv6Literal.java
@@ -22,28 +22,30 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.IPv6Type;
 
+import com.googlecode.ipv6.IPv6Address;
+
 import java.util.regex.Pattern;
 
 /**
  * Represents IPv6 literal
  */
-public class IPv6Literal extends Literal {
+public class IPv6Literal extends Literal implements ComparableLiteral {
 
     private static final Pattern IPV6_STD_REGEX =
             Pattern.compile("^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$");
     private static final Pattern IPV6_COMPRESS_REGEX =
             Pattern.compile("^(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4})*)?)::((([0-9A-Fa-f]{1,4}:)*[0-9A-Fa-f]{1,4})?)$");
 
-    private final String value;
+    private final IPv6Address value;
 
     public IPv6Literal(String ipv6) throws AnalysisException {
         super(IPv6Type.INSTANCE);
         checkValueValid(ipv6);
-        this.value = ipv6;
+        this.value = IPv6Address.fromString(ipv6);
     }
 
     @Override
-    public String getValue() {
+    public IPv6Address getValue() {
         return value;
     }
 
@@ -55,10 +57,25 @@ public class IPv6Literal extends Literal {
     @Override
     public LiteralExpr toLegacyLiteral() {
         try {
-            return new org.apache.doris.analysis.IPv6Literal(value);
+            return new org.apache.doris.analysis.IPv6Literal(value.toString());
         } catch (Exception e) {
             throw new AnalysisException("Invalid IPv6 format.");
         }
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof IPv6Literal) {
+            return value.compareTo(((IPv6Literal) other).value);
+        }
+        if (other instanceof NullLiteral) {
+            return 1;
+        }
+        if (other instanceof MaxLiteral) {
+            return -1;
+        }
+        throw new RuntimeException("Cannot compare two values with different data types: "
+                + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
     }
 
     public void checkValueValid(String ipv6) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IntegerLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IntegerLikeLiteral.java
@@ -19,6 +19,8 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.nereids.types.DataType;
 
+import java.math.BigDecimal;
+
 /** IntegralLiteral */
 public abstract class IntegerLikeLiteral extends NumericLiteral {
     /**
@@ -36,6 +38,11 @@ public abstract class IntegerLikeLiteral extends NumericLiteral {
 
     public long getLongValue() {
         return getNumber().longValue();
+    }
+
+    @Override
+    protected BigDecimal getBigDecimalValue() {
+        return new BigDecimal(getLongValue());
     }
 
     public abstract Number getNumber();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/LargeIntLiteral.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.LargeIntType;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Objects;
 
@@ -60,6 +61,11 @@ public class LargeIntLiteral extends IntegerLikeLiteral {
     @Override
     public double getDouble() {
         return value.doubleValue();
+    }
+
+    @Override
+    protected BigDecimal getBigDecimalValue() {
+        return new BigDecimal(value);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -54,7 +54,7 @@ import java.util.Optional;
  * All data type literal expression in Nereids.
  * TODO: Increase the implementation of sub expression. such as Integer.
  */
-public abstract class Literal extends Expression implements LeafExpression, Comparable<Literal> {
+public abstract class Literal extends Expression implements LeafExpression {
 
     protected final DataType dataType;
 
@@ -155,14 +155,6 @@ public abstract class Literal extends Expression implements LeafExpression, Comp
     @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitLiteral(this, context);
-    }
-
-    /**
-     * literal expr compare.
-     */
-    @Override
-    public int compareTo(Literal other) {
-        return toLegacyLiteral().compareLiteral(other.toLegacyLiteral());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/MaxLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/MaxLiteral.java
@@ -22,7 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.types.DataType;
 
 /** MaxLiteral */
-public class MaxLiteral extends Literal {
+public class MaxLiteral extends Literal implements ComparableLiteral {
     public MaxLiteral(DataType dataType) {
         super(dataType);
     }
@@ -35,6 +35,14 @@ public class MaxLiteral extends Literal {
     @Override
     public LiteralExpr toLegacyLiteral() {
         return org.apache.doris.analysis.MaxLiteral.MAX_VALUE;
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof MaxLiteral) {
+            return 0;
+        }
+        return 1;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NullLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NullLiteral.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * Represents Null literal
  */
-public class NullLiteral extends Literal {
+public class NullLiteral extends Literal implements ComparableLiteral {
 
     public static final NullLiteral INSTANCE = new NullLiteral();
 
@@ -57,6 +57,14 @@ public class NullLiteral extends Literal {
     @Override
     public LiteralExpr toLegacyLiteral() {
         return org.apache.doris.analysis.NullLiteral.create(dataType.toCatalogDataType());
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof NullLiteral) {
+            return 0;
+        }
+        return -1;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
@@ -19,10 +19,13 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.nereids.types.DataType;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 /**
  * numeric literal
  */
-public abstract class NumericLiteral extends Literal {
+public abstract class NumericLiteral extends Literal implements ComparableLiteral {
     /**
      * Constructor for NumericLiteral.
      *
@@ -31,4 +34,39 @@ public abstract class NumericLiteral extends Literal {
     public NumericLiteral(DataType dataType) {
         super(dataType);
     }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof NumericLiteral) {
+            if (this instanceof IntegerLikeLiteral && other instanceof IntegerLikeLiteral) {
+                IntegerLikeLiteral thisInteger = (IntegerLikeLiteral) this;
+                IntegerLikeLiteral otherInteger = (IntegerLikeLiteral) other;
+                if (this instanceof LargeIntLiteral || other instanceof LargeIntLiteral) {
+                    BigInteger leftValue = this instanceof LargeIntLiteral ? ((LargeIntLiteral) this).getValue()
+                            : new BigInteger(String.valueOf(thisInteger.getLongValue()));
+                    BigInteger rightValue = other instanceof LargeIntLiteral ? ((LargeIntLiteral) other).getValue()
+                            : new BigInteger(String.valueOf(otherInteger.getLongValue()));
+                    return leftValue.compareTo(rightValue);
+                } else {
+                    return Long.compare(((IntegerLikeLiteral) this).getLongValue(),
+                            ((IntegerLikeLiteral) other).getLongValue());
+                }
+            }
+            if (this instanceof DecimalLiteral || this instanceof DecimalV3Literal
+                    || other instanceof DecimalLiteral || other instanceof DecimalV3Literal) {
+                return this.getBigDecimalValue().compareTo(((NumericLiteral) other).getBigDecimalValue());
+            }
+            return Double.compare(this.getDouble(), ((Literal) other).getDouble());
+        }
+        if (other instanceof NullLiteral) {
+            return 1;
+        }
+        if (other instanceof MaxLiteral) {
+            return -1;
+        }
+        throw new RuntimeException("Cannot compare two values with different data types: "
+                + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
+    }
+
+    protected abstract BigDecimal getBigDecimalValue();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -18,9 +18,8 @@
 package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.types.DataType;
-
-import com.google.common.base.Preconditions;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Objects;
@@ -81,7 +80,7 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
                 thisBytes = getStringValue().getBytes("UTF-8");
                 otherBytes = ((Literal) other).getStringValue().getBytes("UTF-8");
             } catch (UnsupportedEncodingException e) {
-                Preconditions.checkState(false);
+                throw new AnalysisException(e.getMessage(), e);
             }
 
             int minLength = Math.min(thisBytes.length, otherBytes.length);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLiteral.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.trees.expressions.literal;
 
-import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.StringType;
 
@@ -26,8 +25,6 @@ import org.apache.doris.nereids.types.StringType;
  */
 public class StringLiteral extends StringLikeLiteral {
 
-    private final String value;
-
     /**
      * Constructor for Literal.
      *
@@ -35,21 +32,10 @@ public class StringLiteral extends StringLikeLiteral {
      */
     public StringLiteral(String value) {
         super(value, StringType.INSTANCE);
-        this.value = value;
-    }
-
-    @Override
-    public String getValue() {
-        return value;
     }
 
     @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitStringLiteral(this, context);
-    }
-
-    @Override
-    public LiteralExpr toLegacyLiteral() {
-        return new org.apache.doris.analysis.StringLiteral(value);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/VarcharLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/VarcharLiteral.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.nereids.trees.expressions.literal;
 
-import org.apache.doris.analysis.LiteralExpr;
-import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.VarcharType;
 
@@ -37,17 +35,7 @@ public class VarcharLiteral extends StringLikeLiteral {
     }
 
     @Override
-    public String getValue() {
-        return getStringValue();
-    }
-
-    @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitVarcharLiteral(this, context);
-    }
-
-    @Override
-    public LiteralExpr toLegacyLiteral() {
-        return new StringLiteral(value);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -56,6 +56,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
@@ -585,9 +586,9 @@ public class ExpressionUtils {
     /**
      * return true if all children are literal but not null literal.
      */
-    public static boolean isAllNonNullLiteral(List<Expression> children) {
+    public static boolean isAllNonNullComparableLiteral(List<Expression> children) {
         for (Expression child : children) {
-            if ((!(child instanceof Literal)) || (child instanceof NullLiteral)) {
+            if ((!(child instanceof ComparableLiteral)) || (child instanceof NullLiteral)) {
                 return false;
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -64,6 +64,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Tan;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ToDays;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.UnixTimestamp;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
@@ -280,11 +281,11 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         ConvertTz c = new ConvertTz(DateTimeV2Literal.fromJavaDateType(LocalDateTime.of(1, 1, 1, 1, 1, 1)),
                 StringLiteral.of("Asia/Shanghai"), StringLiteral.of("GMT"));
         Expression rewritten = executor.rewrite(c, context);
-        Assertions.assertTrue(new DateTimeV2Literal("0000-12-31 16:55:18.000000").compareTo((Literal) rewritten) == 0);
+        Assertions.assertTrue(new DateTimeV2Literal("0000-12-31 16:55:18.000000").compareTo((ComparableLiteral) rewritten) == 0);
         c = new ConvertTz(DateTimeV2Literal.fromJavaDateType(LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999999000)),
                         StringLiteral.of("Pacific/Galapagos"), StringLiteral.of("Pacific/Galapagos"));
         rewritten = executor.rewrite(c, context);
-        Assertions.assertTrue(new DateTimeV2Literal("9999-12-31 23:59:59.999999").compareTo((Literal) rewritten) == 0);
+        Assertions.assertTrue(new DateTimeV2Literal("9999-12-31 23:59:59.999999").compareTo((ComparableLiteral) rewritten) == 0);
 
         DateFormat d = new DateFormat(DateTimeLiteral.fromJavaDateType(LocalDateTime.of(1, 1, 1, 1, 1, 1)),
                 StringLiteral.of("%y %m %d"));
@@ -310,7 +311,7 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         t = new DateTrunc(DateTimeV2Literal.fromJavaDateType(LocalDateTime.of(1, 1, 1, 1, 1, 1)),
                 StringLiteral.of("week"));
         rewritten = executor.rewrite(t, context);
-        Assertions.assertTrue(((Literal) rewritten).compareTo(new DateTimeV2Literal("0001-01-01 00:00:00.000000")) == 0);
+        Assertions.assertTrue(((ComparableLiteral) rewritten).compareTo(new DateTimeV2Literal("0001-01-01 00:00:00.000000")) == 0);
         t = new DateTrunc(DateLiteral.fromJavaDateType(LocalDateTime.of(1, 1, 1, 1, 1, 1)),
                 StringLiteral.of("week"));
         rewritten = executor.rewrite(t, context);
@@ -862,9 +863,9 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 new DateTimeLiteral("2023-05-07 02:41:42"),
                 new VarcharLiteral("%x %v %X %V")).toSql());
 
-        Assertions.assertTrue(new DateTimeV2Literal("2021-01-01 12:12:14.000000").compareTo((Literal) TimeRoundSeries
+        Assertions.assertTrue(new DateTimeV2Literal("2021-01-01 12:12:14.000000").compareTo((ComparableLiteral) TimeRoundSeries
                 .secondCeil(new DateTimeV2Literal("2021-01-01 12:12:12.123"), new IntegerLiteral(2))) == 0);
-        Assertions.assertTrue(new DateTimeV2Literal("2021-01-01 12:12:12.000000").compareTo((Literal) TimeRoundSeries
+        Assertions.assertTrue(new DateTimeV2Literal("2021-01-01 12:12:12.000000").compareTo((ComparableLiteral) TimeRoundSeries
                 .secondFloor(new DateTimeV2Literal("2021-01-01 12:12:12.123"), new IntegerLiteral(2))) == 0);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/CompareLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/CompareLiteralTest.java
@@ -1,0 +1,326 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.literal;
+
+import org.apache.doris.common.ExceptionChecker;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+class CompareLiteralTest extends TestWithFeService {
+
+    @Test
+    public void testScalar() {
+        // boolean type
+        checkCompareSameType(0, BooleanLiteral.of(true), BooleanLiteral.of(true));
+        checkCompareSameType(1, BooleanLiteral.of(true), BooleanLiteral.of(false));
+        checkCompareDiffType(BooleanLiteral.of(true), new IntegerLiteral(0));
+        checkCompareDiffType(BooleanLiteral.of(true), new DoubleLiteral(0.5));
+        checkCompareDiffType(BooleanLiteral.of(true), new DecimalLiteral(new BigDecimal("0.5")));
+        checkCompareDiffType(BooleanLiteral.of(true), new IntegerLiteral(1));
+        checkCompareDiffType(BooleanLiteral.of(true), new DoubleLiteral(1.0));
+        checkCompareDiffType(BooleanLiteral.of(true), new DecimalLiteral(new BigDecimal("1.0")));
+        checkCompareDiffType(BooleanLiteral.of(true), new StringLiteral("tru"));
+        checkCompareDiffType(BooleanLiteral.of(true), new StringLiteral("true"));
+        checkCompareDiffType(BooleanLiteral.of(true), new StringLiteral("truea"));
+        checkCompareSameType(0, BooleanLiteral.of(false), BooleanLiteral.of(false));
+        checkCompareDiffType(BooleanLiteral.of(false), new IntegerLiteral(0));
+        checkCompareDiffType(BooleanLiteral.of(false), new DoubleLiteral(0.5));
+        checkCompareDiffType(BooleanLiteral.of(false), new DecimalLiteral(new BigDecimal("0.5")));
+        checkCompareDiffType(BooleanLiteral.of(false), new IntegerLiteral(1));
+        checkCompareDiffType(BooleanLiteral.of(false), new DoubleLiteral(1.0));
+        checkCompareDiffType(BooleanLiteral.of(false), new DecimalLiteral(new BigDecimal("1.0")));
+        checkCompareDiffType(BooleanLiteral.of(false), new StringLiteral("fals"));
+        checkCompareDiffType(BooleanLiteral.of(false), new StringLiteral("false"));
+        checkCompareDiffType(BooleanLiteral.of(false), new StringLiteral("falsea"));
+
+        // numeric type
+        checkCompareSameType(0, new TinyIntLiteral((byte) 127), new TinyIntLiteral((byte) 127));
+        checkCompareSameType(0, new TinyIntLiteral((byte) 127), new DoubleLiteral(127.0));
+        checkCompareSameType(0, new TinyIntLiteral((byte) 127), new DecimalLiteral(new BigDecimal("127.0")));
+        checkCompareSameType(0, new TinyIntLiteral((byte) 127), new DecimalV3Literal(new BigDecimal("127.0")));
+        checkCompareDiffType(new TinyIntLiteral((byte) 127), new StringLiteral("12"));
+        checkCompareDiffType(new TinyIntLiteral((byte) 127), new StringLiteral("127"));
+        checkCompareDiffType(new TinyIntLiteral((byte) 127), new StringLiteral("127.0"));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new SmallIntLiteral((short) 32767));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new DoubleLiteral(32767.0));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new DecimalLiteral(new BigDecimal("32767")));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new DecimalV3Literal(new BigDecimal("32767")));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new IntegerLiteral(2147483647));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new BigIntLiteral(9223372036854775807L));
+        checkCompareSameType(-1, new TinyIntLiteral((byte) 127), new LargeIntLiteral(new BigInteger("9223372036854775808")));
+
+        checkCompareSameType(0, new SmallIntLiteral((short) 32767), new SmallIntLiteral((short) 32767));
+        checkCompareSameType(0, new SmallIntLiteral((short) 32767), new DoubleLiteral(32767.0));
+        checkCompareSameType(0, new SmallIntLiteral((short) 32767), new DecimalLiteral(new BigDecimal("32767.0")));
+        checkCompareSameType(0, new SmallIntLiteral((short) 32767), new DecimalV3Literal(new BigDecimal("32767.0")));
+        checkCompareDiffType(new SmallIntLiteral((short) 32767), new StringLiteral("3276"));
+        checkCompareDiffType(new SmallIntLiteral((short) 32767), new StringLiteral("32767"));
+        checkCompareDiffType(new SmallIntLiteral((short) 32767), new StringLiteral("32767.0"));
+        checkCompareSameType(-1, new SmallIntLiteral((short) 32767), new IntegerLiteral(2147483647));
+        checkCompareSameType(-1, new SmallIntLiteral((short) 32767), new DoubleLiteral(2147483647.0));
+        checkCompareSameType(-1, new SmallIntLiteral((short) 32767), new DecimalLiteral(new BigDecimal("2147483647")));
+        checkCompareSameType(-1, new SmallIntLiteral((short) 32767), new DecimalV3Literal(new BigDecimal("2147483647")));
+        checkCompareSameType(-1, new SmallIntLiteral((short) 32767), new BigIntLiteral(9223372036854775807L));
+        checkCompareSameType(-1, new SmallIntLiteral((short) 32767), new LargeIntLiteral(new BigInteger("9223372036854775808")));
+
+        checkCompareSameType(0, new IntegerLiteral(2147483647), new IntegerLiteral(2147483647));
+        checkCompareSameType(0, new IntegerLiteral(2147483647), new DoubleLiteral(2147483647.0));
+        checkCompareSameType(0, new IntegerLiteral(2147483647), new DecimalLiteral(new BigDecimal("2147483647.0")));
+        checkCompareSameType(0, new IntegerLiteral(2147483647), new DecimalV3Literal(new BigDecimal("2147483647.0")));
+        checkCompareDiffType(new IntegerLiteral(2147483647), new StringLiteral("214748364"));
+        checkCompareDiffType(new IntegerLiteral(2147483647), new StringLiteral("2147483647"));
+        checkCompareDiffType(new IntegerLiteral(2147483647), new StringLiteral("2147483647.0"));
+        checkCompareSameType(-1, new IntegerLiteral(2147483647), new DecimalLiteral(new BigDecimal("922337203685477580")));
+        checkCompareSameType(-1, new IntegerLiteral(2147483647), new DecimalV3Literal(new BigDecimal("9223372036854775807")));
+        checkCompareSameType(-1, new IntegerLiteral(2147483647), new BigIntLiteral(9223372036854775807L));
+        checkCompareSameType(-1, new IntegerLiteral(2147483647), new LargeIntLiteral(new BigInteger("9223372036854775808")));
+
+        checkCompareSameType(0, new BigIntLiteral(9223372036854775807L), new BigIntLiteral(9223372036854775807L));
+        checkCompareSameType(0, new BigIntLiteral(922337203685477580L), new DecimalLiteral(new BigDecimal("922337203685477580.0")));
+        checkCompareSameType(0, new BigIntLiteral(9223372036854775807L), new DecimalV3Literal(new BigDecimal("9223372036854775807.0")));
+        checkCompareDiffType(new BigIntLiteral(9223372036854775807L), new StringLiteral("922337203685477580"));
+        checkCompareDiffType(new BigIntLiteral(9223372036854775807L), new StringLiteral("9223372036854775807"));
+        checkCompareDiffType(new BigIntLiteral(9223372036854775807L), new StringLiteral("9223372036854775807.0"));
+        checkCompareSameType(-1, new BigIntLiteral(922337203685477587L), new DecimalLiteral(new BigDecimal("922337203685477588")));
+        checkCompareSameType(-1, new BigIntLiteral(9223372036854775807L), new DecimalV3Literal(new BigDecimal("9223372036854775808")));
+        checkCompareSameType(-1, new BigIntLiteral(9223372036854775807L), new LargeIntLiteral(new BigInteger("9223372036854775808")));
+
+        checkCompareSameType(0, new LargeIntLiteral(new BigInteger("9223372036854775808")), new LargeIntLiteral(new BigInteger("9223372036854775808")));
+        checkCompareSameType(0, new LargeIntLiteral(new BigInteger("922337203685477588")), new DecimalLiteral(new BigDecimal("922337203685477588.0")));
+        checkCompareSameType(0, new LargeIntLiteral(new BigInteger("9223372036854775808")), new DecimalV3Literal(new BigDecimal("9223372036854775808.0")));
+        checkCompareDiffType(new LargeIntLiteral(new BigInteger("9223372036854775808")), new StringLiteral("922337203685477580"));
+        checkCompareDiffType(new LargeIntLiteral(new BigInteger("9223372036854775808")), new StringLiteral("9223372036854775808"));
+        checkCompareDiffType(new LargeIntLiteral(new BigInteger("9223372036854775808")), new StringLiteral("9223372036854775808.0"));
+        checkCompareSameType(-1, new LargeIntLiteral(new BigInteger("922337203685477588")), new DecimalLiteral(new BigDecimal("922337203685477589")));
+        checkCompareSameType(-1, new LargeIntLiteral(new BigInteger("9223372036854775808")), new DecimalV3Literal(new BigDecimal("9223372036854775809")));
+
+        checkCompareSameType(0, new FloatLiteral(100.5f), new FloatLiteral(100.5f));
+        checkCompareSameType(0, new FloatLiteral(100.5f), new DoubleLiteral(100.5));
+        checkCompareSameType(0, new FloatLiteral(100.5f), new DecimalLiteral(new BigDecimal("100.5")));
+        checkCompareSameType(0, new FloatLiteral(100.5f), new DecimalV3Literal(new BigDecimal("100.5")));
+        checkCompareDiffType(new FloatLiteral(100.0f), new StringLiteral("100"));
+        checkCompareDiffType(new FloatLiteral(100.0f), new StringLiteral("100.0"));
+        checkCompareDiffType(new FloatLiteral(100.0f), new StringLiteral("100.00"));
+        checkCompareSameType(-1, new FloatLiteral(100.5f), new FloatLiteral(100.6f));
+        checkCompareSameType(-1, new FloatLiteral(100.5f), new DoubleLiteral(100.6));
+        checkCompareSameType(-1, new FloatLiteral(100.5f), new DecimalLiteral(new BigDecimal("100.6")));
+        checkCompareSameType(-1, new FloatLiteral(100.5f), new DecimalV3Literal(new BigDecimal("100.6")));
+
+        checkCompareSameType(0, new DoubleLiteral(100.5), new DoubleLiteral(100.5));
+        checkCompareSameType(0, new DoubleLiteral(100.5), new DoubleLiteral(100.5));
+        checkCompareSameType(0, new DoubleLiteral(100.5), new DecimalLiteral(new BigDecimal("100.5")));
+        checkCompareSameType(0, new DoubleLiteral(100.5), new DecimalV3Literal(new BigDecimal("100.5")));
+        checkCompareDiffType(new DoubleLiteral(100.0), new StringLiteral("100"));
+        checkCompareDiffType(new DoubleLiteral(100.0), new StringLiteral("100.0"));
+        checkCompareDiffType(new DoubleLiteral(100.0), new StringLiteral("100.00"));
+        checkCompareSameType(-1, new DoubleLiteral(100.5), new FloatLiteral(100.6f));
+        checkCompareSameType(-1, new DoubleLiteral(100.5), new DoubleLiteral(100.6));
+        checkCompareSameType(-1, new DoubleLiteral(100.5), new DecimalLiteral(new BigDecimal("100.6")));
+        checkCompareSameType(-1, new DoubleLiteral(100.5), new DecimalV3Literal(new BigDecimal("100.6")));
+
+        checkCompareSameType(0, new DecimalLiteral(new BigDecimal("100.5")), new DoubleLiteral(100.5));
+        checkCompareSameType(0, new DecimalLiteral(new BigDecimal("100.5")), new DecimalLiteral(new BigDecimal("100.5")));
+        checkCompareSameType(0, new DecimalLiteral(new BigDecimal("100.5")), new DecimalV3Literal(new BigDecimal("100.5")));
+        checkCompareDiffType(new DecimalLiteral(new BigDecimal("100.0")), new StringLiteral("100"));
+        checkCompareDiffType(new DecimalLiteral(new BigDecimal("100.0")), new StringLiteral("100.0"));
+        checkCompareDiffType(new DecimalLiteral(new BigDecimal("100.0")), new StringLiteral("100.00"));
+        checkCompareSameType(-1, new DecimalLiteral(new BigDecimal("100.5")), new FloatLiteral(100.6f));
+        checkCompareSameType(-1, new DecimalLiteral(new BigDecimal("100.5")), new DoubleLiteral(100.6));
+        checkCompareSameType(-1, new DecimalLiteral(new BigDecimal("100.5")), new DecimalLiteral(new BigDecimal("100.6")));
+        checkCompareSameType(-1, new DecimalLiteral(new BigDecimal("100.5")), new DecimalV3Literal(new BigDecimal("100.6")));
+
+        checkCompareSameType(0, new DecimalV3Literal(new BigDecimal("100.5")), new DoubleLiteral(100.5));
+        checkCompareSameType(0, new DecimalV3Literal(new BigDecimal("100.5")), new DecimalLiteral(new BigDecimal("100.5")));
+        checkCompareSameType(0, new DecimalV3Literal(new BigDecimal("100.5")), new DecimalV3Literal(new BigDecimal("100.5")));
+        checkCompareDiffType(new DecimalV3Literal(new BigDecimal("100.0")), new StringLiteral("100"));
+        checkCompareDiffType(new DecimalV3Literal(new BigDecimal("100.0")), new StringLiteral("100.0"));
+        checkCompareDiffType(new DecimalV3Literal(new BigDecimal("100.0")), new StringLiteral("100.00"));
+        checkCompareSameType(-1, new DecimalV3Literal(new BigDecimal("100.5")), new FloatLiteral(100.6f));
+        checkCompareSameType(-1, new DecimalV3Literal(new BigDecimal("100.5")), new DoubleLiteral(100.6));
+        checkCompareSameType(-1, new DecimalV3Literal(new BigDecimal("100.5")), new DecimalLiteral(new BigDecimal("100.6")));
+        checkCompareSameType(-1, new DecimalV3Literal(new BigDecimal("100.5")), new DecimalV3Literal(new BigDecimal("100.6")));
+
+        // date type
+        checkCompareSameType(0, new DateLiteral("2020-01-10"), new DateLiteral("2020-01-10"));
+        checkCompareSameType(0, new DateLiteral("2020-01-10"), new DateV2Literal("2020-01-10"));
+        checkCompareSameType(0, new DateLiteral("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:00"));
+        checkCompareSameType(0, new DateLiteral("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.00"));
+        checkCompareSameType(1, new DateLiteral("2020-01-10"), new DateLiteral("2020-01-09"));
+        checkCompareSameType(1, new DateLiteral("2020-01-10"), new DateV2Literal("2020-01-09"));
+        checkCompareSameType(1, new DateLiteral("2020-01-10"), new DateTimeLiteral("2020-01-09 00:00:00"));
+        checkCompareSameType(1, new DateLiteral("2020-01-10"), new DateTimeV2Literal("2020-01-09 00:00:00.00"));
+        checkCompareSameType(-1, new DateLiteral("2020-01-10"), new DateLiteral("2020-01-11"));
+        checkCompareSameType(-1, new DateLiteral("2020-01-10"), new DateV2Literal("2020-01-11"));
+        checkCompareSameType(-1, new DateLiteral("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:01"));
+        checkCompareSameType(-1, new DateLiteral("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.01"));
+        checkCompareDiffType(new DateLiteral("2020-01-10"), new StringLiteral("2020-01-1"));
+        checkCompareDiffType(new DateLiteral("2020-01-10"), new StringLiteral("2020-01-10"));
+        checkCompareDiffType(new DateLiteral("2020-01-10"), new StringLiteral("2020-01-10 "));
+        checkCompareSameType(0, new DateV2Literal("2020-01-10"), new DateLiteral("2020-01-10"));
+        checkCompareSameType(0, new DateV2Literal("2020-01-10"), new DateV2Literal("2020-01-10"));
+        checkCompareSameType(0, new DateV2Literal("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:00"));
+        checkCompareSameType(0, new DateV2Literal("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.00"));
+        checkCompareSameType(1, new DateV2Literal("2020-01-10"), new DateLiteral("2020-01-09"));
+        checkCompareSameType(1, new DateV2Literal("2020-01-10"), new DateV2Literal("2020-01-09"));
+        checkCompareSameType(1, new DateV2Literal("2020-01-10"), new DateTimeLiteral("2020-01-09 00:00:00"));
+        checkCompareSameType(1, new DateV2Literal("2020-01-10"), new DateTimeV2Literal("2020-01-09 00:00:00.00"));
+        checkCompareSameType(-1, new DateV2Literal("2020-01-10"), new DateLiteral("2020-01-11"));
+        checkCompareSameType(-1, new DateV2Literal("2020-01-10"), new DateV2Literal("2020-01-11"));
+        checkCompareSameType(-1, new DateV2Literal("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:01"));
+        checkCompareSameType(-1, new DateV2Literal("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.01"));
+        checkCompareDiffType(new DateV2Literal("2020-01-10"), new StringLiteral("2020-01-1"));
+        checkCompareDiffType(new DateV2Literal("2020-01-10"), new StringLiteral("2020-01-10"));
+        checkCompareDiffType(new DateV2Literal("2020-01-10"), new StringLiteral("2020-01-10 "));
+        checkCompareSameType(0, new DateTimeLiteral("2020-01-10"), new DateLiteral("2020-01-10"));
+        checkCompareSameType(0, new DateTimeLiteral("2020-01-10"), new DateV2Literal("2020-01-10"));
+        checkCompareSameType(0, new DateTimeLiteral("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:00"));
+        checkCompareSameType(0, new DateTimeLiteral("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.00"));
+        checkCompareSameType(1, new DateTimeLiteral("2020-01-10"), new DateLiteral("2020-01-09"));
+        checkCompareSameType(1, new DateTimeLiteral("2020-01-10"), new DateV2Literal("2020-01-09"));
+        checkCompareSameType(1, new DateTimeLiteral("2020-01-10"), new DateTimeLiteral("2020-01-09 00:00:00"));
+        checkCompareSameType(1, new DateTimeLiteral("2020-01-10"), new DateTimeV2Literal("2020-01-09 00:00:00.00"));
+        checkCompareSameType(-1, new DateTimeLiteral("2020-01-10"), new DateLiteral("2020-01-11"));
+        checkCompareSameType(-1, new DateTimeLiteral("2020-01-10"), new DateV2Literal("2020-01-11"));
+        checkCompareSameType(-1, new DateTimeLiteral("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:01"));
+        checkCompareSameType(-1, new DateTimeLiteral("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.01"));
+        checkCompareDiffType(new DateTimeLiteral("2020-01-10"), new StringLiteral("2020-01-10 00:00"));
+        checkCompareDiffType(new DateTimeLiteral("2020-01-10"), new StringLiteral("2020-01-10 00:00:00"));
+        checkCompareDiffType(new DateTimeLiteral("2020-01-10"), new StringLiteral("2020-01-10 00:00:00.000"));
+        checkCompareSameType(0, new DateTimeV2Literal("2020-01-10"), new DateLiteral("2020-01-10"));
+        checkCompareSameType(0, new DateTimeV2Literal("2020-01-10"), new DateV2Literal("2020-01-10"));
+        checkCompareSameType(0, new DateTimeV2Literal("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:00"));
+        checkCompareSameType(0, new DateTimeV2Literal("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.00"));
+        checkCompareSameType(1, new DateTimeV2Literal("2020-01-10"), new DateLiteral("2020-01-09"));
+        checkCompareSameType(1, new DateTimeV2Literal("2020-01-10"), new DateV2Literal("2020-01-09"));
+        checkCompareSameType(1, new DateTimeV2Literal("2020-01-10"), new DateTimeLiteral("2020-01-09 00:00:00"));
+        checkCompareSameType(1, new DateTimeV2Literal("2020-01-10"), new DateTimeV2Literal("2020-01-09 00:00:00.00"));
+        checkCompareSameType(-1, new DateTimeV2Literal("2020-01-10"), new DateLiteral("2020-01-11"));
+        checkCompareSameType(-1, new DateTimeV2Literal("2020-01-10"), new DateV2Literal("2020-01-11"));
+        checkCompareSameType(-1, new DateTimeV2Literal("2020-01-10"), new DateTimeLiteral("2020-01-10 00:00:01"));
+        checkCompareSameType(-1, new DateTimeV2Literal("2020-01-10"), new DateTimeV2Literal("2020-01-10 00:00:00.01"));
+        checkCompareDiffType(new DateTimeV2Literal("2020-01-10"), new StringLiteral("2020-01-10 00:00:0"));
+        checkCompareDiffType(new DateTimeV2Literal("2020-01-10"), new StringLiteral("2020-01-10 00:00:00"));
+        checkCompareDiffType(new DateTimeV2Literal("2020-01-10"), new StringLiteral("2020-01-10 00:00:00.00"));
+
+        // string type
+        checkCompareSameType(0, new CharLiteral("abc", -1), new CharLiteral("abc", -1));
+        checkCompareSameType(1, new CharLiteral("abc", -1), new CharLiteral("abc", 1));
+        checkCompareSameType(0, new CharLiteral("abc", -1), new StringLiteral("abc"));
+        checkCompareSameType(0, new CharLiteral("abc", -1), new VarcharLiteral("abc"));
+        checkCompareSameType(0, new CharLiteral("abc", -1), new VarcharLiteral("abc", -1));
+        checkCompareSameType(1, new CharLiteral("abc", -1), new VarcharLiteral("abc", 1));
+        checkCompareSameType(1, new CharLiteral("abc", -1), new CharLiteral("ab", -1));
+        checkCompareSameType(1, new CharLiteral("abc", -1), new StringLiteral("ab"));
+        checkCompareSameType(1, new CharLiteral("abc", -1), new VarcharLiteral("ab"));
+        checkCompareSameType(1, new CharLiteral("abc", -1), new VarcharLiteral("ab", -1));
+        checkCompareSameType(-1, new CharLiteral("abc", -1), new CharLiteral("abcd", -1));
+        checkCompareSameType(0, new CharLiteral("abc", -1), new CharLiteral("abcd", 3));
+        checkCompareSameType(-1, new CharLiteral("abc", -1), new StringLiteral("abcd"));
+        checkCompareSameType(-1, new CharLiteral("abc", -1), new VarcharLiteral("abcd"));
+        checkCompareSameType(-1, new CharLiteral("abc", -1), new VarcharLiteral("abcd", -1));
+        checkCompareSameType(0, new CharLiteral("abc", -1), new VarcharLiteral("abcd", 3));
+
+        // ip type
+        checkCompareSameType(0, new IPv4Literal("170.0.0.100"), new IPv4Literal("170.0.0.100"));
+        checkCompareSameType(1, new IPv4Literal("170.0.0.100"), new IPv4Literal("160.0.0.200"));
+        checkCompareDiffType(new IPv4Literal("172.0.0.100"), new IPv6Literal("1080:0:0:0:8:800:200C:417A"));
+        checkCompareSameType(0, new IPv6Literal("1080:0:0:0:8:800:200C:417A"), new IPv6Literal("1080:0:0:0:8:800:200C:417A"));
+        checkCompareSameType(1, new IPv6Literal("1080:0:0:0:8:800:200C:417A"), new IPv6Literal("1000:0:0:0:8:800:200C:41AA"));
+        IPv4Literal ipv4 = new IPv4Literal("170.0.0.100");
+        Assertions.assertEquals(ipv4, new IPv4Literal(ipv4.toLegacyLiteral().getStringValue()));
+        IPv6Literal ipv6 = new IPv6Literal("1080:0:0:0:8:800:200C:417A");
+        Assertions.assertEquals(ipv6, new IPv6Literal(ipv6.toLegacyLiteral().getStringValue()));
+
+        // null type and max type
+        Assertions.assertEquals(0, (new NullLiteral(IntegerType.INSTANCE)).compareTo(new NullLiteral(IntegerType.INSTANCE)));
+        Assertions.assertEquals(-1, (new NullLiteral(IntegerType.INSTANCE)).compareTo(new MaxLiteral(IntegerType.INSTANCE)));
+        Assertions.assertEquals(0, (new MaxLiteral(IntegerType.INSTANCE)).compareTo(new MaxLiteral(IntegerType.INSTANCE)));
+    }
+
+    @Test
+    public void testComplex() throws Exception {
+        // array type
+        checkCompareSameType(0,
+                new ArrayLiteral(ImmutableList.of(new IntegerLiteral(100), new IntegerLiteral(200))),
+                new ArrayLiteral(ImmutableList.of(new IntegerLiteral(100), new IntegerLiteral(200))));
+        checkCompareSameType(1,
+                new ArrayLiteral(ImmutableList.of(new IntegerLiteral(200))),
+                new ArrayLiteral(ImmutableList.of(new IntegerLiteral(100), new IntegerLiteral(200))));
+        checkCompareSameType(1,
+                new ArrayLiteral(ImmutableList.of(new IntegerLiteral(100), new IntegerLiteral(200), new IntegerLiteral(1))),
+                new ArrayLiteral(ImmutableList.of(new IntegerLiteral(100), new IntegerLiteral(200))));
+        checkComparableNoException("select array(1,2) = array(1, 2)");
+        checkComparableNoException("select array(1,2) > array(1, 2)");
+
+        // json type
+        checkNotComparable("select cast ('[1, 2]' as json) = cast('[1, 2]' as json)",
+                "comparison predicate could not contains json type");
+        checkNotComparable("select cast('[1, 2]' as json) > cast('[1, 2]' as json)",
+                "comparison predicate could not contains json type");
+
+        // map type
+        checkNotComparable("select map(1, 2) = map(1, 2)",
+                "comparison predicate could not contains complex type");
+        checkNotComparable("select map(1, 2) > map(1, 2)",
+                "comparison predicate could not contains complex type");
+        checkNotComparable("select cast('(1, 2)' as map<int, int>) = cast('(1, 2)' as map<int, int>)",
+                "comparison predicate could not contains complex type");
+
+        // struct type
+        checkNotComparable("select struct(1, 2) = struct(1, 2)",
+                "comparison predicate could not contains complex type");
+        checkNotComparable("select struct(1, 2) > struct(1, 2)",
+                "comparison predicate could not contains complex type");
+    }
+
+    private void checkCompareSameType(int expect, ComparableLiteral left, ComparableLiteral right) {
+        Assertions.assertEquals(expect, left.compareTo(right));
+        Assertions.assertEquals(- expect, right.compareTo(left));
+        if (((Literal) left).dataType.equals(((Literal) right).dataType)
+                && !(left instanceof IPv4Literal) && !(left instanceof IPv6Literal)) {
+            Assertions.assertEquals(expect, ((Literal) left).toLegacyLiteral()
+                    .compareTo(((Literal) right).toLegacyLiteral()));
+            Assertions.assertEquals(- expect, ((Literal) right).toLegacyLiteral()
+                    .compareTo(((Literal) left).toLegacyLiteral()));
+        }
+
+        Assertions.assertEquals(1, left.compareTo(new NullLiteral(IntegerType.INSTANCE)));
+        Assertions.assertEquals(-1, left.compareTo(new MaxLiteral(IntegerType.INSTANCE)));
+    }
+
+    private void checkCompareDiffType(ComparableLiteral left, ComparableLiteral right) {
+        Assertions.assertThrowsExactly(RuntimeException.class, () -> left.compareTo(right));
+        Assertions.assertThrowsExactly(RuntimeException.class, () -> right.compareTo(left));
+    }
+
+    private void checkComparableNoException(String sql) throws Exception {
+        ExceptionChecker.expectThrowsNoException(() -> executeSql(sql));
+    }
+
+    private void checkNotComparable(String sql, String expectErrMsg) throws Exception {
+        ExceptionChecker.expectThrowsWithMsg(IllegalStateException.class, expectErrMsg,
+                () -> executeSql(sql));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -616,6 +616,16 @@ public abstract class TestWithFeService {
         }
     }
 
+    public void executeSql(String queryStr) throws Exception {
+        connectContext.getState().reset();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, queryStr);
+        stmtExecutor.execute();
+        if (connectContext.getState().getStateType() == QueryState.MysqlStateType.ERR
+                || connectContext.getState().getErrorCode() != null) {
+            throw new IllegalStateException(connectContext.getState().getErrorMessage());
+        }
+    }
+
     public void createDatabase(String db) throws Exception {
         String createDbStmtStr = "CREATE DATABASE " + db;
         CreateDbStmt createDbStmt = (CreateDbStmt) parseAndAnalyzeStmt(createDbStmtStr);

--- a/regression-test/suites/nereids_p0/literal/test_compare_literal.groovy
+++ b/regression-test/suites/nereids_p0/literal/test_compare_literal.groovy
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_compare_literal') {
+    for (def val in [true, false]) {
+        sql "set debug_skip_fold_constant=${val}"
+
+        // ipv4
+        test {
+            sql "select cast('170.0.0.100' as ipv4) = cast('170.0.0.100' as ipv4)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('170.0.0.100' as ipv4) >= cast('170.0.0.100' as ipv4)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('170.0.0.100' as ipv4) > cast('170.0.0.100' as ipv4)"
+            result([[false]])
+        }
+        test {
+            sql "select cast('170.0.0.100' as ipv4) = cast('160.0.0.200' as ipv4)"
+            result([[false]])
+        }
+        test {
+            sql "select cast('170.0.0.100' as ipv4) >= cast('160.0.0.200' as ipv4)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('170.0.0.100' as ipv4) > cast('160.0.0.200' as ipv4)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('170.0.0.100' as ipv4) < cast('160.0.0.200' as ipv4)"
+            result([[false]])
+        }
+
+        // ipv6
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) = cast('1080:0:0:0:8:800:200C:417A' as ipv6)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) >= cast('1080:0:0:0:8:800:200C:417A' as ipv6)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) > cast('1080:0:0:0:8:800:200C:417A' as ipv6)"
+            result([[false]])
+        }
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) = cast('1000:0:0:0:8:800:200C:41AA' as ipv6)"
+            result([[false]])
+        }
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) >= cast('1000:0:0:0:8:800:200C:41AA' as ipv6)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) > cast('1000:0:0:0:8:800:200C:41AA' as ipv6)"
+            result([[true]])
+        }
+        test {
+            sql "select cast('1080:0:0:0:8:800:200C:417A' as ipv6) < cast('1000:0:0:0:8:800:200C:41AA' as ipv6)"
+            result([[false]])
+        }
+
+        // array
+        test {
+            sql 'select array(5, 6) = array(5, 6)'
+            result([[true]])
+        }
+        test {
+            sql 'select array(5, 6) >= array(5, 6)'
+            result([[true]])
+        }
+        test {
+            sql 'select array(5, 6) > array(5, 6)'
+            result([[false]])
+        }
+        test {
+            sql 'select array(5, 6) = array(5, 7)'
+            result([[false]])
+        }
+        test {
+            sql 'select array(5, 6) >= array(5, 7)'
+            result([[false]])
+        }
+        test {
+            sql 'select array(5, 6) > array(5, 7)'
+            result([[false]])
+        }
+        test {
+            sql 'select array(5, 6) < array(5, 7)'
+            result([[true]])
+        }
+        test {
+            sql 'select array(5, 6) < array(5, 6, 1)'
+            result([[true]])
+        }
+        test {
+            sql 'select array(5, 6) < array(6)'
+            result([[true]])
+        }
+    }
+
+    // test not comparable
+    sql 'set debug_skip_fold_constant=false'
+
+    // json
+    test {
+        sql "select cast('[1, 2]' as json) = cast('[1, 2]' as json)"
+        exception 'comparison predicate could not contains json type'
+    }
+    test {
+        sql "select cast('[1, 2]' as json) > cast('[1, 2]' as json)"
+        exception 'comparison predicate could not contains json type'
+    }
+
+    // map
+    test {
+        sql 'select map(1, 2) = map(1, 2)'
+        exception 'comparison predicate could not contains complex type'
+    }
+    test {
+        sql 'select map(1, 2) > map(1, 2)'
+        exception 'comparison predicate could not contains complex type'
+    }
+
+    // struct
+    test {
+        sql 'select struct(1, 2) = struct(1, 2)'
+        exception 'comparison predicate could not contains complex type'
+    }
+    test {
+        sql 'select struct(1, 2) > struct(1, 2)'
+        exception 'comparison predicate could not contains complex type'
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

as #45181 mention, when sorting literals, toLegacyLiteral may cost a lot of time, so compare literal don't use toLegacyLiteral any more.

legacy literal may have an unknown behaviour  comparing two values with different data type.

for neredis literals,  different data type value compare will throw an exception,  it support valid compare with data types:
1. boolean vs boolean;
2. numeric vs numeric;
3. string like vs string like;
4. date like vs date like;
5. ipv4 vs ipv4;
6. ipv6 vs ipv6;
7. array vs array;
8. above data types vs null and max;

what's more, this pr also:
1. nereids literal remove implements Comparable<Literal>;
2. add a new interface ComparableLiteral,  and the above  type literals will implement it;
3. fix  ipv4 / ipv6 / map / struct compareTo always return 0;


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

