### PR TITLE
[fix](nereids) fix range inference generate an empty range

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
@@ -359,6 +359,12 @@ public class AddMinMax implements ExpressionPatternRuleFactory {
                             if (!newRange.isEmpty()) {
                                 value.range = newRange;
                                 value.isDiscrete = value.isDiscrete && otherValue.isDiscrete;
+                                if (newRange.hasLowerBound() && newRange.hasUpperBound()
+                                        && newRange.lowerEndpoint().compareTo(newRange.upperEndpoint()) == 0
+                                        && newRange.lowerBoundType() == BoundType.CLOSED
+                                        && newRange.upperBoundType() == BoundType.CLOSED) {
+                                    value.isDiscrete = true;
+                                }
                             } else {
                                 value.range = null;
                             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
@@ -355,8 +355,13 @@ public class AddMinMax implements ExpressionPatternRuleFactory {
                         value.range = null;
                     } else if (value.range != null) {
                         if (value.range.isConnected(otherValue.range)) {
-                            value.range = value.range.intersection(otherValue.range);
-                            value.isDiscrete = value.isDiscrete && otherValue.isDiscrete;
+                            Range<Literal> newRange = value.range.intersection(otherValue.range);
+                            if (!newRange.isEmpty()) {
+                                value.range = newRange;
+                                value.isDiscrete = value.isDiscrete && otherValue.isDiscrete;
+                            } else {
+                                value.range = null;
+                            }
                         } else {
                             value.range = null;
                         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
@@ -355,7 +355,7 @@ public class AddMinMax implements ExpressionPatternRuleFactory {
                         value.range = null;
                     } else if (value.range != null) {
                         if (value.range.isConnected(otherValue.range)) {
-                            Range<Literal> newRange = value.range.intersection(otherValue.range);
+                            Range<ComparableLiteral> newRange = value.range.intersection(otherValue.range);
                             if (!newRange.isEmpty()) {
                                 value.range = newRange;
                                 // If newRange.lowerEndpoint().equals(newRange.upperEndpoint()),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/AddMinMax.java
@@ -358,13 +358,10 @@ public class AddMinMax implements ExpressionPatternRuleFactory {
                             Range<Literal> newRange = value.range.intersection(otherValue.range);
                             if (!newRange.isEmpty()) {
                                 value.range = newRange;
+                                // If newRange.lowerEndpoint().equals(newRange.upperEndpoint()),
+                                // then isDiscrete should be true.
+                                // But no need to do that because AddMinMax will not handle discrete value cases.
                                 value.isDiscrete = value.isDiscrete && otherValue.isDiscrete;
-                                if (newRange.hasLowerBound() && newRange.hasUpperBound()
-                                        && newRange.lowerEndpoint().compareTo(newRange.upperEndpoint()) == 0
-                                        && newRange.lowerBoundType() == BoundType.CLOSED
-                                        && newRange.upperBoundType() == BoundType.CLOSED) {
-                                    value.isDiscrete = true;
-                                }
                             } else {
                                 value.range = null;
                             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -367,7 +367,10 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             if (other instanceof RangeValue) {
                 RangeValue o = (RangeValue) other;
                 if (range.isConnected(o.range)) {
-                    return new RangeValue(context, reference, range.intersection(o.range));
+                    Range<Literal> newRange = range.intersection(o.range);
+                    if (!newRange.isEmpty()) {
+                        return new RangeValue(context, reference, newRange);
+                    }
                 }
                 return new EmptyValue(context, reference);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -369,7 +369,14 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
                 if (range.isConnected(o.range)) {
                     Range<Literal> newRange = range.intersection(o.range);
                     if (!newRange.isEmpty()) {
-                        return new RangeValue(context, reference, newRange);
+                        if (newRange.hasLowerBound() && newRange.hasUpperBound()
+                                && newRange.lowerEndpoint().compareTo(newRange.upperEndpoint()) == 0
+                                && newRange.lowerBoundType() == BoundType.CLOSED
+                                && newRange.lowerBoundType() == BoundType.CLOSED) {
+                            return new DiscreteValue(context, reference, Sets.newHashSet(newRange.lowerEndpoint()));
+                        } else {
+                            return new RangeValue(context, reference, newRange);
+                        }
                     }
                 }
                 return new EmptyValue(context, reference);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -367,7 +367,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             if (other instanceof RangeValue) {
                 RangeValue o = (RangeValue) other;
                 if (range.isConnected(o.range)) {
-                    Range<Literal> newRange = range.intersection(o.range);
+                    Range<ComparableLiteral> newRange = range.intersection(o.range);
                     if (!newRange.isEmpty()) {
                         if (newRange.hasLowerBound() && newRange.hasUpperBound()
                                 && newRange.lowerEndpoint().compareTo(newRange.upperEndpoint()) == 0

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -312,6 +312,10 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
         assertRewriteAfterTypeCoercion("(TA + TC > 10 and TB > 10) or (TB > 10 and TB > 20)", "(TA + TC > 10 or TB > 20) AND TB > 10");
         assertRewriteAfterTypeCoercion("((TA + TC > 10 or TA + TC > 5) and TB > 10) or (TB > 10 and (TB > 20 or TB < 10))",
                 "((TA + TC > 10 or TA + TC > 5) or (TB > 20 or TB < 10)) and TB > 10");
+        assertRewriteAfterTypeCoercion("TA >= 8 and TB >= 1 or TA < 8 and TB <= 10",
+                "TA >= 8 and TB >= 1 or TA < 8 and TB <= 10");
+        assertRewriteAfterTypeCoercion("TA >= 8 and TB >= 1 and TA < 8 and TB <= 10",
+                "TA >= 8 and TB >= 1 and TA < 8 and TB <= 10");
         assertRewriteAfterTypeCoercion("(CA >= date '2024-01-01' and CA <= date '2024-01-03') or (CA > date '2024-01-05' and CA < date '2024-01-07')",
                 "(CA <= date '2024-01-03' or CA > date '2024-01-05') and CA >= date '2024-01-01' and CA < date '2024-01-07')");
         assertRewriteAfterTypeCoercion("CA in (date '2024-01-01',date '2024-01-02',date '2024-01-03') or CA < date '2024-01-01'",

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -114,7 +114,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewrite("(TA > 3 and TA < 1) or (TA > 7 and TA < 5)", "TA is null and null");
         assertRewriteNotNull("TA > 3 and TA < 1", "FALSE");
         assertRewrite("TA > 3 and TA < 1", "TA is null and null");
-        assertRewrite("TA >= 3 and TA < 3", "TA >= 3 and TA < 3");
+        assertRewrite("TA >= 3 and TA < 3", "TA is null and null");
         assertRewriteNotNull("TA = 1 and TA > 10", "FALSE");
         assertRewrite("TA = 1 and TA > 10", "TA is null and null");
         assertRewrite("TA > 5 or TA < 1", "TA < 1 or TA > 5");
@@ -176,7 +176,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewrite("(TA + TC > 3 and TA + TC < 1) or (TA + TC > 7 and TA + TC < 5)", "(TA + TC) is null and null");
         assertRewriteNotNull("TA + TC > 3 and TA + TC < 1", "FALSE");
         assertRewrite("TA + TC > 3 and TA + TC < 1", "(TA + TC) is null and null");
-        assertRewrite("TA + TC >= 3 and TA + TC < 3", "TA + TC >= 3 and TA + TC < 3");
+        assertRewrite("TA + TC >= 3 and TA + TC < 3", "TA + TC is null and null");
         assertRewriteNotNull("TA + TC = 1 and TA + TC > 10", "FALSE");
         assertRewrite("TA + TC = 1 and TA + TC > 10", "(TA + TC) is null and null");
         assertRewrite("TA + TC > 5 or TA + TC < 1", "TA + TC < 1 or TA + TC > 5");
@@ -246,7 +246,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewriteNotNull("AA > date '2024-01-03' and AA < date '2024-01-01'", "FALSE");
         assertRewrite("AA > date '2024-01-03' and AA < date '2024-01-01'", "AA is null and null");
         assertRewrite("AA >= date '2024-01-01' and AA < date '2024-01-01'",
-                "AA >= date '2024-01-01' and AA < date '2024-01-01'");
+                "AA IS NULL AND NULL");
         assertRewriteNotNull("AA = date '2024-01-01' and AA > date '2024-01-10'", "FALSE");
         assertRewrite("AA = date '2024-01-01' and AA > date '2024-01-10'", "AA is null and null");
         assertRewrite("AA > date '2024-01-05' or AA < date '2024-01-01'",
@@ -326,7 +326,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewriteNotNull("CA > timestamp '2024-01-03 00:00:10' and CA < timestamp '2024-01-01 01:00:00'", "FALSE");
         assertRewrite("CA > timestamp '2024-01-03 00:00:10' and CA < timestamp '2024-01-01 01:00:00'", "CA is null and null");
         assertRewrite("CA >= timestamp '2024-01-01 00:00:10' and CA < timestamp '2024-01-01 00:00:10'",
-                "CA >= timestamp '2024-01-01 00:00:10' and CA < timestamp '2024-01-01 00:00:10'");
+                "CA is null and null");
         assertRewriteNotNull("CA = timestamp '2024-01-01 10:00:10' and CA > timestamp '2024-01-10 00:00:10'", "FALSE");
         assertRewrite("CA = timestamp '2024-01-01 10:00:10' and CA > timestamp '2024-01-10 00:00:10'", "CA is null and null");
         assertRewrite("CA > timestamp '2024-01-05 00:00:10' or CA < timestamp '2024-01-01 00:00:10'",

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -117,6 +117,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewrite("TA >= 3 and TA < 3", "TA is null and null");
         assertRewriteNotNull("TA = 1 and TA > 10", "FALSE");
         assertRewrite("TA = 1 and TA > 10", "TA is null and null");
+        assertRewrite("TA >= 1 and TA <= 1", "TA = 1");
         assertRewrite("TA > 5 or TA < 1", "TA < 1 or TA > 5");
         assertRewrite("TA > 5 or TA > 1 or TA > 10", "TA > 1");
         assertRewrite("TA > 5 or TA > 1 or TA < 10", "TA is not null or null");


### PR DESCRIPTION
### What problem does this PR solve?

for `a >= 8 and a <8`  will generate a range(a>=8) interset range(a <8)  = range[8, 8),  this is a empty range.

PR #46303 introduce a RangeSet to hold the union of RangeValues,  for a empty range[8, 8),   RangeSet.asRanges() will return empty. Then cause a index out of bound exception.

```
Caused by: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
        at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
        at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?]
        at java.util.Objects.checkIndex(Objects.java:359) ~[?:?]
        at java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
        at org.apache.doris.nereids.rules.expression.rules.RangeInference.simplify(RangeInference.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.rules.expression.rules.RangeInference.visitOr(RangeInference.java:130) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.rules.expression.rules.RangeInference.visitOr(RangeInference.java:59) ~[doris-fe.jar:1.2-SNAPSHOT]
```

Fix:  for a empty RangeValue like [8, 8),  replace it with an EmptyValue.

What's more,  this PR will also replace singleton RangeValue  like  ([8, 8]) to DiscreteValue([8]),  so after this PR,  simplify range will rewrite `a >= 8 and a <= 8`  to `a = 8`. This is just BetweenToEqual rule do. After this PR,  we can remove rule BetweenToEqual.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

