### PR TITLE
[improve](load) print error string in local fs error messages

### DIFF
--- a/be/src/io/fs/err_utils.cpp
+++ b/be/src/io/fs/err_utils.cpp
@@ -85,36 +85,38 @@ std::string glob_err_to_str(int code) {
 }
 
 Status localfs_error(const std::error_code& ec, std::string_view msg) {
+    auto message = fmt::format("{}: {}", msg, ec.message());
     if (ec == std::errc::io_error) {
-        return Status::Error<IO_ERROR, false>(msg);
+        return Status::Error<IO_ERROR, false>(message);
     } else if (ec == std::errc::no_such_file_or_directory) {
-        return Status::Error<NOT_FOUND, false>(msg);
+        return Status::Error<NOT_FOUND, false>(message);
     } else if (ec == std::errc::file_exists) {
-        return Status::Error<ALREADY_EXIST, false>(msg);
+        return Status::Error<ALREADY_EXIST, false>(message);
     } else if (ec == std::errc::no_space_on_device) {
-        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>(msg);
+        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>(message);
     } else if (ec == std::errc::permission_denied) {
-        return Status::Error<PERMISSION_DENIED, false>(msg);
+        return Status::Error<PERMISSION_DENIED, false>(message);
     } else {
-        return Status::Error<ErrorCode::INTERNAL_ERROR, false>("{}: {}", msg, ec.message());
+        return Status::Error<ErrorCode::INTERNAL_ERROR, false>(message);
     }
 }
 
 Status localfs_error(int posix_errno, std::string_view msg) {
+    char buf[1024];
+    auto message = fmt::format("{}: {}", msg, strerror_r(errno, buf, 1024));
     switch (posix_errno) {
     case EIO:
-        return Status::Error<IO_ERROR, false>(msg);
+        return Status::Error<IO_ERROR, false>(message);
     case ENOENT:
-        return Status::Error<NOT_FOUND, false>(msg);
+        return Status::Error<NOT_FOUND, false>(message);
     case EEXIST:
-        return Status::Error<ALREADY_EXIST, false>(msg);
+        return Status::Error<ALREADY_EXIST, false>(message);
     case ENOSPC:
-        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>(msg);
+        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>(message);
     case EACCES:
-        return Status::Error<PERMISSION_DENIED, false>(msg);
+        return Status::Error<PERMISSION_DENIED, false>(message);
     default:
-        return Status::Error<ErrorCode::INTERNAL_ERROR, false>("{}: {}", msg,
-                                                               std::strerror(posix_errno));
+        return Status::Error<ErrorCode::INTERNAL_ERROR, false>(message);
     }
 }
 

--- a/be/src/io/fs/err_utils.h
+++ b/be/src/io/fs/err_utils.h
@@ -31,6 +31,7 @@ namespace io {
 
 std::string errno_to_str();
 std::string errcode_to_str(const std::error_code& ec);
+int error_code_to_errno(const std::error_code& ec);
 std::string hdfs_error();
 std::string glob_err_to_str(int code);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-18704
Problem Summary:

Human-readable error messages should be displayed alongside the error code in local file system errors.

Example (before):

```
[E-232]failed to write /path/be/storage/data/xxx/xxxx/xxxxx/xxxxxx.dat
```

Example (after):

```
[E-232]failed to write /path/be/storage/data/xxx/xxxx/xxxxx/xxxxxx.dat: No space left on device
```

The error message now includes a more informative description, providing users with a clearer understanding of the issue.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

