### PR TITLE
[Fix](recycler) Fix recycler pipeline case check_meta

### DIFF
--- a/regression-test/suites/correctness_p0/test_mv_case/test_mv_case.groovy
+++ b/regression-test/suites/correctness_p0/test_mv_case/test_mv_case.groovy
@@ -137,4 +137,6 @@ suite("test_mv_case") {
         mv1 a;"""
     waitingMTMVTaskFinishedByMvName("mv2")
     qt_select_mv """ select * from mv2 """
+    sql "drop MATERIALIZED VIEW mv1"
+    sql "drop MATERIALIZED VIEW mv2"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The check_meta case in the recycler pipeline is used to test whether the FE metadata and MS metadata are consistent. This process requires obtaining each index ID from the FE, and then using this index ID to retrieve the table ID and other information. If a table has a large amount of data, the check meta process can take a long time. During this process, if the tablet ID changes, the information previously obtained through the old tablet ID is no longer accurate. In the test_mv_case, the created materialized view (MV) updates every 10 minutes, causing the tablet ID to change. If the check meta process takes longer than 10 minutes, an error will occur. This PR fixes this issue.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

