### PR TITLE
[fix](jni) pass krb5 conf to jni

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -90,6 +90,10 @@ const std::string GetDorisJNIClasspathOption() {
     }
 }
 
+const std::string GetKerb5ConfPath() {
+    return "-Djava.security.krb5.conf=" + config::kerberos_krb5_conf_path;
+}
+
 [[maybe_unused]] void SetEnvIfNecessary() {
     const auto* doris_home = getenv("DORIS_HOME");
     DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
@@ -103,10 +107,11 @@ const std::string GetDorisJNIClasspathOption() {
     // LIBHDFS_OPTS
     const std::string java_opts = getenv("JAVA_OPTS") ? getenv("JAVA_OPTS") : "";
     std::string libhdfs_opts =
-            fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{}", java_opts,
+            fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{} ", java_opts,
                         getenv("DORIS_HOME"), getenv("DORIS_HOME") + std::string("/lib"));
+    libhdfs_opts += fmt::format("{} ", GetKerb5ConfPath());
 
-    setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 0);
+    setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);
 }
 
 // Only used on non-x86 platform
@@ -136,6 +141,7 @@ const std::string GetDorisJNIClasspathOption() {
                                                std::istream_iterator<std::string>());
             options.push_back(GetDorisJNIClasspathOption());
         }
+        options.push_back(GetKerb5ConfPath());
         std::unique_ptr<JavaVMOption[]> jvm_options(new JavaVMOption[options.size()]);
         for (int i = 0; i < options.size(); ++i) {
             jvm_options[i] = {const_cast<char*>(options[i].c_str()), nullptr};

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <vector>
 
+#include "common/config.h"
 #include "gutil/strings/substitute.h"
 #include "util/doris_metrics.h"
 #include "util/jni_native_method.h"


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #47299

Problem Summary:

This pick part of #47299, only related to `jni-util.cpp`.
To pass the krb5.conf config to Jni env

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

