### PR TITLE
[enhance](mtmv)When obtaining the partition list fails, treat the paimon table as an unpartitioned table 

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run01.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run01.sql
@@ -56,3 +56,15 @@ insert into null_partition values(2,null);
 insert into null_partition values(3,NULL);
 insert into null_partition values(4,'null');
 insert into null_partition values(5,'NULL');
+
+drop table if exists date_partition;
+CREATE TABLE date_partition (
+                               id BIGINT,
+                               create_date DATE
+) PARTITIONED BY (create_date) TBLPROPERTIES (
+    'primary-key' = 'create_date,id',
+    'bucket'=10,
+    'file.format'='orc'
+);
+
+insert into date_partition values(1,date '2020-01-01');

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
@@ -176,7 +176,13 @@ public class PaimonExternalTable extends ExternalTable implements MTMVRelatedTab
 
     @Override
     public List<Column> getPartitionColumns(Optional<MvccSnapshot> snapshot) {
-        return getPaimonSchemaCacheValue(snapshot).getPartitionColumns();
+        PaimonSchemaCacheValue paimonSchemaCacheValue = getPaimonSchemaCacheValue(snapshot);
+        if (paimonSchemaCacheValue)
+        return paimonSchemaCacheValue.getPartitionColumns();
+    }
+
+    private boolean isPartitionInvalid(PaimonSchemaCacheValue paimonSchemaCacheValue) {
+
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
@@ -165,6 +165,9 @@ public class PaimonExternalTable extends ExternalTable implements MTMVRelatedTab
 
     @Override
     public PartitionType getPartitionType(Optional<MvccSnapshot> snapshot) {
+        if (isPartitionInvalid(snapshot)) {
+            return PartitionType.UNPARTITIONED;
+        }
         return getPartitionColumns(snapshot).size() > 0 ? PartitionType.LIST : PartitionType.UNPARTITIONED;
     }
 
@@ -176,13 +179,15 @@ public class PaimonExternalTable extends ExternalTable implements MTMVRelatedTab
 
     @Override
     public List<Column> getPartitionColumns(Optional<MvccSnapshot> snapshot) {
-        PaimonSchemaCacheValue paimonSchemaCacheValue = getPaimonSchemaCacheValue(snapshot);
-        if (paimonSchemaCacheValue)
-        return paimonSchemaCacheValue.getPartitionColumns();
+        if (isPartitionInvalid(snapshot)) {
+            return Collections.emptyList();
+        }
+        return getPaimonSchemaCacheValue(snapshot).getPartitionColumns();
     }
 
-    private boolean isPartitionInvalid(PaimonSchemaCacheValue paimonSchemaCacheValue) {
-
+    private boolean isPartitionInvalid(Optional<MvccSnapshot> snapshot) {
+        PaimonSnapshotCacheValue paimonSnapshotCacheValue = getOrFetchSnapshotCacheValue(snapshot);
+        return paimonSnapshotCacheValue.getPartitionInfo().isPartitionInvalid();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonPartitionInfo.java
@@ -45,4 +45,9 @@ public class PaimonPartitionInfo {
     public Map<String, PaimonPartition> getNameToPartition() {
         return nameToPartition;
     }
+
+    public boolean isPartitionInvalid() {
+        // when transfer to partitionItem failed, will not equal
+        return nameToPartitionItem.size() != nameToPartition.size();
+    }
 }

--- a/regression-test/data/mtmv_p0/test_paimon_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_paimon_mtmv.out
@@ -140,3 +140,9 @@ true
 4	null
 5	NULL
 
+-- !date_partition_base_table --
+1	2020-01-01
+
+-- !date_partition --
+1	2020-01-01
+


### PR DESCRIPTION
### What problem does this PR solve?

When retrieving data of type Paimon Date in version 0.9 from the system table, the value is an integer and cannot be converted to type Date. 

This issue has been fixed in Paimon's latest code.

This PR downgrades this situation without affecting user data queries

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When obtaining the partition list fails, treat the paimon table as an unpartitioned table 
### Release note
When obtaining the partition list fails, treat the paimon table as an unpartitioned table 

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

