### PR TITLE
[fix](date_function) fix str_to_date function return wrong microsecond issue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -110,6 +110,7 @@ public class DateLiteral extends LiteralExpr {
     private static Map<String, Integer> WEEK_DAY_NAME_DICT = Maps.newHashMap();
     private static Set<Character> TIME_PART_SET = Sets.newHashSet();
     private static final int[] DAYS_IN_MONTH = new int[] {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    private static String MICRO_SECOND_FORMATTER = "%f";
     private static final int ALLOW_SPACE_MASK = 4 | 64;
     private static final int MAX_DATE_PARTS = 8;
     private static final int YY_PART_YEAR = 70;
@@ -998,6 +999,10 @@ public class DateLiteral extends LiteralExpr {
 
     public static boolean hasTimePart(String format) {
         return format.chars().anyMatch(c -> TIME_PART_SET.contains((char) c));
+    }
+
+    public static boolean hasMicroSecondPart(String format) {
+        return format.indexOf(MICRO_SECOND_FORMATTER) != -1;
     }
 
     // Return the date stored in the dateliteral as pattern format.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -1606,7 +1606,7 @@ public class DateLiteral extends LiteralExpr {
 
         // Compute timestamp type
         if ((partUsed & datePart) != 0) { // Ymd part only
-            if ((partUsed & fracPart) != 0) {
+            if (hasMicroSecondPart(format)) {
                 this.type = Type.DATETIMEV2_WITH_MAX_SCALAR;
             } else if ((partUsed & timePart) != 0) {
                 this.type = ScalarType.getDefaultDateType(Type.DATETIME);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -685,7 +685,7 @@ public class DateLiteral extends LiteralExpr {
             int scale = ((ScalarType) type).getScalarScale();
             long scaledMicroseconds = (long) (microsecond / SCALE_FACTORS[scale]);
 
-            if (scaledMicroseconds != 0) {
+            if (scale > 0) {
                 dateTimeChars[19] = '.';
                 fillPaddedValue(dateTimeChars, 20, (int) scaledMicroseconds, scale);
                 return new String(dateTimeChars, 0, 20 + scale);
@@ -1541,6 +1541,9 @@ public class DateLiteral extends LiteralExpr {
                     case 'p':
                     case 'T':
                         partUsed |= timePart;
+                        break;
+                    case 'f':
+                        partUsed |= fracPart;
                         break;
                     default:
                         break;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1978,7 +1978,11 @@ public class FunctionCallExpr extends Expr {
             Expr child1Result = getChild(1).getResultValue(false);
             if (child1Result instanceof StringLiteral) {
                 if (DateLiteral.hasTimePart(child1Result.getStringValue())) {
-                    this.type = Type.DATETIMEV2_WITH_MAX_SCALAR;
+                    if (DateLiteral.hasMicroSecondPart(child1Result.getStringValue())) {
+                        this.type = Type.DATETIMEV2_WITH_MAX_SCALAR;
+                    } else {
+                        this.type = Type.DEFAULT_DATETIMEV2;
+                    }
                 } else {
                     this.type = Type.DATEV2;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/StrToDate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/StrToDate.java
@@ -87,7 +87,8 @@ public class StrToDate extends ScalarFunction
         if (getArgument(1) instanceof StringLikeLiteral) {
             if (DateLiteral.hasTimePart(((StringLikeLiteral) getArgument(1)).getStringValue())) {
                 returnType = DataType.fromCatalogType(ScalarType.getDefaultDateType(Type.DATETIME));
-                if (returnType.isDateTimeV2Type()) {
+                if (returnType.isDateTimeV2Type()
+                        && DateLiteral.hasMicroSecondPart(((StringLikeLiteral) getArgument(1)).getStringValue())) {
                     returnType = DataType.fromCatalogType(Type.DATETIMEV2_WITH_MAX_SCALAR);
                 }
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
@@ -117,13 +117,6 @@ public class DateTimeLiteral extends DateLiteral {
             }
             scale++;
         }
-        // trim the tailing zero
-        for (int i = 19 + scale; i >= 19; i--) {
-            if (s.charAt(i) != '0') {
-                break;
-            }
-            scale--;
-        }
         return scale;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ComparisonPredicateTest.java
@@ -159,7 +159,7 @@ public class ComparisonPredicateTest {
 
         Assert.assertEquals(dateTimeExpr, range1.upperEndpoint());
         Assert.assertEquals(dateTimeV2Expr1, range1.upperEndpoint());
-        Assert.assertEquals(dateTimeV2Expr2, range1.upperEndpoint());
+        Assert.assertNotEquals(dateTimeV2Expr2, range1.upperEndpoint());
         Assert.assertEquals(BoundType.CLOSED, range1.upperBoundType());
         Assert.assertFalse(range1.hasLowerBound());
 
@@ -167,6 +167,6 @@ public class ComparisonPredicateTest {
         Assert.assertEquals(dateTimeV2Expr1, range2.upperEndpoint());
         Assert.assertEquals(BoundType.CLOSED, range2.upperBoundType());
         Assert.assertFalse(range2.hasLowerBound());
-        Assert.assertEquals(dateTimeV2Expr2, range2.upperEndpoint());
+        Assert.assertNotEquals(dateTimeV2Expr2, range2.upperEndpoint());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -93,9 +93,9 @@ class DateTimeLiteralTest {
     @Test
     void testDetermineScale() {
         int scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.0");
-        Assertions.assertEquals(0, scale);
+        Assertions.assertEquals(1, scale);
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.00000");
-        Assertions.assertEquals(0, scale);
+        Assertions.assertEquals(5, scale);
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.000001");
         Assertions.assertEquals(6, scale);
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.123456");
@@ -103,11 +103,11 @@ class DateTimeLiteralTest {
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.0001");
         Assertions.assertEquals(4, scale);
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.00010");
-        Assertions.assertEquals(4, scale);
+        Assertions.assertEquals(5, scale);
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.12010");
-        Assertions.assertEquals(4, scale);
+        Assertions.assertEquals(5, scale);
         scale = DateTimeLiteral.determineScale("2022-08-01T01:01:01.02010");
-        Assertions.assertEquals(4, scale);
+        Assertions.assertEquals(5, scale);
     }
 
     @Test

--- a/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
@@ -132,7 +132,7 @@ suite("test_oracle_jdbc_catalog", "p0,external,oracle,external_docker,external_d
         order_qt_date4  """ select * from TEST_DATE where (T1 > '2022-01-21 00:00:00' and T1 < '2022-01-22 00:00:00') or (T1 > '2022-01-20 00:00:00' and T1 < '2022-01-23 00:00:00'); """
         order_qt_date5  """ select * from TEST_DATE where T1 < '2022-01-22 00:00:00' or T1 = '2022-01-21 05:23:01'; """
         order_qt_date6  """ select * from TEST_DATE where (T1 < '2022-01-22 00:00:00' or T1 > '2022-01-20 00:00:00') and (T1 < '2022-01-23 00:00:00' or T1 > '2022-01-19 00:00:00'); """
-        order_qt_date7  """select * from TEST_TIMESTAMP where T2 < str_to_date('2020-12-21 12:34:56', '%Y-%m-%d %H:%i:%s');"""
+        order_qt_date7  """select * from TEST_TIMESTAMP where T2 < str_to_date('2020-12-21 12:34:56', '%Y-%m-%d %H:%i:%s.%f');"""
 
         // test nvl
         explain {

--- a/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function_v2.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/datetime_functions/test_date_function_v2.groovy
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_date_function_v2") {
+    sql """
+    admin set frontend config ("enable_date_conversion"="true");
+    """
+    sql """SET enable_nereids_planner=true"""
+
+    def tableName = "test_date_function_v2"
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+            CREATE TABLE IF NOT EXISTS ${tableName} (
+                `id` INT,
+                `name` varchar(32),
+                `dt` varchar(32)
+            ) ENGINE=OLAP
+            UNIQUE KEY(`id`)
+            DISTRIBUTED BY HASH(`id`) BUCKETS 1
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+            )
+        """
+    sql """ insert into ${tableName} values (3, 'Carl','2024-12-29 10:11:12') """
+    def result1 = try_sql """
+        select cast(str_to_date(dt, '%Y-%m-%d %H:%i:%s') as string) from ${tableName};
+    """
+    assertEquals(result1[0][0], "2024-12-29 10:11:12");
+
+    def result2 = try_sql """
+        select cast(str_to_date(dt, '%Y-%m-%d %H:%i:%s.%f') as string) from ${tableName};
+    """
+    assertEquals(result2[0][0], "2024-12-29 10:11:12.000000");
+
+    def result3 = try_sql """
+        select cast(str_to_date("2025-01-17 11:59:30", '%Y-%m-%d %H:%i:%s') as string);
+    """
+    assertEquals(result3[0][0], "2025-01-17 11:59:30");
+
+    def result4 = try_sql """
+        select cast(str_to_date("2025-01-17 11:59:30", '%Y-%m-%d %H:%i:%s.%f') as string);
+    """
+    assertEquals(result4[0][0], "2025-01-17 11:59:30.000000");
+
+    // test legacy planner
+    sql """SET enable_nereids_planner=false"""
+    def result5 = try_sql """
+        select cast(str_to_date(dt, '%Y-%m-%d %H:%i:%s') as string) from ${tableName};
+    """
+    assertEquals(result5[0][0], "2024-12-29 10:11:12");
+
+    result5 = try_sql """
+        select cast(str_to_date(dt, '%Y-%m-%d %H:%i:%s.%f') as string) from ${tableName};
+    """
+    assertEquals(result5[0][0], "2024-12-29 10:11:12.000000");
+
+    result5 = try_sql """
+        select cast(str_to_date('2025-01-17 11:59:30', '%Y-%m-%d %H:%i:%s') as string);
+    """
+    assertEquals(result5[0][0], "2025-01-17 11:59:30");
+
+    result5 = try_sql """
+        select cast(str_to_date('2025-01-17 11:59:30', '%Y-%m-%d %H:%i:%s.%f') as string);
+    """
+    assertEquals(result5[0][0], "2025-01-17 11:59:30.000000");
+
+
+    sql """ drop table ${tableName} """
+}


### PR DESCRIPTION
bp https://github.com/apache/doris/pull/47129

fix such issue both in legacy & nereids planner

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

