### PR TITLE
[log](mysql command)Log packet when receive COM_SLEEP

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -83,7 +83,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
         handleStmtClose(stmtId);
     }
 
-    private void debugPacket() {
+    private String getPacket() {
         byte[] bytes = packetBuf.array();
         StringBuilder printB = new StringBuilder();
         for (byte b : bytes) {
@@ -95,8 +95,12 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             }
             printB.append(" ");
         }
+        return printB.toString().substring(0, 200);
+    }
+
+    private void debugPacket() {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("debug packet {}", printB.toString().substring(0, 200));
+            LOG.debug("debug packet {}", getPacket());
         }
     }
 
@@ -270,6 +274,9 @@ public class MysqlConnectProcessor extends ConnectProcessor {
             default:
                 ctx.getState().setError(ErrorCode.ERR_UNKNOWN_COM_ERROR, "Unsupported command(" + command + ")");
                 LOG.warn("Unsupported command(" + command + ")");
+                if (command.equals(MysqlCommand.COM_SLEEP)) {
+                    LOG.warn("COM_SLEEP packet: [{}]", getPacket());
+                }
                 break;
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

This p2 case test_group_commit_insert_into_lineitem_normal.groovy:111) - got exception:java.sql.SQLNonTransientConnectionException: Unsupported command(Sleep)
Don't know why JDBC may send COM_SLEEP to Doris, add log to help investigate.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

