### PR TITLE
[opt](regression-test) Adjust the stream load timeout check of the regression framework

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
@@ -367,10 +367,12 @@ class StreamLoadAction implements SuiteAction {
 
             if (time > 0) {
                 long elapsed = endTime - startTime
-                if (elapsed > time) {
-                    log.info("Stream load consums more time than expected, elapsed ${elapsed} ms, expect ${time} ms")
-                } else {
-                    log.info("Stream load consums time elapsed ${elapsed} ms, expect ${time} ms")
+                try {
+                    // stream load may cost more time than expected in regression test, because of case run in parallel.
+                    // So we allow stream load cost more time, use 3 * time as threshold.
+                    Assert.assertTrue("Stream load Expect elapsed <= 3 * ${time}, but meet ${elapsed}", elapsed <= 3 * time)
+                } catch (Throwable t) {
+                    throw new IllegalStateException("Stream load Expect elapsed <= 3 * ${time}, but meet ${elapsed}")
                 }
             }
         }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
stream load may cost more time than expected in regression test, because of case run in parallel. So we allow stream load cost more time, use 3 * time as threshold.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

