### PR TITLE
[Fix](recycler) Fix protobuf out-of-bounds problem in recycler

### DIFF
--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -876,6 +876,10 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
 
     txn->remove(rs_start, rs_end);
 
+    LOG_INFO("cloud process compaction job txn remove meta rowset key")
+            .tag("rs_start", rs_start)
+            .tag("rs_end", rs_end);
+
     TEST_SYNC_POINT_CALLBACK("process_compaction_job::loop_input_done", &num_rowsets);
 
     if (num_rowsets < 1) {

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -877,8 +877,12 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
     txn->remove(rs_start, rs_end);
 
     LOG_INFO("cloud process compaction job txn remove meta rowset key")
-            .tag("rs_start", rs_start)
-            .tag("rs_end", rs_end);
+            .tag("instance_id", instance_id)
+            .tag("tablet_id", tablet_id)
+            .tag("start_version", start)
+            .tag("end_version", end + 1)
+            .tag("rs_start key", hex(rs_start))
+            .tag("rs_end key", hex(rs_end));
 
     TEST_SYNC_POINT_CALLBACK("process_compaction_job::loop_input_done", &num_rowsets);
 

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2893,9 +2893,9 @@ int InstanceRecycler::recycle_expired_stage_objects() {
     int ret = 0;
     for (const auto& stage : instance_info_.stages()) {
         std::stringstream ss;
-        ss << "instance_id=" << instance_id_ << ", stage_id=" << stage.stage_id()
-           << ", user_name=" << stage.mysql_user_name().at(0)
-           << ", user_id=" << stage.mysql_user_id().at(0)
+        ss << "instance_id=" << instance_id_ << ", stage_id=" << stage.stage_id() << ", user_name="
+           << (stage.mysql_user_name().empty() ? "null" : stage.mysql_user_name().at(0))
+           << ", user_id=" << (stage.mysql_user_id().empty() ? "null" : stage.mysql_user_id().at(0))
            << ", prefix=" << stage.obj_info().prefix();
 
         if (stopped()) break;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: Introduced by #45617 

Problem Summary:

In #45617, some logs were added but array null checks were missing when accessing stage objects, which caused an array out-of-bounds exception in recycler. This PR fixes this issue.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

