### PR TITLE
[fix](external catalog) Persisting the External Catalog comment field

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -139,6 +139,9 @@ public abstract class ExternalCatalog
     // <db name, table name> to tableAutoAnalyzePolicy
     @SerializedName(value = "taap")
     protected Map<Pair<String, String>, String> tableAutoAnalyzePolicy = Maps.newHashMap();
+    @SerializedName(value = "comment")
+    private String comment;
+
     // db name does not contains "default_cluster"
     protected Map<String, Long> dbNameToId = Maps.newConcurrentMap();
     private boolean objectCreated = false;
@@ -147,7 +150,6 @@ public abstract class ExternalCatalog
     protected TransactionManager transactionManager;
 
     private ExternalSchemaCache schemaCache;
-    private String comment;
     // A cached and being converted properties for external catalog.
     // generated from catalog properties.
     private byte[] propLock = new byte[0];

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -276,4 +276,37 @@ public class ExternalCatalogTest extends TestWithFeService {
         dis.close();
         file.delete();
     }
+
+    @Test
+    public void testSerializationWithComment() throws Exception {
+        MetaContext metaContext = new MetaContext();
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_CURRENT);
+        metaContext.setThreadLocalInfo();
+
+        // 1. Write objects to file
+        File file = new File("./external_catalog_with_comment_test.dat");
+        file.createNewFile();
+        DataOutputStream dos = new DataOutputStream(Files.newOutputStream(file.toPath()));
+
+        TestExternalCatalog ctl = (TestExternalCatalog) mgr.getCatalog("test1");
+        String testComment = "This is a test comment for serialization";
+        ctl.setComment(testComment); // Set a custom comment value
+        ctl.write(dos);
+        dos.flush();
+        dos.close();
+
+        // 2. Read objects from file
+        DataInputStream dis = new DataInputStream(Files.newInputStream(file.toPath()));
+
+        TestExternalCatalog ctl2 = (TestExternalCatalog) ExternalCatalog.read(dis);
+        Configuration conf = ctl2.getConfiguration();
+        Assertions.assertNotNull(conf);
+
+        // Verify the comment is properly serialized and deserialized
+        Assertions.assertEquals(testComment, ctl2.getComment());
+
+        // 3. delete files
+        dis.close();
+        file.delete();
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Since the comment field is not persisted, the comment will be lost after the FE is restarted after the comment is modified. This PR adds persistence to the comment.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

