### PR TITLE
[fix](nereids)use visitNullableAggregateFunction for NullableAggregateFunction

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/AggregateFunctionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/AggregateFunctionVisitor.java
@@ -158,7 +158,7 @@ public interface AggregateFunctionVisitor<R, C> {
     }
 
     default R visitMultiDistinctGroupConcat(MultiDistinctGroupConcat multiDistinctGroupConcat, C context) {
-        return visitAggregateFunction(multiDistinctGroupConcat, context);
+        return visitNullableAggregateFunction(multiDistinctGroupConcat, context);
     }
 
     default R visitMultiDistinctSum(MultiDistinctSum multiDistinctSum, C context) {
@@ -274,7 +274,7 @@ public interface AggregateFunctionVisitor<R, C> {
     }
 
     default R visitStddev(Stddev stddev, C context) {
-        return visitAggregateFunction(stddev, context);
+        return visitNullableAggregateFunction(stddev, context);
     }
 
     default R visitStddevSamp(StddevSamp stddevSamp, C context) {


### PR DESCRIPTION
should call visitNullableAggregateFunction for Stddev and MultiDistinctGroupConcat

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

