### PR TITLE
[test](move-memtable) mitigate flaky injection test `skip_two_backends`

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_multi_replica_fault_injection.groovy
@@ -75,7 +75,7 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
             file "baseall.txt"
         }
 
-        def load_with_injection = { injection, error_msg, success=false->
+        def load_with_injection = { injection, error_msg, success=false, alt_error_msg=null->
             try {
                 sql "truncate table test"
                 GetDebugPoint().enableDebugPointForAllBEs(injection)
@@ -83,7 +83,8 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
                 assertTrue(success, String.format("Expected Exception '%s', actual success", error_msg))
             } catch(Exception e) {
                 logger.info(e.getMessage())
-                assertTrue(e.getMessage().contains(error_msg), e.toString())
+                boolean e_contains_alt_error_msg = (alt_error_msg != null && e.getMessage().contains(alt_error_msg))
+                assertTrue(e.getMessage().contains(error_msg) || e_contains_alt_error_msg, e.toString())
             } finally {
                 GetDebugPoint().disableDebugPointForAllBEs(injection)
             }
@@ -101,7 +102,7 @@ suite("test_multi_replica_fault_injection", "nonConcurrent") {
         // test one backend open failure
         load_with_injection("VTabletWriterV2._open_streams.skip_one_backend", "success", true)
         // test two backend open failure
-        load_with_injection("VTabletWriterV2._open_streams.skip_two_backends", "not enough streams 1/3")
+        load_with_injection("VTabletWriterV2._open_streams.skip_two_backends", "not enough streams 1/3", false, "succ replica num 1 < load required replica num 2")
         sql """ set enable_memtable_on_sink_node=false """
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-17806
Problem Summary:

Mitigate flaky test `skip_two_backends` in test_multi_replica_fault_injection.

This test assumes a 3 BE environment and injects failure to 2 of them. However, it is currently running in a 4 BE environment. Depending on the replica distribution, the results may vary.
This PR addresses the issue by acknowledging an additional error message. However, certain tablet distributions could still cause the test to be flaky, particularly as the number of backends increases.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

