### PR TITLE
docs: Fix Dockerfile path and add ARM-specific instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -33,12 +33,16 @@ under the License.
     You can remove the `.git` dir in `doris/` to make the dir size smaller.
     So that the following generated docker image can be smaller.
 
-2. Copy Dockerfile
+   2. Copy Dockerfile
 
-    ```console
-    $ cd /to/your/workspace/
-    $ cp doris/docker/Dockerfile ./
-    ```
+   ```console
+   $ cd /to/your/workspace/
+
+   # For x86_64 architecture
+   $ cp doris/docker/compilation/Dockerfile ./
+
+   # For ARM-based machines (e.g., Apple M1/M2 Macs)
+   $ cp doris/docker/compilation/arm/Dockerfile ./
 
 After preparation, your workspace should like this:
 


### PR DESCRIPTION
- Fix incorrect Dockerfile path in development setup documentation
- Add instructions for ARM-based machines (M1/M2 Macs)
- Update documentation to reflect current repository structure

This fixes potential confusion for developers trying to set up the development environment.

### What problem does this PR solve?
Issue Number: N/A
Related PR: N/A
Problem Summary: Current documentation points to a non-existent Dockerfile path and lacks instructions for ARM-based machines, causing confusion for developers during setup.

### Release note
None

### Check List (For Author)
- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Manual test steps:
1. Verified the correct path `doris/docker/compilation/Dockerfile` exists for x86
2. Verified the correct path `doris/docker/compilation/arm/Dockerfile` exists for ARM
3. Tested the Docker build process with the correct paths on both architectures

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No. (This PR itself is a documentation fix)
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)
- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [ ] Add branch pick label