### PR TITLE
[refactor](merger) Simplify sort merger

### DIFF
--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -151,7 +151,7 @@ Status ExchangeSourceOperatorX::get_block(RuntimeState* state, vectorized::Block
     if (_is_merging && !local_state.is_ready) {
         SCOPED_TIMER(local_state.create_merger_timer);
         RETURN_IF_ERROR(local_state.stream_recvr->create_merger(
-                local_state.vsort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order, _nulls_first,
+                local_state.vsort_exec_exprs.ordering_expr_ctxs(), _is_asc_order, _nulls_first,
                 state->batch_size(), _limit, _offset));
         local_state.is_ready = true;
         return Status::OK();

--- a/be/src/pipeline/exec/sort_source_operator.cpp
+++ b/be/src/pipeline/exec/sort_source_operator.cpp
@@ -67,18 +67,5 @@ const vectorized::SortDescription& SortSourceOperatorX::get_sort_description(
     return local_state._shared_state->sorter->get_sort_description();
 }
 
-Status SortSourceOperatorX::build_merger(RuntimeState* state,
-                                         std::unique_ptr<vectorized::VSortedRunMerger>& merger,
-                                         RuntimeProfile* profile) {
-    // now only use in LocalMergeSortExchanger::get_block
-    vectorized::VSortExecExprs vsort_exec_exprs;
-    // clone vsort_exec_exprs in LocalMergeSortExchanger
-    RETURN_IF_ERROR(_vsort_exec_exprs.clone(state, vsort_exec_exprs));
-    merger = std::make_unique<vectorized::VSortedRunMerger>(
-            vsort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order, _nulls_first,
-            state->batch_size(), _limit, _offset, profile);
-    return Status::OK();
-}
-
 #include "common/compile_check_end.h"
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/sort_source_operator.h
+++ b/be/src/pipeline/exec/sort_source_operator.h
@@ -56,11 +56,10 @@ public:
     bool use_local_merge() const { return _merge_by_exchange; }
     const vectorized::SortDescription& get_sort_description(RuntimeState* state) const;
 
-    Status build_merger(RuntimeState* state, std::unique_ptr<vectorized::VSortedRunMerger>& merger,
-                        RuntimeProfile* profile);
-
 private:
+    friend class PipelineFragmentContext;
     friend class SortLocalState;
+
     const bool _merge_by_exchange;
     std::vector<bool> _is_asc_order;
     std::vector<bool> _nulls_first;

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -345,7 +345,7 @@ public:
     LocalMergeSortExchanger(MergeInfo&& merge_info, int running_sink_operators, int num_partitions,
                             int free_block_limit)
             : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions, free_block_limit),
-              _merge_info(merge_info) {}
+              _merge_info(std::move(merge_info)) {}
     ~LocalMergeSortExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;
@@ -361,7 +361,7 @@ public:
 
 private:
     std::unique_ptr<vectorized::VSortedRunMerger> _merger;
-    MergeInfo& _merge_info;
+    MergeInfo _merge_info;
     std::vector<std::atomic_int64_t> _queues_mem_usege;
 };
 

--- a/be/src/pipeline/local_exchange/local_exchanger.h
+++ b/be/src/pipeline/local_exchange/local_exchanger.h
@@ -29,7 +29,6 @@ namespace pipeline {
 class LocalExchangeSourceLocalState;
 class LocalExchangeSinkLocalState;
 class BlockWrapper;
-class SortSourceOperatorX;
 
 struct Profile {
     RuntimeProfile::Counter* compute_hash_value_timer = nullptr;
@@ -335,11 +334,18 @@ public:
 
 class LocalMergeSortExchanger final : public Exchanger<BlockWrapperSPtr> {
 public:
+    struct MergeInfo {
+        const std::vector<bool>& is_asc_order;
+        const std::vector<bool>& nulls_first;
+        const int64_t limit;
+        const int64_t offset;
+        const vectorized::VExprContextSPtrs& ordering_expr_ctxs;
+    };
     ENABLE_FACTORY_CREATOR(LocalMergeSortExchanger);
-    LocalMergeSortExchanger(std::shared_ptr<SortSourceOperatorX> sort_source,
-                            int running_sink_operators, int num_partitions, int free_block_limit)
+    LocalMergeSortExchanger(MergeInfo&& merge_info, int running_sink_operators, int num_partitions,
+                            int free_block_limit)
             : Exchanger<BlockWrapperSPtr>(running_sink_operators, num_partitions, free_block_limit),
-              _sort_source(std::move(sort_source)) {}
+              _merge_info(merge_info) {}
     ~LocalMergeSortExchanger() override = default;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos, Profile&& profile,
                 SinkInfo&& sink_info) override;
@@ -355,7 +361,7 @@ public:
 
 private:
     std::unique_ptr<vectorized::VSortedRunMerger> _merger;
-    std::shared_ptr<SortSourceOperatorX> _sort_source;
+    MergeInfo& _merge_info;
     std::vector<std::atomic_int64_t> _queues_mem_usege;
 };
 

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -818,7 +818,10 @@ Status PipelineFragmentContext::_add_local_exchange_impl(
                     child_op->get_name());
         }
         shared_state->exchanger = LocalMergeSortExchanger::create_unique(
-                sort_source, cur_pipe->num_tasks(), _num_instances,
+                LocalMergeSortExchanger::MergeInfo {
+                        sort_source->_is_asc_order, sort_source->_nulls_first, sort_source->_limit,
+                        sort_source->_offset, sort_source->_vsort_exec_exprs.ordering_expr_ctxs()},
+                cur_pipe->num_tasks(), _num_instances,
                 _runtime_state->query_options().__isset.local_exchange_free_blocks_limit
                         ? cast_set<int>(
                                   _runtime_state->query_options().local_exchange_free_blocks_limit)

--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -195,9 +195,9 @@ void HeapSorter::_do_filter(HeapSortCursorBlockView& block_view, size_t num_rows
 }
 
 Status HeapSorter::_prepare_sort_descs(Block* block) {
-    _sort_description.resize(_vsort_exec_exprs.lhs_ordering_expr_ctxs().size());
+    _sort_description.resize(_vsort_exec_exprs.ordering_expr_ctxs().size());
     for (int i = 0; i < _sort_description.size(); i++) {
-        const auto& ordering_expr = _vsort_exec_exprs.lhs_ordering_expr_ctxs()[i];
+        const auto& ordering_expr = _vsort_exec_exprs.ordering_expr_ctxs()[i];
         RETURN_IF_ERROR(ordering_expr->execute(block, &_sort_description[i].column_number));
 
         _sort_description[i].direction = _is_asc_order[i] ? 1 : -1;

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -180,10 +180,10 @@ Status Sorter::partial_sort(Block& src_block, Block& dest_block) {
         dest_block.swap(new_block);
     }
 
-    _sort_description.resize(_vsort_exec_exprs.lhs_ordering_expr_ctxs().size());
+    _sort_description.resize(_vsort_exec_exprs.ordering_expr_ctxs().size());
     Block* result_block = _materialize_sort_exprs ? &dest_block : &src_block;
     for (int i = 0; i < _sort_description.size(); i++) {
-        const auto& ordering_expr = _vsort_exec_exprs.lhs_ordering_expr_ctxs()[i];
+        const auto& ordering_expr = _vsort_exec_exprs.ordering_expr_ctxs()[i];
         RETURN_IF_ERROR(ordering_expr->execute(result_block, &_sort_description[i].column_number));
 
         _sort_description[i].direction = _is_asc_order[i] ? 1 : -1;

--- a/be/src/vec/common/sort/vsort_exec_exprs.h
+++ b/be/src/vec/common/sort/vsort_exec_exprs.h
@@ -58,10 +58,7 @@ public:
     }
 
     // Can only be used after calling prepare()
-    const VExprContextSPtrs& lhs_ordering_expr_ctxs() const { return _lhs_ordering_expr_ctxs; }
-
-    // Can only be used after calling open()
-    const VExprContextSPtrs& rhs_ordering_expr_ctxs() const { return _rhs_ordering_expr_ctxs; }
+    const VExprContextSPtrs& ordering_expr_ctxs() const { return _ordering_expr_ctxs; }
 
     bool need_materialize_tuple() const { return _materialize_tuple; }
 
@@ -73,8 +70,7 @@ public:
 
 private:
     // Create two VExprContexts for evaluating over the TupleRows.
-    VExprContextSPtrs _lhs_ordering_expr_ctxs;
-    VExprContextSPtrs _rhs_ordering_expr_ctxs;
+    VExprContextSPtrs _ordering_expr_ctxs;
 
     // If true, the tuples to be sorted are materialized by
     // _sort_tuple_slot_exprs before the actual sort is performed.
@@ -85,15 +81,9 @@ private:
     // _materialize_tuple is true.
     VExprContextSPtrs _sort_tuple_slot_expr_ctxs;
 
-    // for some reason, _sort_tuple_slot_expr_ctxs is not-null but _lhs_ordering_expr_ctxs is nullable
+    // for some reason, _sort_tuple_slot_expr_ctxs is not-null but _ordering_expr_ctxs is nullable
     // this flag list would be used to convert column to nullable.
     std::vector<bool> _need_convert_to_nullable_flags;
-
-    // Initialize directly from already-created VExprContexts. Callers should manually call
-    // Prepare(), Open(), and Close() on input VExprContexts (instead of calling the
-    // analogous functions in this class). Used for testing.
-    Status init(const VExprContextSPtrs& lhs_ordering_expr_ctxs,
-                const VExprContextSPtrs& rhs_ordering_expr_ctxs);
 
     // Initialize the ordering and (optionally) materialization expressions from the thrift
     // TExprs into the specified pool. sort_tuple_slot_exprs is NULL if the tuple is not

--- a/be/test/vec/exec/sort/sort_test.cpp
+++ b/be/test/vec/exec/sort/sort_test.cpp
@@ -59,7 +59,7 @@ public:
 
         sort_exec_exprs._materialize_tuple = false;
 
-        sort_exec_exprs._lhs_ordering_expr_ctxs.push_back(
+        sort_exec_exprs._ordering_expr_ctxs.push_back(
                 VExprContext::create_shared(std::make_shared<MockSlotRef>(0)));
 
         switch (sort_type) {


### PR DESCRIPTION
### What problem does this PR solve?

1. Delete unused variable in `VSortExecExprs`.
2. De-couple sort operator and local exchange operator.
3. Use local exchange 's profile to collect sort merger's metrics instead of sort operator's.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

