### PR TITLE
[enhance](paimon) cache deletion vector in paimon native reader

### DIFF
--- a/be/src/util/deletion_vector.h
+++ b/be/src/util/deletion_vector.h
@@ -30,6 +30,9 @@ class DeletionVector {
 public:
     const static uint32_t MAGIC_NUMBER = 1581511376;
     DeletionVector(roaring::Roaring roaring_bitmap) : _roaring_bitmap(std::move(roaring_bitmap)) {};
+    DeletionVector(const DeletionVector& other) = default;
+    DeletionVector(DeletionVector&& other) noexcept
+            : _roaring_bitmap(std::move(other._roaring_bitmap)) {}
     ~DeletionVector() = default;
 
     bool checked_delete(uint32_t postition) { return _roaring_bitmap.addChecked(postition); }

--- a/be/src/vec/exec/format/table/paimon_reader.h
+++ b/be/src/vec/exec/format/table/paimon_reader.h
@@ -20,16 +20,18 @@
 #include <memory>
 #include <vector>
 
+#include "common/status.h"
 #include "vec/exec/format/orc/vorc_reader.h"
 #include "vec/exec/format/parquet/vparquet_reader.h"
 #include "vec/exec/format/table/table_format_reader.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
+class ShardedKVCache;
 class PaimonReader : public TableFormatReader {
 public:
     PaimonReader(std::unique_ptr<GenericReader> file_format_reader, RuntimeProfile* profile,
-                 const TFileScanRangeParams& params);
+                 const TFileScanRangeParams& params, ShardedKVCache* kv_cache);
     ~PaimonReader() override = default;
 
     Status init_row_filters(const TFileRangeDesc& range, io::IOContext* io_ctx) final;
@@ -46,14 +48,15 @@ protected:
 
 private:
     const TFileScanRangeParams& _params;
+    ShardedKVCache* _kv_cache;
 };
 
 class PaimonOrcReader final : public PaimonReader {
 public:
     ENABLE_FACTORY_CREATOR(PaimonOrcReader);
     PaimonOrcReader(std::unique_ptr<GenericReader> file_format_reader, RuntimeProfile* profile,
-                    const TFileScanRangeParams& params)
-            : PaimonReader(std::move(file_format_reader), profile, params) {};
+                    const TFileScanRangeParams& params, ShardedKVCache* kv_cache)
+            : PaimonReader(std::move(file_format_reader), profile, params, kv_cache) {};
     ~PaimonOrcReader() final = default;
 
     void set_delete_rows() override {
@@ -66,8 +69,8 @@ class PaimonParquetReader final : public PaimonReader {
 public:
     ENABLE_FACTORY_CREATOR(PaimonParquetReader);
     PaimonParquetReader(std::unique_ptr<GenericReader> file_format_reader, RuntimeProfile* profile,
-                        const TFileScanRangeParams& params)
-            : PaimonReader(std::move(file_format_reader), profile, params) {};
+                        const TFileScanRangeParams& params, ShardedKVCache* kv_cache)
+            : PaimonReader(std::move(file_format_reader), profile, params, kv_cache) {};
     ~PaimonParquetReader() final = default;
 
     void set_delete_rows() override {

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -1006,7 +1006,7 @@ Status VFileScanner::_get_next_reader() {
                         &_slot_id_to_filter_conjuncts);
                 std::unique_ptr<PaimonParquetReader> paimon_reader =
                         PaimonParquetReader::create_unique(std::move(parquet_reader), _profile,
-                                                           *_params);
+                                                           *_params, _kv_cache);
                 RETURN_IF_ERROR(paimon_reader->init_row_filters(range, _io_ctx.get()));
                 _cur_reader = std::move(paimon_reader);
             } else {
@@ -1068,8 +1068,8 @@ Status VFileScanner::_get_next_reader() {
                         &_file_col_names, _colname_to_value_range, _push_down_conjuncts, false,
                         _real_tuple_desc, _default_val_row_desc.get(),
                         &_not_single_slot_filter_conjuncts, &_slot_id_to_filter_conjuncts);
-                std::unique_ptr<PaimonOrcReader> paimon_reader =
-                        PaimonOrcReader::create_unique(std::move(orc_reader), _profile, *_params);
+                std::unique_ptr<PaimonOrcReader> paimon_reader = PaimonOrcReader::create_unique(
+                        std::move(orc_reader), _profile, *_params, _kv_cache);
                 RETURN_IF_ERROR(paimon_reader->init_row_filters(range, _io_ctx.get()));
                 _cur_reader = std::move(paimon_reader);
             } else {


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #18074 

Problem Summary:
1. FE will split the PaimonSplit into split. So a file can have several splits.
2. BE will scan each split, read the deletion vector of this file (if deletion file exists).
3. If 2 splits belongs to a same PaimonSplit, the deletion vector of this file will be read twice.

### Release note
Use ShardedKVCache to cache these deletion vectors, the kv cache is belong to a scan node, so all paimon native reader belong to this scan node will share same kv cache.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

