### PR TITLE
[fix](hive) Incorrect location conversion for target path

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
@@ -87,7 +87,7 @@ public class LocationPath {
         this(location, props, true);
     }
 
-    private LocationPath(String originLocation, Map<String, String> props, boolean convertPath) {
+    public LocationPath(String originLocation, Map<String, String> props, boolean convertPath) {
         isBindBroker = props.containsKey(HMSExternalCatalog.BIND_BROKER_NAME);
         String tmpLocation = originLocation;
         if (!(originLocation.contains(SCHEME_DELIM) || originLocation.contains(NONSTANDARD_SCHEME_DELIM))) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
@@ -122,13 +122,13 @@ public class HiveTableSink extends BaseExternalTableDataSink {
         setSerDeProperties(tSink);
 
         THiveLocationParams locationParams = new THiveLocationParams();
-        LocationPath locationPath = new LocationPath(sd.getLocation(), targetTable.getHadoopProperties());
+        LocationPath locationPath = new LocationPath(sd.getLocation(), targetTable.getHadoopProperties(), false);
         String location = locationPath.getPath().toString();
         String storageLocation = locationPath.toStorageLocation().toString();
         TFileType fileType = locationPath.getTFileTypeForBE();
         if (fileType == TFileType.FILE_S3) {
             locationParams.setWritePath(storageLocation);
-            locationParams.setOriginalWritePath(sd.getLocation());
+            locationParams.setOriginalWritePath(location);
             locationParams.setTargetPath(location);
             if (insertCtx.isPresent()) {
                 HiveInsertCommandContext context = (HiveInsertCommandContext) insertCtx.get();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/HiveTableSinkTest.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Assert;
 import org.junit.Test;
-import org.locationtech.jts.util.Assert;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -94,7 +94,8 @@ public class HiveTableSinkTest {
             HiveTableSink hiveTableSink = new HiveTableSink(tbl);
             hiveTableSink.bindDataSink(Optional.empty());
 
-            Assert.equals(hiveTableSink.tDataSink.hive_table_sink.location.original_write_path, location);
+            Assert.assertEquals(hiveTableSink.tDataSink.hive_table_sink.location.original_write_path, location);
+            Assert.assertEquals(hiveTableSink.tDataSink.hive_table_sink.location.target_path, location);
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #46362

Problem Summary:

For the "target_path" field, when the location is of the S3 type, it should not be converted into the S3 schema. 


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

