### PR TITLE
[opt](debug) remove redundant DCHECK to allow graceful error handling

### DIFF
--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -410,7 +410,6 @@ Status HdfsFileWriter::_append(std::string_view content) {
         if (_batch_buffer.full()) {
             auto error_msg = fmt::format("invalid batch buffer status, capacity {}, size {}",
                                          _batch_buffer.capacity(), _batch_buffer.size());
-            DCHECK(false) << error_msg;
             return Status::InternalError(error_msg);
         }
         size_t append_size = _batch_buffer.append(content);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

I removed the DCHECK statement from the code because it was redundant. The existing error handling, which returns an error status, is sufficient to handle the failure gracefully without causing a crash. This approach ensures that the process can fail as intended without abrupt termination.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

