### PR TITLE
[hotfix](external) Fixed External meta replay check

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -237,8 +237,8 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             LOG.info("Synchronized table (create): [Name: {}, ID: {}, Remote Name: {}]",
                     table.getName(), table.getId(), log.getRemoteTableNames().get(i));
         }
-        // Check whether the remoteName and db Tbl db in idToTbl is empty
-        for (T table : idToTbl.values()) {
+        // Check whether the remoteName and db Tbl db in tmpIdToTbl is empty
+        for (T table : tmpIdToTbl.values()) {
             if (Strings.isNullOrEmpty(table.getRemoteName())
                     || table.getDb() == null) {
                 LOG.info("Table [{}] remoteName or database is empty, mark as uninitialized",
@@ -664,8 +664,8 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                         ((ExternalTable) obj).getName());
             }
         }
-        // Check whether the remoteName and db Tbl db in idToTbl is empty
-        for (T table : idToTbl.values()) {
+        // Check whether the remoteName and db Tbl db in tmpIdToTbl is empty
+        for (T table : tmpIdToTbl.values()) {
             if (Strings.isNullOrEmpty(table.getRemoteName())
                     || table.getDb() == null) {
                 initialized = false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #47603

Problem Summary:

When checking if a table fetched from meta has a remote name, we should use tmpmap

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

