### PR TITLE
[regression-test](fix) fix test_default_current_timestamp.groovy

### DIFF
--- a/regression-test/suites/datatype_p0/date/test_default_current_timestamp.groovy
+++ b/regression-test/suites/datatype_p0/date/test_default_current_timestamp.groovy
@@ -16,7 +16,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.Duration
+
 suite("test_default_current_timestamp") {
+    // This case assumes that the execution will not cross 24:00 during runtime. 
+    // Therefore, if the execution time is greater than 23:59:30, it will wait until 24:00 to proceed.
+    def t = sql "select now()"
+    LocalTime currentTime = t[0][0].toLocalTime()
+    if (currentTime.isAfter(LocalTime.of(23, 59, 30))) {
+        def s = Duration.between(currentTime, LocalTime.of(23, 59, 59)).seconds + 2
+        logger.info("sleep ${s} seconds to 24:00")
+        Thread.sleep(s * 1000)
+    } 
+
     def tbName = "test_default_current_timestamp"
     sql "DROP TABLE IF EXISTS ${tbName}"
     sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
This case assumes that the execution will not cross 24:00 during runtime. Therefore, if the execution time is greater than 23:59:30, it will wait until 24:00 to proceed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

