### PR TITLE
[fix](test) try fix unstable audit log test

### DIFF
--- a/regression-test/suites/audit/test_audit_log_behavior.groovy
+++ b/regression-test/suites/audit/test_audit_log_behavior.groovy
@@ -77,6 +77,7 @@ suite("test_audit_log_behavior") {
         sql "set enable_nereids_planner=${on}"
         sql "truncate table  __internal_schema.audit_log"
         // run queries
+        sql "set global audit_plugin_max_sql_length = 58"
         for (int i = 0; i < cnt; i++) {
             def tuple2 = sqls.get(i)
             sql tuple2[0]
@@ -103,7 +104,7 @@ suite("test_audit_log_behavior") {
                 sleep(1000)
                 res = sql "${query}"
             }
-            assertEquals(res[0][0].toString(), tuple2[1].toString())
+            assertEquals(tuple2[1].toString(), res[0][0].toString());
         }
     }
     // do not turn off


### PR DESCRIPTION
### What problem does this PR solve?

Sometimes the `audit_plugin_max_sql_length` may not take effect.
Try execute `set global audit_plugin_max_sql_length = 58` again to fix it.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

