### PR TITLE
[fix](sort) fix coredump by uncaught exception。  DO NOT MERGE 

### DIFF
--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -251,7 +251,7 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
         } else if (!status.ok()) {
             // Currently, a known error status is emitted when sender
             // close recei
-            throw std::runtime_error(status.msg());
+            throw Exception(status.code(), status.msg());
         }
         return false;
     }

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -97,7 +97,7 @@ Status VSortedRunMerger::prepare(const vector<BlockSupplier>& input_runs) {
     return Status::OK();
 }
 
-Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
+Status VSortedRunMerger::_get_next_internal(Block* output_block, bool* eos) {
     ScopedTimer<MonotonicStopWatch> timer(_get_next_timer);
     // Only have one receive data queue of data, no need to do merge and
     // copy the data of block.
@@ -211,6 +211,10 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
         *eos = true;
     }
     return Status::OK();
+}
+
+Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
+    RETURN_IF_CATCH_EXCEPTION(return _get_next_internal(output_block, eos));
 }
 
 bool VSortedRunMerger::next_heap(MergeSortCursor& current) {

--- a/be/src/vec/runtime/vsorted_run_merger.h
+++ b/be/src/vec/runtime/vsorted_run_merger.h
@@ -99,6 +99,8 @@ private:
     /// In pipeline engine, return false if need to read one more block from sender.
     bool next_heap(MergeSortCursor& current);
     bool has_next_block(MergeSortCursor& current);
+
+    Status _get_next_internal(Block* output_block, bool* eos);
 };
 
 } // namespace vectorized


### PR DESCRIPTION
NOT  MERGE this PR

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

coredump:
```
Query id: 8a5e4545d3cc4fee-8b5c7c7a40552fe2 ***
tablet id: 0 ***
Aborted at 1731121806 (unix time) try "date -d @1731121806" if you are using GNU date ***
Current BE git commitID: 856270f167 ***
SIGABRT unknown detail explain (@0x3e8000f1daf) received by PID 990639 (TID 2743004 OR 0x7fd0b69c6700) from PID 990639; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/selectdb-core/be/src/common/signal_handler.h:435
1# 0x00007FD86B4AB400 in /lib64/libc.so.6
2# __GI_raise in /lib64/libc.so.6
3# __GI_abort in /lib64/libc.so.6
4# _gnu_cxx::_verbose_terminate_handler() [clone .cold] at ../../../../libstdc+-v3/libsupc+/vterminate.cc:75
5# _cxxabiv1::_terminate(void ()) at ../../../../libstdc+-v3/libsupc+/eh_terminate.cc:48
6# 0x000055A693ED7F01 in /opt/selectdb/3.0.10.3/be/lib/doris_be
7# 0x000055A693ED8054 in /opt/selectdb/3.0.10.3/be/lib/doris_be
8# doris::vectorized::BlockSupplierSortCursorImpl::has_next_block() in /opt/selectdb/3.0.10.3/be/lib/doris_be
9# doris::vectorized::VSortedRunMerger::has_next_block(doris::vectorized::MergeSortCursor&) in /opt/selectdb/3.0.10.3/be/lib/doris_be
10# doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*) at /root/selectdb-core/be/src/vec/runtime/vsorted_run_merger.cpp:193
11# doris::vectorized::VDataStreamRecvr::get_next(doris::vectorized::Block*, bool*) in /opt/selectdb/3.0.10.3/be/lib/doris_be
12# doris::vectorized::VExchangeNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/selectdb-core/be/src/vec/exec/vexchange_node.cpp:107
13# std::_Function_handler<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*), std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)> >::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /root/tools/ldb-16/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
14# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)> const&, bool) at /root/selectdb-core/be/src/exec/exec_node.cpp:597
15# doris::PlanFragmentExecutor::get_vectorized_internal(doris::vectorized::Block*, bool*) at /root/selectdb-core/be/src/runtime/plan_fragment_executor.cpp:356
16# doris::PlanFragmentExecutor::open_vectorized_internal() in /opt/selectdb/3.0.10.3/be/lib/doris_be
17# doris::PlanFragmentExecutor::open() at /root/selectdb-core/be/src/runtime/plan_fragment_executor.cpp:265
18# doris::FragmentExecState::execute() at /root/selectdb-core/be/src/runtime/fragment_mgr.cpp:281
19# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /root/selectdb-core/be/src/runtime/fragment_mgr.cpp:554
20# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /root/tools/ldb-16/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
21# doris::ThreadPool::dispatch_thread() in /opt/selectdb/3.0.10.3/be/lib/doris_be
22# doris::Thread::supervise_thread(void*) at /root/selectdb-core/be/src/util/thread.cpp:499
23# start_thread in /lib64/libpthread.so.0
24# _GI__clone in /lib64/libc.so.6
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

