### PR TITLE
[fix](Export) Enhance `removeOldExportJobs` Logic

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -194,7 +194,7 @@ public class Config extends ConfigBase {
             "针对 EXPORT 作业，如果系统内 EXPORT 作业数量超过这个值，则会删除最老的记录。",
             "For EXPORT jobs, If the number of EXPORT jobs in the system exceeds this value, "
                     + "the oldest records will be deleted."})
-    public static int maximum_history_job_num = 1000; // 7 days
+    public static int max_export_history_job_num = 1000;
 
     @ConfField(description = {"事务的清理周期，单位为秒。每个周期内，将会清理已经结束的并且过期的历史事务信息",
             "The clean interval of transaction, in seconds. "

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -190,6 +190,12 @@ public class Config extends ConfigBase {
             "For ALTER, EXPORT jobs, remove the finished job if expired."})
     public static int history_job_keep_max_second = 7 * 24 * 3600; // 7 days
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+            "针对 EXPORT 作业，如果系统内 EXPORT 作业数量超过这个值，则会删除最老的记录。",
+            "For EXPORT jobs, If the number of EXPORT jobs in the system exceeds this value, "
+                    + "the oldest records will be deleted."})
+    public static int maximum_history_job_num = 1000; // 7 days
+
     @ConfField(description = {"事务的清理周期，单位为秒。每个周期内，将会清理已经结束的并且过期的历史事务信息",
             "The clean interval of transaction, in seconds. "
                     + "In each cycle, the expired history transaction will be cleaned"})

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2547,6 +2547,10 @@ public class Env {
         long curTime = System.currentTimeMillis();
         List<ExportJob> jobs = exportMgr.getJobs().stream().filter(t -> !t.isExpired(curTime))
                 .collect(Collectors.toList());
+        jobs.sort(Comparator.comparingLong(ExportJob::getCreateTimeMs));
+        while (jobs.size() > Config.max_export_history_job_num) {
+            jobs.remove(0);
+        }
         int size = jobs.size();
         checksum ^= size;
         dos.writeInt(size);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
@@ -54,6 +54,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -540,6 +541,23 @@ public class ExportMgr {
                         if (labelJobs.isEmpty()) {
                             dbTolabelToExportJobId.remove(job.getDbId());
                         }
+                    }
+                }
+            }
+
+            int maximumHistoryJobNum = Config.maximum_history_job_num;
+            List<Map.Entry<Long, ExportJob>> jobList = new ArrayList<>(exportIdToJob.entrySet());
+            jobList.sort(Comparator.comparingLong(entry -> entry.getValue().getCreateTimeMs()));
+
+            while (exportIdToJob.size() > maximumHistoryJobNum) {
+                // Remove the oldest job
+                Map.Entry<Long, ExportJob> oldestEntry = jobList.remove(0);
+                exportIdToJob.remove(oldestEntry.getKey());
+                Map<String, Long> labelJobs = dbTolabelToExportJobId.get(oldestEntry.getValue().getDbId());
+                if (labelJobs != null) {
+                    labelJobs.remove(oldestEntry.getValue().getLabel());
+                    if (labelJobs.isEmpty()) {
+                        dbTolabelToExportJobId.remove(oldestEntry.getValue().getDbId());
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
@@ -545,19 +545,19 @@ public class ExportMgr {
                 }
             }
 
-            int maximumHistoryJobNum = Config.maximum_history_job_num;
-            List<Map.Entry<Long, ExportJob>> jobList = new ArrayList<>(exportIdToJob.entrySet());
-            jobList.sort(Comparator.comparingLong(entry -> entry.getValue().getCreateTimeMs()));
-
-            while (exportIdToJob.size() > maximumHistoryJobNum) {
-                // Remove the oldest job
-                Map.Entry<Long, ExportJob> oldestEntry = jobList.remove(0);
-                exportIdToJob.remove(oldestEntry.getKey());
-                Map<String, Long> labelJobs = dbTolabelToExportJobId.get(oldestEntry.getValue().getDbId());
-                if (labelJobs != null) {
-                    labelJobs.remove(oldestEntry.getValue().getLabel());
-                    if (labelJobs.isEmpty()) {
-                        dbTolabelToExportJobId.remove(oldestEntry.getValue().getDbId());
+            if (exportIdToJob.size() > Config.max_export_history_job_num) {
+                List<Map.Entry<Long, ExportJob>> jobList = new ArrayList<>(exportIdToJob.entrySet());
+                jobList.sort(Comparator.comparingLong(entry -> entry.getValue().getCreateTimeMs()));
+                while (exportIdToJob.size() > Config.max_export_history_job_num) {
+                    // Remove the oldest job
+                    Map.Entry<Long, ExportJob> oldestEntry = jobList.remove(0);
+                    exportIdToJob.remove(oldestEntry.getKey());
+                    Map<String, Long> labelJobs = dbTolabelToExportJobId.get(oldestEntry.getValue().getDbId());
+                    if (labelJobs != null) {
+                        labelJobs.remove(oldestEntry.getValue().getLabel());
+                        if (labelJobs.isEmpty()) {
+                            dbTolabelToExportJobId.remove(oldestEntry.getValue().getDbId());
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
@@ -19,9 +19,11 @@ package org.apache.doris.load.loadv2;
 
 import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.TableName;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.load.ExportJob;
+import org.apache.doris.load.ExportJobState;
 import org.apache.doris.load.ExportMgr;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.MockedAuth;
@@ -31,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
@@ -74,6 +77,49 @@ public class ExportMgrTest {
         List<List<String>> r6 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "%dd", true, null, null, -1);
         Assert.assertEquals(r6.size(), 1);
 
+    }
+
+    @Test
+    public void testRemoveOldExportJobs() {
+        // Setup: Create jobs with different creation times
+        long currentTime = System.currentTimeMillis();
+        for (int i = 1; i <= 10; i++) {
+            ExportJob job = makeExportJob(i, "label" + i);
+            // Jobs created 1, 2...10 days ago
+            Deencapsulation.setField(job, "createTimeMs", currentTime - (i * 24 * 3600 * 1000));
+            Deencapsulation.setField(job, "state", ExportJobState.FINISHED);
+            exportMgr.unprotectAddJob(job);
+        }
+
+        // Invoke the method
+        exportMgr.removeOldExportJobs();
+
+        // Assertions: Check the number of jobs remaining
+        List<ExportJob> remainingJobs = exportMgr.getJobs();
+        Assert.assertTrue(remainingJobs.size() <= Config.maximum_history_job_num);
+        Assert.assertEquals(7, remainingJobs.size()); // Expecting 8 jobs to remain
+
+
+        for (int i = 11; i <= 1010; i++) {
+            ExportJob job = makeExportJob(i, "label" + i);
+            // Jobs created 0, 1, 2, 3, 4...1000 seconds ago
+            Deencapsulation.setField(job, "createTimeMs", currentTime - (i * 1000));
+            Deencapsulation.setField(job, "state", ExportJobState.FINISHED);
+            exportMgr.unprotectAddJob(job);
+        }
+
+        // Invoke the method
+        exportMgr.removeOldExportJobs();
+        // Assertions: Check the number of jobs remaining
+        remainingJobs = exportMgr.getJobs();
+        Assert.assertTrue(remainingJobs.size() <= Config.maximum_history_job_num);
+        Assert.assertEquals(1000, remainingJobs.size()); // Expecting 1000 jobs to remain
+
+        // check the created time
+        remainingJobs.sort(Comparator.comparingLong(entry -> entry.getCreateTimeMs()));
+        for (int i = 0; i < remainingJobs.size(); ++i) {
+            Assert.assertEquals(1010 - i, remainingJobs.get(i).getId());
+        }
     }
 
     private ExportJob makeExportJob(long id, String label) {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
@@ -96,7 +96,7 @@ public class ExportMgrTest {
 
         // Assertions: Check the number of jobs remaining
         List<ExportJob> remainingJobs = exportMgr.getJobs();
-        Assert.assertTrue(remainingJobs.size() <= Config.maximum_history_job_num);
+        Assert.assertTrue(remainingJobs.size() <= Config.history_job_keep_max_second);
         Assert.assertEquals(7, remainingJobs.size()); // Expecting 8 jobs to remain
 
 
@@ -112,7 +112,7 @@ public class ExportMgrTest {
         exportMgr.removeOldExportJobs();
         // Assertions: Check the number of jobs remaining
         remainingJobs = exportMgr.getJobs();
-        Assert.assertTrue(remainingJobs.size() <= Config.maximum_history_job_num);
+        Assert.assertTrue(remainingJobs.size() <= Config.history_job_keep_max_second);
         Assert.assertEquals(1000, remainingJobs.size()); // Expecting 1000 jobs to remain
 
         // check the created time


### PR DESCRIPTION
### What problem does this PR solve?

This pull request introduces improvements to the removeOldExportJobs() method in the ExportMgr class, ensuring that it efficiently manages the number of historical export jobs based on the configured limit. The following changes have been made:

Logic Enhancement:
- The method now retains a maximum number of historical jobs, removing the oldest jobs only when the count exceeds the defined limit.

Unit Tests:
- Added a comprehensive unit test for removeOldExportJobs() in the ExportMgrTest class.
- The test verifies that the method correctly removes jobs based on their creation time and maintains the maximum allowed number of historical jobs.
- Additional checks ensure that the jobs remaining after the removal process are the most recent ones.

These changes improve the efficiency and reliability of the job management system, ensuring that it adheres to the specified constraints while providing robust testing coverage.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

