### PR TITLE
[feat](catalog)Simplify HMS Catalog Create Statement

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/KerberosAuthenticationConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/KerberosAuthenticationConfig.java
@@ -42,22 +42,32 @@ public class KerberosAuthenticationConfig extends AuthenticationConfig {
     }
 
     public void setKerberosKeytab(String kerberosKeytab) {
-        // Try to convert the provided keytab path to a Path object
+        // Convert the provided keytab path to a Path object
         Path keytabPath = Paths.get(kerberosKeytab);
-        // If the provided path is an existing file, use it directly
-        if (keytabPath.toFile().exists()) {
-            this.kerberosKeytab = kerberosKeytab;
-            return;
-        }
-        // If the file does not exist, try to resolve it by concatenating with the custom config directory
-        String resolvedKeytabPath = Config.custom_config_dir + File.separator + kerberosKeytab;
-        keytabPath = Paths.get(resolvedKeytabPath);
 
-        // If the resolved path also does not exist, throw an exception
-        if (!keytabPath.toFile().exists()) {
-            throw new RuntimeException("Keytab file does not exist: " + kerberosKeytab);
+        // Check if the provided path is an absolute path
+        if (keytabPath.isAbsolute()) {
+            // If it's an absolute path, check if the file exists
+            if (keytabPath.toFile().exists()) {
+                // If the file exists, set the kerberosKeytab
+                this.kerberosKeytab = kerberosKeytab;
+            } else {
+                // If the file does not exist, throw an exception
+                throw new RuntimeException("Keytab file does not exist: " + kerberosKeytab);
+            }
+        } else {
+            // If it's not an absolute path, resolve it with the custom config directory
+            String resolvedKeytabPath = Config.custom_config_dir + File.separator + kerberosKeytab;
+            keytabPath = Paths.get(resolvedKeytabPath);
+
+            // Check if the resolved path exists
+            if (keytabPath.toFile().exists()) {
+                // If the file exists, set the kerberosKeytab
+                this.kerberosKeytab = keytabPath.toString();
+            } else {
+                // If the file does not exist, throw an exception
+                throw new RuntimeException("Keytab file does not exist: " + keytabPath.toString());
+            }
         }
-        // If a valid keytab file path is found, save it
-        this.kerberosKeytab = resolvedKeytabPath;
     }
 }

--- a/fe/fe-common/src/test/java/org/apache/doris/common/security/authentication/AuthenticationTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/security/authentication/AuthenticationTest.java
@@ -17,29 +17,103 @@
 
 package org.apache.doris.common.security.authentication;
 
+import org.apache.doris.common.Config;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
 public class AuthenticationTest {
 
     @Test
     public void testAuthConf() {
+        // simple
         Configuration conf = new Configuration();
-
         AuthenticationConfig conf1 = AuthenticationConfig.getKerberosConfig(conf);
         Assert.assertEquals(SimpleAuthenticationConfig.class, conf1.getClass());
 
+        // simple
         conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
-
         AuthenticationConfig conf2 = AuthenticationConfig.getKerberosConfig(conf);
         Assert.assertEquals(SimpleAuthenticationConfig.class, conf2.getClass());
 
-        conf.set(AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL, "principal");
-        conf.set(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB, "keytab");
+        // kerberos will be tested below
+    }
 
-        AuthenticationConfig conf3 = AuthenticationConfig.getKerberosConfig(conf);
-        Assert.assertEquals(KerberosAuthenticationConfig.class, conf3.getClass());
+    @Test
+    public void testSetKerberosKeytabWithAbsolutePath() throws IOException {
+        // Create a temporary keytab file
+        File tempKeytab = File.createTempFile("test", ".keytab");
+        tempKeytab.deleteOnExit();
+
+        Configuration conf = new Configuration();
+        conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+        conf.set(AuthenticationConfig.HADOOP_KERBEROS_PRINCIPAL, "principal");
+        conf.set(AuthenticationConfig.HADOOP_KERBEROS_KEYTAB, tempKeytab.getAbsolutePath().toString());
+        AuthenticationConfig authConf = AuthenticationConfig.getKerberosConfig(conf);
+        Assert.assertEquals(KerberosAuthenticationConfig.class, authConf.getClass());
+
+        KerberosAuthenticationConfig config = (KerberosAuthenticationConfig) authConf;
+        Assert.assertEquals(tempKeytab.getAbsolutePath(), config.getKerberosKeytab());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSetKerberosKeytabWithNonExistentAbsolutePath() {
+        KerberosAuthenticationConfig config = new KerberosAuthenticationConfig();
+        config.setKerberosKeytab("/non/existent/path/test.keytab");
+    }
+
+    @Test
+    public void testSetKerberosKeytabWithRelativePath() throws IOException {
+        // Save original custom_config_dir value
+        String originalConfigDir = Config.custom_config_dir;
+
+        try {
+            // Create a temporary directory to serve as custom_config_dir
+            File tempDir = Files.createTempDirectory("test_config").toFile();
+            tempDir.deleteOnExit();
+
+            // Create a keytab file in the temporary directory
+            File tempKeytab = new File(tempDir, "test.keytab");
+            tempKeytab.createNewFile();
+            tempKeytab.deleteOnExit();
+
+            // Set custom_config_dir to our temporary directory
+            Config.custom_config_dir = tempDir.getAbsolutePath();
+
+            KerberosAuthenticationConfig config = new KerberosAuthenticationConfig();
+            config.setKerberosKeytab("test.keytab");
+
+            Assert.assertEquals(tempKeytab.getAbsolutePath(), config.getKerberosKeytab());
+        } finally {
+            // Restore original custom_config_dir
+            Config.custom_config_dir = originalConfigDir;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSetKerberosKeytabWithNonExistentRelativePath() throws IOException {
+        // Save original custom_config_dir value
+        String originalConfigDir = Config.custom_config_dir;
+
+        try {
+            // Create a temporary directory to serve as custom_config_dir
+            File tempDir = Files.createTempDirectory("test_config").toFile();
+            tempDir.deleteOnExit();
+
+            // Set custom_config_dir to our temporary directory
+            Config.custom_config_dir = tempDir.getAbsolutePath();
+
+            KerberosAuthenticationConfig config = new KerberosAuthenticationConfig();
+            config.setKerberosKeytab("non_existent.keytab");
+        } finally {
+            // Restore original custom_config_dir
+            Config.custom_config_dir = originalConfigDir;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSExternalCatalogTest.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import org.apache.doris.common.Config;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HMSExternalCatalogTest {
+    private Map<String, String> properties;
+    private String confDir;
+
+    @Before
+    public void setUp() {
+        properties = new HashMap<>();
+
+        // Get the path to test configuration files
+        URL url = getClass().getClassLoader().getResource("data/hadoop-conf");
+        confDir = url.getPath();
+
+        // Add configuration directory property
+        properties.put("hadoop.conf.dir", confDir);
+
+        // Add HDFS configuration that will override values in hdfs-site.xml
+        properties.put("dfs.nameservices", "testcluster");  // override "defaultcluster"
+        properties.put("dfs.ha.namenodes.testcluster", "nn1,nn2");  // override "default1,default2"
+        properties.put("dfs.namenode.rpc-address.testcluster.nn1", "node1:8020");  // override "default1:8020"
+        properties.put("dfs.namenode.rpc-address.testcluster.nn2", "node2:8020");  // new property
+        properties.put("dfs.client.failover.proxy.provider.testcluster",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+
+        // Add Hive configuration that will override values in hive-site.xml
+        properties.put("hive.metastore.uris", "thrift://localhost:9083");  // override "thrift://default:9083"
+        properties.put("hive.metastore.warehouse.dir", "/user/hive/warehouse");  // override "/user/hive/default"
+    }
+
+    @Test
+    public void testLoadHdfsConfiguration() {
+        // First load configuration without properties to verify default values
+        HdfsConfiguration defaultConf = new HdfsConfiguration();
+        Assert.assertEquals("defaultcluster", defaultConf.get("dfs.nameservices"));
+        Assert.assertEquals("default1,default2", defaultConf.get("dfs.ha.namenodes.testcluster"));
+        Assert.assertEquals("default1:8020", defaultConf.get("dfs.namenode.rpc-address.testcluster.nn1"));
+
+        // Then load configuration with properties to verify overridden values
+        Configuration hdfsConf = HMSExternalCatalog.loadHdfsConfiguration(properties);
+        Assert.assertEquals("testcluster", hdfsConf.get("dfs.test-from-file"));
+        Assert.assertEquals("testcluster", hdfsConf.get("dfs.nameservices"));
+        Assert.assertEquals("nn1,nn2", hdfsConf.get("dfs.ha.namenodes.testcluster"));
+        Assert.assertEquals("node1:8020", hdfsConf.get("dfs.namenode.rpc-address.testcluster.nn1"));
+        Assert.assertEquals("node2:8020", hdfsConf.get("dfs.namenode.rpc-address.testcluster.nn2"));
+        Assert.assertEquals(
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+                hdfsConf.get("dfs.client.failover.proxy.provider.testcluster"));
+    }
+
+    @Test
+    public void testLoadHiveConf() {
+        // First load configuration without properties to verify default values
+        HiveConf defaultConf = new HiveConf();
+        Assert.assertEquals("thrift://default:9083", defaultConf.get("hive.metastore.uris"));
+        Assert.assertEquals("/user/hive/default", defaultConf.get("hive.metastore.warehouse.dir"));
+
+        // Then load configuration with properties to verify overridden values
+        HiveConf hiveConf = HMSExternalCatalog.loadHiveConf(properties);
+        Assert.assertEquals("thrift://localhost:9083", hiveConf.get("hive.metastore.uris"));
+        Assert.assertEquals("/user/hive/warehouse", hiveConf.get("hive.metastore.warehouse.dir"));
+        Assert.assertEquals(String.valueOf(Config.hive_metastore_client_timeout_second),
+                hiveConf.get(HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT.name()));
+    }
+}

--- a/fe/fe-core/src/test/resources/data/hadoop-conf/hdfs-site.xml
+++ b/fe/fe-core/src/test/resources/data/hadoop-conf/hdfs-site.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>dfs.nameservices</name>
+        <value>defaultcluster</value>
+    </property>
+    <property>
+        <name>dfs.ha.namenodes.testcluster</name>
+        <value>default1,default2</value>
+    </property>
+    <property>
+        <name>dfs.namenode.rpc-address.testcluster.nn1</name>
+        <value>default1:8020</value>
+    </property>
+    <property>
+        <name>dfs.test-from-file</name>
+        <value>test-from-file</value>
+    </property>
+</configuration> 

--- a/fe/fe-core/src/test/resources/data/hadoop-conf/hive-site.xml
+++ b/fe/fe-core/src/test/resources/data/hadoop-conf/hive-site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://default:9083</value>
+    </property>
+    <property>
+        <name>hive.metastore.warehouse.dir</name>
+        <value>/user/hive/default</value>
+    </property>
+</configuration> 

--- a/fe/fe-core/src/test/resources/hdfs-site.xml
+++ b/fe/fe-core/src/test/resources/hdfs-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>dfs.nameservices</name>
+        <value>defaultcluster</value>
+    </property>
+    <property>
+        <name>dfs.ha.namenodes.testcluster</name>
+        <value>default1,default2</value>
+    </property>
+    <property>
+        <name>dfs.namenode.rpc-address.testcluster.nn1</name>
+        <value>default1:8020</value>
+    </property>
+</configuration> 

--- a/fe/fe-core/src/test/resources/hive-site.xml
+++ b/fe/fe-core/src/test/resources/hive-site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://default:9083</value>
+    </property>
+    <property>
+        <name>hive.metastore.warehouse.dir</name>
+        <value>/user/hive/default</value>
+    </property>
+</configuration> 


### PR DESCRIPTION
## Background:
Currently, when creating an HMS Catalog, users are required to explicitly declare certain configuration parameters (e.g., dfs) in the CREATE CATALOG statement. However, if users have provided these parameters in a configuration file (e.g., XML file), the parameters in the SQL statement become redundant. To simplify the user experience and reduce unnecessary configuration, we decided to move the parameter validation to the backend, load the configuration file first, and then check if the necessary parameters are present.

## Changes:
The parameter validation is moved from the CREATE CATALOG statement to the backend logic. The CREATE CATALOG statement is simplified to the following:
```sql

CREATE CATALOG `hms_test` PROPERTIES (
  "type" = "hms"
);
```
We will load configuration files (e.g., XML), then validate whether the required parameters are present. If any necessary parameters are missing, an error will be triggered to ensure the user's configuration is complete.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

