### PR TITLE
[Bug](runtime-filter) fix bloom_filter_func use after free on get_build_bf_cardinality

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -867,11 +867,12 @@ void IRuntimeFilter::update_runtime_filter_type_to_profile(uint64_t local_merge_
 
 std::string IRuntimeFilter::debug_string() const {
     return fmt::format(
-            "RuntimeFilter: (id = {}, type = {}, is_broadcast: {}, ignored: {}, "
+            "RuntimeFilter: (id = {}, type = {}, is_broadcast: {}, ignored: {}, disabled: {}, "
             "build_bf_cardinality: {}, dependency: {}, synced_size: {}, has_local_target: {}, "
             "has_remote_target: {}, error_msg: [{}]",
             _filter_id, to_string(_runtime_filter_type), _is_broadcast_join,
-            _wrapper->_context->ignored, _wrapper->get_build_bf_cardinality(),
+            _wrapper->_context->ignored, _wrapper->_context->disabled,
+            _wrapper->get_build_bf_cardinality(),
             _dependency ? _dependency->debug_string() : "none", _synced_size, _has_local_target,
             _has_remote_target, _wrapper->_context->err_msg);
 }
@@ -1182,11 +1183,7 @@ Status RuntimePredicateWrapper::init_bloom_filter(const size_t build_bf_cardinal
 }
 
 bool RuntimePredicateWrapper::get_build_bf_cardinality() const {
-    if (_filter_type == RuntimeFilterType::BLOOM_FILTER ||
-        _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
-        return _context->bloom_filter_func->get_build_bf_cardinality();
-    }
-    return false;
+    return _context->bloom_filter_func && _context->bloom_filter_func->get_build_bf_cardinality();
 }
 
 void RuntimePredicateWrapper::insert_to_bloom_filter(BloomFilterFuncBase* bloom_filter) const {


### PR DESCRIPTION
### What problem does this PR solve?
fix bloom_filter_func use after free on get_build_bf_cardinality

In https://github.com/apache/doris/pull/46789 we release memory after rf disabled, but fuzzy_disable_runtime_filter_in_be will disable all rf at join_operator::open() and lead use after free

```cpp
/root/doris/be/src/exprs/runtime_filter.cpp:376:49: runtime error: member call on null pointer of type 'doris::BloomFilterFuncBase'
19:06:00   *** Query id: a1c642ea781748a7-964e332695678128 ***
19:06:00   *** is nereids: 1 ***
19:06:00   *** tablet id: 0 ***
19:06:00   *** Aborted at 1736938943 (unix time) try "date -d @1736938943" if you are using GNU date ***
19:06:00   *** Current BE git commitID: e3f29ba692 ***
19:06:00   *** SIGSEGV address not mapped to object (@0x0) received by PID 1874761 (TID 1877271 OR 0x7fb56c5c7700) from PID 0; stack trace: ***
19:06:00    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
19:06:00    1# PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
19:06:00    2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
19:06:00    3# 0x00007FB7232D9090 in /lib/x86_64-linux-gnu/libc.so.6
19:06:00    4# doris::RuntimePredicateWrapper::get_build_bf_cardinality() const at /root/doris/be/src/exprs/runtime_filter.cpp:376
19:06:00    5# doris::IRuntimeFilter::need_sync_filter_size() at /root/doris/be/src/exprs/runtime_filter.cpp:1634
19:06:00    6# doris::VRuntimeFilterSlots::send_filter_size(doris::RuntimeState*, unsigned long, std::shared_ptr<doris::pipeline::CountedFinishDependency>) at /root/doris/be/src/exprs/runtime_filter_slots.h:50
19:06:00    7# doris::pipeline::HashJoinBuildSinkLocalState::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:156
19:06:00    8# doris::pipeline::DataSinkOperatorXBase::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/pipeline/exec/operator.h:497
19:06:00    9# doris::pipeline::PipelineTask::close(doris::Status, bool) at /root/doris/be/src/pipeline/pipeline_task.cpp:468
19:06:00   10# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::Status) at /root/doris/be/src/pipeline/task_scheduler.cpp:90
19:06:00   11# doris::pipeline::TaskScheduler::_do_work(int) at /root/doris/be/src/pipeline/task_scheduler.cpp:175
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

