### PR TITLE
[fix](iceberg)Different catalogs should use different client pools

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/HiveCompatibleCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/HiveCompatibleCatalog.java
@@ -45,11 +45,11 @@ public abstract class HiveCompatibleCatalog extends BaseMetastoreCatalog impleme
     protected Configuration conf;
     protected ClientPool<IMetaStoreClient, TException> clients;
     protected FileIO fileIO;
-    protected String uid;
+    protected String catalogName;
 
     public void initialize(String name, FileIO fileIO,
                            ClientPool<IMetaStoreClient, TException> clients) {
-        this.uid = name;
+        this.catalogName = name;
         this.fileIO = fileIO;
         this.clients = clients;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
@@ -22,8 +22,6 @@ import org.apache.doris.datasource.iceberg.dlf.DLFCatalog;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.HMSProperties;
 
-import com.aliyun.datalake.metastore.common.DataLakeConfig;
-
 import java.util.Map;
 
 public class IcebergDLFExternalCatalog extends IcebergExternalCatalog {
@@ -43,8 +41,8 @@ public class IcebergDLFExternalCatalog extends IcebergExternalCatalog {
         dlfCatalog.setConf(getConfiguration());
         // initialize catalog
         Map<String, String> catalogProperties = catalogProperty.getHadoopProperties();
-        String dlfUid = catalogProperties.get(DataLakeConfig.CATALOG_USER_ID);
-        dlfCatalog.initialize(dlfUid, catalogProperties);
+        String catalogName = getName();
+        dlfCatalog.initialize(catalogName, catalogProperties);
         catalog = dlfCatalog;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergGlueExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergGlueExternalCatalog.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 
-import java.util.List;
 import java.util.Map;
 
 public class IcebergGlueExternalCatalog extends IcebergExternalCatalog {
@@ -60,10 +59,5 @@ public class IcebergGlueExternalCatalog extends IcebergExternalCatalog {
 
         glueCatalog.initialize(getName(), catalogProperties);
         catalog = glueCatalog;
-    }
-
-    @Override
-    protected List<String> listDatabaseNames() {
-        return metadataOps.listDatabaseNames();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/dlf/DLFCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/dlf/DLFCatalog.java
@@ -46,7 +46,7 @@ public class DLFCatalog extends HiveCompatibleCatalog {
     protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
         String dbName = tableIdentifier.namespace().level(0);
         String tableName = tableIdentifier.name();
-        return new DLFTableOperations(this.conf, this.clients, this.fileIO, this.uid, dbName, tableName);
+        return new DLFTableOperations(this.conf, this.clients, this.fileIO, this.catalogName, dbName, tableName);
     }
 
     protected FileIO initializeFileIO(Map<String, String> properties, Configuration hadoopConf) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.dlf.client;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class IcebergDLFExternalCatalogTest {
+    @Test
+    public void testDatabaseList() {
+        HashMap<String, String> props = new HashMap<>();
+        Configuration conf = new Configuration();
+
+        DLFCachedClientPool cachedClientPool1 = new DLFCachedClientPool(conf, props);
+        DLFCachedClientPool cachedClientPool2 = new DLFCachedClientPool(conf, props);
+        DLFClientPool dlfClientPool1 = cachedClientPool1.clientPool();
+        DLFClientPool dlfClientPool2 = cachedClientPool2.clientPool();
+        // This cache should belong to the catalog level,
+        // so the object addresses of clients in different pools must be different
+        Assert.assertNotSame(dlfClientPool1, dlfClientPool2);
+
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. This cached client pool should belong to the catalog level, each catalog has its own pool.
Otherwise, different dlf configurations will be connected to the same dlf.
2. The catalog name should be used to initialize the catalog, not the uid in the dlf.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

