### PR TITLE
 [fix][nereids] fix split count distinct for null can't join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SplitMultiDistinct.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SplitMultiDistinct.java
@@ -24,9 +24,9 @@ import org.apache.doris.nereids.rules.rewrite.SplitMultiDistinct.DistinctSplitCo
 import org.apache.doris.nereids.trees.copier.DeepCopierContext;
 import org.apache.doris.nereids.trees.copier.LogicalPlanDeepCopier;
 import org.apache.doris.nereids.trees.expressions.Alias;
-import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
@@ -273,7 +273,7 @@ public class SplitMultiDistinct extends DefaultPlanRewriter<DistinctSplitContext
             List<Slot> rightSlots = newAggs.get(1).getOutput();
             List<Expression> hashConditions = new ArrayList<>();
             for (int i = 0; i < len; ++i) {
-                hashConditions.add(new EqualTo(leftSlots.get(i), rightSlots.get(i)));
+                hashConditions.add(new NullSafeEqual(leftSlots.get(i), rightSlots.get(i)));
             }
             join = new LogicalJoin<>(JoinType.INNER_JOIN, hashConditions, newAggs.get(0), newAggs.get(1), null);
             for (int j = 2; j < newAggs.size(); ++j) {
@@ -281,7 +281,7 @@ public class SplitMultiDistinct extends DefaultPlanRewriter<DistinctSplitContext
                 List<Slot> belowRightSlots = newAggs.get(j).getOutput();
                 List<Expression> aboveHashConditions = new ArrayList<>();
                 for (int i = 0; i < len; ++i) {
-                    aboveHashConditions.add(new EqualTo(belowJoinSlots.get(i), belowRightSlots.get(i)));
+                    aboveHashConditions.add(new NullSafeEqual(belowJoinSlots.get(i), belowRightSlots.get(i)));
                 }
                 join = new LogicalJoin<>(JoinType.INNER_JOIN, aboveHashConditions, join, newAggs.get(j), null);
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/SplitMultiDistinctTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/SplitMultiDistinctTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.MatchingUtils;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
@@ -180,6 +182,8 @@ public class SplitMultiDistinctTest extends TestWithFeService implements MemoPat
                                                                     physicalHashAggregate(
                                                                             physicalDistribute(
                                                                                     physicalHashAggregate(any()))))
+                                                    ).when(join ->
+                                                        join.getJoinType() == JoinType.INNER_JOIN && join.getHashJoinConjuncts().get(0) instanceof NullSafeEqual
                                                     )
                                             )
                                     )

--- a/regression-test/data/nereids_rules_p0/distinct_split/disitinct_split.out
+++ b/regression-test/data/nereids_rules_p0/distinct_split/disitinct_split.out
@@ -380,7 +380,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalOlapScan[test_distinct_multi]
 --PhysicalResultSink
-----hashJoin[INNER_JOIN] hashCondition=((.d = .d)) otherCondition=()
+----hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
 ------hashAgg[DISTINCT_LOCAL]
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
@@ -415,9 +415,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalOlapScan[test_distinct_multi]
 --PhysicalResultSink
-----hashJoin[INNER_JOIN] hashCondition=((.d = .d)) otherCondition=()
-------hashJoin[INNER_JOIN] hashCondition=((.d = .d)) otherCondition=()
---------hashJoin[INNER_JOIN] hashCondition=((.d = .d)) otherCondition=()
+----hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
+--------hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
 ----------hashAgg[DISTINCT_LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
@@ -463,7 +463,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalResultSink
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
---------hashJoin[INNER_JOIN] hashCondition=((.c = .c)) otherCondition=()
+--------hashJoin[INNER_JOIN] hashCondition=((.c <=> .c)) otherCondition=()
 ----------hashAgg[DISTINCT_LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
@@ -497,4 +497,7 @@ PhysicalResultSink
 ----hashAgg[LOCAL]
 ------PhysicalRepeat
 --------PhysicalOlapScan[test_distinct_multi]
+
+-- !null_hash --
+1	\N	0	0.0
 

--- a/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
+++ b/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
@@ -90,11 +90,6 @@ suite("distinct_split") {
     qt_111_five """select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e order by 1,2,3,4,5"""
     qt_111_three_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a) from test_distinct_multi group by c,a  order by 1,2,3"""
     qt_111_four_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a), count(distinct c) from test_distinct_multi group by e,a,b order by 1,2,3,4"""
-
-    def aa = sql """explain select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e,a,b,c,d order by 1,2,3,4,5"""
-
-    logger.info("=====null hash jon ==== : \n" + aa)
-
     qt_111_five_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e,a,b,c,d order by 1,2,3,4,5"""
     // sum has two dimensions: 1. Is there one or more projection columns (0 for one, 1 for more) 2. Is there a group by (0 for none, 1 for yes)
     qt_00_sum """select sum(distinct b) from test_distinct_multi"""

--- a/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
+++ b/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
@@ -90,8 +90,12 @@ suite("distinct_split") {
     qt_111_five """select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e order by 1,2,3,4,5"""
     qt_111_three_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a) from test_distinct_multi group by c,a  order by 1,2,3"""
     qt_111_four_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a), count(distinct c) from test_distinct_multi group by e,a,b order by 1,2,3,4"""
-    qt_111_five_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e,a,b,c,d order by 1,2,3,4,5"""
 
+    def aa = sql """explain select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e,a,b,c,d order by 1,2,3,4,5"""
+
+    logger.info("=====null hash jon ==== : \n" + aa)
+
+    qt_111_five_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e,a,b,c,d order by 1,2,3,4,5"""
     // sum has two dimensions: 1. Is there one or more projection columns (0 for one, 1 for more) 2. Is there a group by (0 for none, 1 for yes)
     qt_00_sum """select sum(distinct b) from test_distinct_multi"""
     qt_10_sum """select sum(distinct b), sum(distinct a) from test_distinct_multi"""
@@ -207,4 +211,9 @@ suite("distinct_split") {
         group by grouping sets((a,b),(c));"""
         exception "The query contains multi count distinct or sum distinct, each can't have multi columns"
     }
+
+    //----------------test null hash join ------------------------
+    sql "truncate table test_distinct_multi;"
+    sql "insert into test_distinct_multi values(1,null,null,null,'2024-12-08');"
+    qt_null_hash "SELECT a, b, count(distinct c,e), count(distinct concat(d,e))/count(distinct e) FROM test_distinct_multi where e = '2024-12-08' GROUP BY a, b;"
 }

--- a/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
+++ b/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
@@ -213,7 +213,8 @@ suite("distinct_split") {
     }
 
     //----------------test null hash join ------------------------
-    sql "truncate table test_distinct_multi;"
-    sql "insert into test_distinct_multi values(1,null,null,null,'2024-12-08');"
-    qt_null_hash "SELECT a, b, count(distinct c,e), count(distinct concat(d,e))/count(distinct e) FROM test_distinct_multi where e = '2024-12-08' GROUP BY a, b;"
+    sql "drop table if exists test_distinct_multi_null_hash;"
+    sql "create table test_distinct_multi_null_hash(a int, b int, c int, d varchar(10), e date) distributed by hash(a) properties('replication_num'='1');"
+    sql "insert into test_distinct_multi_null_hash values(1,null,null,null,'2024-12-08');"
+    qt_null_hash "SELECT a, b, count(distinct c,e), count(distinct concat(d,e))/count(distinct e) FROM test_distinct_multi_null_hash where e = '2024-12-08' GROUP BY a, b;"
 }

--- a/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
+++ b/regression-test/suites/nereids_rules_p0/distinct_split/disitinct_split.groovy
@@ -91,6 +91,7 @@ suite("distinct_split") {
     qt_111_three_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a) from test_distinct_multi group by c,a  order by 1,2,3"""
     qt_111_four_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a), count(distinct c) from test_distinct_multi group by e,a,b order by 1,2,3,4"""
     qt_111_five_gby_multi """select count(distinct a,b), count(distinct a,c) , count(distinct a,d), count(distinct c) , count(distinct a,b,c,d) from test_distinct_multi group by e,a,b,c,d order by 1,2,3,4,5"""
+
     // sum has two dimensions: 1. Is there one or more projection columns (0 for one, 1 for more) 2. Is there a group by (0 for none, 1 for yes)
     qt_00_sum """select sum(distinct b) from test_distinct_multi"""
     qt_10_sum """select sum(distinct b), sum(distinct a) from test_distinct_multi"""


### PR DESCRIPTION
### What problem does this PR solve?

related pr: #45209

If split cout distinct and group by are used, inner join will be used to link the results, but if the group by column has a null value, inner join will not be linked, so we use `NullSafeEqual` as the link condition

detail sedd regression test cases 


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

