### PR TITLE
[refine](exchange) Use clone to avoid multiple initializations of the partitioner

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -263,6 +263,9 @@ private:
     // The receiver will sort the collected data, so the sender must ensure that the data sent is ordered.
     const bool _dest_is_merge;
     const std::vector<TUniqueId>& _fragment_instance_ids;
+
+    std::unique_ptr<vectorized::PartitionerBase> _partitioner = nullptr;
+    size_t _partition_count = 0;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
### What problem does this PR solve?
Similar to PartitionedHashJoinSinkOperatorX. Initialize the partitioner in the Operator and clone it in the local state.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

