### PR TITLE
[Fix](ShortCircuite) fix point query crash with prepared statement when encounter delete sign

### DIFF
--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -34,7 +34,6 @@
 #include "cloud/cloud_tablet.h"
 #include "cloud/config.h"
 #include "common/consts.h"
-#include "common/exception.h"
 #include "common/status.h"
 #include "gutil/integral_types.h"
 #include "olap/lru_cache.h"

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -34,6 +34,7 @@
 #include "cloud/cloud_tablet.h"
 #include "cloud/config.h"
 #include "common/consts.h"
+#include "common/exception.h"
 #include "common/status.h"
 #include "gutil/integral_types.h"
 #include "olap/lru_cache.h"
@@ -517,14 +518,23 @@ Status PointQueryExecutor::_lookup_row_data() {
     }
     // filter rows by delete sign
     if (_row_hits > 0 && _reusable->delete_sign_idx() != -1) {
-        vectorized::ColumnPtr delete_filter_columns =
-                _result_block->get_columns()[_reusable->delete_sign_idx()];
-        const auto& filter =
-                assert_cast<const vectorized::ColumnInt8*>(delete_filter_columns.get())->get_data();
-        size_t count = filter.size() - simd::count_zero_num((int8_t*)filter.data(), filter.size());
-        if (count == filter.size()) {
-            _result_block->clear();
-        } else if (count > 0) {
+        size_t filtered = 0;
+        size_t total = 0;
+        {
+            // clear_column_data will check reference of ColumnPtr, so we need to release
+            // reference before clear_column_data
+            vectorized::ColumnPtr delete_filter_columns =
+                    _result_block->get_columns()[_reusable->delete_sign_idx()];
+            const auto& filter =
+                    assert_cast<const vectorized::ColumnInt8*>(delete_filter_columns.get())
+                            ->get_data();
+            filtered = filter.size() - simd::count_zero_num((int8_t*)filter.data(), filter.size());
+            total = filter.size();
+        }
+
+        if (filtered == total) {
+            _result_block->clear_column_data();
+        } else if (filtered > 0) {
             return Status::NotSupported("Not implemented since only single row at present");
         }
     }

--- a/regression-test/data/point_query_p0/test_point_query.out
+++ b/regression-test/data/point_query_p0/test_point_query.out
@@ -190,3 +190,9 @@ user_guid	feature	sk	feature_value	2021-01-01T00:00
 -- !point_select --
 user_guid	feature	sk	feature_value	2021-01-01T00:00
 
+-- !point_select --
+
+-- !point_select --
+
+-- !point_select --
+

--- a/regression-test/suites/point_query_p0/test_point_query.groovy
+++ b/regression-test/suites/point_query_p0/test_point_query.groovy
@@ -395,6 +395,13 @@ suite("test_point_query", "nonConcurrent") {
         qe_point_select partial_prepared_stmt
         qe_point_select partial_prepared_stmt
 
+        partial_prepared_stmt = prepareStatement " select * from regression_test_point_query_p0.table_3821461 where col1 = ? and col2 = ? and loc3 = 'aabc'"
+        partial_prepared_stmt.setInt(1, 10)
+        partial_prepared_stmt.setInt(2, 20)
+        qe_point_select partial_prepared_stmt
+        qe_point_select partial_prepared_stmt
+        qe_point_select partial_prepared_stmt
+
         // test prepared statement should not be short-circuited plan which use nondeterministic function
         try (PreparedStatement pstmt = prepareStatement("select now(3) data_time from regression_test_point_query_p0.test_partial_prepared_statement where sk = 'sk' and user_guid = 'user_guid' and  feature = 'feature'")) {
             def result1 = ""


### PR DESCRIPTION
Block should not call `clear`, because it will be returned to block pool

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

