### PR TITLE
[opt](mvn) remove iceberg-aws-bundle and upgrade aws sdk to 2.29.26

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -32,7 +32,6 @@ under the License.
         <doris.home>${basedir}/../../</doris.home>
         <doris.thirdparty>${basedir}/../../thirdparty</doris.thirdparty>
         <fe_ut_parallel>1</fe_ut_parallel>
-        <awssdk.version>2.20.131</awssdk.version>
         <huaweiobs.version>3.1.1-hw-46</huaweiobs.version>
         <tencentcos.version>8.2.7</tencentcos.version>
     </properties>
@@ -653,11 +652,6 @@ under the License.
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-aws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-aws-bundle</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.paimon</groupId>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -495,10 +495,10 @@ under the License.
             <artifactId>s3</artifactId>
             <version>${awssdk.version}</version>
             <exclusions>
-                <exclusion>
+                <!--exclusion>
                     <groupId>software.amazon.awssdk</groupId>
                     <artifactId>apache-client</artifactId>
-                </exclusion>
+                </exclusion-->
             </exclusions>
         </dependency>
         <!-- tencent cloud sts -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1310,11 +1310,6 @@ under the License.
                 <version>${iceberg.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.iceberg</groupId>
-                <artifactId>iceberg-aws-bundle</artifactId>
-                <version>${iceberg.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.aliyun.odps</groupId>
                 <artifactId>odps-sdk-core</artifactId>
                 <version>${maxcompute.version}</version>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -379,6 +379,7 @@ under the License.
         <azure.sdk.batch.version>12.22.0</azure.sdk.batch.version>
         <semver4j.version>5.3.0</semver4j.version>
         <aliyun-sdk-oss.version>3.15.0</aliyun-sdk-oss.version>
+        <awssdk.version>2.29.26</awssdk.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
### What problem does this PR solve?

1. No need to depend on iceberg-aws-bundle, because we've already declare the depends we need separately.
2. upgrade aws sdk to 2.29.26 to prepare for s3 tables

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

