### PR TITLE
[fix](cloud) shorten cache lock held time and add metrics

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1060,7 +1060,8 @@ DEFINE_Bool(enable_ttl_cache_evict_using_lru, "true");
 DEFINE_mBool(enbale_dump_error_file, "false");
 // limit the max size of error log on disk
 DEFINE_mInt64(file_cache_error_log_limit_bytes, "209715200"); // 200MB
-DEFINE_mInt64(cache_lock_long_tail_threshold, "1000");
+DEFINE_mInt64(cache_lock_wait_long_tail_threshold_us, "30000000");
+DEFINE_mInt64(cache_lock_held_long_tail_threshold_us, "30000000");
 DEFINE_mBool(enable_file_cache_keep_base_compaction_output, "false");
 DEFINE_mInt64(file_cache_remove_block_qps_limit, "1000");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1100,7 +1100,8 @@ DECLARE_Bool(enable_ttl_cache_evict_using_lru);
 DECLARE_mBool(enbale_dump_error_file);
 // limit the max size of error log on disk
 DECLARE_mInt64(file_cache_error_log_limit_bytes);
-DECLARE_mInt64(cache_lock_long_tail_threshold);
+DECLARE_mInt64(cache_lock_wait_long_tail_threshold_us);
+DECLARE_mInt64(cache_lock_held_long_tail_threshold_us);
 // Base compaction may retrieve and produce some less frequently accessed data,
 // potentially affecting the file cache hit rate.
 // This configuration determines whether to retain the output within the file cache.

--- a/be/src/io/cache/file_block.cpp
+++ b/be/src/io/cache/file_block.cpp
@@ -59,6 +59,10 @@ FileBlock::State FileBlock::state() const {
     return _download_state;
 }
 
+FileBlock::State FileBlock::state_unsafe() const {
+    return _download_state;
+}
+
 uint64_t FileBlock::get_caller_id() {
     uint64_t id;
 #if defined(__APPLE__)
@@ -144,7 +148,7 @@ Status FileBlock::append(Slice data) {
 
 Status FileBlock::finalize() {
     if (_downloaded_size != 0 && _downloaded_size != _block_range.size()) {
-        SCOPED_CACHE_LOCK(_mgr->_mutex);
+        SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);
         size_t old_size = _block_range.size();
         _block_range.right = _block_range.left + _downloaded_size - 1;
         size_t new_size = _block_range.size();
@@ -179,7 +183,7 @@ Status FileBlock::change_cache_type_between_ttl_and_others(FileCacheType new_typ
 }
 
 Status FileBlock::change_cache_type_between_normal_and_index(FileCacheType new_type) {
-    SCOPED_CACHE_LOCK(_mgr->_mutex);
+    SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);
     std::lock_guard block_lock(_mutex);
     bool expr = (new_type != FileCacheType::TTL && _key.meta.type != FileCacheType::TTL);
     if (!expr) {
@@ -293,7 +297,7 @@ FileBlocksHolder::~FileBlocksHolder() {
                 }
             }
             if (should_remove) {
-                SCOPED_CACHE_LOCK(_mgr->_mutex);
+                SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);
                 std::lock_guard block_lock(file_block->_mutex);
                 if (file_block.use_count() == 2) {
                     DCHECK(file_block->state_unlock(block_lock) != FileBlock::State::DOWNLOADING);

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -66,6 +66,7 @@ public:
     ~FileBlock() = default;
 
     State state() const;
+    State state_unsafe() const;
 
     static std::string state_to_string(FileBlock::State state);
 

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -488,7 +488,7 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
     std::vector<BatchLoadArgs> batch_load_buffer;
     batch_load_buffer.reserve(scan_length);
     auto add_cell_batch_func = [&]() {
-        SCOPED_CACHE_LOCK(_mgr->_mutex);
+        SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);
 
         auto f = [&](const BatchLoadArgs& args) {
             // in async load mode, a cell may be added twice.

--- a/build.sh
+++ b/build.sh
@@ -458,7 +458,7 @@ if [[ -z "${ENABLE_INJECTION_POINT}" ]]; then
 fi
 
 if [[ -z "${ENABLE_CACHE_LOCK_DEBUG}" ]]; then
-    ENABLE_CACHE_LOCK_DEBUG='OFF'
+    ENABLE_CACHE_LOCK_DEBUG='ON'
 fi
 
 if [[ -z "${BUILD_BENCHMARK}" ]]; then


### PR DESCRIPTION
when update bvar metrics, we held block lock in the critical context of cache lock, make the later lock held too long and affect other cache logic. we use unsafe method to update the bvar to boost performance.

some key metrics of lock and other meaningful metrics are also added for better monitoring cache time costs.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

