### PR TITLE
[opt](resource) Implement `ResourceContext` to manage task resources

### DIFF
--- a/be/src/cloud/cloud_delta_writer.cpp
+++ b/be/src/cloud/cloud_delta_writer.cpp
@@ -29,7 +29,7 @@ CloudDeltaWriter::CloudDeltaWriter(CloudStorageEngine& engine, const WriteReques
                                    RuntimeProfile* profile, const UniqueId& load_id)
         : BaseDeltaWriter(req, profile, load_id), _engine(engine) {
     _rowset_builder = std::make_unique<CloudRowsetBuilder>(engine, req, profile);
-    _query_thread_context.init_unlocked();
+    _resource_ctx = thread_context()->resource_ctx();
 }
 
 CloudDeltaWriter::~CloudDeltaWriter() = default;
@@ -47,7 +47,7 @@ Status CloudDeltaWriter::batch_init(std::vector<CloudDeltaWriter*> writers) {
         }
 
         tasks.emplace_back([writer] {
-            SCOPED_ATTACH_TASK(writer->query_thread_context());
+            SCOPED_ATTACH_TASK(writer->resource_context());
             std::lock_guard<bthread::Mutex> lock(writer->_mtx);
             if (writer->_is_init || writer->_is_cancelled) {
                 return Status::OK();

--- a/be/src/cloud/cloud_delta_writer.h
+++ b/be/src/cloud/cloud_delta_writer.h
@@ -20,6 +20,7 @@
 #include <bthread/mutex.h>
 
 #include "olap/delta_writer.h"
+#include "runtime/workload_management/resource_context.h"
 
 namespace doris {
 
@@ -51,8 +52,7 @@ public:
     Status commit_rowset();
 
     Status set_txn_related_delete_bitmap();
-
-    QueryThreadContext query_thread_context() { return _query_thread_context; }
+    std::shared_ptr<ResourceContext> resource_context() { return _resource_ctx; }
 
 private:
     // Convert `_rowset_builder` from `BaseRowsetBuilder` to `CloudRowsetBuilder`
@@ -60,7 +60,7 @@ private:
 
     bthread::Mutex _mtx;
     CloudStorageEngine& _engine;
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 };
 
 } // namespace doris

--- a/be/src/olap/calc_delete_bitmap_executor.cpp
+++ b/be/src/olap/calc_delete_bitmap_executor.cpp
@@ -39,11 +39,11 @@ Status CalcDeleteBitmapToken::submit(BaseTabletSPtr tablet, RowsetSharedPtr cur_
     {
         std::shared_lock rlock(_lock);
         RETURN_IF_ERROR(_status);
-        _query_thread_context.init_unlocked();
+        _resource_ctx = thread_context()->resource_ctx();
     }
 
     return _thread_token->submit_func([=, this]() {
-        SCOPED_ATTACH_TASK(_query_thread_context);
+        SCOPED_ATTACH_TASK(_resource_ctx);
         auto st = tablet->calc_segment_delete_bitmap(cur_rowset, cur_segment, target_rowsets,
                                                      delete_bitmap, end_version, rowset_writer,
                                                      tablet_delete_bitmap);

--- a/be/src/olap/calc_delete_bitmap_executor.h
+++ b/be/src/olap/calc_delete_bitmap_executor.h
@@ -67,7 +67,7 @@ private:
     // Records the current status of the calc delete bitmap job.
     // Note: Once its value is set to Failed, it cannot return to SUCCESS.
     Status _status;
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 };
 
 // CalcDeleteBitmapExecutor is responsible for calc delete bitmap concurrently.

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -106,7 +106,7 @@ Status BaseDeltaWriter::init() {
     auto* t_ctx = doris::thread_context(true);
     std::shared_ptr<WorkloadGroup> wg_sptr = nullptr;
     if (t_ctx) {
-        wg_sptr = t_ctx->workload_group().lock();
+        wg_sptr = t_ctx->resource_ctx()->workload_group_context()->workload_group();
     }
     RETURN_IF_ERROR(_rowset_builder->init());
     RETURN_IF_ERROR(_memtable_writer->init(

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -105,7 +105,7 @@ Status BaseDeltaWriter::init() {
     }
     auto* t_ctx = doris::thread_context(true);
     std::shared_ptr<WorkloadGroup> wg_sptr = nullptr;
-    if (t_ctx) {
+    if (t_ctx && t_ctx->is_attach_task()) {
         wg_sptr = t_ctx->resource_ctx()->workload_group_context()->workload_group();
     }
     RETURN_IF_ERROR(_rowset_builder->init());

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -60,7 +60,7 @@ MemTable::MemTable(int64_t tablet_id, std::shared_ptr<TabletSchema> tablet_schem
           _offsets_of_aggregate_states(tablet_schema->num_columns()),
           _total_size_of_aggregate_states(0) {
     g_memtable_cnt << 1;
-    _query_thread_context.init_unlocked();
+    _resource_ctx = thread_context()->resource_ctx();
     _arena = std::make_unique<vectorized::Arena>();
     _vec_row_comparator = std::make_shared<RowInBlockComparator>(_tablet_schema);
     _num_columns = _tablet_schema->num_columns();
@@ -143,7 +143,7 @@ void MemTable::_init_agg_functions(const vectorized::Block* block) {
 }
 
 MemTable::~MemTable() {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_thread_context.query_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_resource_ctx->memory_context()->mem_tracker());
     {
         SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
         g_memtable_cnt << -1;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -196,7 +196,7 @@ public:
 
     const MemTableStat& stat() { return _stat; }
 
-    QueryThreadContext query_thread_context() { return _query_thread_context; }
+    std::shared_ptr<ResourceContext> resource_ctx() { return _resource_ctx; }
 
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
 
@@ -226,7 +226,7 @@ private:
 
     std::shared_ptr<RowInBlockComparator> _vec_row_comparator;
 
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 
     std::shared_ptr<MemTracker> _mem_tracker;
     // Only the rows will be inserted into block can allocate memory from _arena.

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -144,7 +144,7 @@ Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, in
     memtable->update_mem_type(MemType::FLUSH);
     int64_t duration_ns;
     SCOPED_RAW_TIMER(&duration_ns);
-    SCOPED_ATTACH_TASK(memtable->query_thread_context());
+    SCOPED_ATTACH_TASK(memtable->resource_ctx());
     signal::set_signal_task_id(_rowset_writer->load_id());
     signal::tablet_id = memtable->tablet_id();
     {

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -70,7 +70,7 @@ Status MemTableWriter::init(std::shared_ptr<RowsetWriter> rowset_writer,
     _tablet_schema = tablet_schema;
     _unique_key_mow = unique_key_mow;
     _partial_update_info = partial_update_info;
-    _query_thread_context.init_unlocked();
+    _resource_ctx = thread_context()->resource_ctx();
 
     _reset_mem_table();
 
@@ -144,7 +144,7 @@ Status MemTableWriter::flush_async() {
     // into thread context, ATTACH cannot be repeated here.
     // 2. call by remote, from `LoadChannelMgr::_get_load_channel`, no ATTACH because LoadChannelMgr
     // not know Load context.
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_thread_context.query_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_resource_ctx->memory_context()->mem_tracker());
     if (!_is_init || _is_closed) {
         // This writer is uninitialized or closed before flushing, do nothing.
         // We return OK instead of NOT_INITIALIZED or ALREADY_CLOSED.

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -132,7 +132,7 @@ private:
     std::vector<std::weak_ptr<MemTable>> _freezed_mem_tables;
     // The lock to protect _memtable and _freezed_mem_tables structure to avoid concurrency modification or read
     SpinLock _mem_table_ptr_lock;
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 
     std::mutex _lock;
 

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -30,7 +30,7 @@ PageBase<TAllocator>::PageBase(size_t b, bool use_cache, segment_v2::PageTypePB 
     if (use_cache) {
         _mem_tracker_by_allocator = StoragePageCache::instance()->mem_tracker(page_type);
     } else {
-        _mem_tracker_by_allocator = thread_context()->thread_mem_tracker_mgr->mem_tracker();
+        _mem_tracker_by_allocator = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
     }
     {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker_by_allocator);

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -30,7 +30,7 @@ PageBase<TAllocator>::PageBase(size_t b, bool use_cache, segment_v2::PageTypePB 
     if (use_cache) {
         _mem_tracker_by_allocator = StoragePageCache::instance()->mem_tracker(page_type);
     } else {
-        _mem_tracker_by_allocator = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
+        _mem_tracker_by_allocator = thread_context()->thread_mem_tracker_mgr->mem_tracker();
     }
     {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker_by_allocator);

--- a/be/src/olap/rowid_conversion.h
+++ b/be/src/olap/rowid_conversion.h
@@ -46,12 +46,14 @@ public:
                         "consuming "
                         "tracker:<{}>, peak used {}, current used {}.",
                         doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str(),
-                        doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->label(),
                         doris::thread_context()
-                                ->thread_mem_tracker_mgr->mem_tracker()
+                                ->thread_mem_tracker_mgr->limiter_mem_tracker()
+                                ->label(),
+                        doris::thread_context()
+                                ->thread_mem_tracker_mgr->limiter_mem_tracker()
                                 ->peak_consumption(),
                         doris::thread_context()
-                                ->thread_mem_tracker_mgr->mem_tracker()
+                                ->thread_mem_tracker_mgr->limiter_mem_tracker()
                                 ->consumption()));
             }
 

--- a/be/src/olap/rowid_conversion.h
+++ b/be/src/olap/rowid_conversion.h
@@ -46,9 +46,13 @@ public:
                         "consuming "
                         "tracker:<{}>, peak used {}, current used {}.",
                         doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str(),
-                        doris::thread_context()->thread_mem_tracker()->label(),
-                        doris::thread_context()->thread_mem_tracker()->peak_consumption(),
-                        doris::thread_context()->thread_mem_tracker()->consumption()));
+                        doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->label(),
+                        doris::thread_context()
+                                ->thread_mem_tracker_mgr->mem_tracker()
+                                ->peak_consumption(),
+                        doris::thread_context()
+                                ->thread_mem_tracker_mgr->mem_tracker()
+                                ->consumption()));
             }
 
             uint32_t id = _segments_rowid_map.size();

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -422,7 +422,7 @@ bool PipelineTask::should_revoke_memory(RuntimeState* state, int64_t revocable_m
         return false;
     } else if (is_wg_mem_low_water_mark) {
         int64_t spill_threshold = query_ctx->spill_threshold();
-        int64_t memory_usage = query_ctx->query_mem_tracker->consumption();
+        int64_t memory_usage = query_ctx->query_mem_tracker()->consumption();
         if (spill_threshold == 0 || memory_usage < spill_threshold) {
             return false;
         }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -741,9 +741,9 @@ Status FragmentMgr::_get_or_create_query_ctx(const TPipelineFragmentParams& para
 
                         // This may be a first fragment request of the query.
                         // Create the query fragments context.
-                        query_ctx = QueryContext::create_shared(
-                                query_id, _exec_env, params.query_options, params.coord,
-                                params.is_nereids, params.current_connect_fe, query_source);
+                        query_ctx = QueryContext::create(query_id, _exec_env, params.query_options,
+                                                         params.coord, params.is_nereids,
+                                                         params.current_connect_fe, query_source);
                         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_ctx->query_mem_tracker());
                         RETURN_IF_ERROR(DescriptorTbl::create(
                                 &(query_ctx->obj_pool), params.desc_tbl, &(query_ctx->desc_tbl)));

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -46,27 +46,26 @@ LoadChannel::LoadChannel(const UniqueId& load_id, int64_t timeout_s, bool is_hig
           _enable_profile(enable_profile) {
     std::shared_ptr<QueryContext> query_context =
             ExecEnv::GetInstance()->fragment_mgr()->get_query_ctx(_load_id.to_thrift());
-    std::shared_ptr<MemTrackerLimiter> mem_tracker = nullptr;
-    WorkloadGroupPtr wg_ptr = nullptr;
 
     if (query_context != nullptr) {
-        mem_tracker = query_context->query_mem_tracker;
-        wg_ptr = query_context->workload_group();
+        _resource_ctx = query_context->resource_ctx;
     } else {
+        _resource_ctx = ResourceContext::create_shared();
+        _resource_ctx->task_controller()->set_task_id(_load_id.to_thrift());
         // when memtable on sink is not enabled, load can not find queryctx
-        mem_tracker = MemTrackerLimiter::create_shared(
+        std::shared_ptr<MemTrackerLimiter> mem_tracker = MemTrackerLimiter::create_shared(
                 MemTrackerLimiter::Type::LOAD,
                 fmt::format("(FromLoadChannel)Load#Id={}", _load_id.to_string()));
+        _resource_ctx->memory_context()->set_mem_tracker(mem_tracker);
+        WorkloadGroupPtr wg_ptr = nullptr;
         if (wg_id > 0) {
-            WorkloadGroupPtr workload_group_ptr =
-                    ExecEnv::GetInstance()->workload_group_mgr()->get_group(wg_id);
-            if (workload_group_ptr) {
-                wg_ptr = workload_group_ptr;
+            wg_ptr = ExecEnv::GetInstance()->workload_group_mgr()->get_group(wg_id);
+            if (wg_ptr != nullptr) {
                 wg_ptr->add_mem_tracker_limiter(mem_tracker);
+                _resource_ctx->workload_group_context()->set_workload_group(wg_ptr);
             }
         }
     }
-    _query_thread_context = {_load_id.to_thrift(), mem_tracker, wg_ptr};
 
     g_loadchannel_cnt << 1;
     // _last_updated_time should be set before being inserted to
@@ -108,7 +107,7 @@ Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
                 "The txn expiration of PTabletWriterOpenRequest is invalid, value={}",
                 params.txn_expiration());
     }
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
 
     int64_t index_id = params.index_id();
     std::shared_ptr<BaseTabletsChannel> channel;
@@ -175,7 +174,7 @@ Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
                               PTabletWriterAddBlockResult* response) {
     SCOPED_TIMER(_add_batch_timer);
     COUNTER_UPDATE(_add_batch_times, 1);
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     int64_t index_id = request.index_id();
     // 1. get tablets channel
     std::shared_ptr<BaseTabletsChannel> channel;

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -109,7 +109,7 @@ private:
     // set to true if at least one tablets channel has been opened
     bool _opened = false;
 
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 
     std::atomic<time_t> _last_updated_time;
 

--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -638,7 +638,7 @@ int LoadStream::on_received_messages(StreamId id, butil::IOBuf* const messages[]
 void LoadStream::_dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* data) {
     VLOG_DEBUG << PStreamHeader_Opcode_Name(hdr.opcode()) << " from " << hdr.src_id()
                << " with tablet " << hdr.tablet_id();
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     // CLOSE_LOAD message should not be fault injected,
     // otherwise the message will be ignored and causing close wait timeout
     if (hdr.opcode() != PStreamHeader::CLOSE_LOAD) {

--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -426,19 +426,22 @@ LoadStream::LoadStream(PUniqueId load_id, LoadStreamMgr* load_stream_mgr, bool e
     std::shared_ptr<QueryContext> query_context =
             ExecEnv::GetInstance()->fragment_mgr()->get_query_ctx(load_tid);
     if (query_context != nullptr) {
-        _query_thread_context = {load_tid, query_context->query_mem_tracker,
-                                 query_context->workload_group()};
+        _resource_ctx = query_context->resource_ctx;
     } else {
-        _query_thread_context = {load_tid, MemTrackerLimiter::create_shared(
-                                                   MemTrackerLimiter::Type::LOAD,
-                                                   fmt::format("(FromLoadStream)Load#Id={}",
-                                                               ((UniqueId)load_id).to_string()))};
+        _resource_ctx = ResourceContext::create_shared();
+        _resource_ctx->task_controller()->set_task_id(load_tid);
+        std::shared_ptr<MemTrackerLimiter> mem_tracker = MemTrackerLimiter::create_shared(
+                MemTrackerLimiter::Type::LOAD,
+                fmt::format("(FromLoadStream)Load#Id={}", ((UniqueId)load_id).to_string()));
+        _resource_ctx->memory_context()->set_mem_tracker(mem_tracker);
     }
 #else
-    _query_thread_context = {load_tid, MemTrackerLimiter::create_shared(
-                                               MemTrackerLimiter::Type::LOAD,
-                                               fmt::format("(FromLoadStream)Load#Id={}",
-                                                           ((UniqueId)load_id).to_string()))};
+    _resource_ctx = ResourceContext::create_shared();
+    _resource_ctx->task_controller()->set_task_id(load_tid);
+    std::shared_ptr<MemTrackerLimiter> mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::LOAD,
+            fmt::format("(FromLoadStream)Load#Id={}", ((UniqueId)load_id).to_string()));
+    _resource_ctx->memory_context()->set_mem_tracker(mem_tracker);
 #endif
 }
 

--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -176,7 +176,7 @@ private:
     RuntimeProfile::Counter* _append_data_timer = nullptr;
     RuntimeProfile::Counter* _close_wait_timer = nullptr;
     LoadStreamMgr* _load_stream_mgr = nullptr;
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
     bool _is_incremental = false;
 };
 

--- a/be/src/runtime/load_stream_writer.cpp
+++ b/be/src/runtime/load_stream_writer.cpp
@@ -80,7 +80,7 @@ LoadStreamWriter::LoadStreamWriter(WriteRequest* context, RuntimeProfile* profil
     // TODO(plat1ko): CloudStorageEngine
     _rowset_builder = std::make_unique<RowsetBuilder>(
             ExecEnv::GetInstance()->storage_engine().to_local(), *context, profile);
-    _query_thread_context.init_unlocked(); // from load stream
+    _resource_ctx = thread_context()->resource_ctx(); // from load stream
 }
 
 LoadStreamWriter::~LoadStreamWriter() {
@@ -100,7 +100,7 @@ Status LoadStreamWriter::init() {
 
 Status LoadStreamWriter::append_data(uint32_t segid, uint64_t offset, butil::IOBuf buf,
                                      FileType file_type) {
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     io::FileWriter* file_writer = nullptr;
     auto& file_writers =
             file_type == FileType::SEGMENT_FILE ? _segment_file_writers : _inverted_file_writers;
@@ -141,7 +141,7 @@ Status LoadStreamWriter::append_data(uint32_t segid, uint64_t offset, butil::IOB
 }
 
 Status LoadStreamWriter::close_writer(uint32_t segid, FileType file_type) {
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     io::FileWriter* file_writer = nullptr;
     auto& file_writers =
             file_type == FileType::SEGMENT_FILE ? _segment_file_writers : _inverted_file_writers;
@@ -183,7 +183,7 @@ Status LoadStreamWriter::close_writer(uint32_t segid, FileType file_type) {
 
 Status LoadStreamWriter::add_segment(uint32_t segid, const SegmentStatistics& stat,
                                      TabletSchemaSPtr flush_schema) {
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     size_t segment_file_size = 0;
     size_t inverted_file_size = 0;
     {
@@ -246,7 +246,7 @@ Status LoadStreamWriter::_calc_file_size(uint32_t segid, FileType file_type, siz
 }
 
 Status LoadStreamWriter::_pre_close() {
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     if (!_is_init) {
         // if this delta writer is not initialized, but close() is called.
         // which means this tablet has no data loaded, but at least one tablet

--- a/be/src/runtime/load_stream_writer.h
+++ b/be/src/runtime/load_stream_writer.h
@@ -96,7 +96,7 @@ private:
     std::mutex _segment_stat_map_lock;
     std::vector<io::FileWriterPtr> _segment_file_writers;
     std::vector<io::FileWriterPtr> _inverted_file_writers;
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 };
 
 using LoadStreamWriterSharedPtr = std::shared_ptr<LoadStreamWriter>;

--- a/be/src/runtime/memory/global_memory_arbitrator.cpp
+++ b/be/src/runtime/memory/global_memory_arbitrator.cpp
@@ -62,7 +62,7 @@ bool GlobalMemoryArbitrator::try_reserve_process_memory(int64_t bytes) {
     return true;
 }
 
-void GlobalMemoryArbitrator::release_process_reserved_memory(int64_t bytes) {
+void GlobalMemoryArbitrator::shrink_process_reserved(int64_t bytes) {
     _process_reserved_memory.fetch_sub(bytes, std::memory_order_relaxed);
 }
 

--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -90,7 +90,7 @@ public:
     }
 
     static bool try_reserve_process_memory(int64_t bytes);
-    static void release_process_reserved_memory(int64_t bytes);
+    static void shrink_process_reserved(int64_t bytes);
 
     static inline int64_t process_reserved_memory() {
         return _process_reserved_memory.load(std::memory_order_relaxed);

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -224,7 +224,7 @@ public:
         return rt;
     }
 
-    void release_reserved(int64_t bytes) {
+    void shrink_reserved(int64_t bytes) {
         _reserved_counter.sub(bytes);
         DCHECK(reserved_consumption() >= 0);
     }

--- a/be/src/runtime/memory/memory_profile.h
+++ b/be/src/runtime/memory/memory_profile.h
@@ -33,27 +33,27 @@ public:
     void make_memory_profile(RuntimeProfile* profile) const;
 
     std::string print_memory_overview_profile() const {
-        return return_memory_profile_str(_memory_overview_profile.get());
+        return _memory_overview_profile->pretty_print();
     }
 
     std::string print_global_memory_profile() const {
-        return return_memory_profile_str(_global_memory_profile.get().get());
+        return _global_memory_profile.get()->pretty_print();
     }
 
     std::string print_metadata_memory_profile() const {
-        return return_memory_profile_str(_metadata_memory_profile.get().get());
+        return _metadata_memory_profile.get()->pretty_print();
     }
 
     std::string print_cache_memory_profile() const {
-        return return_memory_profile_str(_cache_memory_profile.get().get());
+        return _cache_memory_profile.get()->pretty_print();
     }
 
     std::string print_top_memory_tasks_profile() const {
-        return return_memory_profile_str(_top_memory_tasks_profile.get().get());
+        return _top_memory_tasks_profile.get()->pretty_print();
     }
 
     std::string print_tasks_memory_profile() const {
-        return return_memory_profile_str(_tasks_memory_profile.get().get());
+        return _tasks_memory_profile.get()->pretty_print();
     }
 
     static int64_t query_current_usage();
@@ -67,12 +67,6 @@ public:
     void print_log_process_usage();
 
 private:
-    std::string return_memory_profile_str(const RuntimeProfile* profile) const {
-        std::stringstream ss;
-        profile->pretty_print(&ss);
-        return ss.str();
-    }
-
     void init_memory_overview_counter();
 
     std::unique_ptr<RuntimeProfile> _memory_overview_profile;

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -20,26 +20,8 @@
 #include <gen_cpp/types.pb.h>
 
 #include "runtime/exec_env.h"
-#include "runtime/fragment_mgr.h"
 
 namespace doris {
-
-class AsyncCancelQueryTask : public Runnable {
-    ENABLE_FACTORY_CREATOR(AsyncCancelQueryTask);
-
-public:
-    AsyncCancelQueryTask(TUniqueId query_id, const std::string& exceed_msg)
-            : _query_id(query_id), _exceed_msg(exceed_msg) {}
-    ~AsyncCancelQueryTask() override = default;
-    void run() override {
-        ExecEnv::GetInstance()->fragment_mgr()->cancel_query(
-                _query_id, Status::MemoryLimitExceeded(_exceed_msg));
-    }
-
-private:
-    TUniqueId _query_id;
-    const std::string _exceed_msg;
-};
 
 void ThreadMemTrackerMgr::attach_limiter_tracker(
         const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
@@ -50,8 +32,8 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(
     if (_reserved_mem != 0) {
         // _untracked_mem temporary store bytes that not synchronized to process reserved memory,
         // but bytes have been subtracted from thread _reserved_mem.
-        doris::GlobalMemoryArbitrator::release_process_reserved_memory(_untracked_mem);
-        _limiter_tracker->release_reserved(_untracked_mem);
+        doris::GlobalMemoryArbitrator::shrink_process_reserved(_untracked_mem);
+        _limiter_tracker->shrink_reserved(_untracked_mem);
         _reserved_mem = 0;
         _untracked_mem = 0;
     }
@@ -63,28 +45,12 @@ void ThreadMemTrackerMgr::detach_limiter_tracker(
         const std::shared_ptr<MemTrackerLimiter>& old_mem_tracker) {
     CHECK(init());
     flush_untracked_mem();
-    release_reserved();
+    shrink_reserved();
     DCHECK(!_last_attach_snapshots_stack.empty());
     _reserved_mem = _last_attach_snapshots_stack.back().reserved_mem;
     _consumer_tracker_stack = _last_attach_snapshots_stack.back().consumer_tracker_stack;
     _last_attach_snapshots_stack.pop_back();
     _limiter_tracker = old_mem_tracker;
-}
-
-void ThreadMemTrackerMgr::cancel_query(const std::string& exceed_msg) {
-    if (is_attach_query() && !_is_query_cancelled) {
-        Status submit_st = ExecEnv::GetInstance()->lazy_release_obj_pool()->submit(
-                AsyncCancelQueryTask::create_shared(_query_id, exceed_msg));
-        if (submit_st.ok()) {
-            // Use this flag to avoid the cancel request submit to pool many times, because even we cancel the query
-            // successfully, but the application may not use if (state.iscancelled) to exist quickly. And it may try to
-            // allocate memory and may failed again and the pool will be full.
-            _is_query_cancelled = true;
-        } else {
-            LOG(WARNING) << "Failed to submit cancel query task to pool, query_id "
-                         << print_id(_query_id) << ", error st " << submit_st;
-        }
-    }
 }
 
 } // namespace doris

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -20,7 +20,6 @@
 #include <fmt/format.h>
 #include <gen_cpp/Types_types.h>
 #include <glog/logging.h>
-#include <stdint.h>
 
 #include <algorithm>
 #include <memory>
@@ -35,11 +34,17 @@
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/workload_group/workload_group.h"
 #include "util/stack_util.h"
-#include "util/uid_util.h"
 
 namespace doris {
 
 constexpr size_t SYNC_PROC_RESERVED_INTERVAL_BYTES = (1ULL << 20); // 1M
+static std::string MEMORY_ORPHAN_CHECK_MSG =
+        "If you crash here, it means that SCOPED_ATTACH_TASK and "
+        "SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of "
+        "each thread is expected to use SCOPED_ATTACH_TASK to bind a MemTrackerLimiter belonging "
+        "to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the "
+        "thread will crash. If you want to switch MemTrackerLimiter during thread execution, "
+        "please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not repeat Attach.";
 
 // Memory Hook is counted in the memory tracker of the current thread.
 class ThreadMemTrackerMgr {
@@ -61,6 +66,24 @@ public:
     void detach_limiter_tracker(const std::shared_ptr<MemTrackerLimiter>& old_mem_tracker =
                                         ExecEnv::GetInstance()->orphan_mem_tracker());
 
+    void attach_task(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
+                     const std::weak_ptr<WorkloadGroup>& wg_wptr) {
+        DCHECK(mem_tracker);
+        // Orphan is thread default tracker.
+        // will only attach_task at the beginning of the thread function, there should be no duplicate attach_task.
+        DCHECK(_limiter_tracker->label() == "Orphan")
+                << ", thread mem tracker label: " << _limiter_tracker->label()
+                << ", attach mem tracker label: " << mem_tracker->label();
+        attach_limiter_tracker(mem_tracker);
+        _wg_wptr = wg_wptr;
+        enable_wait_gc();
+    }
+    void detach_task() {
+        detach_limiter_tracker();
+        _wg_wptr.reset();
+        disable_wait_gc();
+    }
+
     // Must be fast enough! Thread update_tracker may be called very frequently.
     bool push_consumer_tracker(MemTracker* mem_tracker);
     void pop_consumer_tracker();
@@ -68,32 +91,18 @@ public:
         return _consumer_tracker_stack.empty() ? "" : _consumer_tracker_stack.back()->label();
     }
 
-    void set_query_id(const TUniqueId& query_id) { _query_id = query_id; }
-
-    TUniqueId query_id() { return _query_id; }
-
-    void set_wg_wptr(const std::weak_ptr<WorkloadGroup>& wg_wptr) { _wg_wptr = wg_wptr; }
-
-    void reset_wg_wptr() { _wg_wptr.reset(); }
-
     // Note that, If call the memory allocation operation in Memory Hook,
     // such as calling LOG/iostream/sstream/stringstream/etc. related methods,
     // must increase the control to avoid entering infinite recursion, otherwise it may cause crash or stuck,
     // Returns whether the memory exceeds limit, and will consume mem trcker no matter whether the limit is exceeded.
-    void consume(int64_t size, int skip_large_memory_check = 0);
+    void consume(int64_t size);
     void flush_untracked_mem();
 
     doris::Status try_reserve(int64_t size);
 
-    void release_reserved();
+    void shrink_reserved();
 
-    bool is_attach_query() { return _query_id != TUniqueId(); }
-
-    bool is_query_cancelled() const { return _is_query_cancelled; }
-
-    void reset_query_cancelled_flag(bool new_val) { _is_query_cancelled = new_val; }
-
-    std::shared_ptr<MemTrackerLimiter> limiter_mem_tracker() {
+    std::shared_ptr<MemTrackerLimiter> mem_tracker() {
         CHECK(init());
         return _limiter_tracker;
     }
@@ -101,7 +110,6 @@ public:
     void enable_wait_gc() { _wait_gc = true; }
     void disable_wait_gc() { _wait_gc = false; }
     [[nodiscard]] bool wait_gc() const { return _wait_gc; }
-    void cancel_query(const std::string& exceed_msg);
 
     std::string print_debug_string() {
         fmt::memory_buffer consumer_tracker_buf;
@@ -117,6 +125,17 @@ public:
 
     int64_t untracked_mem() const { return _untracked_mem; }
     int64_t reserved_mem() const { return _reserved_mem; }
+
+    int skip_memory_check = 0;
+    int skip_large_memory_check = 0;
+
+    void memory_orphan_check() {
+#ifdef USE_MEM_TRACKER
+        DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check ||
+               _limiter_tracker->label() != "Orphan")
+                << doris::MEMORY_ORPHAN_CHECK_MSG;
+#endif
+    }
 
 private:
     struct LastAttachSnapshot {
@@ -136,7 +155,7 @@ private:
     // so `attach_limiter_tracker` may be nested.
     std::vector<LastAttachSnapshot> _last_attach_snapshots_stack;
 
-    std::string _failed_consume_msg = std::string();
+    std::string _failed_consume_msg;
     // If true, the Allocator will wait for the GC to free memory if it finds that the memory exceed limit.
     // A thread of query/load will only wait once during execution.
     bool _wait_gc = false;
@@ -147,14 +166,14 @@ private:
 
     // If there is a memory new/delete operation in the consume method, it may enter infinite recursion.
     bool _stop_consume = false;
-    TUniqueId _query_id = TUniqueId();
-    bool _is_query_cancelled = false;
 };
 
 inline bool ThreadMemTrackerMgr::init() {
     // 1. Initialize in the thread context when the thread starts
-    // 2. ExecEnv not initialized when thread start, initialized in limiter_mem_tracker().
-    if (_init) return true;
+    // 2. ExecEnv not initialized when thread start, initialized in mem_tracker().
+    if (_init) {
+        return true;
+    }
     if (ExecEnv::GetInstance()->orphan_mem_tracker() != nullptr) {
         _limiter_tracker = ExecEnv::GetInstance()->orphan_mem_tracker();
         _wait_gc = true;
@@ -178,7 +197,8 @@ inline void ThreadMemTrackerMgr::pop_consumer_tracker() {
     _consumer_tracker_stack.pop_back();
 }
 
-inline void ThreadMemTrackerMgr::consume(int64_t size, int skip_large_memory_check) {
+inline void ThreadMemTrackerMgr::consume(int64_t size) {
+    memory_orphan_check();
     // `consumer_tracker` not support reserve memory and not require use `_untracked_mem` to batch consume,
     // because `consumer_tracker` will not be bound by many threads, so there is no performance problem.
     for (auto* tracker : _consumer_tracker_stack) {
@@ -199,8 +219,8 @@ inline void ThreadMemTrackerMgr::consume(int64_t size, int skip_large_memory_che
             // If _untracked_mem < 0, used reserved memory is returned, will increase reserved memory,
             // if _untracked_mem less than -SYNC_PROC_RESERVED_INTERVAL_BYTES, increase process reserved memory.
             if (std::abs(_untracked_mem) >= SYNC_PROC_RESERVED_INTERVAL_BYTES) {
-                doris::GlobalMemoryArbitrator::release_process_reserved_memory(_untracked_mem);
-                _limiter_tracker->release_reserved(_untracked_mem);
+                doris::GlobalMemoryArbitrator::shrink_process_reserved(_untracked_mem);
+                _limiter_tracker->shrink_reserved(_untracked_mem);
                 _untracked_mem = 0;
             }
             return;
@@ -210,9 +230,8 @@ inline void ThreadMemTrackerMgr::consume(int64_t size, int skip_large_memory_che
             // and reset _reserved_mem to 0, and subtract the remaining _reserved_mem from
             // process global reserved memory, this means that all reserved memory has been used by BE process.
             size -= _reserved_mem;
-            doris::GlobalMemoryArbitrator::release_process_reserved_memory(_reserved_mem +
-                                                                           _untracked_mem);
-            _limiter_tracker->release_reserved(_reserved_mem + _untracked_mem);
+            doris::GlobalMemoryArbitrator::shrink_process_reserved(_reserved_mem + _untracked_mem);
+            _limiter_tracker->shrink_reserved(_reserved_mem + _untracked_mem);
             _reserved_mem = 0;
             _untracked_mem = 0;
         }
@@ -236,23 +255,19 @@ inline void ThreadMemTrackerMgr::consume(int64_t size, int skip_large_memory_che
             size > doris::config::stacktrace_in_alloc_large_memory_bytes) {
             _stop_consume = true;
             LOG(WARNING) << fmt::format(
-                    "alloc large memory: {}, {}, this is just a warning, not prevent memory alloc, "
+                    "alloc large memory: {}, consume tracker: {}, this is just a warning, not "
+                    "prevent memory alloc, "
                     "stacktrace:\n{}",
-                    size,
-                    is_attach_query() ? "in query or load: " + print_id(_query_id)
-                                      : "not in query or load",
-                    get_stack_trace());
+                    size, _limiter_tracker->label(), get_stack_trace());
             _stop_consume = false;
         }
         if (doris::config::crash_in_alloc_large_memory_bytes > 0 &&
             size > doris::config::crash_in_alloc_large_memory_bytes) {
-            throw Exception(Status::FatalError(
-                    "alloc large memory: {}, {}, crash generate core dumpsto help analyze, "
-                    "stacktrace:\n{}",
-                    size,
-                    is_attach_query() ? "in query or load: " + print_id(_query_id)
-                                      : "not in query or load",
-                    get_stack_trace()));
+            throw Exception(
+                    Status::FatalError("alloc large memory: {}, consume tracker: {}, crash "
+                                       "generate core dumpsto help analyze, "
+                                       "stacktrace:\n{}",
+                                       size, _limiter_tracker->label(), get_stack_trace()));
         }
     }
 }
@@ -282,6 +297,7 @@ inline doris::Status ThreadMemTrackerMgr::try_reserve(int64_t size) {
     DCHECK(_limiter_tracker);
     DCHECK(size >= 0);
     CHECK(init());
+    memory_orphan_check();
     // if _reserved_mem not equal to 0, repeat reserve,
     // _untracked_mem store bytes that not synchronized to process reserved memory.
     flush_untracked_mem();
@@ -297,16 +313,16 @@ inline doris::Status ThreadMemTrackerMgr::try_reserve(int64_t size) {
         if (!wg_ptr->add_wg_refresh_interval_memory_growth(size)) {
             auto err_msg = fmt::format("reserve memory failed, size: {}, because {}", size,
                                        wg_ptr->memory_debug_string());
-            _limiter_tracker->release(size);          // rollback
-            _limiter_tracker->release_reserved(size); // rollback
+            _limiter_tracker->release(size);         // rollback
+            _limiter_tracker->shrink_reserved(size); // rollback
             return doris::Status::MemoryLimitExceeded(err_msg);
         }
     }
     if (!doris::GlobalMemoryArbitrator::try_reserve_process_memory(size)) {
         auto err_msg = fmt::format("reserve memory failed, size: {}, because {}", size,
                                    GlobalMemoryArbitrator::process_mem_log_str());
-        _limiter_tracker->release(size);          // rollback
-        _limiter_tracker->release_reserved(size); // rollback
+        _limiter_tracker->release(size);         // rollback
+        _limiter_tracker->shrink_reserved(size); // rollback
         if (wg_ptr) {
             wg_ptr->sub_wg_refresh_interval_memory_growth(size); // rollback
         }
@@ -316,11 +332,11 @@ inline doris::Status ThreadMemTrackerMgr::try_reserve(int64_t size) {
     return doris::Status::OK();
 }
 
-inline void ThreadMemTrackerMgr::release_reserved() {
+inline void ThreadMemTrackerMgr::shrink_reserved() {
+    memory_orphan_check();
     if (_reserved_mem != 0) {
-        doris::GlobalMemoryArbitrator::release_process_reserved_memory(_reserved_mem +
-                                                                       _untracked_mem);
-        _limiter_tracker->release_reserved(_reserved_mem + _untracked_mem);
+        doris::GlobalMemoryArbitrator::shrink_process_reserved(_reserved_mem + _untracked_mem);
+        _limiter_tracker->shrink_reserved(_reserved_mem + _untracked_mem);
         _limiter_tracker->release(_reserved_mem);
         auto wg_ptr = _wg_wptr.lock();
         if (wg_ptr) {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -80,13 +80,13 @@ QueryContext::QueryContext(TUniqueId query_id, ExecEnv* exec_env,
           _is_nereids(is_nereids),
           _query_options(query_options),
           _query_source(query_source) {
-    _init_query_mem_tracker();
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_mem_tracker);
+    _init_resource_context();
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_mem_tracker());
     _query_watcher.start();
     _shared_hash_table_controller.reset(new vectorized::SharedHashTableController());
     _execution_dependency = pipeline::Dependency::create_unique(-1, -1, "ExecutionDependency");
     _runtime_filter_mgr = std::make_unique<RuntimeFilterMgr>(
-            TUniqueId(), RuntimeFilterParamsContext::create(this), query_mem_tracker, true);
+            TUniqueId(), RuntimeFilterParamsContext::create(this), query_mem_tracker(), true);
 
     _timeout_second = query_options.execution_timeout;
 
@@ -120,6 +120,7 @@ void QueryContext::_init_query_mem_tracker() {
                     << ". Using process memory limit instead";
         _bytes_limit = MemInfo::mem_limit();
     }
+    std::shared_ptr<MemTrackerLimiter> query_mem_tracker;
     if (_query_options.query_type == TQueryType::SELECT) {
         query_mem_tracker = MemTrackerLimiter::create_shared(
                 MemTrackerLimiter::Type::QUERY, fmt::format("Query#Id={}", print_id(_query_id)),
@@ -128,34 +129,46 @@ void QueryContext::_init_query_mem_tracker() {
         query_mem_tracker = MemTrackerLimiter::create_shared(
                 MemTrackerLimiter::Type::LOAD, fmt::format("Load#Id={}", print_id(_query_id)),
                 _bytes_limit);
-    } else { // EXTERNAL
+    } else if (_query_options.query_type == TQueryType::EXTERNAL) { // spark/flink/etc..
         query_mem_tracker = MemTrackerLimiter::create_shared(
-                MemTrackerLimiter::Type::LOAD, fmt::format("External#Id={}", print_id(_query_id)),
+                MemTrackerLimiter::Type::QUERY, fmt::format("External#Id={}", print_id(_query_id)),
                 _bytes_limit);
+    } else {
+        LOG(FATAL) << "__builtin_unreachable";
+        __builtin_unreachable();
     }
     if (_query_options.__isset.is_report_success && _query_options.is_report_success) {
         query_mem_tracker->enable_print_log_usage();
     }
+    resource_ctx->memory_context()->set_mem_tracker(query_mem_tracker);
+}
+
+void QueryContext::_init_resource_context() {
+    resource_ctx = ResourceContext::create_shared();
+    resource_ctx->task_controller()->set_task_id(_query_id);
+
+    // TODO, set query cpu/memory/etc. context
+    _init_query_mem_tracker();
 }
 
 QueryContext::~QueryContext() {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_mem_tracker());
     // query mem tracker consumption is equal to 0, it means that after QueryContext is created,
     // it is found that query already exists in _query_ctx_map, and query mem tracker is not used.
     // query mem tracker consumption is not equal to 0 after use, because there is memory consumed
     // on query mem tracker, released on other trackers.
     std::string mem_tracker_msg;
-    if (query_mem_tracker->peak_consumption() != 0) {
+    if (query_mem_tracker()->peak_consumption() != 0) {
         mem_tracker_msg = fmt::format(
                 "deregister query/load memory tracker, queryId={}, Limit={}, CurrUsed={}, "
                 "PeakUsed={}",
-                print_id(_query_id), MemCounter::print_bytes(query_mem_tracker->limit()),
-                MemCounter::print_bytes(query_mem_tracker->consumption()),
-                MemCounter::print_bytes(query_mem_tracker->peak_consumption()));
+                print_id(_query_id), MemCounter::print_bytes(query_mem_tracker()->limit()),
+                MemCounter::print_bytes(query_mem_tracker()->consumption()),
+                MemCounter::print_bytes(query_mem_tracker()->peak_consumption()));
     }
     [[maybe_unused]] uint64_t group_id = 0;
-    if (_workload_group) {
-        group_id = _workload_group->id(); // before remove
+    if (workload_group()) {
+        group_id = workload_group()->id(); // before remove
     }
 
 #ifndef BE_TEST
@@ -206,8 +219,8 @@ QueryContext::~QueryContext() {
 void QueryContext::set_ready_to_execute(Status reason) {
     set_execution_dependency_ready();
     _exec_status.update(reason);
-    if (query_mem_tracker && !reason.ok()) {
-        query_mem_tracker->set_is_query_cancelled(!reason.ok());
+    if (query_mem_tracker() && !reason.ok()) {
+        query_mem_tracker()->set_is_query_cancelled(!reason.ok());
     }
 }
 
@@ -292,8 +305,8 @@ std::shared_ptr<QueryStatistics> QueryContext::get_query_statistics() {
 }
 
 void QueryContext::register_memory_statistics() {
-    if (query_mem_tracker) {
-        std::shared_ptr<QueryStatistics> qs = query_mem_tracker->get_query_statistics();
+    if (query_mem_tracker()) {
+        std::shared_ptr<QueryStatistics> qs = query_mem_tracker()->get_query_statistics();
         std::string query_id = print_id(_query_id);
         if (qs) {
 #ifndef BE_TEST
@@ -318,7 +331,7 @@ void QueryContext::register_cpu_statistics() {
 }
 
 doris::pipeline::TaskScheduler* QueryContext::get_pipe_exec_scheduler() {
-    if (_workload_group) {
+    if (workload_group()) {
         if (_task_scheduler) {
             return _task_scheduler;
         }
@@ -327,7 +340,7 @@ doris::pipeline::TaskScheduler* QueryContext::get_pipe_exec_scheduler() {
 }
 
 ThreadPool* QueryContext::get_memtable_flush_pool() {
-    if (_workload_group) {
+    if (workload_group()) {
         return _memtable_flush_pool;
     } else {
         return nullptr;
@@ -335,12 +348,12 @@ ThreadPool* QueryContext::get_memtable_flush_pool() {
 }
 
 void QueryContext::set_workload_group(WorkloadGroupPtr& tg) {
-    _workload_group = tg;
+    resource_ctx->workload_group_context()->set_workload_group(tg);
     // Should add query first, then the workload group will not be deleted.
     // see task_group_manager::delete_workload_group_by_ids
-    _workload_group->add_mem_tracker_limiter(query_mem_tracker);
-    _workload_group->get_query_scheduler(&_task_scheduler, &_scan_task_scheduler,
-                                         &_memtable_flush_pool, &_remote_scan_task_scheduler);
+    workload_group()->add_mem_tracker_limiter(query_mem_tracker());
+    workload_group()->get_query_scheduler(&_task_scheduler, &_scan_task_scheduler,
+                                          &_memtable_flush_pool, &_remote_scan_task_scheduler);
 }
 
 void QueryContext::add_fragment_profile(

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -94,10 +94,6 @@ public:
         QueryTaskController(const std::shared_ptr<QueryContext>& query_ctx)
                 : query_ctx_(query_ctx) {}
 
-        // Gets the shared pointer to the associated query ctx to ensure its
-        // liveness during the query control operation.
-        std::shared_ptr<QueryContext> ensure_query_ctx() const { return query_ctx_.lock(); }
-
         const std::weak_ptr<QueryContext> query_ctx_;
     };
 
@@ -136,11 +132,20 @@ public:
         QueryMemoryContext() = default;
     };
 
+    static std::shared_ptr<QueryContext> create(TUniqueId query_id, ExecEnv* exec_env,
+                                                const TQueryOptions& query_options,
+                                                TNetworkAddress coord_addr, bool is_nereids,
+                                                TNetworkAddress current_connect_fe,
+                                                QuerySource query_type);
+
+    // use QueryContext::create, cannot be made private because of ENABLE_FACTORY_CREATOR::create_shared.
     QueryContext(TUniqueId query_id, ExecEnv* exec_env, const TQueryOptions& query_options,
                  TNetworkAddress coord_addr, bool is_nereids, TNetworkAddress current_connect_fe,
                  QuerySource query_type);
 
     ~QueryContext();
+
+    void init_query_task_controller();
 
     ExecEnv* exec_env() { return _exec_env; }
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -79,7 +79,7 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
         _query_mem_tracker = query_mem_tracker;
     } else {
         DCHECK(ctx != nullptr);
-        _query_mem_tracker = ctx->query_mem_tracker;
+        _query_mem_tracker = ctx->query_mem_tracker();
     }
 #ifdef BE_TEST
     if (_query_mem_tracker == nullptr) {
@@ -114,7 +114,7 @@ RuntimeState::RuntimeState(const TUniqueId& instance_id, const TUniqueId& query_
           _query_ctx(ctx) {
     [[maybe_unused]] auto status = init(instance_id, query_options, query_globals, exec_env);
     DCHECK(status.ok());
-    _query_mem_tracker = ctx->query_mem_tracker;
+    _query_mem_tracker = ctx->query_mem_tracker();
 #ifdef BE_TEST
     if (_query_mem_tracker == nullptr) {
         init_mem_trackers();
@@ -145,7 +145,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, int32_t fragment_id,
     // TODO: do we really need instance id?
     Status status = init(TUniqueId(), query_options, query_globals, exec_env);
     DCHECK(status.ok());
-    _query_mem_tracker = ctx->query_mem_tracker;
+    _query_mem_tracker = ctx->query_mem_tracker();
 #ifdef BE_TEST
     if (_query_mem_tracker == nullptr) {
         init_mem_trackers();

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -142,10 +142,6 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
         }
     };
 
-    // Reset thread memory tracker, otherwise SCOPED_ATTACH_TASK will be called nested, nesting is
-    // not allowed, first time in on_chunk_data, second time in StreamLoadExecutor::execute_plan_fragment.
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
-
     if (ctx->put_result.__isset.params) {
         st = _exec_env->fragment_mgr()->exec_plan_fragment(ctx->put_result.params,
                                                            QuerySource::STREAM_LOAD, exec_fragment);

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -58,8 +58,8 @@ SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(
         const std::shared_ptr<doris::MemTrackerLimiter>& mem_tracker) {
     DCHECK(mem_tracker);
     doris::ThreadLocalHandle::create_thread_local_if_not_exits();
-    if (mem_tracker != thread_context()->thread_mem_tracker_mgr->mem_tracker()) {
-        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->mem_tracker();
+    if (mem_tracker != thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
+        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
         thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker);
     }
 }
@@ -71,8 +71,8 @@ SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(ResourceContext* rc
            rc->task_controller()->task_id());
     DCHECK(rc->memory_context()->mem_tracker());
     if (rc->memory_context()->mem_tracker() !=
-        thread_context()->thread_mem_tracker_mgr->mem_tracker()) {
-        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->mem_tracker();
+        thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
+        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
         thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
                 rc->memory_context()->mem_tracker());
     }

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -20,51 +20,69 @@
 #include "common/signal_handler.h"
 #include "runtime/query_context.h"
 #include "runtime/runtime_state.h"
-#include "runtime/workload_group/workload_group_manager.h"
 
 namespace doris {
 class MemTracker;
 
-QueryThreadContext ThreadContext::query_thread_context() {
-    DCHECK(doris::pthread_context_ptr_init);
-    ORPHAN_TRACKER_CHECK();
-    return {_task_id, thread_mem_tracker_mgr->limiter_mem_tracker(), _wg_wptr};
+void AttachTask::init(const std::shared_ptr<ResourceContext>& rc) {
+    ThreadLocalHandle::create_thread_local_if_not_exits();
+    thread_context()->attach_task(rc);
 }
 
-void AttachTask::init(const QueryThreadContext& query_thread_context) {
-    ThreadLocalHandle::create_thread_local_if_not_exits();
-    signal::set_signal_task_id(query_thread_context.query_id);
-    thread_context()->attach_task(query_thread_context.query_id,
-                                  query_thread_context.query_mem_tracker,
-                                  query_thread_context.wg_wptr);
+AttachTask::AttachTask(const std::shared_ptr<ResourceContext>& rc) {
+    signal::set_signal_task_id(rc->task_controller()->task_id());
+    init(rc);
 }
 
 AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
-    QueryThreadContext query_thread_context = {TUniqueId(), mem_tracker};
-    init(query_thread_context);
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(mem_tracker);
+    init(rc);
 }
 
 AttachTask::AttachTask(RuntimeState* runtime_state) {
     signal::set_signal_is_nereids(runtime_state->is_nereids());
-    QueryThreadContext query_thread_context = {runtime_state->query_id(),
-                                               runtime_state->query_mem_tracker(),
-                                               runtime_state->get_query_ctx()->workload_group()};
-    init(query_thread_context);
-}
-
-AttachTask::AttachTask(const QueryThreadContext& query_thread_context) {
-    init(query_thread_context);
+    init(runtime_state->get_query_ctx()->resource_ctx);
 }
 
 AttachTask::AttachTask(QueryContext* query_ctx) {
-    QueryThreadContext query_thread_context = {query_ctx->query_id(), query_ctx->query_mem_tracker,
-                                               query_ctx->workload_group()};
-    init(query_thread_context);
+    init(query_ctx->resource_ctx);
 }
 
 AttachTask::~AttachTask() {
     thread_context()->detach_task();
     ThreadLocalHandle::del_thread_local_if_count_is_zero();
+}
+
+SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(
+        const std::shared_ptr<doris::MemTrackerLimiter>& mem_tracker) {
+    DCHECK(mem_tracker);
+    doris::ThreadLocalHandle::create_thread_local_if_not_exits();
+    if (mem_tracker != thread_context()->thread_mem_tracker_mgr->mem_tracker()) {
+        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->mem_tracker();
+        thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker);
+    }
+}
+
+SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(ResourceContext* rc) {
+    doris::ThreadLocalHandle::create_thread_local_if_not_exits();
+    // switch in the same task execution thread.
+    DCHECK(thread_context()->resource_ctx()->task_controller()->task_id() ==
+           rc->task_controller()->task_id());
+    DCHECK(rc->memory_context()->mem_tracker());
+    if (rc->memory_context()->mem_tracker() !=
+        thread_context()->thread_mem_tracker_mgr->mem_tracker()) {
+        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->mem_tracker();
+        thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
+                rc->memory_context()->mem_tracker());
+    }
+}
+
+SwitchThreadMemTrackerLimiter::~SwitchThreadMemTrackerLimiter() {
+    if (_old_mem_tracker != nullptr) {
+        thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker(_old_mem_tracker);
+    }
+    doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(MemTracker* mem_tracker) {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -106,52 +106,52 @@
         __VA_ARGS__;                                                                    \
     } while (0)
 
-#define LIMIT_LOCAL_SCAN_IO(data_dir, bytes_read)                            \
-    std::shared_ptr<IOThrottle> iot = nullptr;                               \
-    auto* t_ctx = doris::thread_context(true);                               \
-    if (t_ctx) {                                                             \
-        iot = t_ctx->resource_ctx()                                          \
-                      ->workload_group_context()                             \
-                      ->workload_group()                                     \
-                      ->get_local_scan_io_throttle(data_dir);                \
-    }                                                                        \
-    if (iot) {                                                               \
-        iot->acquire(-1);                                                    \
-    }                                                                        \
-    Defer defer {                                                            \
-        [&]() {                                                              \
-            if (iot) {                                                       \
-                iot->update_next_io_time(*bytes_read);                       \
-                iot = t_ctx->resource_ctx()                                  \
-                              ->workload_group_context()                     \
-                              ->workload_group()                             \
-                              ->update_local_scan_io(data_dir, *bytes_read); \
-            }                                                                \
-        }                                                                    \
+#define LIMIT_LOCAL_SCAN_IO(data_dir, bytes_read)                      \
+    std::shared_ptr<IOThrottle> iot = nullptr;                         \
+    auto* t_ctx = doris::thread_context(true);                         \
+    if (t_ctx) {                                                       \
+        iot = t_ctx->resource_ctx()                                    \
+                      ->workload_group_context()                       \
+                      ->workload_group()                               \
+                      ->get_local_scan_io_throttle(data_dir);          \
+    }                                                                  \
+    if (iot) {                                                         \
+        iot->acquire(-1);                                              \
+    }                                                                  \
+    Defer defer {                                                      \
+        [&]() {                                                        \
+            if (iot) {                                                 \
+                iot->update_next_io_time(*bytes_read);                 \
+                t_ctx->resource_ctx()                                  \
+                        ->workload_group_context()                     \
+                        ->workload_group()                             \
+                        ->update_local_scan_io(data_dir, *bytes_read); \
+            }                                                          \
+        }                                                              \
     }
 
-#define LIMIT_REMOTE_SCAN_IO(bytes_read)                            \
-    std::shared_ptr<IOThrottle> iot = nullptr;                      \
-    auto* t_ctx = doris::thread_context(true);                      \
-    if (t_ctx) {                                                    \
-        iot = t_ctx->resource_ctx()                                 \
-                      ->workload_group_context()                    \
-                      ->workload_group()                            \
-                      ->get_remote_scan_io_throttle(data_dir);      \
-    }                                                               \
-    if (iot) {                                                      \
-        iot->acquire(-1);                                           \
-    }                                                               \
-    Defer defer {                                                   \
-        [&]() {                                                     \
-            if (iot) {                                              \
-                iot->update_next_io_time(*bytes_read);              \
-                iot = t_ctx->resource_ctx()                         \
-                              ->workload_group_context()            \
-                              ->workload_group()                    \
-                              ->update_remote_scan_io(*bytes_read); \
-            }                                                       \
-        }                                                           \
+#define LIMIT_REMOTE_SCAN_IO(bytes_read)                      \
+    std::shared_ptr<IOThrottle> iot = nullptr;                \
+    auto* t_ctx = doris::thread_context(true);                \
+    if (t_ctx) {                                              \
+        iot = t_ctx->resource_ctx()                           \
+                      ->workload_group_context()              \
+                      ->workload_group()                      \
+                      ->get_remote_scan_io_throttle();        \
+    }                                                         \
+    if (iot) {                                                \
+        iot->acquire(-1);                                     \
+    }                                                         \
+    Defer defer {                                             \
+        [&]() {                                               \
+            if (iot) {                                        \
+                iot->update_next_io_time(*bytes_read);        \
+                t_ctx->resource_ctx()                         \
+                        ->workload_group_context()            \
+                        ->workload_group()                    \
+                        ->update_remote_scan_io(*bytes_read); \
+            }                                                 \
+        }                                                     \
     }
 
 namespace doris {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -19,20 +19,17 @@
 
 #include <bthread/bthread.h>
 #include <bthread/types.h>
-#include <gen_cpp/Types_types.h>
-#include <stdint.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <thread>
 
 #include "common/exception.h"
 #include "common/logging.h"
-#include "gutil/macros.h"
 #include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/memory/thread_mem_tracker_mgr.h"
+#include "runtime/workload_management/resource_context.h"
 #include "util/defer_op.h" // IWYU pragma: keep
 
 // Used to tracking query/load/compaction/e.g. execution thread memory usage.
@@ -57,17 +54,9 @@
 #define SCOPED_CONSUME_MEM_TRACKER(mem_tracker) \
     auto VARNAME_LINENUM(add_mem_consumer) = doris::AddThreadMemTrackerConsumer(mem_tracker)
 
-#define DEFER_RELEASE_RESERVED() \
-    Defer VARNAME_LINENUM(defer) {[&]() { doris::thread_context()->release_reserved_memory(); }};
-
-#define ORPHAN_TRACKER_CHECK()                                                  \
-    DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check || \
-           doris::thread_context()->thread_mem_tracker()->label() != "Orphan")  \
-            << doris::memory_orphan_check_msg
-
-#define MEMORY_ORPHAN_CHECK()                                                 \
-    DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check) \
-            << doris::memory_orphan_check_msg;
+#define DEFER_RELEASE_RESERVED()   \
+    Defer VARNAME_LINENUM(defer) { \
+            [&]() { doris::thread_context()->thread_mem_tracker_mgr->shrink_reserved(); }};
 #else
 // thread context need to be initialized, required by Allocator and elsewhere.
 #define SCOPED_ATTACH_TASK(arg1, ...) \
@@ -77,8 +66,6 @@
 #define SCOPED_CONSUME_MEM_TRACKER(mem_tracker) \
     auto VARNAME_LINENUM(scoped_tls_cmt) = doris::ScopedInitThreadContext()
 #define DEFER_RELEASE_RESERVED() (void)0
-#define ORPHAN_TRACKER_CHECK() (void)0
-#define MEMORY_ORPHAN_CHECK() (void)0
 #endif
 
 #if defined(USE_MEM_TRACKER) && !defined(BE_TEST)
@@ -108,22 +95,49 @@
 #define SCOPED_SKIP_MEMORY_CHECK() \
     auto VARNAME_LINENUM(scope_skip_memory_check) = doris::ScopeSkipMemoryCheck()
 
-#define SKIP_LARGE_MEMORY_CHECK(...)                                       \
-    do {                                                                   \
-        doris::ThreadLocalHandle::create_thread_local_if_not_exits();      \
-        doris::thread_context()->skip_large_memory_check++;                \
-        DEFER({                                                            \
-            doris::thread_context()->skip_large_memory_check--;            \
-            doris::ThreadLocalHandle::del_thread_local_if_count_is_zero(); \
-        });                                                                \
-        __VA_ARGS__;                                                       \
+#define SKIP_LARGE_MEMORY_CHECK(...)                                                    \
+    do {                                                                                \
+        doris::ThreadLocalHandle::create_thread_local_if_not_exits();                   \
+        doris::thread_context()->thread_mem_tracker_mgr->skip_large_memory_check++;     \
+        DEFER({                                                                         \
+            doris::thread_context()->thread_mem_tracker_mgr->skip_large_memory_check--; \
+            doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();              \
+        });                                                                             \
+        __VA_ARGS__;                                                                    \
     } while (0)
 
-#define LIMIT_LOCAL_SCAN_IO(data_dir, bytes_read)                   \
+#define LIMIT_LOCAL_SCAN_IO(data_dir, bytes_read)                            \
+    std::shared_ptr<IOThrottle> iot = nullptr;                               \
+    auto* t_ctx = doris::thread_context(true);                               \
+    if (t_ctx) {                                                             \
+        iot = t_ctx->resource_ctx()                                          \
+                      ->workload_group_context()                             \
+                      ->workload_group()                                     \
+                      ->get_local_scan_io_throttle(data_dir);                \
+    }                                                                        \
+    if (iot) {                                                               \
+        iot->acquire(-1);                                                    \
+    }                                                                        \
+    Defer defer {                                                            \
+        [&]() {                                                              \
+            if (iot) {                                                       \
+                iot->update_next_io_time(*bytes_read);                       \
+                iot = t_ctx->resource_ctx()                                  \
+                              ->workload_group_context()                     \
+                              ->workload_group()                             \
+                              ->update_local_scan_io(data_dir, *bytes_read); \
+            }                                                                \
+        }                                                                    \
+    }
+
+#define LIMIT_REMOTE_SCAN_IO(bytes_read)                            \
     std::shared_ptr<IOThrottle> iot = nullptr;                      \
     auto* t_ctx = doris::thread_context(true);                      \
     if (t_ctx) {                                                    \
-        iot = t_ctx->get_local_scan_io_throttle(data_dir);          \
+        iot = t_ctx->resource_ctx()                                 \
+                      ->workload_group_context()                    \
+                      ->workload_group()                            \
+                      ->get_remote_scan_io_throttle(data_dir);      \
     }                                                               \
     if (iot) {                                                      \
         iot->acquire(-1);                                           \
@@ -132,27 +146,12 @@
         [&]() {                                                     \
             if (iot) {                                              \
                 iot->update_next_io_time(*bytes_read);              \
-                t_ctx->update_local_scan_io(data_dir, *bytes_read); \
+                iot = t_ctx->resource_ctx()                         \
+                              ->workload_group_context()            \
+                              ->workload_group()                    \
+                              ->update_remote_scan_io(*bytes_read); \
             }                                                       \
         }                                                           \
-    }
-
-#define LIMIT_REMOTE_SCAN_IO(bytes_read)                   \
-    std::shared_ptr<IOThrottle> iot = nullptr;             \
-    auto* t_ctx = doris::thread_context(true);             \
-    if (t_ctx) {                                           \
-        iot = t_ctx->get_remote_scan_io_throttle();        \
-    }                                                      \
-    if (iot) {                                             \
-        iot->acquire(-1);                                  \
-    }                                                      \
-    Defer defer {                                          \
-        [&]() {                                            \
-            if (iot) {                                     \
-                iot->update_next_io_time(*bytes_read);     \
-                t_ctx->update_remote_scan_io(*bytes_read); \
-            }                                              \
-        }                                                  \
     }
 
 namespace doris {
@@ -160,8 +159,6 @@ namespace doris {
 class ThreadContext;
 class MemTracker;
 class RuntimeState;
-class QueryThreadContext;
-class WorkloadGroup;
 
 extern bthread_key_t btls_key;
 
@@ -170,14 +167,6 @@ inline thread_local bool pthread_context_ptr_init = false;
 inline thread_local constinit ThreadContext* thread_context_ptr = nullptr;
 // use mem hook to consume thread mem tracker.
 inline thread_local bool use_mem_hook = false;
-
-static std::string memory_orphan_check_msg =
-        "If you crash here, it means that SCOPED_ATTACH_TASK and "
-        "SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. starting position of "
-        "each thread is expected to use SCOPED_ATTACH_TASK to bind a MemTrackerLimiter belonging "
-        "to Query/Load/Compaction/Other Tasks, otherwise memory alloc using Doris Allocator in the "
-        "thread will crash. If you want to switch MemTrackerLimiter during thread execution, "
-        "please use SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER, do not repeat Attach.";
 
 // The thread context saves some info about a working thread.
 // 2 required info:
@@ -194,34 +183,23 @@ public:
 
     ~ThreadContext() = default;
 
-    void attach_task(const TUniqueId& task_id,
-                     const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
-                     const std::weak_ptr<WorkloadGroup>& wg_wptr) {
-        // will only attach_task at the beginning of the thread function, there should be no duplicate attach_task.
-        DCHECK(mem_tracker);
-        // Orphan is thread default tracker.
-        DCHECK(thread_mem_tracker()->label() == "Orphan")
-                << ", thread mem tracker label: " << thread_mem_tracker()->label()
-                << ", attach mem tracker label: " << mem_tracker->label();
-        _task_id = task_id;
-        _wg_wptr = wg_wptr;
-        thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker);
-        thread_mem_tracker_mgr->set_query_id(_task_id);
-        thread_mem_tracker_mgr->set_wg_wptr(_wg_wptr);
-        thread_mem_tracker_mgr->enable_wait_gc();
-        thread_mem_tracker_mgr->reset_query_cancelled_flag(false);
+    void attach_task(const std::shared_ptr<ResourceContext>& rc) {
+        resource_ctx_ = rc;
+        thread_mem_tracker_mgr->attach_task(rc->memory_context()->mem_tracker(),
+                                            rc->workload_group_context()->workload_group());
     }
 
     void detach_task() {
-        _task_id = TUniqueId();
-        _wg_wptr.reset();
-        thread_mem_tracker_mgr->detach_limiter_tracker();
-        thread_mem_tracker_mgr->set_query_id(TUniqueId());
-        thread_mem_tracker_mgr->reset_wg_wptr();
-        thread_mem_tracker_mgr->disable_wait_gc();
+        resource_ctx_.reset();
+        thread_mem_tracker_mgr->detach_task();
     }
 
-    [[nodiscard]] const TUniqueId& task_id() const { return _task_id; }
+    bool is_attach_task() { return resource_ctx_ != nullptr; }
+
+    std::shared_ptr<ResourceContext> resource_ctx() {
+        CHECK(is_attach_task());
+        return resource_ctx_;
+    }
 
     static std::string get_thread_id() {
         std::stringstream ss;
@@ -235,74 +213,10 @@ public:
     // to nullptr, but the object it points to is not initialized. At this time, when the memory
     // is released somewhere, the hook is triggered to cause the crash.
     std::unique_ptr<ThreadMemTrackerMgr> thread_mem_tracker_mgr;
-    [[nodiscard]] std::shared_ptr<MemTrackerLimiter> thread_mem_tracker() const {
-        return thread_mem_tracker_mgr->limiter_mem_tracker();
-    }
-
-    QueryThreadContext query_thread_context();
-
-    void consume_memory(const int64_t size) const {
-#ifdef USE_MEM_TRACKER
-        DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check ||
-               thread_mem_tracker()->label() != "Orphan")
-                << doris::memory_orphan_check_msg;
-#endif
-        thread_mem_tracker_mgr->consume(size, skip_large_memory_check);
-    }
-
-    doris::Status try_reserve_memory(const int64_t size) const {
-#ifdef USE_MEM_TRACKER
-        DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check ||
-               thread_mem_tracker()->label() != "Orphan")
-                << doris::memory_orphan_check_msg;
-#endif
-        return thread_mem_tracker_mgr->try_reserve(size);
-    }
-
-    void release_reserved_memory() const {
-#ifdef USE_MEM_TRACKER
-        DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check ||
-               thread_mem_tracker()->label() != "Orphan")
-                << doris::memory_orphan_check_msg;
-#endif
-        thread_mem_tracker_mgr->release_reserved();
-    }
-
-    std::weak_ptr<WorkloadGroup> workload_group() { return _wg_wptr; }
-
-    std::shared_ptr<IOThrottle> get_local_scan_io_throttle(const std::string& data_dir) {
-        if (std::shared_ptr<WorkloadGroup> wg_ptr = _wg_wptr.lock()) {
-            return wg_ptr->get_local_scan_io_throttle(data_dir);
-        }
-        return nullptr;
-    }
-
-    std::shared_ptr<IOThrottle> get_remote_scan_io_throttle() {
-        if (std::shared_ptr<WorkloadGroup> wg_ptr = _wg_wptr.lock()) {
-            return wg_ptr->get_remote_scan_io_throttle();
-        }
-        return nullptr;
-    }
-
-    void update_local_scan_io(std::string path, size_t bytes_read) {
-        if (std::shared_ptr<WorkloadGroup> wg_ptr = _wg_wptr.lock()) {
-            wg_ptr->update_local_scan_io(path, bytes_read);
-        }
-    }
-
-    void update_remote_scan_io(size_t bytes_read) {
-        if (std::shared_ptr<WorkloadGroup> wg_ptr = _wg_wptr.lock()) {
-            wg_ptr->update_remote_scan_io(bytes_read);
-        }
-    }
-
     int thread_local_handle_count = 0;
-    int skip_memory_check = 0;
-    int skip_large_memory_check = 0;
 
 private:
-    TUniqueId _task_id;
-    std::weak_ptr<WorkloadGroup> _wg_wptr;
+    std::shared_ptr<ResourceContext> resource_ctx_;
 };
 
 class ThreadLocalHandle {
@@ -379,44 +293,8 @@ static ThreadContext* thread_context(bool allow_return_null = false) {
     }
     // It means that use thread_context() but this thread not attached a query/load using SCOPED_ATTACH_TASK macro.
     throw Exception(
-            Status::FatalError("__builtin_unreachable, {}", doris::memory_orphan_check_msg));
+            Status::FatalError("__builtin_unreachable, {}", doris::MEMORY_ORPHAN_CHECK_MSG));
 }
-
-// belong to one query object member, not be shared by multiple queries.
-class QueryThreadContext {
-public:
-    QueryThreadContext() = default;
-    QueryThreadContext(const TUniqueId& query_id,
-                       const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
-                       const std::weak_ptr<WorkloadGroup>& wg_wptr)
-            : query_id(query_id), query_mem_tracker(mem_tracker), wg_wptr(wg_wptr) {}
-    // If use WorkloadGroup and can get WorkloadGroup ptr, must as a parameter.
-    QueryThreadContext(const TUniqueId& query_id,
-                       const std::shared_ptr<MemTrackerLimiter>& mem_tracker)
-            : query_id(query_id), query_mem_tracker(mem_tracker) {}
-
-    // Not thread safe, generally be called in class constructor, shared_ptr use_count may be
-    // wrong when called by multiple threads, cause crash after object be destroyed prematurely.
-    void init_unlocked() {
-#ifndef BE_TEST
-        ORPHAN_TRACKER_CHECK();
-        query_id = doris::thread_context()->task_id();
-        query_mem_tracker = doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
-        wg_wptr = doris::thread_context()->workload_group();
-#else
-        query_id = TUniqueId();
-        query_mem_tracker = doris::ExecEnv::GetInstance()->orphan_mem_tracker();
-#endif
-    }
-
-    std::shared_ptr<MemTrackerLimiter> get_memory_tracker() { return query_mem_tracker; }
-
-    WorkloadGroupPtr get_workload_group_ptr() { return wg_wptr.lock(); }
-
-    TUniqueId query_id;
-    std::shared_ptr<MemTrackerLimiter> query_mem_tracker;
-    std::weak_ptr<WorkloadGroup> wg_wptr;
-};
 
 class ScopedPeakMem {
 public:
@@ -446,7 +324,9 @@ public:
 
 class AttachTask {
 public:
-    // not query or load, initialize with memory tracker, empty query id and default normal workload group.
+    explicit AttachTask(const std::shared_ptr<ResourceContext>& rc);
+
+    // Shortcut attach task, initialize an empty resource context, and set the memory tracker.
     explicit AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker);
 
     // is query or load, initialize with memory tracker, query id and workload group wptr.
@@ -454,9 +334,7 @@ public:
 
     explicit AttachTask(QueryContext* query_ctx);
 
-    explicit AttachTask(const QueryThreadContext& query_thread_context);
-
-    void init(const QueryThreadContext& query_thread_context);
+    void init(const std::shared_ptr<ResourceContext>& rc);
 
     ~AttachTask();
 };
@@ -464,34 +342,10 @@ public:
 class SwitchThreadMemTrackerLimiter {
 public:
     explicit SwitchThreadMemTrackerLimiter(
-            const std::shared_ptr<doris::MemTrackerLimiter>& mem_tracker) {
-        DCHECK(mem_tracker);
-        doris::ThreadLocalHandle::create_thread_local_if_not_exits();
-        if (mem_tracker != thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
-            _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
-            thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker);
-        }
-    }
+            const std::shared_ptr<doris::MemTrackerLimiter>& mem_tracker);
+    explicit SwitchThreadMemTrackerLimiter(ResourceContext* rc);
 
-    explicit SwitchThreadMemTrackerLimiter(const doris::QueryThreadContext& query_thread_context) {
-        doris::ThreadLocalHandle::create_thread_local_if_not_exits();
-        DCHECK(thread_context()->task_id() ==
-               query_thread_context.query_id); // workload group alse not change
-        DCHECK(query_thread_context.query_mem_tracker);
-        if (query_thread_context.query_mem_tracker !=
-            thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
-            _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
-            thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
-                    query_thread_context.query_mem_tracker);
-        }
-    }
-
-    ~SwitchThreadMemTrackerLimiter() {
-        if (_old_mem_tracker != nullptr) {
-            thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker(_old_mem_tracker);
-        }
-        doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
-    }
+    ~SwitchThreadMemTrackerLimiter();
 
 private:
     std::shared_ptr<doris::MemTrackerLimiter> _old_mem_tracker {nullptr};
@@ -526,11 +380,11 @@ class ScopeSkipMemoryCheck {
 public:
     explicit ScopeSkipMemoryCheck() {
         ThreadLocalHandle::create_thread_local_if_not_exits();
-        doris::thread_context()->skip_memory_check++;
+        doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check++;
     }
 
     ~ScopeSkipMemoryCheck() {
-        doris::thread_context()->skip_memory_check--;
+        doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check--;
         ThreadLocalHandle::del_thread_local_if_count_is_zero();
     }
 };
@@ -538,58 +392,69 @@ public:
 // Basic macros for mem tracker, usually do not need to be modified and used.
 #if defined(USE_MEM_TRACKER) && !defined(BE_TEST)
 // used to fix the tracking accuracy of caches.
-#define THREAD_MEM_TRACKER_TRANSFER_TO(size, tracker)                                        \
-    do {                                                                                     \
-        ORPHAN_TRACKER_CHECK();                                                              \
-        doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->transfer_to( \
-                size, tracker);                                                              \
+#define THREAD_MEM_TRACKER_TRANSFER_TO(size, tracker)                                         \
+    do {                                                                                      \
+        DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check ||           \
+               doris::thread_context()->thread_mem_tracker()->label() != "Orphan")            \
+                << doris::memory_orphan_check_msg;                                            \
+        doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->transfer_to(size,     \
+                                                                                    tracker); \
     } while (0)
 
-#define THREAD_MEM_TRACKER_TRANSFER_FROM(size, tracker)                                        \
-    do {                                                                                       \
-        ORPHAN_TRACKER_CHECK();                                                                \
-        tracker->transfer_to(                                                                  \
-                size, doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()); \
+#define THREAD_MEM_TRACKER_TRANSFER_FROM(size, tracker)                                       \
+    do {                                                                                      \
+        DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check ||           \
+               doris::thread_context()->thread_mem_tracker()->label() != "Orphan")            \
+                << doris::memory_orphan_check_msg;                                            \
+        tracker->transfer_to(size,                                                            \
+                             doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()); \
     } while (0)
 
 // Mem Hook to consume thread mem tracker
-#define CONSUME_THREAD_MEM_TRACKER_BY_HOOK(size)           \
-    do {                                                   \
-        if (doris::use_mem_hook) {                         \
-            doris::thread_context()->consume_memory(size); \
-        }                                                  \
-    } while (0)
-#define RELEASE_THREAD_MEM_TRACKER_BY_HOOK(size) CONSUME_THREAD_MEM_TRACKER_BY_HOOK(-size)
-#define CONSUME_THREAD_MEM_TRACKER_BY_HOOK_WITH_FN(size_fn, ...)           \
-    do {                                                                   \
-        if (doris::use_mem_hook) {                                         \
-            doris::thread_context()->consume_memory(size_fn(__VA_ARGS__)); \
-        }                                                                  \
-    } while (0)
-#define RELEASE_THREAD_MEM_TRACKER_BY_HOOK_WITH_FN(size_fn, ...)            \
+#define CONSUME_THREAD_MEM_TRACKER_BY_HOOK(size)                            \
     do {                                                                    \
         if (doris::use_mem_hook) {                                          \
-            doris::thread_context()->consume_memory(-size_fn(__VA_ARGS__)); \
+            doris::thread_context()->thread_mem_tracker_mgr->consume(size); \
         }                                                                   \
+    } while (0)
+#define RELEASE_THREAD_MEM_TRACKER_BY_HOOK(size) CONSUME_THREAD_MEM_TRACKER_BY_HOOK(-size)
+#define CONSUME_THREAD_MEM_TRACKER_BY_HOOK_WITH_FN(size_fn, ...)                            \
+    do {                                                                                    \
+        if (doris::use_mem_hook) {                                                          \
+            doris::thread_context()->thread_mem_tracker_mgr->consume(size_fn(__VA_ARGS__)); \
+        }                                                                                   \
+    } while (0)
+#define RELEASE_THREAD_MEM_TRACKER_BY_HOOK_WITH_FN(size_fn, ...)                             \
+    do {                                                                                     \
+        if (doris::use_mem_hook) {                                                           \
+            doris::thread_context()->thread_mem_tracker_mgr->consume(-size_fn(__VA_ARGS__)); \
+        }                                                                                    \
     } while (0)
 
 // if use mem hook, avoid repeated consume.
 // must call create_thread_local_if_not_exits() before use thread_context().
-#define CONSUME_THREAD_MEM_TRACKER(size)                                                       \
-    do {                                                                                       \
-        if (size == 0 || doris::use_mem_hook) {                                                \
-            break;                                                                             \
-        }                                                                                      \
-        if (doris::pthread_context_ptr_init) {                                                 \
-            DCHECK(bthread_self() == 0);                                                       \
-            doris::thread_context_ptr->consume_memory(size);                                   \
-        } else if (bthread_self() != 0) {                                                      \
-            static_cast<doris::ThreadContext*>(bthread_getspecific(doris::btls_key))           \
-                    ->consume_memory(size);                                                    \
-        } else if (doris::ExecEnv::ready()) {                                                  \
-            MEMORY_ORPHAN_CHECK();                                                             \
-            doris::ExecEnv::GetInstance()->orphan_mem_tracker()->consume_no_update_peak(size); \
-        }                                                                                      \
+#define CONSUME_THREAD_MEM_TRACKER(size)                                                           \
+    do {                                                                                           \
+        if (size == 0 || doris::use_mem_hook) {                                                    \
+            break;                                                                                 \
+        }                                                                                          \
+        if (doris::pthread_context_ptr_init) {                                                     \
+            DCHECK(bthread_self() == 0);                                                           \
+            doris::thread_context_ptr->thread_mem_tracker_mgr->consume(size);                      \
+        } else if (bthread_self() != 0) {                                                          \
+            auto* bthread_context =                                                                \
+                    static_cast<doris::ThreadContext*>(bthread_getspecific(doris::btls_key));      \
+            DCHECK(bthread_context != nullptr);                                                    \
+            if (bthread_context != nullptr) {                                                      \
+                bthread_context->thread_mem_tracker_mgr->consume(size);                            \
+            } else {                                                                               \
+                doris::ExecEnv::GetInstance()->orphan_mem_tracker()->consume_no_update_peak(size); \
+            }                                                                                      \
+        } else if (doris::ExecEnv::ready()) {                                                      \
+            DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check)              \
+                    << doris::MEMORY_ORPHAN_CHECK_MSG;                                             \
+            doris::ExecEnv::GetInstance()->orphan_mem_tracker()->consume_no_update_peak(size);     \
+        }                                                                                          \
     } while (0)
 #define RELEASE_THREAD_MEM_TRACKER(size) CONSUME_THREAD_MEM_TRACKER(-size)
 

--- a/be/src/runtime/workload_management/cpu_context.h
+++ b/be/src/runtime/workload_management/cpu_context.h
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+#include <queue>
+#include <shared_mutex>
+#include <string>
+
+#include "common/status.h"
+
+namespace doris {
+
+class CPUContext : public std::enable_shared_from_this<CPUContext> {
+    ENABLE_FACTORY_CREATOR(CPUContext);
+
+public:
+    // Used to collect cpu execution stats.
+    // The stats is not thread safe.
+    // For example, you should use a seperate object for every scanner and do merge and reset
+    class CPUStats {
+    public:
+        // Should add some cpu stats relared method here.
+        void reset();
+        void merge(CPUStats& stats);
+        std::string debug_string();
+    };
+
+public:
+    CPUContext() {}
+    virtual ~CPUContext() = default;
+    // Bind current thread to cgroup, only some load thread should do this.
+    void bind_workload_group() {
+        // Call workload group method to bind current thread to cgroup
+    }
+    CPUStats* cpu_stats() { return &stats_; }
+
+private:
+    CPUStats stats_;
+};
+
+} // namespace doris

--- a/be/src/runtime/workload_management/cpu_context.h
+++ b/be/src/runtime/workload_management/cpu_context.h
@@ -54,7 +54,7 @@ public:
         // TODO: Call workload group method to bind current thread to cgroup
     }
 
-private:
+protected:
     Stats stats_;
 };
 

--- a/be/src/runtime/workload_management/cpu_context.h
+++ b/be/src/runtime/workload_management/cpu_context.h
@@ -17,16 +17,8 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include <atomic>
-#include <memory>
-#include <queue>
-#include <shared_mutex>
-#include <string>
-
-#include "common/status.h"
+#include "common/factory_creator.h"
+#include "util/runtime_profile.h"
 
 namespace doris {
 
@@ -34,28 +26,36 @@ class CPUContext : public std::enable_shared_from_this<CPUContext> {
     ENABLE_FACTORY_CREATOR(CPUContext);
 
 public:
-    // Used to collect cpu execution stats.
-    // The stats is not thread safe.
-    // For example, you should use a seperate object for every scanner and do merge and reset
-    class CPUStats {
-    public:
-        // Should add some cpu stats relared method here.
-        void reset();
-        void merge(CPUStats& stats);
-        std::string debug_string();
+    /*
+    * 1. operate them thread-safe.
+    * 2. all tasks are unified.
+    * 3. should not be operated frequently, use local variables to update Counter.
+    */
+    struct Stats {
+        RuntimeProfile::Counter* cpu_cost_ms_counter_;
+
+        RuntimeProfile* profile() { return profile_.get(); }
+        void init_profile() {
+            profile_ = std::make_unique<RuntimeProfile>("MemoryContext");
+            cpu_cost_ms_counter_ = ADD_COUNTER(profile_, "RevokeWaitTimeMs", TUnit::TIME_MS);
+        }
+        std::string debug_string() { return profile_->pretty_print(); }
+
+    private:
+        std::unique_ptr<RuntimeProfile> profile_;
     };
 
-public:
-    CPUContext() {}
+    CPUContext() { stats_.init_profile(); }
     virtual ~CPUContext() = default;
+    Stats* stats() { return &stats_; }
+
     // Bind current thread to cgroup, only some load thread should do this.
     void bind_workload_group() {
-        // Call workload group method to bind current thread to cgroup
+        // TODO: Call workload group method to bind current thread to cgroup
     }
-    CPUStats* cpu_stats() { return &stats_; }
 
 private:
-    CPUStats stats_;
+    Stats stats_;
 };
 
 } // namespace doris

--- a/be/src/runtime/workload_management/io_context.h
+++ b/be/src/runtime/workload_management/io_context.h
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+#include <queue>
+#include <shared_mutex>
+#include <string>
+
+#include "common/status.h"
+
+namespace doris {
+
+class IOContext : public std::enable_shared_from_this<IOContext> {
+    ENABLE_FACTORY_CREATOR(IOContext);
+
+public:
+    // Used to collect io execution stats.
+    class IOStats {
+    public:
+        IOStats() = default;
+        virtual ~IOStats() = default;
+        void merge(IOStats stats);
+        void reset();
+        std::string debug_string();
+        int64_t scan_rows() { return scan_rows_; }
+        int64_t scan_bytes() { return scan_bytes_; }
+        int64_t scan_bytes_from_local_storage() { return scan_bytes_from_local_storage_; }
+        int64_t scan_bytes_from_remote_storage() { return scan_bytes_from_remote_storage_; }
+        int64_t returned_rows() { return returned_rows_; }
+        int64_t shuffle_send_bytes() { return shuffle_send_bytes_; }
+        int64_t shuffle_send_rows() { return shuffle_send_rows_; }
+
+        int64_t incr_scan_rows(int64_t delta) { return scan_rows_ + delta; }
+        int64_t incr_scan_bytes(int64_t delta) { return scan_bytes_ + delta; }
+        int64_t incr_scan_bytes_from_local_storage(int64_t delta) {
+            return scan_bytes_from_local_storage_ + delta;
+        }
+        int64_t incr_scan_bytes_from_remote_storage(int64_t delta) {
+            return scan_bytes_from_remote_storage_ + delta;
+        }
+        int64_t incr_returned_rows(int64_t delta) { return returned_rows_ + delta; }
+        int64_t incr_shuffle_send_bytes(int64_t delta) { return shuffle_send_bytes_ + delta; }
+        int64_t incr_shuffle_send_rows(int64_t delta) { return shuffle_send_rows_ + delta; }
+        std::string debug_string();
+
+    private:
+        int64_t scan_rows_ = 0;
+        int64_t scan_bytes_ = 0;
+        int64_t scan_bytes_from_local_storage_ = 0;
+        int64_t scan_bytes_from_remote_storage_ = 0;
+        // number rows returned by query.
+        // only set once by result sink when closing.
+        int64_t returned_rows_ = 0;
+        int64_t shuffle_send_bytes_ = 0;
+        int64_t shuffle_send_rows_ = 0;
+    };
+
+public:
+    IOContext() {}
+    virtual ~IOContext() = default;
+    IOThrottle* io_throttle() {
+        // get io throttle from workload group
+    }
+    IOStats* stats() { return &stats_; }
+
+private:
+    IOStats stats_;
+};
+
+} // namespace doris

--- a/be/src/runtime/workload_management/io_context.h
+++ b/be/src/runtime/workload_management/io_context.h
@@ -17,16 +17,9 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include <atomic>
-#include <memory>
-#include <queue>
-#include <shared_mutex>
-#include <string>
-
-#include "common/status.h"
+#include "common/factory_creator.h"
+#include "runtime/workload_management/io_throttle.h"
+#include "util/runtime_profile.h"
 
 namespace doris {
 
@@ -34,57 +27,53 @@ class IOContext : public std::enable_shared_from_this<IOContext> {
     ENABLE_FACTORY_CREATOR(IOContext);
 
 public:
-    // Used to collect io execution stats.
-    class IOStats {
-    public:
-        IOStats() = default;
-        virtual ~IOStats() = default;
-        void merge(IOStats stats);
-        void reset();
-        std::string debug_string();
-        int64_t scan_rows() { return scan_rows_; }
-        int64_t scan_bytes() { return scan_bytes_; }
-        int64_t scan_bytes_from_local_storage() { return scan_bytes_from_local_storage_; }
-        int64_t scan_bytes_from_remote_storage() { return scan_bytes_from_remote_storage_; }
-        int64_t returned_rows() { return returned_rows_; }
-        int64_t shuffle_send_bytes() { return shuffle_send_bytes_; }
-        int64_t shuffle_send_rows() { return shuffle_send_rows_; }
-
-        int64_t incr_scan_rows(int64_t delta) { return scan_rows_ + delta; }
-        int64_t incr_scan_bytes(int64_t delta) { return scan_bytes_ + delta; }
-        int64_t incr_scan_bytes_from_local_storage(int64_t delta) {
-            return scan_bytes_from_local_storage_ + delta;
-        }
-        int64_t incr_scan_bytes_from_remote_storage(int64_t delta) {
-            return scan_bytes_from_remote_storage_ + delta;
-        }
-        int64_t incr_returned_rows(int64_t delta) { return returned_rows_ + delta; }
-        int64_t incr_shuffle_send_bytes(int64_t delta) { return shuffle_send_bytes_ + delta; }
-        int64_t incr_shuffle_send_rows(int64_t delta) { return shuffle_send_rows_ + delta; }
-        std::string debug_string();
-
-    private:
-        int64_t scan_rows_ = 0;
-        int64_t scan_bytes_ = 0;
-        int64_t scan_bytes_from_local_storage_ = 0;
-        int64_t scan_bytes_from_remote_storage_ = 0;
+    /*
+    * 1. operate them thread-safe.
+    * 2. all tasks are unified.
+    * 3. should not be operated frequently, use local variables to update Counter.
+    */
+    struct Stats {
+        RuntimeProfile::Counter* scan_rows_counter_;
+        RuntimeProfile::Counter* scan_bytes_counter_;
+        RuntimeProfile::Counter* scan_bytes_from_local_storage_counter_;
+        RuntimeProfile::Counter* scan_bytes_from_remote_storage_counter_;
         // number rows returned by query.
         // only set once by result sink when closing.
-        int64_t returned_rows_ = 0;
-        int64_t shuffle_send_bytes_ = 0;
-        int64_t shuffle_send_rows_ = 0;
+        RuntimeProfile::Counter* returned_rows_counter_;
+        RuntimeProfile::Counter* shuffle_send_bytes_counter_;
+        RuntimeProfile::Counter* shuffle_send_rows_counter_;
+
+        RuntimeProfile* profile() { return profile_.get(); }
+        void init_profile() {
+            profile_ = std::make_unique<RuntimeProfile>("MemoryContext");
+            scan_rows_counter_ = ADD_COUNTER(profile_, "ScanRows", TUnit::UNIT);
+            scan_bytes_counter_ = ADD_COUNTER(profile_, "ScanBytes", TUnit::BYTES);
+            scan_bytes_from_local_storage_counter_ =
+                    ADD_COUNTER(profile_, "ScanBytesFromLocalStorage", TUnit::BYTES);
+            scan_bytes_from_remote_storage_counter_ =
+                    ADD_COUNTER(profile_, "ScanBytesFromRemoteStorage", TUnit::BYTES);
+            returned_rows_counter_ = ADD_COUNTER(profile_, "ReturnedRows", TUnit::UNIT);
+            shuffle_send_bytes_counter_ = ADD_COUNTER(profile_, "ShuffleSendBytes", TUnit::BYTES);
+            shuffle_send_rows_counter_ =
+                    ADD_COUNTER(profile_, "ShuffleSendRowsCounter_", TUnit::UNIT);
+        }
+        std::string debug_string() { return profile_->pretty_print(); }
+
+    private:
+        std::unique_ptr<RuntimeProfile> profile_;
     };
 
-public:
-    IOContext() {}
+    IOContext() { stats_.init_profile(); }
     virtual ~IOContext() = default;
+    Stats* stats() { return &stats_; }
+
     IOThrottle* io_throttle() {
-        // get io throttle from workload group
+        // TODO: get io throttle from workload group
+        return nullptr;
     }
-    IOStats* stats() { return &stats_; }
 
 private:
-    IOStats stats_;
+    Stats stats_;
 };
 
 } // namespace doris

--- a/be/src/runtime/workload_management/io_context.h
+++ b/be/src/runtime/workload_management/io_context.h
@@ -72,7 +72,7 @@ public:
         return nullptr;
     }
 
-private:
+protected:
     Stats stats_;
 };
 

--- a/be/src/runtime/workload_management/memory_context.h
+++ b/be/src/runtime/workload_management/memory_context.h
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+#include <queue>
+#include <shared_mutex>
+#include <string>
+
+#include "common/status.h"
+
+namespace doris {
+
+class MemoryContext : public std::enable_shared_from_this<MemoryContext> {
+    ENABLE_FACTORY_CREATOR(MemoryContext);
+
+public:
+    // Used to collect memory execution stats.
+    // The stats class is not thread safe, should not do concurrent modifications.
+    class MemoryStats {
+    public:
+        MemoryStats() = default;
+        virtual ~MemoryStats() = default;
+        void merge(MemoryStats& stats);
+        void reset();
+        std::string debug_string();
+        int64_t revoke_attempts() { return revoke_attempts_; }
+        int64_t revoke_wait_time_ms() { return revoke_wait_time_ms_; }
+        int64_t revoked_bytes() { return revoked_bytes_; }
+        int64_t max_peak_memory_bytes() { return max_peak_memory_bytes_; }
+        int64_t current_used_memory_bytes() { return current_used_memory_bytes_; }
+
+    private:
+        // Maximum memory peak for all backends.
+        // only set once by result sink when closing.
+        int64_t max_peak_memory_bytes_ = 0;
+        int64_t current_used_memory_bytes_ = 0;
+        // The total number of times that the revoke method is called.
+        int64_t revoke_attempts_ = 0;
+        // The time that waiting for revoke finished.
+        int64_t revoke_wait_time_ms_ = 0;
+        // The revoked bytes
+        int64_t revoked_bytes_ = 0;
+    };
+
+public:
+    MemoryContext(std::shared_ptr<MemtrackerLimiter> memtracker)
+            : memtracker_limiter_(memtracker) {}
+
+    virtual ~MemoryContext() = default;
+
+    MemtrackerLimiter* memtracker_limiter() { return memtracker_limiter_.get(); }
+
+    MemoryStats* stats() { return &stats_; }
+
+    // Following method is related with spill disk.
+    // Compute the number of bytes could be released.
+    virtual int64_t revokable_bytes() { return 0; }
+
+    virtual bool ready_do_revoke() { return true; }
+
+    // Begin to do revoke memory task.
+    virtual Status revoke(int64_t bytes) { return Status::OK(); }
+
+    virtual Status enter_arbitration(Status reason) { return Status::OK(); }
+
+    virtual Status leave_arbitration(Status reason) { return Status::OK(); }
+
+private:
+    MemoryStats stats_;
+    std::shared_ptr<MemtrackerLimiter> memtracker_limiter_;
+};
+
+} // namespace doris

--- a/be/src/runtime/workload_management/memory_context.h
+++ b/be/src/runtime/workload_management/memory_context.h
@@ -91,7 +91,7 @@ public:
 
     virtual Status leave_arbitration(Status reason) { return Status::OK(); }
 
-private:
+protected:
     Stats stats_;
     // MemTracker that is shared by all fragment instances running on this host.
     std::shared_ptr<MemTrackerLimiter> mem_tracker_;

--- a/be/src/runtime/workload_management/memory_context.h
+++ b/be/src/runtime/workload_management/memory_context.h
@@ -17,60 +17,66 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include <atomic>
-#include <memory>
-#include <queue>
-#include <shared_mutex>
+#include <cstdint>
 #include <string>
 
+#include "common/factory_creator.h"
 #include "common/status.h"
+#include "util/runtime_profile.h"
 
 namespace doris {
+
+class MemTrackerLimiter;
 
 class MemoryContext : public std::enable_shared_from_this<MemoryContext> {
     ENABLE_FACTORY_CREATOR(MemoryContext);
 
 public:
-    // Used to collect memory execution stats.
-    // The stats class is not thread safe, should not do concurrent modifications.
-    class MemoryStats {
-    public:
-        MemoryStats() = default;
-        virtual ~MemoryStats() = default;
-        void merge(MemoryStats& stats);
-        void reset();
-        std::string debug_string();
-        int64_t revoke_attempts() { return revoke_attempts_; }
-        int64_t revoke_wait_time_ms() { return revoke_wait_time_ms_; }
-        int64_t revoked_bytes() { return revoked_bytes_; }
-        int64_t max_peak_memory_bytes() { return max_peak_memory_bytes_; }
-        int64_t current_used_memory_bytes() { return current_used_memory_bytes_; }
-
-    private:
+    /*
+    * 1. operate them thread-safe.
+    * 2. all tasks are unified.
+    * 3. should not be operated frequently, use local variables to update Counter.
+    */
+    struct Stats {
+        RuntimeProfile::Counter* current_memory_bytes_counter_;
+        RuntimeProfile::Counter* peak_memory_bytes_counter_;
         // Maximum memory peak for all backends.
         // only set once by result sink when closing.
-        int64_t max_peak_memory_bytes_ = 0;
-        int64_t current_used_memory_bytes_ = 0;
+        RuntimeProfile::Counter* max_peak_memory_bytes_counter_;
         // The total number of times that the revoke method is called.
-        int64_t revoke_attempts_ = 0;
+        RuntimeProfile::Counter* revoke_attempts_counter_;
         // The time that waiting for revoke finished.
-        int64_t revoke_wait_time_ms_ = 0;
+        RuntimeProfile::Counter* revoke_wait_time_ms_counter_;
         // The revoked bytes
-        int64_t revoked_bytes_ = 0;
+        RuntimeProfile::Counter* revoked_bytes_counter_;
+
+        RuntimeProfile* profile() { return profile_.get(); }
+        void init_profile() {
+            profile_ = std::make_unique<RuntimeProfile>("MemoryContext");
+            current_memory_bytes_counter_ =
+                    ADD_COUNTER(profile_, "CurrentMemoryBytes", TUnit::BYTES);
+            peak_memory_bytes_counter_ = ADD_COUNTER(profile_, "PeakMemoryBytes", TUnit::BYTES);
+            max_peak_memory_bytes_counter_ =
+                    ADD_COUNTER(profile_, "MaxPeakMemoryBytes", TUnit::BYTES);
+            revoke_attempts_counter_ = ADD_COUNTER(profile_, "RevokeAttempts", TUnit::UNIT);
+            revoke_wait_time_ms_counter_ =
+                    ADD_COUNTER(profile_, "RevokeWaitTimeMs", TUnit::TIME_MS);
+            revoked_bytes_counter_ = ADD_COUNTER(profile_, "RevokedBytes", TUnit::BYTES);
+        }
+        std::string debug_string() { return profile_->pretty_print(); }
+
+    private:
+        std::unique_ptr<RuntimeProfile> profile_;
     };
 
-public:
-    MemoryContext(std::shared_ptr<MemtrackerLimiter> memtracker)
-            : memtracker_limiter_(memtracker) {}
-
+    MemoryContext() { stats_.init_profile(); }
     virtual ~MemoryContext() = default;
+    Stats* stats() { return &stats_; }
 
-    MemtrackerLimiter* memtracker_limiter() { return memtracker_limiter_.get(); }
-
-    MemoryStats* stats() { return &stats_; }
+    std::shared_ptr<MemTrackerLimiter> mem_tracker() { return mem_tracker_; }
+    void set_mem_tracker(const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
+        mem_tracker_ = mem_tracker;
+    }
 
     // Following method is related with spill disk.
     // Compute the number of bytes could be released.
@@ -86,8 +92,9 @@ public:
     virtual Status leave_arbitration(Status reason) { return Status::OK(); }
 
 private:
-    MemoryStats stats_;
-    std::shared_ptr<MemtrackerLimiter> memtracker_limiter_;
+    Stats stats_;
+    // MemTracker that is shared by all fragment instances running on this host.
+    std::shared_ptr<MemTrackerLimiter> mem_tracker_;
 };
 
 } // namespace doris

--- a/be/src/runtime/workload_management/resource_context.h
+++ b/be/src/runtime/workload_management/resource_context.h
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+#include <queue>
+#include <shared_mutex>
+#include <string>
+
+#include "common/status.h"
+
+namespace doris {
+
+// Any task that allow cancel should implement this class.
+class TaskController {
+    ENABLE_FACTORY_CREATOR(TaskController);
+
+public:
+    virtual Status cancel(Status cancel_reason) { return Status::OK(); }
+    virtual Status running_time(int64_t* running_time_msecs) {
+        *running_time_msecs = 0;
+        return Status::OK();
+    }
+};
+
+// Every task should have its own resource context. And BE may adjust the resource
+// context during running.
+// Workload group will hold the resource context and do some control work.
+class ResourceContext : public std::enable_shared_from_this<ResourceContext> {
+    ENABLE_FACTORY_CREATOR(ResourceContext);
+
+public:
+    ResourceContext() {
+        // These all default values, it may be reset.
+        cpu_context_ = std::make_shared<CPUContext>();
+        memory_context_ = std::make_shared<MemoryContext>();
+        io_context_ = std::make_shared<IOContext>();
+        reclaimer_ = std::make_shared<ResourceReclaimer>();
+    }
+    virtual ~ResourceContext() = default;
+
+    // The caller should not hold the object, since it is a raw pointer.
+    CPUContext* cpu_context() { return cpu_context_.get(); }
+    MemoryContext* memory_context() { return memory_context_.get(); }
+    IOContext* io_context() { return io_context_.get(); }
+    TaskController* task_controller() { return task_controller_.get(); }
+
+    void set_cpu_context(std::shared_ptr<CPUContext> cpu_context) { cpu_context_ = cpu_context; }
+    void set_memory_context(std::shared_ptr<MemoryContext> memory_context) {
+        memory_context_ = memory_context;
+    }
+    void set_io_context(std::shared_ptr<IOContext> io_context) { io_context_ = io_context; }
+    void set_task_controller(std::shared_ptr<TaskController> task_controller) {
+        task_controller_ = task_controller;
+    }
+
+    void set_workload_group(std::shared_ptr<WorkloadGroup> wg) {
+        // update all child context's workload group property
+        workload_group_ = wg;
+    }
+
+    std::shared_ptr<WorkloadGroup> workload_group() { return workload_group_.lock(); }
+
+private:
+    // The controller's init value is nullptr, it means the resource context will ignore this controller.
+    std::shared_ptr<CPUContext> cpu_context_ = nullptr;
+    std::shared_ptr<MemoryContext> memory_context_ = nullptr;
+    std::shared_ptr<IOContext> io_context_ = nullptr;
+    std::shared_ptr<TaskController> task_controller_ = nullptr;
+    // Workload group will own resource context, so that resource context only have weak ptr for workload group.
+    // TODO: should use atomic weak ptr to avoid the concurrent modification of the pointer.
+    std::weak_ptr<WorkloadGroup> workload_group_ = nullptr;
+};
+
+} // namespace doris

--- a/be/src/runtime/workload_management/resource_context.h
+++ b/be/src/runtime/workload_management/resource_context.h
@@ -56,19 +56,19 @@ public:
     WorkloadGroupContext* workload_group_context() { return workload_group_context_.get(); }
     TaskController* task_controller() { return task_controller_.get(); }
 
-    void set_cpu_context(std::unique_ptr<CPUContext>& cpu_context) {
+    void set_cpu_context(std::unique_ptr<CPUContext> cpu_context) {
         cpu_context_ = std::move(cpu_context);
     }
-    void set_memory_context(std::unique_ptr<MemoryContext>& memory_context) {
+    void set_memory_context(std::unique_ptr<MemoryContext> memory_context) {
         memory_context_ = std::move(memory_context);
     }
-    void set_io_context(std::unique_ptr<IOContext>& io_context) {
+    void set_io_context(std::unique_ptr<IOContext> io_context) {
         io_context_ = std::move(io_context);
     }
-    void set_workload_group_context(std::unique_ptr<WorkloadGroupContext>& wg_context) {
+    void set_workload_group_context(std::unique_ptr<WorkloadGroupContext> wg_context) {
         workload_group_context_ = std::move(wg_context);
     }
-    void set_task_controller(std::unique_ptr<TaskController>& task_controller) {
+    void set_task_controller(std::unique_ptr<TaskController> task_controller) {
         task_controller_ = std::move(task_controller);
     }
 

--- a/be/src/runtime/workload_management/task_controller.h
+++ b/be/src/runtime/workload_management/task_controller.h
@@ -31,16 +31,18 @@ public:
     TaskController() { task_id_ = TUniqueId(); };
     virtual ~TaskController() = default;
 
+    bool is_attach_task() { return task_id_ != TUniqueId(); }
     const TUniqueId& task_id() const { return task_id_; }
     void set_task_id(TUniqueId task_id) { task_id_ = task_id; }
 
-    virtual Status cancel(Status cancel_reason) { return Status::OK(); }
+    virtual bool is_cancelled() const { return false; }
+    virtual Status cancel(const Status& reason) { return Status::OK(); }
     virtual Status running_time(int64_t* running_time_msecs) {
         *running_time_msecs = 0;
         return Status::OK();
     }
 
-private:
+protected:
     TUniqueId task_id_;
 };
 

--- a/be/src/runtime/workload_management/task_controller.h
+++ b/be/src/runtime/workload_management/task_controller.h
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gen_cpp/Types_types.h>
+
+#include "common/factory_creator.h"
+#include "common/status.h"
+
+namespace doris {
+
+class TaskController {
+    ENABLE_FACTORY_CREATOR(TaskController);
+
+public:
+    TaskController() { task_id_ = TUniqueId(); };
+    virtual ~TaskController() = default;
+
+    const TUniqueId& task_id() const { return task_id_; }
+    void set_task_id(TUniqueId task_id) { task_id_ = task_id; }
+
+    virtual Status cancel(Status cancel_reason) { return Status::OK(); }
+    virtual Status running_time(int64_t* running_time_msecs) {
+        *running_time_msecs = 0;
+        return Status::OK();
+    }
+
+private:
+    TUniqueId task_id_;
+};
+
+} // namespace doris

--- a/be/src/runtime/workload_management/workload_group_context.h
+++ b/be/src/runtime/workload_management/workload_group_context.h
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/factory_creator.h"
+#include "runtime/workload_group/workload_group.h"
+
+namespace doris {
+
+class WorkloadGroupContext {
+    ENABLE_FACTORY_CREATOR(WorkloadGroupContext);
+
+public:
+    WorkloadGroupContext() = default;
+    virtual ~WorkloadGroupContext() = default;
+
+    WorkloadGroupPtr workload_group() { return _workload_group; }
+    void set_workload_group(WorkloadGroupPtr wg) { _workload_group = wg; }
+
+private:
+    WorkloadGroupPtr _workload_group = nullptr;
+};
+
+} // namespace doris

--- a/be/src/runtime/workload_management/workload_group_context.h
+++ b/be/src/runtime/workload_management/workload_group_context.h
@@ -32,7 +32,7 @@ public:
     WorkloadGroupPtr workload_group() { return _workload_group; }
     void set_workload_group(WorkloadGroupPtr wg) { _workload_group = wg; }
 
-private:
+protected:
     WorkloadGroupPtr _workload_group = nullptr;
 };
 

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -73,7 +73,7 @@ private:
             : pos(0),
               limit(capacity_),
               capacity(capacity_),
-              mem_tracker_(doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
+              mem_tracker_(doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()) {
         ptr = reinterpret_cast<char*>(Allocator<false>::alloc(capacity_));
     }
 

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -73,7 +73,7 @@ private:
             : pos(0),
               limit(capacity_),
               capacity(capacity_),
-              mem_tracker_(doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()) {
+              mem_tracker_(doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
         ptr = reinterpret_cast<char*>(Allocator<false>::alloc(capacity_));
     }
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -385,6 +385,11 @@ public:
     // Does not hold locks when it makes any function calls.
     void pretty_print(std::ostream* s, const std::string& prefix = "",
                       int64_t profile_level = 2) const;
+    std::string pretty_print() const {
+        std::stringstream ss;
+        pretty_print(&ss);
+        return ss.str();
+    };
 
     // Serializes profile to thrift.
     // Does not hold locks when it makes any function calls.

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -86,9 +86,9 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
         err_msg += fmt::format(
                 "Allocator sys memory check failed: Cannot alloc:{}, consuming "
                 "tracker:<{}>, peak used {}, current used {}, exec node:<{}>, {}.",
-                size, doris::thread_context()->thread_mem_tracker()->label(),
-                doris::thread_context()->thread_mem_tracker()->peak_consumption(),
-                doris::thread_context()->thread_mem_tracker()->consumption(),
+                size, doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->label(),
+                doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->peak_consumption(),
+                doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->consumption(),
                 doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(),
                 doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
 
@@ -175,10 +175,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_
     if (doris::thread_context()->skip_memory_check != 0) {
         return;
     }
-    auto st = doris::thread_context()->thread_mem_tracker()->check_limit(size);
+    auto st = doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->check_limit(size);
     if (!st) {
         auto err_msg = fmt::format("Allocator mem tracker check failed, {}", st.to_string());
-        doris::thread_context()->thread_mem_tracker()->print_log_usage(err_msg);
+        doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->print_log_usage(err_msg);
         // If the external catch, throw bad::alloc first, let the query actively cancel. Otherwise asynchronous cancel.
         if (doris::thread_context()->thread_mem_tracker_mgr->is_attach_query()) {
             doris::thread_context()->thread_mem_tracker_mgr->disable_wait_gc();
@@ -239,7 +239,8 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_add
         return;
     }
 #endif
-    doris::thread_context()->thread_mem_tracker()->add_address_sanitizers(buf, size);
+    doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->add_address_sanitizers(buf,
+                                                                                           size);
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
@@ -250,7 +251,8 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_
         return;
     }
 #endif
-    doris::thread_context()->thread_mem_tracker()->remove_address_sanitizers(buf, size);
+    doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->remove_address_sanitizers(buf,
+                                                                                              size);
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -84,9 +84,14 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
         err_msg += fmt::format(
                 "Allocator sys memory check failed: Cannot alloc:{}, consuming "
                 "tracker:<{}>, peak used {}, current used {}, exec node:<{}>, {}.",
-                size, doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->label(),
-                doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->peak_consumption(),
-                doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->consumption(),
+                size,
+                doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                doris::thread_context()
+                        ->thread_mem_tracker_mgr->limiter_mem_tracker()
+                        ->peak_consumption(),
+                doris::thread_context()
+                        ->thread_mem_tracker_mgr->limiter_mem_tracker()
+                        ->consumption(),
                 doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(),
                 doris::GlobalMemoryArbitrator::process_limit_exceeded_errmsg_str());
 
@@ -186,10 +191,12 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_
     if (doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0) {
         return;
     }
-    auto st = doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->check_limit(size);
+    auto st = doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->check_limit(
+            size);
     if (!st) {
         auto err_msg = fmt::format("Allocator mem tracker check failed, {}", st.to_string());
-        doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->print_log_usage(err_msg);
+        doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->print_log_usage(
+                err_msg);
         if (doris::thread_context()->resource_ctx()->task_controller()->is_attach_task()) {
             doris::thread_context()->thread_mem_tracker_mgr->disable_wait_gc();
             // If the outside will catch the exception, after throwing an exception,
@@ -261,8 +268,8 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_add
         return;
     }
 #endif
-    doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->add_address_sanitizers(buf,
-                                                                                           size);
+    doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->add_address_sanitizers(
+            buf, size);
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
@@ -273,8 +280,9 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_
         return;
     }
 #endif
-    doris::thread_context()->thread_mem_tracker_mgr->mem_tracker()->remove_address_sanitizers(buf,
-                                                                                              size);
+    doris::thread_context()
+            ->thread_mem_tracker_mgr->limiter_mem_tracker()
+            ->remove_address_sanitizers(buf, size);
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -74,8 +74,7 @@ ScannerContext::ScannerContext(
         limit = -1;
     }
     MAX_SCALE_UP_RATIO = _state->scanner_scale_up_ratio();
-    _query_thread_context = {_query_id, _state->query_mem_tracker(),
-                             _state->get_query_ctx()->workload_group()};
+    _resource_ctx = _state->get_query_ctx()->resource_ctx;
     _dependency = dependency;
 
     DorisMetrics::instance()->scanner_ctx_cnt->increment(1);

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -318,8 +318,7 @@ VDataStreamRecvr::VDataStreamRecvr(VDataStreamMgr* stream_mgr,
         : HasTaskExecutionCtx(state),
           _mgr(stream_mgr),
           _memory_used_counter(memory_used_counter),
-          _query_thread_context(state->query_id(), state->query_mem_tracker(),
-                                state->get_query_ctx()->workload_group()),
+          _resource_ctx(state->get_query_ctx()->resource_ctx),
           _fragment_instance_id(fragment_instance_id),
           _dest_node_id(dest_node_id),
           _row_desc(row_desc),
@@ -392,7 +391,7 @@ Status VDataStreamRecvr::add_block(std::unique_ptr<PBlock> pblock, int sender_id
                                    int64_t packet_seq, ::google::protobuf::Closure** done,
                                    const int64_t wait_for_worker,
                                    const uint64_t time_to_find_recvr) {
-    SCOPED_ATTACH_TASK(_query_thread_context);
+    SCOPED_ATTACH_TASK(_resource_ctx);
     int use_sender_id = _is_merging ? sender_id : 0;
     return _sender_queues[use_sender_id]->add_block(std::move(pblock), be_number, packet_seq, done,
                                                     wait_for_worker, time_to_find_recvr);

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -126,7 +126,7 @@ private:
 
     RuntimeProfile::HighWaterMarkCounter* _memory_used_counter = nullptr;
 
-    QueryThreadContext _query_thread_context;
+    std::shared_ptr<ResourceContext> _resource_ctx;
 
     // Fragment and node id of the destination exchange node this receiver is used by.
     TUniqueId _fragment_instance_id;

--- a/be/test/pipeline/pipeline_test.cpp
+++ b/be/test/pipeline/pipeline_test.cpp
@@ -59,9 +59,9 @@ public:
         auto fe_address = TNetworkAddress();
         fe_address.hostname = LOCALHOST;
         fe_address.port = DUMMY_PORT;
-        _query_ctx = QueryContext::create_shared(_query_id, ExecEnv::GetInstance(), _query_options,
-                                                 fe_address, true, fe_address,
-                                                 QuerySource::INTERNAL_FRONTEND);
+        _query_ctx =
+                QueryContext::create(_query_id, ExecEnv::GetInstance(), _query_options, fe_address,
+                                     true, fe_address, QuerySource::INTERNAL_FRONTEND);
         _query_ctx->runtime_filter_mgr()->set_runtime_filter_params(
                 TRuntimeFilterParamsBuilder().build());
         ExecEnv::GetInstance()->set_stream_mgr(_mgr.get());
@@ -106,9 +106,9 @@ private:
         auto fe_address = TNetworkAddress();
         fe_address.hostname = LOCALHOST;
         fe_address.port = DUMMY_PORT;
-        _query_ctx = QueryContext::create_shared(_query_id, ExecEnv::GetInstance(), _query_options,
-                                                 fe_address, true, fe_address,
-                                                 QuerySource::INTERNAL_FRONTEND);
+        _query_ctx =
+                QueryContext::create(_query_id, ExecEnv::GetInstance(), _query_options, fe_address,
+                                     true, fe_address, QuerySource::INTERNAL_FRONTEND);
         _runtime_state.clear();
         _context.clear();
         _fragment_id = 0;
@@ -933,7 +933,7 @@ TEST_F(PipelineTest, PLAN_HASH_JOIN) {
         for (int j = 0; j < parallelism; j++) {
             auto runtime_filter_state = RuntimeFilterParamsContext::create(_query_ctx.get());
             _runtime_filter_mgrs[j] = std::make_unique<RuntimeFilterMgr>(
-                    _query_id, runtime_filter_state, _query_ctx->query_mem_tracker, false);
+                    _query_id, runtime_filter_state, _query_ctx->query_mem_tracker(), false);
         }
         for (size_t i = 0; i < _pipelines.size(); i++) {
             EXPECT_EQ(_pipelines[i]->id(), i);

--- a/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
+++ b/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
@@ -41,48 +41,51 @@ TEST_F(ThreadMemTrackerMgrTest, ConsumeMemory) {
     std::unique_ptr<ThreadContext> thread_context = std::make_unique<ThreadContext>();
     std::shared_ptr<MemTrackerLimiter> t =
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER, "UT-ConsumeMemory");
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(t);
+    rc->workload_group_context()->set_workload_group(workload_group);
 
     int64_t size1 = 4 * 1024;
     int64_t size2 = 4 * 1024 * 1024;
 
-    thread_context->attach_task(TUniqueId(), t, workload_group);
-    thread_context->consume_memory(size1);
+    thread_context->attach_task(rc);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     // size1 < config::mem_tracker_consume_min_size_bytes, not consume mem tracker.
     EXPECT_EQ(t->consumption(), 0);
 
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     // size1 + size2 > onfig::mem_tracker_consume_min_size_bytes, consume mem tracker.
     EXPECT_EQ(t->consumption(), size1 + size2);
 
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     // std::abs(-size1) < config::mem_tracker_consume_min_size_bytes, not consume mem tracker.
     EXPECT_EQ(t->consumption(), size1 + size2);
 
     thread_context->thread_mem_tracker_mgr->flush_untracked_mem();
     EXPECT_EQ(t->consumption(), size2);
 
-    thread_context->consume_memory(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
     // std::abs(-size2) > onfig::mem_tracker_consume_min_size_bytes, consume mem tracker.
     EXPECT_EQ(t->consumption(), 0);
 
-    thread_context->consume_memory(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
     EXPECT_EQ(t->consumption(), -size2);
 
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     EXPECT_EQ(t->consumption(), -size2);
 
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size2 * 2);
-    thread_context->consume_memory(size2 * 10);
-    thread_context->consume_memory(size2 * 100);
-    thread_context->consume_memory(size2 * 1000);
-    thread_context->consume_memory(size2 * 10000);
-    thread_context->consume_memory(-size2 * 2);
-    thread_context->consume_memory(-size2 * 10);
-    thread_context->consume_memory(-size2 * 100);
-    thread_context->consume_memory(-size2 * 1000);
-    thread_context->consume_memory(-size2 * 10000);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2 * 2);
+    thread_context->thread_mem_tracker_mgr->consume(size2 * 10);
+    thread_context->thread_mem_tracker_mgr->consume(size2 * 100);
+    thread_context->thread_mem_tracker_mgr->consume(size2 * 1000);
+    thread_context->thread_mem_tracker_mgr->consume(size2 * 10000);
+    thread_context->thread_mem_tracker_mgr->consume(-size2 * 2);
+    thread_context->thread_mem_tracker_mgr->consume(-size2 * 10);
+    thread_context->thread_mem_tracker_mgr->consume(-size2 * 100);
+    thread_context->thread_mem_tracker_mgr->consume(-size2 * 1000);
+    thread_context->thread_mem_tracker_mgr->consume(-size2 * 10000);
     thread_context->detach_task();
     EXPECT_EQ(t->consumption(), 0); // detach automatic call flush_untracked_mem.
 }
@@ -99,23 +102,26 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
             MemTrackerLimiter::Type::OTHER, "UT-NestedSwitchMemTracker2");
     std::shared_ptr<MemTrackerLimiter> t3 = MemTrackerLimiter::create_shared(
             MemTrackerLimiter::Type::OTHER, "UT-NestedSwitchMemTracker3");
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(t1);
+    rc->workload_group_context()->set_workload_group(workload_group);
 
     int64_t size1 = 4 * 1024;
     int64_t size2 = 4 * 1024 * 1024;
 
-    thread_context->attach_task(TUniqueId(), t1, workload_group);
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
+    thread_context->attach_task(rc);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t1->consumption(), size1 + size2);
 
-    thread_context->consume_memory(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t2);
     EXPECT_EQ(t1->consumption(),
               size1 + size2 + size1); // attach automatic call flush_untracked_mem.
 
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1); // not changed, now consume t2
     EXPECT_EQ(t2->consumption(), size1 + size2);
 
@@ -123,24 +129,24 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
     EXPECT_EQ(t2->consumption(),
               size1 + size2 + size1); // detach automatic call flush_untracked_mem.
 
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), size1 + size2 + size1); // not changed, now consume t1
 
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t2);
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t3);
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), size1 + size2); // attach automatic call flush_untracked_mem.
     EXPECT_EQ(t3->consumption(), size1 + size2);
 
-    thread_context->consume_memory(-size1);
-    thread_context->consume_memory(-size2);
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     EXPECT_EQ(t3->consumption(), size1);
 
     thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(t2); // detach
@@ -148,9 +154,9 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
     EXPECT_EQ(t2->consumption(), size1 + size2);
     EXPECT_EQ(t3->consumption(), 0);
 
-    thread_context->consume_memory(-size1);
-    thread_context->consume_memory(-size2);
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), 0);
 
@@ -158,7 +164,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), -size1);
 
-    thread_context->consume_memory(-t1->consumption());
+    thread_context->thread_mem_tracker_mgr->consume(-t1->consumption());
     thread_context->detach_task(); // detach t1
     EXPECT_EQ(t1->consumption(), 0);
 }
@@ -169,14 +175,17 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER, "UT-MultiMemTracker1");
     std::shared_ptr<MemTracker> t2 = std::make_shared<MemTracker>("UT-MultiMemTracker2");
     std::shared_ptr<MemTracker> t3 = std::make_shared<MemTracker>("UT-MultiMemTracker3");
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(t1);
+    rc->workload_group_context()->set_workload_group(workload_group);
 
     int64_t size1 = 4 * 1024;
     int64_t size2 = 4 * 1024 * 1024;
 
-    thread_context->attach_task(TUniqueId(), t1, workload_group);
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size1);
+    thread_context->attach_task(rc);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     EXPECT_EQ(t1->consumption(), size1 + size2);
 
     bool rt = thread_context->thread_mem_tracker_mgr->push_consumer_tracker(t2.get());
@@ -184,21 +193,21 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
     EXPECT_EQ(t1->consumption(), size1 + size2); // _untracked_mem = size1
     EXPECT_EQ(t2->consumption(), 0);
 
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2);
     EXPECT_EQ(t2->consumption(), size2);
 
     rt = thread_context->thread_mem_tracker_mgr->push_consumer_tracker(t2.get());
     EXPECT_EQ(rt, false);
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), size2 + size2);
 
     rt = thread_context->thread_mem_tracker_mgr->push_consumer_tracker(t3.get());
     EXPECT_EQ(rt, true);
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(-size1); // _untracked_mem = -size1
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size1); // _untracked_mem = -size1
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2 + size1 + size2);
     EXPECT_EQ(t2->consumption(), size2 + size2 + size2);
     EXPECT_EQ(t3->consumption(), size2);
@@ -208,16 +217,16 @@ TEST_F(ThreadMemTrackerMgrTest, MultiMemTracker) {
     EXPECT_EQ(t2->consumption(), size2 + size2 + size2);
     EXPECT_EQ(t3->consumption(), size2);
 
-    thread_context->consume_memory(-size2);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
     thread_context->thread_mem_tracker_mgr->pop_consumer_tracker();
     EXPECT_EQ(t1->consumption(),
               size1 + size2 + size1 + size2 + size2 + size1 + size2 - size1 - size2);
     EXPECT_EQ(t2->consumption(), size2 + size2);
     EXPECT_EQ(t3->consumption(), size2);
 
-    thread_context->consume_memory(-t1->consumption());
+    thread_context->thread_mem_tracker_mgr->consume(-t1->consumption());
     thread_context->detach_task(); // detach t1
     EXPECT_EQ(t1->consumption(), 0);
     EXPECT_EQ(t2->consumption(), size2 + size2);
@@ -228,87 +237,90 @@ TEST_F(ThreadMemTrackerMgrTest, ReserveMemory) {
     std::unique_ptr<ThreadContext> thread_context = std::make_unique<ThreadContext>();
     std::shared_ptr<MemTrackerLimiter> t =
             MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER, "UT-ReserveMemory");
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(t);
+    rc->workload_group_context()->set_workload_group(workload_group);
 
     int64_t size1 = 4 * 1024;
     int64_t size2 = 4 * 1024 * 1024;
     int64_t size3 = size2 * 2;
 
-    thread_context->attach_task(TUniqueId(), t, workload_group);
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
+    thread_context->attach_task(rc);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t->consumption(), size1 + size2);
 
-    auto st = thread_context->try_reserve_memory(size3);
+    auto st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);
 
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(-size2);
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
-    thread_context->consume_memory(-size1);
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     // std::abs(-size1 - size1) < SYNC_PROC_RESERVED_INTERVAL_BYTES, not update process_reserved_memory.
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size1 + size1);
 
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     // reserved memory used done
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), 0);
 
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     // no reserved memory, normal memory consumption
     EXPECT_EQ(t->consumption(), size1 + size2 + size3 + size1 + size2);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), 0);
 
-    thread_context->consume_memory(-size3);
-    thread_context->consume_memory(-size1);
-    thread_context->consume_memory(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size3);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
     EXPECT_EQ(t->consumption(), size1 + size2);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), 0);
 
-    st = thread_context->try_reserve_memory(size3);
+    st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);
 
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     // ThreadMemTrackerMgr _reserved_mem = size3 + size1
     // ThreadMemTrackerMgr _untracked_mem = -size1
-    thread_context->consume_memory(size3);
+    thread_context->thread_mem_tracker_mgr->consume(size3);
     // ThreadMemTrackerMgr _reserved_mem = size1
     // ThreadMemTrackerMgr _untracked_mem = -size1 + size3
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(),
               size1); // size3 + size1 - size3
 
-    thread_context->consume_memory(-size3);
+    thread_context->thread_mem_tracker_mgr->consume(-size3);
     // ThreadMemTrackerMgr _reserved_mem = size1 + size3
     // ThreadMemTrackerMgr _untracked_mem = 0, std::abs(-size3) > SYNC_PROC_RESERVED_INTERVAL_BYTES,
     // so update process_reserved_memory.
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size1 + size3);
 
-    thread_context->consume_memory(size1);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size1);
     // ThreadMemTrackerMgr _reserved_mem = size1 + size3 - size1 - size2 - size1 = size3 - size2 - size1
     // ThreadMemTrackerMgr _untracked_mem = size1
     EXPECT_EQ(t->consumption(), size1 + size2 + size3);
     // size1 + size3 - (size1 + size2)
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
-    thread_context->release_reserved_memory();
+    thread_context->thread_mem_tracker_mgr->shrink_reserved();
     // size1 + size2 + size3 - _reserved_mem, size1 + size2 + size3 - (size3 - size2 - size1)
     EXPECT_EQ(t->consumption(), size1 + size2 + size1 + size2);
     // size3 - size2 - (_reserved_mem + _untracked_mem) = 0, size3 - size2 - ((size3 - size2 - size1) + (size1)) = 0
@@ -323,24 +335,27 @@ TEST_F(ThreadMemTrackerMgrTest, NestedReserveMemory) {
     std::unique_ptr<ThreadContext> thread_context = std::make_unique<ThreadContext>();
     std::shared_ptr<MemTrackerLimiter> t = MemTrackerLimiter::create_shared(
             MemTrackerLimiter::Type::OTHER, "UT-NestedReserveMemory");
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(t);
+    rc->workload_group_context()->set_workload_group(workload_group);
 
     int64_t size2 = 4 * 1024 * 1024;
     int64_t size3 = size2 * 2;
 
-    thread_context->attach_task(TUniqueId(), t, workload_group);
-    auto st = thread_context->try_reserve_memory(size3);
+    thread_context->attach_task(rc);
+    auto st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);
 
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     // ThreadMemTrackerMgr _reserved_mem = size3 - size2
     // ThreadMemTrackerMgr _untracked_mem = 0, size2 > SYNC_PROC_RESERVED_INTERVAL_BYTES,
     // update process_reserved_memory.
     EXPECT_EQ(t->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
-    st = thread_context->try_reserve_memory(size2);
+    st = thread_context->thread_mem_tracker_mgr->try_reserve(size2);
     EXPECT_TRUE(st.ok()) << st.to_string();
     // ThreadMemTrackerMgr _reserved_mem = size3 - size2 + size2
     // ThreadMemTrackerMgr _untracked_mem = 0
@@ -348,19 +363,19 @@ TEST_F(ThreadMemTrackerMgrTest, NestedReserveMemory) {
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(),
               size3); // size3 - size2 + size2
 
-    st = thread_context->try_reserve_memory(size3);
+    st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
-    st = thread_context->try_reserve_memory(size3);
+    st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
-    thread_context->consume_memory(size3);
-    thread_context->consume_memory(size2);
-    thread_context->consume_memory(size3);
+    thread_context->thread_mem_tracker_mgr->consume(size3);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size3);
     // ThreadMemTrackerMgr _reserved_mem = size3 - size2
     // ThreadMemTrackerMgr _untracked_mem = 0
     EXPECT_EQ(t->consumption(), size3 + size2 + size3 + size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
-    thread_context->release_reserved_memory();
+    thread_context->thread_mem_tracker_mgr->shrink_reserved();
     // size3 + size2 + size3 + size3 - _reserved_mem, size3 + size2 + size3 + size3 - (size3 - size2)
     EXPECT_EQ(t->consumption(), size3 + size2 + size3 + size2);
     // size3 - size2 - (_reserved_mem + _untracked_mem) = 0, size3 - size2 - ((size3 - size2 - size1) + (size1)) = 0
@@ -379,40 +394,43 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTrackerReserveMemory) {
             MemTrackerLimiter::Type::OTHER, "UT-NestedSwitchMemTrackerReserveMemory2");
     std::shared_ptr<MemTrackerLimiter> t3 = MemTrackerLimiter::create_shared(
             MemTrackerLimiter::Type::OTHER, "UT-NestedSwitchMemTrackerReserveMemory3");
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    rc->memory_context()->set_mem_tracker(t1);
+    rc->workload_group_context()->set_workload_group(workload_group);
 
     int64_t size1 = 4 * 1024;
     int64_t size2 = 4 * 1024 * 1024;
     int64_t size3 = size2 * 2;
 
-    thread_context->attach_task(TUniqueId(), t1, workload_group);
-    auto st = thread_context->try_reserve_memory(size3);
+    thread_context->attach_task(rc);
+    auto st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
-    thread_context->consume_memory(size2);
+    thread_context->thread_mem_tracker_mgr->consume(size2);
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t2);
-    st = thread_context->try_reserve_memory(size3);
+    st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(t2->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2 + size3);
 
-    thread_context->consume_memory(size2 + size3); // reserved memory used done
+    thread_context->thread_mem_tracker_mgr->consume(size2 + size3); // reserved memory used done
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(t2->consumption(), size3 + size2);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
     thread_context->thread_mem_tracker_mgr->attach_limiter_tracker(t3);
-    st = thread_context->try_reserve_memory(size3);
+    st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(t2->consumption(), size3 + size2);
     EXPECT_EQ(t3->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2 + size3);
 
-    thread_context->consume_memory(-size2);
-    thread_context->consume_memory(-size1);
+    thread_context->thread_mem_tracker_mgr->consume(-size2);
+    thread_context->thread_mem_tracker_mgr->consume(-size1);
     // ThreadMemTrackerMgr _reserved_mem = size3 + size2 + size1
     // ThreadMemTrackerMgr _untracked_mem = -size1
     EXPECT_EQ(t1->consumption(), size3);


### PR DESCRIPTION
### What problem does this PR solve?

All tasks in Doris, query/load/compaction/etc., must have a unique `ResourceContext` to manage the resource usage of this Task, including `CpuContext`, `MemoryContext`, `IOContext`, `WorkloadGroupContext` and `TaskController`.

What can `ResourceContext` do:

1. Save task resource stat, such as profile counter of CPU/Memory/IO.

2. Hold resource objects such as `WorkloadGroupPtr`, `MemTrackerPtr`.

3. Provide methods for operating task resources, such as `revokable_bytes`, `cancel task`.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

