### PR TITLE
[Fix](recycler) Avoid accessing moved S3Conf object in S3Accessor initialization

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2915,17 +2915,16 @@ int InstanceRecycler::recycle_expired_stage_objects() {
             continue;
         }
 
-        std::string prefix = s3_conf->prefix;
         s3_conf->prefix = stage.obj_info().prefix();
         std::shared_ptr<S3Accessor> accessor;
-        int ret1 = S3Accessor::create(std::move(*s3_conf), &accessor);
+        int ret1 = S3Accessor::create(*s3_conf, &accessor);
         if (ret1 != 0) {
             LOG(WARNING) << "failed to init s3 accessor ret=" << ret1 << " " << ss.str();
             ret = -1;
             continue;
         }
 
-        if (prefix.find("/stage/") == std::string::npos) {
+        if (s3_conf->prefix.find("/stage/") == std::string::npos) {
             LOG(WARNING) << "try to delete illegal prefix, which is catastrophic, " << ss.str();
             ret = -1;
             continue;

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2915,6 +2915,7 @@ int InstanceRecycler::recycle_expired_stage_objects() {
             continue;
         }
 
+        std::string prefix = s3_conf->prefix;
         s3_conf->prefix = stage.obj_info().prefix();
         std::shared_ptr<S3Accessor> accessor;
         int ret1 = S3Accessor::create(std::move(*s3_conf), &accessor);
@@ -2924,7 +2925,7 @@ int InstanceRecycler::recycle_expired_stage_objects() {
             continue;
         }
 
-        if (s3_conf->prefix.find("/stage/") == std::string::npos) {
+        if (prefix.find("/stage/") == std::string::npos) {
             LOG(WARNING) << "try to delete illegal prefix, which is catastrophic, " << ss.str();
             ret = -1;
             continue;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

