### PR TITLE
[regression-test](fix) fix test_audit_log_behavior.groovy bug (#46100)

### DIFF
--- a/regression-test/suites/audit/test_audit_log_behavior.groovy
+++ b/regression-test/suites/audit/test_audit_log_behavior.groovy
@@ -92,8 +92,8 @@ suite("test_audit_log_behavior") {
         // check result
         for (int i = 0; i < cnt; i++) {
             def tuple2 = sqls.get(i)
-            def retry = 90
-            def res = sql "select stmt from __internal_schema.audit_log where stmt like '%3F6B9A_${i}%' order by time asc limit 1"
+            def retry = 180
+            def res = sql "select stmt from __internal_schema.audit_log where stmt like 'insert%3F6B9A_${i}%' order by time asc limit 1"
             while (res.isEmpty()) {
                 if (retry-- < 0) {
                     logger.warn("It has retried a few but still failed, you need to check it")


### PR DESCRIPTION
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
In this case, select stmt from __internal_schema.audit_log where stmt like '%3F6B9A_1%' order by time asc limit 1
will also be inserted into audit log table, and be selected, which will cause assert fail in test case, which want a insert stmt.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

