### PR TITLE
[Fix](catalog)Fixes query failures for Paimon tables stored in Kerberized HDFS

### DIFF
--- a/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
+++ b/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
@@ -20,6 +20,8 @@ package org.apache.doris.hudi;
 import org.apache.doris.common.classloader.ThreadClassLoaderContext;
 import org.apache.doris.common.jni.JniScanner;
 import org.apache.doris.common.jni.vec.ColumnType;
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticatorCache;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -92,6 +94,8 @@ public class HadoopHudiJniScanner extends JniScanner {
     private final int fetchSize;
     private final ClassLoader classLoader;
 
+    private final PreExecutionAuthenticator preExecutionAuthenticator;
+
     public HadoopHudiJniScanner(int fetchSize, Map<String, String> params) {
         this.basePath = params.get("base_path");
         this.dataFilePath = params.get("data_file_path");
@@ -120,6 +124,7 @@ public class HadoopHudiJniScanner extends JniScanner {
                 LOG.debug("get hudi params {}: {}", entry.getKey(), entry.getValue());
             }
         }
+        this.preExecutionAuthenticator = PreExecutionAuthenticatorCache.getAuthenticator(fsOptionsProps);
 
         ZoneId zoneId;
         if (Strings.isNullOrEmpty(params.get("time_zone"))) {
@@ -135,10 +140,14 @@ public class HadoopHudiJniScanner extends JniScanner {
     @Override
     public void open() throws IOException {
         try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
-            initRequiredColumnsAndTypes();
-            initTableInfo(requiredTypes, requiredFields, fetchSize);
-            Properties properties = getReaderProperties();
-            initReader(properties);
+            preExecutionAuthenticator.execute(() -> {
+                initRequiredColumnsAndTypes();
+                initTableInfo(requiredTypes, requiredFields, fetchSize);
+                Properties properties = getReaderProperties();
+                initReader(properties);
+                return null;
+            });
+
         } catch (Exception e) {
             close();
             LOG.warn("failed to open hadoop hudi jni scanner", e);
@@ -149,25 +158,27 @@ public class HadoopHudiJniScanner extends JniScanner {
     @Override
     public int getNext() throws IOException {
         try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
-            NullWritable key = reader.createKey();
-            ArrayWritable value = reader.createValue();
-            int numRows = 0;
-            for (; numRows < fetchSize; numRows++) {
-                if (!reader.next(key, value)) {
-                    break;
+            return preExecutionAuthenticator.execute(() -> {
+                NullWritable key = reader.createKey();
+                ArrayWritable value = reader.createValue();
+                int numRows = 0;
+                for (; numRows < fetchSize; numRows++) {
+                    if (!reader.next(key, value)) {
+                        break;
+                    }
+                    Object rowData = deserializer.deserialize(value);
+                    for (int i = 0; i < fields.length; i++) {
+                        Object fieldData = rowInspector.getStructFieldData(rowData, structFields[i]);
+                        columnValue.setRow(fieldData);
+                        // LOG.info("rows: {}, column: {}, col name: {}, col type: {}, inspector: {}",
+                        //        numRows, i, types[i].getName(), types[i].getType().name(),
+                        //        fieldInspectors[i].getTypeName());
+                        columnValue.setField(types[i], fieldInspectors[i]);
+                        appendData(i, columnValue);
+                    }
                 }
-                Object rowData = deserializer.deserialize(value);
-                for (int i = 0; i < fields.length; i++) {
-                    Object fieldData = rowInspector.getStructFieldData(rowData, structFields[i]);
-                    columnValue.setRow(fieldData);
-                    // LOG.info("rows: {}, column: {}, col name: {}, col type: {}, inspector: {}",
-                    //        numRows, i, types[i].getName(), types[i].getType().name(),
-                    //        fieldInspectors[i].getTypeName());
-                    columnValue.setField(types[i], fieldInspectors[i]);
-                    appendData(i, columnValue);
-                }
-            }
-            return numRows;
+                return numRows;
+            });
         } catch (Exception e) {
             close();
             LOG.warn("failed to get next in hadoop hudi jni scanner", e);

--- a/fe/be-java-extensions/paimon-scanner/pom.xml
+++ b/fe/be-java-extensions/paimon-scanner/pom.xml
@@ -39,12 +39,6 @@ under the License.
             <groupId>org.apache.doris</groupId>
             <artifactId>java-common</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>fe-common</artifactId>
-                    <groupId>org.apache.doris</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -20,13 +20,11 @@ package org.apache.doris.paimon;
 import org.apache.doris.common.jni.JniScanner;
 import org.apache.doris.common.jni.vec.ColumnType;
 import org.apache.doris.common.jni.vec.TableSchema;
-import org.apache.doris.common.security.authentication.AuthenticationConfig;
-import org.apache.doris.common.security.authentication.HadoopAuthenticator;
 import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticatorCache;
 import org.apache.doris.paimon.PaimonTableCache.PaimonTableCacheKey;
 import org.apache.doris.paimon.PaimonTableCache.TableExt;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -109,14 +107,7 @@ public class PaimonJniScanner extends JniScanner {
                 .filter(kv -> kv.getKey().startsWith(HADOOP_OPTION_PREFIX))
                 .collect(Collectors
                         .toMap(kv1 -> kv1.getKey().substring(HADOOP_OPTION_PREFIX.length()), kv1 -> kv1.getValue()));
-        Configuration conf = new Configuration();
-        hadoopOptionParams.forEach(conf::set);
-        preExecutionAuthenticator = new PreExecutionAuthenticator();
-        AuthenticationConfig authenticationConfig = AuthenticationConfig.getKerberosConfig(conf,
-                AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL,
-                AuthenticationConfig.HADOOP_KERBEROS_KEYTAB);
-        HadoopAuthenticator hadoopAuthenticator = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig);
-        preExecutionAuthenticator.setHadoopAuthenticator(hadoopAuthenticator);
+        this.preExecutionAuthenticator = PreExecutionAuthenticatorCache.getAuthenticator(hadoopOptionParams);
     }
 
     @Override

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -127,11 +127,7 @@ public class PaimonJniScanner extends JniScanner {
 
         } catch (Throwable e) {
             LOG.warn("Failed to open paimon_scanner: " + e.getMessage(), e);
-            try {
-                throw e;
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
+            throw new RuntimeException(e);
         }
     }
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
@@ -46,9 +46,9 @@ public abstract class AuthenticationConfig {
         if (AuthType.KERBEROS.getDesc().equals(authentication)) {
             return conf.get(HADOOP_KERBEROS_PRINCIPAL) + "-" + conf.get(HADOOP_KERBEROS_KEYTAB) + "-"
                     + conf.getOrDefault(DORIS_KRB5_DEBUG, "false");
+        } else {
+            return conf.getOrDefault(HADOOP_USER_NAME, DEFAULT_HADOOP_USERNAME);
         }
-        // kerberos config
-        return getHadoopUserName(conf);
     }
 
     /**
@@ -104,23 +104,8 @@ public abstract class AuthenticationConfig {
     private static AuthenticationConfig createSimpleAuthenticationConfig(Configuration conf) {
         // AuthType.SIMPLE
         SimpleAuthenticationConfig simpleAuthenticationConfig = new SimpleAuthenticationConfig();
-        simpleAuthenticationConfig.setUsername(conf.get(HADOOP_USER_NAME));
-        String hadoopUserName = conf.get(HADOOP_USER_NAME);
-        if (hadoopUserName == null) {
-            hadoopUserName = DEFAULT_HADOOP_USERNAME;
-            simpleAuthenticationConfig.setUsername(hadoopUserName);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("{} is unset, use default user: hadoop", AuthenticationConfig.HADOOP_USER_NAME);
-            }
-        }
+        String hadoopUserName = conf.get(HADOOP_USER_NAME, DEFAULT_HADOOP_USERNAME);
+        simpleAuthenticationConfig.setUsername(hadoopUserName);
         return simpleAuthenticationConfig;
-    }
-
-    private static String getHadoopUserName(Map<String, String> conf) {
-        String hadoopUserName = conf.get(HADOOP_USER_NAME);
-        if (hadoopUserName == null) {
-            hadoopUserName = DEFAULT_HADOOP_USERNAME;
-        }
-        return hadoopUserName;
     }
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/AuthenticationConfig.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Map;
+
 public abstract class AuthenticationConfig {
     private static final Logger LOG = LogManager.getLogger(AuthenticationConfig.class);
     public static String HADOOP_USER_NAME = "hadoop.username";
@@ -31,11 +33,23 @@ public abstract class AuthenticationConfig {
     public static String HIVE_KERBEROS_PRINCIPAL = "hive.metastore.kerberos.principal";
     public static String HIVE_KERBEROS_KEYTAB = "hive.metastore.kerberos.keytab.file";
     public static String DORIS_KRB5_DEBUG = "doris.krb5.debug";
+    private static final String DEFAULT_HADOOP_USERNAME = "hadoop";
 
     /**
      * @return true if the config is valid, otherwise false.
      */
     public abstract boolean isValid();
+
+    protected static String generalAuthenticationConfigKey(Map<String, String> conf) {
+        String authentication = conf.getOrDefault(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
+                null);
+        if (AuthType.KERBEROS.getDesc().equals(authentication)) {
+            return conf.get(HADOOP_KERBEROS_PRINCIPAL) + "-" + conf.get(HADOOP_KERBEROS_KEYTAB) + "-"
+                    + conf.getOrDefault(DORIS_KRB5_DEBUG, "false");
+        }
+        // kerberos config
+        return getHadoopUserName(conf);
+    }
 
     /**
      * get kerberos config from hadoop conf
@@ -91,6 +105,22 @@ public abstract class AuthenticationConfig {
         // AuthType.SIMPLE
         SimpleAuthenticationConfig simpleAuthenticationConfig = new SimpleAuthenticationConfig();
         simpleAuthenticationConfig.setUsername(conf.get(HADOOP_USER_NAME));
+        String hadoopUserName = conf.get(HADOOP_USER_NAME);
+        if (hadoopUserName == null) {
+            hadoopUserName = DEFAULT_HADOOP_USERNAME;
+            simpleAuthenticationConfig.setUsername(hadoopUserName);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} is unset, use default user: hadoop", AuthenticationConfig.HADOOP_USER_NAME);
+            }
+        }
         return simpleAuthenticationConfig;
+    }
+
+    private static String getHadoopUserName(Map<String, String> conf) {
+        String hadoopUserName = conf.get(HADOOP_USER_NAME);
+        if (hadoopUserName == null) {
+            hadoopUserName = DEFAULT_HADOOP_USERNAME;
+        }
+        return hadoopUserName;
     }
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/PreExecutionAuthenticatorCache.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/PreExecutionAuthenticatorCache.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.security.authentication;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A cache class for storing and retrieving PreExecutionAuthenticator instances based on Hadoop configurations.
+ * This class caches PreExecutionAuthenticator objects to avoid recreating them for the same Hadoop configuration.
+ * It uses a Least Recently Used (LRU) cache, where the least recently used entries are removed when the cache exceeds
+ * the maximum size (MAX_CACHE_SIZE).
+ * <p>
+ * The purpose of this class is to ensure that for identical Hadoop configurations (key-value pairs),
+ * only one PreExecutionAuthenticator instance is created and reused, optimizing performance by reducing
+ * redundant instantiations.
+ */
+public class PreExecutionAuthenticatorCache {
+    private static final Logger LOG = LogManager.getLogger(PreExecutionAuthenticatorCache.class);
+    private static final int MAX_CACHE_SIZE = 100;
+    private static final Map<HadoopConfigWrapper, PreExecutionAuthenticator> preExecutionAuthenticatorCache =
+            new LinkedHashMap<HadoopConfigWrapper, PreExecutionAuthenticator>(MAX_CACHE_SIZE, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<HadoopConfigWrapper, PreExecutionAuthenticator> eldest) {
+                    return size() > MAX_CACHE_SIZE;
+                }
+            };
+
+    /**
+     * Retrieves a PreExecutionAuthenticator instance from the cache or creates a new one if it doesn't exist.
+     * This method first checks if the configuration is already cached. If not, it computes a new instance and
+     * caches it for future use.
+     *
+     * @param hadoopConfig The Hadoop configuration (key-value pairs)
+     * @return A PreExecutionAuthenticator instance for the given configuration
+     */
+    public static PreExecutionAuthenticator getAuthenticator(Map<String, String> hadoopConfig) {
+
+        HadoopConfigWrapper hadoopConfigWrapper = new HadoopConfigWrapper(hadoopConfig);
+        PreExecutionAuthenticator cachedAuthenticator = preExecutionAuthenticatorCache.get(hadoopConfigWrapper);
+        if (cachedAuthenticator != null) {
+            return cachedAuthenticator;
+        }
+        return preExecutionAuthenticatorCache.computeIfAbsent(hadoopConfigWrapper, config -> {
+            Configuration conf = new Configuration();
+            hadoopConfig.forEach(conf::set);
+            PreExecutionAuthenticator preExecutionAuthenticator = new PreExecutionAuthenticator();
+            AuthenticationConfig authenticationConfig = AuthenticationConfig.getKerberosConfig(conf,
+                    AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL,
+                    AuthenticationConfig.HADOOP_KERBEROS_KEYTAB);
+            HadoopAuthenticator authenticator = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig);
+            preExecutionAuthenticator.setHadoopAuthenticator(authenticator);
+            LOG.info("Created new authenticator for configuration: " + hadoopConfigWrapper);
+            return preExecutionAuthenticator;
+        });
+    }
+
+
+    /**
+     * Hadoop configuration wrapper class that wraps a Map<String, String> configuration.
+     * This class overrides the equals() and hashCode() methods to enable comparison of
+     * the configurations in the cache, ensuring that identical configurations (with the same key-value pairs)
+     * are considered equal and can reuse the same cached PreExecutionAuthenticator instance.
+     * <p>
+     * The purpose of this class is to ensure that in the cache, if two configurations are identical
+     * (i.e., they have the same key-value pairs), only one instance of PreExecutionAuthenticator is created and cached.
+     * By implementing custom equals() and hashCode() methods, we ensure that even if different Map instances
+     * hold the same configuration data, they are considered equal in the cache.
+     */
+    private static class HadoopConfigWrapper {
+        private final Map<String, String> config;
+
+        /**
+         * Constructor that takes a Map<String, String> configuration.
+         *
+         * @param config The Hadoop configuration, typically a Map<String, String> containing configuration key-value
+         *               pairs
+         */
+        public HadoopConfigWrapper(Map<String, String> config) {
+            this.config = new HashMap<>(config);
+        }
+
+        /**
+         * Checks if two HadoopConfigWrapper objects are equal.
+         * Two objects are considered equal if their wrapped Map configurations are identical
+         * (i.e., the key-value pairs are the same).
+         *
+         * @param obj The object to compare with the current object
+         * @return true if the two HadoopConfigWrapper objects have the same wrapped configuration; false otherwise
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            HadoopConfigWrapper that = (HadoopConfigWrapper) obj;
+            return config.equals(that.config);
+        }
+
+        /**
+         * Generates a hash code based on the Hadoop configuration.
+         * Objects with the same configuration will generate the same hash code, ensuring
+         * that they can be correctly matched in a Map.
+         *
+         * @return The hash code of the Hadoop configuration
+         */
+        @Override
+        public int hashCode() {
+            return config.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?
Using JNI to directly read Paimon tables can lead to query failures when the Paimon storage is on HDFS with Kerberos authentication enabled.

#### Reproduction Steps:
- Create a Paimon catalog stored on an HDFS cluster with Kerberos authentication enabled.
- Execute the command: SET force_jni_scanner=true;.
- To ensure a clean environment, restart the BE (Backend) service.
- Perform any query on a table within the catalog.

```
2025-01-18 09:25:06  WARN Thread-13 org.apache.doris.paimon.PaimonJniScanner.open(PaimonJniScanner.java:126) - Failed to open paimon_scanner: java.io.UncheckedIOException: org.apache.hadoop.security.AccessControlException: org.apache.hadoop.security.AccessControlException: SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]
com.google.common.util.concurrent.UncheckedExecutionException: java.io.UncheckedIOException: org.apache.hadoop.security.AccessControlException: org.apache.hadoop.security.AccessControlException: SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085)
        at com.google.common.cache.LocalCache.get(LocalCache.java:4017)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4040)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4989)
        at org.apache.doris.paimon.PaimonTableCache.getTable(PaimonTableCache.java:84)
        at org.apache.doris.paimon.PaimonJniScanner.initTable(PaimonJniScanner.java:237)
        at org.apache.doris.paimon.PaimonJniScanner.open(PaimonJniScanner.java:122)
Caused by: java.io.UncheckedIOException: org.apache.hadoop.security.AccessControlException: org.apache.hadoop.security.AccessControlException: SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]
        at org.apache.paimon.hive.HiveCatalog.createHiveCatalog(HiveCatalog.java:708)
        at org.apache.paimon.hive.HiveCatalogFactory.create(HiveCatalogFactory.java:48)
        at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:76)
        at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:66)
        at org.apache.doris.paimon.PaimonTableCache.createCatalog(PaimonTableCache.java:75)
        at org.apache.doris.paimon.PaimonTableCache.loadTable(PaimonTableCache.java:58)
        at org.apache.doris.paimon.PaimonTableCache.access$000(PaimonTableCache.java:38)
        at org.apache.doris.paimon.PaimonTableCache$1.load(PaimonTableCache.java:51)
        at org.apache.doris.paimon.PaimonTableCache$1.load(PaimonTableCache.java:48)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3574)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2316)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
        ... 6 more
```
#### changes

This PR addresses an issue where queries fail when attempting to directly read Paimon tables using JNI, specifically in environments where HDFS is used as the storage backend and Kerberos authentication is enabled. The failure is caused by the lack of proper Kerberos authentication handling in the JNI implementation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    After updating the code, repeat the reproduction steps outlined above.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

