### PR TITLE
[bug](analytic) fix duplicate add _num_rows_returned issue

### DIFF
--- a/be/src/pipeline/exec/analytic_source_operator.cpp
+++ b/be/src/pipeline/exec/analytic_source_operator.cpp
@@ -81,7 +81,6 @@ Status AnalyticSourceOperatorX::get_block(RuntimeState* state, vectorized::Block
     local_state.reached_limit(output_block, eos);
     if (!output_block->empty()) {
         auto return_rows = output_block->rows();
-        local_state._num_rows_returned += return_rows;
         COUNTER_UPDATE(local_state._filtered_rows_counter, output_rows - return_rows);
     }
     return Status::OK();

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_column_boundary.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_column_boundary.groovy
@@ -20,7 +20,7 @@ suite("test_column_boundary") {
     sql """
         CREATE TABLE IF NOT EXISTS test_column_boundary (
             u_id int NULL COMMENT "",
-            u_city varchar(20) NULL COMMENT ""
+            u_city varchar(40) NULL COMMENT ""
         ) ENGINE=OLAP
         DUPLICATE KEY(`u_id`, `u_city`)
         DISTRIBUTED BY HASH(`u_id`, `u_city`) BUCKETS 1


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
the _num_rows_returned have been add twice
introduced by https://github.com/apache/doris/pull/46181,
and only in master.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

