### PR TITLE
[draft]  Collect bloom runtime filter filtering statistics.

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -553,6 +554,7 @@ Status IRuntimeFilter::push_to_remote(RuntimeState* state, const TNetworkAddress
 
 Status IRuntimeFilter::get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr>& probe_ctxs,
                                           std::vector<vectorized::VRuntimeFilterPtr>& push_exprs,
+                                          ExprRuntimeFilterInfo& expr_rf_info,
                                           bool is_late_arrival) {
     DCHECK(is_consumer());
     auto origin_size = push_exprs.size();
@@ -569,6 +571,11 @@ Status IRuntimeFilter::get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr
         push_exprs[i]->attach_profile_counter(expr_filtered_rows_counter, expr_input_rows_counter,
                                               always_true_counter);
     }
+    // The runtime filter is pushed down, adding filtering information.
+    // expr_rf_info record the runtime filter use as a expr.
+    expr_rf_info.always_true_counter = always_true_counter;
+    expr_rf_info.expr_filtered_rows_counter = expr_filtered_rows_counter;
+    expr_rf_info.expr_input_rows_counter = expr_input_rows_counter;
     return Status::OK();
 }
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -115,6 +115,15 @@ static RuntimeFilterType get_runtime_filter_type(const TRuntimeFilterDesc* desc)
 
 enum class RuntimeFilterRole { PRODUCER = 0, CONSUMER = 1 };
 
+// ExprRuntimeFilterInfo is used to record the filtering information of runtime filter as an Expr
+// runtime filter may also be executed as a predicate, so it is necessary to separate expr and predicate
+struct ExprRuntimeFilterInfo {
+    RuntimeFilterType type;
+    RuntimeProfile::Counter* expr_filtered_rows_counter = nullptr;
+    RuntimeProfile::Counter* expr_input_rows_counter = nullptr;
+    RuntimeProfile::Counter* always_true_counter = nullptr;
+};
+
 struct RuntimeFilterParams {
     RuntimeFilterParams()
             : filter_type(RuntimeFilterType::UNKNOWN_FILTER),
@@ -232,7 +241,7 @@ public:
 
     Status get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr>& probe_ctxs,
                               std::vector<vectorized::VRuntimeFilterPtr>& push_exprs,
-                              bool is_late_arrival);
+                              ExprRuntimeFilterInfo& expr_rf_info, bool is_late_arrival);
 
     bool is_broadcast_join() const { return _is_broadcast_join; }
 

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -40,23 +40,6 @@ struct PredicateParams {
     bool marked_by_runtime_filter = false;
 };
 
-enum class PredicateType {
-    UNKNOWN = 0,
-    EQ = 1,
-    NE = 2,
-    LT = 3,
-    LE = 4,
-    GT = 5,
-    GE = 6,
-    IN_LIST = 7,
-    NOT_IN_LIST = 8,
-    IS_NULL = 9,
-    IS_NOT_NULL = 10,
-    BF = 11,            // BloomFilter
-    BITMAP_FILTER = 12, // BitmapFilter
-    MATCH = 13,         // fulltext match
-};
-
 template <PrimitiveType primitive_type, typename ResultType>
 ResultType get_zone_map_value(void* data_ptr) {
     ResultType res;
@@ -263,9 +246,9 @@ public:
     }
 
     virtual int get_filter_id() const { return -1; }
-    PredicateFilterInfo get_filtered_info() const {
-        return PredicateFilterInfo {static_cast<int>(type()), _evaluated_rows - 1,
-                                    _evaluated_rows - 1 - _passed_rows};
+    PredicateRuntimeFilterInfo get_filtered_info() const {
+        return PredicateRuntimeFilterInfo {type(), _evaluated_rows - 1,
+                                           _evaluated_rows - 1 - _passed_rows};
     }
 
     std::shared_ptr<PredicateParams> predicate_params() { return _predicate_params; }

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -76,8 +76,26 @@ struct DataDirInfo {
     DataDirType data_dir_type = DataDirType::OLAP_DATA_DIR;
     std::string metric_name;
 };
-struct PredicateFilterInfo {
-    int type = 0;
+
+enum class PredicateType {
+    UNKNOWN = 0,
+    EQ = 1,
+    NE = 2,
+    LT = 3,
+    LE = 4,
+    GT = 5,
+    GE = 6,
+    IN_LIST = 7,
+    NOT_IN_LIST = 8,
+    IS_NULL = 9,
+    IS_NOT_NULL = 10,
+    BF = 11,            // BloomFilter
+    BITMAP_FILTER = 12, // BitmapFilter
+    MATCH = 13,         // fulltext match
+};
+
+struct PredicateRuntimeFilterInfo {
+    PredicateType type;
     uint64_t input_row = 0;
     uint64_t filtered_row = 0;
 };
@@ -335,7 +353,7 @@ struct OlapReaderStatistics {
     int64_t expr_filter_ns = 0;
     int64_t output_col_ns = 0;
 
-    std::map<int, PredicateFilterInfo> filter_info;
+    std::map<int, PredicateRuntimeFilterInfo> filter_info;
 
     int64_t rows_key_range_filtered = 0;
     int64_t rows_stats_filtered = 0;

--- a/be/src/pipeline/common/runtime_filter_consumer.h
+++ b/be/src/pipeline/common/runtime_filter_consumer.h
@@ -69,6 +69,10 @@ protected:
     std::mutex _rf_locks;
     RuntimeState* _state = nullptr;
 
+    // mapping from filter id to filter info
+    // there are two types of filter info, since runtime filter can be executed as predicate or expression.
+    std::map<int, ExprRuntimeFilterInfo> _expr_rf_info;
+
 private:
     int32_t _filter_id;
 

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -588,18 +588,19 @@ Status OlapScanLocalState::_build_key_ranges_and_filters() {
     return Status::OK();
 }
 
-void OlapScanLocalState::add_filter_info(int id, const PredicateFilterInfo& update_info) {
+void OlapScanLocalState::add_predicate_rf_info(int id,
+                                               const PredicateRuntimeFilterInfo& update_info) {
     std::unique_lock lock(_profile_mtx);
     // update
-    _filter_info[id].filtered_row += update_info.filtered_row;
-    _filter_info[id].input_row += update_info.input_row;
-    _filter_info[id].type = update_info.type;
+    _predicate_rf_info[id].filtered_row += update_info.filtered_row;
+    _predicate_rf_info[id].input_row += update_info.input_row;
+    _predicate_rf_info[id].type = update_info.type;
     // to string
-    auto& info = _filter_info[id];
+    auto& info = _predicate_rf_info[id];
     std::string filter_name = "RuntimeFilterInfo id ";
     filter_name += std::to_string(id);
     std::string info_str;
-    info_str += "type = " + type_to_string(static_cast<PredicateType>(info.type)) + ", ";
+    info_str += "type = " + type_to_string(info.type) + ", ";
     info_str += "input = " + std::to_string(info.input_row) + ", ";
     info_str += "filtered = " + std::to_string(info.filtered_row);
     info_str = "[" + info_str + "]";

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -85,7 +85,7 @@ private:
 
     Status _init_scanners(std::list<vectorized::VScannerSPtr>* scanners) override;
 
-    void add_filter_info(int id, const PredicateFilterInfo& info);
+    void add_predicate_rf_info(int id, const PredicateRuntimeFilterInfo& info);
 
     Status _build_key_ranges_and_filters();
 
@@ -117,7 +117,6 @@ private:
     RuntimeProfile::Counter* _short_cond_timer = nullptr;
     RuntimeProfile::Counter* _expr_filter_timer = nullptr;
     RuntimeProfile::Counter* _output_col_timer = nullptr;
-    std::map<int, PredicateFilterInfo> _filter_info;
 
     RuntimeProfile::Counter* _stats_filtered_counter = nullptr;
     RuntimeProfile::Counter* _stats_rp_filtered_counter = nullptr;
@@ -210,8 +209,6 @@ private:
 
     RuntimeProfile::Counter* _segment_create_column_readers_timer = nullptr;
     RuntimeProfile::Counter* _segment_load_index_timer = nullptr;
-
-    std::mutex _profile_mtx;
 };
 
 class OlapScanOperatorX final : public ScanOperatorX<OlapScanLocalState> {

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -97,6 +97,22 @@ protected:
 
     virtual Status _init_profile() = 0;
 
+    // Collect bloom runtime filter filtering statistics.
+    // Runtime filters can be executed either as expressions or predicates.
+    // When executed as predicates, some filters may be transformed into other predicates
+    // (e.g., minmax filters become max/min predicates for index lookup, or combined with
+    // other predicates into key ranges). In such cases, it's difficult to track the filter id.
+    // Therefore, we only collect statistics for bloom filters here to help optimizer analysis.
+    void collect_bloom_runtime_filter_statistics();
+
+    // mapping from filter id to filter info
+    // there are two types of filter info, since runtime filter can be executed as predicate or expression.
+    std::map<int, PredicateRuntimeFilterInfo> _predicate_rf_info;
+    // _expr_rf_info in RuntimeFilterConsumer
+
+    // use to lock _predicate_rf_info
+    std::mutex _profile_mtx;
+
     std::atomic<bool> _opened {false};
 
     DependencySPtr _scan_dependency = nullptr;

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -596,7 +596,7 @@ void NewOlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_rows_short_circuit_cond_input_counter,
                    stats.short_circuit_cond_input_rows);
     for (auto& [id, info] : stats.filter_info) {
-        local_state->add_filter_info(id, info);
+        local_state->add_predicate_rf_info(id, info);
     }
     COUNTER_UPDATE(local_state->_stats_filtered_counter, stats.rows_stats_filtered);
     COUNTER_UPDATE(local_state->_stats_rp_filtered_counter, stats.rows_stats_rp_filtered);


### PR DESCRIPTION
### What problem does this PR solve?

Runtime filters can be executed either as expressions or predicates.
When executed as predicates, some filters may be transformed into other predicates 
(e.g., minmax filters become max/min predicates for index lookup, or combined with 
other predicates into key ranges). In such cases, it's difficult to track the filter id.
Therefore, we only collect statistics for bloom filters here to help optimizer analysis.

like this 

```
   -  BloomRuntimeFilterInfo:  
                                                      -  bloom  filter  id  =  3  filtered:  1.004809288B  (1004809288)
                                                      -  bloom  filter  id  =  3  input:  1.005995884B  (1005995884)
                                                      -  bloom  filter  id  =  5  filtered:  1.000712946B  (1000712946)
                                                      -  bloom  filter  id  =  5  input:  1.001186596B  (1001186596)

```


data from 

```
 // predicates
                                                  -  RuntimeFilterInfo:  
                                                      -  filter  id  =  1  filtered:  384.144K  (384144)
                                                      -  filter  id  =  1  input:  473.65K  (473650)
                                                      -  filter  id  =  3  filtered:  4.809288M  (4809288)
                                                      -  filter  id  =  3  input:  5.995884M  (5995884)
                                                      -  filter  id  =  5  filtered:  712.946K  (712946)
                                                      -  filter  id  =  5  input:  1.186596M  (1186596)
 // expr 
                                                RuntimeFilter:  (id  =  0,  type  =  minmax):
                                                      -  Info:  [Id  =  0,  IsPushDown  =  true,  RuntimeFilterState  =  READY,  HasRemoteTarget  =  false,  HasLocalTarget  =  true,  Ignored  =  false,  Disabled  =  false,  Type  =  1,  WaitTimeMS  =  1000]
                                                      -  RealRuntimeFilterType:  minmax
                                                      -  LocalMergeTime:  0.000000  s
                                                      -  AlwaysTruePassRows:  0
                                                      -  ExprFilteredRows:  1.0B  (1000000000)
                                                      -  ExprInputRows:  1.0B  (1000000000)
                                                      -  WaitTime:  84.0ms
                                                RuntimeFilter:  (id  =  1,  type  =  in_or_bloomfilter):
                                                      -  Info:  [Id  =  1,  IsPushDown  =  true,  RuntimeFilterState  =  READY,  HasRemoteTarget  =  false,  HasLocalTarget  =  true,  Ignored  =  false,  Disabled  =  false,  Type  =  0,  WaitTimeMS  =  1000]
                                                      -  RealRuntimeFilterType:  in
                                                      -  LocalMergeTime:  0.000000  s
                                                      -  InFilterSize:  378
                                                      -  AlwaysTruePassRows:  0
                                                      -  ExprFilteredRows:  1.0B  (1000000000)
                                                      -  ExprInputRows:  1.0B  (1000000000)
                                                      -  WaitTime:  83.0ms
                                                RuntimeFilter:  (id  =  2,  type  =  minmax):
                                                      -  Info:  [Id  =  2,  IsPushDown  =  true,  RuntimeFilterState  =  READY,  HasRemoteTarget  =  false,  HasLocalTarget  =  true,  Ignored  =  false,  Disabled  =  false,  Type  =  1,  WaitTimeMS  =  1000]
                                                      -  RealRuntimeFilterType:  minmax
                                                      -  LocalMergeTime:  0.000000  s
                                                      -  AlwaysTruePassRows:  0
                                                      -  ExprFilteredRows:  1.0B  (1000000000)
                                                      -  ExprInputRows:  1.0B  (1000000000)
                                                      -  WaitTime:  86.0ms
                                                RuntimeFilter:  (id  =  3,  type  =  in_or_bloomfilter):
                                                      -  Info:  [Id  =  3,  IsPushDown  =  true,  RuntimeFilterState  =  READY,  HasRemoteTarget  =  false,  HasLocalTarget  =  true,  Ignored  =  false,  Disabled  =  false,  Type  =  2,  WaitTimeMS  =  1000]
                                                      -  RealRuntimeFilterType:  bloomfilter
                                                      -  LocalMergeTime:  0.000000  s
                                                      -  BloomFilterSize:  1048576
                                                      -  AlwaysTruePassRows:  0
                                                      -  ExprFilteredRows:  1.0B  (1000000000)
                                                      -  ExprInputRows:  1.0B  (1000000000)
                                                      -  WaitTime:  86.0ms
                                                RuntimeFilter:  (id  =  4,  type  =  minmax):
                                                      -  Info:  [Id  =  4,  IsPushDown  =  true,  RuntimeFilterState  =  READY,  HasRemoteTarget  =  false,  HasLocalTarget  =  true,  Ignored  =  false,  Disabled  =  false,  Type  =  1,  WaitTimeMS  =  1000]
                                                      -  RealRuntimeFilterType:  minmax
                                                      -  LocalMergeTime:  0.000000  s
                                                      -  AlwaysTruePassRows:  0
                                                      -  ExprFilteredRows:  1.0B  (1000000000)
                                                      -  ExprInputRows:  1.0B  (1000000000)
                                                      -  WaitTime:  112.0ms
                                                RuntimeFilter:  (id  =  5,  type  =  in_or_bloomfilter):
                                                      -  Info:  [Id  =  5,  IsPushDown  =  true,  RuntimeFilterState  =  READY,  HasRemoteTarget  =  false,  HasLocalTarget  =  true,  Ignored  =  false,  Disabled  =  false,  Type  =  2,  WaitTimeMS  =  1000]
                                                      -  RealRuntimeFilterType:  bloomfilter
                                                      -  LocalMergeTime:  0.000000  s
                                                      -  BloomFilterSize:  1048576
                                                      -  AlwaysTruePassRows:  0
                                                      -  ExprFilteredRows:  1.0B  (1000000000)
                                                      -  ExprInputRows:  1.0B  (1000000000)
                                                      -  WaitTime:  112.0ms
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

