### PR TITLE
[improve](cloud-mow) batch get tablet stats when get_delete_bitmap_update_lock

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -291,6 +291,9 @@ CONF_Strings(recycler_storage_vault_white_list, "");
 // for test only
 CONF_mBool(enable_update_delete_bitmap_kv_check, "false");
 
+// for get_delete_bitmap_update_lock
+CONF_mBool(enable_batch_get_mow_tablet_stats_and_meta, "true");
+
 // aws sdk log level
 //    Off = 0,
 //    Fatal = 1,

--- a/cloud/src/meta-service/meta_service.h
+++ b/cloud/src/meta-service/meta_service.h
@@ -324,6 +324,12 @@ private:
             const AlterInstanceRequest* request,
             std::function<std::pair<MetaServiceCode, std::string>(InstanceInfoPB*)> action);
 
+    bool get_mow_tablet_stats_and_meta(MetaServiceCode& code, std::string& msg,
+                                       const GetDeleteBitmapUpdateLockRequest* request,
+                                       GetDeleteBitmapUpdateLockResponse* response,
+                                       std::string& instance_id, std::string& lock_key,
+                                       std::string lock_use_version);
+
     void get_delete_bitmap_update_lock_v2(google::protobuf::RpcController* controller,
                                           const GetDeleteBitmapUpdateLockRequest* request,
                                           GetDeleteBitmapUpdateLockResponse* response,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

as the title, 
before:
![1](https://github.com/user-attachments/assets/0851a103-fdaa-454f-af8e-d3e1d8421a52)

after:
![2](https://github.com/user-attachments/assets/e316ba43-43fe-4d7c-8406-4ee310c66f97)



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

