### PR TITLE
[fix](Nereids) let anonymous alias same as user input

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundAlias.java
@@ -36,21 +36,29 @@ import java.util.Optional;
  */
 public class UnboundAlias extends NamedExpression implements UnaryExpression, Unbound, PropagateNullable {
 
-    private Optional<String> alias;
+    private final Optional<String> alias;
+    private final boolean nameFromChild;
 
     public UnboundAlias(Expression child) {
-        super(ImmutableList.of(child));
-        this.alias = Optional.empty();
+        this(ImmutableList.of(child), Optional.empty());
     }
 
     public UnboundAlias(Expression child, String alias) {
-        super(ImmutableList.of(child));
-        this.alias = Optional.of(alias);
+        this(ImmutableList.of(child), Optional.of(alias));
+    }
+
+    public UnboundAlias(Expression child, String alias, boolean nameFromChild) {
+        this(ImmutableList.of(child), Optional.of(alias), nameFromChild);
     }
 
     private UnboundAlias(List<Expression> children, Optional<String> alias) {
+        this(children, alias, false);
+    }
+
+    private UnboundAlias(List<Expression> children, Optional<String> alias, boolean nameFromChild) {
         super(children);
         this.alias = alias;
+        this.nameFromChild = nameFromChild;
     }
 
     @Override
@@ -88,5 +96,9 @@ public class UnboundAlias extends NamedExpression implements UnaryExpression, Un
 
     public Optional<String> getAlias() {
         return alias;
+    }
+
+    public boolean isNameFromChild() {
+        return nameFromChild;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -2130,10 +2130,16 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             if (ctx.identifierOrText() == null) {
                 if (expression instanceof NamedExpression) {
                     return (NamedExpression) expression;
-                } else if (expression instanceof Literal) {
-                    return new Alias(expression);
                 } else {
-                    return new UnboundAlias(expression);
+                    int start = ctx.expression().start.getStartIndex();
+                    int stop = ctx.expression().stop.getStopIndex();
+                    String alias = ctx.start.getInputStream()
+                            .getText(new org.antlr.v4.runtime.misc.Interval(start, stop));
+                    if (expression instanceof Literal) {
+                        return new Alias(expression, alias, true);
+                    } else {
+                        return new UnboundAlias(expression, alias, true);
+                    }
                 }
             }
             String alias = visitIdentifierOrText(ctx.identifierOrText());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -265,7 +265,7 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
     public Expression visitUnboundAlias(UnboundAlias unboundAlias, ExpressionRewriteContext context) {
         Expression child = unboundAlias.child().accept(this, context);
         if (unboundAlias.getAlias().isPresent()) {
-            return new Alias(child, unboundAlias.getAlias().get());
+            return new Alias(child, unboundAlias.getAlias().get(), unboundAlias.isNameFromChild());
             // TODO: the variant bind element_at(slot, 'name') will return a slot, and we should
             //       assign an Alias to this function, this is trick and should refactor it
         } else if (!(unboundAlias.child() instanceof ElementAt) && child instanceof NamedExpression) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -48,7 +48,11 @@ public class Alias extends NamedExpression implements UnaryExpression {
      * @param name alias name
      */
     public Alias(Expression child, String name) {
-        this(StatementScopeIdGenerator.newExprId(), child, name, false);
+        this(child, name, false);
+    }
+
+    public Alias(Expression child, String name, boolean nameFromChild) {
+        this(StatementScopeIdGenerator.newExprId(), child, name, nameFromChild);
     }
 
     public Alias(Expression child) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
@@ -240,7 +240,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                         ).when(FieldChecker.check("projects", Lists.newArrayList(a1.toSlot(), sumA2.toSlot()))));
 
         sql = "SELECT a1, sum(a1 + a2) FROM t1 GROUP BY a1 HAVING sum(a1 + a2) > 0";
-        Alias sumA1A2 = new Alias(new ExprId(3), new Sum(new Add(a1, a2)), "sum((a1 + a2))");
+        Alias sumA1A2 = new Alias(new ExprId(3), new Sum(new Add(a1, a2)), "sum(a1 + a2)");
         PlanChecker.from(connectContext).analyze(sql)
                 .matches(
                         logicalProject(
@@ -363,7 +363,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         Alias sumA1 = new Alias(new ExprId(9), new Sum(a1), "sum(a1)");
         Alias countA1 = new Alias(new ExprId(13), new Count(a1), "count(a1)");
         Alias countA11 = new Alias(new ExprId(10), new Add(countA1.toSlot(), Literal.of((byte) 1)), "(count(a1) + 1)");
-        Alias sumA1A2 = new Alias(new ExprId(11), new Sum(new Add(a1, a2)), "sum((a1 + a2))");
+        Alias sumA1A2 = new Alias(new ExprId(11), new Sum(new Add(a1, a2)), "sum(a1 + a2)");
         Alias v1 = new Alias(new ExprId(12), new Count(a2), "v1");
         PlanChecker.from(connectContext).analyze(sql)
                 .matches(
@@ -476,7 +476,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                         ).when(FieldChecker.check("projects", Lists.newArrayList(a1.toSlot(), sumA2.toSlot()))));
 
         sql = "SELECT a1, sum(a1 + a2) FROM t1 GROUP BY a1 ORDER BY sum(a1 + a2)";
-        Alias sumA1A2 = new Alias(new ExprId(3), new Sum(new Add(a1, a2)), "sum((a1 + a2))");
+        Alias sumA1A2 = new Alias(new ExprId(3), new Sum(new Add(a1, a2)), "sum(a1 + a2)");
         PlanChecker.from(connectContext).analyze(sql)
                 .matches(
                         logicalSort(
@@ -562,7 +562,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         Alias sumA1 = new Alias(new ExprId(9), new Sum(a1), "sum(a1)");
         Alias countA1 = new Alias(new ExprId(13), new Count(a1), "count(a1)");
         Alias countA11 = new Alias(new ExprId(10), new Add(new Count(a1), Literal.of((byte) 1)), "(count(a1) + 1)");
-        Alias sumA1A2 = new Alias(new ExprId(11), new Sum(new Add(a1, a2)), "sum((a1 + a2))");
+        Alias sumA1A2 = new Alias(new ExprId(11), new Sum(new Add(a1, a2)), "sum(a1 + a2)");
         Alias v1 = new Alias(new ExprId(12), new Count(a2), "v1");
         PlanChecker.from(connectContext).analyze(sql)
                 .matches(logicalProject(logicalSort(logicalProject(logicalAggregate(logicalProject(

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join.out
@@ -91,7 +91,7 @@ PhysicalResultSink
 
 -- !groupby_pushdown_having --
 PhysicalResultSink
---filter((count(score) > 100))
+--filter((count(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
@@ -546,7 +546,7 @@ SyntaxError:
 
 -- !with_hint_groupby_pushdown_having --
 PhysicalResultSink
---filter((count(score) > 100))
+--filter((count(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_count_through_join_one_side.out
@@ -91,7 +91,7 @@ PhysicalResultSink
 
 -- !groupby_pushdown_having --
 PhysicalResultSink
---filter((count(score) > 100))
+--filter((count(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
@@ -572,7 +572,7 @@ SyntaxError:
 
 -- !with_hint_groupby_pushdown_having --
 PhysicalResultSink
---filter((count(score) > 100))
+--filter((count(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_min_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_min_through_join.out
@@ -91,7 +91,7 @@ PhysicalResultSink
 
 -- !groupby_pushdown_having --
 PhysicalResultSink
---filter((min(score) > 100))
+--filter((min(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
@@ -376,7 +376,7 @@ SyntaxError:
 
 -- !with_hint_groupby_pushdown_having --
 PhysicalResultSink
---filter((min(score) > 100))
+--filter((min(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join.out
@@ -91,7 +91,7 @@ PhysicalResultSink
 
 -- !groupby_pushdown_having --
 PhysicalResultSink
---filter((sum(score) > 100))
+--filter((sum(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
@@ -366,7 +366,7 @@ SyntaxError:
 
 -- !with_hint_groupby_pushdown_having --
 PhysicalResultSink
---filter((sum(score) > 100))
+--filter((sum(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.out
@@ -91,7 +91,7 @@ PhysicalResultSink
 
 -- !groupby_pushdown_having --
 PhysicalResultSink
---filter((sum(score) > 100))
+--filter((sum(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
@@ -392,7 +392,7 @@ SyntaxError:
 
 -- !with_hint_groupby_pushdown_having --
 PhysicalResultSink
---filter((sum(score) > 100))
+--filter((sum(t1.score) > 100))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()

--- a/regression-test/data/nereids_rules_p0/filter_push_down/push_filter_through.out
+++ b/regression-test/data/nereids_rules_p0/filter_push_down/push_filter_through.out
@@ -221,7 +221,7 @@ PhysicalResultSink
 
 -- !filter_aggregation_filtered_agg_func --
 PhysicalResultSink
---filter((count(*) > 10))
+--filter((count() > 10))
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
 --------PhysicalOlapScan[t1]

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query54.out
@@ -11,9 +11,9 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+----------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=()
 --------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query54.out
@@ -11,9 +11,9 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+----------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query54.out
@@ -13,9 +13,9 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=()
 ------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query54.out
@@ -13,9 +13,9 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query54.out
@@ -13,9 +13,9 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query54.out
@@ -13,9 +13,9 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
@@ -13,9 +13,9 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query54.out
@@ -13,9 +13,9 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject

--- a/regression-test/suites/nereids_p0/subquery/test_duplicate_name_in_view.groovy
+++ b/regression-test/suites/nereids_p0/subquery/test_duplicate_name_in_view.groovy
@@ -77,7 +77,7 @@ suite("test_duplicate_name_in_view") {
                         issue_19611_t1.c0 + 1
                     FROM issue_19611_t1 ) tmp;
         """
-        exception "Duplicated inline view column alias: '(c0 + 1)' in inline view: 'tmp'"
+        exception "Duplicated inline view column alias: 'issue_19611_t1.c0 + 1' in inline view: 'tmp'"
     }
 
     test {

--- a/regression-test/suites/nereids_syntax_p0/select_const.groovy
+++ b/regression-test/suites/nereids_syntax_p0/select_const.groovy
@@ -49,4 +49,6 @@ suite("select_with_const") {
     """
 
     sql "select all 1"
+
+    sql "select `1  + 2` from (select 1  + 2) t"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

use user input as alias if no explict alias for named expression

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change --> All named expression without alias will get a default alias from sql text

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

