### PR TITLE
[fix](regression) fix sql bug: q24_1.sql missing join condition

### DIFF
--- a/regression-test/suites/tpcds_sf100_dup_without_key_p2/sql/q24_1.sql
+++ b/regression-test/suites/tpcds_sf100_dup_without_key_p2/sql/q24_1.sql
@@ -24,6 +24,7 @@ WITH
       AND (ss_customer_sk = c_customer_sk)
       AND (ss_item_sk = i_item_sk)
       AND (ss_store_sk = s_store_sk)
+      and c_current_addr_sk = ca_address_sk
       AND (c_birth_country = upper(ca_country))
       AND (s_zip = ca_zip)
       AND (s_market_id = 8)


### PR DESCRIPTION
### What problem does this PR solve?
regression-test/suites/tpcds_sf100_dup_without_key_p2/sql/q24_1.sql
a join condition is missing

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

