### PR TITLE
[fix](Export) Fix the issue where the show export status stays stuck on EXPORTING.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -715,7 +715,7 @@ public class ExportJob implements Writable {
 
     private void exportExportJob() throws JobException {
         if (getState() == ExportJobState.CANCELLED || getState() == ExportJobState.FINISHED) {
-            throw new JobException("export job has been cancelled or finished.");
+            throw new JobException("export job has been {}, can not be update to `EXPORTING` state", getState());
         }
         // The first exportTaskExecutor will set state to EXPORTING,
         // other exportTaskExecutors do not need to set up state.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -713,7 +713,10 @@ public class ExportJob implements Writable {
         LOG.info("cancel export job {}", id);
     }
 
-    private void exportExportJob() {
+    private void exportExportJob() throws JobException {
+        if (getState() == ExportJobState.CANCELLED || getState() == ExportJobState.FINISHED) {
+            throw new JobException("export job has been cancelled or finished.");
+        }
         // The first exportTaskExecutor will set state to EXPORTING,
         // other exportTaskExecutors do not need to set up state.
         if (getState() == ExportJobState.EXPORTING) {

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskHandler.java
@@ -23,7 +23,8 @@ import org.apache.doris.scheduler.executor.TransientTaskExecutor;
 import org.apache.doris.scheduler.manager.TransientTaskManager;
 
 import com.lmax.disruptor.WorkHandler;
-import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This class represents a work handler for processing event tasks consumed by a Disruptor.
@@ -32,9 +33,8 @@ import lombok.extern.log4j.Log4j2;
  * If the event job execution fails, the work handler logs an error message and pauses the event job.
  * The work handler also handles system events by scheduling batch scheduler tasks.
  */
-@Log4j2
 public class TaskHandler implements WorkHandler<TaskEvent> {
-
+    private static final Logger LOG = LogManager.getLogger(TaskHandler.class);
 
     /**
      * Processes an event task by retrieving the associated event job and executing it if it is running.
@@ -50,7 +50,7 @@ public class TaskHandler implements WorkHandler<TaskEvent> {
                 onTransientTaskHandle(event);
                 break;
             default:
-                log.warn("unknown task type: {}", event.getTaskType());
+                LOG.warn("unknown task type: {}", event.getTaskType());
                 break;
         }
     }
@@ -60,14 +60,14 @@ public class TaskHandler implements WorkHandler<TaskEvent> {
         TransientTaskManager transientTaskManager = Env.getCurrentEnv().getTransientTaskManager();
         TransientTaskExecutor taskExecutor = transientTaskManager.getMemoryTaskExecutor(taskId);
         if (taskExecutor == null) {
-            log.info("Memory task executor is null, task id: {}", taskId);
+            LOG.info("Memory task executor is null, task id: {}", taskId);
             return;
         }
 
         try {
             taskExecutor.execute();
         } catch (JobException e) {
-            log.warn("Memory task execute failed, taskId: {}, msg : {}", taskId, e.getMessage());
+            LOG.warn("Memory task execute failed, taskId: {}, msg : {}", taskId, e.getMessage());
         } finally {
             transientTaskManager.removeMemoryTask(taskId);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/TransientTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/TransientTaskManager.java
@@ -63,8 +63,9 @@ public class TransientTaskManager {
     }
 
     public void cancelMemoryTask(Long taskId) throws JobException {
-        if (taskExecutorMap.containsKey(taskId)) {
-            taskExecutorMap.get(taskId).cancel();
+        TransientTaskExecutor transientTaskExecutor = taskExecutorMap.get(taskId);
+        if (transientTaskExecutor != null) {
+            transientTaskExecutor.cancel();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/TransientTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/TransientTaskManager.java
@@ -63,10 +63,8 @@ public class TransientTaskManager {
     }
 
     public void cancelMemoryTask(Long taskId) throws JobException {
-        try {
+        if (taskExecutorMap.containsKey(taskId)) {
             taskExecutorMap.get(taskId).cancel();
-        } finally {
-            removeMemoryTask(taskId);
         }
     }
 


### PR DESCRIPTION
Problem Summary:

Each Export task will be deleted after execution in the finally block of the TaskHandler#onTransientTaskHandle() method. Therefore, when removing a task in the TransientTaskManager#cancelMemoryTask method, there should be a check to see if the task exists. Otherwise, a null pointer exception may occur, causing the Export Job status update to fail.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

