### PR TITLE
[fix](group commit) replay wal failed when enable global enable_memtable_on_sink_node

### DIFF
--- a/be/src/http/action/http_stream.cpp
+++ b/be/src/http/action/http_stream.cpp
@@ -338,6 +338,9 @@ Status HttpStreamAction::process_put(HttpRequest* http_req,
     } else {
         LOG(WARNING) << "_exec_env->cluster_info not set backend_id";
     }
+    if (ctx->wal_id > 0) {
+        request.__set_partial_update(false);
+    }
 
     // plan this load
     TNetworkAddress master_addr = _exec_env->cluster_info()->master_fe_addr;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -2136,6 +2136,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             ctx.getSessionVariable().enableMemtableOnSinkNode = Config.stream_load_default_memtable_on_sink_node;
         }
         ctx.getSessionVariable().groupCommit = request.getGroupCommitMode();
+        if (request.isSetPartialUpdate() && !request.isPartialUpdate()) {
+            ctx.getSessionVariable().setEnableUniqueKeyPartialUpdate(false);
+        }
         try {
             HttpStreamParams httpStreamParams = initHttpStreamPlan(request, ctx);
             int loadStreamPerNode = 2;

--- a/regression-test/suites/insert_p0/group_commit/test_group_commit_replay_wal.groovy
+++ b/regression-test/suites/insert_p0/group_commit/test_group_commit_replay_wal.groovy
@@ -42,6 +42,11 @@ suite("test_group_commit_replay_wal", "nonConcurrent") {
         properties("replication_num" = "1", "group_commit_interval_ms"="2000")
     """
 
+    sql """ set global enable_memtable_on_sink_node = true """
+    onFinish {
+        sql """ set global enable_memtable_on_sink_node = false """
+    }
+
     // 1. load success but commit rpc timeout
     // 2. should skip replay because of fe throw LabelAlreadyUsedException and txn status is VISIBLE
     GetDebugPoint().clearDebugPointsForAllBEs()


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

if `set global enable_memtable_on_sink_node = true`, replay wal will failed:
```
failed to replay wal=/data3/storage/wal/118291/1739470368974/1_40199330_47385148733034496_group_commit_104d6db2bc9875fe_f7d1b359986d9c83, st=[INTERNAL_ERROR][INTERNAL_ERROR]close wait failed coz rpc error. VNodeChannel[1739470368975-40199330], load_id=ca40e6a07491aacf-a1aa8bb9dc1c31a5, txn_id=47401455637994497, node=[192.168.35.80:8060](http://192.168.35.80:8060/), add batch req success but status isn't ok, err: [INVALID_ARGUMENT]PStatus: ([192.168.35.80](http://192.168.35.80/))[INVALID_ARGUMENT]illegal partial update block columns: 61, num key columns: 2, total schema columns: 61, host: [192.168.35.80](http://192.168.35.80/)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

