### PR TITLE
[enhancement](plugin) filebeat: support multi-table

### DIFF
--- a/extension/beats/doris/client.go
+++ b/extension/beats/doris/client.go
@@ -172,6 +172,7 @@ func NewDorisClient(s clientSettings) (*client, error) {
 
 		database:      s.Database,
 		tableSelector: s.TableSelector,
+		defaultTable:  s.DefaultTable,
 		labelPrefix:   s.LabelPrefix,
 		lineDelimiter: s.LineDelimiter,
 		logRequest:    s.LogRequest,
@@ -351,6 +352,10 @@ func (client *client) publishEvents(tableEventsMap map[string]*Events) ([]publis
 
 		tableEvents.serialization = stringBuilder.String()
 
+		if tableEvents.serialization == "" {
+			continue
+		}
+
 		var requestErr error
 		tableEvents.request, requestErr = http.NewRequest(http.MethodPut, client.url(table), strings.NewReader(tableEvents.serialization))
 		if requestErr != nil {
@@ -389,6 +394,9 @@ func (client *client) publishEvents(tableEventsMap map[string]*Events) ([]publis
 		}
 
 		response := tableEvents.response
+		if response == nil {
+			continue
+		}
 
 		if tableEvents.err != nil {
 			client.logger.Errorf("Failed to stream-load request: %v", tableEvents.err)

--- a/extension/beats/doris/client.go
+++ b/extension/beats/doris/client.go
@@ -50,6 +50,7 @@ type client struct {
 
 	database      string
 	tableSelector *fmtSelector
+	defaultTable  string
 	labelPrefix   string
 	lineDelimiter string
 	logRequest    bool
@@ -69,6 +70,7 @@ type clientSettings struct {
 
 	Database      string
 	TableSelector *fmtSelector
+	DefaultTable  string
 	LabelPrefix   string
 	LineDelimiter string
 	LogRequest    bool
@@ -287,7 +289,14 @@ func (client *client) makeTableEventsMap(_ context.Context, events []publisher.E
 				table, err := client.tableSelector.Sel.Select(&e.Content)
 				if err != nil {
 					client.logger.Errorf("Failed to select table: %+v", err)
-					table = nilTable
+				}
+				if table == nilTable {
+					if client.defaultTable == nilTable {
+						client.logger.Warnf("table format error, the default table is not set, the data will be dropped")
+					} else {
+						table = client.defaultTable
+						client.logger.Warnf("table format error, use the default table: %s", client.defaultTable)
+					}
 				}
 				_, ok := tableEventsMap[table]
 				if !ok {

--- a/extension/beats/doris/client.go
+++ b/extension/beats/doris/client.go
@@ -22,11 +22,13 @@ package doris
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -39,14 +41,14 @@ import (
 )
 
 type client struct {
-	url        string
+	dbURL      string
 	httpClient *http.Client
 	headers    map[string]string
 	beat       beat.Info
 	codec      codec.Codec
 
 	database      string
-	table         string
+	tableSelector *fmtSelector
 	labelPrefix   string
 	lineDelimiter string
 	logRequest    bool
@@ -56,13 +58,15 @@ type client struct {
 	logger   *logp.Logger
 }
 
+var _ outputs.NetworkClient = (*client)(nil)
+
 type clientSettings struct {
-	URL     string
+	DBURL   string
 	Timeout time.Duration
 	Headers map[string]string
 
 	Database      string
-	Table         string
+	TableSelector *fmtSelector
 	LabelPrefix   string
 	LineDelimiter string
 	LogRequest    bool
@@ -75,7 +79,7 @@ type clientSettings struct {
 }
 
 func (s clientSettings) String() string {
-	str := fmt.Sprintf("clientSettings{%s, %s, %s, %s}", s.URL, s.Timeout, s.LabelPrefix, s.Headers)
+	str := fmt.Sprintf("clientSettings{%s/{table}/_stream_load, %s, %s, %s}", s.DBURL, s.Timeout, s.LabelPrefix, s.Headers)
 	if _, ok := s.Headers["Authorization"]; ok {
 		return strings.Replace(str, "Authorization:"+s.Headers["Authorization"], "Authorization:Basic ******", 1)
 	}
@@ -155,14 +159,14 @@ func NewDorisClient(s clientSettings) (*client, error) {
 	s.Logger.Infof("Received settings: %s", s)
 
 	client := &client{
-		url: s.URL,
+		dbURL: s.DBURL,
 		httpClient: &http.Client{
 			Timeout: s.Timeout,
 		},
 		headers: s.Headers,
 
 		database:      s.Database,
-		table:         s.Table,
+		tableSelector: s.TableSelector,
 		labelPrefix:   s.LabelPrefix,
 		lineDelimiter: s.LineDelimiter,
 		logRequest:    s.LogRequest,
@@ -184,124 +188,306 @@ func (client *client) Close() error {
 }
 
 func (client *client) String() string {
-	str := fmt.Sprintf("doris{%s, %s, %s}", client.url, client.labelPrefix, client.headers)
+	str := fmt.Sprintf("doris{%s, %s, %s}", client.url("{table}"), client.labelPrefix, client.headers)
 	if _, ok := client.headers["Authorization"]; ok {
 		return strings.Replace(str, "Authorization:"+client.headers["Authorization"], "Authorization:Basic ******", 1)
 	}
 	return str
 }
 
-func (client *client) Publish(_ context.Context, batch publisher.Batch) error {
+func (client *client) url(table string) string {
+	return fmt.Sprintf("%s/%s/_stream_load", client.dbURL, table)
+}
+
+func (client *client) label(table string) string {
+	return fmt.Sprintf("%s_%s_%s_%d_%s", client.labelPrefix, client.database, table, time.Now().UnixMilli(), uuid.New())
+}
+
+// Publish sends events to doris.
+// batch.Events() are grouped by table first (tableEvents).
+// For each tableEvents, call the http stream load api to send the tableEvents to doris.
+// If a tableEvents returns an error, add a barrier to the last event of the tableEvents.
+// A barrier contains a table, a stream load label, and the length of the tableEvents.
+// Add all failed tableEvents to the retryEvents.
+// So if the last event in the batch.Events() has a barrier, it means that this is a retry.
+// In this case, we will split the batch.Events() to some tableEvents by the barrier events
+// and send each tableEvents to doris again reusing the label in the barrier.
+func (client *client) Publish(ctx context.Context, batch publisher.Batch) error {
 	events := batch.Events()
 	length := len(events)
 	client.logger.Debugf("Received events: %d", length)
 
-	label := fmt.Sprintf("%s_%s_%s_%d_%s", client.labelPrefix, client.database, client.table, time.Now().UnixMilli(), uuid.New())
-	rest, err := client.publishEvents(label, events)
+	tableEventsMap := client.makeTableEventsMap(ctx, events)
+	rest, err := client.publishEvents(tableEventsMap)
 
 	if len(rest) == 0 {
 		batch.ACK()
-		client.logger.Debugf("Success send %d events", length)
 	} else {
-		client.observer.Failed(length)
 		batch.RetryEvents(rest)
-		client.logger.Warnf("Retry send %d events", length)
+		client.logger.Warnf("Retry send %d events", len(rest))
 	}
 	return err
 }
 
-func (client *client) publishEvents(lable string, events []publisher.Event) ([]publisher.Event, error) {
+const nilTable = ""
+
+type Events struct {
+	Label  string
+	Events []publisher.Event
+
+	// used in publishEvents
+	serialization string
+	dropped       int64
+	request       *http.Request
+	response      *http.Response
+	err           error
+}
+
+func (client *client) makeTableEventsMap(_ context.Context, events []publisher.Event) map[string]*Events {
+	tableEventsMap := make(map[string]*Events)
+	if len(events) == 0 {
+		return tableEventsMap
+	}
+
+	barrier, err := getBarrierFromEvent(&events[len(events)-1])
+	if err == nil { // retry
+		if client.tableSelector.Sel.IsConst() { // table is const
+			removeBarrierFromEvent(&events[len(events)-1])
+			tableEventsMap[barrier.Table] = &Events{
+				Label:  barrier.Label,
+				Events: events,
+			}
+		} else { // split events by barrier
+			for end := len(events); end > 0; {
+				barrier, _ := getBarrierFromEvent(&events[end-1])
+				removeBarrierFromEvent(&events[end-1])
+				start := end - barrier.Length
+
+				tableEventsMap[barrier.Table] = &Events{
+					Label:  barrier.Label,
+					Events: events[start:end], // should not do any append to the array, because here is a slice of the original array
+				}
+
+				end = start
+			}
+		}
+	} else { // first time
+		if client.tableSelector.Sel.IsConst() { // table is const
+			table, _ := client.tableSelector.Sel.Select(&events[0].Content)
+			label := client.label(table)
+			tableEventsMap[table] = &Events{
+				Label:  label,
+				Events: events,
+			}
+		} else { // select table for each event
+			for _, e := range events {
+				table, err := client.tableSelector.Sel.Select(&e.Content)
+				if err != nil {
+					client.logger.Errorf("Failed to select table: %+v", err)
+					table = nilTable
+				}
+				_, ok := tableEventsMap[table]
+				if !ok {
+					tableEventsMap[table] = &Events{
+						Label:  client.label(table),
+						Events: []publisher.Event{e},
+					}
+				} else {
+					tableEventsMap[table].Events = append(tableEventsMap[table].Events, e)
+				}
+			}
+		}
+	}
+
+	return tableEventsMap
+}
+
+func (client *client) publishEvents(tableEventsMap map[string]*Events) ([]publisher.Event, error) {
 	begin := time.Now()
 
-	var logFirstEvent []byte
-	var stringBuilder strings.Builder
+	for table, tableEvents := range tableEventsMap {
+		events := tableEvents.Events
 
-	dropped := 0
-	for i := range events {
-		event := &events[i]
-		serializedEvent, err := client.codec.Encode(client.beat.Beat, &event.Content)
-
-		if err != nil {
-			if event.Guaranteed() {
-				client.logger.Errorf("Failed to serialize the event: %+v", err)
-			} else {
-				client.logger.Warnf("Failed to serialize the event: %+v", err)
-			}
-			client.logger.Debugf("Failed event: %v", event)
-
-			dropped++
-			client.reporter.IncrFailedRows(1)
+		if table == nilTable {
+			client.logger.Errorf("Invalid table for %v events", len(events))
+			tableEvents.dropped = int64(len(events))
+			tableEvents.err = fmt.Errorf("invalid table for %v events", len(events))
 			continue
 		}
 
-		if logFirstEvent == nil {
-			logFirstEvent = serializedEvent
+		var stringBuilder strings.Builder
+
+		for i := range events {
+			event := &events[i]
+			serializedEvent, err := client.codec.Encode(client.beat.Beat, &event.Content)
+
+			if err != nil {
+				if event.Guaranteed() {
+					client.logger.Errorf("Failed to serialize the event: %+v", err)
+				} else {
+					client.logger.Warnf("Failed to serialize the event: %+v", err)
+				}
+				client.logger.Debugf("Failed event: %v", event)
+
+				tableEvents.dropped++
+				continue
+			}
+
+			stringBuilder.Write(serializedEvent)
+			stringBuilder.WriteString(client.lineDelimiter)
 		}
-		stringBuilder.Write(serializedEvent)
-		stringBuilder.WriteString(client.lineDelimiter)
-	}
-	request, requestErr := http.NewRequest(http.MethodPut, client.url, strings.NewReader(stringBuilder.String()))
-	if requestErr != nil {
-		client.logger.Errorf("Failed to create request: %s", requestErr)
-		return events, requestErr
-	}
 
-	var groupCommit = false
-	for k, v := range client.headers {
-		request.Header.Set(k, v)
-		if k == "group_commit" && v != "off_mode" {
-			groupCommit = true
+		tableEvents.serialization = stringBuilder.String()
+
+		var requestErr error
+		tableEvents.request, requestErr = http.NewRequest(http.MethodPut, client.url(table), strings.NewReader(tableEvents.serialization))
+		if requestErr != nil {
+			client.logger.Errorf("Failed to create request: %v", requestErr)
+			continue
+		}
+
+		var groupCommit = false
+		for k, v := range client.headers {
+			tableEvents.request.Header.Set(k, v)
+			if k == "group_commit" && v != "off_mode" {
+				groupCommit = true
+			}
+		}
+		if !groupCommit {
+			tableEvents.request.Header.Set("label", tableEvents.Label)
 		}
 	}
-	if !groupCommit {
-		request.Header.Set("label", lable)
+
+	wg := sync.WaitGroup{}
+	for _, tableEvents := range tableEventsMap {
+		request := tableEvents.request
+		if request != nil {
+			wg.Add(1)
+			go func(e *Events) {
+				e.response, e.err = client.httpClient.Do(request)
+				wg.Done()
+			}(tableEvents)
+		}
+	}
+	wg.Wait()
+
+	for table, tableEvents := range tableEventsMap {
+		if table == nilTable {
+			continue
+		}
+
+		response := tableEvents.response
+
+		if tableEvents.err != nil {
+			client.logger.Errorf("Failed to stream-load request: %v", tableEvents.err)
+			continue
+		}
+
+		defer response.Body.Close()
+
+		var responseBytes []byte
+		responseBytes, tableEvents.err = httputil.DumpResponse(response, true)
+		if tableEvents.err != nil {
+			client.logger.Errorf("Failed to dump doris stream load response: %v, error: %v", response, tableEvents.err)
+			continue
+		}
+
+		if client.logRequest {
+			client.logger.Infof("doris stream load response response:\n%s", string(responseBytes))
+		}
+
+		var body []byte
+		body, tableEvents.err = ioutil.ReadAll(response.Body)
+		if tableEvents.err != nil {
+			client.logger.Errorf("Failed to read doris stream load response body, error: %v, response:\n%v", tableEvents.err, string(responseBytes))
+			continue
+		}
+
+		var status ResponseStatus
+		tableEvents.err = json.Unmarshal(body, &status)
+		if tableEvents.err != nil {
+			client.logger.Errorf("Failed to parse doris stream load response to JSON, error: %v, response:\n%v", tableEvents.err, string(responseBytes))
+			continue
+		}
+
+		if status.Status != "Success" && status.Status != "Publish Timeout" && status.Status != "Label Already Exists" {
+			client.logger.Errorf("doris stream load status: '%v' is not 'Success', full response: %v", status.Status, string(responseBytes))
+			tableEvents.err = errors.New("doris stream load status: " + status.Status)
+			continue
+		}
+
+		if status.Status == "Label Already Exists" {
+			client.logger.Warnf("doris stream load status: '%v', %v events skipped", status.Status, int64(len(tableEvents.Events))-tableEvents.dropped)
+		}
 	}
 
-	response, responseErr := client.httpClient.Do(request)
-	if responseErr != nil {
-		client.logger.Errorf("Failed to stream-load request: %v", responseErr)
-		return events, responseErr
+	var errs error
+	var retryEvents []publisher.Event
+	var retryRows int64 = 0
+	var droppedRows int64 = 0
+	var successRows int64 = 0
+	var successBytes int64 = 0
+
+	for table, tableEvents := range tableEventsMap {
+		if table == nilTable {
+			errs = errors.Join(errs, tableEvents.err)
+			droppedRows += tableEvents.dropped
+			continue
+		}
+
+		if tableEvents.err != nil {
+			errs = errors.Join(errs, tableEvents.err)
+			retryRows += int64(len(tableEvents.Events))
+			addBarrier(table, tableEvents)
+			retryEvents = append(retryEvents, tableEvents.Events...)
+			continue
+		}
+
+		droppedRows += tableEvents.dropped
+		successRows += int64(len(tableEvents.Events)) - tableEvents.dropped
+		successBytes += int64(len(tableEvents.serialization))
 	}
 
-	defer response.Body.Close()
+	client.logger.Debugf("Stream-Load publish events: %d events have been published to doris in %v.", successRows, time.Since(begin))
 
-	responseBytes, responseErr := httputil.DumpResponse(response, true)
-	if responseErr != nil {
-		client.logger.Errorf("Failed to dump doris stream load response: %v, error: %v", response, responseErr)
-		return events, responseErr
+	client.observer.Dropped(int(droppedRows))
+	client.observer.Acked(int(successRows))
+	client.observer.Failed(int(retryRows))
+
+	client.reporter.IncrTotalBytes(successBytes)
+	client.reporter.IncrTotalRows(successRows)
+
+	return retryEvents, errs
+}
+
+const barrierKey = "__#BARRIER#__"
+
+type barrierT struct {
+	Table  string `json:"table"`
+	Label  string `json:"label"`
+	Length int    `json:"length"`
+}
+
+func addBarrier(table string, events *Events) {
+	events.Events[len(events.Events)-1].Content.Fields[barrierKey] = &barrierT{
+		Table:  table,
+		Label:  events.Label,
+		Length: len(events.Events),
 	}
+}
 
-	if client.logRequest {
-		client.logger.Infof("doris stream load response response:\n%s", string(responseBytes))
+func getBarrierFromEvent(event *publisher.Event) (*barrierT, error) {
+	value, err := event.Content.Fields.GetValue(barrierKey)
+	if err != nil {
+		return nil, err
 	}
-
-	body, bodyErr := ioutil.ReadAll(response.Body)
-	if bodyErr != nil {
-		client.logger.Errorf("Failed to read doris stream load response body, error: %v, response:\n%v", bodyErr, string(responseBytes))
-		return events, bodyErr
+	barrier, ok := value.(*barrierT)
+	if !ok {
+		return nil, fmt.Errorf("invalid barrier event: %+v", event)
 	}
+	return barrier, nil
+}
 
-	var status ResponseStatus
-	parseErr := json.Unmarshal(body, &status)
-	if parseErr != nil {
-		client.logger.Errorf("Failed to parse doris stream load response to JSON, error: %v, response:\n%v", parseErr, string(responseBytes))
-		return events, parseErr
-	}
-
-	if status.Status != "Success" {
-		client.logger.Errorf("doris stream load status: '%v' is not 'Success', full response: %v", status.Status, string(responseBytes))
-		return events, &status
-	}
-
-	client.logger.Debugf("Stream-Load publish events: %d events have been published to doris in %v.",
-		len(events)-dropped,
-		time.Now().Sub(begin))
-
-	client.observer.Dropped(dropped)
-	client.observer.Acked(len(events) - dropped)
-
-	client.reporter.IncrTotalBytes(int64(stringBuilder.Len()))
-	client.reporter.IncrTotalRows(int64(len(events) - dropped))
-
-	return nil, nil
+func removeBarrierFromEvent(event *publisher.Event) {
+	_ = event.Content.Fields.Delete(barrierKey)
 }

--- a/extension/beats/doris/common_test.go
+++ b/extension/beats/doris/common_test.go
@@ -139,6 +139,23 @@ func TestSelectorWithDefaultTable(t *testing.T) {
 	}
 }
 
+func TestWorkers(t *testing.T) {
+	dorisConfig := map[string]interface{}{
+		"fenodes":  []string{"http://localhost:8030", "http://localhost:8031"},
+		"user":     "admin",
+		"password": "",
+		"database": "db",
+		"table":    "table",
+		"worker":   3,
+	}
+
+	cfg, err := common.NewConfigFrom(dorisConfig)
+	require.NoError(t, err)
+	group, err := makeDoris(nil, beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, 2*3, len(group.Clients))
+}
+
 func TestMultiTable(t *testing.T) {
 	database := "log_db"
 	table := "%{[message]}"

--- a/extension/beats/doris/common_test.go
+++ b/extension/beats/doris/common_test.go
@@ -1,0 +1,297 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package doris
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/format" // codec format
+	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"   // codec json
+	"github.com/elastic/beats/v7/libbeat/outputs/outest"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/stretchr/testify/require"
+)
+
+type Attr struct {
+	Table   string
+	Message string
+	Result  string
+	Const   bool
+}
+
+func TestSelector(t *testing.T) {
+	now := time.Now()
+	fmt.Println(now)
+
+	attrs := []*Attr{
+		{"tablE", "123", "tablE", true},
+		{"table_%{[message]}", "123", "table_123", false},
+		{"table_%{+yyyy-MM-dd}", "123", fmt.Sprintf("table_%s", now.Format("2006-01-02")), false},
+		{"table_%{[message]}", "%{[message]}", "table_%{[message]}", false},
+	}
+
+	for i, attr := range attrs {
+		fmt.Printf("table%v: %v\n", i, attr.Table)
+
+		dorisConfig := map[string]interface{}{
+			"fenodes":  []string{"http://localhost:8030"},
+			"user":     "admin",
+			"password": "",
+			"database": "db",
+			"table":    attr.Table,
+		}
+
+		cfg, err := common.NewConfigFrom(dorisConfig)
+		require.NoError(t, err)
+		_, err = makeDoris(nil, beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), cfg)
+		require.NoError(t, err)
+
+		tableSelector, err := buildTableSelector(cfg)
+		require.NoError(t, err)
+		require.Equal(t, tableSelector.Sel.IsConst(), attr.Const)
+
+		event := &beat.Event{
+			Timestamp: now,
+			Fields: common.MapStr{
+				"message": attr.Message,
+			},
+		}
+		s, err := tableSelector.Sel.Select(event)
+		fmt.Printf("result: %v\n", s)
+		require.NoError(t, err)
+		require.Equal(t, attr.Result, s)
+	}
+}
+
+func TestSelectorWithDefaultTable(t *testing.T) {
+	now := time.Now()
+	fmt.Println(now)
+
+	attrs := []*Attr{
+		{"", "123", "DEFAULT", false},
+		{"tablE", "123", "tablE", true},
+		{"table_%{[message]}", "123", "table_123", false},
+		{"table_%{+yyyy-MM-dd}", "123", fmt.Sprintf("table_%s", now.Format("2006-01-02")), false},
+		{"table_%{[message]}", "%{[message]}", "table_%{[message]}", false},
+		{"table_%{[no_such_field]}", "any_thing", "DEFAULT", false},
+	}
+
+	for i, attr := range attrs {
+		fmt.Printf("table%v: %v\n", i, attr.Table)
+
+		dorisConfig := map[string]interface{}{
+			"fenodes":  []string{"http://localhost:8030"},
+			"user":     "admin",
+			"password": "",
+			"database": "db",
+			"tables": []map[string]interface{}{
+				{
+					"table":   attr.Table,
+					"default": "DEFAULT",
+				},
+			},
+		}
+
+		cfg, err := common.NewConfigFrom(dorisConfig)
+		require.NoError(t, err)
+		_, err = makeDoris(nil, beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), cfg)
+		require.NoError(t, err)
+
+		tableSelector, err := buildTableSelector(cfg)
+		require.NoError(t, err)
+		require.Equal(t, tableSelector.Sel.IsConst(), attr.Const)
+
+		event := &beat.Event{
+			Timestamp: now,
+			Fields: common.MapStr{
+				"message": attr.Message,
+			},
+		}
+		s, err := tableSelector.Sel.Select(event)
+		fmt.Printf("result: %v\n", s)
+		require.NoError(t, err)
+		require.Equal(t, attr.Result, s)
+	}
+}
+
+func TestMultiTable(t *testing.T) {
+	database := "log_db"
+	table := "%{[message]}"
+
+	messages := []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5}
+	var events []beat.Event
+	for _, m := range messages {
+		events = append(events, beat.Event{
+			Timestamp: time.Now(),
+			Fields: common.MapStr{
+				"message": fmt.Sprintf("t_%d", m),
+			},
+		})
+	}
+	// will be dropped, beacuse of nil table
+	events = append(events, beat.Event{Fields: common.MapStr{"message": ""}})
+	events = append(events, beat.Event{Fields: common.MapStr{"message": ""}})
+	// will be dropped, because of serialization error
+	events = append(events, beat.Event{Fields: common.MapStr{}})
+	events = append(events, beat.Event{Fields: common.MapStr{}})
+
+	apiList := []*api{
+		{database: database, table: "t_1", status: "Success"},
+		{database: database, table: "t_2", status: "Publish Timeout"},
+		{database: database, table: "t_3", status: "Label Already Exists"},
+		{database: database, table: "t_4", status: "Fail"},
+		{database: database, table: "t_5", status: "Fail"},
+	}
+
+	port, err := findRandomPort()
+	require.NoError(t, err)
+	server := mockDorisServer(port, apiList)
+	fmt.Printf("mock doris server started on localhost:%d\n", port)
+	defer server.Close()
+
+	dorisConfig := map[string]interface{}{
+		"fenodes":  []string{fmt.Sprintf("http://localhost:%d", port)},
+		"user":     "root",
+		"password": "",
+		"database": database,
+		// "table":    table,
+		"tables": []map[string]interface{}{
+			{
+				"table": table,
+				// "default": "DEFAULT",
+			},
+		},
+		"codec_format_string": "%{[message]}",
+		"headers": map[string]interface{}{
+			"format":            "json",
+			"read_json_by_line": true,
+		},
+	}
+
+	cfg, err := common.NewConfigFrom(dorisConfig)
+	require.NoError(t, err)
+	grp, err := makeDoris(nil, beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), cfg)
+	require.NoError(t, err)
+
+	output := grp.Clients[0].(outputs.NetworkClient)
+	err = output.Connect()
+	require.NoError(t, err)
+	defer output.Close()
+
+	batch := outest.NewBatch(events[:2]...) // Success
+	err0 := fmt.Errorf("Not Started")
+	for i := 0; err0 != nil && i < 10; i++ { // until server started
+		err0 = output.Publish(context.Background(), batch)
+		fmt.Printf("%+v\n", err0)
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.NoError(t, err0)
+	require.Equal(t, outest.BatchACK, batch.Signals[len(batch.Signals)-1].Tag)
+
+	batch = outest.NewBatch(events[:4]...) // Success + Publish Timeout
+	err0 = output.Publish(context.Background(), batch)
+	require.NoError(t, err0)
+	require.Equal(t, outest.BatchACK, batch.Signals[len(batch.Signals)-1].Tag)
+
+	batch = outest.NewBatch(events[:6]...) // Success + Publish Timeout + Label Already Exists
+	err0 = output.Publish(context.Background(), batch)
+	require.NoError(t, err0)
+	require.Equal(t, outest.BatchACK, batch.Signals[len(batch.Signals)-1].Tag)
+
+	batch = outest.NewBatch(events[:10]...) // Success + Publish Timeout + Label Already Exists + Fail
+	err0 = output.Publish(context.Background(), batch)
+	require.Error(t, err0)
+	require.Equal(t, outest.BatchRetryEvents, batch.Signals[len(batch.Signals)-1].Tag)
+	require.Equal(t, 4, len(batch.Signals[len(batch.Signals)-1].Events)) // 4 retry events
+
+	retryEvents := make([]beat.Event, 0)
+	for _, e := range batch.Signals[len(batch.Signals)-1].Events {
+		retryEvents = append(retryEvents, e.Content)
+	}
+	_, err0 = getBarrierFromEvent(&publisher.Event{Content: retryEvents[1]}) // has barrier
+	require.NoError(t, err0)
+	_, err0 = getBarrierFromEvent(&publisher.Event{Content: retryEvents[3]}) // has barrier
+	require.NoError(t, err0)
+
+	batch = outest.NewBatch(retryEvents...) // Fail (retry)
+	err0 = output.Publish(context.Background(), batch)
+	require.Error(t, err0)
+	require.Equal(t, outest.BatchRetryEvents, batch.Signals[len(batch.Signals)-1].Tag)
+	require.Equal(t, 4, len(batch.Signals[len(batch.Signals)-1].Events)) // 4 retry events
+
+	batch = outest.NewBatch(events[10:14]...) // Dropped before sending
+	err0 = output.Publish(context.Background(), batch)
+	require.Error(t, err0)
+	require.Equal(t, outest.BatchACK, batch.Signals[len(batch.Signals)-1].Tag)
+}
+
+type api struct {
+	database string
+	table    string
+	status   string
+}
+
+func mockDorisServer(port int, apiList []*api) *http.Server {
+	server := &http.Server{
+		ReadTimeout: 3 * time.Second,
+		Addr:        fmt.Sprintf(":%d", port),
+	}
+
+	mux := http.NewServeMux()
+	for _, api := range apiList {
+		url := fmt.Sprintf("/api/%s/%s/_stream_load", api.database, api.table)
+		response := fmt.Sprintf(`{"Status":"%s"}`, api.status)
+		mux.HandleFunc(url, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(response))
+		})
+	}
+
+	server.Handler = mux
+	go func() {
+		_ = server.ListenAndServe()
+	}()
+
+	return server
+}
+
+func findRandomPort() (int, error) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	port := l.Addr().(*net.TCPAddr).Port
+
+	err = l.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	return port, nil
+}

--- a/extension/beats/doris/common_test.go
+++ b/extension/beats/doris/common_test.go
@@ -233,9 +233,9 @@ func TestMultiTable(t *testing.T) {
 	for _, e := range batch.Signals[len(batch.Signals)-1].Events {
 		retryEvents = append(retryEvents, e.Content)
 	}
-	_, err0 = getBarrierFromEvent(&publisher.Event{Content: retryEvents[1]}) // has barrier
+	_, err0 = getBarrierFromEvent(&publisher.Event{Content: retryEvents[0]}) // has barrier
 	require.NoError(t, err0)
-	_, err0 = getBarrierFromEvent(&publisher.Event{Content: retryEvents[3]}) // has barrier
+	_, err0 = getBarrierFromEvent(&publisher.Event{Content: retryEvents[2]}) // has barrier
 	require.NoError(t, err0)
 
 	batch = outest.NewBatch(retryEvents...) // Fail (retry)

--- a/extension/beats/doris/config.go
+++ b/extension/beats/doris/config.go
@@ -29,16 +29,17 @@ import (
 )
 
 type config struct {
-	Hosts               []string `config:"fenodes"`
-	HttpHosts           []string `config:"http_hosts"`
-	User                string   `config:"user" validate:"required"`
-	Password            string   `config:"password"`
-	Database            string   `config:"database" validate:"required"`
-	Table               string   `config:"table" validate:"required"`
-	LabelPrefix         string   `config:"label_prefix"`
-	LineDelimiter       string   `config:"line_delimiter"`
-	LogRequest          bool     `config:"log_request"`
-	LogProgressInterval int      `config:"log_progress_interval"`
+	Hosts               []string         `config:"fenodes"`
+	HttpHosts           []string         `config:"http_hosts"`
+	User                string           `config:"user" validate:"required"`
+	Password            string           `config:"password"`
+	Database            string           `config:"database" validate:"required"`
+	Table               string           `config:"table"`
+	Tables              []map[string]any `config:"tables"`
+	LabelPrefix         string           `config:"label_prefix"`
+	LineDelimiter       string           `config:"line_delimiter"`
+	LogRequest          bool             `config:"log_request"`
+	LogProgressInterval int              `config:"log_progress_interval"`
 
 	Headers map[string]string `config:"headers"`
 
@@ -82,8 +83,8 @@ func (c *config) Validate() error {
 	if len(c.Database) == 0 {
 		return errors.New("no database configured")
 	}
-	if len(c.Table) == 0 {
-		return errors.New("no table configured")
+	if len(c.Table) == 0 && len(c.Tables) == 0 {
+		return errors.New("no tables configured")
 	}
 	if len(c.CodecFormatString) == 0 && &c.Codec == nil {
 		return errors.New("no codec_format_expression|codec configured")

--- a/extension/beats/doris/config.go
+++ b/extension/beats/doris/config.go
@@ -35,6 +35,7 @@ type config struct {
 	Password            string           `config:"password"`
 	Database            string           `config:"database" validate:"required"`
 	Table               string           `config:"table"`
+	DefaultTable        string           `config:"default_table"`
 	Tables              []map[string]any `config:"tables"`
 	LabelPrefix         string           `config:"label_prefix"`
 	LineDelimiter       string           `config:"line_delimiter"`

--- a/extension/beats/doris/config.go
+++ b/extension/beats/doris/config.go
@@ -49,6 +49,7 @@ type config struct {
 	BulkMaxSize       int           `config:"bulk_max_size" validate:"min=1,nonzero"`
 	MaxRetries        int           `config:"max_retries" validate:"min=-1,nonzero"`
 	Backoff           backoff       `config:"backoff"`
+	Worker            int           `config:"worker"`
 }
 
 type backoff struct {
@@ -70,6 +71,7 @@ func defaultConfig() config {
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
+		Worker: 1,
 	}
 }
 

--- a/extension/beats/doris/doris.go
+++ b/extension/beats/doris/doris.go
@@ -105,6 +105,7 @@ func makeDoris(
 			LabelPrefix:   config.LabelPrefix,
 			Database:      config.Database,
 			TableSelector: tableSelector,
+			DefaultTable:  config.DefaultTable,
 
 			Reporter: reporter,
 			Logger:   logger,

--- a/extension/beats/doris/doris.go
+++ b/extension/beats/doris/doris.go
@@ -20,8 +20,6 @@
 package doris
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -68,13 +66,12 @@ func makeDoris(
 			return outputs.Fail(err)
 		}
 
-		dbPath := fmt.Sprintf("/api/%s", config.Database)
-		dbURL, err := common.MakeURL(url.Scheme, dbPath, host, 8030)
+		urlPrefix, err := common.MakeURL(url.Scheme, "/api", host, 8030)
 		if err != nil {
 			logger.Errorf("Invalid host param set: %s, Error: %+v", host, err)
 			return outputs.Fail(err)
 		}
-		logger.Infof("http connection endpoint: %s/{table}/_stream_load", dbURL)
+		logger.Infof("http connection endpoint: %s/%s/{table}/_stream_load", urlPrefix, config.Database)
 		if len(config.Tables) > 0 {
 			logger.Infof("tables: %+v", config.Tables)
 		}
@@ -89,7 +86,8 @@ func makeDoris(
 
 		var client outputs.NetworkClient
 		client, err = NewDorisClient(clientSettings{
-			DBURL:         dbURL,
+			URLPrefix:     urlPrefix,
+			DB:            config.Database,
 			Timeout:       config.Timeout,
 			Observer:      observer,
 			Headers:       config.createHeaders(),

--- a/extension/beats/doris/doris.go
+++ b/extension/beats/doris/doris.go
@@ -58,8 +58,15 @@ func makeDoris(
 
 	reporter := NewProgressReporter(config.LogProgressInterval, logger)
 
-	clients := make([]outputs.NetworkClient, len(config.Hosts))
-	for i, host := range config.Hosts {
+	// duplicate entries config.Worker times
+	hosts := make([]string, 0, len(config.Hosts)*config.Worker)
+	for _, entry := range config.Hosts {
+		for i := 0; i < config.Worker; i++ {
+			hosts = append(hosts, entry)
+		}
+	}
+	clients := make([]outputs.NetworkClient, len(hosts))
+	for i, host := range hosts {
 		logger.Info("Making client for host: " + host)
 		url, err := parseURL(host)
 		if err != nil {

--- a/extension/beats/doris/doris.go
+++ b/extension/beats/doris/doris.go
@@ -94,7 +94,6 @@ func makeDoris(
 		var client outputs.NetworkClient
 		client, err = NewDorisClient(clientSettings{
 			URLPrefix:     urlPrefix,
-			DB:            config.Database,
 			Timeout:       config.Timeout,
 			Observer:      observer,
 			Headers:       config.createHeaders(),

--- a/extension/beats/go.mod
+++ b/extension/beats/go.mod
@@ -4,6 +4,8 @@ go 1.20
 
 require (
 	github.com/elastic/beats/v7 v7.17.5
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.7.0
 	gotest.tools v2.2.0+incompatible
 )
 
@@ -65,7 +67,6 @@ require (
 	github.com/google/flatbuffers v1.12.1 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
@@ -114,7 +115,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tsg/gopacket v0.0.0-20200626092518-2ab8e397a786 // indirect
 	github.com/urso/diag v0.0.0-20200210123136-21b3cc8eb797 // indirect
 	github.com/urso/go-bin v0.0.0-20180220135811-781c575c9f0e // indirect

--- a/extension/beats/go.sum
+++ b/extension/beats/go.sum
@@ -466,7 +466,6 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -1297,7 +1296,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Support filebeat plugin to write multiple tables.

Tables without default:
```yaml
output.doris:
  table: "github_events_%{[message][type]}"
  ...
```

Tables with default:
```yaml
output.doris:
  tables:
    - table: "github_events_%{[message][type]}"
      default: "github_events"
  ...
```

The config `table` and `tables` are similar with `index` and `indices` in beats elasticsearch plugin.

References:
1. https://www.elastic.co/guide/en/beats/filebeat/7.17/elasticsearch-output.html#index-option-es
2. https://www.elastic.co/guide/en/beats/filebeat/7.17/elasticsearch-output.html#indices-option-es

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

