### PR TITLE
[Fix](cloud) Remove pending delete bitmap's `lock_id` check when commit txn in MS

### DIFF
--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -997,12 +997,10 @@ void process_mow_when_commit_txn(
             }
 
             if (pending_info.has_lock_id() && pending_info.lock_id() != lock_id) {
-                code = MetaServiceCode::PENDING_DELETE_BITMAP_WRONG;
-                msg = fmt::format(
+                LOG_WARNING(
                         "wrong lock_id in pending delete bitmap infos, expect lock_id={}, but "
                         "found {} tablet_id={} instance_id={}",
                         lock_id, pending_info.lock_id(), tablet_id, instance_id);
-                return;
             }
 
             txn->remove(pending_key);

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -997,6 +997,8 @@ void process_mow_when_commit_txn(
             }
 
             if (pending_info.has_lock_id() && pending_info.lock_id() != lock_id) {
+                TEST_SYNC_POINT_CALLBACK("commit_txn:check_pending_delete_bitmap_lock_id",
+                                         &tablet_id);
                 LOG_WARNING(
                         "wrong lock_id in pending delete bitmap infos, expect lock_id={}, but "
                         "found {} tablet_id={} instance_id={}",


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: https://github.com/apache/doris/pull/46039

Problem Summary:

https://github.com/apache/doris/pull/46039 add a defensive check when commit_txn in MS to check whether the `lock_id` of pending delete bitmaps on tablets involved in the txn is the current txn's `lock_id`. But this may report a false negative in the following circumstance:

1. heavy schema change begins and add shadow index to table.
2. txn A load data to base index and shadow index.
3. txn A write its pending delete bitmaps on MS. This includes tablets of base index and shadow index.
4. txn A failed to remove its pending delete bitmaps for some reson(e.g. `commit_txn()` failed due to too large value)
5. txn B load data to base index and shadow index.
6. schema change failed for some reason and **remove shadow index on table.**
7. txn B send delete bitmap calculation task to BE. **Note that this will not involved tablets under shadow index because these tablets have been dropped.**  **So these tablets' pending delete bitmaps will still be txn A's**.
8. txn B commit txn on MS and find that pending delete bitmaps' `lock_id` on tablets under shadow index not match. And txn B will failed.

We can see that the checks on these dropped tablets are useless so we remove the mandatory check to avoid this false negative and print a warning log instead to help locate problems.

Cases will be added later. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

