### PR TITLE
[opt](nereids) optimize not found function error message

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -237,7 +237,7 @@ public class FunctionRegistry {
                                 = ((BuiltinFunctionBuilder) builder).getBuilderMethod();
                         if (Modifier.isAbstract(builderMethod.getModifiers())
                                 || !Modifier.isPublic(builderMethod.getModifiers())) {
-                           return false;
+                            return false;
                         }
                         for (Class<?> parameterType : builderMethod.getParameterTypes()) {
                             if (!Expression.class.isAssignableFrom(parameterType)

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -232,21 +232,22 @@ public class FunctionRegistry {
     public String getCandidateHint(String name, List<FunctionBuilder> candidateBuilders) {
         return candidateBuilders.stream()
                 .filter(builder -> {
-                   if (builder instanceof BuiltinFunctionBuilder) {
-                       Constructor<BoundFunction> builderMethod = ((BuiltinFunctionBuilder) builder).getBuilderMethod();
-                       if (Modifier.isAbstract(builderMethod.getModifiers())
-                               || !Modifier.isPublic(builderMethod.getModifiers())) {
+                    if (builder instanceof BuiltinFunctionBuilder) {
+                        Constructor<BoundFunction> builderMethod
+                                = ((BuiltinFunctionBuilder) builder).getBuilderMethod();
+                        if (Modifier.isAbstract(builderMethod.getModifiers())
+                                || !Modifier.isPublic(builderMethod.getModifiers())) {
                            return false;
-                       }
-                       for (Class<?> parameterType : builderMethod.getParameterTypes()) {
-                           if (!Expression.class.isAssignableFrom(parameterType)
-                                   && !(parameterType.isArray()
+                        }
+                        for (Class<?> parameterType : builderMethod.getParameterTypes()) {
+                            if (!Expression.class.isAssignableFrom(parameterType)
+                                    && !(parameterType.isArray()
                                         && Expression.class.isAssignableFrom(parameterType.getComponentType()))) {
-                               return false;
-                           }
-                       }
-                   }
-                   return true;
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
                 })
                 .map(builder -> name + builder.parameterDisplayString())
                 .collect(Collectors.joining(", ", "[", "]"));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
@@ -145,6 +145,11 @@ public class AggCombinerFunctionBuilder extends FunctionBuilder {
         return null;
     }
 
+    @Override
+    public String parameterDisplayString() {
+        return nestedBuilder.parameterDisplayString();
+    }
+
     public static boolean isAggStateCombinator(String name) {
         return name.toLowerCase().endsWith(STATE_SUFFIX) || name.toLowerCase().endsWith(MERGE_SUFFIX)
                 || name.toLowerCase().endsWith(UNION_SUFFIX) || name.toLowerCase().endsWith(FOREACH_SUFFIX);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BuiltinFunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/BuiltinFunctionBuilder.java
@@ -53,6 +53,10 @@ public class BuiltinFunctionBuilder extends FunctionBuilder {
         this.isVariableLength = arity > 0 && builderMethod.getParameterTypes()[arity - 1].isArray();
     }
 
+    public Constructor<BoundFunction> getBuilderMethod() {
+        return builderMethod;
+    }
+
     @Override
     public Class<? extends BoundFunction> functionClass() {
         return functionClass;
@@ -146,4 +150,16 @@ public class BuiltinFunctionBuilder extends FunctionBuilder {
                 .collect(ImmutableList.toImmutableList());
     }
 
+    @Override
+    public String parameterDisplayString() {
+        return Arrays.stream(builderMethod.getParameterTypes())
+                .map(p -> {
+                    if (p.isArray()) {
+                        return p.getComponentType().getSimpleName() + "...";
+                    } else {
+                        return p.getSimpleName();
+                    }
+                })
+                .collect(Collectors.joining(", ", "(", ")"));
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/FunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/FunctionBuilder.java
@@ -47,4 +47,9 @@ public abstract class FunctionBuilder {
      */
     public abstract Pair<? extends Expression, ? extends BoundFunction> build(
             String name, List<? extends Object> arguments);
+
+    /**
+     * return the parameters string for display candidate functions, for example: `(int, decimal, varchar)`
+     */
+    public abstract String parameterDisplayString();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/AliasUdfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/AliasUdfBuilder.java
@@ -114,4 +114,11 @@ public class AliasUdfBuilder extends UdfBuilder {
 
         return Pair.of(udfAnalyzer.analyze(aliasUdf.getUnboundFunction()), boundAliasFunction);
     }
+
+    @Override
+    public String parameterDisplayString() {
+        return aliasUdf.getArgTypes().stream()
+                .map(DataType::toString)
+                .collect(Collectors.joining(", ", "(", ")"));
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdafBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdafBuilder.java
@@ -85,4 +85,19 @@ public class JavaUdafBuilder extends UdfBuilder {
                         .collect(Collectors.toList()))
         );
     }
+
+    @Override
+    public String parameterDisplayString() {
+        StringBuilder string = new StringBuilder("(");
+        for (int i = 0; i < udaf.getArgumentsTypes().size(); ++i) {
+            if (i > 0) {
+                string.append(", ");
+            }
+            string.append(udaf.getArgumentsTypes().get(i));
+            if (isVarArgs && i + 1 == udaf.getArgumentsTypes().size()) {
+                string.append("...");
+            }
+        }
+        return string.append(")").toString();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdfBuilder.java
@@ -90,4 +90,19 @@ public class JavaUdfBuilder extends UdfBuilder {
         }
         return Pair.ofSame(udf.withChildren(processedExprs));
     }
+
+    @Override
+    public String parameterDisplayString() {
+        StringBuilder string = new StringBuilder("(");
+        for (int i = 0; i < udf.getArgumentsTypes().size(); ++i) {
+            if (i > 0) {
+                string.append(", ");
+            }
+            string.append(udf.getArgumentsTypes().get(i));
+            if (isVarArgs && i + 1 == udf.getArgumentsTypes().size()) {
+                string.append("...");
+            }
+        }
+        return string.append(")").toString();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtfBuilder.java
@@ -90,4 +90,19 @@ public class JavaUdtfBuilder extends UdfBuilder {
         }
         return Pair.ofSame(udf.withChildren(processedExprs));
     }
+
+    @Override
+    public String parameterDisplayString() {
+        StringBuilder string = new StringBuilder("(");
+        for (int i = 0; i < udf.getArgumentsTypes().size(); ++i) {
+            if (i > 0) {
+                string.append(", ");
+            }
+            string.append(udf.getArgumentsTypes().get(i));
+            if (isVarArgs && i + 1 == udf.getArgumentsTypes().size()) {
+                string.append("...");
+            }
+        }
+        return string.append(")").toString();
+    }
 }

--- a/regression-test/suites/function_p0/not_found_function.groovy
+++ b/regression-test/suites/function_p0/not_found_function.groovy
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("not_found_function") {
+    test {
+        sql "select group_concat()"
+        exception "Can not found function 'group_concat' which has 0 arity. Candidate functions are: [group_concat(Expression, Expression...)]"
+    }
+
+    test {
+        sql "select sum()"
+        exception "Can not found function 'sum' which has 0 arity. Candidate functions are: [sum(Expression)]"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

```sql
select sum()
```

before this pr:
```
Can not found function 'sum' which has 0 arity. Candidate functions are: [sumorg.apache.doris.nereids.trees.expressions.functions.BuiltinFunctionBuilder@45a63d2e, sumorg.apache.doris.nereids.trees.expressions.functions.BuiltinFunctionBuilder@73fa50f1, sumorg.apache.doris.nereids.trees.expressions.functions.BuiltinFunctionBuilder@395c255a]
```

after this pr:
```
Can not found function 'sum' which has 0 arity. Candidate functions are: [sum(Expression)]
```



### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

