### PR TITLE
[fix](external catalog) Fix missing fields when rebuilding metadata from image

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -759,7 +759,7 @@ public abstract class ExternalCatalog
                         log.getRefreshDbIds().get(i), name);
                 continue;
             }
-            db.get().setRemoteName(log.getRemoteDbNames().get(i));
+            db.get().setRemoteName(log.getRefreshRemoteDbNames().get(i));
             Preconditions.checkNotNull(db.get());
             tmpDbNameToId.put(db.get().getFullName(), db.get().getId());
             tmpIdToDb.put(db.get().getId(), db.get());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -399,7 +399,7 @@ public abstract class ExternalCatalog
                     db.setRemoteName(remoteDbName);
                 }
                 tmpIdToDb.put(dbId, db);
-                initCatalogLog.addRefreshDb(dbId);
+                initCatalogLog.addRefreshDb(dbId, remoteDbName);
             } else {
                 dbId = Env.getCurrentEnv().getNextId();
                 tmpDbNameToId.put(localDbName, dbId);
@@ -769,6 +769,18 @@ public abstract class ExternalCatalog
                 tmpIdToDb.put(db.getId(), db);
                 LOG.info("Synchronized database (create): [Name: {}, ID: {}, Remote Name: {}]",
                         db.getFullName(), db.getId(), log.getRemoteDbNames().get(i));
+            }
+        }
+        // Check whether the remoteName of db in tmpIdToDb is empty
+        for (ExternalDatabase<? extends ExternalTable> db : tmpIdToDb.values()) {
+            if (Strings.isNullOrEmpty(db.getRemoteName())) {
+                LOG.info("Database [{}] remoteName is empty in catalog [{}], mark as uninitialized",
+                        db.getFullName(), name);
+                dbNameToId = Maps.newConcurrentMap();
+                idToDb = Maps.newConcurrentMap();
+                lastUpdateTime = log.getLastUpdateTime();
+                initialized = false;
+                return;
             }
         }
         dbNameToId = tmpDbNameToId;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -759,7 +759,7 @@ public abstract class ExternalCatalog
                         log.getRefreshDbIds().get(i), name);
                 continue;
             }
-            // db.get().setRemoteName(log.getRemoteDbNames().get(i));
+            db.get().setRemoteName(log.getRemoteDbNames().get(i));
             Preconditions.checkNotNull(db.get());
             tmpDbNameToId.put(db.get().getFullName(), db.get().getId());
             tmpIdToDb.put(db.get().getId(), db.get());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -734,8 +734,12 @@ public abstract class ExternalCatalog
     }
 
     public void replayInitCatalog(InitCatalogLog log) {
-        // If the remote name is missing during upgrade, all databases in the Map will be reinitialized.
-        if (log.getCreateCount() > 0 && (log.getRemoteDbNames() == null || log.getRemoteDbNames().isEmpty())) {
+        // If the remote name is missing during upgrade, or
+        // the refresh db's remote name is empty,
+        // all databases in the Map will be reinitialized.
+        if ((log.getCreateCount() > 0 && (log.getRemoteDbNames() == null || log.getRemoteDbNames().isEmpty()))
+                || (log.getRefreshCount() > 0
+                && (log.getRefreshRemoteDbNames() == null || log.getRefreshRemoteDbNames().isEmpty()))) {
             dbNameToId = Maps.newConcurrentMap();
             idToDb = Maps.newConcurrentMap();
             lastUpdateTime = log.getLastUpdateTime();
@@ -755,6 +759,7 @@ public abstract class ExternalCatalog
                         log.getRefreshDbIds().get(i), name);
                 continue;
             }
+            // db.get().setRemoteName(log.getRemoteDbNames().get(i));
             Preconditions.checkNotNull(db.get());
             tmpDbNameToId.put(db.get().getFullName(), db.get().getId());
             tmpIdToDb.put(db.get().getId(), db.get());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -191,7 +191,9 @@ public abstract class ExternalDatabase<T extends ExternalTable>
 
     public void replayInitDb(InitDatabaseLog log, ExternalCatalog catalog) {
         // If the remote name is missing during upgrade, all tables in the Map will be reinitialized.
-        if (log.getCreateCount() > 0 && (log.getRemoteTableNames() == null || log.getRemoteTableNames().isEmpty())) {
+        if ((log.getCreateCount() > 0 && (log.getRemoteTableNames() == null || log.getRemoteTableNames().isEmpty()))
+                || (log.getRefreshCount() > 0
+                && (log.getRefreshRemoteTableNames() == null || log.getRefreshRemoteTableNames().isEmpty()))) {
             tableNameToId = Maps.newConcurrentMap();
             idToTbl = Maps.newConcurrentMap();
             lastUpdateTime = log.getLastUpdateTime();
@@ -209,6 +211,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             // So we need add a validation here to avoid table(s) not found, this is just a temporary solution
             // because later we will remove all the logics about InitCatalogLog/InitDatabaseLog.
             if (table.isPresent()) {
+                table.get().setRemoteName(log.getRefreshRemoteTableNames().get(i));
                 tmpTableNameToId.put(table.get().getName(), table.get().getId());
                 tmpIdToTbl.put(table.get().getId(), table.get());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InitCatalogLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InitCatalogLog.java
@@ -58,6 +58,9 @@ public class InitCatalogLog implements Writable {
     @SerializedName(value = "refreshDbIds")
     private List<Long> refreshDbIds;
 
+    @SerializedName(value = "refreshRemoteDbNames")
+    private List<String> refreshRemoteDbNames;
+
     @SerializedName(value = "createDbIds")
     private List<Long> createDbIds;
 
@@ -78,15 +81,17 @@ public class InitCatalogLog implements Writable {
         createCount = 0;
         catalogId = 0;
         refreshDbIds = Lists.newArrayList();
+        refreshRemoteDbNames = Lists.newArrayList();
         createDbIds = Lists.newArrayList();
         createDbNames = Lists.newArrayList();
         remoteDbNames = Lists.newArrayList();
         type = Type.UNKNOWN;
     }
 
-    public void addRefreshDb(long id) {
+    public void addRefreshDb(long id, String remoteName) {
         refreshCount += 1;
         refreshDbIds.add(id);
+        refreshRemoteDbNames.add(remoteName);
     }
 
     public void addCreateDb(long id, String name, String remoteName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InitDatabaseLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InitDatabaseLog.java
@@ -62,6 +62,9 @@ public class InitDatabaseLog implements Writable {
     @SerializedName(value = "refreshTableIds")
     private List<Long> refreshTableIds;
 
+    @SerializedName(value = "refreshRemoteTableNames")
+    private List<String> refreshRemoteTableNames;
+
     @SerializedName(value = "createTableIds")
     private List<Long> createTableIds;
 
@@ -83,15 +86,17 @@ public class InitDatabaseLog implements Writable {
         catalogId = 0;
         dbId = 0;
         refreshTableIds = Lists.newArrayList();
+        refreshRemoteTableNames = Lists.newArrayList();
         createTableIds = Lists.newArrayList();
         createTableNames = Lists.newArrayList();
         remoteTableNames = Lists.newArrayList();
         type = Type.UNKNOWN;
     }
 
-    public void addRefreshTable(long id) {
+    public void addRefreshTable(long id, String remoteName) {
         refreshCount += 1;
         refreshTableIds.add(id);
+        refreshRemoteTableNames.add(remoteName);
     }
 
     public void addCreateTable(long id, String name, String remoteName) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #41510

Problem Summary:

In PR #41510, we added several fields to External Catalog. However, we only handled the upgrade scenario for EditLog but not for Image. This causes Catalogs rebuilt from Image to miss these fields, resulting in NullPointerException during queries. This PR fixes this issue.

Specifically:
1. Added null check and initialization for fields in gsonPostProcess
2. Ensured consistent behavior between EditLog replay and Image deserialization
3. Added proper logging for better troubleshooting

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

