### PR TITLE
[Bug](dead lock) Fix dead lock in Tablet Stat Mgr

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -305,7 +305,7 @@ public class Config extends ConfigBase {
 
     @ConfField(masterOnly = true, description = {"TabletStatMgr线程数",
             "Num of thread to update tablet stat"})
-    public static int tablet_stat_mgr_threads_num = 16;
+    public static int tablet_stat_mgr_threads_num = -1;
 
     @ConfField(masterOnly = true, description = {"Agent任务线程池的线程数",
             "Num of thread to handle agent task in agent task thread-pool"})

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -303,6 +303,10 @@ public class Config extends ConfigBase {
             "Queue size to store heartbeat task in heartbeat_mgr"})
     public static int heartbeat_mgr_blocking_queue_size = 1024;
 
+    @ConfField(masterOnly = true, description = {"TabletStatMgr线程数",
+            "Num of thread to update tablet stat"})
+    public static int tablet_stat_mgr_threads_num = 16;
+
     @ConfField(masterOnly = true, description = {"Agent任务线程池的线程数",
             "Num of thread to handle agent task in agent task thread-pool"})
     public static int max_agent_task_threads_num = 4096;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.BackendService;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -244,7 +245,7 @@ public class TabletStatMgr extends MasterDaemon {
     public void waitForTabletStatUpdate() {
         boolean ok = true;
         try {
-            if (!updateTabletStatsLatch.await(60, TimeUnit.SECONDS)) {
+            if (!updateTabletStatsLatch.await(600, TimeUnit.SECONDS)) {
                 LOG.info("timeout waiting {} update tablet stats tasks finish after {} seconds.",
                         updateTabletStatsLatch.getCount(), 60);
                 ok = false;
@@ -261,6 +262,9 @@ public class TabletStatMgr extends MasterDaemon {
             }
             LOG.warn("Failed to update tablet stats reason: {}, unfinished backends: {}",
                     status.getErrorMsg(), unfinishedBackendIds);
+            if (MetricRepo.isInit) {
+                MetricRepo.COUNTER_UPDATE_TABLET_STAT_FAILED.increase(1L);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -53,7 +53,7 @@ public class TabletStatMgr extends MasterDaemon {
         int minimunParallelism = Math.max(8, Runtime.getRuntime().availableProcessors());
         int maximunParallelism = 64;
         int newParallelism = Math.min(backendSize, maximunParallelism);
-        newParallelism = Math.max(newParallelism, maximunParallelism);
+        newParallelism = Math.max(newParallelism, minimunParallelism);
         newParallelism = (newParallelism + 7) / 8 * 8; // Round up to the multiple of 8
         if (taskPool == null || taskPool.getParallelism() != newParallelism) {
             return new ForkJoinPool(newParallelism);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -61,7 +61,7 @@ public class TabletStatMgr extends MasterDaemon {
         long start = System.currentTimeMillis();
         taskPool.submit(() -> {
             // no need to get tablet stat if backend is not alive
-            backends.values().stream().filter(Backend::isAlive).parallel().forEach(backend -> {
+            backends.values().stream().filter(Backend::isAlive).forEach(backend -> {
                 BackendService.Client client = null;
                 TNetworkAddress address = null;
                 boolean ok = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -247,7 +247,7 @@ public class TabletStatMgr extends MasterDaemon {
         try {
             if (!updateTabletStatsLatch.await(600, TimeUnit.SECONDS)) {
                 LOG.info("timeout waiting {} update tablet stats tasks finish after {} seconds.",
-                        updateTabletStatsLatch.getCount(), 60);
+                        updateTabletStatsLatch.getCount(), 600);
                 ok = false;
             }
         } catch (InterruptedException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -50,8 +50,10 @@ public class TabletStatMgr extends MasterDaemon {
     }
 
     private ForkJoinPool adjustThreadPool(int backendSize) {
-        int newParallelism = Math.min(backendSize, 64);
-        newParallelism = Math.max(newParallelism, 8);
+        int minimunParallelism = Math.max(8, Runtime.getRuntime().availableProcessors());
+        int maximunParallelism = 64;
+        int newParallelism = Math.min(backendSize, maximunParallelism);
+        newParallelism = Math.max(newParallelism, maximunParallelism);
         newParallelism = (newParallelism + 7) / 8 * 8; // Round up to the multiple of 8
         if (taskPool == null || taskPool.getParallelism() != newParallelism) {
             return new ForkJoinPool(newParallelism);

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -101,6 +101,8 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_CACHE_HIT_SQL;
     public static LongCounterMetric COUNTER_CACHE_HIT_PARTITION;
 
+    public static LongCounterMetric COUNTER_UPDATE_TABLET_STAT_FAILED;
+
     public static LongCounterMetric COUNTER_EDIT_LOG_WRITE;
     public static LongCounterMetric COUNTER_EDIT_LOG_READ;
     public static LongCounterMetric COUNTER_EDIT_LOG_CURRENT;
@@ -495,6 +497,10 @@ public final class MetricRepo {
                 "counter of failed transactions");
         COUNTER_TXN_FAILED.addLabel(new MetricLabel("type", "failed"));
         DORIS_METRIC_REGISTER.addMetrics(COUNTER_TXN_FAILED);
+        COUNTER_UPDATE_TABLET_STAT_FAILED = new LongCounterMetric("update_tablet_stat_failed", MetricUnit.REQUESTS,
+            "counter of failed to update tablet stat");
+        COUNTER_UPDATE_TABLET_STAT_FAILED.addLabel(new MetricLabel("type", "failed"));
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_UPDATE_TABLET_STAT_FAILED);
         HISTO_TXN_EXEC_LATENCY = METRIC_REGISTER.histogram(
             MetricRegistry.name("txn", "exec", "latency", "ms"));
         HISTO_TXN_PUBLISH_LATENCY = METRIC_REGISTER.histogram(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #28608

Problem Summary:

In TabletStatMgr, We use stream().parallel() or parallelStream() in a ForkJoinTask，when they are called, the stream will allocate the `ForEach` task to multiple threads. However, when the stream is within a ForkJoinTask, it will attempt to steal threads from the ForkJoinPool. When the number of threads in the ForkJoinPool is small, thread competition is very likely to occur, ultimately leading to a deadlock.

Here is a deadlock stack of 4-core Fe with 3 Be:

Dead Lock Stack:

The address 0x00000005cc189d48 is the ForkJoinPool in TabletStatMgr.

```
"tablet stat mgr" #28 daemon prio=5 os_prio=0 cpu=12322.96ms elapsed=2159051.95s allocated=8527M defined_classes=5 tid=0x00007f4d241d6800 nid=0x24b6 in Object.wait()  [0x00007f4cfb37a000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(java.base@11.0.24/Native Method)
        - waiting on <no object reference available>
        at java.util.concurrent.ForkJoinTask.externalAwaitDone(java.base@11.0.24/ForkJoinTask.java:330)
        - waiting to re-lock in wait() <0x00000005debf6e00> (a java.util.concurrent.ForkJoinTask$AdaptedRunnableAction)
        at java.util.concurrent.ForkJoinTask.doJoin(java.base@11.0.24/ForkJoinTask.java:398)
        at java.util.concurrent.ForkJoinTask.join(java.base@11.0.24/ForkJoinTask.java:721)
        at org.apache.doris.catalog.TabletStatMgr.runAfterCatalogReady(TabletStatMgr.java:85)
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58)
        at org.apache.doris.common.util.Daemon.run(Daemon.java:119)

   Locked ownable synchronizers:
        - None

"ForkJoinPool-2-worker-9" #444184 daemon prio=5 os_prio=0 cpu=2.16ms elapsed=175074.53s allocated=1076K defined_classes=0 tid=0x00007f4d60dc6000 nid=0xd4a06 waiting on condition  [0x00007f4ce315f000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@11.0.24/Native Method)
        - parking to wait for  <0x00000005cc189d48> (a java.util.concurrent.ForkJoinPool)
        at java.util.concurrent.locks.LockSupport.park(java.base@11.0.24/LockSupport.java:194)
        at java.util.concurrent.ForkJoinPool.runWorker(java.base@11.0.24/ForkJoinPool.java:1628)
        at java.util.concurrent.ForkJoinWorkerThread.run(java.base@11.0.24/ForkJoinWorkerThread.java:183)

"ForkJoinPool-2-worker-11" #444199 daemon prio=5 os_prio=0 cpu=1.27ms elapsed=175014.53s allocated=555K defined_classes=0 tid=0x00007f4d802a1800 nid=0xd4cd6 waiting on condition  [0x00007f4cdc32e000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@11.0.24/Native Method)
        - parking to wait for  <0x00000005cc189d48> (a java.util.concurrent.ForkJoinPool)
        at java.util.concurrent.locks.LockSupport.park(java.base@11.0.24/LockSupport.java:194)
        at java.util.concurrent.ForkJoinPool.runWorker(java.base@11.0.24/ForkJoinPool.java:1628)
        at java.util.concurrent.ForkJoinWorkerThread.run(java.base@11.0.24/ForkJoinWorkerThread.java:183)

"ForkJoinPool-2-worker-13" #444212 daemon prio=5 os_prio=0 cpu=0.09ms elapsed=174954.53s allocated=32784B defined_classes=0 tid=0x00007f4d7cedd000 nid=0xd4fa5 waiting on condition  [0x00007f4cd9520000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@11.0.24/Native Method)
        - parking to wait for  <0x00000005cc189d48> (a java.util.concurrent.ForkJoinPool)
        at java.util.concurrent.locks.LockSupport.park(java.base@11.0.24/LockSupport.java:194)
        at java.util.concurrent.ForkJoinPool.runWorker(java.base@11.0.24/ForkJoinPool.java:1628)
        at java.util.concurrent.ForkJoinWorkerThread.run(java.base@11.0.24/ForkJoinWorkerThread.java:183)
```

This commit will abandon ForkJoinPool and use a regular thread pool instead.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

