### PR TITLE
[fix](java) should use JAVA_OPTS_FOR_JDK_17 instead of JAVA_OPTS

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -107,7 +107,7 @@ const std::string GetKerb5ConfPath() {
     setenv("CLASSPATH", classpath.c_str(), 0);
 
     // LIBHDFS_OPTS
-    const std::string java_opts = getenv("JAVA_OPTS") ? getenv("JAVA_OPTS") : "";
+    const std::string java_opts = getenv("JAVA_OPTS_FOR_JDK_17") ? getenv("JAVA_OPTS_FOR_JDK_17") : "";
     std::string libhdfs_opts =
             fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{} ", java_opts,
                         getenv("DORIS_HOME"), getenv("DORIS_HOME") + std::string("/lib"));
@@ -123,7 +123,7 @@ const std::string GetKerb5ConfPath() {
     if (rv == 0) {
         std::vector<std::string> options;
 
-        char* java_opts = getenv("JAVA_OPTS");
+        char* java_opts = getenv("JAVA_OPTS_FOR_JDK_17");
         if (java_opts == nullptr) {
             options = {
                     GetDorisJNIClasspathOption(), fmt::format("-Xmx{}", "1g"),
@@ -216,7 +216,7 @@ Status JniLocalFrame::push(JNIEnv* env, int max_local_ref) {
 }
 
 void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
-    // The start_be.sh would set JAVA_OPTS inside LIBHDFS_OPTS
+    // The start_be.sh would set JAVA_OPTS_FOR_JDK_17 inside LIBHDFS_OPTS
     std::string java_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     std::istringstream iss(java_opts);
     std::string opt;

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -107,7 +107,8 @@ const std::string GetKerb5ConfPath() {
     setenv("CLASSPATH", classpath.c_str(), 0);
 
     // LIBHDFS_OPTS
-    const std::string java_opts = getenv("JAVA_OPTS_FOR_JDK_17") ? getenv("JAVA_OPTS_FOR_JDK_17") : "";
+    const std::string java_opts =
+            getenv("JAVA_OPTS_FOR_JDK_17") ? getenv("JAVA_OPTS_FOR_JDK_17") : "";
     std::string libhdfs_opts =
             fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{} ", java_opts,
                         getenv("DORIS_HOME"), getenv("DORIS_HOME") + std::string("/lib"));

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -418,6 +418,7 @@ fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -384,7 +384,7 @@ if [[ -f "${DORIS_HOME}/conf/hdfs-site.xml" ]]; then
     export LIBHDFS3_CONF="${DORIS_HOME}/conf/hdfs-site.xml"
 fi
 
-# check java version and choose correct JAVA_OPTS
+# check java version and choose correct JAVA_OPTS_FOR_JDK_17
 java_version="$(
     set -e
     jdk_version "${JAVA_HOME}/bin/java"
@@ -412,7 +412,7 @@ if [[ "${MACHINE_OS}" == "Darwin" ]]; then
     fi
 
     if [[ -n "${JAVA_OPTS_FOR_JDK_17}" ]] && ! echo "${JAVA_OPTS_FOR_JDK_17}" | grep "${max_fd_limit/-/\\-}" >/dev/null; then
-        export JAVA_OPTS="${JAVA_OPTS_FOR_JDK_17} ${max_fd_limit}"
+        export JAVA_OPTS_FOR_JDK_17="${JAVA_OPTS_FOR_JDK_17} ${max_fd_limit}"
     fi
 fi
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -204,6 +204,7 @@ else
 fi
 log "Using Java version ${java_version}"
 log "${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # add libs to CLASSPATH
 DORIS_FE_JAR=

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -91,10 +91,10 @@ export DORIS_HOME
 
 # export env variables from fe.conf
 #
-# JAVA_OPTS
+# JAVA_OPTS_FOR_JDK_17
 # LOG_DIR
 # PID_DIR
-export JAVA_OPTS="-Xmx1024m"
+export JAVA_OPTS_FOR_JDK_17="-Xmx1024m"
 export LOG_DIR="${DORIS_HOME}/log"
 PID_DIR="$(
     cd "${curdir}"

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -20,9 +20,6 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # Log dir
 LOG_DIR="${DORIS_HOME}/log/"
 
-# For jdk 8
-JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx2048m -DlogPath=$LOG_DIR/jni.log -Xloggc:$LOG_DIR/be.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
-
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djol.skipHotspotSAAttach=true -Xmx2048m -DlogPath=$LOG_DIR/jni.log -Xlog:gc*:$LOG_DIR/be.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED -Darrow.enable_null_check_for_get=false"
 

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -26,9 +26,6 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # Log dir
 LOG_DIR = ${DORIS_HOME}/log
 
-# For jdk 8
-JAVA_OPTS="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintClassHistogramAfterFullGC -Xloggc:$LOG_DIR/log/fe.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Dlog4j2.formatMsgNoLookups=true"
-
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR -Xlog:gc*,classhisto*=trace:$LOG_DIR/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #47299

Problem Summary:

The master branch only support java 17+, so should remote all `JAVA_OPTS` and use `JAVA_OPTS_FOR_JDK_17`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

