### PR TITLE
[opt](nereids) simplify range kept in predicate options' order

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -217,7 +217,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         /** merge discrete and ranges only, no merge other value desc */
         public static List<ValueDesc> unionDiscreteAndRange(ExpressionRewriteContext context,
                 Expression reference, List<ValueDesc> valueDescs) {
-            Set<ComparableLiteral> discreteValues = Sets.newHashSet();
+            Set<ComparableLiteral> discreteValues = Sets.newLinkedHashSet();
             for (ValueDesc valueDesc : valueDescs) {
                 if (valueDesc instanceof DiscreteValue) {
                     discreteValues.addAll(((DiscreteValue) valueDesc).getValues());
@@ -269,7 +269,8 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         /** intersect */
         public static ValueDesc intersect(ExpressionRewriteContext context, RangeValue range, DiscreteValue discrete) {
             Set<ComparableLiteral> newValues = discrete.values.stream().filter(x -> range.range.contains(x))
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(
+                            () -> Sets.newLinkedHashSetWithExpectedSize(discrete.values.size())));
             if (newValues.isEmpty()) {
                 return new EmptyValue(context, range.reference);
             } else {
@@ -296,10 +297,12 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             return new RangeValue(context, predicate.left(), range);
         }
 
-        public static ValueDesc discrete(ExpressionRewriteContext context, InPredicate in) {
+        private static ValueDesc discrete(ExpressionRewriteContext context, InPredicate in) {
             // Set<ComparableLiteral> literals = (Set) Utils.fastToImmutableSet(in.getOptions());
             Set<ComparableLiteral> literals = in.getOptions().stream()
-                    .map(ComparableLiteral.class::cast).collect(Collectors.toSet());
+                    .map(ComparableLiteral.class::cast)
+                    .collect(Collectors.toCollection(
+                            () -> Sets.newLinkedHashSetWithExpectedSize(in.getOptions().size())));
             return new DiscreteValue(context, in.getCompareExpr(), literals);
         }
     }
@@ -417,7 +420,7 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
                 return other.union(this);
             }
             if (other instanceof DiscreteValue) {
-                Set<ComparableLiteral> newValues = Sets.newHashSet();
+                Set<ComparableLiteral> newValues = Sets.newLinkedHashSet();
                 newValues.addAll(((DiscreteValue) other).values);
                 newValues.addAll(this.values);
                 return new DiscreteValue(context, reference, newValues);
@@ -434,9 +437,9 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
                 return other.intersect(this);
             }
             if (other instanceof DiscreteValue) {
-                Set<ComparableLiteral> newValues = Sets.newHashSet();
-                newValues.addAll(((DiscreteValue) other).values);
-                newValues.retainAll(this.values);
+                Set<ComparableLiteral> newValues = Sets.newLinkedHashSet();
+                newValues.addAll(this.values);
+                newValues.retainAll(((DiscreteValue) other).values);
                 if (newValues.isEmpty()) {
                     return new EmptyValue(context, reference);
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -217,6 +217,10 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         /** merge discrete and ranges only, no merge other value desc */
         public static List<ValueDesc> unionDiscreteAndRange(ExpressionRewriteContext context,
                 Expression reference, List<ValueDesc> valueDescs) {
+            // Since in-predicate's options is a list, the discrete values need to kept options' order.
+            // If not keep options' order, the result in-predicate's option list will not equals to
+            // the input in-predicate, later nereids will need to simplify the new in-predicate,
+            // then cause dead loop.
             Set<ComparableLiteral> discreteValues = Sets.newLinkedHashSet();
             for (ValueDesc valueDesc : valueDescs) {
                 if (valueDesc instanceof DiscreteValue) {
@@ -268,6 +272,10 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
 
         /** intersect */
         public static ValueDesc intersect(ExpressionRewriteContext context, RangeValue range, DiscreteValue discrete) {
+            // Since in-predicate's options is a list, the discrete values need to kept options' order.
+            // If not keep options' order, the result in-predicate's option list will not equals to
+            // the input in-predicate, later nereids will need to simplify the new in-predicate,
+            // then cause dead loop.
             Set<ComparableLiteral> newValues = discrete.values.stream().filter(x -> range.range.contains(x))
                     .collect(Collectors.toCollection(
                             () -> Sets.newLinkedHashSetWithExpectedSize(discrete.values.size())));
@@ -298,6 +306,10 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         }
 
         private static ValueDesc discrete(ExpressionRewriteContext context, InPredicate in) {
+            // Since in-predicate's options is a list, the discrete values need to kept options' order.
+            // If not keep options' order, the result in-predicate's option list will not equals to
+            // the input in-predicate, later nereids will need to simplify the new in-predicate,
+            // then cause dead loop.
             // Set<ComparableLiteral> literals = (Set) Utils.fastToImmutableSet(in.getOptions());
             Set<ComparableLiteral> literals = in.getOptions().stream()
                     .map(ComparableLiteral.class::cast)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstantTest.java
@@ -41,7 +41,7 @@ class InPredicateExtractNonConstantTest extends SqlTestBase {
                 .rewrite()
                 .matches(
                         logicalFilter().when(f -> f.getPredicate().toString().equals(
-                                "OR[id#0 IN (20, 10, 300, 30),(id#0 = score#1),(id#0 = (score#1 + 10)),(id#0 = (score#1 + score#1))]"
+                                "OR[id#0 IN (10, 20, 30, 300),(id#0 = score#1),(id#0 = (score#1 + 10)),(id#0 = (score#1 + score#1))]"
                 )));
     }
 }

--- a/regression-test/suites/nereids_rules_p0/expression/test_simplify_range.groovy
+++ b/regression-test/suites/nereids_rules_p0/expression/test_simplify_range.groovy
@@ -17,6 +17,8 @@
 
 suite('test_simplify_range') {
     def tbl_1 = 'test_simplify_range_tbl_1'
+    sql "set disable_nereids_rules='PRUNE_EMPTY_PARTITION'"
+
     sql "DROP TABLE IF EXISTS  ${tbl_1} FORCE"
     sql "CREATE TABLE ${tbl_1}(a DECIMAL(16,8), b INT) PROPERTIES ('replication_num' = '1')"
     sql "INSERT INTO ${tbl_1} VALUES(null, 10)"
@@ -24,5 +26,37 @@ suite('test_simplify_range') {
         sql "SELECT a BETWEEN 100.02 and 40.123 OR a IN (54.0402) AND b < 10 FROM ${tbl_1}"
         result([[null]])
     }
+    sql "DROP TABLE IF EXISTS  ${tbl_1} FORCE"
+
+    sql """
+         create table ${tbl_1}
+        (
+            pk_id                   varchar(32) not null,
+            collect_time            varchar(16),
+            item_id                 bigint      null,
+        )
+        unique key(pk_id, collect_time)
+        auto partition by list(collect_time)()
+        distributed by hash(pk_id) buckets auto
+        properties (
+            "replication_allocation" = "tag.location.default: 1",
+            "enable_unique_key_merge_on_write" = "true"
+        );
+        """
+
+    // may cause dead loop because simplify range will output new in-predicate for options in new order.
+    // test the in predicate again.
+    test {
+        sql """SELECT *
+            FROM ${tbl_1}
+            WHERE  ITEM_ID IN
+                (1595012731474280448, 1595013220588847104, 1595013220634984448, 1595013220672733184, 1595013220718870528,
+                1595013220760813568, 1595013220798562304, 1595013220832116736, 1595013220869865472, 1595013220911808512,
+                1595013220945362944, 1595013220983111680, 1595013221025054720, 1595013221066997760, 1595013221104746496,
+                1595013221146689536, 1595013221188632576, 1595013221222187008, 1595013221255741440, 1595013221289295872)
+            AND COLLECT_TIME IN ('2025-02-09','2025-02-10','2025-02-11') """
+        result([])
+    }
+
     sql "DROP TABLE IF EXISTS  ${tbl_1} FORCE"
 }


### PR DESCRIPTION
### What problem does this PR solve?

#45181 may introduce a dead loop when IN predicate's order is not stable,  then it will cause nereids timeout.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

