### PR TITLE
[fix](spark-connector) fix selected_columns in the response of open_scanner result is inconsistent with the data order.

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1208,7 +1208,8 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params,
                "processed";
         return Status::InvalidArgument(msg.str());
     }
-    TupleDescriptor* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+    auto output_tuple_id = t_query_plan_info.plan_fragment.plan.nodes.front().output_tuple_id;
+    TupleDescriptor* tuple_desc = desc_tbl->get_tuple_descriptor(output_tuple_id);
     if (tuple_desc == nullptr) {
         LOG(WARNING) << "open context error: extract TupleDescriptor failure";
         std::stringstream msg;


### PR DESCRIPTION
… order

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #39627 

Problem Summary:

When the Spark connector reads Doris, it first requests `/_query_plan` to obtain the execution plan. Since the previous pr updated the planner to the Nereids planner, the tuple descriptor in the plan fragment has two parts, one is the tuple output by the `scan node`, the order of which is consistent with the column order in the table, and the other is the tuple output by the `result sink`, the order of which is consistent with the select order.
The difference is that there is only one tuple descriptor in the query plan generated by the old planner, so When executing a query and the column order in the select is inconsistent with that defined in the table, the connector requests be to call the `open_scanner` interface to execute the `exec_external_plan_fragment` method, and by default goes back to obtain the column order in the first tuple descriptor and fills in the selected_columns attribute, which causes the spark connector to have a type mismatch when obtaining data in the arrow vector according to selected_columns.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

