### PR TITLE
[enhancement](brpc) remove client from brpc cache if the underlying channel has error

### DIFF
--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -72,11 +72,10 @@ public:
         auto* cntl = static_cast<brpc::Controller*>(_controller);
         if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
             Status error_st = Status::NetworkError(
-                    "1Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
+                    "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
                     berror(cntl->ErrorCode()), cntl->ErrorText(), BackendOptions::get_localhost(),
                     cntl->latency_us());
             LOG(WARNING) << error_st;
-            std::cout << error_st << std::endl;
             _channel_st->update(error_st);
         }
         // Sometimes done == nullptr, for example hand_shake API.
@@ -118,11 +117,10 @@ public:
             auto* cntl = static_cast<brpc::Controller*>(controller);
             if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
                 Status error_st = Status::NetworkError(
-                        "2Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
+                        "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
                         berror(cntl->ErrorCode()), cntl->ErrorText(),
                         BackendOptions::get_localhost(), cntl->latency_us());
                 LOG(WARNING) << error_st;
-                std::cout << error_st << std::endl;
                 _channel_st->update(error_st);
             }
         }

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -76,8 +76,10 @@ public:
                     berror(cntl->ErrorCode()), cntl->ErrorText(), BackendOptions::get_localhost(),
                     cntl->latency_us());
             LOG(WARNING) << error_st;
+            std::cout << error_st << std::endl;
             _channel_st->update(error_st);
         }
+        // Sometimes done == nullptr, for example hand_shake API.
         if (_done != nullptr) {
             _done->Run();
         }

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -114,11 +114,12 @@ public:
         }
         ::brpc::Channel::CallMethod(method, controller, request, response, failure_detect_closure);
         if (done == nullptr) {
-            if (controller->Failed() && controller->ErrorCode() == EHOSTDOWN) {
+            auto* cntl = static_cast<brpc::Controller*>(_controller);
+            if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
                 Status error_st = Status::NetworkError(
                         "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
-                        berror(controller->ErrorCode()), controller->ErrorText(),
-                        BackendOptions::get_localhost(), controller->latency_us());
+                        berror(cntl->ErrorCode()), cntl->ErrorText(),
+                        BackendOptions::get_localhost(), cntl->latency_us());
                 LOG(WARNING) << error_st;
                 std::cout << error_st << std::endl;
                 _channel_st->update(error_st);

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -92,7 +92,7 @@ private:
 // If some non-recoverable rpc failure happens, it will save the error status in
 // _channel_st.
 // And brpc client cache will depend on it to detect if the client is health.
-class FailureDetectChannel : ::brpc::Channel {
+class FailureDetectChannel : public ::brpc::Channel {
 public:
     FailureDetectChannel() : ::brpc::Channel() {
         _channel_st = std::make_shared<AtomicStatus>(); // default OK

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -72,7 +72,7 @@ public:
         if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
             Status error_st = Status::NetworkError(
                     "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
-                    berror(cntl->ErrorCode()), cntl > ErrorText(), BackendOptions::get_localhost(),
+                    berror(cntl->ErrorCode()), cntl->ErrorText(), BackendOptions::get_localhost(),
                     cntl->latency_us());
             LOG(WARNING) << error_st;
             _channel_st->update(error_st);
@@ -105,7 +105,7 @@ public:
         ::brpc::Channel::CallMethod(method, controller, request, response, failure_detect_closure);
     }
 
-    AtomicStatus& channel_status() { return _channel_st; }
+    std::shared_ptr<AtomicStatus> channel_status() { return _channel_st; }
 
 private:
     std::shared_ptr<AtomicStatus> _channel_st;

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -106,7 +106,10 @@ public:
                     google::protobuf::RpcController* controller,
                     const google::protobuf::Message* request, google::protobuf::Message* response,
                     google::protobuf::Closure* done) override {
-        auto* failure_detect_closure = new FailureDetectClosure(_channel_st, controller, done);
+        FailureDetectClosure* failure_detect_closure = nullptr;
+        if (done != nullptr) {
+            failure_detect_closure = new FailureDetectClosure(_channel_st, controller, done);
+        }
         ::brpc::Channel::CallMethod(method, controller, request, response, failure_detect_closure);
     }
 

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -72,7 +72,7 @@ public:
         auto* cntl = static_cast<brpc::Controller*>(_controller);
         if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
             Status error_st = Status::NetworkError(
-                    "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
+                    "1Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
                     berror(cntl->ErrorCode()), cntl->ErrorText(), BackendOptions::get_localhost(),
                     cntl->latency_us());
             LOG(WARNING) << error_st;
@@ -118,7 +118,7 @@ public:
             auto* cntl = static_cast<brpc::Controller*>(controller);
             if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
                 Status error_st = Status::NetworkError(
-                        "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
+                        "2Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",
                         berror(cntl->ErrorCode()), cntl->ErrorText(),
                         BackendOptions::get_localhost(), cntl->latency_us());
                 LOG(WARNING) << error_st;

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -113,8 +113,9 @@ public:
             failure_detect_closure = new FailureDetectClosure(_channel_st, controller, done);
         }
         ::brpc::Channel::CallMethod(method, controller, request, response, failure_detect_closure);
+        // Done == nullptr, it is a sync call, should also deal with the bad channel.
         if (done == nullptr) {
-            auto* cntl = static_cast<brpc::Controller*>(_controller);
+            auto* cntl = static_cast<brpc::Controller*>(controller);
             if (cntl->Failed() && cntl->ErrorCode() == EHOSTDOWN) {
                 Status error_st = Status::NetworkError(
                         "Failed to send brpc, error={}, error_text={}, client: {}, latency = {}",

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -78,7 +78,9 @@ public:
             LOG(WARNING) << error_st;
             _channel_st->update(error_st);
         }
-        _done->Run();
+        if (_done != nullptr) {
+            _done->Run();
+        }
         // _done->Run may throw exception, so that move delete this to Defer.
         // delete this;
     }

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -42,6 +42,7 @@
 #include "common/config.h"
 #include "common/status.h"
 #include "runtime/exec_env.h"
+#include "service/backend_options.h"
 #include "util/dns_cache.h"
 #include "util/network_util.h"
 
@@ -157,7 +158,7 @@ public:
             // All client created from this cache will use FailureDetectChannel, so it is
             // safe to do static cast here.
             // Check if the base channel is OK, if not ignore the stub and create new one.
-            if (static_cast<FailureDetectChannel*>(stub_ptr->channel())->channel_status().ok()) {
+            if (static_cast<FailureDetectChannel*>(stub_ptr->channel())->channel_status()->ok()) {
                 return stub_ptr;
             } else {
                 _stub_map.erase(host_port);

--- a/be/test/util/brpc_client_cache_test.cpp
+++ b/be/test/util/brpc_client_cache_test.cpp
@@ -100,7 +100,7 @@ TEST_F(BrpcClientCacheTest, failure) {
     EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub4->channel())->channel_status()->ok());
 
     // Check map size is 1
-    EXPECT_NE(1, cache.size());
+    EXPECT_EQ(1, cache.size());
 }
 
 } // namespace doris

--- a/be/test/util/brpc_client_cache_test.cpp
+++ b/be/test/util/brpc_client_cache_test.cpp
@@ -84,6 +84,22 @@ TEST_F(BrpcClientCacheTest, failure) {
     // Call handshake method, it will trigger host is down error.
     cache.available(stub3, address.hostname, address.port);
     EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub3->channel())->channel_status()->ok());
+
+    std::shared_ptr<PBackendService_Stub> stub4 = cache.get_client(address);
+    EXPECT_NE(nullptr, stub4);
+    EXPECT_TRUE(static_cast<FailureDetectChannel*>(stub4->channel())->channel_status()->ok());
+
+    // Call handshake method, it will trigger host is down error.
+    PHandShakeRequest request;
+    request.set_hello(message);
+    PHandShakeResponse response;
+    brpc::Controller cntl4;
+    stub4->hand_shake(&cntl4, &request, &response, brpc::DoNothing());
+    brpc::Join(cntl4.call_id());
+    EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub4->channel())->channel_status()->ok());
+
+    // Check map size is 1
+    EXPECT_NE(1, cache.size());
 }
 
 } // namespace doris

--- a/be/test/util/brpc_client_cache_test.cpp
+++ b/be/test/util/brpc_client_cache_test.cpp
@@ -69,7 +69,7 @@ TEST_F(BrpcClientCacheTest, failure) {
     EXPECT_EQ(stub1, stub2);
     EXPECT_TRUE(static_cast<FailureDetectChannel*>(stub1->channel())->channel_status()->ok());
 
-    // update channel st to error
+    // update channel st to error, will get a new stub
     static_cast<FailureDetectChannel*>(stub1->channel())
             ->channel_status()
             ->update(Status::NetworkError("test brpc error"));
@@ -81,7 +81,7 @@ TEST_F(BrpcClientCacheTest, failure) {
     // The previous channel is not ok.
     EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub2->channel())->channel_status()->ok());
 
-    // Call handshake method, it will trigger host is down error.
+    // Call handshake method, it will trigger host is down error. It is a sync call, not use closure.
     cache.available(stub3, address.hostname, address.port);
     EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub3->channel())->channel_status()->ok());
 
@@ -89,7 +89,7 @@ TEST_F(BrpcClientCacheTest, failure) {
     EXPECT_NE(nullptr, stub4);
     EXPECT_TRUE(static_cast<FailureDetectChannel*>(stub4->channel())->channel_status()->ok());
 
-    // Call handshake method, it will trigger host is down error.
+    // Call handshake method, it will trigger host is down error. It is a async all, will use closure.
     PHandShakeRequest request;
     request.set_hello(message);
     PHandShakeResponse response;

--- a/be/test/util/brpc_client_cache_test.cpp
+++ b/be/test/util/brpc_client_cache_test.cpp
@@ -90,6 +90,7 @@ TEST_F(BrpcClientCacheTest, failure) {
     EXPECT_TRUE(static_cast<FailureDetectChannel*>(stub4->channel())->channel_status()->ok());
 
     // Call handshake method, it will trigger host is down error. It is a async all, will use closure.
+    std::string message = "hello doris!";
     PHandShakeRequest request;
     request.set_hello(message);
     PHandShakeResponse response;

--- a/be/test/util/brpc_client_cache_test.cpp
+++ b/be/test/util/brpc_client_cache_test.cpp
@@ -82,7 +82,7 @@ TEST_F(BrpcClientCacheTest, failure) {
     EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub2->channel())->channel_status()->ok());
 
     // Call handshake method, it will trigger host is down error.
-    cache.available(stub3, "127.0.0.1:123");
+    cache.available(stub3, address.hostname, address.port);
     EXPECT_FALSE(static_cast<FailureDetectChannel*>(stub3->channel())->channel_status()->ok());
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

If the channel in the stub has error, it should not be reused any more, it should be removed from the cache.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

