### PR TITLE
[fix](edit_log) throw exception when replay alter constraint on catalog table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -321,34 +321,25 @@ public interface TableIf {
     }
 
     default void replayAddConstraint(Constraint constraint) {
-        // Since constraints are not indispensable, we only log when replay fails
-        try {
-            if (constraint instanceof UniqueConstraint) {
-                UniqueConstraint uniqueConstraint = (UniqueConstraint) constraint;
-                this.addUniqueConstraint(constraint.getName(),
-                        ImmutableList.copyOf(uniqueConstraint.getUniqueColumnNames()), true);
-            } else if (constraint instanceof PrimaryKeyConstraint) {
-                PrimaryKeyConstraint primaryKeyConstraint = (PrimaryKeyConstraint) constraint;
-                this.addPrimaryKeyConstraint(primaryKeyConstraint.getName(),
-                        ImmutableList.copyOf(primaryKeyConstraint.getPrimaryKeyNames()), true);
-            } else if (constraint instanceof ForeignKeyConstraint) {
-                ForeignKeyConstraint foreignKey = (ForeignKeyConstraint) constraint;
-                this.addForeignConstraint(foreignKey.getName(),
-                        ImmutableList.copyOf(foreignKey.getForeignKeyNames()),
-                        foreignKey.getReferencedTable(),
-                        ImmutableList.copyOf(foreignKey.getReferencedColumnNames()), true);
-            }
-        } catch (Exception e) {
-            LOG.error(e.getMessage());
+        if (constraint instanceof UniqueConstraint) {
+            UniqueConstraint uniqueConstraint = (UniqueConstraint) constraint;
+            this.addUniqueConstraint(constraint.getName(),
+                    ImmutableList.copyOf(uniqueConstraint.getUniqueColumnNames()), true);
+        } else if (constraint instanceof PrimaryKeyConstraint) {
+            PrimaryKeyConstraint primaryKeyConstraint = (PrimaryKeyConstraint) constraint;
+            this.addPrimaryKeyConstraint(primaryKeyConstraint.getName(),
+                    ImmutableList.copyOf(primaryKeyConstraint.getPrimaryKeyNames()), true);
+        } else if (constraint instanceof ForeignKeyConstraint) {
+            ForeignKeyConstraint foreignKey = (ForeignKeyConstraint) constraint;
+            this.addForeignConstraint(foreignKey.getName(),
+                    ImmutableList.copyOf(foreignKey.getForeignKeyNames()),
+                    foreignKey.getReferencedTable(),
+                    ImmutableList.copyOf(foreignKey.getReferencedColumnNames()), true);
         }
     }
 
     default void replayDropConstraint(String name) {
-        try {
-            dropConstraint(name, true);
-        } catch (Exception e) {
-            LOG.error(e.getMessage());
-        }
+        dropConstraint(name, true);
     }
 
     default void dropConstraint(String name, boolean replay) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1025,12 +1025,20 @@ public class EditLog {
                 }
                 case OperationType.OP_ADD_CONSTRAINT: {
                     final AlterConstraintLog log = (AlterConstraintLog) journal.getData();
-                    log.getTableIf().replayAddConstraint(log.getConstraint());
+                    try {
+                        log.getTableIf().replayAddConstraint(log.getConstraint());
+                    } catch (Exception e) {
+                        LOG.error("Failed to replay add constraint", e);
+                    }
                     break;
                 }
                 case OperationType.OP_DROP_CONSTRAINT: {
                     final AlterConstraintLog log = (AlterConstraintLog) journal.getData();
-                    log.getTableIf().replayDropConstraint(log.getConstraint().getName());
+                    try {
+                        log.getTableIf().replayDropConstraint(log.getConstraint().getName());
+                    } catch (Exception e) {
+                        LOG.error("Failed to replay drop constraint", e);
+                    }
                     break;
                 }
                 case OperationType.OP_ALTER_USER: {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #29767

Problem Summary:

when replay edit log, catalog do not do initialization. So alter constraint will fail by database is missing.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

