### PR TITLE
[fix](resource) Fix `MemTableWriter` attach resource context to thread context

### DIFF
--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -139,12 +139,10 @@ Status MemTableWriter::_flush_memtable_async() {
 
 Status MemTableWriter::flush_async() {
     std::lock_guard<std::mutex> l(_lock);
-    // In order to avoid repeated ATTACH, use SWITCH here. have two calling paths:
-    // 1. call by local, from `VTabletWriterV2::_write_memtable`, has been ATTACH Load memory tracker
-    // into thread context, ATTACH cannot be repeated here.
-    // 2. call by remote, from `LoadChannelMgr::_get_load_channel`, no ATTACH because LoadChannelMgr
-    // not know Load context.
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_resource_ctx->memory_context()->mem_tracker());
+    // Two calling paths:
+    // 1. call by local, from `VTabletWriterV2::_write_memtable`.
+    // 2. call by remote, from `LoadChannelMgr::_get_load_channel`.
+    SCOPED_SWITCH_RESOURCE_CONTEXT(_resource_ctx);
     if (!_is_init || _is_closed) {
         // This writer is uninitialized or closed before flushing, do nothing.
         // We return OK instead of NOT_INITIALIZED or ALREADY_CLOSED.

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -174,7 +174,6 @@ Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
                               PTabletWriterAddBlockResult* response) {
     SCOPED_TIMER(_add_batch_timer);
     COUNTER_UPDATE(_add_batch_times, 1);
-    SCOPED_ATTACH_TASK(_resource_ctx);
     int64_t index_id = request.index_id();
     // 1. get tablets channel
     std::shared_ptr<BaseTabletsChannel> channel;

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -69,6 +69,8 @@ public:
 
     bool is_high_priority() const { return _is_high_priority; }
 
+    std::shared_ptr<ResourceContext> resource_ctx() const { return _resource_ctx; }
+
     RuntimeProfile::Counter* get_mgr_add_batch_timer() { return _mgr_add_batch_timer; }
     RuntimeProfile::Counter* get_handle_mem_limit_timer() { return _handle_mem_limit_timer; }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -144,6 +144,7 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
         return status;
     }
     SCOPED_TIMER(channel->get_mgr_add_batch_timer());
+    SCOPED_ATTACH_TASK(channel->resource_ctx());
 
     if (!channel->is_high_priority()) {
         // 2. check if mem consumption exceed limit

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -26,11 +26,11 @@ class MemTracker;
 
 void AttachTask::init(const std::shared_ptr<ResourceContext>& rc) {
     ThreadLocalHandle::create_thread_local_if_not_exits();
+    signal::set_signal_task_id(rc->task_controller()->task_id());
     thread_context()->attach_task(rc);
 }
 
 AttachTask::AttachTask(const std::shared_ptr<ResourceContext>& rc) {
-    signal::set_signal_task_id(rc->task_controller()->task_id());
     init(rc);
 }
 
@@ -50,8 +50,32 @@ AttachTask::AttachTask(QueryContext* query_ctx) {
 }
 
 AttachTask::~AttachTask() {
+    signal::set_signal_task_id(TUniqueId());
     thread_context()->detach_task();
     ThreadLocalHandle::del_thread_local_if_count_is_zero();
+}
+
+SwitchResourceContext::SwitchResourceContext(const std::shared_ptr<ResourceContext>& rc) {
+    DCHECK(rc != nullptr);
+    DCHECK(thread_context()->is_attach_task());
+    doris::ThreadLocalHandle::create_thread_local_if_not_exits();
+    if (rc != thread_context()->resource_ctx()) {
+        signal::set_signal_task_id(rc->task_controller()->task_id());
+        old_resource_ctx_ = thread_context()->resource_ctx();
+        thread_context()->resource_ctx_ = rc;
+        thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
+                rc->memory_context()->mem_tracker(),
+                rc->workload_group_context()->workload_group());
+    }
+}
+
+SwitchResourceContext::~SwitchResourceContext() {
+    if (old_resource_ctx_ != nullptr) {
+        signal::set_signal_task_id(old_resource_ctx_->task_controller()->task_id());
+        thread_context()->resource_ctx_ = old_resource_ctx_;
+        thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker();
+    }
+    doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
 }
 
 SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(
@@ -59,28 +83,14 @@ SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(
     DCHECK(mem_tracker);
     doris::ThreadLocalHandle::create_thread_local_if_not_exits();
     if (mem_tracker != thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
-        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
         thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker);
-    }
-}
-
-SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(ResourceContext* rc) {
-    doris::ThreadLocalHandle::create_thread_local_if_not_exits();
-    // switch in the same task execution thread.
-    DCHECK(thread_context()->resource_ctx()->task_controller()->task_id() ==
-           rc->task_controller()->task_id());
-    DCHECK(rc->memory_context()->mem_tracker());
-    if (rc->memory_context()->mem_tracker() !=
-        thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()) {
-        _old_mem_tracker = thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker();
-        thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
-                rc->memory_context()->mem_tracker());
+        is_switched_ = true;
     }
 }
 
 SwitchThreadMemTrackerLimiter::~SwitchThreadMemTrackerLimiter() {
-    if (_old_mem_tracker != nullptr) {
-        thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker(_old_mem_tracker);
+    if (is_switched_) {
+        thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker();
     }
     doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
 }

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -64,6 +64,8 @@
 // thread context need to be initialized, required by Allocator and elsewhere.
 #define SCOPED_ATTACH_TASK(arg1, ...) \
     auto VARNAME_LINENUM(scoped_tls_at) = doris::ScopedInitThreadContext()
+#define SCOPED_SWITCH_RESOURCE_CONTEXT(arg1) \
+    auto VARNAME_LINENUM(switch_resource_context) = doris::ScopedInitThreadContext()
 #define SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(arg1) \
     auto VARNAME_LINENUM(scoped_tls_stmtl) = doris::ScopedInitThreadContext()
 #define SCOPED_CONSUME_MEM_TRACKER(mem_tracker) \

--- a/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
+++ b/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
@@ -125,7 +125,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1); // not changed, now consume t2
     EXPECT_EQ(t2->consumption(), size1 + size2);
 
-    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(t1); // detach
+    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(); // detach
     EXPECT_EQ(t2->consumption(),
               size1 + size2 + size1); // detach automatic call flush_untracked_mem.
 
@@ -149,7 +149,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
     thread_context->thread_mem_tracker_mgr->consume(-size1);
     EXPECT_EQ(t3->consumption(), size1);
 
-    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(t2); // detach
+    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(); // detach
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), size1 + size2);
     EXPECT_EQ(t3->consumption(), 0);
@@ -160,7 +160,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTracker) {
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), 0);
 
-    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(t1); // detach
+    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(); // detach
     EXPECT_EQ(t1->consumption(), size1 + size2 + size1 + size2 + size2);
     EXPECT_EQ(t2->consumption(), -size1);
 
@@ -439,14 +439,14 @@ TEST_F(ThreadMemTrackerMgrTest, NestedSwitchMemTrackerReserveMemory) {
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(),
               size3 - size2 + size3 + size2);
 
-    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(t2); // detach
+    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(); // detach
     EXPECT_EQ(t1->consumption(), size3);
     EXPECT_EQ(t2->consumption(), size3 + size2);
     EXPECT_EQ(t3->consumption(), -size1 - size2); // size3 - _reserved_mem
     //  size3 - size2 + size3 + size2 - (_reserved_mem + _untracked_mem)
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3 - size2);
 
-    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(t1); // detach
+    thread_context->thread_mem_tracker_mgr->detach_limiter_tracker(); // detach
     EXPECT_EQ(t1->consumption(), size3);
     // not changed, reserved memory used done.
     EXPECT_EQ(t2->consumption(), size3 + size2);


### PR DESCRIPTION
### What problem does this PR solve?

Introduced from: [#47274](https://github.com/apache/doris/pull/47274)
fix:
```
*** SIGABRT unknown detail explain (@0x1c75) received by PID 7285 (TID 8020 OR 0x7fbc0ad10640) from PID 7285; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007FBDAA304520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055E21156252D in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# 0x000055E211554B6A in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# doris::MemTable::MemTable(long, std::shared_ptr<doris::TabletSchema>, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const*, doris::TupleDescriptor*, bool, doris::PartialUpdateInfo*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable.cpp:59
11# doris::MemTableWriter::_reset_mem_table() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_writer.cpp:188
12# doris::MemTableWriter::flush_async() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
13# doris::MemTableMemoryLimiter::_flush_active_memtables(long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:190
14# doris::MemTableMemoryLimiter::handle_memtable_flush() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:144
15# doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel_mgr.cpp:154
16# std::_Function_handler<void (), doris::PInternalService::tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
17# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_master/doris/be/src/util/work_thread_pool.hpp:159
18# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
19# start_thread at ./nptl/pthread_create.c:442
20# 0x00007FBDAA3E8850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

