### PR TITLE
[enhance](auth)The priority of attributes is higher than session variable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -76,6 +76,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.netty.util.concurrent.FastThreadLocal;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
@@ -1042,11 +1043,18 @@ public class ConnectContext {
      * @return insertTimeoutS
      */
     public int getInsertTimeoutS() {
-        int userInsertTimeout = getEnv().getAuth().getInsertTimeout(getQualifiedUser());
+        int userInsertTimeout = getInsertTimeoutSFromProperty();
         if (userInsertTimeout > 0) {
             return userInsertTimeout;
         }
         return sessionVariable.getInsertTimeoutS();
+    }
+
+    private int getInsertTimeoutSFromProperty() {
+        if (env == null || env.getAuth() == null || StringUtils.isEmpty(getQualifiedUser())) {
+            return 0;
+        }
+        return env.getAuth().getInsertTimeout(getQualifiedUser());
     }
 
     /**
@@ -1055,11 +1063,18 @@ public class ConnectContext {
      * @return queryTimeoutS
      */
     public int getQueryTimeoutS() {
-        int userQueryTimeout = getEnv().getAuth().getQueryTimeout(getQualifiedUser());
+        int userQueryTimeout = getQueryTimeoutSFromProperty();
         if (userQueryTimeout > 0) {
             return userQueryTimeout;
         }
         return sessionVariable.getQueryTimeoutS();
+    }
+
+    private int getQueryTimeoutSFromProperty() {
+        if (env == null || env.getAuth() == null || StringUtils.isEmpty(getQualifiedUser())) {
+            return 0;
+        }
+        return env.getAuth().getQueryTimeout(getQualifiedUser());
     }
 
     /**
@@ -1068,11 +1083,18 @@ public class ConnectContext {
      * @return maxExecMemByte
      */
     public long getMaxExecMemByte() {
-        long userLimit = getEnv().getAuth().getExecMemLimit(getQualifiedUser());
+        long userLimit = getMaxExecMemByteFromProperty();
         if (userLimit > 0) {
             return userLimit;
         }
         return sessionVariable.getMaxExecMemByte();
+    }
+
+    private long getMaxExecMemByteFromProperty() {
+        if (env == null || env.getAuth() == null || StringUtils.isEmpty(getQualifiedUser())) {
+            return 0L;
+        }
+        return env.getAuth().getExecMemLimit(getQualifiedUser());
     }
 
     /**
@@ -1081,11 +1103,18 @@ public class ConnectContext {
      * @return workloadGroup
      */
     public String getWorkloadGroup() {
-        String groupName = getEnv().getAuth().getWorkloadGroup(getQualifiedUser());
+        String groupName = getWorkloadGroupFromProperty();
         if (!Strings.isNullOrEmpty(groupName)) {
             return groupName;
         }
         return sessionVariable.getWorkloadGroup();
+    }
+
+    private String getWorkloadGroupFromProperty() {
+        if (env == null || env.getAuth() == null || StringUtils.isEmpty(getQualifiedUser())) {
+            return null;
+        }
+        return env.getAuth().getWorkloadGroup(getQualifiedUser());
     }
 
     public void setResultAttachedInfo(Map<String, String> resultAttachedInfo) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1027,13 +1027,65 @@ public class ConnectContext {
     public int getExecTimeout() {
         if (executor != null && executor.isSyncLoadKindStmt()) {
             // particular for insert stmt, we can expand other type of timeout in the same way
-            return Math.max(sessionVariable.getInsertTimeoutS(), sessionVariable.getQueryTimeoutS());
+            return Math.max(getInsertTimeoutS(), getQueryTimeoutS());
         } else if (executor != null && executor.isAnalyzeStmt()) {
             return sessionVariable.getAnalyzeTimeoutS();
         } else {
             // normal query stmt
-            return sessionVariable.getQueryTimeoutS();
+            return getQueryTimeoutS();
         }
+    }
+
+    /**
+     * First, retrieve from the user's attributes. If not, retrieve from the session variable
+     *
+     * @return insertTimeoutS
+     */
+    public int getInsertTimeoutS() {
+        int userInsertTimeout = getEnv().getAuth().getInsertTimeout(getQualifiedUser());
+        if (userInsertTimeout > 0) {
+            return userInsertTimeout;
+        }
+        return sessionVariable.getInsertTimeoutS();
+    }
+
+    /**
+     * First, retrieve from the user's attributes. If not, retrieve from the session variable
+     *
+     * @return queryTimeoutS
+     */
+    public int getQueryTimeoutS() {
+        int userQueryTimeout = getEnv().getAuth().getQueryTimeout(getQualifiedUser());
+        if (userQueryTimeout > 0) {
+            return userQueryTimeout;
+        }
+        return sessionVariable.getQueryTimeoutS();
+    }
+
+    /**
+     * First, retrieve from the user's attributes. If not, retrieve from the session variable
+     *
+     * @return maxExecMemByte
+     */
+    public long getMaxExecMemByte() {
+        long userLimit = getEnv().getAuth().getExecMemLimit(getQualifiedUser());
+        if (userLimit > 0) {
+            return userLimit;
+        }
+        return sessionVariable.getMaxExecMemByte();
+    }
+
+    /**
+     * First, retrieve from the user's attributes. If not, retrieve from the session variable
+     *
+     * @return workloadGroup
+     */
+    public String getWorkloadGroup() {
+        String groupName = getEnv().getAuth().getWorkloadGroup(getQualifiedUser());
+        if (!Strings.isNullOrEmpty(groupName)) {
+            return groupName;
+        }
+        return sessionVariable.getWorkloadGroup();
     }
 
     public void setResultAttachedInfo(Map<String, String> resultAttachedInfo) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1097,26 +1097,6 @@ public class ConnectContext {
         return env.getAuth().getExecMemLimit(getQualifiedUser());
     }
 
-    /**
-     * First, retrieve from the user's attributes. If not, retrieve from the session variable
-     *
-     * @return workloadGroup
-     */
-    public String getWorkloadGroup() {
-        String groupName = getWorkloadGroupFromProperty();
-        if (!Strings.isNullOrEmpty(groupName)) {
-            return groupName;
-        }
-        return sessionVariable.getWorkloadGroup();
-    }
-
-    private String getWorkloadGroupFromProperty() {
-        if (env == null || env.getAuth() == null || StringUtils.isEmpty(getQualifiedUser())) {
-            return null;
-        }
-        return env.getAuth().getWorkloadGroup(getQualifiedUser());
-    }
-
     public void setResultAttachedInfo(Map<String, String> resultAttachedInfo) {
         this.resultAttachedInfo = resultAttachedInfo;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -401,9 +401,7 @@ public class Coordinator implements CoordInterface {
             this.queryOptions.setResourceLimit(resourceLimit);
         }
         // set exec mem limit
-        long maxExecMemByte = connectContext.getSessionVariable().getMaxExecMemByte();
-        long memLimit = maxExecMemByte > 0 ? maxExecMemByte :
-                Env.getCurrentEnv().getAuth().getExecMemLimit(qualifiedUser);
+        long memLimit = connectContext.getMaxExecMemByte();
         if (memLimit > 0) {
             // overwrite the exec_mem_limit from session variable;
             this.queryOptions.setMemLimit(memLimit);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
@@ -364,9 +364,7 @@ public class CoordinatorContext {
             queryOptions.setResourceLimit(resourceLimit);
         }
         // set exec mem limit
-        long maxExecMemByte = connectContext.getSessionVariable().getMaxExecMemByte();
-        long memLimit = maxExecMemByte > 0 ? maxExecMemByte :
-                Env.getCurrentEnv().getAuth().getExecMemLimit(qualifiedUser);
+        long memLimit = connectContext.getMaxExecMemByte();
         if (memLimit > 0) {
             // overwrite the exec_mem_limit from session variable;
             queryOptions.setMemLimit(memLimit);

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -342,7 +342,10 @@ public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPost
     }
 
     private String getWorkloadGroupNameAndCheckPriv(ConnectContext context) throws AnalysisException {
-        String groupName = context.getWorkloadGroup();
+        String groupName = context.getSessionVariable().getWorkloadGroup();
+        if (Strings.isNullOrEmpty(groupName)) {
+            groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(context.getQualifiedUser());
+        }
         if (Strings.isNullOrEmpty(groupName)) {
             groupName = DEFAULT_GROUP_NAME;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -342,10 +342,7 @@ public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPost
     }
 
     private String getWorkloadGroupNameAndCheckPriv(ConnectContext context) throws AnalysisException {
-        String groupName = context.getSessionVariable().getWorkloadGroup();
-        if (Strings.isNullOrEmpty(groupName)) {
-            groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(context.getQualifiedUser());
-        }
+        String groupName = context.getWorkloadGroup();
         if (Strings.isNullOrEmpty(groupName)) {
             groupName = DEFAULT_GROUP_NAME;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.thrift.TUniqueId;
 
+import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
@@ -201,5 +202,97 @@ public class ConnectContextTest {
         ctx.setThreadLocalInfo();
         Assert.assertNotNull(ConnectContext.get());
         Assert.assertEquals(ctx, ConnectContext.get());
+    }
+
+    @Test
+    public void testGetWorkloadGroup() {
+        ConnectContext context = new ConnectContext();
+        context.setQualifiedUser("a");
+        context.setEnv(env);
+        String sessionGroup = "session_g1";
+        String propertyGroup = "property_g1";
+        // only session
+        context.getSessionVariable().setWorkloadGroup(sessionGroup);
+        String result = context.getWorkloadGroup();
+        Assert.assertEquals(sessionGroup, result);
+        // has property
+        new Expectations() {
+            {
+                auth.getWorkloadGroup(anyString);
+                minTimes = 0;
+                result = propertyGroup;
+            }
+        };
+        result = context.getWorkloadGroup();
+        Assert.assertEquals(propertyGroup, result);
+    }
+
+    @Test
+    public void testGetMaxExecMemByte() {
+        ConnectContext context = new ConnectContext();
+        context.setQualifiedUser("a");
+        context.setEnv(env);
+        long sessionValue = 2097153L;
+        long propertyValue = 2097154L;
+        // only session
+        context.getSessionVariable().setMaxExecMemByte(sessionValue);
+        long result = context.getMaxExecMemByte();
+        Assert.assertEquals(sessionValue, result);
+        // has property
+        new Expectations() {
+            {
+                auth.getExecMemLimit(anyString);
+                minTimes = 0;
+                result = propertyValue;
+            }
+        };
+        result = context.getMaxExecMemByte();
+        Assert.assertEquals(propertyValue, result);
+    }
+
+    @Test
+    public void testGetQueryTimeoutS() {
+        ConnectContext context = new ConnectContext();
+        context.setQualifiedUser("a");
+        context.setEnv(env);
+        int sessionValue = 1;
+        int propertyValue = 2;
+        // only session
+        context.getSessionVariable().setQueryTimeoutS(sessionValue);
+        long result = context.getQueryTimeoutS();
+        Assert.assertEquals(sessionValue, result);
+        // has property
+        new Expectations() {
+            {
+                auth.getQueryTimeout(anyString);
+                minTimes = 0;
+                result = propertyValue;
+            }
+        };
+        result = context.getQueryTimeoutS();
+        Assert.assertEquals(propertyValue, result);
+    }
+
+    @Test
+    public void testInsertQueryTimeoutS() {
+        ConnectContext context = new ConnectContext();
+        context.setQualifiedUser("a");
+        context.setEnv(env);
+        int sessionValue = 1;
+        int propertyValue = 2;
+        // only session
+        context.getSessionVariable().setInsertTimeoutS(sessionValue);
+        long result = context.getInsertTimeoutS();
+        Assert.assertEquals(sessionValue, result);
+        // has property
+        new Expectations() {
+            {
+                auth.getInsertTimeout(anyString);
+                minTimes = 0;
+                result = propertyValue;
+            }
+        };
+        result = context.getInsertTimeoutS();
+        Assert.assertEquals(propertyValue, result);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -205,29 +205,6 @@ public class ConnectContextTest {
     }
 
     @Test
-    public void testGetWorkloadGroup() {
-        ConnectContext context = new ConnectContext();
-        context.setQualifiedUser("a");
-        context.setEnv(env);
-        String sessionGroup = "session_g1";
-        String propertyGroup = "property_g1";
-        // only session
-        context.getSessionVariable().setWorkloadGroup(sessionGroup);
-        String result = context.getWorkloadGroup();
-        Assert.assertEquals(sessionGroup, result);
-        // has property
-        new Expectations() {
-            {
-                auth.getWorkloadGroup(anyString);
-                minTimes = 0;
-                result = propertyGroup;
-            }
-        };
-        result = context.getWorkloadGroup();
-        Assert.assertEquals(propertyGroup, result);
-    }
-
-    @Test
     public void testGetMaxExecMemByte() {
         ConnectContext context = new ConnectContext();
         context.setQualifiedUser("a");

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -44,6 +44,13 @@ suite("test_property_session") {
         }
     }
 
+    // the priority of property should be higher than session
+    sql """set property for '${userName}' 'query_timeout' = '10';"""
+    connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
+        sql """
+            select sleep(3);
+        """
+    }
 
     sql """drop user if exists ${userName}"""
 }

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Assert;
+
+suite("test_property_session","p0") {
+    String suiteName = "test_paimon_mtmv"
+    String userName = "${suiteName}_user"
+    String pwd = 'C123_567p'
+    sql """drop user if exists ${userName}"""
+    sql """CREATE USER '${userName}' IDENTIFIED BY '${pwd}'"""
+    //cloud-mode
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${userName}""";
+    }
+     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
+         sql """set query_timeout=1"""
+        test {
+            sql """select sleep(3)""
+            exception "timeout"
+        }
+    }
+    // the priority of property should be higher than session
+    set property for '${userName}' 'query_timeout' = '10';
+    connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
+        sql """select sleep(3)""
+    }
+    sql """drop user if exists ${userName}"""
+}

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -31,9 +31,12 @@ suite("test_property_session") {
         def validCluster = clusters[0][0]
         sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${userName}""";
     }
-
+    sql """GRANT select_PRIV ON *.*.* TO ${userName}""";
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
         test {
+              sql """
+                  set query_timeout=1;
+              """
               sql """
                   select sleep(3);
               """

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -23,24 +23,8 @@ suite("test_property_session") {
     String pwd = 'C123_567p'
     sql """drop user if exists ${userName}"""
     sql """CREATE USER '${userName}' IDENTIFIED BY '${pwd}'"""
-    //cloud-mode
-    if (isCloudMode()) {
-        def clusters = sql " SHOW CLUSTERS; "
-        assertTrue(!clusters.isEmpty())
-        def validCluster = clusters[0][0]
-        sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${userName}""";
-    }
-     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
-         sql """set query_timeout=1"""
-        test {
-            sql """select sleep(3)""
-            exception "timeout"
-        }
-    }
-    // the priority of property should be higher than session
 
-    connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
-        sql """select sleep(3)""
-    }
+
+
     sql """drop user if exists ${userName}"""
 }

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -24,6 +24,14 @@ suite("test_property_session") {
     sql """drop user if exists ${userName}"""
     sql """CREATE USER '${userName}' IDENTIFIED BY '${pwd}'"""
 
+    //cloud-mode
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${userName}""";
+    }
+
 
 
     sql """drop user if exists ${userName}"""

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -33,10 +33,10 @@ suite("test_property_session") {
     }
     sql """GRANT select_PRIV ON *.*.* TO ${userName}""";
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
+        sql """
+              set query_timeout=1;
+          """
         test {
-              sql """
-                  set query_timeout=1;
-              """
               sql """
                   select sleep(3);
               """

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -32,6 +32,13 @@ suite("test_property_session") {
         sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${userName}""";
     }
 
+    connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
+        sql """set query_timeout=1"""
+        test {
+            sql """select sleep(3)""
+            exception "timeout"
+        }
+    }
 
 
     sql """drop user if exists ${userName}"""

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -33,10 +33,11 @@ suite("test_property_session") {
     }
 
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
-        sql """set query_timeout=1"""
         test {
-            sql """select sleep(3)""
-            exception "timeout"
+              sql """
+                  select sleep(3);
+              """
+              exception "timeout"
         }
     }
 

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -38,7 +38,7 @@ suite("test_property_session") {
         }
     }
     // the priority of property should be higher than session
-    sql """set property for ${userName} 'query_timeout' = '10';"""
+
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
         sql """select sleep(3)""
     }

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -38,7 +38,7 @@ suite("test_property_session") {
         }
     }
     // the priority of property should be higher than session
-    set property for '${userName}' 'query_timeout' = '10';
+    sql """set property for '${userName}' 'query_timeout' = '10';"""
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
         sql """select sleep(3)""
     }

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -38,7 +38,7 @@ suite("test_property_session") {
         }
     }
     // the priority of property should be higher than session
-    sql """set property for '${userName}' 'query_timeout' = '10';"""
+    // sql """set property for '${userName}' 'query_timeout' = '10';"""
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
         sql """select sleep(3)""
     }

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -38,7 +38,7 @@ suite("test_property_session") {
         }
     }
     // the priority of property should be higher than session
-    // sql """set property for '${userName}' 'query_timeout' = '10';"""
+    sql """set property for ${userName} 'query_timeout' = '10';"""
     connect(user=userName, password="${pwd}", url=context.config.jdbcUrl) {
         sql """select sleep(3)""
     }

--- a/regression-test/suites/account_p0/test_property_session.groovy
+++ b/regression-test/suites/account_p0/test_property_session.groovy
@@ -17,8 +17,8 @@
 
 import org.junit.Assert;
 
-suite("test_property_session","p0") {
-    String suiteName = "test_paimon_mtmv"
+suite("test_property_session") {
+    String suiteName = "test_property_session"
     String userName = "${suiteName}_user"
     String pwd = 'C123_567p'
     sql """drop user if exists ${userName}"""


### PR DESCRIPTION
### What problem does this PR solve?
The current priority is that session variable is higher than user property, which is incorrect because session variable can be set freely by ordinary users and will bypass the restrictions set by administrators

Scope of Impact:
- getInsertTimeoutS
- getQueryTimeoutS
- getMaxExecMemByte

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

