### PR TITLE
[Fix](QueryCache) Fix cache order different may cause error

### DIFF
--- a/be/src/pipeline/exec/cache_source_operator.cpp
+++ b/be/src/pipeline/exec/cache_source_operator.cpp
@@ -70,14 +70,7 @@ Status CacheSourceLocalState::init(RuntimeState* state, LocalStateInfo& info) {
         _hit_cache_results = _query_cache_handle.get_cache_result();
         auto hit_cache_slot_orders = _query_cache_handle.get_cache_slot_orders();
 
-        bool need_reorder = _slot_orders.size() != hit_cache_slot_orders->size();
-        if (!need_reorder) {
-            for (int i = 0; i < _slot_orders.size(); ++i) {
-                need_reorder = _slot_orders[i] != (*hit_cache_slot_orders)[i];
-            }
-        }
-
-        if (need_reorder) {
+        if (_slot_orders != *hit_cache_slot_orders) {
             for (auto slot_id : _slot_orders) {
                 auto find_res = std::find(hit_cache_slot_orders->begin(),
                                           hit_cache_slot_orders->end(), slot_id);

--- a/regression-test/data/query_p0/cache/query_cache.out
+++ b/regression-test/data/query_p0/cache/query_cache.out
@@ -20,3 +20,11 @@
 1	1	1
 2	2	2
 
+-- !query_cache7 --
+\N	\N	\N	0	\N
+6	6	6	1	6
+
+-- !query_cache8 --
+0	\N	\N	\N	\N
+1	6	6	6	6
+

--- a/regression-test/suites/query_p0/cache/query_cache.groovy
+++ b/regression-test/suites/query_p0/cache/query_cache.groovy
@@ -160,4 +160,26 @@ suite("query_cache") {
         GROUP BY field3
     """
 
+    order_qt_query_cache7 """
+        SELECT
+        col_int_undef_signed,
+            MIN(`col_int_undef_signed`) AS field1,
+            MAX(`col_int_undef_signed`) AS field2,
+            COUNT(`col_int_undef_signed`) AS field3,
+            SUM(`col_int_undef_signed`) AS field4
+        FROM ${tableName}
+        GROUP BY col_int_undef_signed
+    """
+
+    // reorder the order_qt_query_cache7 select list to test the cache hit
+    order_qt_query_cache8 """
+ SELECT
+    COUNT(`col_int_undef_signed`) AS field3,  -- Count of col_int_undef_signed (Original field3)
+    col_int_undef_signed,                      -- The original unsigned integer column (Original col_int_undef_signed)
+    SUM(`col_int_undef_signed`) AS field4,     -- Sum of col_int_undef_signed (Original field4)
+    MIN(`col_int_undef_signed`) AS field1,     -- Minimum value of col_int_undef_signed (Original field1)
+    MAX(`col_int_undef_signed`) AS field2      -- Maximum value of col_int_undef_signed (Original field2). Note: Trailing comma removed to avoid syntax error.
+FROM ${tableName}
+GROUP BY col_int_undef_signed;
+    """
 } 


### PR DESCRIPTION
### What problem does this PR solve?

the origin judge may cause the need reorder judge error:
```
   bool need_reorder = _slot_orders.size() != hit_cache_slot_orders->size();
        if (!need_reorder) {
            for (int i = 0; i < _slot_orders.size(); ++i) {
                need_reorder = _slot_orders[i] != (*hit_cache_slot_orders)[i];
            }
        }
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

