### PR TITLE
[fix](inverted index) fix wrong read data for primary key

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_pk_no_need_read_data.groovy
+++ b/regression-test/suites/inverted_index_p0/test_pk_no_need_read_data.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_pk_no_need_read_data", "nonConcurent"){
+suite("test_pk_no_need_read_data", "nonConcurrent"){
     def table1 = "test_pk_no_need_read_data"
 
     sql "drop table if exists ${table1}"
@@ -63,7 +63,7 @@ suite("test_pk_no_need_read_data", "nonConcurent"){
         GetDebugPoint().disableDebugPointForAllBEs("segment_iterator._read_columns_by_index")
     }
     qt_select_1 "SELECT COUNT() FROM ${table1} WHERE year(date)='2017'"
-    // case1: disable count on index
+    // case2: disable count on index
     sql "set enable_count_on_index_pushdown = false"
     qt_select_2 "SELECT COUNT() FROM ${table1} WHERE date='2017-10-01'"
     qt_select_3 "SELECT COUNT() FROM ${table1} WHERE year(date)='2017'"

--- a/regression-test/suites/inverted_index_p0/test_pk_no_need_read_data.groovy
+++ b/regression-test/suites/inverted_index_p0/test_pk_no_need_read_data.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_pk_no_need_read_data", "p0"){
+suite("test_pk_no_need_read_data", "nonConcurent"){
     def table1 = "test_pk_no_need_read_data"
 
     sql "drop table if exists ${table1}"
@@ -56,12 +56,15 @@ suite("test_pk_no_need_read_data", "p0"){
     sql "set enable_count_on_index_pushdown = true"
     sql """ set enable_common_expr_pushdown = true """
 
-    qt_select_0 "SELECT COUNT() FROM ${table1} WHERE date='2017-10-01'"
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("segment_iterator._read_columns_by_index")
+        qt_select_0 "SELECT COUNT() FROM ${table1} WHERE date='2017-10-01'"
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("segment_iterator._read_columns_by_index")
+    }
     qt_select_1 "SELECT COUNT() FROM ${table1} WHERE year(date)='2017'"
-
     // case1: disable count on index
     sql "set enable_count_on_index_pushdown = false"
-
     qt_select_2 "SELECT COUNT() FROM ${table1} WHERE date='2017-10-01'"
     qt_select_3 "SELECT COUNT() FROM ${table1} WHERE year(date)='2017'"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Previously, queries like SELECT COUNT(*) FROM table WHERE date='2017-10-01' required reading the date column in the first read phase, even though it was only used for filtering and not in the aggregation. This PR optimizes the execution plan to eliminate unnecessary column reads, improving performance.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

