### PR TITLE
[chore] Add Clang 18/19 Support

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -267,6 +267,8 @@ add_compile_options(-g
                     $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
 
 add_compile_options(-Wno-unused-parameter
+                    $<$<COMPILE_LANGUAGE:CXX>:-Wno-incompatible-pointer-types>
+                    -Wno-deprecated-declarations
                     -Wno-sign-compare)
 
 if (COMPILER_GCC)

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -414,7 +414,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
 }
 
 void ExchangeSinkBuffer::_ended(InstanceLoId id) {
-    if (!_instance_to_package_queue_mutex.template contains(id)) {
+    if (!_instance_to_package_queue_mutex.contains(id)) {
         std::stringstream ss;
         ss << "failed find the instance id:" << id
            << " now mutex map size:" << _instance_to_package_queue_mutex.size();

--- a/be/src/pipeline/exec/hashjoin_probe_operator.cpp
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.cpp
@@ -252,7 +252,7 @@ Status HashJoinProbeOperatorX::pull(doris::RuntimeState* state, vectorized::Bloc
                     if constexpr (!std::is_same_v<HashTableProbeType, std::monostate>) {
                         using HashTableCtxType = std::decay_t<decltype(arg)>;
                         if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
-                            st = process_hashtable_ctx.template process(
+                            st = process_hashtable_ctx.process(
                                     arg,
                                     local_state._null_map_column
                                             ? &local_state._null_map_column->get_data()

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -451,7 +451,7 @@ template <typename T>
 void ColumnDecimal<T>::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                                    IColumn::Permutation& perms, EqualRange& range,
                                    bool last_column) const {
-    sorter->template sort_column(static_cast<const Self&>(*this), flags, perms, range, last_column);
+    sorter->sort_column(static_cast<const Self&>(*this), flags, perms, range, last_column);
 }
 
 template <typename T>

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -152,7 +152,7 @@ template <typename T>
 void ColumnVector<T>::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                                   IColumn::Permutation& perms, EqualRange& range,
                                   bool last_column) const {
-    sorter->template sort_column(static_cast<const Self&>(*this), flags, perms, range, last_column);
+    sorter->sort_column(static_cast<const Self&>(*this), flags, perms, range, last_column);
 }
 
 template <typename T>

--- a/be/src/vec/exec/jni_connector.h
+++ b/be/src/vec/exec/jni_connector.h
@@ -93,7 +93,7 @@ public:
     struct ScanPredicate {
         ScanPredicate() = default;
         ~ScanPredicate() = default;
-        const std::string column_name;
+        std::string column_name;
         SQLFilterOp op;
         std::vector<const CppType*> values;
         int scale;

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -560,7 +560,7 @@ private:
         if constexpr (IsDecimalV2<B> || IsDecimalV2<A>) {
             // Now, Doris only support decimal +-*/ decimal.
             if constexpr (check_overflow) {
-                auto res = Op::template apply(DecimalV2Value(a), DecimalV2Value(b)).value();
+                auto res = Op::apply(DecimalV2Value(a), DecimalV2Value(b)).value();
                 if (res > max_result_number.value || res < -max_result_number.value) {
                     THROW_DECIMAL_BINARY_OP_OVERFLOW_EXCEPTION(
                             DecimalV2Value(a).to_string(), Name::name,
@@ -569,7 +569,7 @@ private:
                 }
                 return res;
             } else {
-                return Op::template apply(DecimalV2Value(a), DecimalV2Value(b)).value();
+                return Op::apply(DecimalV2Value(a), DecimalV2Value(b)).value();
             }
         } else {
             NativeResultType res;
@@ -664,7 +664,7 @@ private:
         if constexpr (IsDecimalV2<B> || IsDecimalV2<A>) {
             DecimalV2Value l(a);
             DecimalV2Value r(b);
-            auto ans = Op::template apply(l, r, is_null);
+            auto ans = Op::apply(l, r, is_null);
             using ANS_TYPE = std::decay_t<decltype(ans)>;
             if constexpr (check_overflow && OpTraits::is_division) {
                 if constexpr (std::is_same_v<ANS_TYPE, DecimalV2Value>) {

--- a/build.sh
+++ b/build.sh
@@ -286,7 +286,7 @@ if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 # build thirdparty libraries if necessary
-if [[ ! -f "${DORIS_THIRDPARTY}/installed/lib/libbacktrace.a" ]]; then
+if [[ ! -f "${DORIS_THIRDPARTY}/installed/lib/hadoop_hdfs/native/libhdfs.a" ]]; then
     echo "Thirdparty libraries need to be build ..."
     # need remove all installed pkgs because some lib like lz4 will throw error if its lib alreay exists
     rm -rf "${DORIS_THIRDPARTY}/installed"

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1052,13 +1052,13 @@ build_arrow() {
         -DBoost_USE_STATIC_RUNTIME=ON \
         -DARROW_GFLAGS_USE_SHARED=OFF \
         -Dgflags_ROOT="${TP_INSTALL_DIR}" \
-        -DGLOG_ROOT="${TP_INSTALL_DIR}" \
-        -DRE2_ROOT="${TP_INSTALL_DIR}" \
+        -Dglog_ROOT="${TP_INSTALL_DIR}" \
+        -Dre2_ROOT="${TP_INSTALL_DIR}" \
         -DZLIB_SOURCE=SYSTEM \
         -DZLIB_LIBRARY="${TP_INSTALL_DIR}/lib/libz.a" -DZLIB_INCLUDE_DIR="${TP_INSTALL_DIR}/include" \
         -DRapidJSON_SOURCE=SYSTEM \
         -DRapidJSON_ROOT="${TP_INSTALL_DIR}" \
-        -DORC_ROOT="${TP_INSTALL_DIR}" \
+        -Dorc_ROOT="${TP_INSTALL_DIR}" \
         -Dxsimd_SOURCE=BUNDLED \
         -DBrotli_SOURCE=BUNDLED \
         -DARROW_LZ4_USE_SHARED=OFF \
@@ -1069,7 +1069,7 @@ build_arrow() {
         -Dzstd_SOURCE=SYSTEM \
         -DSnappy_LIB="${TP_INSTALL_DIR}/lib/libsnappy.a" -DSnappy_INCLUDE_DIR="${TP_INSTALL_DIR}/include" \
         -DSnappy_SOURCE=SYSTEM \
-        -DBOOST_ROOT="${TP_INSTALL_DIR}" --no-warn-unused-cli \
+        -DBoost_ROOT="${TP_INSTALL_DIR}" --no-warn-unused-cli \
         -DARROW_JEMALLOC=OFF -DARROW_MIMALLOC=OFF \
         -DJEMALLOC_HOME="${TP_INSTALL_DIR}" \
         -DARROW_THRIFT_USE_SHARED=OFF \

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -425,6 +425,7 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " AWS_SDK " ]]; then
                 bash ./prefetch_crt_dependency.sh
             fi
             patch -p1 <"${TP_PATCH_DIR}/aws-sdk-cpp-1.11.119.patch"
+            patch -p1 <"${TP_PATCH_DIR}/aws-sdk-cpp-1.11.119-cmake.patch"
         else
             bash ./prefetch_crt_dependency.sh
         fi
@@ -487,6 +488,58 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " BASE64 " ]]; then
         cd -
     fi
     echo "Finished patching ${BASE64_SOURCE}"
+fi
+
+# patch libuuid
+if [[ " ${TP_ARCHIVES[*]} " =~ " LIBUUID " ]]; then
+    if [[ "${LIBUUID_SOURCE}" = "libuuid-1.0.3" ]]; then
+        cd "${TP_SOURCE_DIR}/${LIBUUID_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            patch -p1 <"${TP_PATCH_DIR}/libuuid-1.0.3.patch"
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${LIBUUID_SOURCE}"
+fi
+
+# patch libdivide
+if [[ " ${TP_ARCHIVES[*]} " =~ " LIBDIVIDE " ]]; then
+    if [[ "${LIBDIVIDE_SOURCE}" = "libdivide-5.0" ]]; then
+        cd "${TP_SOURCE_DIR}/${LIBDIVIDE_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            patch -p1 <"${TP_PATCH_DIR}/libdivide-5.0.patch"
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${LIBDIVIDE_SOURCE}"
+fi
+
+# patch grpc
+if [[ " ${TP_ARCHIVES[*]} " =~ " GRPC " ]]; then
+    if [[ "${GRPC_SOURCE}" = "grpc-1.54.3" ]]; then
+        cd "${TP_SOURCE_DIR}/${GRPC_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            patch -p1 <"${TP_PATCH_DIR}/grpc-1.54.3.patch"
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${GRPC_SOURCE}"
+fi
+
+# patch flatbuffer
+if [[ " ${TP_ARCHIVES[*]} " =~ " FLATBUFFERS " ]]; then
+    if [[ "${FLATBUFFERS_SOURCE}" = "flatbuffers-2.0.0" ]]; then
+        cd "${TP_SOURCE_DIR}/${FLATBUFFERS_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            patch -p1 <"${TP_PATCH_DIR}/flatbuffers-2.0.0.patch"
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${FLATBUFFERS_SOURCE}"
 fi
 
 # patch krb

--- a/thirdparty/patches/aws-sdk-cpp-1.11.119-cmake.patch
+++ b/thirdparty/patches/aws-sdk-cpp-1.11.119-cmake.patch
@@ -1,0 +1,11 @@
+--- a/crt/aws-crt-cpp/crt/aws-c-cal/CMakeLists.txt	2025-01-06 21:23:51.057566544 +0800
++++ b/crt/aws-crt-cpp/crt/aws-c-cal/CMakeLists.txt	2025-01-06 16:50:56.480567259 +0800
+@@ -8,7 +8,7 @@
+     cmake_policy(SET CMP0069 NEW) # Enable LTO/IPO if available in the compiler, see AwsCFlags
+ endif()
+ 
+-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
++# set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+ 
+ option(BYO_CRYPTO "Set this if you want to provide your own cryptography implementation. This will cause the defaults to not be compiled." OFF)
+ option(USE_OPENSSL "Set this if you want to use your system's OpenSSL 1.0.2/1.1.1 compatible libcrypto" OFF)

--- a/thirdparty/patches/flatbuffers-2.0.0.patch
+++ b/thirdparty/patches/flatbuffers-2.0.0.patch
@@ -1,0 +1,11 @@
+--- a/include/flatbuffers/stl_emulation.h	2021-05-11 02:45:16.000000000 +0800
++++ b/include/flatbuffers/stl_emulation.h	2025-01-06 22:43:47.538175771 +0800
+@@ -625,7 +625,7 @@
+  private:
+   // This is a naive implementation with 'count_' member even if (Extent != dynamic_extent).
+   pointer const data_;
+-  const size_type count_;
++  size_type count_;
+ };
+ 
+  #if !defined(FLATBUFFERS_SPAN_MINIMAL)

--- a/thirdparty/patches/grpc-1.54.3.patch
+++ b/thirdparty/patches/grpc-1.54.3.patch
@@ -1,0 +1,11 @@
+--- a/src/core/lib/promise/detail/basic_seq.h	2025-01-06 22:41:37.857651534 +0800
++++ b/src/core/lib/promise/detail/basic_seq.h	2025-01-06 22:41:42.308703853 +0800
+@@ -471,7 +471,7 @@
+           cur_ = next;
+           state_.~State();
+           Construct(&state_,
+-                    Traits::template CallSeqFactory(f_, *cur_, std::move(arg)));
++                    Traits::CallSeqFactory(f_, *cur_, std::move(arg)));
+           return PollNonEmpty();
+         });
+   }

--- a/thirdparty/patches/libdivide-5.0.patch
+++ b/thirdparty/patches/libdivide-5.0.patch
@@ -1,0 +1,11 @@
+--- a/libdivide.h	2025-01-06 22:27:33.308725176 +0800
++++ b/libdivide.h	2025-01-06 22:27:41.517821664 +0800
+@@ -3017,7 +3017,7 @@
+     T recover() const { return div.recover(); }
+ 
+     bool operator==(const divider<T, ALGO> &other) const {
+-        return div.denom.magic == other.denom.magic && div.denom.more == other.denom.more;
++        return div.denom.magic == other.div.denom.magic && div.denom.more == other.div.denom.more;
+     }
+ 
+     bool operator!=(const divider<T, ALGO> &other) const { return !(*this == other); }

--- a/thirdparty/patches/libuuid-1.0.3.patch
+++ b/thirdparty/patches/libuuid-1.0.3.patch
@@ -1,0 +1,19 @@
+--- a/gen_uuid.c	2025-01-06 21:27:05.241857362 +0800
++++ b/gen_uuid.c	2025-01-06 17:30:03.201419206 +0800
+@@ -38,6 +38,8 @@
+  */
+ #define _SVID_SOURCE
+ 
++#include "c.h"
++
+ #ifdef _WIN32
+ #define _WIN32_WINNT 0x0500
+ #include <windows.h>
+@@ -91,7 +93,6 @@
+ #include "uuidP.h"
+ #include "uuidd.h"
+ #include "randutils.h"
+-#include "c.h"
+ 
+ #ifdef HAVE_TLS
+ #define THREAD_LOCAL static __thread


### PR DESCRIPTION
This PR adds support to compile Doris backend with Clang 19.  

I've tested this PR with both Clang 16 and Clang 19 using:  
```bash  
env DISABLE_BUILD_AZURE=1 ./build.sh --be --clean  
```  
*(Azure was disabled due to challenges patching deps in `azure-sdk-for-cpp-azure-core_1.10.3` via vcpkg.)*  

I've released a new toolchain with GCC 14 and Clang 19 here: [ldb_toolchain](https://github.com/amosbird/ldb_toolchain_gen/releases/tag/v0.23).  

Happy New Year to the Doris community! 🎉  

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

