### PR TITLE
fix kerberos_ticket_mgr.cpp

### DIFF
--- a/be/src/common/kerberos/kerberos_ticket_mgr.cpp
+++ b/be/src/common/kerberos/kerberos_ticket_mgr.cpp
@@ -112,7 +112,9 @@ Status KerberosTicketMgr::get_or_set_ticket_cache(
     new_ticket_cache->start_periodic_refresh();
 
     // Insert into _ticket_caches
-    KerberosTicketEntry entry {.cache = new_ticket_cache};
+    KerberosTicketEntry entry {.cache = new_ticket_cache
+                               .last_access_time = std::chrono::steady_clock::now()};
+    
     auto [inserted_it, success] = _ticket_caches.emplace(key, std::move(entry));
     if (!success) {
         return Status::InternalError("Failed to insert ticket cache into map");


### PR DESCRIPTION
### What problem does this PR solve?
fix the KerberosTicketEntry entry in file kerberos_ticket_mgr.cpp:
```cpp
KerberosTicketEntry entry {.cache = new_ticket_cache
                                           .last_access_time = std::chrono::steady_clock::now()};

```


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

