### PR TITLE
[fix](beut) Fix `s3_file_writer_test` maybe memory leak

### DIFF
--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1121,7 +1121,7 @@ public:
     ObjectStorageUploadResponse upload_part(const ObjectStoragePathOptions& opts,
                                             std::string_view stream, int part_num) override {
         upload_part_count++;
-        upload_part_params.push_back({opts, std::string(stream), part_num});
+        // upload_part_params.push_back({opts, std::string(stream), part_num});
         last_opts = opts;
         last_stream = std::string(stream);
         last_part_num = part_num;
@@ -1232,7 +1232,7 @@ public:
     // Vectors to store parameters from each call
     std::vector<ObjectStoragePathOptions> create_multipart_params;
     std::vector<std::pair<ObjectStoragePathOptions, std::string>> put_object_params;
-    std::vector<UploadPartParams> upload_part_params;
+    // std::vector<UploadPartParams> upload_part_params;
     std::vector<CompleteMultipartParams> complete_multipart_params;
     std::map<std::string, std::string> objects;
     std::map<std::string, std::string> complete;
@@ -1256,7 +1256,7 @@ public:
 
         create_multipart_params.clear();
         put_object_params.clear();
-        upload_part_params.clear();
+        // upload_part_params.clear();
         complete_multipart_params.clear();
         objects.clear();
         complete.clear();


### PR DESCRIPTION
* SimpleMockObjStorageClient.upload_part_params is not thread safe, and can be accessed by muti thread, the field is useless now, so comment it.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

