### PR TITLE
[chore](rename) Forbid renaming partition columns since this is a buggy feature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -5150,6 +5150,13 @@ public class Env {
             throw new DdlException("Same column name");
         }
 
+        // @NOTE: Rename partition columns should also rename column names in partition expressions
+        // but this is not implemented currently. Therefore, forbid renaming partition columns temporarily.
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        if (partitionInfo.getPartitionColumns().stream().anyMatch(c -> c.getName().equalsIgnoreCase(colName))) {
+            throw new DdlException("Renaming partition columns has problems, forbidden in current Doris version");
+        }
+
         Map<Long, MaterializedIndexMeta> indexIdToMeta = table.getIndexIdToMeta();
         for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
             // rename column is not implemented for non-light-schema-change table.
@@ -5209,14 +5216,17 @@ public class Env {
             throw new DdlException("Column[" + colName + "] does not exists");
         }
 
+        // @NOTE: Rename partition columns should also rename column names in partition expressions
+        // but this is not implemented currently. Therefore, forbid renaming partition columns temporarily.
+        //
         // 2. modify partition key
-        PartitionInfo partitionInfo = table.getPartitionInfo();
-        List<Column> partitionColumns = partitionInfo.getPartitionColumns();
-        for (Column column : partitionColumns) {
-            if (column.getName().equalsIgnoreCase(colName)) {
-                column.setName(newColName);
-            }
-        }
+        // PartitionInfo partitionInfo = table.getPartitionInfo();
+        // List<Column> partitionColumns = partitionInfo.getPartitionColumns();
+        // for (Column column : partitionColumns) {
+        //    if (column.getName().equalsIgnoreCase(colName)) {
+        //        column.setName(newColName);
+        //    }
+        //}
 
         // 3. modify index
         List<Index> indexes = table.getIndexes();

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_rename.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_rename.groovy
@@ -38,23 +38,26 @@ suite("test_dynamic_partition_with_rename") {
     assertEquals(7, result.size())
 
     // rename distributed column, then try to add too more dynamic partition
-    sql "alter table test_dynamic_partition_with_rename rename column k1 renamed_k1"
-    sql """ ADMIN SET FRONTEND CONFIG ('dynamic_partition_check_interval_seconds' = '1') """
-    sql """ alter table ${tbl} set('dynamic_partition.end'='5') """
-    result = sql_return_maparray "show partitions from ${tbl}"
-    for (def retry = 0; retry < 120; retry++) { // at most wait 120s
-        if (result.size() == 9) {
-            break;
-        }
-        logger.info("wait dynamic partition scheduler, sleep 1s")
-        sleep(1000); // sleep 1s
-        result = sql_return_maparray "show partitions from ${tbl}"
+    test {
+        sql "alter table test_dynamic_partition_with_rename rename column k1 renamed_k1"
+        exception """Renaming partition columns has problems, forbidden in current Doris version"""
     }
-    assertEquals(9, result.size())
-    for (def line = 0; line < result.size(); line++) {
-        // XXX: DistributionKey at pos(7), next maybe impl by sql meta
-        assertEquals("renamed_k1", result.get(line).DistributionKey)
-    }
+    // sql """ ADMIN SET FRONTEND CONFIG ('dynamic_partition_check_interval_seconds' = '1') """
+    // sql """ alter table ${tbl} set('dynamic_partition.end'='5') """
+    // result = sql_return_maparray "show partitions from ${tbl}"
+    // for (def retry = 0; retry < 120; retry++) { // at most wait 120s
+    //    if (result.size() == 9) {
+    //        break;
+    //    }
+    //    logger.info("wait dynamic partition scheduler, sleep 1s")
+    //    sleep(1000); // sleep 1s
+    //    result = sql_return_maparray "show partitions from ${tbl}"
+    // }
+    // assertEquals(9, result.size())
+    // for (def line = 0; line < result.size(); line++) {
+    //    // XXX: DistributionKey at pos(7), next maybe impl by sql meta
+    //    assertEquals("renamed_k1", result.get(line).DistributionKey)
+    // }
 
-    sql "drop table test_dynamic_partition_with_rename"
+    // sql "drop table test_dynamic_partition_with_rename"
 }

--- a/regression-test/suites/schema_change_p0/test_rename_partition_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_rename_partition_column.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_rename_partition_column") {
+    def tblName = "test_rename_partition_column"
+    sql """DROP TABLE IF EXISTS ${tblName} FORCE; """
+
+    sql """
+        CREATE TABLE `${tblName}`
+        (
+            `siteid` INT DEFAULT '10',
+            `citycode` SMALLINT,
+            `username` VARCHAR(32) DEFAULT 'test',
+            `pv` BIGINT SUM DEFAULT '0'
+        )
+        AGGREGATE KEY(`siteid`, `citycode`, `username`)
+        PARTITION BY RANGE(`siteid`)
+                (
+                    partition `old_p1` values [("1"), ("2")),
+                    partition `old_p2` values [("2"), ("3"))
+                )
+        DISTRIBUTED BY HASH(siteid) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    test {
+        sql """ ALTER TABLE ${tblName} RENAME COLUMN siteid new_siteid """
+        exception """Renaming partition columns has problems, forbidden in current Doris version"""
+    }
+}


### PR DESCRIPTION

### What problem does this PR solve

Problem Summary:

Rename partition columns should also rename column names in partition expressions, but this is not implemented currently. Therefore, forbid renaming partition columns temporarily.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

