### PR TITLE
[fix](Nereids) bind schema table qualified column failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -417,7 +417,9 @@ public class BindRelation extends OneAnalysisRuleFactory {
                             qualifierWithoutTableName, unboundRelation.getTableSample(),
                             unboundRelation.getTableSnapshot());
                 case SCHEMA:
-                    return new LogicalSchemaScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);
+                    // schema table's name is case-insensitive, we need save its name in SQL text to get correct case.
+                    return new LogicalSubQueryAlias<>(qualifiedTableName,
+                            new LogicalSchemaScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName));
                 case JDBC_EXTERNAL_TABLE:
                 case JDBC:
                     return new LogicalJdbcScan(unboundRelation.getRelationId(), table, qualifierWithoutTableName);

--- a/regression-test/suites/nereids_syntax_p0/information_schema.groovy
+++ b/regression-test/suites/nereids_syntax_p0/information_schema.groovy
@@ -27,5 +27,5 @@ suite("information_schema") {
 
     // INFORMATION_SCHEMA
     sql "SELECT table_name FROM INFORMATION_SCHEMA.TABLES where table_schema=\"test%\" and TABLE_TYPE = \"BASE TABLE\" order by table_name"
-    sql "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = \"test%\" AND column_name LIKE \"k%\""
+    sql "SELECT COLUMNS.COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = \"test%\" AND column_name LIKE \"k%\""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

since schema table's name is case insensitive, we should compare column's qulifier with table name in SQL text, not with table's name in meta data.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

