### PR TITLE
[opt](docker)Replace healthy container with `--wait`

### DIFF
--- a/docker/thirdparties/docker-compose/clickhouse/clickhouse.yaml.tpl
+++ b/docker/thirdparties/docker-compose/clickhouse/clickhouse.yaml.tpl
@@ -39,13 +39,6 @@ services:
       - ./init:/docker-entrypoint-initdb.d
     networks:
       - doris--clickhouse
-  doris--clickhouse-hello-world:
-    image: hello-world
-    depends_on:
-      doris--clickhouse:
-        condition: service_healthy
-    networks:
-      - doris--clickhouse
 
 networks:
   doris--clickhouse:

--- a/docker/thirdparties/docker-compose/db2/db2.yaml.tpl
+++ b/docker/thirdparties/docker-compose/db2/db2.yaml.tpl
@@ -39,13 +39,6 @@ services:
     restart: always
     networks:
       - doris--db2_network
-  db2-hello-world:
-    image: hello-world
-    depends_on:
-      doris--db2_11:
-        condition: service_healthy
-    networks:
-      - doris--db2_network
 networks:
   doris--db2_network:
     ipam:

--- a/docker/thirdparties/docker-compose/hive/hive-2x.yaml.tpl
+++ b/docker/thirdparties/docker-compose/hive/hive-2x.yaml.tpl
@@ -107,11 +107,3 @@ services:
       interval: 5s
       timeout: 60s
       retries: 120
-
-  hive-hello-world:
-    image: hello-world
-    container_name: ${CONTAINER_UID}hive2-hello-world
-    depends_on:
-      hive-metastore:
-        condition: service_healthy
-    network_mode: "host"

--- a/docker/thirdparties/docker-compose/hive/hive-3x.yaml.tpl
+++ b/docker/thirdparties/docker-compose/hive/hive-3x.yaml.tpl
@@ -107,11 +107,3 @@ services:
       interval: 5s
       timeout: 60s
       retries: 120
-
-  hive-hello-world:
-    image: hello-world
-    container_name: ${CONTAINER_UID}hive3-hello-world
-    depends_on:
-      hive-metastore:
-        condition: service_healthy
-    network_mode: "host"

--- a/docker/thirdparties/docker-compose/iceberg/iceberg.yaml.tpl
+++ b/docker/thirdparties/docker-compose/iceberg/iceberg.yaml.tpl
@@ -136,14 +136,6 @@ services:
       echo 'copy data';
       mc cp -r /mnt/data/input/minio/warehouse/* minio/warehouse/;
       "
-  
-  iceberg-hello-world:
-    image: hello-world
-    container_name: doris--iceberg-hello-world
-    depends_on:
-      spark-iceberg:
-        condition: service_healthy
-    network_mode: "host"
 
 networks:
   doris--iceberg:

--- a/docker/thirdparties/docker-compose/mariadb/mariadb-10.yaml.tpl
+++ b/docker/thirdparties/docker-compose/mariadb/mariadb-10.yaml.tpl
@@ -39,13 +39,6 @@ services:
       - ./init:/docker-entrypoint-initdb.d
     networks:
       - doris--mariadb
-  doris--mariadb-hello-world:
-    image: hello-world
-    depends_on:
-      doris--mariadb:
-        condition: service_healthy 
-    networks:
-      - doris--mariadb
 
 networks:
   doris--mariadb:

--- a/docker/thirdparties/docker-compose/mysql/mysql-5.7.yaml.tpl
+++ b/docker/thirdparties/docker-compose/mysql/mysql-5.7.yaml.tpl
@@ -40,13 +40,7 @@ services:
       - ./my.cnf:/etc/mysql/conf.d/my.cnf
     networks:
       - doris--mysql_57
-  doris--mysql-hello-world:
-    image: hello-world
-    depends_on:
-      doris--mysql_57:
-        condition: service_healthy 
-    networks:
-      - doris--mysql_57
+
 networks:
   doris--mysql_57:
     ipam:

--- a/docker/thirdparties/docker-compose/oceanbase/oceanbase.yaml.tpl
+++ b/docker/thirdparties/docker-compose/oceanbase/oceanbase.yaml.tpl
@@ -36,13 +36,7 @@ services:
       - ./init:/root/boot/init.d
     networks:
       - doris--oceanbase
-  doris--oceanbase-hello-world:
-    image: hello-world
-    depends_on:
-      doris--oceanbase:
-        condition: service_healthy
-    networks:
-      - doris--oceanbase
+
 networks:
   doris--oceanbase:
     ipam:

--- a/docker/thirdparties/docker-compose/oracle/oracle-11.yaml.tpl
+++ b/docker/thirdparties/docker-compose/oracle/oracle-11.yaml.tpl
@@ -39,13 +39,6 @@ services:
       - TZ=Asia/Shanghai
     networks:
       - doris--oracle_11
-  doris--oracle-hello-world:
-    image: hello-world
-    depends_on:
-      doris--oracle_11:
-        condition: service_healthy 
-    networks:
-      - doris--oracle_11
 
 networks:
   doris--oracle_11:

--- a/docker/thirdparties/docker-compose/postgresql/postgresql-14.yaml.tpl
+++ b/docker/thirdparties/docker-compose/postgresql/postgresql-14.yaml.tpl
@@ -35,13 +35,6 @@ services:
       - ./init:/docker-entrypoint-initdb.d
     networks:
       - doris--postgres
-  doris--postgres--hello-world:
-    image: hello-world
-    depends_on:
-      doris--postgres:
-        condition: service_healthy
-    networks:
-      - doris--postgres
 
 networks:
   doris--postgres:

--- a/docker/thirdparties/docker-compose/sqlserver/sqlserver.yaml.tpl
+++ b/docker/thirdparties/docker-compose/sqlserver/sqlserver.yaml.tpl
@@ -62,13 +62,7 @@ services:
       - SA_PASSWORD=Doris123456
     networks:
       - doris--sqlserver_2022
-  doris--sqlserver-hello-world:
-    image: hello-world
-    depends_on:
-      doris--sqlserver_2022:
-        condition: service_healthy
-    networks:
-      - doris--sqlserver_2022
+
 networks:
   doris--sqlserver_2022:
     ipam:

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -239,7 +239,7 @@ start_mysql() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/mysql/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/mysql/data/
-        sudo docker compose -f "${ROOT}"/docker-compose/mysql/mysql-5.7.yaml --env-file "${ROOT}"/docker-compose/mysql/mysql-5.7.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/mysql/mysql-5.7.yaml --env-file "${ROOT}"/docker-compose/mysql/mysql-5.7.env up -d --wait
     fi
 }
 
@@ -251,7 +251,7 @@ start_pg() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/postgresql/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/postgresql/data/data
-        sudo docker compose -f "${ROOT}"/docker-compose/postgresql/postgresql-14.yaml --env-file "${ROOT}"/docker-compose/postgresql/postgresql-14.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/postgresql/postgresql-14.yaml --env-file "${ROOT}"/docker-compose/postgresql/postgresql-14.env up -d --wait
     fi
 }
 
@@ -263,7 +263,7 @@ start_oracle() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/oracle/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/oracle/data/
-        sudo docker compose -f "${ROOT}"/docker-compose/oracle/oracle-11.yaml --env-file "${ROOT}"/docker-compose/oracle/oracle-11.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/oracle/oracle-11.yaml --env-file "${ROOT}"/docker-compose/oracle/oracle-11.env up -d --wait
     fi
 }
 
@@ -275,7 +275,7 @@ start_db2() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/db2/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/db2/data/
-        sudo docker compose -f "${ROOT}"/docker-compose/db2/db2.yaml --env-file "${ROOT}"/docker-compose/db2/db2.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/db2/db2.yaml --env-file "${ROOT}"/docker-compose/db2/db2.env up -d --wait
     fi
 }
 
@@ -287,7 +287,7 @@ start_oceanbase() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/oceanbase/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/oceanbase/data/
-        sudo docker compose -f "${ROOT}"/docker-compose/oceanbase/oceanbase.yaml --env-file "${ROOT}"/docker-compose/oceanbase/oceanbase.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/oceanbase/oceanbase.yaml --env-file "${ROOT}"/docker-compose/oceanbase/oceanbase.env up -d --wait
     fi
 }
 
@@ -299,7 +299,7 @@ start_sqlserver() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/sqlserver/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/sqlserver/data/
-        sudo docker compose -f "${ROOT}"/docker-compose/sqlserver/sqlserver.yaml --env-file "${ROOT}"/docker-compose/sqlserver/sqlserver.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/sqlserver/sqlserver.yaml --env-file "${ROOT}"/docker-compose/sqlserver/sqlserver.env up -d --wait
     fi
 }
 
@@ -311,7 +311,7 @@ start_clickhouse() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo rm "${ROOT}"/docker-compose/clickhouse/data/* -rf
         sudo mkdir -p "${ROOT}"/docker-compose/clickhouse/data/
-        sudo docker compose -f "${ROOT}"/docker-compose/clickhouse/clickhouse.yaml --env-file "${ROOT}"/docker-compose/clickhouse/clickhouse.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/clickhouse/clickhouse.yaml --env-file "${ROOT}"/docker-compose/clickhouse/clickhouse.env up -d --wait
     fi
 }
 
@@ -382,7 +382,7 @@ start_hive2() {
     envsubst <"${ROOT}"/docker-compose/hive/hadoop-hive-2x.env.tpl >> "${ROOT}"/docker-compose/hive/hadoop-hive-2x.env
     sudo docker compose -p ${CONTAINER_UID}hive2 -f "${ROOT}"/docker-compose/hive/hive-2x.yaml --env-file "${ROOT}"/docker-compose/hive/hadoop-hive-2x.env down
     if [[ "${STOP}" -ne 1 ]]; then
-        sudo docker compose -p ${CONTAINER_UID}hive2 -f "${ROOT}"/docker-compose/hive/hive-2x.yaml --env-file "${ROOT}"/docker-compose/hive/hadoop-hive-2x.env up --build --remove-orphans -d
+        sudo docker compose -p ${CONTAINER_UID}hive2 -f "${ROOT}"/docker-compose/hive/hive-2x.yaml --env-file "${ROOT}"/docker-compose/hive/hadoop-hive-2x.env up --build --remove-orphans -d --wait
     fi
 }
 
@@ -421,7 +421,7 @@ start_hive3() {
     envsubst <"${ROOT}"/docker-compose/hive/hadoop-hive-3x.env.tpl >> "${ROOT}"/docker-compose/hive/hadoop-hive-3x.env
     sudo docker compose -p ${CONTAINER_UID}hive3 -f "${ROOT}"/docker-compose/hive/hive-3x.yaml --env-file "${ROOT}"/docker-compose/hive/hadoop-hive-3x.env down
     if [[ "${STOP}" -ne 1 ]]; then
-        sudo docker compose -p ${CONTAINER_UID}hive3 -f "${ROOT}"/docker-compose/hive/hive-3x.yaml --env-file "${ROOT}"/docker-compose/hive/hadoop-hive-3x.env up --build --remove-orphans -d
+        sudo docker compose -p ${CONTAINER_UID}hive3 -f "${ROOT}"/docker-compose/hive/hive-3x.yaml --env-file "${ROOT}"/docker-compose/hive/hadoop-hive-3x.env up --build --remove-orphans -d --wait
     fi
 }
 
@@ -455,7 +455,7 @@ start_iceberg() {
             echo "${ICEBERG_DIR}/data exist, continue !"
         fi
 
-        sudo docker compose -f "${ROOT}"/docker-compose/iceberg/iceberg.yaml --env-file "${ROOT}"/docker-compose/iceberg/iceberg.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/iceberg/iceberg.yaml --env-file "${ROOT}"/docker-compose/iceberg/iceberg.env up -d --wait
     fi
 }
 
@@ -564,7 +564,7 @@ start_mariadb() {
     if [[ "${STOP}" -ne 1 ]]; then
         sudo mkdir -p "${ROOT}"/docker-compose/mariadb/data/
         sudo rm "${ROOT}"/docker-compose/mariadb/data/* -rf
-        sudo docker compose -f "${ROOT}"/docker-compose/mariadb/mariadb-10.yaml --env-file "${ROOT}"/docker-compose/mariadb/mariadb-10.env up -d
+        sudo docker compose -f "${ROOT}"/docker-compose/mariadb/mariadb-10.yaml --env-file "${ROOT}"/docker-compose/mariadb/mariadb-10.env up -d --wait
     fi
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Docker compose `--wait` does the same things as those `hello-world` containers: Wait main service to be health. So just replace the `hello-world` containers to `--wait`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

