### PR TITLE
[feat](binlog) Speed binlog gc by locked binlogs

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2547,7 +2547,7 @@ public class Config extends ConfigBase {
     public static int max_binlog_messsage_size = 1024 * 1024 * 1024;
 
     @ConfField(mutable = true, masterOnly = true, description = {
-            "是否禁止使用 WITH REOSOURCE 语句创建 Catalog。",
+            "是否禁止使用 WITH RESOURCE 语句创建 Catalog。",
             "Whether to disable creating catalog with WITH RESOURCE statement."})
     public static boolean disallow_create_catalog_with_resource = true;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -112,6 +112,10 @@ public class BinlogManager {
             return;
         }
 
+        LOG.debug("add binlog, db {}, table {}, commitSeq {}, timestamp {}, type {}, data {}",
+                binlog.getDbId(), binlog.getTableIds(), binlog.getCommitSeq(), binlog.getTimestamp(), binlog.getType(),
+                binlog.getData());
+
         DBBinlog dbBinlog;
         lock.writeLock().lock();
         try {
@@ -595,7 +599,6 @@ public class BinlogManager {
 
         return tombstones;
     }
-
 
     public void replayGc(BinlogGcInfo binlogGcInfo) {
         lock.writeLock().lock();

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
@@ -39,6 +39,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -171,6 +172,15 @@ public class TableBinlog {
         return Pair.of(new TStatus(TStatusCode.OK), lockCommitSeq);
     }
 
+    public Optional<Long> getMinLockedCommitSeq() {
+        lock.readLock().lock();
+        try {
+            return lockedBinlogs.values().stream().min(Long::compareTo);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     private Pair<TBinlog, Long> getLastUpsertAndLargestCommitSeq(BinlogComparator checker) {
         if (binlogs.size() <= 1) {
             return null;
@@ -199,7 +209,7 @@ public class TableBinlog {
             return null;
         }
 
-        long expiredCommitSeq = lastExpiredBinlog.getCommitSeq();
+        final long expiredCommitSeq = lastExpiredBinlog.getCommitSeq();
         dummyBinlog.setCommitSeq(expiredCommitSeq);
 
         Iterator<Pair<Long, Long>> timeIterator = timestamps.iterator();
@@ -207,6 +217,7 @@ public class TableBinlog {
             timeIterator.remove();
         }
 
+        lockedBinlogs.entrySet().removeIf(ent -> ent.getValue() <= expiredCommitSeq);
         return Pair.of(tombstoneUpsert, expiredCommitSeq);
     }
 
@@ -278,6 +289,13 @@ public class TableBinlog {
                         break;
                     }
                     expiredCommitSeq = entry.first;
+                }
+
+                // find the min locked binlog commit seq, if not exists, use the last binlog commit seq.
+                Optional<Long> minLockedCommitSeq = lockedBinlogs.values().stream().min(Long::compareTo);
+                if (minLockedCommitSeq.isPresent() && expiredCommitSeq + 1L < minLockedCommitSeq.get()) {
+                    // Speed up the gc progress by the min locked commit seq.
+                    expiredCommitSeq = minLockedCommitSeq.get() - 1L;
                 }
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #46887, https://github.com/selectdb/ccr-syncer/pull/399/files

Problem Summary:

This is the second PR for locking binlogs.

To reduce the cost of maintaining binlogs, an API named lockBinlog has
been added. Users use this API to indicate which binlogs are not
permitted for GC.

The binlog gcer will recycle all binlogs until the locked one. However, in order to remain compatible with the old behaviors, if no binlog is locked here, it falls through to the previous behavior (keep the entire binlogs until they are expired)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

