### PR TITLE
[fix](memory) Fix `RuntimeFilterContext.hybrid_set` destruction memory tracking

### DIFF
--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "runtime/thread_context.h"
 #include "vec/core/block.h"
 
 namespace doris {
@@ -49,6 +50,14 @@ struct RuntimeFilterContext {
     bool ignored = false;
     bool disabled = false;
     std::string err_msg;
+    QueryThreadContext query_thread_context;
+
+    RuntimeFilterContext() { query_thread_context.init_unlocked(); }
+
+    ~RuntimeFilterContext() {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_thread_context.query_mem_tracker);
+        hybrid_set.reset();
+    }
 };
 
 using RuntimeFilterContextSPtr = std::shared_ptr<RuntimeFilterContext>;


### PR DESCRIPTION
### What problem does this PR solve?

fixed:
```
*** tablet id: 0 ***
*** Aborted at 1736214814 (unix time) try "date -d @1736214814" if you are using GNU date ***
*** Current BE git commitID: 443e87e203 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 35200 (TID 36538 OR 0x7f0d731ed700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_release/doris/be/src/common/signal_handler.h:421
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/java/jdk1.8.0_351/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 2# JVM_handle_linux_signal in /usr/java/jdk1.8.0_351/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 3# signalHandler(int, siginfo*, void*) in /usr/java/jdk1.8.0_351/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 4# 0x00007F1120505400 in /lib64/libc.so.6
 5# Allocator<true, false, false, DefaultMemoryAllocator>::release_memory(unsigned long) const at /home/zcp/repo_center/doris_release/doris/be/src/vec/common/allocator.cpp:199
 6# doris::StringSet<doris::DynamicContainer<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::~StringSet() at /home/zcp/repo_center/doris_release/doris/be/src/exprs/hybrid_set.h:428
 7# doris::StringSet<doris::DynamicContainer<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::~StringSet() at /home/zcp/repo_center/doris_release/doris/be/src/exprs/hybrid_set.h:428
 8# doris::RuntimeFilterContext::~RuntimeFilterContext() at /home/zcp/repo_center/doris_release/doris/be/src/vec/runtime/shared_hash_table_controller.h:43
 9# std::_Sp_counted_ptr<doris::RuntimeFilterContext*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348
10# doris::SyncSizeClosure::~SyncSizeClosure() at /home/zcp/repo_center/doris_release/doris/be/src/exprs/runtime_filter.cpp:1036
11# brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) in /opt/module/be/lib/doris_be
12# brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*) in /opt/module/be/lib/doris_be
13# brpc::ProcessInputMessage(void*) in /opt/module/be/lib/doris_be
14# bthread::TaskGroup::task_runner(long) in /opt/module/be/lib/doris_be
15# bthread_make_fcontext in /opt/module/be/lib/doris_be
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

