### PR TITLE
[fix](regression) topn-filter unstable case

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopnFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopnFilterPushDownVisitor.java
@@ -221,7 +221,7 @@ public class TopnFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownCont
             // in ut, relation.getStats() may return null
             if (relation.getStats() == null || ConnectContext.get() == null
                     || ConnectContext.get().getSessionVariable() == null
-                    || relation.getStats().getRowCount()
+                    || Math.max(relation.getStats().getRowCount(), 1)
                             * ConnectContext.get().getSessionVariable().topnFilterRatio > ctx.topn.getLimit()
                                     + ctx.topn.getOffset()) {
                 topnFilterContext.addTopnFilter(ctx.topn, relation, ctx.probeExpr);

--- a/regression-test/suites/query_p0/test_array_orderby_limit.groovy
+++ b/regression-test/suites/query_p0/test_array_orderby_limit.groovy
@@ -39,7 +39,7 @@ suite("test_array_char_orderby", "query") {
     sql "analyze table test_array_char_orderby with sync"
     // set topn_opt_limit_threshold = 1024 to make sure _internal_service to be request with proto request
     sql """ set topn_opt_limit_threshold = 1024 """
-    sql """ set topn_filter_ratio = 1 """
+    sql """ set topn_filter_ratio = 2 """
     explain{
         sql("select * from test_array_char_orderby order by k1 limit 1")
         contains "TOPN"

--- a/regression-test/suites/query_p0/test_array_orderby_limit.groovy
+++ b/regression-test/suites/query_p0/test_array_orderby_limit.groovy
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_array_char_orderby", "query") {
+suite("test_array_orderby_limit", "query") {
     // define a sql table
     def testTable = "test_array_char_orderby"
 
     sql """
+            drop table if exists test_array_char_orderby;
             CREATE TABLE IF NOT EXISTS test_array_char_orderby (
               `k1` INT(11) NULL,
               `k2` array<array<char(50)>> NULL
@@ -32,7 +33,7 @@ suite("test_array_char_orderby", "query") {
             "in_memory" = "false",
             "storage_format" = "V2",
             "disable_auto_compaction" = "false"
-            )
+            );
             """
     // prepare data
     sql """ INSERT INTO test_array_char_orderby VALUES (100, [['abc']]), (200, [['xyz']]) """
@@ -40,6 +41,10 @@ suite("test_array_char_orderby", "query") {
     // set topn_opt_limit_threshold = 1024 to make sure _internal_service to be request with proto request
     sql """ set topn_opt_limit_threshold = 1024 """
     sql """ set topn_filter_ratio = 2 """
+    def table_stats = sql("show table stats test_array_char_orderby")
+    log.info(table_stats.join("\n"))
+    def memo = sql ("explain memo plan select * from test_array_char_orderby order by k1 limit 1")
+    log.info(memo.join("\n"))
     explain{
         sql("select * from test_array_char_orderby order by k1 limit 1")
         contains "TOPN"


### PR DESCRIPTION
### What problem does this PR solve?
regression-test/suites/query_p0/test_array_orderby_limit.groovy is unstable
when case failed, plan shows that the table row count is 0.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

