### PR TITLE
[fix](memory) Fix stream load memory tracking

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -142,8 +142,8 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
         }
     };
 
-    // Reset thread memory tracker, otherwise SCOPED_ATTACH_TASK will be called nested, nesting is
-    // not allowed, first time in on_chunk_data, second time in StreamLoadExecutor::execute_plan_fragment.
+    // Reset thread memory tracker, exec_plan_fragment will call SCOPED_ATTACH_TASK
+    // and check that the thread memory tracker must be orphan tracker.
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
 
     if (ctx->put_result.__isset.params) {


### PR DESCRIPTION
### What problem does this PR solve?

In HttpStreamAction::on_chunk_data
     -> process_put
     -> StreamLoadExecutor::execute_plan_fragment
     -> exec_plan_fragment
, SCOPED_ATTACH_TASK will be called.
So, SCOPED_ATTACH_TASK cannot be used here because it does not allow nesting.
If stream pipe needs to use ResourceContext in the future, maybe SCOPED_ATTACH_TASK should be allowed to support nesting?

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

