### PR TITLE
[Fix](insert-job)Fix Issue with Missing StatementContext in StmtExecutor, Leading to Incorrect SQL_BLOCK Handling

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -29,6 +29,8 @@ import org.apache.doris.job.task.AbstractTask;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.loadv2.LoadJob;
 import org.apache.doris.load.loadv2.LoadStatistic;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand;
 import org.apache.doris.qe.ConnectContext;
@@ -159,13 +161,15 @@ public class InsertTask extends AbstractTask {
             ctx.setDatabase(currentDb);
         }
         TUniqueId queryId = generateQueryId(UUID.randomUUID().toString());
-        stmtExecutor = new StmtExecutor(ctx, (String) null);
+        StatementContext statementContext = new StatementContext();
         ctx.setQueryId(queryId);
+        ctx.setStatementContext(statementContext);
         if (StringUtils.isNotEmpty(sql)) {
             NereidsParser parser = new NereidsParser();
             this.command = (InsertIntoTableCommand) parser.parseSingle(sql);
             this.command.setLabelName(Optional.of(getJobId() + LABEL_SPLITTER + getTaskId()));
             this.command.setJobId(getTaskId());
+            stmtExecutor = new StmtExecutor(ctx, new LogicalPlanAdapter(command, ctx.getStatementContext()));
         }
 
         super.before();

--- a/regression-test/suites/job_p0/test_base_insert_job.groovy
+++ b/regression-test/suites/job_p0/test_base_insert_job.groovy
@@ -73,6 +73,17 @@ suite("test_base_insert_job") {
         );
         """
     sql """
+       DROP SQL_BLOCK_RULE IF EXISTS test_base_insert_job_rule
+        """
+    sql """
+        CREATE SQL_BLOCK_RULE test_base_insert_job_rule
+            PROPERTIES(
+            "sql"="select \\\\* from test_base_insert_job_rule",
+            "global"="true",
+            "enable"="true"
+            );
+        """
+    sql """
         insert into ${tableName} values
         ('2023-03-18', 1, 1)
         """
@@ -242,6 +253,9 @@ suite("test_base_insert_job") {
         //resume tasks size should be greater than before pause
         afterResumeTasks.size() > tasks.size()
     })
+    sql """
+       DROP SQL_BLOCK_RULE IF EXISTS test_base_insert_job_rule
+        """
     // check resume job status
     def afterResumeJobStatus = sql """
         select status from jobs("type"="insert") where Name='${jobName}'


### PR DESCRIPTION



### What problem does this PR solve?

During the task construction process of the Insert Job, the StmtExecutor was not provided with a corresponding StatementContext, which causes a default StatementContext to be generated. This can lead to issues where certain properties related to StatementContext, such as the globally set SQL_BLOCK, do not function correctly.

**How to reproduce**
```
mysql> create job test on SCHEDULE every 2 second do INSERT INTO image values ('2023-10-13',1,2);
Query OK, 0 rows affected (0.07 sec)
mysql> CREATE SQL_BLOCK_RULE test_sql_block
    -> PROPERTIES(
    -> "sql"="select \\* from order_analysis",
    -> "global"="true",
    -> "enable"="true"
    -> );


 2025-01-09 18:38:03 |             | {"Unfinished backends":{},"ScannedRows":0,"TaskNumber":0,"LoadBytes":0,"All backends":{},"FileNumber":0,"FileSize":0} | root |
| 7377995488171 | 7170662367696 | test    | 7170662367696_7377995488171 | SUCCESS |                                                                                                             | 2025-01-09 18:38:05 | 2025-01-09 18:38:05 | 2025-01-09 18:38:05 |             | {"Unfinished backends":{},"ScannedRows":0,"TaskNumber":0,"LoadBytes":0,"All backends":{},"FileNumber":0,"FileSize":0} | root |
| 7379811123912 | 7170662367696 | test    | 7170662367696_7379811123912 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:07 | 2025-01-09 18:38:07 |                     |             |                                                                                                                       | root |
| 7382097155737 | 7170662367696 | test    | 7170662367696_7382097155737 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:09 | 2025-01-09 18:38:09 |                     |             |                                                                                                                       | root |
| 7383760717194 | 7170662367696 | test    | 7170662367696_7383760717194 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:11 | 2025-01-09 18:38:11 |                     |             |                                                                                                                       | root |
| 7385509219729 | 7170662367696 | test    | 7170662367696_7385509219729 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:13 | 2025-01-09 18:38:13 |                     |             |                                                                                                                       | root |
| 7388113399522 | 7170662367696 | test    | 7170662367696_7388113399522 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:15 | 2025-01-09 18:38:15 |                     |             |                                                                                                                       | root |
| 7389678516159 | 7170662367696 | test    | 7170662367696_7389678516159 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:17 | 2025-01-09 18:38:17 |                     |             |                                                                                                                       | root |
| 7391506550186 | 7170662367696 | test    | 7170662367696_7391506550186 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:19 | 2025-01-09 18:38:19 |                     |             |                                                                                                                       | root |
| 7393442362259 | 7170662367696 | test    | 7170662367696_7393442362259 | FAILED  | java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null | 2025-01-09 18:38:21 | 2025-01-09 18:38:21 |                     |             |                                                                                                                       | root |
+---------------+---------------+---------+-----------------------------+---------+-------------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+-------------+-----------------------------------------------------------------------------------------------------------------------+------+
62 rows in set (0.14 sec)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

