### PR TITLE
[fix](Nereids) fix fe folding constant of string functions and add more cases (#45233)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -114,7 +114,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "length")
     public static Expression lengthVarchar(StringLikeLiteral first) {
-        return new IntegerLiteral(first.getValue().length());
+        return new IntegerLiteral(first.getValue().getBytes(StandardCharsets.UTF_8).length);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -318,7 +318,20 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "locate")
     public static Expression locate(StringLikeLiteral first, StringLikeLiteral second) {
-        return new IntegerLiteral(second.getValue().trim().indexOf(first.getValue()) + 1);
+        return new IntegerLiteral(second.getValue().indexOf(first.getValue()) + 1);
+    }
+
+    /**
+     * Executable arithmetic functions Locate
+     */
+    @ExecFunction(name = "locate")
+    public static Expression locate(StringLikeLiteral first, StringLikeLiteral second, IntegerLiteral third) {
+        int result = second.getValue().indexOf(first.getValue()) + 1;
+        if (third.getValue() <= 0 || !substringImpl(second.getValue(), third.getValue(),
+                second.getValue().length()).contains(first.getValue())) {
+            result = 0;
+        }
+        return new IntegerLiteral(result);
     }
 
     /**
@@ -333,12 +346,14 @@ public class StringArithmetic {
      * Executable arithmetic functions Ascii
      */
     @ExecFunction(name = "ascii")
-    public static Expression ascii(StringLikeLiteral first) {
+    public static Expression ascii(StringLikeLiteral first) throws UnsupportedEncodingException {
         if (first.getValue().length() == 0) {
             return new IntegerLiteral(0);
         }
-        char firstChar = first.getValue().charAt(0);
-        return new IntegerLiteral(firstChar);
+        String character = first.getValue();
+        byte[] utf8Bytes = character.getBytes("UTF-8");
+        int firstByteAscii = utf8Bytes[0] & 0xFF;
+        return new IntegerLiteral(firstByteAscii);
     }
 
     /**
@@ -583,7 +598,7 @@ public class StringArithmetic {
     }
 
     private static int findStringInSet(String target, String input) {
-        String[] split = input.split(",");
+        String[] split = input.split(",", -1);
         for (int i = 0; i < split.length; i++) {
             if (split[i].equals(target)) {
                 return i + 1;
@@ -605,6 +620,10 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "repeat")
     public static Expression repeat(StringLikeLiteral first, IntegerLiteral second) {
+        // when it is too large for fe to make result string, do not folding on fe, limit 1 MB
+        if ((first.getValue().length() * second.getValue()) > 1000000) {
+            throw new AnalysisException("repeat too large to fold const by fe");
+        }
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < second.getValue(); i++) {
             sb.append(first.getValue());
@@ -627,6 +646,10 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "space")
     public static Expression space(IntegerLiteral first) {
+        // when it is too large for fe to make result string, do not folding on fe, limit 1 MB
+        if (first.getValue() > 1000000) {
+            throw new AnalysisException("space too large to fold const by fe");
+        }
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < first.getValue(); i++) {
             sb.append(' ');
@@ -639,7 +662,7 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "split_by_char")
     public static Expression splitByChar(StringLikeLiteral first, StringLikeLiteral second) {
-        String[] result = first.getValue().split(second.getValue());
+        String[] result = first.getValue().split(second.getValue(), -1);
         List<Literal> items = new ArrayList<>();
         for (int i = 1; i < result.length; i++) {
             items.add((Literal) castStringLikeLiteral(first, result[i]));
@@ -666,16 +689,16 @@ public class StringArithmetic {
             if (".$|()[{^?*+\\".contains(separator) || separator.startsWith("\\")) {
                 separator = "\\" + separator;
             }
-            parts = sb.reverse().toString().split(separator);
+            parts = sb.reverse().toString().split(separator, -1);
         } else {
             if (".$|()[{^?*+\\".contains(separator) || separator.startsWith("\\")) {
                 separator = "\\" + separator;
             }
-            parts = first.getValue().split(separator);
+            parts = first.getValue().split(separator, -1);
         }
 
         if (parts.length < Math.abs(number.getValue()) || number.getValue() == 0) {
-            if (parts.length == Math.abs(number.getValue()) - 1) {
+            if (parts.length == Math.abs(number.getValue())) {
                 if (number.getValue() < 0 && first.getValue().startsWith(chr.getValue())
                         || number.getValue() > 0 && first.getValue().endsWith(chr.getValue())) {
                     return castStringLikeLiteral(first, "");
@@ -695,7 +718,10 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "substring_index")
     public static Expression substringIndex(StringLikeLiteral first, StringLikeLiteral chr, IntegerLiteral number) {
-        String[] parts = first.getValue().split(chr.getValue());
+        if (chr.getValue().isEmpty()) {
+            return chr;
+        }
+        String[] parts = first.getValue().split(chr.getValue(), -1);
         if (Math.abs(number.getValue()) >= parts.length) {
             return first;
         }
@@ -904,13 +930,13 @@ public class StringArithmetic {
             return castStringLikeLiteral(first, "");
         }
 
-        String[] urlParts = first.getValue().split("\\?");
+        String[] urlParts = first.getValue().split("\\?", -1);
         if (urlParts.length > 1) {
             String query = urlParts[1];
-            String[] pairs = query.split("&");
+            String[] pairs = query.split("&", -1);
 
             for (String pair : pairs) {
-                String[] keyValue = pair.split("=");
+                String[] keyValue = pair.split("=", -1);
                 if (second.getValue().equals(keyValue[0])) {
                     return castStringLikeLiteral(first, keyValue[1]);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -902,6 +902,9 @@ public class StringArithmetic {
      */
     @ExecFunction(name = "append_trailing_char_if_absent")
     public static Expression appendTrailingCharIfAbsent(StringLikeLiteral first, StringLikeLiteral second) {
+        if (second.getValue().length() != 1) {
+            return new NullLiteral(first.getDataType());
+        }
         if (first.getValue().endsWith(second.getValue())) {
             return first;
         } else {

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -684,4 +684,91 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("select url_encode('http://www.apache.org/licenses/LICENSE-2.0')")
     testFoldConst("select url_encode(' http://www.apache.org/licenses/LICENSE-2.0 ')")
 
+    // Normal Usage Test Cases
+
+    // Test Case 1: Append missing trailing character
+    testFoldConst("select append_trailing_char_if_absent('hello', '!')")
+    // Expected Output: 'hello!'
+
+    // Test Case 2: Trailing character already present
+    testFoldConst("select append_trailing_char_if_absent('hello!', '!')")
+    // Expected Output: 'hello!'
+
+    // Test Case 3: Append trailing space
+    testFoldConst("select append_trailing_char_if_absent('hello', ' ')")
+    // Expected Output: 'hello '
+
+    // Test Case 4: Empty string input
+    testFoldConst("select append_trailing_char_if_absent('', '!')")
+    // Expected Output: '!'
+
+    // Test Case 5: Append different character
+    testFoldConst("select append_trailing_char_if_absent('hello', '?')")
+    // Expected Output: 'hello?'
+
+    // Test Case 6: String ends with a different character
+    testFoldConst("select append_trailing_char_if_absent('hello?', '!')")
+    // Expected Output: 'hello?!'
+
+    // Edge and Unusual Usage Test Cases
+
+    // Test Case 7: Input is NULL
+    testFoldConst("select append_trailing_char_if_absent(NULL, '!')")
+    // Expected Output: NULL
+
+    // Test Case 8: Trailing character is NULL
+    testFoldConst("select append_trailing_char_if_absent('hello', NULL)")
+    // Expected Output: NULL
+
+    // Test Case 9: Empty trailing character
+    testFoldConst("select append_trailing_char_if_absent('hello', '')")
+    // Expected Output: Error or no change depending on implementation
+
+    // Test Case 10: Trailing character is more than 1 character long
+    testFoldConst("select append_trailing_char_if_absent('hello', 'ab')")
+    // Expected Output: Error
+
+    // Test Case 11: Input string is a number
+    testFoldConst("select append_trailing_char_if_absent(12345, '!')")
+    // Expected Output: Error or '12345!'
+
+    // Test Case 12: Trailing character is a number
+    testFoldConst("select append_trailing_char_if_absent('hello', '1')")
+    // Expected Output: 'hello1'
+
+    // Test Case 13: Input is a single character
+    testFoldConst("select append_trailing_char_if_absent('h', '!')")
+    // Expected Output: 'h!'
+
+    // Test Case 14: Unicode character as input and trailing character
+    testFoldConst("select append_trailing_char_if_absent('こんにちは', '!')")
+    // Expected Output: 'こんにちは!'
+
+    // Test Case 15: Multibyte character as trailing character
+    testFoldConst("select append_trailing_char_if_absent('hello', '😊')")
+    // Expected Output: 'hello😊'
+
+    // Test Case 16: Long string input
+    testFoldConst("select append_trailing_char_if_absent('This is a very long string', '.')")
+    // Expected Output: 'This is a very long string.'
+
+    // Error Handling Test Cases
+
+    // Test Case 17: Invalid trailing character data type (numeric)
+    testFoldConst("select append_trailing_char_if_absent('hello', 1)")
+    // Expected Output: Error
+
+    // Test Case 18: Invalid input data type (integer)
+    testFoldConst("select append_trailing_char_if_absent(12345, '!')")
+    // Expected Output: Error or '12345!'
+
+    // Test Case 19: Non-ASCII characters
+    testFoldConst("select append_trailing_char_if_absent('Привет', '!')")
+    // Expected Output: 'Привет!'
+
+    // Test Case 20: Trailing character with whitespace
+    testFoldConst("select append_trailing_char_if_absent('hello', ' ')")
+    // Expected Output: 'hello '
+
+
 }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -16,675 +16,672 @@
 // under the License.
 
 suite("fold_constant_string_arithmatic") {
-    def db = "fold_constant_string_arithmatic"
-    sql "create database if not exists ${db}"
-
     sql "set enable_nereids_planner=true"
     sql "set enable_fallback_to_original_planner=false"
     sql "set enable_fold_constant_by_be=false"
-
-    testFoldConst("SELECT  Concat('Hello', ' ', 'World')")
-    testFoldConst("SELECT  Substring('Hello World', 1, 5)")
-    testFoldConst("SELECT  Substring('1', 1, 1)")
-    testFoldConst("select  100, 'abc', substring('abc', 1, 2), substring(substring('abcdefg', 4, 3), 1, 2), null")
-    testFoldConst("SELECT  Length('Hello World')")
-    testFoldConst("SELECT  Lower('Hello World')")
-    testFoldConst("SELECT  Upper('Hello World')")
-    testFoldConst("SELECT  Trim('  Hello World  ')")
-    testFoldConst("SELECT  Trim('11111', 11)")
-    testFoldConst("SELECT  Ltrim('  Hello World  ')")
-    testFoldConst("SELECT  LTrim(' 11111', 11)")
-    testFoldConst("SELECT  LTrim('11111 ', 11)")
-    testFoldConst("SELECT  Rtrim('  Hello World  ')")
-    testFoldConst("SELECT  RTrim('11111 ', 11)")
-    testFoldConst("SELECT  RTrim(' 11111', 11)")
-    testFoldConst("SELECT  Replace('Hello World', 'World', 'Everyone')")
-    testFoldConst("SELECT  Left('Hello World', 5)")
-    testFoldConst("SELECT  Right('Hello World', 5)")
-    testFoldConst("SELECT  Locate('World', 'Hello World')")
-    testFoldConst("SELECT  Instr('Hello World', 'World')")
-    testFoldConst("SELECT  Ascii('A')")
-    testFoldConst("SELECT  Bin(5)")
-    testFoldConst("SELECT  Hex(255)")
-    testFoldConst("SELECT  Unhex('FF')")
-    testFoldConst("SELECT  Concat_Ws('-', '2024', '09', '02')")
-    testFoldConst("SELECT  Char(65)")
-    testFoldConst("SELECT  Character_Length('Hello World')")
-    testFoldConst("SELECT  Initcap('hello world')")
-    testFoldConst("SELECT  Md5('Hello World')")
-    testFoldConst("SELECT  Md5Sum('Hello World')")
-//    testFoldConst("SELECT  JsonExtract('{"key": "value"}', '$.key')")
-//    testFoldConst("SELECT  JsonbExtractString('{"key": "value"}', '$.key')")
-//    testFoldConst("SELECT  JsonContains('{"key": "value"}', '"key"')")
-//    testFoldConst("SELECT  JsonLength('{"key1": "value1", "key2": "value2"}')")
-//    testFoldConst("SELECT  JsonObject('key', 'value')")
-//    testFoldConst("SELECT  JsonArray('value1', 'value2')")
-//    testFoldConst("SELECT  JsonKeys('{"key1": "value1", "key2": "value2"}')")
-//    testFoldConst("SELECT  JsonInsert('{"key1": "value1"}', '$.key2', 'value2')")
-//    testFoldConst("SELECT  JsonReplace('{"key1": "value1"}', '$.key1', 'new_value')")
-//    testFoldConst("SELECT  JsonSet('{"key1": "value1"}', '$.key2', 'value2')")
-//    testFoldConst("SELECT  Json_Quote('Hello World')")
-//    testFoldConst("SELECT  Json_UnQuote('"Hello World"')")
-    testFoldConst("SELECT  Field('b', 'a', 'b', 'c')")
-    testFoldConst("SELECT  Find_In_Set('b', 'a,b,c')")
-    testFoldConst("SELECT  Repeat('Hello', 3)")
-    testFoldConst("SELECT  Reverse('Hello')")
-    testFoldConst("SELECT  length(Space(10))")
-//    testFoldConst("SELECT  Split_By_Char('a,b,c',',')")  has bug in be execution
-    testFoldConst("SELECT  Split_By_String('a::b::c', '::')")
-    testFoldConst("SELECT  Split_Part('a,b,c', ',', 2)")
-    testFoldConst("SELECT  Substring_Index('a,b,c', ',', 2)")
-    testFoldConst("SELECT  Strcmp('abc', 'abd')")
-    testFoldConst("SELECT  StrLeft('Hello World', 5)")
-    testFoldConst("SELECT  StrRight('Hello World', 5)")
-//    testFoldConst("SELECT  Overlay('abcdef', '123', 3, 2)")
-    testFoldConst("SELECT  Parse_Url('http://www.example.com/path?query=abc', 'HOST')")
-    testFoldConst("SELECT  Url_Decode('+Hello+World+')")
-    testFoldConst("SELECT  Url_Encode(' Hello World ')")
-
-    // Substring with negative start index
-    // Expected behavior: Depending on the SQL engine, might return an empty string or error.
-    testFoldConst("SELECT Substring('Hello World', -1, 5)")
-
-    // Substring with length exceeding the string length
-    // Expected behavior: Return 'Hello' as the length exceeds the string length.
-    testFoldConst("SELECT Substring('Hello', 1, 10)")
-
-    // Left with length greater than string length
-    // Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Left('Hello', 10)")
-
-    // Right with length greater than string length
-    // Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Right('Hello', 10)")
-
-    // SplitPart with part number greater than the number of parts
-    // Expected behavior: Return an empty string or error.
-    testFoldConst("SELECT Split_Part('a,b,c', ',', 5)")
-
-    // SplitPart with negative part number
-    // Expected behavior: Return an empty string or error.
-    testFoldConst("SELECT Split_Part('a,b,c', ',', -1)")
-
-    // Locate with the substring not present
-    // Expected behavior: Return 0 as 'World' is not found.
-    testFoldConst("SELECT Locate('World', 'Hello')")
-
-    // Instr with the substring not present
-    // Expected behavior: Return 0 as 'World' is not found.
-    testFoldConst("SELECT Instr('Hello', 'World')")
-
-    // Replace with an empty search string
-    // Expected behavior: Some SQL engines may treat this as a no-op, others might throw an error.
-    testFoldConst("SELECT Replace('Hello World', '', 'Everyone')")
-
-    // Replace with an empty replacement string
-    // Expected behavior: Return 'Hello '.
-    testFoldConst("SELECT Replace('Hello World', 'World', '')")
-
-    // Concat with NULL values
-    // Expected behavior: Depending on the SQL engine, may return 'HelloWorld' or NULL.
-    testFoldConst("SELECT Concat('Hello', NULL, 'World')")
-
-    // Ltrim with a string that has no leading spaces
-    // Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Ltrim('Hello')")
-
-    // Rtrim with a string that has no trailing spaces
-    // Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Rtrim('Hello')")
-
-    // JsonExtract with an invalid JSON path
-    // Expected behavior: Return NULL or an empty string.
-//    testFoldConst("SELECT Json_Extract('{"key": "value"}', '$.invalid')")
-
-    // JsonLength with a non-JSON string
-    // Expected behavior: Return NULL or error.
-    testFoldConst("SELECT Json_Length('Hello World')")
-
-    // Field with a value not present in the list
-    // Expected behavior: Return 0 as 'd' is not found.
-    testFoldConst("SELECT Field('d', 'a', 'b', 'c')")
-
-    // FindInSet with a value not present in the set
-    // Expected behavior: Return 0 as 'd' is not found.
-    testFoldConst("SELECT Find_In_Set('d', 'a,b,c')")
-
-    // Repeat with a negative repeat count
-    // Expected behavior: Return an empty string or error.
-    testFoldConst("SELECT Repeat('Hello', -3)")
-
-    // Space with a negative number of spaces
-    // Expected behavior: Return an empty string or error.
-    testFoldConst("SELECT Space(-5)")
-
-    // SplitByChar with a delimiter not present in the string
-    // Expected behavior: Return the original string in a single element array.
-//    testFoldConst("SELECT Split_By_Char('abc', ',')")
-
-    // SplitByString with a delimiter not present in the string
-    // Expected behavior: Return the original string in a single element array.
-    testFoldConst("SELECT Split_By_String('::', 'abc')")
-
-    // Strcmp with two identical strings
-    // Expected behavior: Return 0 as the strings are equal.
-    testFoldConst("SELECT Strcmp('abc', 'abc')")
-
-    // Strcmp with a null string
-    // Expected behavior: Return NULL or -1 depending on the SQL engine.
-    testFoldConst("SELECT Strcmp('abc', NULL)")
-
-    // Hex with a negative number
-    // Expected behavior: Return the hexadecimal representation of the two's complement, or an error depending on the SQL engine.
-    testFoldConst("SELECT Hex(-255)")
-
-    // Unhex with an invalid hexadecimal string
-    // Expected behavior: Return NULL or error as 'GHIJ' is not a valid hex string.
-    testFoldConst("SELECT Unhex('GHIJ')")
-
-    // JsonReplace with a path that does not exist
-    // Expected behavior: Depending on the engine, might return the original JSON or an error.
-//    testFoldConst("SELECT Json_Replace('{"key": "value"}', '$.nonexistent', 'new_value')")
-
-    // UrlDecode with an invalid percent-encoded string
-    // Expected behavior: Return NULL or error due to invalid encoding.
-//    testFoldConst("SELECT Url_Decode('%ZZHello%20World')")
-
-    testFoldConst("select elt(0, \"hello\", \"doris\")")
-    testFoldConst("select elt(1, \"hello\", \"doris\")")
-    testFoldConst("select elt(2, \"hello\", \"doris\")")
-    testFoldConst("select elt(3, \"hello\", \"doris\")")
-    testFoldConst("select c1, c2, elt(c1, c2) from (select number as c1, 'varchar' as c2 from numbers('number'='5') where number > 0) a")
-
+    
+    // append_trailing_char_if_absent
+    testFoldConst("select append_trailing_char_if_absent('', '!')")
+    testFoldConst("select append_trailing_char_if_absent(12345, '!')")
     testFoldConst("select append_trailing_char_if_absent('a','c')")
     testFoldConst("select append_trailing_char_if_absent('ac','c')")
-
+    testFoldConst("select append_trailing_char_if_absent(cast('a' as string), cast('c' as string))")
+    testFoldConst("select append_trailing_char_if_absent(cast('ac' as string), cast('c' as string))")
+    testFoldConst("select append_trailing_char_if_absent('hello!', '!')")
+    testFoldConst("select append_trailing_char_if_absent('hello', '😊')")
+    testFoldConst("select append_trailing_char_if_absent('hello😊', '😊')")
+    testFoldConst("select append_trailing_char_if_absent('hello😊', '(ಥ _ ಥ)')")
+    testFoldConst("select append_trailing_char_if_absent('hello', ' ')")
+    testFoldConst("select append_trailing_char_if_absent('hello', '')")
+    testFoldConst("select append_trailing_char_if_absent('hello', '?')")
+    testFoldConst("select append_trailing_char_if_absent('hello?', '!')")
+    testFoldConst("select append_trailing_char_if_absent('hello', '1')")
+    testFoldConst("select append_trailing_char_if_absent('hello', 1)")
+    testFoldConst("select append_trailing_char_if_absent('hello', 'ab')")
+    testFoldConst("select append_trailing_char_if_absent('hello', NULL)")
+    testFoldConst("select append_trailing_char_if_absent('hello', 'ell')")
+    testFoldConst("select append_trailing_char_if_absent('hello', 'ello')")
+    testFoldConst("select append_trailing_char_if_absent('ello', 'hello')")
+    testFoldConst("select append_trailing_char_if_absent('it','a')")
+    testFoldConst("select append_trailing_char_if_absent(NULL, '!')")
+    testFoldConst("select append_trailing_char_if_absent('This is a very long string', '.')")
+    testFoldConst("select append_trailing_char_if_absent('Привет', '!')")
+    testFoldConst("select append_trailing_char_if_absent('Привет', 'вет')")
+    testFoldConst("select append_trailing_char_if_absent('こんにちは', '!')")
+    testFoldConst("select append_trailing_char_if_absent('\n\t', '\n')")
+    testFoldConst("select append_trailing_char_if_absent('こんにちは', 'ちは')")
+    
+    // ascii
+    testFoldConst("select ascii('!')")
     testFoldConst("select ascii('1')")
     testFoldConst("select ascii('a')")
     testFoldConst("select ascii('A')")
-    testFoldConst("select ascii('!')")
+    testFoldConst("select ascii('こ')")
+    testFoldConst("select ascii('안')")
+    testFoldConst("select ascii('안こ')")
+    testFoldConst("select ascii('')")
+    testFoldConst("select ascii('中')")
+    
+    // bin
+    testFoldConst("select bin(5)")
+    testFoldConst("select bin(-5)")
+    testFoldConst("select bin(9223372036854775807)")
+    testFoldConst("select bin(9223372036854775808)")
+    testFoldConst("select bin(-9223372036854775809)")
+    
+    // bit_length
+    testFoldConst("select bit_length('abc')")
+    testFoldConst("select bit_length(cast('abc' as string))")
+    testFoldConst("select bit_length('こんにちは世界')")
+    testFoldConst("select bit_length('안녕하세요 세계!')")
+    testFoldConst("select bit_length('')")
+    
+    // char
+    testFoldConst("select char(65)")
+    testFoldConst("select char(-1)")
+    testFoldConst("select char(65535)")
+    
+    // character_length
+    testFoldConst("select character_length(cast('Hello World' as string))")
+    testFoldConst("select character_length('Hello World')")
+    testFoldConst("select character_length('你好 世界')")
+    testFoldConst("select character_length(' Hello World')")
+    testFoldConst("select character_length('  你好 世界')")
+    testFoldConst("select character_length('Hello World  ')")
+    testFoldConst("select character_length('  你好 世界  ')")
+    testFoldConst("select char_length('abc')")
+    testFoldConst("select char_length(cast('abc' as string))")
+    testFoldConst("select char_length('你好 世界')")
+    testFoldConst("select char_length('  abc')")
+    testFoldConst("select char_length('  你好 世界')")
+    testFoldConst("select char_length('你好 世界  ')")
 
-    testFoldConst("select bit_length(\"abc\")")
+    // concat
+    testFoldConst("select concat('a', 'b')")
+    testFoldConst("select concat('a', 'b', 'c')")
+    testFoldConst("select concat('a', null, 'c')")
+    testFoldConst("select concat('Hello', NULL, 'World')")
+    testFoldConst("select concat('Hello', ' ', 'World')")
+    testFoldConst("select concat('你好', ' ', '世界')")
+    testFoldConst("select concat('', '你好', ' ', '世界')")
+    testFoldConst("select concat('你好', ' ', '世界', '')")
+    
+    // concat_ws
+    testFoldConst("select concat_ws('-', '2024', '09', '02')")
+    testFoldConst("select concat_ws('', '2024', '09', '02')")
+    testFoldConst("select concat_ws('-', '', '2024', '09', '02')")
+    testFoldConst("select concat_ws(NULL, ['d', 'is'])")
+    testFoldConst("select concat_ws(NULL, 'd', 'is')")
+    testFoldConst("select concat_ws('or', ['d', '','is'])")
+    testFoldConst("select concat_ws('or', ['d', 'is'])")
+    testFoldConst("select concat_ws('or', 'd', 'is')")
+    testFoldConst("select concat_ws('or', ['d', NULL,'is'])")
+    testFoldConst("select concat_ws('or', 'd', NULL,'is')")
+    testFoldConst("select concat_ws(' ', '你好', '世界')")
+    testFoldConst("select concat_ws(' ', [])")
+    
+    // elt
+    testFoldConst("select elt(0, cast('hello' as string), cast('doris' as string))")
+    testFoldConst("select elt(0, 'hello', 'doris')")
+    testFoldConst("select elt(1, cast('hello' as string), cast('doris' as string))")
+    testFoldConst("select elt(1, 'hello', 'doris')")
+    testFoldConst("select elt(2, cast('hello' as string), cast('doris' as string))")
+    testFoldConst("select elt(2, 'hello', 'doris')")
+    testFoldConst("select elt(3, cast('hello' as string), cast('doris' as string))")
+    testFoldConst("select elt(3, 'hello', 'doris')")
+    testFoldConst("select c1, c2, elt(c1, c2) from (select number as c1, 'varchar' as c2 from numbers('number'='5') where number > 0) a")
 
-    testFoldConst("select char_length(\"abc\")")
+    // ends_with
+    testFoldConst("select ends_with(cast('Hello doris' as string), cast('doris' as string))")
+    testFoldConst("select ends_with('Hello doris', 'doris')")
+    testFoldConst("select ends_with('こんにちは世界！안녕하세요 세계', '안녕하세요 세계')")
+    testFoldConst("select ends_with('안녕하세요 세계こんにちは世界！', 'こんにちは世界！')")
+    testFoldConst("select ends_with('안녕하세요 세계こんにちは世界', 'こんにちは世界')")
+    testFoldConst("select ends_with('안녕하세요 세계こんにちは世界', 'こんにちは')")
+    testFoldConst("select ends_with('Hello doris', '')")
+    testFoldConst("select ends_with('', 'Hello doris')")
+    testFoldConst("select ends_with(null, 'Hello doris')")
+    testFoldConst("select ends_with('Hello doris', null)")
+    testFoldConst("select ends_with(' ', '')")
+    testFoldConst("select ends_with(' ', ' ')")
+    testFoldConst("select ends_with('', ' ')")
+    testFoldConst("select ends_with('', '')")
 
-    testFoldConst("select concat(\"a\", \"b\")")
-    testFoldConst("select concat(\"a\", \"b\", \"c\")")
-    testFoldConst("select concat(\"a\", null, \"c\")")
-
-    testFoldConst("select concat_ws(\"or\", \"d\", \"is\")")
-    testFoldConst("select concat_ws(NULL, \"d\", \"is\")")
-    testFoldConst("select concat_ws(\"or\", \"d\", NULL,\"is\")")
-    testFoldConst("select concat_ws(\"or\", [\"d\", \"is\"])")
-    testFoldConst("select concat_ws(NULL, [\"d\", \"is\"])")
-    testFoldConst("select concat_ws(\"or\", [\"d\", NULL,\"is\"])")
-    testFoldConst("select concat_ws(\"or\", [\"d\", \"\",\"is\"])")
-
-    testFoldConst("select ends_with(\"Hello doris\", \"doris\")")
-    testFoldConst("select ends_with(\"Hello doris\", \"Hello\")")
-
-    testFoldConst("select find_in_set(\"b\", \"a,b,c\")")
-    testFoldConst("select find_in_set(\"d\", \"a,b,c\")")
-    testFoldConst("select find_in_set(null, \"a,b,c\")")
-    testFoldConst("select find_in_set(\"a\", null)")
-
-    testFoldConst("select hex('1')")
-    testFoldConst("select hex('12')")
+    // field
+    testFoldConst("select field('b', 'a', 'b', 'c')")
+    testFoldConst("select field('d', 'a', 'b', 'c')")
+    testFoldConst("select field('こ', 'ん', 'に', 'ち', 'こ')")
+    testFoldConst("select field('=', '+', '=', '=', 'こ')")
+    testFoldConst("select field('==', '+', '=', '==', 'こ')")
+    testFoldConst("select field('=', '+', '==', '==', 'こ')")
+    
+    // find_in_set
+    testFoldConst("select find_in_set('a', null)")
+    testFoldConst("select find_in_set('b', 'a,b,c')")
+    testFoldConst("select find_in_set('b', ' a,b,c')")
+    testFoldConst("select find_in_set('b', 'a ,b,c')")
+    testFoldConst("select find_in_set('b', 'a, b,c')")
+    testFoldConst("select find_in_set('b', 'a,b,c ')")
+    testFoldConst("select find_in_set('a,b,c ', 'a,b,c')")
+    testFoldConst("select find_in_set('b', 'a,b,c')")
+    testFoldConst("select find_in_set(cast('a' as string), NULL)")
+    testFoldConst("select find_in_set(cast('b' as string), cast('a,b,c' as string))")
+    testFoldConst("select find_in_set(cast('b' as string), cast('a,b,c' as string))")
+    testFoldConst("select find_in_set(cast('d' as string), cast('a,b,c' as string))")
+    testFoldConst("select find_in_set(cast('d' as string), cast('a,b,c' as string))")
+    testFoldConst("select find_in_set('d', 'a,b,c')")
+    testFoldConst("select find_in_set('d', 'a,b,c')")
+    testFoldConst("select find_in_set(null, 'a,b,c')")
+    testFoldConst("select find_in_set(NULL, cast('a,b,c' as string))")
+    testFoldConst("SELECT find_in_set('A', '哈哈哈AAA')")
+    testFoldConst("SELECT find_in_set('哈','哈哈哈AAA')")
+    testFoldConst("SELECT find_in_set(' ','哈哈哈AAA')")
+    testFoldConst("SELECT find_in_set('','哈哈哈AAA')")
+    testFoldConst("SELECT find_in_set(',','a,')")
+    testFoldConst("SELECT find_in_set(',','哈哈哈AAA')")
+    
+    // hex
     testFoldConst("select hex('@')")
-    testFoldConst("select hex('A')")
-    testFoldConst("select hex(12)")
+    testFoldConst("select hex('1')")
     testFoldConst("select hex(-1)")
+    testFoldConst("select hex(-1)")
+    testFoldConst("select hex('12')")
+    testFoldConst("select hex(12)")
+    testFoldConst("select hex(12)")
+    testFoldConst("select hex(-255)")
+    testFoldConst("select hex(-255)")
+    testFoldConst("select hex(255)")
+    testFoldConst("select hex(255)")
+    testFoldConst("select hex('A')")
+    testFoldConst("select hex(cast('12' as string))")
+    testFoldConst("select hex(cast('1' as string))")
+    testFoldConst("select hex(cast('A' as string))")
+    testFoldConst("select hex(cast('@' as string))")
+    testFoldConst("select hex(cast('hello,doris' as string))")
     testFoldConst("select hex('hello,doris')")
+    
+    // ifnull
+    testFoldConst("select ifnull(null,3)")
+    testFoldConst("select ifnull(3,null)")
+    testFoldConst("select ifnull(null,null)")
+    
+    // initcap
+    testFoldConst("select initcap('AbC123abc abc.abc,?|abc')")
+    testFoldConst("select initcap(cast('AbC123abc abc.abc,?|abc' as string))")
+    testFoldConst("select initcap(cast('hello world' as string))")
+    testFoldConst("select initcap('hello world')")
+    testFoldConst("select initcap(' hello world')")
+    testFoldConst("select initcap('こんにちは')")
+    testFoldConst("select initcap('上海天津北京杭州')")
+    
+    // instr
+    testFoldConst("select instr('上海天津北京杭州', '北京')")
+    testFoldConst("select instr('abc', 'b')")
+    testFoldConst("select instr('abc', 'd')")
+    testFoldConst("select instr('abc', 'abcd')")
+    testFoldConst("select instr('abc', null)")
+    testFoldConst("select instr(cast('Hello' as string), cast('World' as string))")
+    testFoldConst("select instr(cast('Hello World' as string), cast('World' as string))")
+    testFoldConst("select instr('foobar', '')")
+    testFoldConst("select instr('Hello', 'World')")
+    testFoldConst("select instr('Hello World', 'World')")
+    testFoldConst("select instr(null, 'a')")
+    testFoldConst("select instr(NULL, cast('a' as string))")
+    testFoldConst("select instr('', 'World')")
+    
+    // lcase
+    testFoldConst("select lcase('AbC123')")
+    testFoldConst("select lcase(cast('AbC123' as string))")
+    testFoldConst("select lcase('上海天津北京杭州')")
+    testFoldConst("select lcase('こんにちは')")
+    
+    // left
+    testFoldConst("select left(CAST('good morning' AS STRING), 120)")
+    testFoldConst("select left(CAST('good morning' AS STRING), -5)")
+    testFoldConst("select left(CAST('good morning' AS STRING), NULL)")
+    testFoldConst("select left(cast('Hello' as string), 10)")
+    testFoldConst("select left(cast('Hello doris' as string), 5)")
+    testFoldConst("select left(CAST('Hello doris' AS STRING), 5)")
+    testFoldConst("select left(cast('Hello World' as string), 5)")
+    testFoldConst("select left(CAST(NULL AS STRING), 1)")
+    testFoldConst("select left('good morning', 120)")
+    testFoldConst("select left('good morning', -5)")
+    testFoldConst("select left('good morning', NULL)")
+    testFoldConst("select left('Hello', 10)")
+    testFoldConst("select left('', 10)")
+    testFoldConst("select left(' Hello', 10)")
+    testFoldConst("select left('Hello doris', 5)")
+    testFoldConst("select left('Hello doris',5)")
+    testFoldConst("select left('Hello World', 5)")
+    testFoldConst("select left(NULL, 1)")
+    testFoldConst("select left('上海天津北京杭州', 5)")
+    testFoldConst("select left('上海天津北京杭州', -5)")
+    testFoldConst("select left('上海天津北京杭州', 0)")
+    
+    // length
+    testFoldConst("select length('你')")
+    testFoldConst("select length('abc')")
+    testFoldConst("select length(cast('abc' as string))")
+    testFoldConst("select length(cast('Hello World' as string))")
+    testFoldConst("select length('Hello World')")
+    testFoldConst("select length('')")
+    testFoldConst("select length(' Hello World')")
+    testFoldConst("select length(space(10))")
 
-    testFoldConst("select unhex('@')")
-    testFoldConst("select unhex('68656C6C6F2C646F726973')")
-    testFoldConst("select unhex('41')")
-    testFoldConst("select unhex('4142')")
-    testFoldConst("select unhex('')")
-    testFoldConst("select unhex(NULL)")
+    // locate
+    testFoldConst("select locate('北京', '上海天津北京杭州')")
+    testFoldConst("select locate('上海天津北京杭州', '北京')")
+    testFoldConst("select locate('bar', 'foobarbar')")
+    testFoldConst("select locate(cast('北京' as string), cast('上海天津北京杭州' as string))")
+    testFoldConst("select locate(cast('' as string), cast('foobar' as string))")
+    testFoldConst("select locate(cast('bar' as string), cast('foobarbar' as string))")
+    testFoldConst("select locate(cast('World' as string), cast('Hello' as string))")
+    testFoldConst("select locate(cast('World' as string), cast('Hello World' as string))")
+    testFoldConst("select locate(cast('xbar' as string), cast('foobar' as string))")
+    testFoldConst("select locate('', 'foobar')")
+    testFoldConst("select locate('World', 'Hello')")
+    testFoldConst("select locate('World', 'Hello World')")
+    testFoldConst("select locate('xbar', 'foobar')")
+    testFoldConst("select locate('北京', '上海天津北京杭州', 4)")
+    testFoldConst("select locate('北京', '上海天津北京杭州', 5)")
+    testFoldConst("select locate('北京', '上海天津北京杭州', -4)")
+    testFoldConst("select locate('北京', '上海天津北京杭州', -5)")
+    testFoldConst("select locate('2', '   123  ', 1)")
+    
+    // lower
+    testFoldConst("select lower('AbC123')")
+    testFoldConst("select lower(cast('AbC123' as string))")
+    testFoldConst("select lower(cast('Hello World' as string))")
+    testFoldConst("select lower('Hello World')")
+    
+    // lpad
+    testFoldConst("select lpad(cast('hi' as string), 1, cast('xy' as string))")
+    testFoldConst("select lpad(cast('hi' as string), 5, cast('xy' as string))")
+    testFoldConst("select lpad('hi', 1, 'xy')")
+    testFoldConst("select lpad('hi', 5, 'xy')")
+    testFoldConst("select lpad('hi', 1, '')")
+    testFoldConst("select lpad('', 1, 'xy')")
+    testFoldConst("select lpad('hi', 1, ' ')")
+    testFoldConst("select lpad(' ', 1, 'xy')")
+    testFoldConst("select lpad(cast('北京' as string), 1, cast('杭州' as string))")
+    testFoldConst("select lpad(cast('北京' as string), 5, cast('杭州' as string))")
+    
+    // ltrim
+    testFoldConst("select ltrim(' 11111', 11)")
+    testFoldConst("select ltrim('11111 ', 11)")
+    testFoldConst("select ltrim('   ab d')")
+    testFoldConst("select ltrim(cast(' 11111' as string), cast(11 as string))")
+    testFoldConst("select ltrim(cast('11111 ' as string), cast(11 as string))")
+    testFoldConst("select ltrim(cast('   ab d' as string))")
+    testFoldConst("select ltrim(cast('Hello' as string))")
+    testFoldConst("select ltrim(cast('  Hello World  ' as string))")
+    testFoldConst("select ltrim('Hello')")
+    testFoldConst("select ltrim('  Hello World  ')")
+    testFoldConst("select ltrim('  上海天津北京杭州  ')")
+    
+    // md5
+    testFoldConst("select md5(cast('Hello World' as string))")
+    testFoldConst("select md5('Hello World')")
+    testFoldConst("select md5(' Hello World')")
+    testFoldConst("select md5('Hello World ')")
+    testFoldConst("select md5('')")
+    testFoldConst("select md5('こんにちは')")
+    testFoldConst("select md5sum('Hello World')")
+    testFoldConst("select md5sum('こんにちは')")
+    testFoldConst("select md5sum('===*+-')")
 
-    testFoldConst("select instr(\"abc\", \"b\")")
-    testFoldConst("select instr(\"abc\", \"d\")")
-    testFoldConst("select instr(\"abc\", null)")
-    testFoldConst("select instr(null, \"a\")")
-    testFoldConst("SELECT instr('foobar', '')")
-    testFoldConst("SELECT instr('上海天津北京杭州', '北京')")
-
-    testFoldConst("SELECT lcase(\"AbC123\")")
-    testFoldConst("SELECT lower(\"AbC123\")")
-
-    testFoldConst("SELECT initcap(\"AbC123abc abc.abc,?|abc\")")
-
-    testFoldConst("select left(\"Hello doris\",5)")
-    testFoldConst("select right(\"Hello doris\",5)")
-
-    testFoldConst("select length(\"abc\")")
-
-    testFoldConst("SELECT LOCATE('bar', 'foobarbar')")
-    testFoldConst("SELECT LOCATE('xbar', 'foobar')")
-    testFoldConst("SELECT LOCATE('', 'foobar')")
-    testFoldConst("SELECT LOCATE('北京', '上海天津北京杭州')")
-
-    testFoldConst("SELECT lpad(\"hi\", 5, \"xy\")")
-    testFoldConst("SELECT lpad(\"hi\", 1, \"xy\")")
-    testFoldConst("SELECT rpad(\"hi\", 5, \"xy\")")
-    testFoldConst("SELECT rpad(\"hi\", 1, \"xy\")")
-
-    testFoldConst("SELECT ltrim('   ab d')")
-
-    testFoldConst("select money_format(17014116)")
-    testFoldConst("select money_format(1123.456)")
+    // money_format
     testFoldConst("select money_format(1123.4)")
+    testFoldConst("select money_format(1123.456)")
+    testFoldConst("select money_format(17014116)")
     testFoldConst("select money_format(truncate(1000,10))")
-
-    testFoldConst("select null_or_empty(null)")
-    testFoldConst("select null_or_empty(\"\")")
-    testFoldConst("select null_or_empty(\"a\")")
-
+    testFoldConst("select money_format(-1123.4)")
+    testFoldConst("select money_format(-1123.456)")
+    testFoldConst("select money_format(-17014116)")
+    testFoldConst("select money_format(-truncate(1000,10))")
+    
+    // not_null_or_empty
+    testFoldConst("select not_null_or_empty('')")
+    testFoldConst("select not_null_or_empty('a')")
+    testFoldConst("select not_null_or_empty(cast('a' as string))")
+    testFoldConst("select not_null_or_empty(cast('' as string))")
+    testFoldConst("select not_null_or_empty(cast('       ' as string))")
     testFoldConst("select not_null_or_empty(null)")
-    testFoldConst("select not_null_or_empty(\"\")")
-    testFoldConst("select not_null_or_empty(\"a\")")
+    testFoldConst("select not_null_or_empty(NULL)")
+    testFoldConst("select not_null_or_empty('\b')")
+    testFoldConst("select not_null_or_empty(' \b')")
+    
+    // null_or_empty
+    testFoldConst("select null_or_empty('')")
+    testFoldConst("select null_or_empty('a')")
+    testFoldConst("select null_or_empty(cast('a' as string))")
+    testFoldConst("select null_or_empty(cast('' as string))")
+    testFoldConst("select null_or_empty(null)")
+    testFoldConst("select null_or_empty(NULL)")
+    testFoldConst("select null_or_empty('\b')")
+    testFoldConst("select null_or_empty(' \b')")
+    
+    // overlay
+    testFoldConst("select overlay('abcdef', 3, 2, '123')")
+    testFoldConst("select overlay('abcdef', 10, 20, '123')")
+    testFoldConst("select overlay(null, 3, 2, '123')")
+    testFoldConst("select overlay('abcdef', 3, 2, null)")
+    testFoldConst("select overlay(cast('abcdef' as string), 3, 2, cast('123' as string))")
+    testFoldConst("select overlay('PRD-1234-5678', 5, 4, '9876')")
+    // be has bug
+//    testFoldConst("select overlay('こんにちは', 1, 2, 'にちは')")
+    
+    // parse_url
+    testFoldConst("select parse_url(cast('http://www.example.com/path?query=abc' as string), cast('HOST' as string))")
+    testFoldConst("select parse_url('http://www.example.com/path?query=abc', 'HOST')")
+    testFoldConst("select parse_url('http://www.example.com/path?query=abc', 'QUERY')")
+    testFoldConst("select parse_url('http://www.example.com/path?query=こんにちは', 'QUERY')")
+    testFoldConst("select parse_url(\"http://www.example.com/path?query=a\b\'\", 'QUERY')")
+    testFoldConst("select parse_url(\"http://www.example.com/path.query=a\b\'\", 'QUERY')")
 
-    testFoldConst("SELECT repeat(\"a\", 3)")
-    testFoldConst("SELECT repeat(\"a\", -1)")
-    testFoldConst("SELECT repeat(\"a\", 0)")
-    testFoldConst("SELECT repeat(\"a\",null)")
-    testFoldConst("SELECT repeat(null,1)")
+    // repeat
+    testFoldConst("select repeat('a', 0)")
+    testFoldConst("select repeat('a', -1)")
+    testFoldConst("select repeat('a', 3)")
+    testFoldConst("select repeat('a',null)")
+    testFoldConst("select repeat(cast('a' as string), 0)")
+    testFoldConst("select repeat(cast('a' as string), -1)")
+    testFoldConst("select repeat(cast('a' as string), 3)")
+    testFoldConst("select repeat(cast('Hello' as string), -3)")
+    testFoldConst("select repeat(cast('Hello' as string), 3)")
+    testFoldConst("select repeat('Hello', -3)")
+    testFoldConst("select repeat('Hello', 3)")
+    testFoldConst("select repeat(NULL, 1)")
+    testFoldConst("select repeat('', 3)")
+    testFoldConst("select repeat(' ', 3)")
+    testFoldConst("select repeat('前进',4)")
+    
+    // replace
+    testFoldConst("select replace(cast('Hello World' as string), '', cast('Everyone' as string))")
+    testFoldConst("select replace(cast('Hello World' as string), cast('World' as string), '')")
+    testFoldConst("select replace(cast('Hello World' as string), cast('World' as string), cast('Everyone' as string))")
+    testFoldConst("select replace(cast('https://doris.apache.org:9090' as string), cast(':9090' as string), cast('' as string))")
+    testFoldConst("select replace(cast('https://doris.apache.org:9090' as string), cast('' as string), cast('new_str' as string))")
+    testFoldConst("select replace('Hello World', '', 'Everyone')")
+    testFoldConst("select replace('Hello World', 'World', '')")
+    testFoldConst("select replace('Hello World', 'World', 'Everyone')")
+    testFoldConst("select replace('https://doris.apache.org:9090', ':9090', '')")
+    testFoldConst("select replace('https://doris.apache.org:9090', '', 'new_str')")
+    testFoldConst("select replace('https://doris.apache.org:9090', './*', 'new_str')")
+    
+    // reverse
+    testFoldConst("select reverse('Hello')")
+    testFoldConst("select reverse('')")
+    testFoldConst("select reverse('こんにちは')")
+    
+    // right
+    testFoldConst("select right(CAST('good morning' AS STRING), NULL)")
+    testFoldConst("select right(cast('Hello' as string), 10)")
+    testFoldConst("select right(CAST('Hello doris' AS STRING), 120)")
+    testFoldConst("select right(cast('Hello doris' as string), 5)")
+    testFoldConst("select right(CAST('Hello doris' AS STRING), 5)")
+    testFoldConst("select right(CAST('Hello doris' AS STRING), -6)")
+    testFoldConst("select right(cast('Hello World' as string), 5)")
+    testFoldConst("select right(CAST(NULL AS STRING), 1)")
+    testFoldConst("select right('good morning', NULL)")
+    testFoldConst("select right('Hello', 10)")
+    testFoldConst("select right('Hello doris', 120)")
+    testFoldConst("select right('Hello doris', 5)")
+    testFoldConst("select right('Hello doris',5)")
+    testFoldConst("select right('Hello doris', -6)")
+    testFoldConst("select right('Hello World', 5)")
+    testFoldConst("select right('Hello World', 0)")
+    testFoldConst("select right(NULL, 1)")
+    
+    // rpad
+    testFoldConst("select rpad(cast('hi' as string), 1, cast('xy' as string))")
+    testFoldConst("select rpad(cast('hi' as string), 5, cast('xy' as string))")
+    testFoldConst("select rpad('hi', 1, 'xy')")
+    testFoldConst("select rpad('hi', 5, 'xy')")
+    
+    // rtrim
+    testFoldConst("select rtrim(' 11111', 11)")
+    testFoldConst("select rtrim('11111 ', 11)")
+    testFoldConst("select rtrim(cast(' 11111' as string), cast(11 as string))")
+    testFoldConst("select rtrim(cast('11111 ' as string), cast(11 as string))")
+    testFoldConst("select rtrim(cast('Hello' as string))")
+    testFoldConst("select rtrim(cast('  Hello World  ' as string))")
+    testFoldConst("select rtrim('Hello')")
+    testFoldConst("select rtrim('  Hello World  ')")
+    
+    // space
+    testFoldConst("select space(-5)")
+    testFoldConst("select space(5)")
+    testFoldConst("select space(0)")
 
-    testFoldConst("select replace(\"https://doris.apache.org:9090\", \":9090\", \"\")")
-    testFoldConst("select replace(\"https://doris.apache.org:9090\", \"\", \"new_str\")")
-
-    testFoldConst("SELECT REVERSE('hello')")
-
-    testFoldConst("select split_part('hello world', ' ', 1)")
-    testFoldConst("select split_part('hello world', ' ', 2)")
+    // split_by_string
+    testFoldConst("select split_by_string('::', 'abc')")
+    testFoldConst("select split_by_string('a::b::c', '::')")
+    testFoldConst("select split_by_string(cast('a::b::c' as string), cast('::' as string))")
+    testFoldConst("select split_by_string(cast('abc' as string), cast('::' as string))")
+    testFoldConst("select split_by_string('上海天津北京杭州', '北')")
+    testFoldConst("select split_by_string('abccccc', 'c')")
+    
+    // split_part
+    testFoldConst("select split_part('a,b,c', ',', -1)")
+    testFoldConst("select split_part('abc##123###xyz', '##', 0)")
+    testFoldConst("select split_part('abc##123###xyz', '##', -1)")
+    testFoldConst("select split_part('abc##123###xyz', '##', 1)")
+    testFoldConst("select split_part('abc##123###xyz', '##', -2)")
+    testFoldConst("select split_part('abc##123###xyz', '##', 3)")
+    testFoldConst("select split_part('abc##123###xyz', '##', -4)")
+    testFoldConst("select split_part('abc##123###xyz', '##', 5)")
+    testFoldConst("select split_part('a,b,c', ',', 2)")
+    testFoldConst("select split_part('a,b,c', ',', 5)")
+    testFoldConst("select split_part(cast('a,b,c' as string), cast(',' as string), -1)")
+    testFoldConst("select split_part(cast('a,b,c' as string), cast(',' as string), 2)")
+    testFoldConst("select split_part(cast('a,b,c' as string), cast(',' as string), 5)")
+    testFoldConst("select split_part(cast('hello world' as string), cast(' ' as string), 1)")
+    testFoldConst("select split_part(cast('hello world' as string), cast(' ' as string), 2)")
+    testFoldConst("select split_part(cast('hello world' as string), cast(' ' as string), 3)")
     testFoldConst("select split_part('hello world', ' ', 0)")
     testFoldConst("select split_part('hello world', ' ', -1)")
+    testFoldConst("select split_part('hello world', ' ', 1)")
     testFoldConst("select split_part('hello world', ' ', -2)")
+    testFoldConst("select split_part('hello world', ' ', 2)")
     testFoldConst("select split_part('hello world', ' ', -3)")
-    testFoldConst("select split_part('abc##123###xyz', '##', 0)")
-    testFoldConst("select split_part('abc##123###xyz', '##', 1)")
-    testFoldConst("select split_part('abc##123###xyz', '##', 3)")
-    testFoldConst("select split_part('abc##123###xyz', '##', 5)")
-    testFoldConst("select split_part('abc##123###xyz', '##', -1)")
-    testFoldConst("select split_part('abc##123###xyz', '##', -2)")
-    testFoldConst("select split_part('abc##123###xyz', '##', -4)")
-
-    testFoldConst("select starts_with(\"hello world\",\"hello\")")
-    testFoldConst("select starts_with(\"hello world\",\"world\")")
-    testFoldConst("select starts_with(\"hello world\",null)")
-
-    testFoldConst("select strleft(NULL, 1)")
-    testFoldConst("select strleft(\"good morning\", NULL)")
-    testFoldConst("select left(NULL, 1)")
-    testFoldConst("select left(\"good morning\", NULL)")
-    testFoldConst("select strleft(\"Hello doris\", 5)")
-    testFoldConst("select left(\"Hello doris\", 5)")
-    testFoldConst("select strright(NULL, 1)")
-    testFoldConst("select strright(\"good morning\", NULL)")
-    testFoldConst("select right(NULL, 1)")
-    testFoldConst("select right(\"good morning\", NULL)")
-    testFoldConst("select strright(\"Hello doris\", 5)")
-    testFoldConst("select right(\"Hello doris\", 5)")
-    testFoldConst("select strleft(\"good morning\", 120)")
-    testFoldConst("select strleft(\"good morning\", -5)")
-    testFoldConst("select strright(\"Hello doris\", 120)")
-    testFoldConst("select strright(\"Hello doris\", -5)")
-    testFoldConst("select left(\"good morning\", 120)")
-    testFoldConst("select left(\"good morning\", -5)")
-    testFoldConst("select right(\"Hello doris\", 120)")
-    testFoldConst("select right(\"Hello doris\", -6)")
-
-    testFoldConst("select substring('abc1', 2)")
-    testFoldConst("select substring('abc1', -2)")
-    testFoldConst("select substring('abc1', 5)")
-    testFoldConst("select substring('abc1def', 2, 2)")
-    testFoldConst("select substring('abcdef',3,-1)")
-    testFoldConst("select substring('abcdef',-3,-1)")
-    testFoldConst("select substring('abcdef',10,1)")
-
-    testFoldConst("select substr('a',3,1)")
-    testFoldConst("select substr('a',2,1)")
-    testFoldConst("select substr('a',1,1)")
-    testFoldConst("select substr('a',0,1)")
-    testFoldConst("select substr('a',-1,1)")
-    testFoldConst("select substr('a',-2,1)")
-    testFoldConst("select substr('a',-3,1)")
-    testFoldConst("select substr('abcdef',3,-1)")
-    testFoldConst("select substr('abcdef',-3,-1)")
-
-    testFoldConst("select sub_replace(\"this is origin str\",\"NEW-STR\",1)")
-    testFoldConst("select sub_replace(\"doris\",\"***\",1,2)")
-
-    testFoldConst("select substring_index(\"hello world\", \" \", 1)")
-    testFoldConst("select substring_index(\"hello world\", \" \", 2)")
-    testFoldConst("select substring_index(\"hello world\", \" \", 3)")
-    testFoldConst("select substring_index(\"hello world\", \" \", -1)")
-    testFoldConst("select substring_index(\"hello world\", \" \", -2)")
-    testFoldConst("select substring_index(\"hello world\", \" \", -3)")
-    testFoldConst("select substring_index(\"prefix__string2\", \"__\", 2)")
-    testFoldConst("select substring_index(\"prefix__string2\", \"_\", 2)")
-    testFoldConst("select substring_index(\"prefix_string2\", \"__\", 1)")
-    testFoldConst("select substring_index(null, \"__\", 1)")
-    testFoldConst("select substring_index(\"prefix_string\", null, 1)")
-    testFoldConst("select substring_index(\"prefix_string\", \"_\", null)")
-    testFoldConst("select substring_index(\"prefix_string\", \"__\", -1)")
-
-    testFoldConst("select elt(0, \"hello\", \"doris\")")
-    testFoldConst("select elt(1, \"hello\", \"doris\")")
-    testFoldConst("select elt(2, \"hello\", \"doris\")")
-    testFoldConst("select elt(3, \"hello\", \"doris\")")
-
-    testFoldConst("select sub_replace(\"this is origin str\",\"NEW-STR\",1)")
-    testFoldConst("select sub_replace(\"doris\",\"***\",1,2)")
-
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', -5)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', -4)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', -3)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', -2)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', -1)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', 0)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', 1)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', 2)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', 3)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', 4)")
+    testFoldConst("SELECT split_part('哈哈哈AAA','A', 5)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', -4)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', -3)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', -2)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', -1)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', 0)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', 1)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', 2)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', 3)")
+    testFoldConst("SELECT split_part('哈哈哈AA+','A', 4)")
+    
+    // starts_with
+    testFoldConst("select starts_with('hello world','hello')")
+    testFoldConst("select starts_with('hello world',null)")
+    testFoldConst("select starts_with('hello world','world')")
+    testFoldConst("select starts_with(' hello world','world')")
+    testFoldConst("select starts_with('上海天津北京杭州','上海')")
+    testFoldConst("select starts_with('上海天津北京杭州','北京')")
+    
+    // strcmp
     testFoldConst("select strcmp('a', 'abc')")
     testFoldConst("select strcmp('abc', 'abc')")
+    testFoldConst("select strcmp('abc', 'abc')")
+    testFoldConst("select strcmp('abc', 'abd')")
     testFoldConst("select strcmp('abcd', 'abc')")
+    testFoldConst("select strcmp('abc', NULL)")
+    testFoldConst("select strcmp(CAST('a' AS STRING), CAST('abc' AS STRING))")
+    testFoldConst("select strcmp(cast('abc' as string), cast('abc' as string))")
+    testFoldConst("select strcmp(CAST('abc' AS STRING), CAST('abc' AS STRING))")
+    testFoldConst("select strcmp(cast('abc' as string), cast('abd' as string))")
+    testFoldConst("select strcmp(cast('abc' as string), NULL)")
+    testFoldConst("select strcmp(CAST('abcd' AS STRING), CAST('abc' AS STRING))")
+    
+    // strleft
+    testFoldConst("select strleft('good morning', 120)")
+    testFoldConst("select strleft('good morning', -5)")
+    testFoldConst("select strleft('good morning', NULL)")
+    testFoldConst("select strleft('Hello doris', 5)")
+    testFoldConst("select strleft('Hello World', 5)")
+    testFoldConst("select strleft(' Hello World', 5)")
+    testFoldConst("select strleft('Hello World ', 50)")
+    testFoldConst("select strleft(NULL, 1)")
+    
+    // strright
+    testFoldConst("select strright('good morning', NULL)")
+    testFoldConst("select strright('Hello doris', 120)")
+    testFoldConst("select strright('Hello doris', -5)")
+    testFoldConst("select strright('Hello doris', 5)")
+    testFoldConst("select strright('Hello World', 5)")
+    testFoldConst("select strright(' Hello World', 5)")
+    testFoldConst("select strright('Hello World  ', 5)")
+    testFoldConst("select strright(NULL, 1)")
+    
+    // sub_replace
+    testFoldConst("select sub_replace(CAST('doris' AS STRING), CAST('***' AS STRING), 1, 2)")
+    testFoldConst("select sub_replace(CAST('doris' AS STRING), CAST('***' AS STRING), 1, 2)")
+    testFoldConst("select sub_replace(CAST('this is origin str' AS STRING), CAST('NEW-STR' AS STRING), 1)")
+    testFoldConst("select sub_replace(CAST('this is origin str' AS STRING), CAST('NEW-STR' AS STRING), 1)")
+    testFoldConst("select sub_replace('doris','***',1,2)")
+    testFoldConst("select sub_replace('doris','***',1,2)")
+    testFoldConst("select sub_replace('this is origin str','NEW-STR',1)")
+    testFoldConst("select sub_replace('this is origin str','NEW-STR',1)")
+    testFoldConst("select sub_replace(CAST('doris' AS STRING), CAST('***' AS STRING), -1, 2)")
+    testFoldConst("select sub_replace('上海天津北京杭州', '天津', 3, 4)")
+    testFoldConst("select sub_replace('上海天津北京杭州', '天津', 30, 4)")
+    
+    // substr
+    testFoldConst("select substr('a',0,1)")
+    testFoldConst("select substr('a',-1,1)")
+    testFoldConst("select substr('a',1,1)")
+    testFoldConst("select substr('a',-2,1)")
+    testFoldConst("select substr('a',2,1)")
+    testFoldConst("select substr('a',-3,1)")
+    testFoldConst("select substr('a',3,1)")
+    testFoldConst("select substr('abcdef',-3,-1)")
+    testFoldConst("select substr('abcdef',3,-1)")
+    testFoldConst("select substr('',3,-1)")
+    testFoldConst("select substr('abcdef',3,10)")
 
-    testFoldConst("SELECT Concat(cast('Hello' as string), cast(' ' as string), cast('World' as string))")
-    testFoldConst("SELECT Substring(cast('Hello World' as string), 1, 5)")
-    testFoldConst("SELECT Substring(cast('1' as string), 1, 1)")
-    testFoldConst("SELECT 100, cast('abc' as string), Substring(cast('abc' as string), 1, 2), Substring(Substring(cast('abcdefg' as string), 4, 3), 1, 2), null")
-    testFoldConst("SELECT Length(cast('Hello World' as string))")
-    testFoldConst("SELECT Lower(cast('Hello World' as string))")
-    testFoldConst("SELECT Upper(cast('Hello World' as string))")
-    testFoldConst("SELECT Trim(cast('  Hello World  ' as string))")
-    testFoldConst("SELECT Trim(cast('11111' as string), cast(11 as string))")
-    testFoldConst("SELECT Ltrim(cast('  Hello World  ' as string))")
-    testFoldConst("SELECT LTrim(cast(' 11111' as string), cast(11 as string))")
-    testFoldConst("SELECT LTrim(cast('11111 ' as string), cast(11 as string))")
-    testFoldConst("SELECT Rtrim(cast('  Hello World  ' as string))")
-    testFoldConst("SELECT RTrim(cast('11111 ' as string), cast(11 as string))")
-    testFoldConst("SELECT RTrim(cast(' 11111' as string), cast(11 as string))")
-    testFoldConst("SELECT Replace(cast('Hello World' as string), cast('World' as string), cast('Everyone' as string))")
-    testFoldConst("SELECT Left(cast('Hello World' as string), 5)")
-    testFoldConst("SELECT Right(cast('Hello World' as string), 5)")
-    testFoldConst("SELECT Locate(cast('World' as string), cast('Hello World' as string))")
-    testFoldConst("SELECT Instr(cast('Hello World' as string), cast('World' as string))")
-    testFoldConst("SELECT Ascii(cast('A' as string))")
-    testFoldConst("SELECT Bin(5)")
-    testFoldConst("SELECT Hex(255)")
-    testFoldConst("SELECT Unhex(cast('FF' as string))")
-//    testFoldConst("SELECT Concat_Ws(cast('-' as string), cast('2024' as string), cast('09' as string), cast('02' as string))")
-    testFoldConst("SELECT Char(65)")
-    testFoldConst("SELECT Character_Length(cast('Hello World' as string))")
-    testFoldConst("SELECT Initcap(cast('hello world' as string))")
-    testFoldConst("SELECT Md5(cast('Hello World' as string))")
-//    testFoldConst("SELECT Md5Sum(cast('Hello World' as string))")
-// testFoldConst("SELECT JsonExtract(cast('{\"key\": \"value\"}' as string), cast('$.key' as string))")
-// testFoldConst("SELECT JsonbExtractString(cast('{\"key\": \"value\"}' as string), cast('$.key' as string))")
-// testFoldConst("SELECT JsonContains(cast('{\"key\": \"value\"}' as string), cast('\"key\"' as string))")
-// testFoldConst("SELECT JsonLength(cast('{\"key1\": \"value1\", \"key2\": \"value2\"}' as string))")
-// testFoldConst("SELECT JsonObject(cast('key' as string), cast('value' as string))")
-// testFoldConst("SELECT JsonArray(cast('value1' as string), cast('value2' as string))")
-// testFoldConst("SELECT JsonKeys(cast('{\"key1\": \"value1\", \"key2\": \"value2\"}' as string))")
-// testFoldConst("SELECT JsonInsert(cast('{\"key1\": \"value1\"}' as string), cast('$.key2' as string), cast('value2' as string))")
-// testFoldConst("SELECT JsonReplace(cast('{\"key1\": \"value1\"}' as string), cast('$.key1' as string), cast('new_value' as string))")
-// testFoldConst("SELECT JsonSet(cast('{\"key1\": \"value1\"}' as string), cast('$.key2' as string), cast('value2' as string))")
-// testFoldConst("SELECT Json_Quote(cast('Hello World' as string))")
-// testFoldConst("SELECT Json_UnQuote(cast('\"Hello World\"' as string))")
-//    testFoldConst("SELECT Field(cast('b' as string), cast('a' as string), cast('b' as string), cast('c' as string))")
-    testFoldConst("SELECT Find_In_Set(cast('b' as string), cast('a,b,c' as string))")
-    testFoldConst("SELECT Repeat(cast('Hello' as string), 3)")
-    testFoldConst("SELECT Reverse(cast('Hello' as string))")
-    testFoldConst("SELECT length(Space(10))")
-// testFoldConst("SELECT Split_By_Char(cast('a,b,c' as string), cast(',' as string))")  has bug in be execution
-    testFoldConst("SELECT Split_By_String(cast('a::b::c' as string), cast('::' as string))")
-    testFoldConst("SELECT Split_Part(cast('a,b,c' as string), cast(',' as string), 2)")
-    testFoldConst("SELECT Substring_Index(cast('a,b,c' as string), cast(',' as string), 2)")
-    testFoldConst("SELECT Strcmp(cast('abc' as string), cast('abd' as string))")
-    testFoldConst("SELECT StrLeft(cast('Hello World' as string), 5)")
-    testFoldConst("SELECT StrRight(cast('Hello World' as string), 5)")
-//    testFoldConst("SELECT Overlay(cast('abcdef' as string), cast('123' as string), 3, 2)")
-    testFoldConst("SELECT Parse_Url(cast('http://www.example.com/path?query=abc' as string), cast('HOST' as string))")
-//    testFoldConst("SELECT Url_Decode(cast('%20Hello%20World%20' as string))")
-    testFoldConst("SELECT Url_Decode(cast('+Hello+World+' as string))")
-    testFoldConst("SELECT Url_Encode(cast(' Hello World ' as string))")
+    // substring
+    testFoldConst("select substring('1', 1, 1)")
+    testFoldConst("select substring('abc1', -2)")
+    testFoldConst("select substring('abc1', 2)")
+    testFoldConst("select substring('abc1', 5)")
+    testFoldConst("select substring('abc1def', 2, 2)")
+    testFoldConst("select substring('abcdef',10,1)")
+    testFoldConst("select substring('abcdef',-3,-1)")
+    testFoldConst("select substring('abcdef',3,-1)")
+    testFoldConst("select substring(cast('1' as string), 1, 1)")
+    testFoldConst("select substring(CAST('abc1' AS STRING), -2)")
+    testFoldConst("select substring(CAST('abc1' AS STRING), 2)")
+    testFoldConst("select substring(CAST('abc1' AS STRING), 5)")
+    testFoldConst("select substring(CAST('abc1def' AS STRING), 2, 2)")
+    testFoldConst("select substring(CAST('abcdef' AS STRING), 10, 1)")
+    testFoldConst("select substring(CAST('abcdef' AS STRING), -3, -1)")
+    testFoldConst("select substring(CAST('abcdef' AS STRING), 3, -1)")
+    testFoldConst("select substring(cast('Hello' as string), 1, 10)")
+    testFoldConst("select substring(cast('Hello World' as string), -1, 5)")
+    testFoldConst("select substring(cast('Hello World' as string), 1, 5)")
+    testFoldConst("select substring('Hello', 1, 10)")
+    testFoldConst("select substring('Hello World', -1, 5)")
+    testFoldConst("select substring('Hello World', 1, 5)")
+    testFoldConst("select substring('', 1, 5)")
+    testFoldConst("select substring('Hello World', 1, 50)")
 
-// Substring with negative start index
-// Expected behavior: Depending on the SQL engine, might return an empty string or error.
-    testFoldConst("SELECT Substring(cast('Hello World' as string), -1, 5)")
+    // substring_index
+    testFoldConst("select substring_index('a,b,c', ',', 2)")
+    testFoldConst("select substring_index('a,b,c', '', 2)")
+    testFoldConst("select substring_index(cast('a,b,c' as string), cast(',' as string), 2)")
+    testFoldConst("select substring_index(CAST('hello world' AS STRING), CAST(' ' AS STRING), -1)")
+    testFoldConst("select substring_index(CAST('hello world' AS STRING), CAST(' ' AS STRING), 1)")
+    testFoldConst("select substring_index(CAST('hello world' AS STRING), CAST(' ' AS STRING), -2)")
+    testFoldConst("select substring_index(CAST('hello world' AS STRING), CAST(' ' AS STRING), 2)")
+    testFoldConst("select substring_index(CAST('hello world' AS STRING), CAST(' ' AS STRING), -3)")
+    testFoldConst("select substring_index(CAST('hello world' AS STRING), CAST(' ' AS STRING), 3)")
+    testFoldConst("select substring_index(CAST(NULL AS STRING), CAST('__' AS STRING), 1)")
+    testFoldConst("select substring_index(CAST('prefix_string2' AS STRING), CAST('__' AS STRING), 1)")
+    testFoldConst("select substring_index(CAST('prefix__string2' AS STRING), CAST('_' AS STRING), 2)")
+    testFoldConst("select substring_index(CAST('prefix__string2' AS STRING), CAST('__' AS STRING), 2)")
+    testFoldConst("select substring_index(CAST('prefix_string' AS STRING), CAST('__' AS STRING), -1)")
+    testFoldConst("select substring_index(CAST('prefix_string' AS STRING), CAST('_' AS STRING), NULL)")
+    testFoldConst("select substring_index(CAST('prefix_string' AS STRING), CAST(NULL AS STRING), 1)")
+    testFoldConst("select substring_index('hello world', ' ', -1)")
+    testFoldConst("select substring_index('hello world', ' ', 1)")
+    testFoldConst("select substring_index('hello world', ' ', -2)")
+    testFoldConst("select substring_index('hello world', ' ', 2)")
+    testFoldConst("select substring_index('hello world', ' ', -3)")
+    testFoldConst("select substring_index('hello world', ' ', 3)")
+    testFoldConst("select substring_index(null, '__', 1)")
+    testFoldConst("select substring_index('prefix_string', '__', -1)")
+    testFoldConst("select substring_index('prefix_string2', '__', 1)")
+    testFoldConst("select substring_index('prefix__string2', '_', 2)")
+    testFoldConst("select substring_index('prefix__string2', '__', 2)")
+    testFoldConst("select substring_index('prefix_string', '_', null)")
+    testFoldConst("select substring_index('prefix_string', null, 1)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', -5)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', -4)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', -3)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', -2)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', -1)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', 0)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', 1)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', 2)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', 3)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', 4)")
+    testFoldConst("SELECT substring_index('哈哈哈AAA','A', 5)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', -4)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', -3)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', -2)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', -1)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', 0)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', 1)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', 2)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', 3)")
+    testFoldConst("SELECT substring_index('哈哈哈AA+','A', 4)")
 
-// Substring with length exceeding the string length
-// Expected behavior: Return 'Hello' as the length exceeds the string length.
-    testFoldConst("SELECT Substring(cast('Hello' as string), 1, 10)")
+    // trim
+    testFoldConst("select trim('11111', 11)")
+    testFoldConst("select trim(cast('11111' as string), cast(11 as string))")
+    testFoldConst("select trim(cast('  Hello World  ' as string))")
+    testFoldConst("select trim('  Hello World  ')")
 
-// Left with length greater than string length
-// Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Left(cast('Hello' as string), 10)")
+    // unhex
+    testFoldConst("select unhex('')")
+    testFoldConst("select unhex('@')")
+    testFoldConst("select unhex('41')")
+    testFoldConst("select unhex('4142')")
+    testFoldConst("select unhex('68656C6C6F2C646F726973')")
+    testFoldConst("select unhex(cast('4142' as string))")
+    testFoldConst("select unhex(cast('41' as string))")
+    testFoldConst("select unhex(cast('68656C6C6F2C646F726973' as string))")
+    testFoldConst("select unhex(cast('' as string))")
+    testFoldConst("select unhex(cast('@' as string))")
+    testFoldConst("select unhex(cast('FF' as string))")
+    testFoldConst("select unhex(cast('GHIJ' as string))")
+    testFoldConst("select unhex('FF')")
+    testFoldConst("select unhex('GHIJ')")
+    testFoldConst("select unhex(NULL)")
+    testFoldConst("select unhex(NULL)")
+    testFoldConst("select upper(cast('Hello World' as string))")
+    testFoldConst("select upper('Hello World')")
 
-// Right with length greater than string length
-// Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Right(cast('Hello' as string), 10)")
-
-// SplitPart with part number greater than the number of parts
-// Expected behavior: Return an empty string or error.
-    testFoldConst("SELECT Split_Part(cast('a,b,c' as string), cast(',' as string), 5)")
-
-// SplitPart with negative part number
-// Expected behavior: Return an empty string or error.
-    testFoldConst("SELECT Split_Part(cast('a,b,c' as string), cast(',' as string), -1)")
-
-// Locate with the substring not present
-// Expected behavior: Return 0 as 'World' is not found.
-    testFoldConst("SELECT Locate(cast('World' as string), cast('Hello' as string))")
-
-// Instr with the substring not present
-// Expected behavior: Return 0 as 'World' is not found.
-    testFoldConst("SELECT Instr(cast('Hello' as string), cast('World' as string))")
-
-// Replace with an empty search string
-// Expected behavior: Some SQL engines may treat this as a no-op, others might throw an error.
-    testFoldConst("SELECT Replace(cast('Hello World' as string), '', cast('Everyone' as string))")
-
-// Replace with an empty replacement string
-// Expected behavior: Return 'Hello '.
-    testFoldConst("SELECT Replace(cast('Hello World' as string), cast('World' as string), '')")
-
-// Concat with NULL values
-// Expected behavior: Depending on the SQL engine, may return 'HelloWorld' or NULL.
-    testFoldConst("SELECT Concat(cast('Hello' as string), NULL, cast('World' as string))")
-
-// Ltrim with a string that has no leading spaces
-// Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Ltrim(cast('Hello' as string))")
-
-// Rtrim with a string that has no trailing spaces
-// Expected behavior: Return 'Hello'.
-    testFoldConst("SELECT Rtrim(cast('Hello' as string))")
-
-// Testing JSON Length function with a non-JSON string
-    testFoldConst("SELECT Json_Length(cast('Hello World' as string))")
-
-// Field with a value not present in the list
-//    testFoldConst("SELECT Field(cast('d' as string), cast('a' as string), cast('b' as string), cast('c' as string))")
-
-// FindInSet with a value not present in the set
-    testFoldConst("SELECT Find_In_Set(cast('d' as string), cast('a,b,c' as string))")
-
-// Repeat with a negative repeat count
-    testFoldConst("SELECT Repeat(cast('Hello' as string), -3)")
-
-// Space with a negative number of spaces
-    testFoldConst("SELECT Space(-5)")
-
-// SplitByChar with a delimiter not present in the string
-//    testFoldConst("SELECT Split_By_Char(cast('abc' as string), cast(',' as string))")
-
-// SplitByString with a delimiter not present in the string
-    testFoldConst("SELECT Split_By_String(cast('abc' as string), cast('::' as string))")
-
-// Strcmp with two identical strings
-    testFoldConst("SELECT Strcmp(cast('abc' as string), cast('abc' as string))")
-
-// Strcmp with a null string
-    testFoldConst("SELECT Strcmp(cast('abc' as string), NULL)")
-
-// Hex with a negative number
-    testFoldConst("SELECT Hex(-255)")
-
-// Unhex with an invalid hexadecimal string
-    testFoldConst("SELECT Unhex(cast('GHIJ' as string))")
-
-// UrlDecode with an invalid percent-encoded string
-    // testFoldConst("SELECT Url_Decode(cast('%ZZHello%20World' as string))")
-
-// Additional function tests
-    testFoldConst("SELECT Elt(0, cast('hello' as string), cast('doris' as string))")
-    testFoldConst("SELECT Elt(1, cast('hello' as string), cast('doris' as string))")
-    testFoldConst("SELECT Elt(2, cast('hello' as string), cast('doris' as string))")
-    testFoldConst("SELECT Elt(3, cast('hello' as string), cast('doris' as string))")
-    testFoldConst("SELECT Append_Trailing_Char_If_Absent(cast('a' as string), cast('c' as string))")
-    testFoldConst("SELECT Append_Trailing_Char_If_Absent(cast('ac' as string), cast('c' as string))")
-    testFoldConst("SELECT Ascii(cast('1' as string))")
-    testFoldConst("SELECT Ascii(cast('a' as string))")
-    testFoldConst("SELECT Ascii(cast('A' as string))")
-    testFoldConst("SELECT Ascii(cast('!' as string))")
-    testFoldConst("SELECT Bit_Length(cast('abc' as string))")
-    testFoldConst("SELECT Char_Length(cast('abc' as string))")
-    testFoldConst("SELECT Concat(cast('a' as string), cast('b' as string))")
-    testFoldConst("SELECT Concat(cast('a' as string), cast('b' as string), cast('c' as string))")
-    testFoldConst("SELECT Concat(cast('a' as string), NULL, cast('c' as string))")
-//    testFoldConst("SELECT Concat_Ws(cast('or' as string), cast('d' as string), cast('is' as string))")
-//    testFoldConst("SELECT Concat_Ws(NULL, cast('d' as string), cast('is' as string))")
-//    testFoldConst("SELECT Concat_Ws(cast('or' as string), cast('d' as string), NULL, cast('is' as string))")
-//    testFoldConst("SELECT Concat_Ws(cast('or' as string), cast('d' as string), cast('' as string), cast('is' as string))")
-    testFoldConst("SELECT Ends_With(cast('Hello doris' as string), cast('doris' as string))")
-    testFoldConst("SELECT Ends_With(cast('Hello doris' as string), cast('Hello' as string))")
-    testFoldConst("SELECT Find_In_Set(cast('b' as string), cast('a,b,c' as string))")
-    testFoldConst("SELECT Find_In_Set(cast('d' as string), cast('a,b,c' as string))")
-    testFoldConst("SELECT Find_In_Set(NULL, cast('a,b,c' as string))")
-    testFoldConst("SELECT Find_In_Set(cast('a' as string), NULL)")
-    testFoldConst("SELECT Hex(cast('1' as string))")
-    testFoldConst("SELECT Hex(cast('12' as string))")
-    testFoldConst("SELECT Hex(cast('@' as string))")
-    testFoldConst("SELECT Hex(cast('A' as string))")
-    testFoldConst("SELECT Hex(12)")
-    testFoldConst("SELECT Hex(-1)")
-    testFoldConst("SELECT Hex(cast('hello,doris' as string))")
-    testFoldConst("SELECT Unhex(cast('@' as string))")
-    testFoldConst("SELECT Unhex(cast('68656C6C6F2C646F726973' as string))")
-    testFoldConst("SELECT Unhex(cast('41' as string))")
-    testFoldConst("SELECT Unhex(cast('4142' as string))")
-    testFoldConst("SELECT Unhex(cast('' as string))")
-    testFoldConst("SELECT Unhex(NULL)")
-    testFoldConst("SELECT Instr(cast('abc' as string), cast('b' as string))")
-    testFoldConst("SELECT Instr(cast('abc' as string), cast('d' as string))")
-    testFoldConst("SELECT Instr(cast('abc' as string), NULL)")
-    testFoldConst("SELECT Instr(NULL, cast('a' as string))")
-    testFoldConst("SELECT Lcase(cast('AbC123' as string))")
-    testFoldConst("SELECT Lower(cast('AbC123' as string))")
-    testFoldConst("SELECT Initcap(cast('AbC123abc abc.abc,?|abc' as string))")
-    testFoldConst("SELECT Left(cast('Hello doris' as string), 5)")
-    testFoldConst("SELECT Right(cast('Hello doris' as string), 5)")
-    testFoldConst("SELECT Length(cast('abc' as string))")
-    testFoldConst("SELECT LOCATE(cast('bar' as string), cast('foobarbar' as string))")
-    testFoldConst("SELECT LOCATE(cast('xbar' as string), cast('foobar' as string))")
-    testFoldConst("SELECT LOCATE(cast('' as string), cast('foobar' as string))")
-    testFoldConst("SELECT LOCATE(cast('北京' as string), cast('上海天津北京杭州' as string))")
-    testFoldConst("SELECT Lpad(cast('hi' as string), 5, cast('xy' as string))")
-    testFoldConst("SELECT Lpad(cast('hi' as string), 1, cast('xy' as string))")
-    testFoldConst("SELECT Rpad(cast('hi' as string), 5, cast('xy' as string))")
-    testFoldConst("SELECT Rpad(cast('hi' as string), 1, cast('xy' as string))")
-    testFoldConst("SELECT Ltrim(cast('   ab d' as string))")
-    testFoldConst("SELECT Money_Format(17014116)")
-    testFoldConst("SELECT Money_Format(1123.456)")
-    testFoldConst("SELECT Money_Format(1123.4)")
-    testFoldConst("SELECT Money_Format(Truncate(1000,10))")
-    testFoldConst("SELECT Null_Or_Empty(NULL)")
-    testFoldConst("SELECT Null_Or_Empty(cast('' as string))")
-    testFoldConst("SELECT Null_Or_Empty(cast('a' as string))")
-    testFoldConst("SELECT Not_Null_Or_Empty(NULL)")
-    testFoldConst("SELECT Not_Null_Or_Empty(cast('' as string))")
-    testFoldConst("SELECT Not_Null_Or_Empty(cast('a' as string))")
-    testFoldConst("SELECT Repeat(cast('a' as string), 3)")
-    testFoldConst("SELECT Repeat(cast('a' as string), -1)")
-    testFoldConst("SELECT Repeat(cast('a' as string), 0)")
-    testFoldConst("SELECT Repeat(NULL, 1)")
-    testFoldConst("SELECT Replace(cast('https://doris.apache.org:9090' as string), cast(':9090' as string), cast('' as string))")
-    testFoldConst("SELECT Replace(cast('https://doris.apache.org:9090' as string), cast('' as string), cast('new_str' as string))")
-    testFoldConst("SELECT REVERSE(cast('hello' as string))")
-    testFoldConst("SELECT Split_Part(cast('hello world' as string), cast(' ' as string), 1)")
-    testFoldConst("SELECT Split_Part(cast('hello world' as string), cast(' ' as string), 2)")
-    testFoldConst("SELECT Split_Part(cast('hello world' as string), cast(' ' as string), 3)")
-    testFoldConst("SELECT Concat(CAST('Hello' AS STRING), CAST(' ' AS STRING), CAST('World' AS STRING))")
-    testFoldConst("SELECT Concat(CAST('Hello' AS STRING), CAST(NULL AS STRING))")
-    testFoldConst("SELECT Concat(CAST(NULL AS STRING), CAST('World' AS STRING))")
-
-    testFoldConst("SELECT Starts_With(CAST('hello world' AS STRING), CAST('hello' AS STRING))")
-    testFoldConst("SELECT Starts_With(CAST('hello world' AS STRING), CAST('world' AS STRING))")
-    testFoldConst("SELECT Starts_With(CAST('hello world' AS STRING), CAST(NULL AS STRING))")
-
-    testFoldConst("SELECT StrLeft(CAST(NULL AS STRING), 1)")
-    testFoldConst("SELECT StrLeft(CAST('good morning' AS STRING), NULL)")
-    testFoldConst("SELECT Left(CAST(NULL AS STRING), 1)")
-    testFoldConst("SELECT Left(CAST('good morning' AS STRING), NULL)")
-    testFoldConst("SELECT StrLeft(CAST('Hello doris' AS STRING), 5)")
-    testFoldConst("SELECT Left(CAST('Hello doris' AS STRING), 5)")
-    testFoldConst("SELECT StrRight(CAST(NULL AS STRING), 1)")
-    testFoldConst("SELECT StrRight(CAST('good morning' AS STRING), NULL)")
-    testFoldConst("SELECT Right(CAST(NULL AS STRING), 1)")
-    testFoldConst("SELECT Right(CAST('good morning' AS STRING), NULL)")
-    testFoldConst("SELECT StrRight(CAST('Hello doris' AS STRING), 5)")
-    testFoldConst("SELECT Right(CAST('Hello doris' AS STRING), 5)")
-    testFoldConst("SELECT StrLeft(CAST('good morning' AS STRING), 120)")
-    testFoldConst("SELECT StrLeft(CAST('good morning' AS STRING), -5)")
-    testFoldConst("SELECT StrRight(CAST('Hello doris' AS STRING), 120)")
-    testFoldConst("SELECT StrRight(CAST('Hello doris' AS STRING), -5)")
-    testFoldConst("SELECT Left(CAST('good morning' AS STRING), 120)")
-    testFoldConst("SELECT Left(CAST('good morning' AS STRING), -5)")
-    testFoldConst("SELECT Right(CAST('Hello doris' AS STRING), 120)")
-    testFoldConst("SELECT Right(CAST('Hello doris' AS STRING), -6)")
-
-    testFoldConst("SELECT Substring(CAST('abc1' AS STRING), 2)")
-    testFoldConst("SELECT Substring(CAST('abc1' AS STRING), -2)")
-    testFoldConst("SELECT Substring(CAST('abc1' AS STRING), 5)")
-    testFoldConst("SELECT Substring(CAST('abc1def' AS STRING), 2, 2)")
-    testFoldConst("SELECT Substring(CAST('abcdef' AS STRING), 3, -1)")
-    testFoldConst("SELECT Substring(CAST('abcdef' AS STRING), -3, -1)")
-    testFoldConst("SELECT Substring(CAST('abcdef' AS STRING), 10, 1)")
-
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), 3, 1)")
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), 2, 1)")
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), 1, 1)")
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), 0, 1)")
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), -1, 1)")
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), -2, 1)")
-    testFoldConst("SELECT Substr(CAST('a' AS STRING), -3, 1)")
-    testFoldConst("SELECT Substr(CAST('abcdef' AS STRING), 3, -1)")
-    testFoldConst("SELECT Substr(CAST('abcdef' AS STRING), -3, -1)")
-
-    testFoldConst("SELECT Sub_Replace(CAST('this is origin str' AS STRING), CAST('NEW-STR' AS STRING), 1)")
-    testFoldConst("SELECT Sub_Replace(CAST('doris' AS STRING), CAST('***' AS STRING), 1, 2)")
-
-    testFoldConst("SELECT Substring_Index(CAST('hello world' AS STRING), CAST(' ' AS STRING), 1)")
-    testFoldConst("SELECT Substring_Index(CAST('hello world' AS STRING), CAST(' ' AS STRING), 2)")
-    testFoldConst("SELECT Substring_Index(CAST('hello world' AS STRING), CAST(' ' AS STRING), 3)")
-    testFoldConst("SELECT Substring_Index(CAST('hello world' AS STRING), CAST(' ' AS STRING), -1)")
-    testFoldConst("SELECT Substring_Index(CAST('hello world' AS STRING), CAST(' ' AS STRING), -2)")
-    testFoldConst("SELECT Substring_Index(CAST('hello world' AS STRING), CAST(' ' AS STRING), -3)")
-    testFoldConst("SELECT Substring_Index(CAST('prefix__string2' AS STRING), CAST('__' AS STRING), 2)")
-    testFoldConst("SELECT Substring_Index(CAST('prefix__string2' AS STRING), CAST('_' AS STRING), 2)")
-    testFoldConst("SELECT Substring_Index(CAST('prefix_string2' AS STRING), CAST('__' AS STRING), 1)")
-    testFoldConst("SELECT Substring_Index(CAST(NULL AS STRING), CAST('__' AS STRING), 1)")
-    testFoldConst("SELECT Substring_Index(CAST('prefix_string' AS STRING), CAST(NULL AS STRING), 1)")
-    testFoldConst("SELECT Substring_Index(CAST('prefix_string' AS STRING), CAST('_' AS STRING), NULL)")
-    testFoldConst("SELECT Substring_Index(CAST('prefix_string' AS STRING), CAST('__' AS STRING), -1)")
-
-    testFoldConst("SELECT Elt(0, CAST('hello' AS STRING), CAST('doris' AS STRING))")
-    testFoldConst("SELECT Elt(1, CAST('hello' AS STRING), CAST('doris' AS STRING))")
-    testFoldConst("SELECT Elt(2, CAST('hello' AS STRING), CAST('doris' AS STRING))")
-    testFoldConst("SELECT Elt(3, CAST('hello' AS STRING), CAST('doris' AS STRING))")
-
-    testFoldConst("SELECT Sub_Replace(CAST('this is origin str' AS STRING), CAST('NEW-STR' AS STRING), 1)")
-    testFoldConst("SELECT Sub_Replace(CAST('doris' AS STRING), CAST('***' AS STRING), 1, 2)")
-
-    testFoldConst("SELECT StrCmp(CAST('a' AS STRING), CAST('abc' AS STRING))")
-    testFoldConst("SELECT StrCmp(CAST('abc' AS STRING), CAST('abc' AS STRING))")
-    testFoldConst("SELECT StrCmp(CAST('abcd' AS STRING), CAST('abc' AS STRING))")
-
-    // fix problem of cast date and time function exception
-    testFoldConst("select ifnull(date_format(CONCAT_WS('', '9999-07', '-00'), '%Y-%m'),3)")
+    // url_decode url_encode
+    testFoldConst("select url_decode(cast('http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0' as string))")
+    testFoldConst("select url_decode('http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-2.0')")
+    testFoldConst("select url_decode('http%3A%2F%2Fwww.apache.org%2Flicenses%2FLICENSE-22.0')")
+    testFoldConst("select url_encode('http://www.apache.org/licenses/LICENSE-2.0')")
+    testFoldConst("select url_encode(' http://www.apache.org/licenses/LICENSE-2.0 ')")
 
 }


### PR DESCRIPTION
pick: #45233 

Issue Number: #44666
Related PR: #40441

Problem Summary:
- select substring_index('哈哈哈AAA','A', 1); String.split function has second parameter 'limit', which is default zero. When 'limit' is zero, it means it would remove trailing empty strings split of '哈哈哈AAA', which would be '哈哈哈' only. But what we expect is '哈哈哈', '','','' when part function is used by substring index. So we should change splitpart limit to -1 to enable trailing empty character in splitpart list
- reorganize fold constant of string functions in fe and add more cases

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

