### PR TITLE
[fix](partition) Add partition of mismatched type to table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionKeyDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionKeyDesc.java
@@ -144,6 +144,10 @@ public class PartitionKeyDesc {
         return partitionKeyValueType;
     }
 
+    public boolean hasInValues() {
+        return inValues != null;
+    }
+
     public void analyze(int partColNum) throws AnalysisException {
         if (isDummy()) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -81,6 +81,10 @@ public class ListPartitionInfo extends PartitionInfo {
         // get partition key
         PartitionKeyDesc partitionKeyDesc = desc.getPartitionKeyDesc();
 
+        if (!partitionKeyDesc.hasInValues()) {
+            throw new DdlException("List partition expected 'VALUES [IN or ((\"xxx\", \"xxx\"), ...)]'");
+        }
+
         // we might receive one whole empty values list, we should add default partition value for
         // such occasion
         for (List<PartitionValue> values : partitionKeyDesc.getInValues()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -86,6 +86,9 @@ public class RangePartitionInfo extends PartitionInfo {
         Range<PartitionKey> newRange = null;
         PartitionKeyDesc partitionKeyDesc = desc.getPartitionKeyDesc();
         // check range
+        if (partitionKeyDesc.hasInValues()) {
+            throw new DdlException("Range partition expected 'VALUES [LESS THAN or [(\"xxx\" ,...), (\"xxx\", ...))]'");
+        }
         try {
             newRange = createAndCheckNewRange(partitionKeyDesc, isTemp);
         } catch (AnalysisException e) {

--- a/regression-test/suites/partition_p0/test_partition_add_mismatched.groovy
+++ b/regression-test/suites/partition_p0/test_partition_add_mismatched.groovy
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_partition_add_mismatched") {
+    sql "drop table if exists test_partition_add_mismatched_list_tbl"
+    sql """
+        CREATE TABLE IF NOT EXISTS test_partition_add_mismatched_list_tbl (
+            k1 int NOT NULL, 
+            k2 bigint NOT NULL
+        ) 
+        PARTITION BY LIST(k1,k2) () 
+        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")
+        """
+
+    sql "drop table if exists test_partition_add_mismatched_range_tbl"
+    sql """
+        CREATE TABLE IF NOT EXISTS test_partition_add_mismatched_range_tbl (
+            k1 int NOT NULL, 
+            k2 bigint NOT NULL
+        ) 
+        PARTITION BY RANGE(k1,k2) () 
+        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")
+        """
+
+	test{
+        sql """ alter table test_partition_add_mismatched_list_tbl add partition p0 values [("0"), ("2")) """
+        exception "List partition expected 'VALUES [IN or ((\"xxx\", \"xxx\"), ...)]'"
+	}
+
+	test{
+        sql """ alter table test_partition_add_mismatched_range_tbl add partition p0 values in (("0", "2")) """
+        exception "Range partition expected 'VALUES [LESS THAN or [(\"xxx\" ,...), (\"xxx\", ...))]'"
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx
before: 
```
mysql> CREATE TABLE t (
    ->     id int null,
    ->     k largeint null
    -> )
    -> PARTITION BY LIST (`id`, `k`)
    -> (
    -> )
    -> DISTRIBUTED BY HASH(`k`) BUCKETS 16
    -> PROPERTIES (
    ->     "replication_num" = "1"
    -> );
Query OK, 0 rows affected (0.00 sec)

mysql> ALTER TABLE t ADD PARTITION p_0_2 VALUES [("0"), ("2"));
ERROR 1105 (HY000): errCode = 2, detailMessage = Cannot invoke "java.util.List.iterator()" because the return value of "org.apache.doris.analysis.PartitionKeyDesc.getInValues()" is null
```
now
```
mysql> ALTER TABLE t ADD PARTITION p_0_2 VALUES [("0"), ("2"));
ERROR 1105 (HY000): errCode = 2, detailMessage = List partition expected 'VALUES [IN or ((\"xxx\", \"xxx\"), ...)]'
```
before
```
mysql> CREATE TABLE t (
    ->     id int null,
    ->     k largeint null
    -> )
    -> PARTITION BY RANGE (`id`, `k`)
    -> (
    -> )
    -> DISTRIBUTED BY HASH(`k`) BUCKETS 16
    -> PROPERTIES (
    ->     "replication_num" = "1"
    -> );
Query OK, 0 rows affected (0.05 sec)

mysql> ALTER TABLE t ADD PARTITION p_0_2 VALUES IN (("0", "2"));
ERROR 1105 (HY000): errCode = 2, detailMessage = Cannot invoke "java.util.List.size()" because "keys" is null
```
now
```
mysql> ALTER TABLE t ADD PARTITION p_0_2 VALUES IN (("0", "2"));
ERROR 1105 (HY000): errCode = 2, detailMessage = Range partition expected 'VALUES [LESS THAN or [(\"xxx\" ,...), (\"xxx\", ...))]'
```


Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

