### PR TITLE
[fix](profile) Fix merge profile failed due to NonZeroCounter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/RuntimeProfile.java
@@ -529,18 +529,20 @@ public class RuntimeProfile {
         for (String childCounterName : childCounterSet) {
             Counter counter = templateProfile.counterMap.get(childCounterName);
             if (counter == null) {
-                throw new RuntimeException("Child counter " + childCounterName + " of " + parentCounterName
-                        + " not found in profile");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Child counter {} of {} not found in profile {}", childCounterName, parentCounterName,
+                        templateProfile.toString());
+                }
+                continue;
             }
             if (counter.getLevel() == 1) {
                 Counter oldCounter = templateCounterMap.get(childCounterName);
                 AggCounter aggCounter = new AggCounter(oldCounter.getType());
                 for (RuntimeProfile profile : profiles) {
+                    // orgCounter could be null if counter structure is changed
+                    // change of counter structure happens when NonZeroCounter is involved.
+                    // So here we have to ignore the counter if it is not found in the profile.
                     Counter orgCounter = profile.counterMap.get(childCounterName);
-                    if (orgCounter == null) {
-                        throw new RuntimeException("Child counter " + childCounterName
-                                                + " of " + parentCounterName + " not found in profile");
-                    }
                     aggCounter.addCounter(orgCounter);
                 }
                 if (nereidsId != null && childCounterName.equals("RowsProduced")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/RuntimeProfile.java
@@ -531,7 +531,7 @@ public class RuntimeProfile {
             if (counter == null) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Child counter {} of {} not found in profile {}", childCounterName, parentCounterName,
-                        templateProfile.toString());
+                            templateProfile.toString());
                 }
                 continue;
             }


### PR DESCRIPTION
### What problem does this PR solve?
orgCounter could be null if counter structure is changed
change of counter structure happens when NonZeroCounter is involved.
So here we have to ignore the counter if it is not found in the profile.

Related PR: https://github.com/apache/doris/pull/47070

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

