### PR TITLE
[opt](nereids) optimize one bucket tpcds performance

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -218,8 +218,7 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<List<List<PhysicalP
         boolean isEnableBucketShuffleJoin = ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin();
         if (!isEnableBucketShuffleJoin) {
             return true;
-        } else if (otherSideSpec.getShuffleType() != ShuffleType.EXECUTION_BUCKETED
-                || !(oneSidePlan instanceof GroupPlan)) {
+        } else if (!(oneSidePlan instanceof GroupPlan)) {
             return false;
         } else {
             PhysicalOlapScan candidate = findDownGradeBucketShuffleCandidate((GroupPlan) oneSidePlan);


### PR DESCRIPTION
### What problem does this PR solve?

use one bucket shuffle hash join is slow than shuffle hash join, so we should downgrade to shuffle hash join when the table only contains one bucket.

this pr is optimized for nereids distribute planner in master branch

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

