### PR TITLE
[chore](BE) make MutableBlock's to_block only accept rvalue

### DIFF
--- a/be/src/olap/rowset/segment_creator.cpp
+++ b/be/src/olap/rowset/segment_creator.cpp
@@ -362,7 +362,7 @@ Status SegmentCreator::add_block(const vectorized::Block* block) {
             LOG(INFO) << "directly flush a single block " << _buffer_block.rows() << " rows"
                       << ", block size " << _buffer_block.bytes() << " block allocated_size "
                       << _buffer_block.allocated_bytes();
-            vectorized::Block block = _buffer_block.to_block();
+            vectorized::Block block = std::move(_buffer_block).to_block();
             RETURN_IF_ERROR(flush_single_block(&block));
             _buffer_block.clear();
         }
@@ -392,7 +392,7 @@ Status SegmentCreator::add_block(const vectorized::Block* block) {
 
 Status SegmentCreator::flush() {
     if (_buffer_block.rows() > 0) {
-        vectorized::Block block = _buffer_block.to_block();
+        vectorized::Block block = std::move(_buffer_block).to_block();
         LOG(INFO) << "directly flush a single block " << block.rows() << " rows"
                   << ", block size " << block.bytes() << " block allocated_size "
                   << block.allocated_bytes();

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -380,7 +380,7 @@ Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block
                         block, block_holder->get_block(), local_state._rpc_channels_num,
                         &serialized, eos));
                 if (serialized) {
-                    auto cur_block = local_state._serializer.get_block()->to_block();
+                    auto cur_block = std::move(*local_state._serializer.get_block()).to_block();
                     if (!cur_block.empty()) {
                         DCHECK(eos || local_state._serializer.is_local()) << debug_string(state, 0);
                         RETURN_IF_ERROR(local_state._serializer.serialize_block(

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -545,7 +545,7 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
     if (local_state._should_build_hash_table && eos) {
         DCHECK(!local_state._build_side_mutable_block.empty());
         local_state._shared_state->build_block = std::make_shared<vectorized::Block>(
-                local_state._build_side_mutable_block.to_block());
+                std::move(local_state._build_side_mutable_block).to_block());
 
         if (!local_state._runtime_filters_disabled) {
             RETURN_IF_ERROR(local_state._runtime_filter_slots->send_filter_size(

--- a/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe_impl.h
@@ -263,7 +263,7 @@ Status ProcessHashTableProbe<JoinOpType>::do_process(HashTableType& hash_table_c
                                  with_other_conjuncts);
     }
 
-    output_block->swap(mutable_block.to_block());
+    output_block->swap(std::move(mutable_block).to_block());
 
     if constexpr (is_mark_join && JoinOpType != TJoinOp::RIGHT_SEMI_JOIN) {
         bool ignore_null_map =
@@ -622,7 +622,7 @@ Status ProcessHashTableProbe<JoinOpType>::finish_probing(HashTableType& hash_tab
                         ->insert_many_defaults(block_size);
             }
         }
-        output_block->swap(mutable_block.to_block(0));
+        output_block->swap(std::move(mutable_block).to_block(0));
         DCHECK(block_size <= _batch_size);
     }
     return Status::OK();

--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -52,7 +52,7 @@ Status SetSinkOperatorX<is_intersect>::sink(RuntimeState* state, vectorized::Blo
 
     if (eos || local_state._mutable_block.allocated_bytes() >= BUILD_BLOCK_MAX_SIZE) {
         SCOPED_TIMER(local_state._build_timer);
-        build_block = local_state._mutable_block.to_block();
+        build_block = std::move(local_state._mutable_block).to_block();
         RETURN_IF_ERROR(_process_build_block(local_state, build_block, state));
         local_state._mutable_block.clear();
 

--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -616,7 +616,7 @@ Status AdaptivePassthroughExchanger::_split_rows(RuntimeState* state,
             std::unique_ptr<vectorized::MutableBlock> mutable_block =
                     vectorized::MutableBlock::create_unique(block->clone_empty());
             RETURN_IF_ERROR(mutable_block->add_rows(block, start, size));
-            auto new_block = mutable_block->to_block();
+            auto new_block = std::move(*mutable_block).to_block();
 
             _enqueue_data_and_set_ready(i, sink_info.local_state,
                                         BlockWrapper::create_shared(std::move(new_block)));

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -1121,16 +1121,13 @@ void MutableBlock::erase(const String& name) {
             ++it;
         }
     }
-    // if (position < row_same_bit.size()) {
-    //     row_same_bit.erase(row_same_bit.begin() + position);
-    // }
 }
 
-Block MutableBlock::to_block(int start_column) {
-    return to_block(start_column, _columns.size());
+Block MutableBlock::to_block(int start_column) && {
+    return std::move(*this).to_block(start_column, _columns.size());
 }
 
-Block MutableBlock::to_block(int start_column, int end_column) {
+Block MutableBlock::to_block(int start_column, int end_column) && {
     ColumnsWithTypeAndName columns_with_schema;
     columns_with_schema.reserve(end_column - start_column);
     for (size_t i = start_column; i < end_column; ++i) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -484,7 +484,7 @@ public:
         DCHECK_LE(column_id, columns());
         DCHECK_LE(n, rows());
         DCHECK_LE(m, rows());
-        auto& column = get_column_by_position(column_id);
+        const auto& column = get_column_by_position(column_id);
         return column->compare_at(n, m, *column, nan_direction_hint);
     }
 
@@ -527,7 +527,7 @@ public:
     std::string dump_types() const {
         std::string res;
         for (auto type : _data_types) {
-            if (res.size()) {
+            if (!res.empty()) {
                 res += ", ";
             }
             res += type->get_name();
@@ -568,7 +568,7 @@ public:
     template <typename T>
     [[nodiscard]] Status merge_impl(T&& block) {
         // merge is not supported in dynamic block
-        if (_columns.size() == 0 && _data_types.size() == 0) {
+        if (_columns.empty() && _data_types.empty()) {
             _data_types = block.get_data_types();
             _names = block.get_names();
             _columns.resize(block.columns());
@@ -614,8 +614,8 @@ public:
     }
 
     // move to columns' data to a Block. this will invalidate
-    Block to_block(int start_column = 0);
-    Block to_block(int start_column, int end_column);
+    Block to_block(int start_column = 0) &&;
+    Block to_block(int start_column, int end_column) &&;
 
     void swap(MutableBlock& other) noexcept;
 

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -386,11 +386,11 @@ Status VCollectIterator::_topn_next(Block* block) {
                 if (mutable_block.rows() > _topn_limit * 2) {
                     VLOG_DEBUG << "topn debug start  shrink mutable_block from "
                                << mutable_block.rows() << " rows";
-                    Block tmp_block = mutable_block.to_block();
+                    Block tmp_block = std::move(mutable_block).to_block();
                     clone_block = tmp_block.clone_empty();
                     mutable_block = vectorized::MutableBlock::build_mutable_block(&clone_block);
-                    for (auto it = sorted_row_pos.begin(); it != sorted_row_pos.end(); it++) {
-                        mutable_block.add_row(&tmp_block, *it);
+                    for (unsigned long sorted_row_po : sorted_row_pos) {
+                        mutable_block.add_row(&tmp_block, sorted_row_po);
                     }
 
                     sorted_row_pos.clear();
@@ -428,7 +428,7 @@ Status VCollectIterator::_topn_next(Block* block) {
     VLOG_DEBUG << "topn debug result _topn_limit=" << _topn_limit
                << " sorted_row_pos.size()=" << sorted_row_pos.size()
                << " mutable_block.rows()=" << mutable_block.rows();
-    *block = mutable_block.to_block();
+    *block = std::move(mutable_block).to_block();
     // append a column to indicate scanner filter_block is already done
     auto filtered_datatype = std::make_shared<DataTypeUInt8>();
     auto filtered_column = filtered_datatype->create_column_const(block->rows(), (uint8_t)1);

--- a/be/src/vec/sink/varrow_flight_result_writer.cpp
+++ b/be/src/vec/sink/varrow_flight_result_writer.cpp
@@ -66,7 +66,7 @@ Status VArrowFlightResultWriter::write(RuntimeState* state, Block& input_block) 
                 vectorized::MutableBlock::create_unique(block.clone_empty());
         RETURN_IF_ERROR(mutable_block->merge_ignore_overflow(std::move(block)));
         std::shared_ptr<vectorized::Block> output_block = vectorized::Block::create_shared();
-        output_block->swap(mutable_block->to_block());
+        output_block->swap(std::move(*mutable_block).to_block());
 
         auto num_rows = output_block->rows();
         // arrow::RecordBatch without `nbytes()` in C++

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -175,7 +175,7 @@ Status Channel::_send_current_block(bool eos) {
 Status Channel::_send_local_block(bool eos) {
     Block block;
     if (_serializer.get_block() != nullptr) {
-        block = _serializer.get_block()->to_block();
+        block = std::move(*_serializer.get_block()).to_block();
         _serializer.get_block()->set_mutable_columns(block.clone_empty_columns());
     }
 
@@ -288,7 +288,7 @@ Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, size_t
 
 Status BlockSerializer::serialize_block(PBlock* dest, size_t num_receivers) {
     if (_mutable_block && _mutable_block->rows() > 0) {
-        auto block = _mutable_block->to_block();
+        auto block = std::move(*_mutable_block).to_block();
         RETURN_IF_ERROR(serialize_block(&block, dest, num_receivers));
         block.clear_column_data();
         _mutable_block->set_mutable_columns(block.mutate_columns());

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -646,7 +646,7 @@ void VNodeChannel::try_send_pending_block(RuntimeState* state) {
 
     // tablet_ids has already set when add row
     request->set_packet_seq(_next_packet_seq);
-    auto block = mutable_block->to_block();
+    auto block = std::move(*mutable_block).to_block();
     CHECK(block.rows() == request->tablet_ids_size())
             << "block rows: " << block.rows()
             << ", tablet_ids_size: " << request->tablet_ids_size();
@@ -1420,7 +1420,8 @@ Status VTabletWriter::_send_new_partition_batch() {
     if (_row_distribution.need_deal_batching()) { // maybe try_close more than 1 time
         RETURN_IF_ERROR(_row_distribution.automatic_create_partition());
 
-        Block tmp_block = _row_distribution._batching_block->to_block(); // Borrow out, for lval ref
+        Block tmp_block = std::move(*_row_distribution._batching_block)
+                                  .to_block(); // Borrow out, for lval ref
 
         // these order is unique.
         //  1. clear batching stats(and flag goes true) so that we won't make a new batching process in dealing batched block.

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -546,7 +546,8 @@ Status VTabletWriterV2::_send_new_partition_batch() {
     if (_row_distribution.need_deal_batching()) { // maybe try_close more than 1 time
         RETURN_IF_ERROR(_row_distribution.automatic_create_partition());
 
-        Block tmp_block = _row_distribution._batching_block->to_block(); // Borrow out, for lval ref
+        Block tmp_block = std::move(*_row_distribution._batching_block)
+                                  .to_block(); // Borrow out, for lval ref
 
         // these order is unique.
         //  1. clear batching stats(and flag goes true) so that we won't make a new batching process in dealing batched block.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

It's good for coding behaviors. use rvalue will make coder cleaner to know it's moved.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

