### PR TITLE
[feat](binlog) Add lock binlog method

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -130,7 +130,7 @@ public class BinlogManager {
     }
 
     private void addBinlog(long dbId, List<Long> tableIds, long commitSeq, long timestamp, TBinlogType type,
-                           String data, boolean removeEnableCache, Object raw) {
+            String data, boolean removeEnableCache, Object raw) {
         if (!Config.enable_feature_binlog) {
             return;
         }
@@ -447,7 +447,6 @@ public class BinlogManager {
         addBinlog(dbId, tableIds, commitSeq, timestamp, type, data, false, info);
     }
 
-
     private boolean supportedRecoverInfo(RecoverInfo info) {
         //table name and partitionName added together.
         // recover table case, tablename must exist in newer version
@@ -507,6 +506,26 @@ public class BinlogManager {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    public Pair<TStatus, Long> lockBinlog(long dbId, long tableId,
+            String jobUniqueId, long lockCommitSeq) {
+        LOG.debug("lock binlog. dbId: {}, tableId: {}, jobUniqueId: {}, lockCommitSeq: {}",
+                dbId, tableId, jobUniqueId, lockCommitSeq);
+
+        DBBinlog dbBinlog = null;
+        lock.readLock().lock();
+        try {
+            dbBinlog = dbBinlogMap.get(dbId);
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        if (dbBinlog == null) {
+            LOG.warn("db binlog not found. dbId: {}", dbId);
+            return Pair.of(new TStatus(TStatusCode.BINLOG_NOT_FOUND_DB), -1L);
+        }
+        return dbBinlog.lockBinlog(tableId, jobUniqueId, lockCommitSeq);
     }
 
     // get the dropped partitions of the db.
@@ -623,7 +642,6 @@ public class BinlogManager {
         }
     }
 
-
     private static void writeTBinlogToStream(DataOutputStream dos, TBinlog binlog) throws TException, IOException {
         TMemoryBuffer buffer = new TMemoryBuffer(BUFFER_SIZE);
         TBinaryProtocol protocol = new TBinaryProtocol(buffer);
@@ -632,7 +650,6 @@ public class BinlogManager {
         dos.writeInt(data.length);
         dos.write(data);
     }
-
 
     // not thread safety, do this without lock
     public long write(DataOutputStream dos, long checksum) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
@@ -75,6 +75,10 @@ public class DBBinlog {
 
     private BinlogConfigCache binlogConfigCache;
 
+    // The binlogs that are locked by the syncer.
+    // syncer id => commit seq
+    private Map<String, Long> lockedBinlogs;
+
     public DBBinlog(BinlogConfigCache binlogConfigCache, TBinlog binlog) {
         lock = new ReentrantReadWriteLock();
         this.dbId = binlog.getDbId();
@@ -89,6 +93,7 @@ public class DBBinlog {
         droppedPartitions = Lists.newArrayList();
         droppedTables = Lists.newArrayList();
         droppedIndexes = Lists.newArrayList();
+        lockedBinlogs = Maps.newHashMap();
 
         TBinlog dummy;
         if (binlog.getType() == TBinlogType.DUMMY) {
@@ -279,6 +284,55 @@ public class DBBinlog {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    public Pair<TStatus, Long> lockBinlog(long tableId, String jobUniqueId, long lockCommitSeq) {
+        TableBinlog tableBinlog = null;
+
+        lock.writeLock().lock();
+        try {
+            if (tableId < 0) {
+                return lockDbBinlog(jobUniqueId, lockCommitSeq);
+            }
+
+            tableBinlog = tableBinlogMap.get(tableId);
+        } finally {
+            lock.writeLock().unlock();
+        }
+
+        if (tableBinlog == null) {
+            LOG.warn("table binlog not found. dbId: {}, tableId: {}", dbId, tableId);
+            return Pair.of(new TStatus(TStatusCode.BINLOG_NOT_FOUND_TABLE), -1L);
+        }
+        return tableBinlog.lockBinlog(jobUniqueId, lockCommitSeq);
+    }
+
+    // Require: the write lock is held by the caller.
+    private Pair<TStatus, Long> lockDbBinlog(String jobUniqueId, long lockCommitSeq) {
+        TBinlog firstBinlog = allBinlogs.first();
+        TBinlog lastBinlog = allBinlogs.last();
+
+        if (lockCommitSeq < 0) {
+            // lock the latest binlog
+            lockCommitSeq = lastBinlog.getCommitSeq();
+        } else if (lockCommitSeq < firstBinlog.getCommitSeq()) {
+            // lock the first binlog
+            lockCommitSeq = firstBinlog.getCommitSeq();
+        } else if (lastBinlog.getCommitSeq() < lockCommitSeq) {
+            LOG.warn("try lock future binlogs, dbId: {}, lockCommitSeq: {}, lastCommitSeq: {}, jobId: {}",
+                    dbId, lockCommitSeq, lastBinlog.getCommitSeq(), jobUniqueId);
+            return Pair.of(new TStatus(TStatusCode.BINLOG_TOO_NEW_COMMIT_SEQ), -1L);
+        }
+
+        // keep idempotent
+        Long commitSeq = lockedBinlogs.get(jobUniqueId);
+        if (commitSeq != null && lockCommitSeq <= commitSeq) {
+            LOG.debug("binlog is locked, commitSeq: {}, jobId: {}, dbId: {}", commitSeq, jobUniqueId, dbId);
+            return Pair.of(new TStatus(TStatusCode.OK), commitSeq);
+        }
+
+        lockedBinlogs.put(jobUniqueId, lockCommitSeq);
+        return Pair.of(new TStatus(TStatusCode.OK), lockCommitSeq);
     }
 
     public BinlogTombstone gc() {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
@@ -26,8 +26,10 @@ import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.thrift.TBinlog;
 import org.apache.doris.thrift.TBinlogType;
 import org.apache.doris.thrift.TStatus;
+import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -54,6 +57,10 @@ public class TableBinlog {
 
     private BinlogConfigCache binlogConfigCache;
 
+    // The binlogs that are locked by the syncer.
+    // syncer id => commit seq
+    private Map<String, Long> lockedBinlogs;
+
     public TableBinlog(BinlogConfigCache binlogConfigCache, TBinlog binlog, long dbId, long tableId) {
         this.dbId = dbId;
         this.tableId = tableId;
@@ -61,6 +68,7 @@ public class TableBinlog {
         lock = new ReentrantReadWriteLock();
         binlogs = Sets.newTreeSet(Comparator.comparingLong(TBinlog::getCommitSeq));
         timestamps = Lists.newArrayList();
+        lockedBinlogs = Maps.newHashMap();
 
         TBinlog dummy;
         if (binlog.getType() == TBinlogType.DUMMY) {
@@ -122,6 +130,45 @@ public class TableBinlog {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    public Pair<TStatus, Long> lockBinlog(String jobUniqueId, long lockCommitSeq) {
+        lock.writeLock().lock();
+        try {
+            return lockTableBinlog(jobUniqueId, lockCommitSeq);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    // Require: the lock is held by the caller.
+    private Pair<TStatus, Long> lockTableBinlog(String jobUniqueId, long lockCommitSeq) {
+        TBinlog firstBinlog = binlogs.first();
+        TBinlog lastBinlog = binlogs.last();
+
+        if (lockCommitSeq < 0) {
+            // lock the latest binlog
+            lockCommitSeq = lastBinlog.getCommitSeq();
+        } else if (lockCommitSeq < firstBinlog.getCommitSeq()) {
+            // lock the first binlog
+            lockCommitSeq = firstBinlog.getCommitSeq();
+        } else if (lastBinlog.getCommitSeq() < lockCommitSeq) {
+            LOG.warn(
+                    "try lock future binlogs, dbId: {}, tableId: {}, lockCommitSeq: {}, lastCommitSeq: {}, jobId: {}",
+                    dbId, tableId, lockCommitSeq, lastBinlog.getCommitSeq(), jobUniqueId);
+            return Pair.of(new TStatus(TStatusCode.BINLOG_TOO_NEW_COMMIT_SEQ), -1L);
+        }
+
+        // keep idempotent
+        Long commitSeq = lockedBinlogs.get(jobUniqueId);
+        if (commitSeq != null && lockCommitSeq <= commitSeq) {
+            LOG.debug("binlog is locked, commitSeq: {}, jobId: {}, dbId: {}, tableId: {}",
+                    commitSeq, jobUniqueId, dbId, tableId);
+            return Pair.of(new TStatus(TStatusCode.OK), commitSeq);
+        }
+
+        lockedBinlogs.put(jobUniqueId, lockCommitSeq);
+        return Pair.of(new TStatus(TStatusCode.OK), lockCommitSeq);
     }
 
     private Pair<TBinlog, Long> getLastUpsertAndLargestCommitSeq(BinlogComparator checker) {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -946,6 +946,29 @@ struct TQueryStatsResult {
     5: optional map<i64, i64> tablet_stats
 }
 
+// Lock the binlogs, to avoid being GC during sync.
+//
+// The caller should lock the binlog before backup, and bumps lock commit seq intervally.
+//
+// The locked binlogs will be kept until the binlog properties ttl_seconds, max_bytes ... are reached.
+struct TLockBinlogRequest {
+    1: optional string cluster
+    2: optional string user
+    3: optional string passwd
+    4: optional string db
+    5: optional string table
+    6: optional i64 table_id
+    7: optional string token
+    8: optional string job_unique_id
+    9: optional i64 lock_commit_seq // if not set, lock the latest binlog
+}
+
+struct TLockBinlogResult {
+    1: optional Status.TStatus status
+    2: optional i64 locked_commit_seq
+    3: optional Types.TNetworkAddress master_address
+}
+
 struct TGetBinlogRequest {
     1: optional string cluster
     2: optional string user
@@ -1532,6 +1555,7 @@ service FrontendService {
     TGetBinlogResult getBinlog(1: TGetBinlogRequest request)
     TGetSnapshotResult getSnapshot(1: TGetSnapshotRequest request)
     TRestoreSnapshotResult restoreSnapshot(1: TRestoreSnapshotRequest request)
+    TLockBinlogResult lockBinlog(1: TLockBinlogRequest request)
 
     TWaitingTxnStatusResult waitingTxnStatus(1: TWaitingTxnStatusRequest request)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This is the first PR for locking binlogs. 

To reduce the cost of maintaining binlogs, an API named lockBinlog has been added. Users use this API to indicate which binlogs are not permitted for GC.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

