### PR TITLE
[fix](nereids) fix LogicalRepeat compute equalset

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
@@ -366,6 +366,10 @@ public class DataTrait {
             fdDgBuilder.removeNotContain(outputSlots);
         }
 
+        public void pruneEqualSetSlots(Set<Slot> outputSlots) {
+            equalSetBuilder.removeNotContain(outputSlots);
+        }
+
         public void replaceUniformBy(Map<Slot, Slot> replaceMap) {
             uniformSet.replace(replaceMap);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
@@ -198,7 +198,6 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public void computeEqualSet(DataTrait.Builder builder) {
-        builder.addEqualSet(child().getLogicalProperties().getTrait());
         Set<Expression> common = getCommonGroupingSetExpressions();
         Set<Slot> slots = new HashSet<>();
         for (Expression expr : common) {
@@ -207,6 +206,7 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
             }
             slots.add((Slot) expr);
         }
+        builder.addEqualSet(child().getLogicalProperties().getTrait());
         builder.pruneEqualSetSlots(slots);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
@@ -34,9 +34,11 @@ import org.apache.doris.nereids.util.Utils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * LogicalRepeat.
@@ -197,6 +199,15 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     @Override
     public void computeEqualSet(DataTrait.Builder builder) {
         builder.addEqualSet(child().getLogicalProperties().getTrait());
+        Set<Expression> common = getCommonGroupingSetExpressions();
+        Set<Slot> slots = new HashSet<>();
+        for (Expression expr : common) {
+            if (!(expr instanceof Slot)) {
+                return;
+            }
+            slots.add((Slot) expr);
+        }
+        builder.pruneEqualSetSlots(slots);
     }
 
     @Override

--- a/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_gby_key.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_gby_key.out
@@ -9,3 +9,12 @@
 1
 1
 
+-- !grouping_equalset --
+1
+1
+1
+1
+
+-- !grouping_equalset_can_eliminate --
+2
+

--- a/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_gby_key.groovy
+++ b/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_gby_key.groovy
@@ -291,4 +291,6 @@ suite("eliminate_gby_key") {
 	sql "create table eli_gbk_t(a int, b int) distributed by hash(a) properties('replication_num'='1');"
 	sql "insert into eli_gbk_t values(1,1),(2,1),(3,1);"
 	qt_grouping """select count(1) from (select b as k, a k3, sum(b) as sum_k1 from  eli_gbk_t where b=1 group by cube(k,a)) t group by k,k3 order by 1"""
+	qt_grouping_equalset """select count(1) from (select a,b from eli_gbk_t where a=b group by cube(a,b)) t group by a,b;"""
+	qt_grouping_equalset_can_eliminate """select count(1) from (select a,b from eli_gbk_t where a=b group by grouping sets((a,b),(b,a))) t group by a,b;"""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
This PR addresses an issue where LogicalRepeat should not propagate equalset because, in scenarios involving group by cube(a, b) with a = b, LogicalRepeat generates four rows (e.g., when a = b = 3, the rows are (3,3), (3,null), (null,3), and (null,null)), which breaks the equalset relationship a = b. To resolve this, the equalset slots are now retained only when they are part of the common set of LogicalRepeat's group by keys. This ensures the integrity of equalset is maintained during group by cube operations, preventing incorrect query results. 
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

