### PR TITLE
[fix](restore) Cut down restore timeout when create replicas failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
@@ -30,11 +30,17 @@ public class MarkedCountDownLatch<K, V> extends CountDownLatch {
     private Multimap<K, V> marks;
     private Multimap<K, V> failedMarks;
     private Status st = Status.OK;
+    private int markCount = 0;
 
     public MarkedCountDownLatch(int count) {
         super(count);
+        this.markCount = count;
         marks = HashMultimap.create();
         failedMarks = HashMultimap.create();
+    }
+
+    public int getMarkCount() {
+        return markCount;
     }
 
     public synchronized void addMark(K key, V value) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

During the restore process of creating replicas, if job is failure, the restore job will be retried until the restore times out. This process takes too long.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

