### PR TITLE
[fix](hive docker)Table `partition_location_1` miss data

### DIFF
--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_location_1/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_location_1/create_table.hql
@@ -17,7 +17,7 @@ TBLPROPERTIES (
   'transient_lastDdlTime'='1682405696');
 
 ALTER TABLE partition_location_1 ADD PARTITION (part='part1') LOCATION '/user/doris/suites/multi_catalog/partition_location_1/part=part1';
-ALTER TABLE partition_location_1 ADD PARTITION (part='part2') LOCATION '/user/doris/suites/multi_catalog/partition_location_1/part=part2';
+ALTER TABLE partition_location_1 ADD PARTITION (part='part2') LOCATION '/user/doris/suites/multi_catalog/partition_location_1/20230425';
 
 set hive.msck.path.validation=ignore;
 msck repair table partition_location_1;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Table `partition_location_1` miss data on CI testing. The reason is `20230425` partition lost.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

