### PR TITLE
[opt](Nereids) avoid lock failed if async mv has invalid base info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
@@ -122,6 +122,10 @@ public class BaseTableInfo {
         }
     }
 
+    public boolean isValid() {
+        return ctlName != null && dbName != null && tableName != null;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
@@ -207,15 +207,18 @@ public class CollectRelation implements AnalysisRuleFactory {
                 mtmv.readMvLock();
                 try {
                     for (BaseTableInfo baseTableInfo : mtmv.getRelation().getBaseTables()) {
+                        if (!baseTableInfo.isValid()) {
+                            continue;
+                        }
                         if (LOG.isDebugEnabled()) {
-                            LOG.info("mtmv {} related base table include {}", new BaseTableInfo(mtmv), baseTableInfo);
+                            LOG.debug("mtmv {} related base table include {}", new BaseTableInfo(mtmv), baseTableInfo);
                         }
                         try {
                             cascadesContext.getStatementContext().getAndCacheTable(baseTableInfo.toList(),
                                     TableFrom.MTMV);
                         } catch (AnalysisException exception) {
-                            LOG.warn("mtmv related base table get err, related table is "
-                                            + baseTableInfo.toList(), exception);
+                            LOG.warn("mtmv related base table get err, related table is {}",
+                                    baseTableInfo.toList(), exception);
                         }
                     }
                 } finally {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

sometimes, after upgrade, async mv may has invalid base table info.
when do lock before plan, we should skip these infos to avoid lock failed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

