### PR TITLE
[fix](function)Fix split_by_regexp function integer parameter couldn't set bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SplitByRegexp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SplitByRegexp.java
@@ -22,7 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
-import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.IntegerType;
@@ -77,8 +77,8 @@ public class SplitByRegexp extends ScalarFunction
     @Override
     public void checkLegalityBeforeTypeCoercion() {
         if (children().size() == 3) {
-            if (!child(2).isConstant() || !(child(2) instanceof IntegerLiteral)
-                    || (((IntegerLiteral) child(2)).getValue() < 0)) {
+            if (!child(2).isConstant() || !(child(2) instanceof IntegerLikeLiteral)
+                    || (((IntegerLikeLiteral) child(2)).getIntValue() < 0)) {
                 throw new AnalysisException("the third parameter of "
                         + getName() + " function must be a positive constant: " + toSql());
             }

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_split_by_regexp.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_split_by_regexp.out
@@ -50,3 +50,21 @@
 \N
 ["a", "b", "c", "12345", ""]
 
+-- !select8 --
+["aa,bbb,cccc"]
+
+-- !select9 --
+["aa", "bbb,cccc"]
+
+-- !select10 --
+["aa", "bbb", "cccc"]
+
+-- !select11 --
+["aa", "bbb", "cccc"]
+
+-- !select12 --
+["aa", "bbb", "cccc"]
+
+-- !select13 --
+["aa", "bbb", "cccc"]
+

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_split_by_regexp.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_split_by_regexp.groovy
@@ -64,5 +64,11 @@ suite("test_split_by_regexp") {
     qt_select5 "select split_by_regexp(v1, ',') from test_split_by_regexp order by k1;"
     qt_select6 "select split_by_regexp('do,ris', v2) from test_split_by_regexp order by k1;"
     qt_select7 "select split_by_regexp(v1, v2) from test_split_by_regexp order by k1;"
+    qt_select8 "select split_by_regexp('aa,bbb,cccc', ',', 1);"
+    qt_select9 "select split_by_regexp('aa,bbb,cccc', ',', 2);"
+    qt_select10 "select split_by_regexp('aa,bbb,cccc', ',', 3);"
+    qt_select11 "select split_by_regexp('aa,bbb,cccc', ',', 4);"
+    qt_select12 "select split_by_regexp('aa,bbb,cccc', ',', 100000000);"
+    qt_select13 "select split_by_regexp('aa,bbb,cccc', ',', 10000000000000);"
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

split_by_regexp function's third parameter doesn't support tinyint. This pr is to fix it.

```
mysql> select split_by_regexp('aa,bb,cc', ',', 1);
ERROR 1105 (HY000): errCode = 2, detailMessage = the third parameter of split_by_regexp function must be a positive constant: split_by_regexp('aa,bb,cc', ',', 1)
```

Related PR: #38259

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

