### PR TITLE
[fix](cloud)(bulk load) fix memory leak in FE observer node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -415,6 +415,7 @@ public class LoadManager implements Writable {
         LOG.info(new LogBuilder(LogKey.LOAD_JOB, operation.getId()).add("operation", operation)
                 .add("msg", "replay end load job").build());
 
+        Env.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(operation.getId());
         // When idToLoadJob size increase 10000 roughly, we run removeOldLoadJob to reduce mem used
         if ((idToLoadJob.size() > 0) && (idToLoadJob.size() % 10000 == 0)) {
             removeOldLoadJob();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

![image](https://github.com/user-attachments/assets/ad83cf90-e148-414c-9278-2cad8f2cd9ed)
The Memory of fe observer node increase over time and cannot significantly reduce after tigger full GC.

![image](https://github.com/user-attachments/assets/ac607b0c-73d1-44bc-a0ef-1a0e91c910fe)
In follower node, when bulk load job replay, A key-value(jobId,-job) will be added to` CallBackFactory` to record the job but will not `removeCallback`, which cause memory leak in FE observer node.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

