### PR TITLE
[Fix](recycler) Delete again to double check when recycle tablet failed by some bugs

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1521,25 +1521,28 @@ int InstanceRecycler::delete_rowset_data(const std::vector<doris::RowsetMetaClou
             InvertedIndexInfo index_info;
             int get_ret =
                     inverted_index_id_cache_->get(rs.index_id(), rs.schema_version(), index_info);
-            if (get_ret != 0) {
-                if (get_ret == 1) { // Schema kv not found
-                    // Check tablet existence
-                    std::string tablet_idx_key, tablet_idx_val;
-                    meta_tablet_idx_key({instance_id_, tablet_id}, &tablet_idx_key);
-                    if (txn_get(txn_kv_.get(), tablet_idx_key, tablet_idx_val) == 1) {
-                        // Tablet has been recycled, rowset data has already been deleted
-                        std::lock_guard lock(recycled_tablets_mtx_);
-                        recycled_tablets_.insert(tablet_id);
-                        continue;
-                    }
+            if (get_ret == 0) {
+                index_format = index_info.first;
+                index_ids = std::move(index_info.second);
+            } else if (get_ret == 1) {
+                // Schema kv not found means tablet has been recycled
+                // Maybe some tablet recycle failed by some bugs
+                // We need to delete again to double check
+                LOG_INFO(
+                        "delete rowset data schema kv not found, need to delete again to double "
+                        "check")
+                        .tag("instance_id", instance_id_)
+                        .tag("tablet_id", tablet_id)
+                        .tag("rowset", rs.ShortDebugString());
+                for (int64_t i = 0; i < num_segments; ++i) {
+                    file_paths.push_back(segment_path(tablet_id, rowset_id, i));
                 }
+            } else {
                 LOG(WARNING) << "failed to get schema kv for rowset, instance_id=" << instance_id_
                              << " tablet_id=" << tablet_id << " rowset_id=" << rowset_id;
                 ret = -1;
                 continue;
             }
-            index_format = index_info.first;
-            index_ids = std::move(index_info.second);
         }
         if (rs.rowset_state() == RowsetStatePB::BEGIN_PARTIAL_UPDATE) {
             // if rowset state is RowsetStatePB::BEGIN_PARTIAL_UPDATE, the number of segments data


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #46798

Problem Summary:

### Background:
1. In PR #46798, we modified the way to recycle tablets because if there is a vault that fails to initialize, the original way of recycling tablets would directly return -1 when encountering a failed vault due to not finding an accessor, resulting in an inability to recycle normally. PR #46798 changed this to traverse rowsets and obtain accessors based on resource IDs. Compared to the previous method of directly returning -1 and not recycling anything, this approach can recycle as many rowsets as possible as long as the vault is normal.

2. The aforementioned PR modified the way of recycling tablets. Due to historical reasons, [0-1] rowsetPB does not have a resource ID. Since we assumed that all rowsetPBs have a resource ID, once there is no resource ID, it would return -1, causing the recycling to fail. This [0-1] recycling failure issue was fixed in PR #47324.

3. The problem addressed by the current PR occurred in the recycler pipeline. The specific phenomenon was that a schema change failed and was aborted, and then the recycler executed the recycling, only to find that the meta was deleted but the rowset object was not.

4. This is because before this PR, if recycle tmp rowset found that the schema of a tablet was missing, it would directly skip recycling the object and only recycle the meta. This method was fine before PR #46798 because recycle tablet would directly delete the tablet folder on the object, and by the time it got to recycle tmp rowset, only recycling the meta was enough. However, after PR #46798, if a tablet only has [0-1] rowsets, and an import fails, then [2-2] will become a tmp rowset. When recycle tablet recycles, it finds only [0-1], so it skips recycling the tablet folder object and only recycles the meta. When recycle tmp rowset, it finds that the tablet schema meta of the tmp rowset is missing, so it thinks [2-2] has been deleted by recycle tablet when it directly deletes the folder, so recycle tmp rowset only deletes the meta.

5. This ultimately led to the deletion of the meta but not the rowset object.

### Solution:
This PR modifies the logic of recycle tmp rowset. Regardless of whether the schema meta of the tablet of this rowset exists, it is necessary to recycle the object file of this rowset, which can ensure that all objects can be recycled. In addition, resource IDs will be added to [0-1] during table creation in the future to ensure that recycle tablet can also delete normally. Once [0-1] has a resource ID, both recycle tablet and recycle tmp rowset will delete the object data, providing two layers of protection.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

