### PR TITLE
[regression-test](framework) fix bug when sql returns two column with same name

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -469,7 +469,7 @@ class Suite implements GroovyInterceptable {
         Set<String> uniqueSet = new HashSet<>()
         Set<String> duplicates = new HashSet<>()
     
-        for (String str : strings) {
+        for (String str : columnNames) {
             if (uniqueSet.contains(str)) {
                 duplicates.add(str)
             } else {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -463,6 +463,24 @@ class Suite implements GroovyInterceptable {
             columnNames.add(meta.getColumnLabel(i + 1))
         }
 
+        // Check if there are duplicates column names.
+        // SQL may return multiple columns with the same name.
+        // which cannot be handled by maps and will result in an error directly.
+        Set<String> uniqueSet = new HashSet<>()
+        Set<String> duplicates = new HashSet<>()
+    
+        for (String str : strings) {
+            if (uniqueSet.contains(str)) {
+                duplicates.add(str)
+            } else {
+                uniqueSet.add(str)
+            }
+        }
+        if (!duplicates.isEmpty()) {
+            def errorMessage = "${sqlStr} returns duplicates headers: ${duplicates}"   
+            throw new Exception(errorMessage)
+        }
+
         // add result to res map list, each row is a map with key is column name
         List<Map<String, Object>> res = new ArrayList<>()
         for (int i = 0; i < result.size(); i++) {

--- a/regression-test/suites/manager/test_manager_interface_1.groovy
+++ b/regression-test/suites/manager/test_manager_interface_1.groovy
@@ -485,12 +485,9 @@ suite('test_manager_interface_1',"p0") {
     }
     test_table_index()
 
-
-//select a.*, b.*, c.NAME as WORKLOAD_GROUP_NAME from information_schema.active_queries a left join information_schema.backend_active_tasks b on a.QUERY_ID = b.QUERY_ID left join information_schema.workload_groups c on a.WORKLOAD_GROUP_ID = c.ID
     def  test_active_query = {
 
         List<List<Object>> result = sql """ select 1;"""
-
 
         def futures = []
         futures.add( thread {
@@ -504,15 +501,10 @@ suite('test_manager_interface_1',"p0") {
         futures.add( thread {
             sleep(1500)
 
-            result = sql """ 
-            select a.*, b.*, c.NAME as WORKLOAD_GROUP_NAME from information_schema.active_queries a left join 
-            information_schema.backend_active_tasks b on a.QUERY_ID = b.QUERY_ID left join information_schema.workload_groups c on a.WORKLOAD_GROUP_ID = c.ID
-            """
-            logger.info("result = ${result}")
-
             result = sql_return_maparray """ 
-            select a.*, b.*, c.NAME as WORKLOAD_GROUP_NAME from information_schema.active_queries a left join 
-            information_schema.backend_active_tasks b on a.QUERY_ID = b.QUERY_ID left join information_schema.workload_groups c on a.WORKLOAD_GROUP_ID = c.ID
+                select a.*, b.TASK_CPU_TIME_MS, b.SCAN_ROWS, b.SCAN_BYTES, b.SHUFFLE_SEND_BYTES, b.SHUFFLE_SEND_ROWS, b.CURRENT_USED_MEMORY_BYTES, c.NAME as WORKLOAD_GROUP_NAME 
+                from information_schema.active_queries a left join 
+                information_schema.backend_active_tasks b on a.QUERY_ID = b.QUERY_ID left join information_schema.workload_groups c on a.WORKLOAD_GROUP_ID = c.ID
             """
             logger.info("result = ${result}")
             


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
sql_return_maparray use map data structure to save sql results. If sql returns two column with same name, map will merge these two column results, causing error results.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

