### PR TITLE
[fix](load) add null check for memtable after write failure reset

### DIFF
--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -168,6 +168,11 @@ Status MemTableWriter::flush_async() {
         return _cancel_status;
     }
 
+    // _mem_table may be null after write failure triggers reset
+    if (_mem_table == nullptr) {
+        return Status::OK();
+    }
+
     VLOG_NOTICE << "flush memtable to reduce mem consumption. memtable size: "
                 << PrettyPrinter::print_bytes(_mem_table->memory_usage())
                 << ", tablet: " << _req.tablet_id << ", load id: " << print_id(_req.load_id);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #47610

Problem Summary:
 SIGSEGV address not mapped to object (@0x0) received by PID 340906 (TID 341622 OR 0x7f7f38784640) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F80B37D0520 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::MemTableWriter::_flush_memtable_async() at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/olap/memtable_writer.cpp:157
 5# doris::MemTableWriter::flush_async() at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/olap/memtable_writer.cpp:187
 6# doris::MemTableMemoryLimiter::_flush_active_memtables(long) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/olap/memtable_memory_limiter.cpp:190
 7# doris::MemTableMemoryLimiter::handle_memtable_flush() at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/olap/memtable_memory_limiter.cpp:144
 8# doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/runtime/load_channel_mgr.cpp:154
 9# std::_Function_handler<void (), doris::PInternalService::tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
10# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/work_thread_pool.hpp:159
11# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
12# start_thread at ./nptl/pthread_create.c:442
13# 0x00007F80B38B4850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

This PR addresses potential null pointer dereference crashes that could occur when write operations fail and the memtable is reset. The changes add defensive null checks to ensure safe handling of the _mem_table state during flush memtable.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

