### PR TITLE
[Fix]Fix metric use-after-free when drop workload group

### DIFF
--- a/be/src/runtime/workload_group/workload_group_metrics.cpp
+++ b/be/src/runtime/workload_group/workload_group_metrics.cpp
@@ -30,6 +30,15 @@ namespace doris {
 
 WorkloadGroupMetrics::~WorkloadGroupMetrics() {
     DorisMetrics::instance()->metric_registry()->deregister_entity(_entity);
+    // NOTE: it must manual release metric_ptr after deregresiter_entity,
+    // otherwise metric maybe visited by other thread before deregister_entity calls here.
+    _cpu_time_metric.reset();
+    _mem_used_bytes_metric.reset();
+    _local_scan_bytes_metric.reset();
+    _remote_scan_bytes_metric.reset();
+    for (const auto& [key, metric_ptr] : _local_scan_bytes_metric_map) {
+        metric_ptr.reset();
+    }
 }
 
 WorkloadGroupMetrics::WorkloadGroupMetrics(WorkloadGroup* wg) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When WorkloadGroupMetrics is destroying, metric_ptr must be released manually after calling deregresiter_entity.
otherwise metric_ptr maybe first released, then _entity can still be visited by other thread, then ```use-after-free``` happens.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

