### PR TITLE
[feature](ES catalog)Support auto detect available nodes in node_discovery mode

### DIFF
--- a/fe/check/checkstyle/suppressions.xml
+++ b/fe/check/checkstyle/suppressions.xml
@@ -68,4 +68,7 @@ under the License.
 
     <!-- ignore hudi disk map copied from hudi/common/util/collection/DiskMap.java -->
     <suppress files="org[\\/]apache[\\/]hudi[\\/]common[\\/]util[\\/]collection[\\/]DiskMap\.java" checks="[a-zA-Z0-9]*"/>
+
+    <!-- Suppress import static check for EsExternalCatalogTest -->
+    <suppress files="org[\\/]apache[\\/]doris[\\/]datasource[\\/]es[\\/]EsExternalCatalogTest\.java" checks="AvoidStaticImport" />
 </suppressions>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -958,6 +958,11 @@ under the License.
             <artifactId>sdk-core</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <!-- for hive-catalog-shade -->

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -607,6 +607,8 @@ public class Env {
 
     private DictionaryManager dictionaryManager;
 
+    private EsNodeDiscovery esNodeDiscovery;
+
     // if a config is relative to a daemon thread. record the relation here. we will proactively change interval of it.
     private final Map<String, Supplier<MasterDaemon>> configtoThreads = ImmutableMap
             .of("dynamic_partition_check_interval_seconds", this::getDynamicPartitionScheduler);
@@ -862,6 +864,7 @@ public class Env {
         this.globalExternalTransactionInfoMgr = new GlobalExternalTransactionInfoMgr();
         this.tokenManager = new TokenManager();
         this.dictionaryManager = new DictionaryManager();
+        this.esNodeDiscovery = new EsNodeDiscovery();
     }
 
     public static Map<String, Long> getSessionReportTimeMap() {
@@ -1960,7 +1963,6 @@ public class Env {
         binlogGcer.start();
         columnIdFlusher.start();
         insertOverwriteManager.start();
-        dictionaryManager.start();
 
         TopicPublisher wgPublisher = new WorkloadGroupPublisher(this);
         topicPublisherThread.addToTopicPublisherList(wgPublisher);
@@ -1974,6 +1976,8 @@ public class Env {
         statisticsCleaner.start();
         statisticsAutoCollector.start();
         statisticsJobAppender.start();
+
+        esNodeDiscovery.start();
     }
 
     // start threads that should run on all FE
@@ -4803,7 +4807,7 @@ public class Env {
     }
 
     public EsNodeDiscovery getEsNodeDiscovery() {
-        return getInternalCatalog().getEsNodeDiscovery();
+        return esNodeDiscovery;
     }
 
     public PolicyMgr getPolicyMgr() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -139,6 +139,7 @@ import org.apache.doris.datasource.ExternalMetaIdMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.SplitSourceManager;
 import org.apache.doris.datasource.es.EsExternalCatalog;
+import org.apache.doris.datasource.es.EsNodeDiscovery;
 import org.apache.doris.datasource.es.EsRepository;
 import org.apache.doris.datasource.hive.HiveTransactionMgr;
 import org.apache.doris.datasource.hive.event.MetastoreEventsProcessor;
@@ -4799,6 +4800,10 @@ public class Env {
 
     public EsRepository getEsRepository() {
         return getInternalCatalog().getEsRepository();
+    }
+
+    public EsNodeDiscovery getEsNodeDiscovery() {
+        return getInternalCatalog().getEsNodeDiscovery();
     }
 
     public PolicyMgr getPolicyMgr() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.datasource.es.EsMetaStateTracker;
+import org.apache.doris.datasource.es.EsNodeInfo;
 import org.apache.doris.datasource.es.EsRestClient;
 import org.apache.doris.datasource.es.EsTablePartitions;
 import org.apache.doris.datasource.es.EsUtil;
@@ -85,6 +86,7 @@ public class EsTable extends Table implements GsonPostProcessable {
     @SerializedName("pi")
     private PartitionInfo partitionInfo;
     private EsTablePartitions esTablePartitions;
+    private Set<EsNodeInfo> availableNodesInfo;
 
     // Whether to enable docvalues scan optimization for fetching fields more fast, default to true
     private boolean enableDocValueScan = Boolean.parseBoolean(EsResource.DOC_VALUE_SCAN_DEFAULT_VALUE);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EsTable.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Elasticsearch table.
@@ -86,7 +87,7 @@ public class EsTable extends Table implements GsonPostProcessable {
     @SerializedName("pi")
     private PartitionInfo partitionInfo;
     private EsTablePartitions esTablePartitions;
-    private Set<EsNodeInfo> availableNodesInfo;
+    private Set<EsNodeInfo> availableNodesInfo = ConcurrentHashMap.newKeySet();
 
     // Whether to enable docvalues scan optimization for fetching fields more fast, default to true
     private boolean enableDocValueScan = Boolean.parseBoolean(EsResource.DOC_VALUE_SCAN_DEFAULT_VALUE);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -47,6 +47,7 @@ import org.apache.doris.common.lock.MonitoredReentrantReadWriteLock;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.es.EsExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalDatabase;
 import org.apache.doris.datasource.hive.HMSExternalTable;
@@ -71,6 +72,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -133,6 +135,9 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                 resource.addReference(catalog.getName(), ReferenceType.CATALOG);
             }
         }
+        if (catalog instanceof EsExternalCatalog) {
+            Env.getCurrentEnv().getEsNodeDiscovery().registerCatalog((EsExternalCatalog) catalog);
+        }
     }
 
     private CatalogIf removeCatalog(long catalogId) {
@@ -152,6 +157,9 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                 }
             }
             Env.getCurrentEnv().getQueryStats().clear(catalog.getId());
+            if (catalog.getType().equals(InitCatalogLog.Type.ES.name().toLowerCase(Locale.ROOT))) {
+                Env.getCurrentEnv().getEsNodeDiscovery().deRegisterCatalog(catalog.getId());
+            }
         }
         return catalog;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -158,7 +158,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             }
             Env.getCurrentEnv().getQueryStats().clear(catalog.getId());
             if (catalog.getType().equals(InitCatalogLog.Type.ES.name().toLowerCase(Locale.ROOT))) {
-                Env.getCurrentEnv().getEsNodeDiscovery().deRegisterCatalog(catalog.getId());
+                Env.getCurrentEnv().getEsNodeDiscovery().deregisterCatalog(catalog.getId());
             }
         }
         return catalog;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -141,6 +141,7 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.es.EsNodeDiscovery;
 import org.apache.doris.datasource.es.EsRepository;
 import org.apache.doris.event.DropPartitionEvent;
 import org.apache.doris.mtmv.MTMVUtil;
@@ -229,6 +230,8 @@ public class InternalCatalog implements CatalogIf<Database> {
     // Add transient to fix gson issue.
     @Getter
     private transient EsRepository esRepository = new EsRepository();
+    @Getter
+    private transient EsNodeDiscovery esNodeDiscovery = new EsNodeDiscovery();
 
     public InternalCatalog() {
         // create internal databases

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -141,7 +141,6 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
-import org.apache.doris.datasource.es.EsNodeDiscovery;
 import org.apache.doris.datasource.es.EsRepository;
 import org.apache.doris.event.DropPartitionEvent;
 import org.apache.doris.mtmv.MTMVUtil;
@@ -230,8 +229,6 @@ public class InternalCatalog implements CatalogIf<Database> {
     // Add transient to fix gson issue.
     @Getter
     private transient EsRepository esRepository = new EsRepository();
-    @Getter
-    private transient EsNodeDiscovery esNodeDiscovery = new EsNodeDiscovery();
 
     public InternalCatalog() {
         // create internal databases

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsExternalTable.java
@@ -102,6 +102,7 @@ public class EsExternalTable extends ExternalTable {
         esTable.setHttpSslEnabled(esCatalog.enableSsl());
         esTable.setLikePushDown(esCatalog.enableLikePushDown());
         esTable.setSeeds(esCatalog.getNodes());
+        esTable.setAvailableNodesInfo(esCatalog.getAvailableNodesInfo());
         esTable.setHosts(String.join(",", esCatalog.getNodes()));
         esTable.syncTableMetaData();
         esTable.setIncludeHiddenIndex(esCatalog.enableIncludeHiddenIndex());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeDiscovery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeDiscovery.java
@@ -51,7 +51,7 @@ public class EsNodeDiscovery extends MasterDaemon {
         LOG.info("register a new catalog [{}] to sync list", esCatalog);
     }
 
-    public void deRegisterCatalog(long catalogId) {
+    public void deregisterCatalog(long catalogId) {
         esCatalogs.remove(catalogId);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeDiscovery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsNodeDiscovery.java
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.es;
+
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.util.MasterDaemon;
+
+import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+
+/**
+ * It is responsible for automatic loading all ES external catalogs' nodes info periodically
+ */
+public class EsNodeDiscovery extends MasterDaemon {
+
+    private static final Logger LOG = LogManager.getLogger(EsNodeDiscovery.class);
+
+    private Map<Long, EsExternalCatalog> esCatalogs;
+
+    public EsNodeDiscovery() {
+        super("es node discovery", Config.es_state_sync_interval_second * 1000);
+        esCatalogs = Maps.newConcurrentMap();
+    }
+
+    public void registerCatalog(EsExternalCatalog esCatalog) {
+        if (Env.isCheckpointThread()) {
+            return;
+        }
+        esCatalogs.put(esCatalog.getId(), esCatalog);
+        LOG.info("register a new catalog [{}] to sync list", esCatalog);
+    }
+
+    public void deRegisterCatalog(long catalogId) {
+        esCatalogs.remove(catalogId);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        for (EsExternalCatalog esCatalog : esCatalogs.values()) {
+            try {
+                esCatalog.detectAvailableNodesInfo();
+            } catch (Throwable e) {
+                LOG.warn("Exception happens when fetch catalog [{}] nodes info data from remote es cluster",
+                        esCatalog.getName(), e);
+                esCatalog.clearAvailableNodesInfo();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsRestClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsRestClient.java
@@ -116,6 +116,21 @@ public class EsRestClient {
         return nodesMap;
     }
 
+    public List<EsNodeInfo> getHttpNodesList() throws DorisEsException {
+        Map<String, Map<String, Object>> nodesData = get("_nodes/http", "nodes");
+        if (nodesData == null) {
+            return Collections.emptyList();
+        }
+        List<EsNodeInfo> nodesList = new ArrayList<>();
+        for (Map.Entry<String, Map<String, Object>> entry : nodesData.entrySet()) {
+            EsNodeInfo node = new EsNodeInfo(entry.getKey(), entry.getValue(), httpSslEnable);
+            if (node.hasHttp()) {
+                nodesList.add(node);
+            }
+        }
+        return nodesList;
+    }
+
     /**
      * Get mapping for indexName.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/PartitionPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/PartitionPhase.java
@@ -36,12 +36,12 @@ public class PartitionPhase implements SearchPhase {
     @Override
     public void execute(SearchContext context) throws DorisEsException {
         shardPartitions = client.searchShards(context.sourceIndex());
+        nodesInfo = new HashMap<>();
         if (context.nodesDiscovery() && !context.getAvailableNodesInfo().isEmpty()) {
             for (EsNodeInfo nodeInfo : context.getAvailableNodesInfo()) {
                 nodesInfo.put(nodeInfo.getId(), nodeInfo);
             }
         } else {
-            nodesInfo = new HashMap<>();
             String[] seeds = context.esTable().getSeeds();
             for (int i = 0; i < seeds.length; i++) {
                 nodesInfo.put(String.valueOf(i), new EsNodeInfo(String.valueOf(i), seeds[i]));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/PartitionPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/PartitionPhase.java
@@ -36,8 +36,10 @@ public class PartitionPhase implements SearchPhase {
     @Override
     public void execute(SearchContext context) throws DorisEsException {
         shardPartitions = client.searchShards(context.sourceIndex());
-        if (context.nodesDiscovery()) {
-            nodesInfo = client.getHttpNodes();
+        if (context.nodesDiscovery() && !context.getAvailableNodesInfo().isEmpty()) {
+            for (EsNodeInfo nodeInfo : context.getAvailableNodesInfo()) {
+                nodesInfo.put(nodeInfo.getId(), nodeInfo);
+            }
         } else {
             nodesInfo = new HashMap<>();
             String[] seeds = context.esTable().getSeeds();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/SearchContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/SearchContext.java
@@ -22,12 +22,14 @@ import org.apache.doris.catalog.EsTable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class encapsulates the state needed to execute a query on ES table such as fields、doc_values、resolved index、
@@ -89,6 +91,9 @@ public class SearchContext {
     // whether the nodes needs to be discovered
     private boolean nodesDiscovery;
 
+    @Getter
+    private Set<EsNodeInfo> availableNodesInfo;
+
 
     public SearchContext(EsTable table) {
         this.table = table;
@@ -96,6 +101,7 @@ public class SearchContext {
         sourceIndex = table.getIndexName();
         type = table.getMappingType();
         nodesDiscovery = table.isNodesDiscovery();
+        availableNodesInfo = table.getAvailableNodesInfo();
     }
 
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/es/EsExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/es/EsExternalCatalogTest.java
@@ -1,0 +1,303 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.es;
+
+import org.apache.doris.catalog.EsResource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class EsExternalCatalogTest {
+
+    @Mock
+    private EsRestClient mockEsRestClient;
+
+    @Mock
+    private EsRestClient mockEsRestClientForNode;
+
+    private EsExternalCatalog catalog;
+    private EsNodeInfo node1;
+    private EsNodeInfo node2;
+    private final String testHost = "http://localhost:";
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        // Setup test catalog
+        Map<String, String> props = new HashMap<>();
+        props.put(EsResource.HOSTS, "http://localhost:9200");
+        catalog = new EsExternalCatalog(1L, "test_catalog", "", props, "") {
+            @Override
+            protected EsRestClient createEsRestClient(String[] nodes, String username, String password, boolean enableSsl) {
+                return mockEsRestClientForNode;
+            }
+        };
+
+        // Setup test nodes
+        String addr1 = testHost + "9200";
+        String addr2 = testHost + "9201";
+        node1 = new EsNodeInfo("node1", addr1);
+        node2 = new EsNodeInfo("node2", addr2);
+
+        // Use setter method to set mock client
+        catalog.setEsRestClient(mockEsRestClient);
+    }
+
+    @Test
+    public void testDetectAvailableNodesInfo() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health()).thenReturn(true);
+
+        // Execute
+        catalog.detectAvailableNodesInfo();
+
+        // Verify
+        assertEquals(2, catalog.getAvailableNodesInfo().size());
+        assertTrue(catalog.getAvailableNodesInfo().contains(node1));
+        assertTrue(catalog.getAvailableNodesInfo().contains(node2));
+    }
+
+    @Test
+    public void testDetectAvailableNodesInfoWithFailures() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health())
+            .thenReturn(true)  // node1 healthy
+                .thenReturn(false); // node2 failed
+
+        // Execute
+        catalog.detectAvailableNodesInfo();
+
+        // Verify
+        assertEquals(1, catalog.getAvailableNodesInfo().size());
+        assertTrue(catalog.getAvailableNodesInfo().contains(node1));
+    }
+
+    @Test
+    public void testGetAvailableNodesInfoEmpty() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Collections.emptyList());
+
+        // Execute
+        Set<EsNodeInfo> nodes = catalog.getAvailableNodesInfo();
+
+        // Verify
+        assertTrue(nodes.isEmpty());
+    }
+
+    @Test
+    public void testClearAvailableNodesInfo() throws IllegalAccessException {
+        // Setup
+        EsExternalCatalog spyCatalog = spy(catalog);
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health()).thenReturn(true);
+        spyCatalog.detectAvailableNodesInfo();
+
+        // Mock getAvailableNodesInfo to return actual set without detect
+        // Use reflection to access the private field
+        Field availableNodesInfoField = null;
+        try {
+            availableNodesInfoField = EsExternalCatalog.class.getDeclaredField("availableNodesInfo");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+        availableNodesInfoField.setAccessible(true);
+
+        // Verify initial state
+        assertEquals(2, ((Set<?>) availableNodesInfoField.get(spyCatalog)).size());
+
+        // Execute
+        spyCatalog.clearAvailableNodesInfo();
+
+        // Verify
+        assertTrue(((Set<?>) availableNodesInfoField.get(spyCatalog)).isEmpty());
+    }
+
+    @Test
+    public void testGetAvailableNodesInfoWithEmptyCache() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health()).thenReturn(true);
+
+        // Execute - should trigger detect
+        Set<EsNodeInfo> nodes = catalog.getAvailableNodesInfo();
+
+        // Verify
+        assertEquals(2, nodes.size());
+        verify(mockEsRestClient, times(1)).getHttpNodesList();
+        verify(mockEsRestClientForNode, times(2)).health(); // Ensure health check is called for each node
+    }
+
+    @Test
+    public void testConcurrentAccess() throws InterruptedException {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health()).thenReturn(true);
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Execute concurrent operations
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        catalog.detectAvailableNodesInfo();
+                        catalog.getAvailableNodesInfo();
+                        catalog.clearAvailableNodesInfo();
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            });
+        }
+
+        // Wait for completion
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // Verify no exceptions were thrown
+        assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testGetAvailableNodesInfoWhenDetectThrowsException() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenThrow(new RuntimeException("Test exception"));
+
+        // Execute
+        Set<EsNodeInfo> nodes = catalog.getAvailableNodesInfo();
+
+        // Verify
+        assertTrue(nodes.isEmpty());
+        verify(mockEsRestClient, times(1)).getHttpNodesList();
+    }
+
+    @Test
+    public void testDetectAvailableNodesInfoWhenGetNodesListReturnsNull() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(null);
+
+        // Execute
+        catalog.detectAvailableNodesInfo();
+
+        // Verify
+        assertTrue(catalog.getAvailableNodesInfo().isEmpty());
+    }
+
+    @Test
+    public void testDetectAvailableNodesInfoWhenHealthThrowsException() {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health()).thenThrow(new RuntimeException("Health check failed"));
+
+        // Execute
+        catalog.detectAvailableNodesInfo();
+
+        // Verify
+        assertTrue(catalog.getAvailableNodesInfo().isEmpty());
+    }
+
+    @Test
+    public void testDetectAvailableNodesInfoWithInvalidNodeAddress() {
+        // Setup
+        EsNodeInfo invalidNode = new EsNodeInfo("invalid", "invalid:port");
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(invalidNode));
+        when(mockEsRestClientForNode.health()).thenReturn(false);
+
+        // Execute
+        catalog.detectAvailableNodesInfo();
+
+        // Verify
+        assertTrue(catalog.getAvailableNodesInfo().isEmpty());
+    }
+
+    @Test
+    public void testClearAvailableNodesInfoWhenAlreadyEmpty() {
+        // Setup - ensure nodes are empty
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Collections.emptyList());
+        catalog.detectAvailableNodesInfo();
+
+        // Execute
+        catalog.clearAvailableNodesInfo();
+
+        // Verify
+        assertTrue(catalog.getAvailableNodesInfo().isEmpty());
+    }
+
+    @Test
+    public void testConcurrentModificationsDuringDetect() throws InterruptedException {
+        // Setup
+        when(mockEsRestClient.getHttpNodesList()).thenReturn(Arrays.asList(node1, node2));
+        when(mockEsRestClientForNode.health()).thenReturn(true);
+
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount * 2);
+        CountDownLatch latch = new CountDownLatch(threadCount * 2);
+
+        // Execute - half threads detect, half threads clear
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    catalog.detectAvailableNodesInfo();
+                } finally {
+                    latch.countDown();
+                }
+            });
+            executor.submit(() -> {
+                try {
+                    catalog.clearAvailableNodesInfo();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait and verify
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+
+        // Final state should be consistent
+        Set<EsNodeInfo> finalNodes = catalog.getAvailableNodesInfo();
+        assertTrue(finalNodes.isEmpty() || finalNodes.size() == 2);
+    }
+}

--- a/regression-test/suites/external_table_p0/es/test_es_query.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_query.groovy
@@ -39,7 +39,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             properties (
                 "type"="es",
                 "elasticsearch.hosts"="http://${externalEnvIp}:$es_5_port",
-                "elasticsearch.nodes_discovery"="false",
+                "elasticsearch.nodes_discovery"="true",
                 "elasticsearch.keyword_sniff"="true"
             );
         """
@@ -48,7 +48,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             properties (
                 "type"="es",
                 "elasticsearch.hosts"="http://${externalEnvIp}:$es_6_port",
-                "elasticsearch.nodes_discovery"="false",
+                "elasticsearch.nodes_discovery"="true",
                 "elasticsearch.keyword_sniff"="true"
             );
         """
@@ -57,7 +57,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
         sql """create catalog if not exists test_es_query_es7 properties(
             "type"="es",
             "hosts"="http://${externalEnvIp}:$es_7_port",
-            "nodes_discovery"="false",
+            "nodes_discovery"="true",
             "enable_keyword_sniff"="true"
         );
         """
@@ -65,7 +65,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
         sql """create catalog if not exists test_es_query_es8 properties(
             "type"="es",
             "hosts"="http://${externalEnvIp}:$es_8_port",
-            "nodes_discovery"="false",
+            "nodes_discovery"="true",
             "enable_keyword_sniff"="true"
         );
         """
@@ -73,7 +73,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
         sql """create catalog if not exists es6_hide properties(
             "type"="es",
             "hosts"="http://${externalEnvIp}:$es_6_port",
-            "nodes_discovery"="false",
+            "nodes_discovery"="true",
             "enable_keyword_sniff"="true",
             "include_hidden_index"="true"
         );
@@ -82,7 +82,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
         sql """create catalog if not exists es7_hide properties(
             "type"="es",
             "hosts"="http://${externalEnvIp}:$es_7_port",
-            "nodes_discovery"="false",
+            "nodes_discovery"="true",
             "enable_keyword_sniff"="true",
             "include_hidden_index"="true"
         );
@@ -123,7 +123,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             PROPERTIES (
                 "hosts" = "http://${externalEnvIp}:$es_8_port",
                 "index" = "test1",
-                "nodes_discovery"="false",
+                "nodes_discovery"="true",
                 "enable_keyword_sniff"="true",
                 "http_ssl_enabled"="false"
             );
@@ -162,7 +162,7 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             PROPERTIES (
                 "hosts" = "http://${externalEnvIp}:$es_8_port",
                 "index" = "test1",
-                "nodes_discovery"="false",
+                "nodes_discovery"="true",
                 "enable_keyword_sniff"="true",
                 "http_ssl_enabled"="false"
             );


### PR DESCRIPTION
### What problem does this PR solve?

Add ES nodes_discovery for automatic node discovery.

When nodes_discovery is enabled, Doris will automatic detect available nodes for build scan range.
And when it is disabled, Doris will use the seeds host only, same as before.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

