### PR TITLE
[improve](cloud-mow)Make some mow calculating delete bitmap config more reasonable

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -208,7 +208,7 @@ DEFINE_Int32(tablet_publish_txn_max_thread, "32");
 // the timeout of EnginPublishVersionTask
 DEFINE_Int32(publish_version_task_timeout_s, "8");
 // the count of thread to calc delete bitmap
-DEFINE_Int32(calc_delete_bitmap_max_thread, "32");
+DEFINE_Int32(calc_delete_bitmap_max_thread, "96");
 // the count of thread to calc delete bitmap worker, only used for cloud
 DEFINE_Int32(calc_delete_bitmap_worker_count, "8");
 // the count of thread to calc tablet delete bitmap task, only used for cloud
@@ -867,8 +867,8 @@ DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
 // The default delete bitmap cache is set to 100MB,
 // which can be insufficient and cause performance issues when the amount of user data is large.
 // To mitigate the problem of an inadequate cache,
-// we will take the larger of 0.5% of the total memory and 100MB as the delete bitmap cache size.
-DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "0.5%");
+// we will take the larger of 1.5% of the total memory and 100MB as the delete bitmap cache size.
+DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "1.5%");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 
 // reference https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#broker-version-compatibility

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -868,7 +868,7 @@ DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
 // which can be insufficient and cause performance issues when the amount of user data is large.
 // To mitigate the problem of an inadequate cache,
 // we will take the larger of 1.5% of the total memory and 100MB as the delete bitmap cache size.
-DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "1.5%");
+DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "1.0%");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 
 // reference https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#broker-version-compatibility

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -208,7 +208,7 @@ DEFINE_Int32(tablet_publish_txn_max_thread, "32");
 // the timeout of EnginPublishVersionTask
 DEFINE_Int32(publish_version_task_timeout_s, "8");
 // the count of thread to calc delete bitmap
-DEFINE_Int32(calc_delete_bitmap_max_thread, "96");
+DEFINE_Int32(calc_delete_bitmap_max_thread, "32");
 // the count of thread to calc delete bitmap worker, only used for cloud
 DEFINE_Int32(calc_delete_bitmap_worker_count, "8");
 // the count of thread to calc tablet delete bitmap task, only used for cloud
@@ -867,7 +867,7 @@ DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
 // The default delete bitmap cache is set to 100MB,
 // which can be insufficient and cause performance issues when the amount of user data is large.
 // To mitigate the problem of an inadequate cache,
-// we will take the larger of 1.5% of the total memory and 100MB as the delete bitmap cache size.
+// we will take the larger of 1.0% of the total memory and 100MB as the delete bitmap cache size.
 DEFINE_String(delete_bitmap_dynamic_agg_cache_limit, "1.0%");
 DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
 


### PR DESCRIPTION
Edit config to let calculate delete bitmap more fast.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

