### PR TITLE
[Fix](memory) Add try catch block for call to `DorisCallOnce::call()`

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -280,7 +280,8 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context, const RowSetSpl
 }
 
 Status BetaRowsetReader::_init_iterator_once() {
-    return _init_iter_once.call([this] { return _init_iterator(); });
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_init_iter_once.call([this] { return _init_iterator(); }));
+    return Status::OK();
 }
 
 Status BetaRowsetReader::_init_iterator() {

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -250,7 +250,8 @@ public:
                 RETURN_IF_ERROR(BitmapTypeCode::validate(*(_data.data + last_offset)));
             }
         }
-        dst->insert_many_continuous_binary_data(_data.data, _offsets.data(), max_fetch);
+        RETURN_IF_CATCH_EXCEPTION(
+                dst->insert_many_continuous_binary_data(_data.data, _offsets.data(), max_fetch));
 
         *n = max_fetch;
         return Status::OK();

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
@@ -34,9 +34,10 @@ namespace segment_v2 {
 
 Status BitmapIndexReader::load(bool use_page_cache, bool kept_in_memory) {
     // TODO yyq: implement a new once flag to avoid status construct.
-    return _load_once.call([this, use_page_cache, kept_in_memory] {
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_load_once.call([this, use_page_cache, kept_in_memory] {
         return _load(use_page_cache, kept_in_memory, std::move(_index_meta));
-    });
+    }));
+    return Status::OK();
 }
 
 Status BitmapIndexReader::_load(bool use_page_cache, bool kept_in_memory,

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.cpp
@@ -34,9 +34,11 @@ namespace segment_v2 {
 Status BloomFilterIndexReader::load(bool use_page_cache, bool kept_in_memory,
                                     OlapReaderStatistics* index_load_stats) {
     // TODO yyq: implement a new once flag to avoid status construct.
-    return _load_once.call([this, use_page_cache, kept_in_memory, index_load_stats] {
-        return _load(use_page_cache, kept_in_memory, index_load_stats);
-    });
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(
+            _load_once.call([this, use_page_cache, kept_in_memory, index_load_stats] {
+                return _load(use_page_cache, kept_in_memory, index_load_stats);
+            }));
+    return Status::OK();
 }
 
 int64_t BloomFilterIndexReader::get_metadata_size() const {

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -72,9 +72,11 @@ Status OrdinalIndexWriter::finish(io::FileWriter* file_writer, ColumnIndexMetaPB
 Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory,
                                 OlapReaderStatistics* index_load_stats) {
     // TODO yyq: implement a new once flag to avoid status construct.
-    return _load_once.call([this, use_page_cache, kept_in_memory, index_load_stats] {
-        return _load(use_page_cache, kept_in_memory, std::move(_meta_pb), index_load_stats);
-    });
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(
+            _load_once.call([this, use_page_cache, kept_in_memory, index_load_stats] {
+                return _load(use_page_cache, kept_in_memory, std::move(_meta_pb), index_load_stats);
+            }));
+    return Status::OK();
 }
 
 Status OrdinalIndexReader::_load(bool use_page_cache, bool kept_in_memory,

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -499,7 +499,7 @@ Status Segment::_load_pk_bloom_filter(OlapReaderStatistics* stats) {
 
 Status Segment::load_pk_index_and_bf(OlapReaderStatistics* index_load_stats) {
     RETURN_IF_ERROR(load_index(index_load_stats));
-    RETURN_IF_ERROR(_load_pk_bloom_filter(index_load_stats));
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_load_pk_bloom_filter(index_load_stats));
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/zone_map_index.cpp
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.cpp
@@ -143,10 +143,12 @@ Status TypedZoneMapIndexWriter<Type>::finish(io::FileWriter* file_writer,
 Status ZoneMapIndexReader::load(bool use_page_cache, bool kept_in_memory,
                                 OlapReaderStatistics* index_load_stats) {
     // TODO yyq: implement a new once flag to avoid status construct.
-    return _load_once.call([this, use_page_cache, kept_in_memory, index_load_stats] {
-        return _load(use_page_cache, kept_in_memory, std::move(_page_zone_maps_meta),
-                     index_load_stats);
-    });
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(
+            _load_once.call([this, use_page_cache, kept_in_memory, index_load_stats] {
+                return _load(use_page_cache, kept_in_memory, std::move(_page_zone_maps_meta),
+                             index_load_stats);
+            }));
+    return Status::OK();
 }
 
 Status ZoneMapIndexReader::_load(bool use_page_cache, bool kept_in_memory,

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -326,7 +326,8 @@ Status Tablet::_init_once_action() {
 }
 
 Status Tablet::init() {
-    return _init_once.call([this] { return _init_once_action(); });
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_init_once.call([this] { return _init_once_action(); }));
+    return Status::OK();
 }
 
 // should save tablet meta to remote meta store


### PR DESCRIPTION
### What problem does this PR solve?

Currently, memory allocation failure exception will only be thrown when there exists `RETURN_IF_CATCH_EXCEPTION/...` in some frame in the calling stack. However, `DorisCallOnce` will catch and store the exception thrown by inner function and re-throw it for later calls in maybe different calling stack in which there is no try catch block. In this case, it will cause coredump. So this PR add try catch block for every call to `DorisCallOnce::call()` to avoid coredump. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

