### PR TITLE
[refactor](opt) remove redundant use_default_implementation_for_nulls() of some BE codes

### DIFF
--- a/be/src/vec/functions/array/function_array_difference.h
+++ b/be/src/vec/functions/array/function_array_difference.h
@@ -66,8 +66,6 @@ public:
 
     size_t get_number_of_arguments() const override { return 1; }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
-
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
         DCHECK(is_array(arguments[0]))
                 << "argument for function: " << name << " should be DataTypeArray but it has type "

--- a/be/src/vec/functions/function_hll.cpp
+++ b/be/src/vec/functions/function_hll.cpp
@@ -152,8 +152,6 @@ public:
 
     size_t get_number_of_arguments() const override { return 1; }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
-
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto res_null_map = ColumnUInt8::create(input_rows_count, 0);

--- a/be/src/vec/functions/function_multi_same_args.h
+++ b/be/src/vec/functions/function_multi_same_args.h
@@ -34,8 +34,6 @@ public:
 
     String get_name() const override { return name; }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
-
     bool is_variadic() const override { return true; }
 
     size_t get_number_of_arguments() const override { return 0; }

--- a/be/src/vec/functions/function_struct_element.cpp
+++ b/be/src/vec/functions/function_struct_element.cpp
@@ -47,8 +47,6 @@ public:
     // Get function name.
     String get_name() const override { return name; }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
-
     size_t get_number_of_arguments() const override { return 2; }
 
     ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }

--- a/be/src/vec/functions/function_time_value_to_field.cpp
+++ b/be/src/vec/functions/function_time_value_to_field.cpp
@@ -47,8 +47,6 @@ public:
         return std::make_shared<ToDataType>();
     }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
-
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         DCHECK_EQ(arguments.size(), 1);

--- a/be/src/vec/functions/function_totype.h
+++ b/be/src/vec/functions/function_totype.h
@@ -462,8 +462,6 @@ public:
         return make_nullable(std::make_shared<typename Impl::ReturnType>());
     }
 
-    bool use_default_implementation_for_nulls() const override { return true; }
-
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto null_map = ColumnUInt8::create(input_rows_count, 0);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The function `use_default_implementation_for_nulls()` has been `true` in their parent class `IFunction{}`, so we can safely remove this part in some BE codes if its value was set to `true`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    -  No need to test or manual test. Explain why:
        -  This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    -  No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    -  No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

