### PR TITLE
[fix](regression-test) alter some cases nonConcurrent to prevent MapRedTask Execution Error

### DIFF
--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_ddl_text_format", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_ddl_text_format", "p0,external,hive,external_docker,external_docker_hive,nonConcurrent") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/mtmv_p0/test_hive_default_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_default_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_default_mtmv", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_default_mtmv", "p0,external,hive,external_docker,external_docker_hive,nonConcurrent") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/mtmv_p0/test_hive_limit_partition_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_limit_partition_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_limit_partition_mtmv", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_limit_partition_mtmv", "p0,external,hive,external_docker,external_docker_hive,nonConcurrent") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/mtmv_p0/test_hive_multi_partition_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_multi_partition_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_multi_partition_mtmv", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_multi_partition_mtmv", "p0,external,hive,external_docker,external_docker_hive,nonConcurrent") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
Some case will report error when run hive sql:
```text
Exception:
java.sql.SQLException: org.apache.hive.service.cli.HiveSQLException: Error while processing statement: FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask
  at org.apache.hive.service.cli.operation.Operation.toSQLException(Operation.java:380)
  at org.apache.hive.service.cli.operation.SQLOperation.runQuery(SQLOperation.java:257)
  at org.apache.hive.service.cli.operation.SQLOperation.access$800(SQLOperation.java:91)
  at org.apache.hive.service.cli.operation.SQLOperation$BackgroundWork$1.run(SQLOperation.java:348)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

