### PR TITLE
[fix](mac compile) fix compile failed on mac

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -98,7 +98,7 @@ struct AggregateFunctionCollectSetData {
     }
 
     void read(BufferReadable& buf) {
-        size_t new_size = 0;
+        UInt64 new_size = 0;
         read_var_uint(new_size, buf);
         ElementNativeType x;
         for (size_t i = 0; i < new_size; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -94,7 +94,7 @@ struct AggregateFunctionDistinctSingleNumericData {
     void deserialize(BufferReadable& buf, Arena*) {
         DCHECK(!stable);
         if constexpr (!stable) {
-            size_t new_size = 0;
+            UInt64 new_size = 0;
             read_var_uint(new_size, buf);
             T x;
             for (size_t i = 0; i < new_size; ++i) {


### PR DESCRIPTION
use `UInt64` replace `size_t` like other usage cases.