### PR TITLE
[fix](build) Fix MacOS compilation error when pch is disabled

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer_v2.h
+++ b/be/src/olap/rowset/beta_rowset_writer_v2.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <arpa/inet.h>
 #include <fmt/format.h>
 #include <gen_cpp/olap_file.pb.h>
 #include <stddef.h>


### PR DESCRIPTION
## Description

When compiling on MacOS with PCH (Precompiled Headers) disabled, the compilation fails with an undefined `INADDR_NONE` error. This is because the required header `<arpa/inet.h>` is not explicitly included. This PR fixes the issue by adding the necessary header inclusion.

The error occurs because:
1. On Linux, `INADDR_NONE` might be indirectly included through other system headers
2. On MacOS, the header dependencies are more strict and require explicit inclusion
3. When PCH is enabled, this issue is masked as all system headers are precompiled

## Changes
- Add `<arpa/inet.h>` inclusion in `be/src/olap/rowset/beta_rowset_writer_v2.h`
