### PR TITLE
[opt](exchange)Optimize read performance in scenarios with large data volumes, high filtering rates, and limits.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -314,6 +314,7 @@ DEFINE_mInt32(doris_scanner_row_num, "16384");
 DEFINE_mInt32(doris_scanner_row_bytes, "10485760");
 // single read execute fragment max run time millseconds
 DEFINE_mInt32(doris_scanner_max_run_time_ms, "1000");
+DEFINE_mInt32(doris_exchange_block_max_wait_time_ms, "500");
 // (Advanced) Maximum size of per-query receive-side buffer
 DEFINE_mInt32(exchg_node_buffer_size_bytes, "20485760");
 DEFINE_mInt32(exchg_buffer_queue_capacity_factor, "64");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -358,6 +358,8 @@ DECLARE_mInt32(doris_scanner_row_num);
 DECLARE_mInt32(doris_scanner_row_bytes);
 // single read execute fragment max run time millseconds
 DECLARE_mInt32(doris_scanner_max_run_time_ms);
+//In the exchange sink operator, the maximum waiting time for a block to be sent.
+DECLARE_mInt32(doris_exchange_block_max_wait_time_ms);
 // (Advanced) Maximum size of per-query receive-side buffer
 DECLARE_mInt32(exchg_node_buffer_size_bytes);
 DECLARE_mInt32(exchg_buffer_queue_capacity_factor);

--- a/be/src/util/stopwatch.hpp
+++ b/be/src/util/stopwatch.hpp
@@ -85,6 +85,8 @@ public:
         return end.tv_sec - _start.tv_sec;
     }
 
+    bool is_running() { return _running; }
+
 private:
     timespec _start;
     uint64_t _total_time; // in nanosec

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -95,6 +95,7 @@ public:
 private:
     pipeline::ExchangeSinkLocalState* _parent;
     std::unique_ptr<MutableBlock> _mutable_block;
+    MonotonicStopWatch _max_block_life_time;
 
     bool _is_local;
     const int _batch_size;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Doris needs to accumulate enough data for a batch before sending it when exchanging. 

When the amount of data to be queried is large and where filters a large amount of data and has a limit, the underlying scan needs to scan all the data to accumulate enough data for a batch or read EOF before sending, resulting in a lot of extra data being read (fe will only send a cancel query after the limit is met). 

I added a timer on the exchange operator to optimize this scenario. When the data exists for longer than `doris_exchange_block_max_wait_time_ms`, the data is sent.

### Release note

Optimize read performance in scenarios with large data volumes, high filtering rates, and limits.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

