### PR TITLE
[fix](exchange)fix exchange sink buffer does not update total_queue_size when EOF.

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -460,6 +460,7 @@ void ExchangeSinkBuffer::_set_receiver_eof(InstanceLoId id) {
 
     std::queue<TransmitInfo, std::list<TransmitInfo>>& q = _instance_to_package_queue[id];
     for (; !q.empty(); q.pop()) {
+        // updata _total_queue_size
         _total_queue_size--;
         if (q.front().block) {
             COUNTER_UPDATE(q.front().channel->_parent->memory_used_counter(),

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -308,6 +308,8 @@ private:
     void get_max_min_rpc_time(int64_t* max_time, int64_t* min_time);
     int64_t get_sum_rpc_time();
 
+    // _total_queue_size is the sum of the sizes of all instance_to_package_queues.
+    // Any modification to instance_to_package_queue requires a corresponding modification to _total_queue_size.
     std::atomic<int> _total_queue_size = 0;
 
     // _running_sink_count is used to track how many sinks have not finished yet.

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -239,6 +239,8 @@ public:
         _queue_deps[sender_ins_id] = queue_dependency;
         _parents[sender_ins_id] = local_state;
     }
+
+    std::string debug_each_instance_queue_size();
 #ifdef BE_TEST
 public:
 #else

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -499,12 +499,13 @@ std::string ExchangeSinkLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer, "{}", Base::debug_string(indentation_level));
     if (_sink_buffer) {
-        fmt::format_to(debug_string_buffer,
-                       ", Sink Buffer: (_is_finishing = {}, blocks in queue: {}, queue capacity: "
-                       "{}, queue dep: {}), _reach_limit: {}, working channels: {}",
-                       _sink_buffer->_is_failed.load(), _sink_buffer->_total_queue_size,
-                       _sink_buffer->_queue_capacity, (void*)_queue_dependency.get(),
-                       _reach_limit.load(), _working_channels_count.load());
+        fmt::format_to(
+                debug_string_buffer,
+                ", Sink Buffer: (_is_finishing = {}, blocks in queue: {}, queue capacity: "
+                "{}, queue dep: {}), _reach_limit: {}, working channels: {} , each queue size: {}",
+                _sink_buffer->_is_failed.load(), _sink_buffer->_total_queue_size,
+                _sink_buffer->_queue_capacity, (void*)_queue_dependency.get(), _reach_limit.load(),
+                _working_channels_count.load(), _sink_buffer->debug_each_instance_queue_size());
     }
     return fmt::to_string(debug_string_buffer);
 }

--- a/be/test/vec/exec/exchange_sink_test.cpp
+++ b/be/test/vec/exec/exchange_sink_test.cpp
@@ -216,7 +216,7 @@ TEST_F(ExchangeSInkTest, test_queue_size) {
 
         EXPECT_EQ(buffer->_total_queue_size, 6);
 
-        std::cout << "ecch queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
+        std::cout << "each queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
 
         pop_block(dest_ins_id_2, PopState::eof);
 
@@ -224,7 +224,7 @@ TEST_F(ExchangeSInkTest, test_queue_size) {
 
         EXPECT_EQ(buffer->_total_queue_size, 4);
 
-        std::cout << "ecch queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
+        std::cout << "each queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
 
         clear_all_done();
     }

--- a/be/test/vec/exec/exchange_sink_test.cpp
+++ b/be/test/vec/exec/exchange_sink_test.cpp
@@ -226,6 +226,9 @@ TEST_F(ExchangeSInkTest, test_queue_size) {
 
         std::cout << "each queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
 
+        EXPECT_EQ(buffer->_rpc_channel_is_turn_off[dest_ins_id_1], false);
+        EXPECT_EQ(buffer->_rpc_channel_is_turn_off[dest_ins_id_2], true);
+        EXPECT_EQ(buffer->_rpc_channel_is_turn_off[dest_ins_id_3], false);
         clear_all_done();
     }
 }

--- a/be/test/vec/exec/exchange_sink_test.cpp
+++ b/be/test/vec/exec/exchange_sink_test.cpp
@@ -193,4 +193,41 @@ TEST_F(ExchangeSInkTest, test_error_end) {
     }
 }
 
+TEST_F(ExchangeSInkTest, test_queue_size) {
+    {
+        auto state = create_runtime_state();
+        auto buffer = create_buffer(state);
+
+        auto sink1 = create_sink(state, buffer);
+
+        EXPECT_EQ(sink1.add_block(dest_ins_id_1, false), Status::OK());
+        EXPECT_EQ(sink1.add_block(dest_ins_id_1, false), Status::OK());
+        EXPECT_EQ(sink1.add_block(dest_ins_id_1, false), Status::OK());
+
+        EXPECT_EQ(sink1.add_block(dest_ins_id_2, false), Status::OK());
+        EXPECT_EQ(sink1.add_block(dest_ins_id_2, false), Status::OK());
+        EXPECT_EQ(sink1.add_block(dest_ins_id_2, false), Status::OK());
+
+        EXPECT_EQ(sink1.add_block(dest_ins_id_3, false), Status::OK());
+        EXPECT_EQ(sink1.add_block(dest_ins_id_3, false), Status::OK());
+        EXPECT_EQ(sink1.add_block(dest_ins_id_3, false), Status::OK());
+
+        std::cout << "queue size : " << buffer->_total_queue_size << "\n";
+
+        EXPECT_EQ(buffer->_total_queue_size, 6);
+
+        std::cout << "ecch queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
+
+        pop_block(dest_ins_id_2, PopState::eof);
+
+        std::cout << "queue size : " << buffer->_total_queue_size << "\n";
+
+        EXPECT_EQ(buffer->_total_queue_size, 4);
+
+        std::cout << "ecch queue size : \n" << buffer->debug_each_instance_queue_size() << "\n";
+
+        clear_all_done();
+    }
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/apache/doris/pull/41602
EOF clears _instance_to_package_queue but does not update total_queue_size, causing incorrect judgments that rely on total_queue_size.

UT

```
mock transmit_blockv2 dest ins id :1
mock transmit_blockv2 dest ins id :2
mock transmit_blockv2 dest ins id :3
queue size : 6
each queue size : 
Instance: 2, queue size: 2
Instance: 1, queue size: 2
Instance: 3, queue size: 2

queue size : 6 // error size 
each queue size :
Instance: 2, queue size: 0
Instance: 1, queue size: 2
Instance: 3, queue size: 2

mock transmit_blockv2 dest ins id :1
mock transmit_blockv2 dest ins id :1
mock transmit_blockv2 dest ins id :3
mock transmit_blockv2 dest ins id :3
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

