### PR TITLE
[fix](routine load) fix incorrect auto-resume interval caused by excessive auto-resume attempts

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -63,6 +63,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -1072,5 +1073,34 @@ public class RoutineLoadManagerTest {
         routineLoadManager.resumeRoutineLoadJob(resumeRoutineLoadStmt);
         Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
         Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob2.getState());
+    }
+
+    @Test
+    public void testCalAutoResumeInterval() throws Exception {
+        RoutineLoadJob jobRoutine = new KafkaRoutineLoadJob();
+
+        Field maxBackOffField = ScheduleRule.class.getDeclaredField("MAX_BACK_OFF_TIME_SEC");
+        maxBackOffField.setAccessible(true);
+        long maxBackOffTimeSec = (long) maxBackOffField.get(null);
+
+        Field backOffBasicField = ScheduleRule.class.getDeclaredField("BACK_OFF_BASIC_TIME_SEC");
+        backOffBasicField.setAccessible(true);
+        long backOffTimeSec = (long) backOffBasicField.get(null);
+
+        jobRoutine.autoResumeCount = 0;
+        long interval = ScheduleRule.calAutoResumeInterval(jobRoutine);
+        Assert.assertEquals(Math.min((long) Math.pow(2, 0) * backOffTimeSec, maxBackOffTimeSec), interval);
+
+        jobRoutine.autoResumeCount = 1;
+        interval = ScheduleRule.calAutoResumeInterval(jobRoutine);
+        Assert.assertEquals(Math.min((long) Math.pow(2, 1) * backOffTimeSec, maxBackOffTimeSec), interval);
+
+        jobRoutine.autoResumeCount = 5;
+        interval = ScheduleRule.calAutoResumeInterval(jobRoutine);
+        Assert.assertEquals(maxBackOffTimeSec, interval);
+
+        jobRoutine.autoResumeCount = 1000;
+        interval = ScheduleRule.calAutoResumeInterval(jobRoutine);
+        Assert.assertEquals(maxBackOffTimeSec, interval);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Incorrect auto-resume interval observed when autoResumeCount is too large. Logs show that when autoResumeCount reaches high values, the auto-resume interval becomes approximately 20 seconds instead of the expected 5 minutes.

```
2025-02-05 14:58:46,830 INFO (Routine load scheduler|187) [ScheduleRule.isNeedAutoSchedule():83] try to auto reschedule routine load 10103, latestResumeTimestamp: 1738738701821,  autoResumeCount: 41555, pause reason: PARTITIONS_ERR
2025-02-05 14:59:11,837 INFO (Routine load scheduler|187) [ScheduleRule.isNeedAutoSchedule():83] try to auto reschedule routine load 10103, latestResumeTimestamp: 1738738726830,  autoResumeCount: 41556, pause reason: PARTITIONS_ERR
2025-02-05 14:59:36,844 INFO (Routine load scheduler|187) [ScheduleRule.isNeedAutoSchedule():83] try to auto reschedule routine load 10103, latestResumeTimestamp: 1738738751837,  autoResumeCount: 41557, pause reason: PARTITIONS_ERR
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

