### PR TITLE
[fix](s3) support chinacloudapi endpoint for azure

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1281,6 +1281,8 @@ DEFINE_Int32(spill_io_thread_pool_queue_size, "102400");
 
 DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
+DEFINE_mBool(ignore_azure_endpoint, "true");
+
 DEFINE_mInt32(max_s3_client_retry, "10");
 DEFINE_mInt32(s3_read_base_wait_time_ms, "100");
 DEFINE_mInt32(s3_read_max_wait_time_ms, "800");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1281,7 +1281,7 @@ DEFINE_Int32(spill_io_thread_pool_queue_size, "102400");
 
 DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
-DEFINE_mBool(use_azure_blob_global_endpoint_only, "false");
+DEFINE_mBool(force_azure_blob_global_endpoint, "false");
 
 DEFINE_mInt32(max_s3_client_retry, "10");
 DEFINE_mInt32(s3_read_base_wait_time_ms, "100");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1281,6 +1281,8 @@ DEFINE_Int32(spill_io_thread_pool_queue_size, "102400");
 
 DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
+DEFINE_mBool(use_azure_blob_global_endpoint_only, "false");
+
 DEFINE_mInt32(max_s3_client_retry, "10");
 DEFINE_mInt32(s3_read_base_wait_time_ms, "100");
 DEFINE_mInt32(s3_read_max_wait_time_ms, "800");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1281,8 +1281,6 @@ DEFINE_Int32(spill_io_thread_pool_queue_size, "102400");
 
 DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
-DEFINE_mBool(ignore_azure_endpoint, "true");
-
 DEFINE_mInt32(max_s3_client_retry, "10");
 DEFINE_mInt32(s3_read_base_wait_time_ms, "100");
 DEFINE_mInt32(s3_read_max_wait_time_ms, "800");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1362,6 +1362,8 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 
 DECLARE_Int32(num_query_ctx_map_partitions);
 
+DECLARE_mBool(ignore_azure_endpoint);
+
 DECLARE_mBool(enable_s3_rate_limiter);
 DECLARE_mInt64(s3_get_bucket_tokens);
 DECLARE_mInt64(s3_get_token_per_second);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1362,8 +1362,6 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 
 DECLARE_Int32(num_query_ctx_map_partitions);
 
-DECLARE_mBool(ignore_azure_endpoint);
-
 DECLARE_mBool(enable_s3_rate_limiter);
 DECLARE_mInt64(s3_get_bucket_tokens);
 DECLARE_mInt64(s3_get_token_per_second);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1362,7 +1362,7 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 
 DECLARE_Int32(num_query_ctx_map_partitions);
 
-DECLARE_mBool(use_azure_blob_global_endpoint_only);
+DECLARE_mBool(force_azure_blob_global_endpoint);
 
 DECLARE_mBool(enable_s3_rate_limiter);
 DECLARE_mInt64(s3_get_bucket_tokens);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1362,6 +1362,8 @@ DECLARE_mBool(check_segment_when_build_rowset_meta);
 
 DECLARE_Int32(num_query_ctx_map_partitions);
 
+DECLARE_mBool(use_azure_blob_global_endpoint_only);
+
 DECLARE_mBool(enable_s3_rate_limiter);
 DECLARE_mInt64(s3_get_bucket_tokens);
 DECLARE_mInt64(s3_get_token_per_second);

--- a/be/src/io/fs/azure_obj_storage_client.cpp
+++ b/be/src/io/fs/azure_obj_storage_client.cpp
@@ -80,6 +80,7 @@ auto s3_put_rate_limit(Func callback) -> decltype(callback()) {
     return s3_rate_limit(doris::S3RateLimitType::PUT, std::move(callback));
 }
 
+constexpr char SAS_TOKEN_GLOBAL_URL_TEMPLATE[] = "https://{}.blob.core.windows.net/{}/{}{}";
 constexpr char SAS_TOKEN_URL_TEMPLATE[] = "{}/{}/{}{}";
 constexpr char BlobNotFound[] = "BlobNotFound";
 } // namespace
@@ -416,6 +417,9 @@ std::string AzureObjStorageClient::generate_presigned_url(const ObjectStoragePat
     std::string sasToken = sas_builder.GenerateSasToken(
             Azure::Storage::StorageSharedKeyCredential(conf.ak, conf.sk));
 
+    if (doris::config::use_azure_blob_global_endpoint_only) {
+        return fmt::format(SAS_TOKEN_GLOBAL_URL_TEMPLATE, conf.ak, conf.bucket, opts.key, sasToken);
+    }
     auto sasURL =
             fmt::format(SAS_TOKEN_URL_TEMPLATE, conf.endpoint, conf.bucket, opts.key, sasToken);
     if (sasURL.find("://") == std::string::npos) {

--- a/be/src/io/fs/azure_obj_storage_client.cpp
+++ b/be/src/io/fs/azure_obj_storage_client.cpp
@@ -80,8 +80,7 @@ auto s3_put_rate_limit(Func callback) -> decltype(callback()) {
     return s3_rate_limit(doris::S3RateLimitType::PUT, std::move(callback));
 }
 
-constexpr char SAS_TOKEN_URL_TEMPLATE[] = "https://{}.blob.core.windows.net/{}/{}{}";
-constexpr char SAS_TOKEN_URL_TEMPL[] = "{}/{}/{}{}";
+constexpr char SAS_TOKEN_URL_TEMPLATE[] = "{}/{}/{}{}";
 constexpr char BlobNotFound[] = "BlobNotFound";
 } // namespace
 
@@ -417,10 +416,7 @@ std::string AzureObjStorageClient::generate_presigned_url(const ObjectStoragePat
     std::string sasToken = sas_builder.GenerateSasToken(
             Azure::Storage::StorageSharedKeyCredential(conf.ak, conf.sk));
 
-    if (doris::config::ignore_azure_endpoint) {
-        return fmt::format(SAS_TOKEN_URL_TEMPLATE, conf.ak, conf.bucket, opts.key, sasToken);
-    }
-    auto sasURL = fmt::format(SAS_TOKEN_URL_TEMPL, conf.endpoint, conf.bucket, opts.key, sasToken);
+    auto sasURL = fmt::format(SAS_TOKEN_URL_TEMPLATE, conf.endpoint, conf.bucket, opts.key, sasToken);
     if (sasURL.find("://") == std::string::npos) {
         sasURL = "https://" + sasURL;
     }

--- a/be/src/io/fs/azure_obj_storage_client.cpp
+++ b/be/src/io/fs/azure_obj_storage_client.cpp
@@ -416,7 +416,8 @@ std::string AzureObjStorageClient::generate_presigned_url(const ObjectStoragePat
     std::string sasToken = sas_builder.GenerateSasToken(
             Azure::Storage::StorageSharedKeyCredential(conf.ak, conf.sk));
 
-    auto sasURL = fmt::format(SAS_TOKEN_URL_TEMPLATE, conf.endpoint, conf.bucket, opts.key, sasToken);
+    auto sasURL =
+            fmt::format(SAS_TOKEN_URL_TEMPLATE, conf.endpoint, conf.bucket, opts.key, sasToken);
     if (sasURL.find("://") == std::string::npos) {
         sasURL = "https://" + sasURL;
     }

--- a/be/src/io/fs/azure_obj_storage_client.cpp
+++ b/be/src/io/fs/azure_obj_storage_client.cpp
@@ -80,7 +80,6 @@ auto s3_put_rate_limit(Func callback) -> decltype(callback()) {
     return s3_rate_limit(doris::S3RateLimitType::PUT, std::move(callback));
 }
 
-constexpr char SAS_TOKEN_GLOBAL_URL_TEMPLATE[] = "https://{}.blob.core.windows.net/{}/{}{}";
 constexpr char SAS_TOKEN_URL_TEMPLATE[] = "{}/{}/{}{}";
 constexpr char BlobNotFound[] = "BlobNotFound";
 } // namespace
@@ -417,11 +416,11 @@ std::string AzureObjStorageClient::generate_presigned_url(const ObjectStoragePat
     std::string sasToken = sas_builder.GenerateSasToken(
             Azure::Storage::StorageSharedKeyCredential(conf.ak, conf.sk));
 
+    std::string endpoint = conf.endpoint;
     if (doris::config::force_azure_blob_global_endpoint) {
-        return fmt::format(SAS_TOKEN_GLOBAL_URL_TEMPLATE, conf.ak, conf.bucket, opts.key, sasToken);
+        endpoint = fmt::format("https://{}.blob.core.windows.net", conf.ak);
     }
-    auto sasURL =
-            fmt::format(SAS_TOKEN_URL_TEMPLATE, conf.endpoint, conf.bucket, opts.key, sasToken);
+    auto sasURL = fmt::format(SAS_TOKEN_URL_TEMPLATE, endpoint, conf.bucket, opts.key, sasToken);
     if (sasURL.find("://") == std::string::npos) {
         sasURL = "https://" + sasURL;
     }

--- a/be/src/io/fs/azure_obj_storage_client.cpp
+++ b/be/src/io/fs/azure_obj_storage_client.cpp
@@ -417,7 +417,7 @@ std::string AzureObjStorageClient::generate_presigned_url(const ObjectStoragePat
     std::string sasToken = sas_builder.GenerateSasToken(
             Azure::Storage::StorageSharedKeyCredential(conf.ak, conf.sk));
 
-    if (doris::config::use_azure_blob_global_endpoint_only) {
+    if (doris::config::force_azure_blob_global_endpoint) {
         return fmt::format(SAS_TOKEN_GLOBAL_URL_TEMPLATE, conf.ak, conf.bucket, opts.key, sasToken);
     }
     auto sasURL =

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -256,7 +256,7 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
 
     const std::string container_name = s3_conf.bucket;
     std::string uri;
-    if (config::use_azure_blob_global_endpoint_only) {
+    if (config::force_azure_blob_global_endpoint) {
         uri = fmt::format("https://{}.blob.core.windows.net/{}", s3_conf.ak, container_name);
     } else {
         uri = fmt::format("{}/{}", s3_conf.endpoint, container_name);

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -255,8 +255,15 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
             std::make_shared<Azure::Storage::StorageSharedKeyCredential>(s3_conf.ak, s3_conf.sk);
 
     const std::string container_name = s3_conf.bucket;
-    const std::string uri =
-            fmt::format("{}://{}.blob.core.windows.net/{}", "https", s3_conf.ak, container_name);
+    std::string uri;
+    if (config::ignore_azure_endpoint) {
+        uri = fmt::format("https://{}.blob.core.windows.net/{}", s3_conf.ak, container_name);
+    } else {
+        uri = fmt::format("{}/{}", s3_conf.endpoint, container_name);
+        if (s3_conf.endpoint.find("://") == std::string::npos) {
+            uri = "https://" + uri;
+        }
+    }
 
     auto containerClient = std::make_shared<Azure::Storage::Blobs::BlobContainerClient>(uri, cred);
     LOG_INFO("create one azure client with {}", s3_conf.to_string());

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -255,14 +255,9 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
             std::make_shared<Azure::Storage::StorageSharedKeyCredential>(s3_conf.ak, s3_conf.sk);
 
     const std::string container_name = s3_conf.bucket;
-    std::string uri;
-    if (config::ignore_azure_endpoint) {
-        uri = fmt::format("https://{}.blob.core.windows.net/{}", s3_conf.ak, container_name);
-    } else {
-        uri = fmt::format("{}/{}", s3_conf.endpoint, container_name);
-        if (s3_conf.endpoint.find("://") == std::string::npos) {
-            uri = "https://" + uri;
-        }
+    std::string uri = fmt::format("{}/{}", s3_conf.endpoint, container_name);
+    if (s3_conf.endpoint.find("://") == std::string::npos) {
+        uri = "https://" + uri;
     }
 
     auto containerClient = std::make_shared<Azure::Storage::Blobs::BlobContainerClient>(uri, cred);

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -255,9 +255,14 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
             std::make_shared<Azure::Storage::StorageSharedKeyCredential>(s3_conf.ak, s3_conf.sk);
 
     const std::string container_name = s3_conf.bucket;
-    std::string uri = fmt::format("{}/{}", s3_conf.endpoint, container_name);
-    if (s3_conf.endpoint.find("://") == std::string::npos) {
-        uri = "https://" + uri;
+    std::string uri;
+    if (config::use_azure_blob_global_endpoint_only) {
+        uri = fmt::format("https://{}.blob.core.windows.net/{}", s3_conf.ak, container_name);
+    } else {
+        uri = fmt::format("{}/{}", s3_conf.endpoint, container_name);
+        if (s3_conf.endpoint.find("://") == std::string::npos) {
+            uri = "https://" + uri;
+        }
     }
 
     auto containerClient = std::make_shared<Azure::Storage::Blobs::BlobContainerClient>(uri, cred);

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -223,6 +223,8 @@ CONF_Validator(s3_client_http_scheme, [](const std::string& config) -> bool {
     return config == "http" || config == "https";
 });
 
+CONF_Bool(force_azure_blob_global_endpoint, "false");
+
 // Max retry times for object storage request
 CONF_mInt64(max_s3_client_retry, "10");
 

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -253,13 +253,9 @@ int S3Accessor::init() {
         options.Retry.MaxRetries = config::max_s3_client_retry;
         auto cred =
                 std::make_shared<Azure::Storage::StorageSharedKeyCredential>(conf_.ak, conf_.sk);
-        if (config::ignore_azure_endpoint) {
-            uri_ = fmt::format("https://{}.blob.core.windows.net/{}", conf_.ak, conf_.bucket);
-        } else {
-            uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);
-            if (uri_.find("://") == std::string::npos) {
-                uri_ = "https://" + uri_;
-            }
+        uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);
+        if (uri_.find("://") == std::string::npos) {
+            uri_ = "https://" + uri_;
         }
         // In Azure's HTTP requests, all policies in the vector are called in a chained manner following the HTTP pipeline approach.
         // Within the RetryPolicy, the nextPolicy is called multiple times inside a loop.

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -253,7 +253,7 @@ int S3Accessor::init() {
         options.Retry.MaxRetries = config::max_s3_client_retry;
         auto cred =
                 std::make_shared<Azure::Storage::StorageSharedKeyCredential>(conf_.ak, conf_.sk);
-        if (config::use_azure_blob_global_endpoint_only) {
+        if (config::force_azure_blob_global_endpoint) {
             uri_ = fmt::format("https://{}.blob.core.windows.net/{}", conf_.ak, conf_.bucket);
         } else {
             uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -253,9 +253,13 @@ int S3Accessor::init() {
         options.Retry.MaxRetries = config::max_s3_client_retry;
         auto cred =
                 std::make_shared<Azure::Storage::StorageSharedKeyCredential>(conf_.ak, conf_.sk);
-        uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);
-        if (uri_.find("://") == std::string::npos) {
-            uri_ = "https://" + uri_;
+        if (config::use_azure_blob_global_endpoint_only) {
+            uri_ = fmt::format("https://{}.blob.core.windows.net/{}", conf_.ak, conf_.bucket);
+        } else {
+            uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);
+            if (uri_.find("://") == std::string::npos) {
+                uri_ = "https://" + uri_;
+            }
         }
         // In Azure's HTTP requests, all policies in the vector are called in a chained manner following the HTTP pipeline approach.
         // Within the RetryPolicy, the nextPolicy is called multiple times inside a loop.

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -253,7 +253,7 @@ int S3Accessor::init() {
         options.Retry.MaxRetries = config::max_s3_client_retry;
         auto cred =
                 std::make_shared<Azure::Storage::StorageSharedKeyCredential>(conf_.ak, conf_.sk);
-        if (config::force_azure_blob_global_endpoint) {
+        if (doris::config::force_azure_blob_global_endpoint) {
             uri_ = fmt::format("https://{}.blob.core.windows.net/{}", conf_.ak, conf_.bucket);
         } else {
             uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -253,8 +253,14 @@ int S3Accessor::init() {
         options.Retry.MaxRetries = config::max_s3_client_retry;
         auto cred =
                 std::make_shared<Azure::Storage::StorageSharedKeyCredential>(conf_.ak, conf_.sk);
-        uri_ = fmt::format("{}://{}.blob.core.windows.net/{}", config::s3_client_http_scheme,
-                           conf_.ak, conf_.bucket);
+        if (config::ignore_azure_endpoint) {
+            uri_ = fmt::format("https://{}.blob.core.windows.net/{}", conf_.ak, conf_.bucket);
+        } else {
+            uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);
+            if (uri_.find("://") == std::string::npos) {
+                uri_ = "https://" + uri_;
+            }
+        }
         // In Azure's HTTP requests, all policies in the vector are called in a chained manner following the HTTP pipeline approach.
         // Within the RetryPolicy, the nextPolicy is called multiple times inside a loop.
         // All policies in the PerRetryPolicies are downstream of the RetryPolicy.

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -253,7 +253,7 @@ int S3Accessor::init() {
         options.Retry.MaxRetries = config::max_s3_client_retry;
         auto cred =
                 std::make_shared<Azure::Storage::StorageSharedKeyCredential>(conf_.ak, conf_.sk);
-        if (doris::config::force_azure_blob_global_endpoint) {
+        if (config::force_azure_blob_global_endpoint) {
             uri_ = fmt::format("https://{}.blob.core.windows.net/{}", conf_.ak, conf_.bucket);
         } else {
             uri_ = fmt::format("{}/{}", conf_.endpoint, conf_.bucket);

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3238,7 +3238,7 @@ public class Config extends ConfigBase {
             + "The default is false, meaning the system will use the user-specified endpoint. "
             + "If set to true, the system will force the use of {account}.blob.core.windows.net."
     })
-    public static boolean use_azure_blob_global_endpoint_only = false;
+    public static boolean force_azure_blob_global_endpoint = false;
 
     @ConfField(mutable = true, description = {"指定Jdbc driver url白名单, 举例: jdbc_driver_url_white_list=a,b,c",
             "the white list for jdbc driver url, if it is empty, no white list will be set"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3232,14 +3232,13 @@ public class Config extends ConfigBase {
     };
 
     @ConfField(mutable = true, description = {
-            "此配置参数决定是否使用用户指定的自定义 Azure endpoint。"
-            + "默认为 false，即使用基于账户名的固定 endpoint，域名是 {account}.blob.core.windows.net。"
-            + "如果设置为 true，则系统将使用用户指定的自定义 endpoint，如 {account}.blob.core.chinacloudapi.cn。",
-            "This parameter controls whether to use a custom Azure endpoint specified by the user. "
-            + "By default, it's set to false, using the fixed endpoint {account}.blob.core.windows.net. "
-            + "If set to true, the user-specified endpoint will be used, such as {account}.blob.core.chinacloudapi.cn."
+            "此参数控制是否强制使用 Azure global endpoint。默认值为 false，系统将使用用户指定的 endpoint。"
+            + "如果设置为 true，系统将强制使用 {account}.blob.core.windows.net。",
+            "This parameter controls whether to force the use of the Azure global endpoint. "
+            + "The default is false, meaning the system will use the user-specified endpoint. "
+            + "If set to true, the system will force the use of {account}.blob.core.windows.net."
     })
-    public static boolean use_custom_azure_endpoint = false;
+    public static boolean use_azure_blob_global_endpoint_only = false;
 
     @ConfField(mutable = true, description = {"指定Jdbc driver url白名单, 举例: jdbc_driver_url_white_list=a,b,c",
             "the white list for jdbc driver url, if it is empty, no white list will be set"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3232,14 +3232,14 @@ public class Config extends ConfigBase {
     };
 
     @ConfField(mutable = true, description = {
-            "此配置参数用于忽略用户指定的 Azure endpoint，默认为 `true`，以保持对旧版本的兼容性。"
-            + "若需要使用诸如 `blob.core.chinacloudapi.cn` 等其他 endpoint，需将该参数设置为 `false`。",
-            "This parameter is used to ignore the user-specified Azure endpoint, "
-            + "with the default set to `true` for backward compatibility. "
-            + "If you need to use other endpoints such as `blob.core.chinacloudapi.cn`, "
-            + "you must set this parameter to `false`."
+            "此配置参数决定是否使用用户指定的自定义 Azure endpoint。"
+            + "默认为 false，即使用基于账户名的固定 endpoint，域名是 {account}.blob.core.windows.net。"
+            + "如果设置为 true，则系统将使用用户指定的自定义 endpoint，如 {account}.blob.core.chinacloudapi.cn。",
+            "This parameter controls whether to use a custom Azure endpoint specified by the user. "
+            + "By default, it's set to false, using the fixed endpoint {account}.blob.core.windows.net. "
+            + "If set to true, the user-specified endpoint will be used, such as {account}.blob.core.chinacloudapi.cn."
     })
-    public static boolean ignore_azure_endpoint = true;
+    public static boolean use_custom_azure_endpoint = false;
 
     @ConfField(mutable = true, description = {"指定Jdbc driver url白名单, 举例: jdbc_driver_url_white_list=a,b,c",
             "the white list for jdbc driver url, if it is empty, no white list will be set"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3221,6 +3221,26 @@ public class Config extends ConfigBase {
             + "for example: s3_load_endpoint_white_list=a,b,c"})
     public static String[] s3_load_endpoint_white_list = {};
 
+    @ConfField(mutable = true, description = {"指定 Azure endpoint 白名单，未设置时使用默认白名单，"
+            + "举例: azure_endpoint_white_list=a,b,c",
+            "the white list for the Azure s3 load endpoint, default white list will be used if it's not set, "
+            + "for example: azure_endpoint_white_list=a,b,c"})
+    public static String[] azure_endpoint_white_list = {
+            "blob.core.windows.net",
+            "blob.core.chinacloudapi.cn",
+            "blob.core.usgovcloudapi.net",
+    };
+
+    @ConfField(mutable = true, description = {
+            "此配置参数用于忽略用户指定的 Azure endpoint，默认为 `true`，以保持对旧版本的兼容性。"
+            + "若需要使用诸如 `blob.core.chinacloudapi.cn` 等其他 endpoint，需将该参数设置为 `false`。",
+            "This parameter is used to ignore the user-specified Azure endpoint, "
+            + "with the default set to `true` for backward compatibility. "
+            + "If you need to use other endpoints such as `blob.core.chinacloudapi.cn`, "
+            + "you must set this parameter to `false`."
+    })
+    public static boolean ignore_azure_endpoint = true;
+
     @ConfField(mutable = true, description = {"指定Jdbc driver url白名单, 举例: jdbc_driver_url_white_list=a,b,c",
             "the white list for jdbc driver url, if it is empty, no white list will be set"
             + "for example: jdbc_driver_url_white_list=a,b,c"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3221,16 +3221,6 @@ public class Config extends ConfigBase {
             + "for example: s3_load_endpoint_white_list=a,b,c"})
     public static String[] s3_load_endpoint_white_list = {};
 
-    @ConfField(mutable = true, description = {"指定 Azure endpoint 白名单，未设置时使用默认白名单，"
-            + "举例: azure_endpoint_white_list=a,b,c",
-            "the white list for the Azure s3 load endpoint, default white list will be used if it's not set, "
-            + "for example: azure_endpoint_white_list=a,b,c"})
-    public static String[] azure_endpoint_white_list = {
-            "blob.core.windows.net",
-            "blob.core.chinacloudapi.cn",
-            "blob.core.usgovcloudapi.net",
-    };
-
     @ConfField(mutable = true, description = {
             "此参数控制是否强制使用 Azure global endpoint。默认值为 false，系统将使用用户指定的 endpoint。"
             + "如果设置为 true，系统将强制使用 {account}.blob.core.windows.net。",

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -71,7 +71,8 @@ public class AzureRemote extends RemoteBase {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk()) + "/" + containerName;
+            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            String uri = endpoint + "/" + containerName;
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
 
@@ -132,7 +133,8 @@ public class AzureRemote extends RemoteBase {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk()) + "/" + containerName;
+            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            String uri = endpoint + "/" + containerName;
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
             BlobServiceClient blobServiceClient = containerClient.getServiceClient();
@@ -226,7 +228,8 @@ public class AzureRemote extends RemoteBase {
                 builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             }
             String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk()) + "/" + containerName;
+            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            String uri = endpoint + "/" + containerName;
             builder.endpoint(uri);
             client = builder.buildClient();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -133,10 +133,6 @@ public class AzureRemote extends RemoteBase {
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
             String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
-            String err = AzureProperties.checkAzureEndpoint(uri, obj.getAk());
-            if (err != null) {
-                throw new DdlException(err);
-            }
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
             BlobServiceClient blobServiceClient = containerClient.getServiceClient();

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -70,9 +70,8 @@ public class AzureRemote extends RemoteBase {
         try {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
-            String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
-            builder.endpoint(uri);
+            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            builder.endpoint(endpoint);
             BlobContainerClient containerClient = builder.buildClient();
 
             BlobClient blobClient = containerClient.getBlobClient(normalizePrefix(fileName));
@@ -131,9 +130,8 @@ public class AzureRemote extends RemoteBase {
         try {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
-            String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
-            builder.endpoint(uri);
+            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            builder.endpoint(endpoint);
             BlobContainerClient containerClient = builder.buildClient();
             BlobServiceClient blobServiceClient = containerClient.getServiceClient();
 
@@ -225,9 +223,8 @@ public class AzureRemote extends RemoteBase {
             } else {
                 builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             }
-            String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
-            builder.endpoint(uri);
+            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            builder.endpoint(endpoint);
             client = builder.buildClient();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -18,6 +18,7 @@
 package org.apache.doris.cloud.storage;
 
 import org.apache.doris.common.DdlException;
+import org.apache.doris.datasource.property.constants.AzureProperties;
 
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
@@ -58,8 +59,6 @@ public class AzureRemote extends RemoteBase {
 
     private static final Logger LOG = LogManager.getLogger(AzureRemote.class);
 
-    private static final String URI_TEMPLATE = "https://%s.blob.core.windows.net/%s";
-
     private BlobContainerClient client;
 
     public AzureRemote(ObjectInfo obj) {
@@ -72,8 +71,7 @@ public class AzureRemote extends RemoteBase {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
-            String uri = String.format(URI_TEMPLATE, obj.getAk(),
-                    containerName);
+            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
 
@@ -134,8 +132,11 @@ public class AzureRemote extends RemoteBase {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
-            String uri = String.format(URI_TEMPLATE, obj.getAk(),
-                    containerName);
+            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            String err = AzureProperties.checkAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            if (err != null) {
+                throw new DdlException(err);
+            }
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
             BlobServiceClient blobServiceClient = containerClient.getServiceClient();
@@ -229,8 +230,7 @@ public class AzureRemote extends RemoteBase {
                 builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             }
             String containerName = obj.getBucket();
-            String uri = String.format(URI_TEMPLATE, obj.getAk(),
-                    containerName);
+            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
             builder.endpoint(uri);
             client = builder.buildClient();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -71,7 +71,7 @@ public class AzureRemote extends RemoteBase {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            String uri = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk()) + "/" + containerName;
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
 
@@ -132,7 +132,7 @@ public class AzureRemote extends RemoteBase {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            String uri = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk()) + "/" + containerName;
             builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
             BlobServiceClient blobServiceClient = containerClient.getServiceClient();
@@ -226,7 +226,7 @@ public class AzureRemote extends RemoteBase {
                 builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             }
             String containerName = obj.getBucket();
-            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            String uri = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk()) + "/" + containerName;
             builder.endpoint(uri);
             client = builder.buildClient();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -133,7 +133,7 @@ public class AzureRemote extends RemoteBase {
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             String containerName = obj.getBucket();
             String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
-            String err = AzureProperties.checkAzureEndpoint(obj.getEndpoint(), obj.getAk());
+            String err = AzureProperties.checkAzureEndpoint(uri, obj.getAk());
             if (err != null) {
                 throw new DdlException(err);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java
@@ -70,8 +70,9 @@ public class AzureRemote extends RemoteBase {
         try {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
-            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
-            builder.endpoint(endpoint);
+            String containerName = obj.getBucket();
+            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
 
             BlobClient blobClient = containerClient.getBlobClient(normalizePrefix(fileName));
@@ -130,8 +131,9 @@ public class AzureRemote extends RemoteBase {
         try {
             BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
             builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
-            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
-            builder.endpoint(endpoint);
+            String containerName = obj.getBucket();
+            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            builder.endpoint(uri);
             BlobContainerClient containerClient = builder.buildClient();
             BlobServiceClient blobServiceClient = containerClient.getServiceClient();
 
@@ -223,8 +225,9 @@ public class AzureRemote extends RemoteBase {
             } else {
                 builder.credential(new StorageSharedKeyCredential(obj.getAk(), obj.getSk()));
             }
-            String endpoint = AzureProperties.formatAzureEndpoint(obj.getEndpoint(), obj.getAk());
-            builder.endpoint(endpoint);
+            String containerName = obj.getBucket();
+            String uri = AzureProperties.formatAzureUri(obj.getEndpoint(), containerName, obj.getAk());
+            builder.endpoint(uri);
             client = builder.buildClient();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -67,4 +67,8 @@ public class AzureProperties extends BaseProperties {
         return "https://" + endpoint;
     }
 
+    public static String formatAzureUri(String endpoint, String bucket, String accountName) {
+        return formatAzureEndpoint(endpoint, accountName) + "/" + bucket;
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -74,31 +74,4 @@ public class AzureProperties extends BaseProperties {
         return formatAzureEndpoint(endpoint, accountName) + "/" + bucket;
     }
 
-    public static String checkAzureEndpoint(String endpoint, String accountName) {
-        URL url;
-        try {
-            url = new URL(endpoint);
-        } catch (MalformedURLException e) {
-            return "Azure endpoint URL: " + e.getMessage();
-        }
-        String hostname = url.getHost();
-
-        // example: https://accountName.blob.core.windows.net
-        if (!hostname.startsWith(accountName)) {
-            return String.format("Azure endpoint URL: hostname must start with storage account name '%s':",
-                    accountName, endpoint);
-        }
-
-        // default whitelist, see https://learn.microsoft.com/en-us/azure/storage/common/storage-explorer-network
-        // - "blob.core.windows.net"
-        // - "blob.core.chinacloudapi.cn"
-        // - "blob.core.usgovcloudapi.net"
-        for (String whitelist : Config.azure_endpoint_white_list) {
-            if (hostname.endsWith(whitelist)) {
-                return null;
-            }
-        }
-        return String.format("Azure endpoint URL: hostname is not in the 'azure_endpoint_white_list': %s",
-                hostname);
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -61,7 +61,7 @@ public class AzureProperties extends BaseProperties {
     }
 
     public static String formatAzureEndpoint(String endpoint, String accountName) {
-        if (Config.ignore_azure_endpoint) {
+        if (!Config.use_custom_azure_endpoint) {
             return String.format(AZURE_ENDPOINT_TEMPLATE, accountName);
         }
         if (endpoint.contains("://")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -67,8 +67,4 @@ public class AzureProperties extends BaseProperties {
         return "https://" + endpoint;
     }
 
-    public static String formatAzureUri(String endpoint, String bucket, String accountName) {
-        return formatAzureEndpoint(endpoint, accountName) + "/" + bucket;
-    }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.datasource.property.constants;
 
-
 import org.apache.doris.common.Config;
 import org.apache.doris.common.credentials.CloudCredential;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -68,8 +68,4 @@ public class AzureProperties extends BaseProperties {
         return "https://" + endpoint;
     }
 
-    public static String formatAzureUri(String endpoint, String bucket, String accountName) {
-        return formatAzureEndpoint(endpoint, accountName) + "/" + bucket;
-    }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -21,8 +21,6 @@ package org.apache.doris.datasource.property.constants;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.credentials.CloudCredential;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -39,7 +39,7 @@ public class AzureProperties extends BaseProperties {
     public static final String SESSION_TOKEN = "azure.session_token";
     public static final List<String> REQUIRED_FIELDS = Arrays.asList(ENDPOINT, ACCESS_KEY, SECRET_KEY);
 
-    public static final String AZURE_ENDPOINT_TEMPLATE = "%s.blob.core.windows.net/%s";
+    public static final String AZURE_ENDPOINT_TEMPLATE = "https://%s.blob.core.windows.net";
 
     public static class FS {
         public static final String SESSION_TOKEN = "fs.azure.session.token";

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -61,7 +61,7 @@ public class AzureProperties extends BaseProperties {
     }
 
     public static String formatAzureEndpoint(String endpoint, String accountName) {
-        if (!Config.use_custom_azure_endpoint) {
+        if (Config.use_azure_blob_global_endpoint_only) {
             return String.format(AZURE_ENDPOINT_TEMPLATE, accountName);
         }
         if (endpoint.contains("://")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AzureProperties.java
@@ -61,7 +61,7 @@ public class AzureProperties extends BaseProperties {
     }
 
     public static String formatAzureEndpoint(String endpoint, String accountName) {
-        if (Config.use_azure_blob_global_endpoint_only) {
+        if (Config.force_azure_blob_global_endpoint) {
             return String.format(AZURE_ENDPOINT_TEMPLATE, accountName);
         }
         if (endpoint.contains("://")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -116,14 +116,14 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
     @Override
     public BlobServiceClient getClient() throws UserException {
         if (client == null) {
-            String endpoint = AzureProperties.formatAzureEndpoint(
-                    properties.get(S3Properties.ENDPOINT), properties.get(S3Properties.ACCESS_KEY));
-            String err = AzureProperties.checkAzureEndpoint(
-                    properties.get(S3Properties.ENDPOINT), properties.get(S3Properties.ACCESS_KEY));
+            final String accountName = properties.get(S3Properties.ACCESS_KEY);
+            final String endpoint = AzureProperties.formatAzureEndpoint(
+                    properties.get(S3Properties.ENDPOINT), accountName);
+            String err = AzureProperties.checkAzureEndpoint(endpoint, accountName);
             if (err != null) {
                 throw new UserException(err);
             }
-            StorageSharedKeyCredential cred = new StorageSharedKeyCredential(properties.get(S3Properties.ACCESS_KEY),
+            StorageSharedKeyCredential cred = new StorageSharedKeyCredential(accountName,
                     properties.get(S3Properties.SECRET_KEY));
             BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
             builder.credential(cred);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -119,10 +119,6 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
             final String accountName = properties.get(S3Properties.ACCESS_KEY);
             final String endpoint = AzureProperties.formatAzureEndpoint(
                     properties.get(S3Properties.ENDPOINT), accountName);
-            String err = AzureProperties.checkAzureEndpoint(endpoint, accountName);
-            if (err != null) {
-                throw new UserException(err);
-            }
             StorageSharedKeyCredential cred = new StorageSharedKeyCredential(accountName,
                     properties.get(S3Properties.SECRET_KEY));
             BlobServiceClientBuilder builder = new BlobServiceClientBuilder();

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.S3URI;
 import org.apache.doris.datasource.property.PropertyConverter;
+import org.apache.doris.datasource.property.constants.AzureProperties;
 import org.apache.doris.datasource.property.constants.S3Properties;
 import org.apache.doris.fs.remote.RemoteFile;
 
@@ -61,7 +62,6 @@ import java.util.TreeMap;
 
 public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
     private static final Logger LOG = LogManager.getLogger(AzureObjStorage.class);
-    private static final String URI_TEMPLATE = "https://%s.blob.core.windows.net";
     protected Map<String, String> properties;
     private BlobServiceClient client;
     private boolean isUsePathStyle = false;
@@ -99,7 +99,7 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
         }
         // Virtual hosted-style is recommended in the s3 protocol.
         // The path-style has been abandoned, but for some unexplainable reasons,
-        // the s3 client will determine whether the endpiont starts with `s3`
+        // the s3 client will determine whether the endpoint starts with `s3`
         // when generating a virtual hosted-sytle request.
         // If not, it will not be converted ( https://github.com/aws/aws-sdk-java-v2/pull/763),
         // but the endpoints of many cloud service providers for object storage do not start with s3,
@@ -116,12 +116,18 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
     @Override
     public BlobServiceClient getClient() throws UserException {
         if (client == null) {
-            String uri = String.format(URI_TEMPLATE, properties.get(S3Properties.ACCESS_KEY));
+            String endpoint = AzureProperties.formatAzureEndpoint(
+                    properties.get(S3Properties.ENDPOINT), properties.get(S3Properties.ACCESS_KEY));
+            String err = AzureProperties.checkAzureEndpoint(
+                    properties.get(S3Properties.ENDPOINT), properties.get(S3Properties.ACCESS_KEY));
+            if (err != null) {
+                throw new UserException(err);
+            }
             StorageSharedKeyCredential cred = new StorageSharedKeyCredential(properties.get(S3Properties.ACCESS_KEY),
                     properties.get(S3Properties.SECRET_KEY));
             BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
             builder.credential(cred);
-            builder.endpoint(uri);
+            builder.endpoint(endpoint);
             client = builder.buildClient();
         }
         return client;
@@ -389,7 +395,8 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
                     + " failed because azure error: " + e.getMessage());
         } catch (Exception e) {
             LOG.warn("errors while glob file " + remotePath, e);
-            st = new Status(Status.ErrCode.COMMON_ERROR, "errors while glob file " + remotePath + e.getMessage());
+            st = new Status(Status.ErrCode.COMMON_ERROR,
+                    "errors while glob file " + remotePath + ": " + e.getMessage());
         } finally {
             long endTime = System.nanoTime();
             long duration = endTime - startTime;

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -119,11 +119,7 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
 
     private String constructEndpoint(Map<String, String> properties, S3URI s3uri) throws AnalysisException {
         // get endpoint first from properties, if not present, get it from s3 uri.
-        // If endpoint is missing, exception will be thrown.
         String endpoint = getOrDefaultAndRemove(properties, S3Properties.ENDPOINT, s3uri.getEndpoint().orElse(""));
-        if (Strings.isNullOrEmpty(endpoint)) {
-            throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ENDPOINT));
-        }
         if (AzureProperties.checkAzureProviderPropertyExist(properties)) {
             String bucket = s3uri.getBucket();
             String accountName = properties.getOrDefault(S3Properties.ACCESS_KEY, "");
@@ -135,6 +131,8 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
             if (err != null) {
                 throw new AnalysisException(err);
             }
+        } else if (Strings.isNullOrEmpty(endpoint)) {
+            throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ENDPOINT));
         }
         return endpoint;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -121,12 +121,11 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
         // get endpoint first from properties, if not present, get it from s3 uri.
         String endpoint = getOrDefaultAndRemove(properties, S3Properties.ENDPOINT, s3uri.getEndpoint().orElse(""));
         if (AzureProperties.checkAzureProviderPropertyExist(properties)) {
-            String bucket = s3uri.getBucket();
             String accountName = properties.getOrDefault(S3Properties.ACCESS_KEY, "");
             if (accountName.isEmpty()) {
                 throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ACCESS_KEY));
             }
-            endpoint = AzureProperties.formatAzureUri(endpoint, bucket, accountName);
+            endpoint = AzureProperties.formatAzureEndpoint(endpoint, accountName);
         } else if (Strings.isNullOrEmpty(endpoint)) {
             throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ENDPOINT));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -127,10 +127,6 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
                 throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ACCESS_KEY));
             }
             endpoint = AzureProperties.formatAzureUri(endpoint, bucket, accountName);
-            String err = AzureProperties.checkAzureEndpoint(endpoint, accountName);
-            if (err != null) {
-                throw new AnalysisException(err);
-            }
         } else if (Strings.isNullOrEmpty(endpoint)) {
             throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ENDPOINT));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -118,21 +118,23 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
     }
 
     private String constructEndpoint(Map<String, String> properties, S3URI s3uri) throws AnalysisException {
-        String endpoint;
-        if (!AzureProperties.checkAzureProviderPropertyExist(properties)) {
-            // get endpoint first from properties, if not present, get it from s3 uri.
-            // If endpoint is missing, exception will be thrown.
-            endpoint = getOrDefaultAndRemove(properties, S3Properties.ENDPOINT, s3uri.getEndpoint().orElse(""));
-            if (Strings.isNullOrEmpty(endpoint)) {
-                throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ENDPOINT));
-            }
-        } else {
+        // get endpoint first from properties, if not present, get it from s3 uri.
+        // If endpoint is missing, exception will be thrown.
+        String endpoint = getOrDefaultAndRemove(properties, S3Properties.ENDPOINT, s3uri.getEndpoint().orElse(""));
+        if (Strings.isNullOrEmpty(endpoint)) {
+            throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ENDPOINT));
+        }
+        if (AzureProperties.checkAzureProviderPropertyExist(properties)) {
             String bucket = s3uri.getBucket();
             String accountName = properties.getOrDefault(S3Properties.ACCESS_KEY, "");
             if (accountName.isEmpty()) {
                 throw new AnalysisException(String.format("Properties '%s' is required.", S3Properties.ACCESS_KEY));
             }
-            endpoint = String.format(AzureProperties.AZURE_ENDPOINT_TEMPLATE, accountName, bucket);
+            endpoint = AzureProperties.formatAzureUri(endpoint, bucket, accountName);
+            String err = AzureProperties.checkAzureEndpoint(endpoint, accountName);
+            if (err != null) {
+                throw new AnalysisException(err);
+            }
         }
         return endpoint;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/AzurePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/AzurePropertiesTest.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.property;
+
+import org.apache.doris.common.Config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AzurePropertiesTest {
+
+    @Test
+    public static String testFormatAzureEndpointGlobal() {
+        Config.force_azure_blob_global_endpoint = true;
+        String endpoint = AzureProperties.formatAzureEndpoint("ANY-ENDPOINT", "ak");
+        Assertions.assertEquals("https://ak.blob.core.windows.net", endpoint);
+    }
+
+    @Test
+    public static String testFormatAzureEndpoint() {
+        Config.force_azure_blob_global_endpoint = false;
+        String endpoint = AzureProperties.formatAzureEndpoint("ak.blob.core.chinacloudapi.cn", "ANY-ACCOUNT");
+        Assertions.assertEquals("https://ak.blob.core.chinacloudapi.cn", endpoint);
+    }
+
+    @Test
+    public static String testFormatAzureEndpointHTTPS() {
+        Config.force_azure_blob_global_endpoint = false;
+        String endpoint = AzureProperties.formatAzureEndpoint("https://ak.blob.core.chinacloudapi.cn", "ANY-ACCOUNT");
+        Assertions.assertEquals("https://ak.blob.core.chinacloudapi.cn", endpoint);
+    }
+
+    @Test
+    public static String testFormatAzureEndpointHTTP() {
+        Config.force_azure_blob_global_endpoint = false;
+        String endpoint = AzureProperties.formatAzureEndpoint("http://ak.blob.core.chinacloudapi.cn", "ANY-ACCOUNT");
+        Assertions.assertEquals("http://ak.blob.core.chinacloudapi.cn", endpoint);
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/constants/AzurePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/constants/AzurePropertiesTest.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.datasource.property;
+package org.apache.doris.datasource.property.constants;
 
 import org.apache.doris.common.Config;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/constants/AzurePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/constants/AzurePropertiesTest.java
@@ -25,28 +25,28 @@ import org.junit.jupiter.api.Test;
 public class AzurePropertiesTest {
 
     @Test
-    public static String testFormatAzureEndpointGlobal() {
+    public static void testFormatAzureEndpointGlobal() {
         Config.force_azure_blob_global_endpoint = true;
         String endpoint = AzureProperties.formatAzureEndpoint("ANY-ENDPOINT", "ak");
         Assertions.assertEquals("https://ak.blob.core.windows.net", endpoint);
     }
 
     @Test
-    public static String testFormatAzureEndpoint() {
+    public static void testFormatAzureEndpoint() {
         Config.force_azure_blob_global_endpoint = false;
         String endpoint = AzureProperties.formatAzureEndpoint("ak.blob.core.chinacloudapi.cn", "ANY-ACCOUNT");
         Assertions.assertEquals("https://ak.blob.core.chinacloudapi.cn", endpoint);
     }
 
     @Test
-    public static String testFormatAzureEndpointHTTPS() {
+    public static void testFormatAzureEndpointHTTPS() {
         Config.force_azure_blob_global_endpoint = false;
         String endpoint = AzureProperties.formatAzureEndpoint("https://ak.blob.core.chinacloudapi.cn", "ANY-ACCOUNT");
         Assertions.assertEquals("https://ak.blob.core.chinacloudapi.cn", endpoint);
     }
 
     @Test
-    public static String testFormatAzureEndpointHTTP() {
+    public static void testFormatAzureEndpointHTTP() {
         Config.force_azure_blob_global_endpoint = false;
         String endpoint = AzureProperties.formatAzureEndpoint("http://ak.blob.core.chinacloudapi.cn", "ANY-ACCOUNT");
         Assertions.assertEquals("http://ak.blob.core.chinacloudapi.cn", endpoint);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: CIR-14357

Problem Summary:

Azure operated in China uses chinacloudapi endpoint.
We should accept user specified endpoint for Azure S3 load.

A new FE and BE config `force_azure_blob_global_endpoint` is added.
This parameter controls whether to force the use of the Azure global endpoint.
The default is `false`, meaning the system will use the user-specified endpoint.
If set to `true`, the system will force the use of `{account}.blob.core.windows.net`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

