### PR TITLE
[fix](third-party) Fix the build of aws-sdk-cpp

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -165,7 +165,6 @@ jobs:
             'maven'
             'node'
             'llvm@15'
-            'llvm@16'
           )
 
           brew install "${packages[@]}" || true
@@ -217,7 +216,6 @@ jobs:
             'maven'
             'node'
             'llvm@15'
-            'llvm@16'
           )
 
           brew install "${packages[@]}" || true

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1250,19 +1250,16 @@ build_aws_sdk() {
     rm -rf "${BUILD_DIR}"
 
     if [[ "${KERNEL}" == 'Darwin' ]]; then
-        # Use llvm@16 to build aws-c-cal instead of llvm@15
-        USE_LLVM_16="-DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm@16/bin/clang"
+        EXTRA_CFLAGS='-DCMAKE_C_FLAGS="-DTARGET_OS_OSX=1"'
     else
-        USE_LLVM_16=''
+        EXTRA_CFLAGS=''
     fi
 
     # -Wno-nonnull gcc-11
     "${CMAKE_CMD}" -G "${GENERATOR}" -B"${BUILD_DIR}" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
         -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTING=OFF \
         -DCURL_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libcurl.a" -DZLIB_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libz.a" \
-        -DBUILD_ONLY="core;s3;s3-crt;transfer" \
-        ${USE_LLVM_16:+${USE_LLVM_16}} \
-        -DCMAKE_CXX_FLAGS="-Wno-nonnull -Wno-deprecated-declarations" -DCPP_STANDARD=17
+        -DBUILD_ONLY="core;s3;s3-crt;transfer" ${EXTRA_CFLAGS:+${EXTRA_CFLAGS}} -DCMAKE_CXX_FLAGS="-Wno-nonnull -Wno-deprecated-declarations" -DCPP_STANDARD=17
 
     cd "${BUILD_DIR}"
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The build of aws-sdk-cpp is broken.

```shell
bash build-thirdparty.sh aws_sdk

...

[59/268] Building C object crt/aws-crt-cpp/crt/aws-c-cal/CMakeFiles/aws-c-cal.dir/source/darwin/securityframework_ecc.c.o
FAILED: crt/aws-crt-cpp/crt/aws-c-cal/CMakeFiles/aws-c-cal.dir/source/darwin/securityframework_ecc.c.o
/opt/homebrew/opt/llvm@15/bin/clang -DENABLE_COMMONCRYPTO_ENCRYPTION -DENABLE_CURL_CLIENT -DHAVE_SYSCONF -DPLATFORM_APPLE -I/Users/doris/Programs/doris/thirdparty/src/aws-sdk-cpp-1.9.211/crt/aws-crt-cpp/crt/aws-c-cal/include -I/Users/doris/Programs/doris/thirdparty/src/aws-sdk-cpp-1.9.211/crt/aws-crt-cpp/crt/aws-c-common/include -I/Users/doris/Programs/doris/thirdparty/src/aws-sdk-cpp-1.9.211/doris_build/crt/aws-crt-cpp/crt/aws-c-common/generated/include -O2 -g -DNDEBUG -std=gnu99 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -Wall -Wstrict-prototypes -fno-omit-frame-pointer -pedantic -Wno-long-long -fPIC -moutline-atomics -Wgnu -Wno-gnu-zero-variadic-macro-arguments -MD -MT crt/aws-crt-cpp/crt/aws-c-cal/CMakeFiles/aws-c-cal.dir/source/darwin/securityframework_ecc.c.o -MF crt/aws-crt-cpp/crt/aws-c-cal/CMakeFiles/aws-c-cal.dir/source/darwin/securityframework_ecc.c.o.d -o crt/aws-crt-cpp/crt/aws-c-cal/CMakeFiles/aws-c-cal.dir/source/darwin/securityframework_ecc.c.o -c /Users/doris/Programs/doris/thirdparty/src/aws-sdk-cpp-1.9.211/crt/aws-crt-cpp/crt/aws-c-cal/source/darwin/securityframework_ecc.c
/Users/doris/Programs/doris/thirdparty/src/aws-sdk-cpp-1.9.211/crt/aws-crt-cpp/crt/aws-c-cal/source/darwin/securityframework_ecc.c:408:25: warning: call to undeclared function 'SecItemExport'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    OSStatus ret_code = SecItemExport(cc_key_pair->priv_key_ref, kSecFormatOpenSSL, 0, NULL, &sec_key_export_data);
                        ^
/Users/doris/Programs/doris/thirdparty/src/aws-sdk-cpp-1.9.211/crt/aws-crt-cpp/crt/aws-c-cal/source/darwin/securityframework_ecc.c:408:66: error: use of undeclared identifier 'kSecFormatOpenSSL'
    OSStatus ret_code = SecItemExport(cc_key_pair->priv_key_ref, kSecFormatOpenSSL, 0, NULL, &sec_key_export_data);
                                                                 ^
1 warning and 1 error generated.
[61/268] Building C object crt/aws-crt-cpp/crt/aws-c-cal/CMakeFiles/aws-c-cal.dir/source/der.c.o
ninja: build stopped: subcommand failed.
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

