### PR TITLE
[fix](exchanger) Fix DCHECK failure when ref count is not set correctly

### DIFF
--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -189,13 +189,13 @@ Status ShuffleExchanger::get_block(RuntimeState* state, vectorized::Block* block
             const auto* offset_start = partitioned_block.second.row_idxs->data() +
                                        partitioned_block.second.offset_start;
             auto block_wrapper = partitioned_block.first;
-            // Make sure reference is already count down before wrapper de-constructed.
-            auto st = mutable_block.add_rows(&block_wrapper->data_block, offset_start,
-                                             offset_start + partitioned_block.second.length);
-            block_wrapper->unref(
-                    source_info.local_state ? source_info.local_state->_shared_state : nullptr,
-                    source_info.channel_id);
-            RETURN_IF_ERROR(st);
+            Defer defer {[&]() {
+                block_wrapper->unref(
+                        source_info.local_state ? source_info.local_state->_shared_state : nullptr,
+                        source_info.channel_id);
+            }};
+            RETURN_IF_ERROR(mutable_block.add_rows(&block_wrapper->data_block, offset_start,
+                                                   offset_start + partitioned_block.second.length));
         } while (mutable_block.rows() < state->batch_size() && !*eos &&
                  _dequeue_data(source_info.local_state, partitioned_block, eos, block,
                                source_info.channel_id));

--- a/be/src/pipeline/local_exchange/local_exchanger.cpp
+++ b/be/src/pipeline/local_exchange/local_exchanger.cpp
@@ -189,11 +189,13 @@ Status ShuffleExchanger::get_block(RuntimeState* state, vectorized::Block* block
             const auto* offset_start = partitioned_block.second.row_idxs->data() +
                                        partitioned_block.second.offset_start;
             auto block_wrapper = partitioned_block.first;
-            RETURN_IF_ERROR(mutable_block.add_rows(&block_wrapper->data_block, offset_start,
-                                                   offset_start + partitioned_block.second.length));
+            // Make sure reference is already count down before wrapper de-constructed.
+            auto st = mutable_block.add_rows(&block_wrapper->data_block, offset_start,
+                                             offset_start + partitioned_block.second.length);
             block_wrapper->unref(
                     source_info.local_state ? source_info.local_state->_shared_state : nullptr,
                     source_info.channel_id);
+            RETURN_IF_ERROR(st);
         } while (mutable_block.rows() < state->batch_size() && !*eos &&
                  _dequeue_data(source_info.local_state, partitioned_block, eos, block,
                                source_info.channel_id));


### PR DESCRIPTION
### What problem does this PR solve?

If execution meet an error, ref count in block wrapper may not count down which will lead to a DCHECK failure.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

