### PR TITLE
[Fix](FS)Disable FileSystem Cache in RemoteFileSystem to Prevent Accidental Closure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -148,7 +148,7 @@ public class S3FileSystem extends ObjFileSystem {
         fileSystems.add("fs.s3.impl.disable.cache");
         fileSystems.add("fs.s3a.impl.disable.cache");
         fileSystems.add("fs.cosn.impl.disable.cache");
-        fileSystems.add("fs.bos.impl.disable.cache");
+        fileSystems.add("fs.obs.impl.disable.cache");
         fileSystems.add("fs.gcs.impl.disable.cache");
         fileSystems.forEach(fileSystem -> conf.set(fileSystem, "true"));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -37,8 +37,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class S3FileSystem extends ObjFileSystem {
 
@@ -78,6 +80,8 @@ public class S3FileSystem extends ObjFileSystem {
                     PropertyConverter.convertToHadoopFSProperties(properties).entrySet().stream()
                             .filter(entry -> entry.getKey() != null && entry.getValue() != null)
                             .forEach(entry -> conf.set(entry.getKey(), entry.getValue()));
+                    // disable cache
+                    disableCacheForFileSystems(conf);
                     // S3 does not support Kerberos authentication,
                     // so here we create a simple authentication
                     AuthenticationConfig authConfig = AuthenticationConfig.getSimpleAuthenticationConfig(conf);
@@ -137,6 +141,16 @@ public class S3FileSystem extends ObjFileSystem {
             return new Status(Status.ErrCode.COMMON_ERROR, "errors while get file status " + e.getMessage());
         }
         return Status.OK;
+    }
+
+    private void disableCacheForFileSystems(Configuration conf) {
+        Set<String> fileSystems = new HashSet<>();
+        fileSystems.add("fs.s3.impl.disable.cache");
+        fileSystems.add("fs.s3a.impl.disable.cache");
+        fileSystems.add("fs.cosn.impl.disable.cache");
+        fileSystems.add("fs.bos.impl.disable.cache");
+        fileSystems.add("fs.gcs.impl.disable.cache");
+        fileSystems.forEach(fileSystem -> conf.set(fileSystem, "true"));
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -89,6 +89,7 @@ public class DFSFileSystem extends RemoteFileSystem {
                     for (Map.Entry<String, String> propEntry : properties.entrySet()) {
                         conf.set(propEntry.getKey(), propEntry.getValue());
                     }
+                    conf.set("fs.hdfs.impl.disable.cache", "true");
                     AuthenticationConfig authConfig = AuthenticationConfig.getKerberosConfig(conf);
                     authenticator = HadoopAuthenticator.getHadoopAuthenticator(authConfig);
                     try {


### PR DESCRIPTION

### Purpose:
To prevent exceptions caused by closing the FS object managed by RemoteFileSystem when it is inadvertently shared across different parts of the application, we have disabled the file system cache. This ensures that RemoteFileSystem-managed FS instances are not closed prematurely due to shared references.

### Changes:
Disabled the cache for file system implementations (such as S3, HDFS, GCS, etc.) by setting fs.<scheme>.impl.disable.cache=true. This ensures a new FileSystem instance is created each time, rather than reusing one from the cache. This change addresses the issue where RemoteFileSystem-managed file system instances could be closed unexpectedly in multi-threaded or multi-reference scenarios, preventing exceptions triggered by prematurely closed FileSystem instances.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

