### PR TITLE
[fix](cloud-mow) Fix the issue of inaccurate estimation of txn size when updating delete bitmap

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -229,6 +229,13 @@ CONF_mInt64(max_s3_client_retry, "10");
 // Max byte getting delete bitmap can return, default is 1GB
 CONF_mInt64(max_get_delete_bitmap_byte, "1073741824");
 
+// Max byte txn commit when updating delete bitmap, default is 7MB.
+// Because the size of one fdb transaction can't exceed 10MB, and
+// fdb does not have an accurate way to estimate the size of txn.
+// In my test, when txn->approximate_bytes() bigger than 8MB,
+// it may meet Transaction exceeds byte limit error. We'd better
+// reserve 1MB of buffer, so setting the default value to 7MB is
+// more reasonable.
 CONF_mInt64(max_txn_commit_byte, "7340032");
 
 CONF_Bool(enable_cloud_txn_lazy_commit, "true");

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -229,6 +229,8 @@ CONF_mInt64(max_s3_client_retry, "10");
 // Max byte getting delete bitmap can return, default is 1GB
 CONF_mInt64(max_get_delete_bitmap_byte, "1073741824");
 
+CONF_mInt64(max_txn_commit_byte, "7340032");
+
 CONF_Bool(enable_cloud_txn_lazy_commit, "true");
 CONF_Int32(txn_lazy_commit_rowsets_thresold, "1000");
 CONF_Int32(txn_lazy_commit_num_threads, "8");

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1851,17 +1851,26 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
     }
 
     // 4. Update delete bitmap for curent txn
-    size_t total_key = 0;
-    size_t total_size = 0;
+    size_t current_key_count = 0;
+    size_t current_value_count = 0;
+    size_t total_key_count = 0;
+    size_t total_value_count = 0;
     for (size_t i = 0; i < request->rowset_ids_size(); ++i) {
         auto& key = delete_bitmap_keys.delete_bitmap_keys(i);
         auto& val = request->segment_delete_bitmaps(i);
 
         // Split into multiple fdb transactions, because the size of one fdb
         // transaction can't exceed 10MB.
-        if (fdb_txn_size + key.size() + val.size() > 9 * 1024 * 1024) {
-            LOG(INFO) << "fdb txn size more than 9MB, current size: " << fdb_txn_size
-                      << " lock_id=" << request->lock_id();
+        if (txn->approximate_bytes() + key.size() * 3 + val.size() > config::max_txn_commit_byte) {
+            LOG(INFO) << "fdb txn size more than " << config::max_txn_commit_byte
+                      << ", current size: " << txn->approximate_bytes() << " lock_id=" << request->lock_id();
+            LOG(INFO) << "update delete bitmap tablet_id=" << tablet_id
+                      << " lock_id=" << request->lock_id()
+                      << " delete_bitmap_key=" << current_key_count
+                      << " delete_bitmap_value=" << current_value_count
+                      << " put_size=" << txn->put_bytes()
+                      << " num_put_keys=" << txn->num_put_keys()
+                      << " txn_size=" << txn->approximate_bytes();
             err = txn->commit();
             if (err != TxnErrorCode::TXN_OK) {
                 code = cast_as<ErrCategory::COMMIT>(err);
@@ -1869,7 +1878,8 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
                 msg = ss.str();
                 return;
             }
-            fdb_txn_size = 0;
+            current_key_count = 0;
+            current_value_count = 0;
             TxnErrorCode err = txn_kv_->create_txn(&txn);
             if (err != TxnErrorCode::TXN_OK) {
                 code = cast_as<ErrCategory::CREATE>(err);
@@ -1888,14 +1898,21 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
         }
         // splitting large values (>90*1000) into multiple KVs
         cloud::put(txn.get(), key, val, 0);
-        fdb_txn_size = fdb_txn_size + key.size() + val.size();
-        total_key++;
-        total_size += key.size() + val.size();
+        current_key_count++;
+        current_value_count += val.size();
+        total_key_count++;
+        total_value_count += val.size();
         VLOG_DEBUG << "xxx update delete bitmap put delete_bitmap_key=" << hex(key)
                    << " lock_id=" << request->lock_id() << " key_size: " << key.size()
                    << " value_size: " << val.size();
     }
-
+    LOG(INFO) << "update delete bitmap tablet_id=" << tablet_id
+              << " lock_id=" << request->lock_id()
+              << " delete_bitmap_key=" << current_key_count
+              << " delete_bitmap_value=" << current_value_count
+              << " put_size=" << txn->put_bytes()
+              << " num_put_keys=" << txn->num_put_keys()
+              << " txn_size=" << txn->approximate_bytes();
     err = txn->commit();
     if (err != TxnErrorCode::TXN_OK) {
         code = cast_as<ErrCategory::COMMIT>(err);
@@ -1903,9 +1920,11 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
         msg = ss.str();
         return;
     }
-    LOG(INFO) << "update_delete_bitmap tablet_id=" << tablet_id << " lock_id=" << request->lock_id()
-              << " rowset_num=" << request->rowset_ids_size() << " total_key=" << total_key
-              << " total_size=" << total_size << " unlock=" << unlock;
+    LOG(INFO) << "update_delete_bitmap tablet_id=" << tablet_id
+              << " lock_id=" << request->lock_id()
+              << " rowset_num=" << request->rowset_ids_size()
+              << " total_key_count=" << total_key_count
+              << " total_value_count=" << total_value_count << " unlock=" << unlock;
 }
 
 void MetaServiceImpl::get_delete_bitmap(google::protobuf::RpcController* controller,

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1860,7 +1860,8 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
         auto& val = request->segment_delete_bitmaps(i);
 
         // Split into multiple fdb transactions, because the size of one fdb
-        // transaction can't exceed 10MB.
+        // transaction can't exceed 10MB.In my test, when txn->approximate_bytes()
+        // bigger than 8.3MB, it will meet Transaction exceeds byte limit error.
         if (txn->approximate_bytes() + key.size() * 3 + val.size() > config::max_txn_commit_byte) {
             LOG(INFO) << "fdb txn size more than " << config::max_txn_commit_byte
                       << ", current size: " << txn->approximate_bytes() << " lock_id=" << request->lock_id();

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1864,13 +1864,13 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
         // bigger than 8.3MB, it will meet Transaction exceeds byte limit error.
         if (txn->approximate_bytes() + key.size() * 3 + val.size() > config::max_txn_commit_byte) {
             LOG(INFO) << "fdb txn size more than " << config::max_txn_commit_byte
-                      << ", current size: " << txn->approximate_bytes() << " lock_id=" << request->lock_id();
+                      << ", current size: " << txn->approximate_bytes()
+                      << " lock_id=" << request->lock_id();
             LOG(INFO) << "update delete bitmap tablet_id=" << tablet_id
                       << " lock_id=" << request->lock_id()
                       << " delete_bitmap_key=" << current_key_count
                       << " delete_bitmap_value=" << current_value_count
-                      << " put_size=" << txn->put_bytes()
-                      << " num_put_keys=" << txn->num_put_keys()
+                      << " put_size=" << txn->put_bytes() << " num_put_keys=" << txn->num_put_keys()
                       << " txn_size=" << txn->approximate_bytes();
             err = txn->commit();
             if (err != TxnErrorCode::TXN_OK) {
@@ -1907,11 +1907,9 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
                    << " lock_id=" << request->lock_id() << " key_size: " << key.size()
                    << " value_size: " << val.size();
     }
-    LOG(INFO) << "update delete bitmap tablet_id=" << tablet_id
-              << " lock_id=" << request->lock_id()
+    LOG(INFO) << "update delete bitmap tablet_id=" << tablet_id << " lock_id=" << request->lock_id()
               << " delete_bitmap_key=" << current_key_count
-              << " delete_bitmap_value=" << current_value_count
-              << " put_size=" << txn->put_bytes()
+              << " delete_bitmap_value=" << current_value_count << " put_size=" << txn->put_bytes()
               << " num_put_keys=" << txn->num_put_keys()
               << " txn_size=" << txn->approximate_bytes();
     err = txn->commit();
@@ -1921,8 +1919,7 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
         msg = ss.str();
         return;
     }
-    LOG(INFO) << "update_delete_bitmap tablet_id=" << tablet_id
-              << " lock_id=" << request->lock_id()
+    LOG(INFO) << "update_delete_bitmap tablet_id=" << tablet_id << " lock_id=" << request->lock_id()
               << " rowset_num=" << request->rowset_ids_size()
               << " total_key_count=" << total_key_count
               << " total_value_count=" << total_value_count << " unlock=" << unlock;


### PR DESCRIPTION
fdb_txn_size is not key size+value size, actually txn size is the triple of key size plus value size at least for writing, so use txn->approximate_bytes() to calculating txn size is more accurate. However, txn->approximate_bytes() is not 100% accurate either, in my test, when txn->approximate_bytes() bingger than 8.3MB, it will meet Transaction exceeds byte limit error.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

