### PR TITLE
[fix])(catalog)add equals for external table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -70,6 +70,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.MasterCatalogExecutor;
 import org.apache.doris.transaction.TransactionManager;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -1167,5 +1168,22 @@ public abstract class ExternalCatalog
 
     public PreExecutionAuthenticator getPreExecutionAuthenticator() {
         return preExecutionAuthenticator;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ExternalCatalog)) {
+            return false;
+        }
+        ExternalCatalog that = (ExternalCatalog) o;
+        return Objects.equal(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -43,6 +43,7 @@ import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.MasterCatalogExecutor;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -749,5 +750,23 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         // Because we have added a test configuration item,
         // it needs to be judged together with Env.isTableNamesCaseInsensitive()
         return Env.isTableNamesCaseInsensitive() || extCatalog.getOnlyTestLowerCaseTableNames() == 2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ExternalDatabase)) {
+            return false;
+        }
+        ExternalDatabase<?> that = (ExternalDatabase<?>) o;
+        return Objects.equal(name, that.name) && Objects.equal(extCatalog,
+                that.extCatalog);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, extCatalog);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -42,6 +42,7 @@ import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.thrift.TTableDescriptor;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
@@ -447,5 +448,22 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
      */
     public boolean supportInternalPartitionPruned() {
         return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ExternalTable)) {
+            return false;
+        }
+        ExternalTable that = (ExternalTable) o;
+        return Objects.equal(name, that.name) && Objects.equal(db, that.db);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, db);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalEqualsTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.datasource;
 
 import org.apache.doris.datasource.test.TestExternalCatalog;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalEqualsTest.java
@@ -1,0 +1,35 @@
+package org.apache.doris.datasource;
+
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.datasource.test.TestExternalDatabase;
+import org.apache.doris.datasource.test.TestExternalTable;
+
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExternalEqualsTest {
+    @Mocked
+    private TestExternalCatalog ctl1;
+    @Mocked
+    private TestExternalCatalog ctl2;
+
+    @Test
+    public void testEquals() {
+        TestExternalDatabase db1 = new TestExternalDatabase(ctl1, 1L, "db1", null);
+        TestExternalDatabase db2 = new TestExternalDatabase(ctl2, 1L, "db2", null);
+        TestExternalDatabase db3 = new TestExternalDatabase(ctl1, 1L, "db2", null);
+        TestExternalDatabase db11 = new TestExternalDatabase(ctl1, 1L, "db1", null);
+        Assert.assertNotEquals(db1, db2);
+        Assert.assertNotEquals(db1, db3);
+        Assert.assertEquals(db1, db11);
+
+        TestExternalTable t1 = new TestExternalTable(1L, "t1", null, ctl1, db1);
+        TestExternalTable t2 = new TestExternalTable(2L, "t2", null, ctl2, db2);
+        TestExternalTable t3 = new TestExternalTable(3L, "t3", null, ctl1, db1);
+        TestExternalTable t11 = new TestExternalTable(4L, "t1", null, ctl1, db1);
+        Assert.assertNotEquals(t1, t2);
+        Assert.assertNotEquals(t1, t3);
+        Assert.assertEquals(t1, t11);
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

The materialized view is created based on external table, and sometimes refreshing the materialized view may report that the corresponding partition cannot be found.

The reason is that when the materialized view is refreshed, predicates are generated based on the refreshed partition, and the problematic plan does not include predicates.

The code for adding predicates is as follows:
```
if (predicates.getPredicates().containsKey(table)) {
return new LogicalFilter<>(ImmutableSet.of(ExpressionUtils.or(predicates.getPredicates().get(table))),
unboundRelation);
}
```
If the table and predicates. get() are not the same object when setting predicates, it will not be obtained, resulting in the absence of predicates

PS: The table cache will refresh within 24 hours by default, and the objects will change






Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

