### PR TITLE
[Chore](runtime-filter) remove ignore runtime filter logic

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -949,9 +949,7 @@ public:
 
     bool is_disabled() const { return _context->disabled; }
 
-    void set_disabled() {
-        _context->disabled = true;
-    }
+    void set_disabled() { _context->disabled = true; }
 
     void batch_assign(const PInFilter* filter,
                       void (*assign_func)(std::shared_ptr<HybridSetBase>& _hybrid_set,

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -951,10 +951,6 @@ public:
 
     void set_disabled() {
         _context->disabled = true;
-        _context->minmax_func.reset();
-        _context->hybrid_set.reset();
-        _context->bloom_filter_func.reset();
-        _context->bitmap_filter_func.reset();
     }
 
     void batch_assign(const PInFilter* filter,

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -300,10 +300,6 @@ public:
     void update_filter(RuntimePredicateWrapper* filter_wrapper, int64_t merge_time,
                        int64_t start_apply);
 
-    void set_ignored();
-
-    bool get_ignored();
-
     void set_disabled();
     bool get_disabled() const;
 

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -77,7 +77,7 @@ public:
         // process ignore duplicate IN_FILTER
         std::unordered_set<int> has_in_filter;
         for (auto filter : _runtime_filters) {
-            if (filter->get_ignored() || filter->get_disabled()) {
+            if (filter->get_disabled()) {
                 continue;
             }
             if (filter->get_real_type() != RuntimeFilterType::IN_FILTER) {
@@ -96,7 +96,7 @@ public:
 
         // process ignore filter when it has IN_FILTER on same expr
         for (auto filter : _runtime_filters) {
-            if (filter->get_ignored() || filter->get_disabled()) {
+            if (filter->get_disabled()) {
                 continue;
             }
             if (filter->get_real_type() == RuntimeFilterType::IN_FILTER ||
@@ -104,13 +104,6 @@ public:
                 continue;
             }
             filter->set_disabled();
-        }
-        return Status::OK();
-    }
-
-    Status ignore_all_filters() {
-        for (auto filter : _runtime_filters) {
-            filter->set_ignored();
         }
         return Status::OK();
     }
@@ -125,7 +118,7 @@ public:
     Status init_filters(RuntimeState* state, uint64_t local_hash_table_size) {
         // process IN_OR_BLOOM_FILTER's real type
         for (auto* filter : _runtime_filters) {
-            if (filter->get_ignored() || filter->get_disabled()) {
+            if (filter->get_disabled()) {
                 continue;
             }
             if (filter->type() == RuntimeFilterType::IN_OR_BLOOM_FILTER &&
@@ -155,7 +148,7 @@ public:
             int result_column_id = _build_expr_context[i]->get_last_result_column_id();
             const auto& column = block->get_by_position(result_column_id).column;
             for (auto* filter : iter->second) {
-                if (filter->get_ignored() || filter->get_disabled()) {
+                if (filter->get_disabled()) {
                     continue;
                 }
                 filter->insert_batch(column, 1);

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -156,7 +156,7 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
         if (state->get_task()->wake_up_early()) {
             // partitial ignore rf to make global rf work or ignore useless rf
             RETURN_IF_ERROR(_runtime_filter_slots->send_filter_size(state, 0, _finish_dependency));
-            RETURN_IF_ERROR(_runtime_filter_slots->ignore_all_filters());
+            RETURN_IF_ERROR(_runtime_filter_slots->disable_all_filters());
         } else if (_should_build_hash_table) {
             auto* block = _shared_state->build_block.get();
             uint64_t hash_table_size = block ? block->rows() : 0;

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -145,7 +145,6 @@ Status RuntimeFilterMgr::register_local_merge_producer_filter(
             RETURN_IF_ERROR(IRuntimeFilter::create(_state, &_pool, &desc, &options,
                                                    RuntimeFilterRole::PRODUCER, -1, &merge_filter,
                                                    build_bf_exactly, true));
-            merge_filter->set_ignored();
             iter->second.filters.emplace_back(merge_filter);
         }
         iter->second.merge_time++;
@@ -253,7 +252,6 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
     auto filter_id = runtime_filter_desc->filter_id;
     RETURN_IF_ERROR(cnt_val->filter->init_with_desc(&cnt_val->runtime_filter_desc, query_options,
                                                     -1, false));
-    cnt_val->filter->set_ignored();
     _filter_map.emplace(filter_id, cnt_val);
     return Status::OK();
 }
@@ -273,7 +271,6 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
             new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool, runtime_filter_desc));
     auto filter_id = runtime_filter_desc->filter_id;
     RETURN_IF_ERROR(cnt_val->filter->init_with_desc(&cnt_val->runtime_filter_desc, query_options));
-    cnt_val->filter->set_ignored();
 
     std::unique_lock<std::shared_mutex> guard(_filter_map_mutex);
     _filter_map.emplace(filter_id, cnt_val);
@@ -456,10 +453,10 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
             void* data = nullptr;
             int len = 0;
             bool has_attachment = false;
-            if (!cnt_val->filter->get_ignored() && !cnt_val->filter->get_disabled()) {
+            if (!cnt_val->filter->get_disabled()) {
                 RETURN_IF_ERROR(cnt_val->filter->serialize(&apply_request, &data, &len));
             } else {
-                apply_request.set_ignored(true);
+                apply_request.set_disabled(true);
                 apply_request.set_filter_type(PFilterType::UNKNOW_FILTER);
             }
 
@@ -535,10 +532,10 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
             void* data = nullptr;
             int len = 0;
             bool has_attachment = false;
-            if (!cnt_val->filter->get_ignored() && !cnt_val->filter->get_disabled()) {
+            if (!cnt_val->filter->get_disabled()) {
                 RETURN_IF_ERROR(cnt_val->filter->serialize(&apply_request, &data, &len));
             } else {
-                apply_request.set_ignored(true);
+                apply_request.set_disabled(true);
                 apply_request.set_filter_type(PFilterType::UNKNOW_FILTER);
             }
 

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -45,7 +45,6 @@ struct RuntimeFilterContext {
     std::shared_ptr<HybridSetBase> hybrid_set;
     std::shared_ptr<BloomFilterFuncBase> bloom_filter_func;
     std::shared_ptr<BitmapFilterFuncBase> bitmap_filter_func;
-    bool ignored = false;
     bool disabled = false;
     std::string err_msg;
 };


### PR DESCRIPTION
Since partial ignoring rf is likely to cause wrong result, we will remove this part of the logic first in the old version and revise it in the subsequent refactors