### PR TITLE
[fix](set operator) Fix invalid access in set operator (#46528)

### DIFF
--- a/be/src/pipeline/exec/set_probe_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_probe_sink_operator.cpp
@@ -123,8 +123,8 @@ Status SetProbeSinkOperatorX<is_intersect>::sink(RuntimeState* state, vectorized
                                 process_hashtable_ctx(&local_state, probe_rows);
                         return process_hashtable_ctx.mark_data_in_hashtable(arg);
                     } else {
-                        LOG(FATAL) << "FATAL: uninited hash table";
-                        __builtin_unreachable();
+                        LOG(WARNING) << "Uninited hash table in Set Probe Sink Operator";
+                        return Status::OK();
                     }
                 },
                 *local_state._shared_state->hash_table_variants));
@@ -283,8 +283,7 @@ void SetProbeSinkOperatorX<is_intersect>::_refresh_hash_table(
                         arg.hash_table = std::move(tmp_hash_table);
                     }
                 } else {
-                    LOG(FATAL) << "FATAL: uninited hash table";
-                    __builtin_unreachable();
+                    LOG(WARNING) << "Uninited hash table in Set Probe Sink Operator";
                 }
             },
             *hash_table_variants);

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -613,7 +613,7 @@ public:
 
     /// init in setup_local_state
     std::unique_ptr<vectorized::SetHashTableVariants> hash_table_variants =
-            nullptr; // the real data HERE.
+            std::make_unique<vectorized::SetHashTableVariants>(); // the real data HERE.
     std::vector<bool> build_not_ignore_null;
 
     /// init in both upstream side.


### PR DESCRIPTION
Introduced by #45207.
For a query plan,
```
set sink operator -- -|
                                    |-> set source operator
set probe operator --|
```
If `set source operators` are finished (due to limit reached), all upstream operators could be finished and waken up at the same time. However, some states are initialized in `set sink operator`. So if `set probe operator` executes before `set sink operator` initialization, it will incur an invalid address access.

*** Query id: cebb723bbda64249-9ab8c9e7aa72c540 *** *** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1736092087 (unix time) try "date -d @1736092087" if you are using GNU date ***
*** Current BE git commitID: 26d68d778a ***
*** SIGSEGV address not mapped to object (@0xf8) received by PID 23579 (TID 26524 OR 0x7f84d4240640) from PID 248; stack trace: *** 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at
/home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so 2# JVM_handle_linux_signal in
/usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F88F4063520 in /lib/x86_64-linux-gnu/libc.so.6
4#
doris::pipeline::SetProbeSinkOperatorX::_finalize_probe(doris::pipeline::SetProbeSinkLocalState&) at
/home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/set_probe_sink_operator.cpp:183 5# doris::pipeline::SetProbeSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at
/home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/set_probe_sink_operator.cpp:99 6# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:383 7# doris::pipeline::TaskScheduler::_do_work(int) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:138 8# doris::ThreadPool::dispatch_thread() in
/mnt/hdd01/ci/master-deploy/be/lib/doris_be
9# doris::Thread::supervise_thread(void*) at
/home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:499 10# start_thread at ./nptl/pthread_create.c:442
11# 0x00007F88F4147850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

