### PR TITLE
[opt](proxy-protocol) Enable mysql connection with and without proxy-protocol

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/BytesChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/BytesChannel.java
@@ -18,6 +18,7 @@
 package org.apache.doris.mysql;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
 public interface BytesChannel {
     /**
@@ -26,4 +27,12 @@ public interface BytesChannel {
      * @return number of bytes read
      */
     public int read(ByteBuffer buffer);
+
+    default int read(ByteBuffer buffer, long time, TimeUnit unit, boolean isFailOnTimeout) {
+        return read(buffer);
+    }
+
+    default int peek(ByteBuffer buffer) {
+        return 0;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ProxyProtocolHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ProxyProtocolHandlerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class ProxyProtocolHandlerTest {
 
@@ -37,11 +38,20 @@ public class ProxyProtocolHandlerTest {
         }
 
         @Override
-        public int read(java.nio.ByteBuffer buffer) {
+        public int read(ByteBuffer buffer) {
             int len = Math.min(buffer.remaining(), data.length - pos);
             if (len > 0) {
                 buffer.put(data, pos, len);
                 pos += len;
+            }
+            return len;
+        }
+
+        @Override
+        public int peek(ByteBuffer buffer) {
+            int len = Math.min(buffer.remaining(), data.length - pos);
+            if (len > 0) {
+                buffer.put(data, pos, len);
             }
             return len;
         }
@@ -131,5 +141,14 @@ public class ProxyProtocolHandlerTest {
         byte[] data = new byte[] {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
         testChannel = new TestChannel(data);
         ProxyProtocolHandler.handle(testChannel);
+    }
+
+    @Test
+    public void handleNoData() throws IOException {
+        byte[] data = new byte[0];
+        testChannel = new TestChannel(data);
+        ProxyProtocolHandler.ProxyProtocolResult result = ProxyProtocolHandler.handle(testChannel);
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isUnknown);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Enables connection with and without proxy protocol to mysql service.
 
Issue Number: close #47908

Problem Summary:
When nginx enables proxy_protocol, and use health `"check type=mysql"`; causes check to fail.
Since, per mysql-protocol client expects server params on connect without any transmission from client, However, ProxyProtocol enabled case server expects PROXY v1/v2 header.

when nginx enables health check with type=mysql; without protocol header connection attempt is done, which will block for 600s. Effectively deselected for connection from nginx.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->
             When `enable_proxy_protocol=true`, On direct connection to FE will have 1s wait on initial connection.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

