### PR TITLE
[Improvement](tablet) Prefetch tablets before opening

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1016,7 +1016,7 @@ DEFINE_mInt32(segcompaction_num_threads, "5");
 DEFINE_Bool(enable_java_support, "true");
 
 // enable prefetch tablets before opening
-DEFINE_Bool(enable_prefetch_tablet, "true");
+DEFINE_mBool(enable_prefetch_tablet, "true");
 
 // Set config randomly to check more issues in github workflow
 DEFINE_Bool(enable_fuzzy_mode, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1015,6 +1015,9 @@ DEFINE_mInt32(segcompaction_num_threads, "5");
 // enable java udf and jdbc scannode
 DEFINE_Bool(enable_java_support, "true");
 
+// enable prefetch tablets before opening
+DEFINE_Bool(enable_prefetch_tablet, "true");
+
 // Set config randomly to check more issues in github workflow
 DEFINE_Bool(enable_fuzzy_mode, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1065,7 +1065,7 @@ DECLARE_mInt32(segcompaction_num_threads);
 DECLARE_Bool(enable_java_support);
 
 // enable prefetch tablets before opening
-DECLARE_Bool(enable_prefetch_tablet);
+DECLARE_mBool(enable_prefetch_tablet);
 
 // Set config randomly to check more issues in github workflow
 DECLARE_Bool(enable_fuzzy_mode);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1064,6 +1064,9 @@ DECLARE_mInt32(segcompaction_num_threads);
 // enable java udf and jdbc scannode
 DECLARE_Bool(enable_java_support);
 
+// enable prefetch tablets before opening
+DECLARE_Bool(enable_prefetch_tablet);
+
 // Set config randomly to check more issues in github workflow
 DECLARE_Bool(enable_fuzzy_mode);
 

--- a/be/src/olap/parallel_scanner_builder.cpp
+++ b/be/src/olap/parallel_scanner_builder.cpp
@@ -164,13 +164,11 @@ Status ParallelScannerBuilder::_build_scanners_by_rowid(std::list<VScannerSPtr>&
  */
 Status ParallelScannerBuilder::_load() {
     _total_rows = 0;
+    size_t idx = 0;
     for (auto&& [tablet, version] : _tablets) {
         const auto tablet_id = tablet->tablet_id();
-        auto& read_source = _all_read_sources[tablet_id];
-        RETURN_IF_ERROR(tablet->capture_rs_readers({0, version}, &read_source.rs_splits, false));
-        if (!_state->skip_delete_predicate()) {
-            read_source.fill_delete_predicates();
-        }
+        _all_read_sources[tablet_id] = _read_sources[idx];
+        const auto& read_source = _all_read_sources[tablet_id];
 
         for (auto& rs_split : read_source.rs_splits) {
             auto rowset = rs_split.rs_reader->rowset();
@@ -186,6 +184,7 @@ Status ParallelScannerBuilder::_load() {
             }
             _total_rows += rowset->num_rows();
         }
+        idx++;
     }
 
     _rows_per_scanner = _total_rows / _max_scanners_count;

--- a/be/src/olap/parallel_scanner_builder.h
+++ b/be/src/olap/parallel_scanner_builder.h
@@ -44,6 +44,7 @@ class ParallelScannerBuilder {
 public:
     ParallelScannerBuilder(pipeline::OlapScanLocalState* parent,
                            const std::vector<TabletWithVersion>& tablets,
+                           std::vector<TabletReader::ReadSource>& read_sources,
                            const std::shared_ptr<RuntimeProfile>& profile,
                            const std::vector<OlapScanRange*>& key_ranges, RuntimeState* state,
                            int64_t limit, bool is_dup_mow_key, bool is_preaggregation)
@@ -54,7 +55,8 @@ public:
               _is_dup_mow_key(is_dup_mow_key),
               _is_preaggregation(is_preaggregation),
               _tablets(tablets.cbegin(), tablets.cend()),
-              _key_ranges(key_ranges.cbegin(), key_ranges.cend()) {}
+              _key_ranges(key_ranges.cbegin(), key_ranges.cend()),
+              _read_sources(read_sources) {}
 
     Status build_scanners(std::list<VScannerSPtr>& scanners);
 
@@ -93,6 +95,7 @@ private:
     std::vector<TabletWithVersion> _tablets;
     std::vector<OlapScanRange*> _key_ranges;
     std::unordered_map<int64_t, TabletReader::ReadSource> _all_read_sources;
+    std::vector<TabletReader::ReadSource>& _read_sources;
 };
 
 } // namespace doris

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -413,7 +413,7 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::VScannerSPtr>* s
                                   state(),
                                   _scanner_profile.get(),
                                   scanner_ranges,
-                                  _tablets[i],
+                                  _tablets[scan_range_idx],
                                   version,
                                   {},
                                   p._limit,

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -50,6 +50,7 @@ public:
                            std::to_string(_parent->node_id()),
                            std::to_string(_parent->nereids_id()), olap_scan_node().table_name);
     }
+    Status hold_tablets();
 
 private:
     friend class vectorized::NewOlapScanner;
@@ -214,6 +215,7 @@ private:
     RuntimeProfile::Counter* _segment_load_index_timer = nullptr;
 
     std::mutex _profile_mtx;
+    std::vector<BaseTabletSPtr> _tablets;
 };
 
 class OlapScanOperatorX final : public ScanOperatorX<OlapScanLocalState> {
@@ -221,6 +223,7 @@ public:
     OlapScanOperatorX(ObjectPool* pool, const TPlanNode& tnode, int operator_id,
                       const DescriptorTbl& descs, int parallel_tasks,
                       const TQueryCacheParam& cache_param);
+    Status hold_tablets(RuntimeState* state) override;
 
 private:
     friend class OlapScanLocalState;

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "common/status.h"
+#include "olap/tablet_reader.h"
 #include "operator.h"
 #include "pipeline/exec/scan_operator.h"
 
@@ -216,6 +217,7 @@ private:
 
     std::mutex _profile_mtx;
     std::vector<BaseTabletSPtr> _tablets;
+    std::vector<TabletReader::ReadSource> _read_sources;
 };
 
 class OlapScanOperatorX final : public ScanOperatorX<OlapScanLocalState> {

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -216,7 +216,7 @@ private:
     RuntimeProfile::Counter* _segment_load_index_timer = nullptr;
 
     std::mutex _profile_mtx;
-    std::vector<BaseTabletSPtr> _tablets;
+    std::vector<TabletWithVersion> _tablets;
     std::vector<TabletReader::ReadSource> _read_sources;
 };
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -636,6 +636,8 @@ public:
     [[nodiscard]] std::string get_name() const override { return _op_name; }
     [[nodiscard]] virtual bool need_more_input_data(RuntimeState* state) const { return true; }
 
+    // Tablets should be hold before open phase.
+    [[nodiscard]] virtual Status hold_tablets(RuntimeState* state) { return Status::OK(); }
     Status open(RuntimeState* state) override;
 
     [[nodiscard]] virtual Status get_block(RuntimeState* state, vectorized::Block* block,

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -303,6 +303,9 @@ Status PipelineTask::execute(bool* eos) {
         query_context()->update_cpu_time(delta_cpu_time);
     }};
     if (_wait_to_start()) {
+        if (config::enable_prefetch_tablet) {
+            RETURN_IF_ERROR(_source->hold_tablets(_state));
+        }
         return Status::OK();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

### Release note

For a scan operator in a query, FE will assign a tablet id to a specific scan operator and then it will be search by storage engine during execution. But this searching process will be done after runtime filter reached. However, if we wait for a runtime filter for a long time and compaction / balance tasks is done at the same time, a tablet / rowset will be lost and we got an error.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

