### PR TITLE
[fix](pipelineX) fix DCHECK error when reuse _join_block in nested loop join

### DIFF
--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -526,8 +526,7 @@ Status NestedLoopJoinProbeOperatorX::pull(RuntimeState* state, vectorized::Block
                         local_state._conjuncts, &local_state._join_block,
                         local_state._join_block.columns()));
             }
-            RETURN_IF_ERROR(
-                    local_state._build_output_block(&local_state._join_block, block, false));
+            RETURN_IF_ERROR(local_state._build_output_block(&local_state._join_block, block));
             local_state._reset_tuple_is_null_column();
         }
         local_state._join_block.clear_column_data(join_block_column_size);


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #46498

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

