### PR TITLE
[fix](regression) regression case: limit_push_down is unstable

### DIFF
--- a/regression-test/data/nereids_rules_p0/limit_push_down/limit_push_down.out
+++ b/regression-test/data/nereids_rules_p0/limit_push_down/limit_push_down.out
@@ -148,18 +148,10 @@ PhysicalResultSink
 ------------------PhysicalOlapScan[t1]
 ------------PhysicalOlapScan[t2]
 
--- !limit_distinct --
-PhysicalResultSink
---PhysicalTopN[MERGE_SORT]
-----PhysicalTopN[LOCAL_SORT]
-------hashAgg[GLOBAL]
---------hashAgg[LOCAL]
-----------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
-------------PhysicalTopN[MERGE_SORT]
---------------PhysicalTopN[LOCAL_SORT]
-----------------hashAgg[LOCAL]
-------------------PhysicalOlapScan[t1]
-------------PhysicalOlapScan[t2]
+Hint log:
+Used: [broadcast]_1
+UnUsed:
+SyntaxError:
 
 -- !limit_offset_agg --
 PhysicalResultSink

--- a/regression-test/suites/nereids_rules_p0/limit_push_down/limit_push_down.groovy
+++ b/regression-test/suites/nereids_rules_p0/limit_push_down/limit_push_down.groovy
@@ -60,9 +60,8 @@ suite("limit_push_down") {
     //`limit 1, agg & scalar agg join:
     qt_limit_distinct """ explain shape plan SELECT distinct t1.id FROM t1 cross join t2 LIMIT 1; """
     //`limit 1, agg & scalar agg left outer join:
-    qt_limit_distinct """ explain shape plan SELECT distinct t1.id FROM t1 left outer join t2 on t1.id = t2.id LIMIT 1; """
-    //`limit 1, agg & scalar agg right outer join:
-    qt_limit_distinct """ explain shape plan SELECT distinct t1.id FROM t1 left outer join t2 on t1.id = t2.id LIMIT 1; """
+    qt_limit_distinct """ explain shape plan SELECT distinct t1.id FROM t1 left outer join[broadcast] t2 on t1.id = t2.id LIMIT 1; """
+
     
     //`limit 1 offset 1, agg & scalar agg`:
     qt_limit_offset_agg """ explain shape plan SELECT distinct t1.id c FROM t1 ORDER BY c LIMIT 1 OFFSET 1; """


### PR DESCRIPTION
### What problem does this PR solve?
the unstable reason is tables are empty, and hence the join shuffle type is unstable. The shuffle type is irrelevant to the main purpose of this case "pushing limit through join" 

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

