### PR TITLE
[opt](nereids)prune unused column after push down common column from agg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -957,7 +957,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         // 1. generate slot reference for each group expression
         List<SlotReference> groupSlots = collectGroupBySlots(groupByExpressions, outputExpressions);
         ArrayList<Expr> execGroupingExpressions = groupByExpressions.stream()
-                .map(e -> ExpressionTranslator.translate(e, context))
+                .map(e -> {
+                    Expr result = ExpressionTranslator.translate(e, context);
+                    if (result == null) {
+                        throw new RuntimeException("translate " + e + " failed");
+                    }
+                    return result;
+                })
                 .collect(Collectors.toCollection(ArrayList::new));
         // 2. collect agg expressions and generate agg function to slot reference map
         List<Slot> aggFunctionOutput = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/ProjectAggregateExpressionsForCse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/ProjectAggregateExpressionsForCse.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * create project under aggregate to enable CSE
@@ -102,10 +103,13 @@ public class ProjectAggregateExpressionsForCse extends PlanPostProcessor {
         }
 
         if (aggregate.child() instanceof PhysicalProject) {
-            PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) aggregate.child();
             List<NamedExpression> newProjections = Lists.newArrayList();
+            PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) aggregate.child();
+            Set<Slot> newInputSlots = aggOutputReplaced.stream()
+                    .flatMap(expr -> expr.getInputSlots().stream())
+                    .collect(Collectors.toSet());
             for (NamedExpression expr : project.getProjects()) {
-                if (!(expr instanceof SlotReference) || aggOutputReplaced.contains(expr)) {
+                if (!(expr instanceof SlotReference) || newInputSlots.contains(expr)) {
                     newProjections.add(expr);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/ProjectAggregateExpressionsForCse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/ProjectAggregateExpressionsForCse.java
@@ -105,7 +105,7 @@ public class ProjectAggregateExpressionsForCse extends PlanPostProcessor {
             PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) aggregate.child();
             List<NamedExpression> newProjections = Lists.newArrayList();
             for (NamedExpression expr : project.getProjects()) {
-                if (aggOutputReplaced.contains(expr)) {
+                if (!(expr instanceof SlotReference) || aggOutputReplaced.contains(expr)) {
                     newProjections.add(expr);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/ProjectAggregateExpressionsForCse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/ProjectAggregateExpressionsForCse.java
@@ -103,7 +103,12 @@ public class ProjectAggregateExpressionsForCse extends PlanPostProcessor {
 
         if (aggregate.child() instanceof PhysicalProject) {
             PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) aggregate.child();
-            List<NamedExpression> newProjections = Lists.newArrayList(project.getProjects());
+            List<NamedExpression> newProjections = Lists.newArrayList();
+            for (NamedExpression expr : project.getProjects()) {
+                if (aggOutputReplaced.contains(expr)) {
+                    newProjections.add(expr);
+                }
+            }
             newProjections.addAll(cseCandidates.values());
             project = project.withProjectionsAndChild(newProjections, (Plan) project.child());
             aggregate = (PhysicalHashAggregate<? extends Plan>) aggregate


### PR DESCRIPTION
### What problem does this PR solve?

after extracting common expressions for agg, the underlying projection may project redundant columns.
for example:
original plan 
Agg(groupkey=[A+B, A+B+1])
--> project(A, B)

after extracting, "A+B as C" is detected as a common expression, and the plan becomes
Agg(groupKey=[C, C+1])
 -->project(A, B, A+B as C)

here A, B should not be projected, since they are not used any more. so the optimal plan is 
Agg(groupKey=[C, C+1])
 -->project(A+B as C)

Related PR: #40473 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

