### PR TITLE
[fix](orc) dont't push down null aware predicate

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -716,7 +716,10 @@ bool OrcReader::_check_expr_can_push_down(const VExprSPtr& expr) {
     case TExprOpcode::NE:
     case TExprOpcode::FILTER_IN:
     case TExprOpcode::FILTER_NOT_IN:
-        return _check_slot_can_push_down(expr) && _check_rest_children_can_push_down(expr);
+        // don't support NULL_AWARE_BINARY_PRED and NULL_AWARE_IN_PRED
+        return expr->node_type() != TExprNodeType::NULL_AWARE_BINARY_PRED &&
+               expr->node_type() != TExprNodeType::NULL_AWARE_IN_PRED &&
+               _check_slot_can_push_down(expr) && _check_rest_children_can_push_down(expr);
 
     case TExprOpcode::INVALID_OPCODE:
         if (expr->node_type() == TExprNodeType::FUNCTION_CALL) {

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -716,7 +716,7 @@ bool OrcReader::_check_expr_can_push_down(const VExprSPtr& expr) {
     case TExprOpcode::NE:
     case TExprOpcode::FILTER_IN:
     case TExprOpcode::FILTER_NOT_IN:
-        // don't support NULL_AWARE_BINARY_PRED and NULL_AWARE_IN_PRED
+        // can't push down if expr is null aware predicate
         return expr->node_type() != TExprNodeType::NULL_AWARE_BINARY_PRED &&
                expr->node_type() != TExprNodeType::NULL_AWARE_IN_PRED &&
                _check_slot_can_push_down(expr) && _check_rest_children_can_push_down(expr);

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_predicate/orc_predicate_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_predicate/orc_predicate_table.hql
@@ -14,3 +14,25 @@ create table type_changed_table (
 ) stored as orc;
 insert into type_changed_table values (1, 'Alice'), (2, 'Bob'), (3, 'Charlie');
 ALTER TABLE type_changed_table CHANGE COLUMN id id STRING;
+
+CREATE TABLE table_a (
+    id INT,
+    age INT
+) STORED AS ORC;
+
+INSERT INTO table_a VALUES
+(1, null),
+(2, 18),
+(3, null),
+(4, 25);
+
+CREATE TABLE table_b (
+    id INT,
+    age INT
+) STORED AS ORC;
+
+INSERT INTO table_b VALUES
+(1, null),
+(2, null),
+(3, 1000000),
+(4, 100);

--- a/regression-test/data/external_table_p0/hive/test_hive_orc_predicate.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_orc_predicate.out
@@ -13,6 +13,10 @@
 -- !predicate_changed_type3 --
 3	Charlie
 
+-- !predicate_null_aware_equal_in_rt --
+1	\N	1	\N
+3	\N	1	\N
+
 -- !predicate_fixed_char1 --
 1	a
 
@@ -26,4 +30,8 @@
 
 -- !predicate_changed_type3 --
 3	Charlie
+
+-- !predicate_null_aware_equal_in_rt --
+1	\N	1	\N
+3	\N	1	\N
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc_predicate.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc_predicate.groovy
@@ -43,6 +43,8 @@ suite("test_hive_orc_predicate", "p0,external,hive,external_docker,external_dock
             qt_predicate_changed_type2 """ select * from type_changed_table where id = '2';"""
             qt_predicate_changed_type3 """ select * from type_changed_table where id = '3';"""
 
+            qt_predicate_null_aware_equal_in_rt """select * from table_a inner join table_b on table_a.age <=> table_b.age and table_b.id in (1,3);"""
+
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
         }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #43255

Problem Summary:
Example:
```sql
CREATE TABLE table_a (
    id INT,
    age INT
) STORED AS ORC;

INSERT INTO table_a VALUES
(1, null),
(2, 18),
(3, null),
(4, 25);

CREATE TABLE table_b (
    id INT,
    age INT
) STORED AS ORC;

INSERT INTO table_b VALUES
(1, null),
(2, null),
(3, 1000000),
(4, 100);
```
run sql
```
select * from table_a inner join table_b on table_a.age <=> table_b.age and table_b.id in (1,3);
```
When executing this SQL, the backend generates a runtime filter on the table_a side during the join operation, resulting in a condition like WHERE table_a.age IN (NULL, 1000000). It’s important to note that since <=> is a null-aware comparison operator, the IN predicate must also be null-aware. However, the ORC predicate pushdown API does not support null-aware IN predicates. As a result, our current approach ignores null values, leading to an empty result set for this query.

To fix this bug, we’ve adjusted the logic so that predicates with null-aware comparisons are not pushed down, ensuring the correct result as follows:
```text
+------+------+------+------+
| id   | age  | id   | age  |
+------+------+------+------+
|    1 | NULL |    1 | NULL |
|    3 | NULL |    1 | NULL |
+------+------+------+------+
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

