### PR TITLE
[enhancement](Nereids) add interface for binary search filtering prune external table's partitions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -142,6 +142,11 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         return getVisibleVersion();
     }
 
+    @Override
+    public long getPartitionMetaLoadTimeMillis(CatalogRelation scan) {
+        return getVisibleVersionTime();
+    }
+
     public enum OlapTableState {
         NORMAL,
         ROLLUP,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -59,6 +59,7 @@ import org.apache.doris.mtmv.MTMVSnapshotIf;
 import org.apache.doris.mtmv.MTMVVersionSnapshot;
 import org.apache.doris.nereids.hint.Hint;
 import org.apache.doris.nereids.hint.UseMvHint;
+import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.persist.ColocatePersistInfo;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -132,12 +133,12 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
     private static final Logger LOG = LogManager.getLogger(OlapTable.class);
 
     @Override
-    public PartitionInfo getOriginPartitionInfo() {
-        return getPartitionInfo();
+    public Map<Long, PartitionItem> getOriginPartitions() {
+        return getPartitionInfo().getIdToItem(false);
     }
 
     @Override
-    public Object getPartitionMetaVersion() {
+    public Object getPartitionMetaVersion(CatalogRelation scan) {
         return getVisibleVersion();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -133,7 +133,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
     private static final Logger LOG = LogManager.getLogger(OlapTable.class);
 
     @Override
-    public Map<Long, PartitionItem> getOriginPartitions() {
+    public Map<Long, PartitionItem> getOriginPartitions(CatalogRelation scan) {
         return getPartitionInfo().getIdToItem(false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -127,8 +127,19 @@ import java.util.stream.Collectors;
  * Internal representation of tableFamilyGroup-related metadata. A OlaptableFamilyGroup contains several tableFamily.
  * Note: when you add a new olap table property, you should modify TableProperty class
  */
-public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProcessable {
+public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProcessable,
+        SupportBinarySearchFilteringPartitions {
     private static final Logger LOG = LogManager.getLogger(OlapTable.class);
+
+    @Override
+    public PartitionInfo getOriginPartitionInfo() {
+        return getPartitionInfo();
+    }
+
+    @Override
+    public Object getPartitionMetaVersion() {
+        return getVisibleVersion();
+    }
 
     public enum OlapTableState {
         NORMAL,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
@@ -32,8 +32,8 @@ public interface SupportBinarySearchFilteringPartitions extends TableIf {
     Map<?, PartitionItem> getOriginPartitions();
 
     /**
-     * return the version of the partitions meta, is the version changed, we should skip the legacy sorted
-     * partitions and reload it.
+     * return the version of the partitions meta, if the version changed, we should skip the legacy sorted
+     * partitions and reload it. you can extract the snapshot if exists in the CatalogRelation
      */
     Object getPartitionMetaVersion(CatalogRelation scan);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
@@ -27,13 +27,14 @@ import java.util.Map;
 public interface SupportBinarySearchFilteringPartitions extends TableIf {
     /**
      * get the origin partition info which maybe not sorted, the NereidsSortedPartitionsCacheManager will
-     * sort this partitions and cache in frontend
+     * sort this partitions and cache in frontend. you can save the partition's meta snapshot id in the
+     * CatalogRelation and get the partitions by the snapshot id.
      */
-    Map<?, PartitionItem> getOriginPartitions();
+    Map<?, PartitionItem> getOriginPartitions(CatalogRelation scan);
 
     /**
      * return the version of the partitions meta, if the version changed, we should skip the legacy sorted
-     * partitions and reload it. you can extract the snapshot if exists in the CatalogRelation
+     * partitions and reload it.
      */
     Object getPartitionMetaVersion(CatalogRelation scan);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
@@ -37,4 +37,10 @@ public interface SupportBinarySearchFilteringPartitions extends TableIf {
      * partitions and reload it.
      */
     Object getPartitionMetaVersion(CatalogRelation scan);
+
+    /**
+     * when the partition meta loaded? if the partition meta load too frequently, we will skip sort partitions meta
+     * and will not use binary search to filtering partitions
+     */
+    long getPartitionMetaLoadTimeMillis(CatalogRelation scan);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+/**
+ * SupportBinarySearchFilteringPartitions: this interface is used to support binary search filtering partitions
+ */
+public interface SupportBinarySearchFilteringPartitions extends TableIf {
+    /**
+     * get the origin partition info which maybe not sorted, the NereidsSortedPartitionsCacheManager will
+     * sort this partitions and cache in frontend
+     */
+    PartitionInfo getOriginPartitionInfo();
+
+    /**
+     * return the version of the partitions meta, is the version changed, we should skip the legacy sorted
+     * partitions and reload it.
+     */
+    Object getPartitionMetaVersion();
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SupportBinarySearchFilteringPartitions.java
@@ -17,6 +17,10 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
+
+import java.util.Map;
+
 /**
  * SupportBinarySearchFilteringPartitions: this interface is used to support binary search filtering partitions
  */
@@ -25,11 +29,11 @@ public interface SupportBinarySearchFilteringPartitions extends TableIf {
      * get the origin partition info which maybe not sorted, the NereidsSortedPartitionsCacheManager will
      * sort this partitions and cache in frontend
      */
-    PartitionInfo getOriginPartitionInfo();
+    Map<?, PartitionItem> getOriginPartitions();
 
     /**
      * return the version of the partitions meta, is the version changed, we should skip the legacy sorted
      * partitions and reload it.
      */
-    Object getPartitionMetaVersion();
+    Object getPartitionMetaVersion(CatalogRelation scan);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
@@ -89,7 +89,7 @@ public class NereidsSortedPartitionsCacheManager {
 
     private SortedPartitionRanges<?> loadCache(
             TableIdentifier key, SupportBinarySearchFilteringPartitions table, CatalogRelation scan) {
-        Map<?, PartitionItem> unsortedMap = table.getOriginPartitions();
+        Map<?, PartitionItem> unsortedMap = table.getOriginPartitions(scan);
         List<Entry<?, PartitionItem>> unsortedList = Lists.newArrayList(unsortedMap.entrySet());
         List<PartitionItemAndRange<?>> sortedRanges = Lists.newArrayListWithCapacity(unsortedMap.size());
         List<PartitionItemAndId<?>> defaultPartitions = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
@@ -89,11 +89,11 @@ public class NereidsSortedPartitionsCacheManager {
 
     private SortedPartitionRanges<?> loadCache(
             TableIdentifier key, SupportBinarySearchFilteringPartitions table, CatalogRelation scan) {
-        Map<?, PartitionItem> unsorted = table.getOriginPartitions();
-        List<Entry<?, PartitionItem>> sortedList = Lists.newArrayList(unsorted.entrySet());
-        List<PartitionItemAndRange<?>> sortedRanges = Lists.newArrayListWithCapacity(unsorted.size());
+        Map<?, PartitionItem> unsortedMap = table.getOriginPartitions();
+        List<Entry<?, PartitionItem>> unsortedList = Lists.newArrayList(unsortedMap.entrySet());
+        List<PartitionItemAndRange<?>> sortedRanges = Lists.newArrayListWithCapacity(unsortedMap.size());
         List<PartitionItemAndId<?>> defaultPartitions = Lists.newArrayList();
-        for (Entry<?, PartitionItem> entry : sortedList) {
+        for (Entry<?, PartitionItem> entry : unsortedList) {
             PartitionItem partitionItem = entry.getValue();
             Object id = entry.getKey();
             if (!partitionItem.isDefaultPartition()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
@@ -98,8 +98,8 @@ public class PruneFileScanPartition extends OneRewriteRuleFactory {
         if (externalTable instanceof SupportBinarySearchFilteringPartitions) {
             NereidsSortedPartitionsCacheManager partitionsCacheManager = Env.getCurrentEnv()
                     .getSortedPartitionsCacheManager();
-            sortedPartitionRanges
-                    = (Optional) partitionsCacheManager.get((SupportBinarySearchFilteringPartitions) externalTable);
+            sortedPartitionRanges = (Optional) partitionsCacheManager.get(
+                            (SupportBinarySearchFilteringPartitions) externalTable, scan);
         }
 
         List<String> prunedPartitions = new ArrayList<>(PartitionPruner.prune(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
@@ -17,13 +17,17 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PartitionItem;
+import org.apache.doris.catalog.SupportBinarySearchFilteringPartitions;
+import org.apache.doris.common.cache.NereidsSortedPartitionsCacheManager;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner.PartitionTableType;
+import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan.SelectedPartitions;
@@ -36,6 +40,7 @@ import org.apache.commons.collections.CollectionUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -89,8 +94,17 @@ public class PruneFileScanPartition extends OneRewriteRuleFactory {
                 .collect(Collectors.toList());
 
         Map<String, PartitionItem> nameToPartitionItem = scan.getSelectedPartitions().selectedPartitions;
+        Optional<SortedPartitionRanges<String>> sortedPartitionRanges = Optional.empty();
+        if (externalTable instanceof SupportBinarySearchFilteringPartitions) {
+            NereidsSortedPartitionsCacheManager partitionsCacheManager = Env.getCurrentEnv()
+                    .getSortedPartitionsCacheManager();
+            sortedPartitionRanges
+                    = (Optional) partitionsCacheManager.get((SupportBinarySearchFilteringPartitions) externalTable);
+        }
+
         List<String> prunedPartitions = new ArrayList<>(PartitionPruner.prune(
-                partitionSlots, filter.getPredicate(), nameToPartitionItem, ctx, PartitionTableType.EXTERNAL));
+                partitionSlots, filter.getPredicate(), nameToPartitionItem, ctx,
+                PartitionTableType.EXTERNAL, sortedPartitionRanges));
 
         for (String name : prunedPartitions) {
             selectedPartitionItems.put(name, nameToPartitionItem.get(name));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
@@ -86,7 +86,8 @@ public class PruneOlapScanPartition extends OneRewriteRuleFactory {
             Map<Long, PartitionItem> idToPartitions;
             Optional<SortedPartitionRanges<Long>> sortedPartitionRanges = Optional.empty();
             if (manuallySpecifiedPartitions.isEmpty()) {
-                Optional<SortedPartitionRanges<?>> sortedPartitionRangesOpt = sortedPartitionsCacheManager.get(table);
+                Optional<SortedPartitionRanges<?>> sortedPartitionRangesOpt
+                        = sortedPartitionsCacheManager.get(table, scan);
                 if (sortedPartitionRangesOpt.isPresent()) {
                     sortedPartitionRanges = (Optional) sortedPartitionRangesOpt;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -214,7 +214,7 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         }
 
         ArrayList<String> partitionNames = Lists.newArrayList(relation.getPartNames());
-        List<Partition> selectedPartitions = getSelectedPartitions(olapTable, filter, partitionNames);
+        List<Partition> selectedPartitions = getSelectedPartitions(olapTable, filter, scan, partitionNames);
 
         Env.getCurrentEnv()
                 .getDeleteHandler()
@@ -240,7 +240,9 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         }
     }
 
-    private List<Partition> getSelectedPartitions(OlapTable olapTable, PhysicalFilter<?> filter,
+    private List<Partition> getSelectedPartitions(
+            OlapTable olapTable, PhysicalFilter<?> filter,
+            PhysicalOlapScan scan,
             List<String> partitionNames) {
         // For un_partitioned table, return all partitions.
         if (olapTable.getPartitionInfo().getType().equals(PartitionType.UNPARTITIONED)) {
@@ -274,7 +276,7 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
                     .collect(Collectors.toMap(Function.identity(), idToPartitions::get));
         } else {
             Optional<SortedPartitionRanges<?>> sortedPartitionRangesOpt
-                    = Env.getCurrentEnv().getSortedPartitionsCacheManager().get(olapTable);
+                    = Env.getCurrentEnv().getSortedPartitionsCacheManager().get(olapTable, scan);
             if (sortedPartitionRangesOpt.isPresent()) {
                 sortedPartitionRanges = (Optional) sortedPartitionRangesOpt;
             }


### PR DESCRIPTION
### What problem does this PR solve?

1. add interface `SupportBinarySearchFilteringPartitions` for binary search filtering prune external table's partitions
2. skip binary search if the recent changed lower than 10s

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

