### PR TITLE
[Fix]Fix double-free when memtable agg

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -433,8 +433,6 @@ void MemTable::_finalize_one_row(RowInBlock* row,
             }
         }
 
-        _arena->clear();
-
         if constexpr (is_final) {
             row->remove_init_agg();
         } else {


### PR DESCRIPTION
### What problem does this PR solve?

A fix for #47150

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

