### PR TITLE
[Do not merge][debug only] encoding segment file info into file cache key for tracing

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1060,6 +1060,9 @@ DEFINE_mInt64(file_cache_error_log_limit_bytes, "209715200"); // 200MB
 DEFINE_mInt64(cache_lock_long_tail_threshold, "1000");
 DEFINE_Int64(file_cache_recycle_keys_size, "1000000");
 DEFINE_mBool(enable_file_cache_keep_base_compaction_output, "false");
+// encoding segment file info into file cache key for tracing, clean cache
+// after change
+DEFINE_Bool(enable_file_cache_debug_hash, "false");
 
 DEFINE_mInt32(index_cache_entry_stay_time_after_lookup_s, "1800");
 DEFINE_mInt32(inverted_index_cache_stale_sweep_time_sec, "600");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1106,6 +1106,9 @@ DECLARE_Int64(file_cache_recycle_keys_size);
 // If your file cache is ample enough to accommodate all the data in your database,
 // enable this option; otherwise, it is recommended to leave it disabled.
 DECLARE_mBool(enable_file_cache_keep_base_compaction_output);
+// encoding segment file info into file cache key for tracing, clean cache
+// after change
+DECLARE_Bool(enable_file_cache_debug_hash);
 
 // inverted index searcher cache
 // cache entry stay time after lookup

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -6815,12 +6815,14 @@ TEST_F(BlockFileCacheTest, evict_privilege_order_for_ttl) {
 }
 
 TEST_F(BlockFileCacheTest, hash) {
+    config::enable_file_cache_debug_hash = true;
     UInt128Wrapper key =
             io::BlockFileCache::hash("02000000008446c25a44a212eaf9d46caaf29264eb3e43a5_0.dat");
     ASSERT_EQ(key.to_string(), "02000000008446c2aaf29264eb3e4300");
     UInt128Wrapper bad_key =
             io::BlockFileCache::hash("0X000000008446c25a44a212eaf9d46caaf29264eb3e43a5_0.dat");
     ASSERT_EQ(bad_key.to_string(), "00000000000000000000000000000000");
+    config::enable_file_cache_debug_hash = false;
 }
 
 } // namespace doris::io

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -6814,4 +6814,13 @@ TEST_F(BlockFileCacheTest, evict_privilege_order_for_ttl) {
     }
 }
 
+TEST_F(BlockFileCacheTest, hash) {
+    UInt128Wrapper key =
+            io::BlockFileCache::hash("02000000008446c25a44a212eaf9d46caaf29264eb3e43a5_0.dat");
+    ASSERT_EQ(key.to_string(), "02000000008446c2aaf29264eb3e4300");
+    UInt128Wrapper bad_key =
+            io::BlockFileCache::hash("0X000000008446c25a44a212eaf9d46caaf29264eb3e43a5_0.dat");
+    ASSERT_EQ(bad_key.to_string(), "00000000000000000000000000000000");
+}
+
 } // namespace doris::io


### PR DESCRIPTION
for segment file name:
```
02000000008446c25a44a212eaf9d46caaf29264eb3e43a5_0.dat
      64bit    |               |    56bit    |
----  keep  ---|---   omit  ---|---  keep  --| omit & append segnum
```
so the corresponding cache key is:
```
02000000008446c2aaf29264eb3e4300
```

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

