### PR TITLE
[fix](nereids) simplify self compare exclude non-foldable expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparison.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparison.java
@@ -59,7 +59,7 @@ public class SimplifySelfComparison implements ExpressionPatternRuleFactory {
         // then `user() = user()` and `current_timestamp() = current_timestamp()` can simplify to `TRUE`.
         // function `random` is not foldable and non-deterministic,
         // then `random(1, 10) = random(1, 10)` cann't simplify to `TRUE`
-        if (left.foldable() && left.equals(comparison.right())) {
+        if (!left.containsNonfoldable() && left.equals(comparison.right())) {
             if (comparison instanceof EqualTo
                     || comparison instanceof GreaterThanEqual
                     || comparison instanceof LessThanEqual) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparison.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparison.java
@@ -54,7 +54,12 @@ public class SimplifySelfComparison implements ExpressionPatternRuleFactory {
 
     private Expression rewrite(ComparisonPredicate comparison) {
         Expression left = comparison.left();
-        if (left.isDeterministic() && left.equals(comparison.right())) {
+        // expression maybe non-deterministic, but if it's foldable, then it still can simplify self comparison.
+        // for example, function `user()`,  `current_timestamp()` are foldable and non-deterministic,
+        // then `user() = user()` and `current_timestamp() = current_timestamp()` can simplify to `TRUE`.
+        // function `random` is not foldable and non-deterministic,
+        // then `random(1, 10) = random(1, 10)` cann't simplify to `TRUE`
+        if (left.foldable() && left.equals(comparison.right())) {
             if (comparison instanceof EqualTo
                     || comparison instanceof GreaterThanEqual
                     || comparison instanceof LessThanEqual) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparison.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparison.java
@@ -54,7 +54,7 @@ public class SimplifySelfComparison implements ExpressionPatternRuleFactory {
 
     private Expression rewrite(ComparisonPredicate comparison) {
         Expression left = comparison.left();
-        if (left.equals(comparison.right())) {
+        if (left.isDeterministic() && left.equals(comparison.right())) {
             if (comparison instanceof EqualTo
                     || comparison instanceof GreaterThanEqual
                     || comparison instanceof LessThanEqual) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExpressionTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExpressionTrait.java
@@ -78,6 +78,13 @@ public interface ExpressionTrait extends TreeNode<Expression> {
     }
 
     /**
+     * Identify the expression is containing non-foldable expr or not
+     */
+    default boolean containsNonfoldable() {
+        return anyMatch(expr -> !((ExpressionTrait) expr).foldable());
+    }
+
+    /**
      * Identify the expression itself is deterministic or not, default true
      */
     default boolean isDeterministic() {
@@ -85,7 +92,7 @@ public interface ExpressionTrait extends TreeNode<Expression> {
     }
 
     /**
-     * Identify the expression is containing deterministic expr or not
+     * Identify the expression is containing non-deterministic expr or not
      */
     default boolean containsNondeterministic() {
         return anyMatch(expr -> !((ExpressionTrait) expr).isDeterministic());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparisonTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparisonTest.java
@@ -32,7 +32,7 @@ class SimplifySelfComparisonTest extends ExpressionRewriteTestHelper {
                 ExpressionRewrite.bottomUp(SimplifySelfComparison.INSTANCE)
         ));
 
-        // deterministic, cast
+        // foldable, cast
         assertRewriteAfterTypeCoercion("TA + TB = TA + TB", "NOT ((TA + TB) IS NULL) OR NULL");
         assertRewriteAfterTypeCoercion("TA + TB >= TA + TB", "NOT ((TA + TB) IS NULL) OR NULL");
         assertRewriteAfterTypeCoercion("TA + TB <= TA + TB", "NOT ((TA + TB) IS NULL) OR NULL");
@@ -40,8 +40,10 @@ class SimplifySelfComparisonTest extends ExpressionRewriteTestHelper {
         assertRewriteAfterTypeCoercion("TA + TB > TA + TB", "(TA + TB) IS NULL AND NULL");
         assertRewriteAfterTypeCoercion("TA + TB < TA + TB", "(TA + TB) IS NULL AND NULL");
         assertRewriteAfterTypeCoercion("DAYS_ADD(CA, 7) <=> DAYS_ADD(CA, 7)", "TRUE");
+        assertRewriteAfterTypeCoercion("USER() = USER()", "TRUE");
+        assertRewriteAfterTypeCoercion("CURRENT_TIMESTAMP() = CURRENT_TIMESTAMP()", "TRUE");
 
-        // not deterministic, not cast
+        // not foldable, not cast
         assertRewriteAfterTypeCoercion("random(5, 10) = random(5, 10)", "random(5, 10) = random(5, 10)");
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparisonTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparisonTest.java
@@ -45,6 +45,7 @@ class SimplifySelfComparisonTest extends ExpressionRewriteTestHelper {
 
         // not foldable, not cast
         assertRewriteAfterTypeCoercion("random(5, 10) = random(5, 10)", "random(5, 10) = random(5, 10)");
+        assertRewriteAfterTypeCoercion("random(5, 10) + 100 = random(5, 10) + 100", "random(5, 10) + 100 = random(5, 10) + 100");
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparisonTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifySelfComparisonTest.java
@@ -32,12 +32,17 @@ class SimplifySelfComparisonTest extends ExpressionRewriteTestHelper {
                 ExpressionRewrite.bottomUp(SimplifySelfComparison.INSTANCE)
         ));
 
+        // deterministic, cast
         assertRewriteAfterTypeCoercion("TA + TB = TA + TB", "NOT ((TA + TB) IS NULL) OR NULL");
         assertRewriteAfterTypeCoercion("TA + TB >= TA + TB", "NOT ((TA + TB) IS NULL) OR NULL");
         assertRewriteAfterTypeCoercion("TA + TB <= TA + TB", "NOT ((TA + TB) IS NULL) OR NULL");
         assertRewriteAfterTypeCoercion("TA + TB <=> TA + TB", "TRUE");
         assertRewriteAfterTypeCoercion("TA + TB > TA + TB", "(TA + TB) IS NULL AND NULL");
         assertRewriteAfterTypeCoercion("TA + TB < TA + TB", "(TA + TB) IS NULL AND NULL");
+        assertRewriteAfterTypeCoercion("DAYS_ADD(CA, 7) <=> DAYS_ADD(CA, 7)", "TRUE");
+
+        // not deterministic, not cast
+        assertRewriteAfterTypeCoercion("random(5, 10) = random(5, 10)", "random(5, 10) = random(5, 10)");
     }
 
 }


### PR DESCRIPTION
### What problem does this PR solve?

#46905 add an rewrite expression rule to simplify self comparison,  for example:  `a = a` will evaluate to `TRUE`.

But if `a` is non-foldable,  it shouldn't simplify.   for example:  function `random`  is non-foldable,  then `random(1, 10) = random(1, 10)` cannot evaluate to `TRUE`.

What's more, if an expression is non-deterministic, but if it's foldable, then self comparison also can fold it too. for example:  function `user` is foldable and non-deterministic, then `user() = user()` can still simplify to `TRUE`.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

