### PR TITLE
[opt](resource) step4: Split `MemInfo` class, add `JemallocControl`

### DIFF
--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -162,6 +162,8 @@ public:
                                                 TUnit::BYTES));
     }
 
+    static void refresh_memory_bvar();
+
     // It is only used after the memory limit is exceeded. When multiple threads are waiting for the available memory of the process,
     // avoid multiple threads starting at the same time and causing OOM.
     static std::atomic<int64_t> refresh_interval_memory_growth;

--- a/be/src/runtime/memory/jemalloc_control.cpp
+++ b/be/src/runtime/memory/jemalloc_control.cpp
@@ -130,11 +130,6 @@ void JemallocControl::je_decay_all_arena_dirty_pages() {
     action_jemallctl(fmt::format("arena.{}.decay", MALLCTL_ARENAS_ALL));
 }
 
-// the limit of `tcache` is the number of pages, not the total number of page bytes.
-// `tcache` has two cleaning opportunities: 1. the number of memory alloc and releases reaches a certain number,
-// recycle pages that has not been used for a long time; 2. recycle all `tcache` when the thread exits.
-// here add a total size limit.
-// only free the thread cache of the current thread, which will be fast.
 void JemallocControl::je_thread_tcache_flush() {
     constexpr size_t TCACHE_LIMIT = (1ULL << 30); // 1G
     if (je_tcache_mem() > TCACHE_LIMIT) {
@@ -143,17 +138,18 @@ void JemallocControl::je_thread_tcache_flush() {
 }
 
 #else
-void action_jemallctl(const std::string& name) {}
-int64_t get_je_all_arena_metrics(const std::string& name) {
+void JemallocControl::action_jemallctl(const std::string& name) {}
+int64_t JemallocControl::get_je_all_arena_metrics(const std::string& name) {
     return 0;
 }
-int64_t get_je_all_arena_extents_metrics(int64_t page_size_index, const std::string& extent_type) {
+int64_t JemallocControl::get_je_all_arena_extents_metrics(int64_t page_size_index,
+                                                          const std::string& extent_type) {
     return 0;
 }
-void je_purge_all_arena_dirty_pages() {}
-void je_reset_all_arena_dirty_decay_ms(ssize_t dirty_decay_ms) {}
-void je_decay_all_arena_dirty_pages() {}
-void je_thread_tcache_flush() {}
+void JemallocControl::je_purge_all_arena_dirty_pages() {}
+void JemallocControl::je_reset_all_arena_dirty_decay_ms(ssize_t dirty_decay_ms) {}
+void JemallocControl::je_decay_all_arena_dirty_pages() {}
+void JemallocControl::je_thread_tcache_flush() {}
 #endif
 
 } // namespace doris

--- a/be/src/runtime/memory/jemalloc_control.cpp
+++ b/be/src/runtime/memory/jemalloc_control.cpp
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/memory/jemalloc_control.h"
+
+#include <atomic>
+#include <condition_variable>
+
+namespace doris {
+
+std::mutex JemallocControl::je_purge_dirty_pages_lock;
+std::atomic<bool> JemallocControl::je_purge_dirty_pages_notify {false};
+std::mutex JemallocControl::je_reset_dirty_decay_lock;
+std::atomic<bool> JemallocControl::je_enable_dirty_page {true};
+std::condition_variable JemallocControl::je_reset_dirty_decay_cv;
+std::atomic<bool> JemallocControl::je_reset_dirty_decay_notify {false};
+
+std::atomic<int64_t> JemallocControl::je_cache_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_tcache_mem_ = 0;
+std::atomic<int64_t> JemallocControl::je_metadata_mem_ = 0;
+std::atomic<int64_t> JemallocControl::je_dirty_pages_mem_ = std::numeric_limits<int64_t>::min();
+std::atomic<int64_t> JemallocControl::je_virtual_memory_used_ = 0;
+
+void JemallocControl::refresh_allocator_mem() {
+#if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
+#elif defined(USE_JEMALLOC)
+    // jemalloc mallctl refer to : https://jemalloc.net/jemalloc.3.html
+    // https://www.bookstack.cn/read/aliyun-rds-core/4a0cdf677f62feb3.md
+    //  Check the Doris BE web page `http://ip:webserver_port/memory` to get the Jemalloc Profile.
+
+    // 'epoch' is a special mallctl -- it updates the statistics. Without it, all
+    // the following calls will return stale values. It increments and returns
+    // the current epoch number, which might be useful to log as a sanity check.
+    uint64_t epoch = 0;
+    size_t sz = sizeof(epoch);
+    jemallctl("epoch", &epoch, &sz, &epoch, sz);
+
+    // Number of extents of the given type in this arena in the bucket corresponding to page size index.
+    // Large size class starts at 16384, the extents have three sizes before 16384: 4096, 8192, and 12288, so + 3
+    int64_t dirty_pages_bytes = 0;
+    for (unsigned i = 0; i < get_jemallctl_value<unsigned>("arenas.nlextents") + 3; i++) {
+        dirty_pages_bytes += get_je_all_arena_extents_metrics(i, "dirty_bytes");
+    }
+    je_dirty_pages_mem_.store(dirty_pages_bytes, std::memory_order_relaxed);
+    je_tcache_mem_.store(get_je_all_arena_metrics("tcache_bytes"));
+
+    // Doris uses Jemalloc as default Allocator, Jemalloc Cache consists of two parts:
+    // - Thread Cache, cache a specified number of Pages in Thread Cache.
+    // - Dirty Page, memory Page that can be reused in all Arenas.
+    je_cache_bytes_.store(je_tcache_mem_ + dirty_pages_bytes, std::memory_order_relaxed);
+    // Total number of bytes dedicated to metadata, which comprise base allocations used
+    // for bootstrap-sensitive allocator metadata structures.
+    je_metadata_mem_.store(get_jemallctl_value<int64_t>("stats.metadata"),
+                           std::memory_order_relaxed);
+    je_virtual_memory_used_.store(get_jemallctl_value<int64_t>("stats.mapped"),
+                                  std::memory_order_relaxed);
+#else
+    je_cache_bytes_.store(get_tc_metrics("tcmalloc.pageheap_free_bytes") +
+                                  get_tc_metrics("tcmalloc.central_cache_free_bytes") +
+                                  get_tc_metrics("tcmalloc.transfer_cache_free_bytes") +
+                                  get_tc_metrics("tcmalloc.thread_cache_free_bytes"),
+                          std::memory_order_relaxed);
+    je_virtual_memory_used_.store(get_tc_metrics("generic.total_physical_bytes") +
+                                          get_tc_metrics("tcmalloc.pageheap_unmapped_bytes"),
+                                  std::memory_order_relaxed);
+#endif
+}
+
+#ifdef USE_JEMALLOC
+void JemallocControl::action_jemallctl(const std::string& name) {
+    try {
+        int err = jemallctl(name.c_str(), nullptr, nullptr, nullptr, 0);
+        if (err) {
+            LOG(WARNING) << fmt::format("Failed, jemallctl action {}", name);
+        }
+    } catch (...) {
+        LOG(WARNING) << fmt::format("Exception, jemallctl action {}", name);
+    }
+}
+
+int64_t JemallocControl::get_je_all_arena_metrics(const std::string& name) {
+    return get_jemallctl_value<int64_t>(
+            fmt::format("stats.arenas.{}.{}", MALLCTL_ARENAS_ALL, name));
+}
+
+int64_t JemallocControl::get_je_all_arena_extents_metrics(int64_t page_size_index,
+                                                          const std::string& extent_type) {
+    return get_jemallctl_value<int64_t>(fmt::format(
+            "stats.arenas.{}.extents.{}.{}", MALLCTL_ARENAS_ALL, page_size_index, extent_type));
+}
+
+void JemallocControl::je_purge_all_arena_dirty_pages() {
+    // https://github.com/jemalloc/jemalloc/issues/2470
+    // If there is a core dump here, it may cover up the real stack, if stack trace indicates heap corruption
+    // (which led to invalid jemalloc metadata), like double free or use-after-free in the application.
+    // Try sanitizers such as ASAN, or build jemalloc with --enable-debug to investigate further.
+    action_jemallctl(fmt::format("arena.{}.purge", MALLCTL_ARENAS_ALL));
+}
+
+void JemallocControl::je_reset_all_arena_dirty_decay_ms(ssize_t dirty_decay_ms) {
+    // Each time this interface is set, all currently unused dirty pages are considered
+    // to have fully decayed, which causes immediate purging of all unused dirty pages unless
+    // the decay time is set to -1
+    //
+    // NOTE: Using "arena.MALLCTL_ARENAS_ALL.dirty_decay_ms" to modify all arenas will fail or even crash,
+    // which may be a bug.
+    for (unsigned i = 0; i < get_jemallctl_value<unsigned>("arenas.narenas"); i++) {
+        set_jemallctl_value<ssize_t>(fmt::format("arena.{}.dirty_decay_ms", i), dirty_decay_ms);
+    }
+}
+
+void JemallocControl::je_decay_all_arena_dirty_pages() {
+    // Trigger decay-based purging of unused dirty/muzzy pages for arena <i>, or for all arenas if <i> equals
+    // MALLCTL_ARENAS_ALL. The proportion of unused dirty/muzzy pages to be purged depends on the
+    // current time; see opt.dirty_decay_ms and opt.muzy_decay_ms for details.
+    action_jemallctl(fmt::format("arena.{}.decay", MALLCTL_ARENAS_ALL));
+}
+
+// the limit of `tcache` is the number of pages, not the total number of page bytes.
+// `tcache` has two cleaning opportunities: 1. the number of memory alloc and releases reaches a certain number,
+// recycle pages that has not been used for a long time; 2. recycle all `tcache` when the thread exits.
+// here add a total size limit.
+// only free the thread cache of the current thread, which will be fast.
+void JemallocControl::je_thread_tcache_flush() {
+    constexpr size_t TCACHE_LIMIT = (1ULL << 30); // 1G
+    if (je_tcache_mem() > TCACHE_LIMIT) {
+        action_jemallctl("thread.tcache.flush");
+    }
+}
+
+#else
+void action_jemallctl(const std::string& name) {}
+int64_t get_je_all_arena_metrics(const std::string& name) {
+    return 0;
+}
+int64_t get_je_all_arena_extents_metrics(int64_t page_size_index, const std::string& extent_type) {
+    return 0;
+}
+void je_purge_all_arena_dirty_pages() {}
+void je_reset_all_arena_dirty_decay_ms(ssize_t dirty_decay_ms) {}
+void je_decay_all_arena_dirty_pages() {}
+void je_thread_tcache_flush() {}
+#endif
+
+} // namespace doris

--- a/be/src/runtime/memory/jemalloc_control.h
+++ b/be/src/runtime/memory/jemalloc_control.h
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <string>
+
+#include "common/logging.h"
+
+#ifdef USE_JEMALLOC
+#include "jemalloc/jemalloc.h"
+#endif
+#if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
+        !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
+#include <gperftools/malloc_extension.h>
+#endif
+
+namespace doris {
+
+class JemallocControl {
+public:
+    static void refresh_allocator_mem();
+
+    static inline int64_t get_tc_metrics(const std::string& name) {
+#if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
+        !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
+        size_t value = 0;
+        MallocExtension::instance()->GetNumericProperty(name.c_str(), &value);
+        return value;
+#endif
+        return 0;
+    }
+
+    template <typename T>
+    static inline T get_jemallctl_value(const std::string& name) {
+#ifdef USE_JEMALLOC
+        T value;
+        size_t value_size = sizeof(T);
+        if (jemallctl(name.c_str(), &value, &value_size, nullptr, 0) != 0) {
+            LOG(WARNING) << fmt::format("Failed, jemallctl get {}", name);
+        }
+        return value;
+#endif
+        return 0;
+    }
+
+    template <typename T>
+    static inline void set_jemallctl_value(const std::string& name, T value) {
+#ifdef USE_JEMALLOC
+        T old_value;
+        size_t old_value_size = sizeof(T);
+        try {
+            int err = jemallctl(name.c_str(), &old_value, &old_value_size,
+                                reinterpret_cast<void*>(&value), sizeof(T));
+            if (err) {
+                LOG(WARNING) << fmt::format("Failed, jemallctl value for {} set to {} (old {})",
+                                            name, value, old_value);
+            }
+        } catch (...) {
+            LOG(WARNING) << fmt::format("Exception, jemallctl value for {} set to {} (old {})",
+                                        name, value, old_value);
+        }
+#endif
+    }
+
+    static void action_jemallctl(const std::string& name);
+    static int64_t get_je_all_arena_metrics(const std::string& name);
+    static int64_t get_je_all_arena_extents_metrics(int64_t page_size_index,
+                                                    const std::string& extent_type);
+    static void je_purge_all_arena_dirty_pages();
+    static void je_reset_all_arena_dirty_decay_ms(ssize_t dirty_decay_ms);
+    static void je_decay_all_arena_dirty_pages();
+    // the limit of `tcache` is the number of pages, not the total number of page bytes.
+    // `tcache` has two cleaning opportunities: 1. the number of memory alloc and releases reaches a certain number,
+    // recycle pages that has not been used for a long time; 2. recycle all `tcache` when the thread exits.
+    // here add a total size limit.
+    // only free the thread cache of the current thread, which will be fast.
+    static void je_thread_tcache_flush();
+    // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
+    // obtained by the process malloc, not the physical memory actually used by the process in the OS.
+
+    static inline size_t je_cache_bytes() {
+        return je_cache_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline size_t je_tcache_mem() { return je_tcache_mem_.load(std::memory_order_relaxed); }
+    static inline size_t je_metadata_mem() {
+        return je_metadata_mem_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_dirty_pages_mem() {
+        return je_dirty_pages_mem_.load(std::memory_order_relaxed);
+    }
+    static inline size_t je_virtual_memory_used() {
+        return je_virtual_memory_used_.load(std::memory_order_relaxed);
+    }
+
+    static std::mutex je_purge_dirty_pages_lock;
+    static std::atomic<bool> je_purge_dirty_pages_notify;
+    static void notify_je_purge_dirty_pages() {
+        je_purge_dirty_pages_notify.store(true, std::memory_order_relaxed);
+    }
+
+    static std::mutex je_reset_dirty_decay_lock;
+    static std::atomic<bool> je_enable_dirty_page;
+    static std::condition_variable je_reset_dirty_decay_cv;
+    static std::atomic<bool> je_reset_dirty_decay_notify;
+    static void notify_je_reset_dirty_decay() {
+        je_reset_dirty_decay_notify.store(true, std::memory_order_relaxed);
+        je_reset_dirty_decay_cv.notify_all();
+    }
+
+private:
+    static std::atomic<int64_t> je_cache_bytes_;
+    static std::atomic<int64_t> je_tcache_mem_;
+    static std::atomic<int64_t> je_metadata_mem_;
+    static std::atomic<int64_t> je_dirty_pages_mem_;
+    static std::atomic<int64_t> je_virtual_memory_used_;
+};
+
+} // namespace doris

--- a/be/src/runtime/memory/jemalloc_control.h
+++ b/be/src/runtime/memory/jemalloc_control.h
@@ -34,8 +34,6 @@ namespace doris {
 
 class JemallocControl {
 public:
-    static void refresh_allocator_mem();
-
     static inline int64_t get_tc_metrics(const std::string& name) {
 #if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
         !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
@@ -91,8 +89,10 @@ public:
     // here add a total size limit.
     // only free the thread cache of the current thread, which will be fast.
     static void je_thread_tcache_flush();
+
     // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
+    static void refresh_allocator_mem();
 
     static inline size_t je_cache_bytes() {
         return je_cache_bytes_.load(std::memory_order_relaxed);

--- a/be/src/runtime/memory/memory_profile.cpp
+++ b/be/src/runtime/memory/memory_profile.cpp
@@ -23,6 +23,7 @@
 #include "olap/tablet_schema_cache.h"
 #include "runtime/exec_env.h"
 #include "runtime/memory/global_memory_arbitrator.h"
+#include "runtime/memory/jemalloc_control.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "util/mem_info.h"
 #include "util/runtime_profile.h"
@@ -243,12 +244,12 @@ void MemoryProfile::refresh_memory_overview_profile() {
     memory_reserved_memory_bytes << GlobalMemoryArbitrator::process_reserved_memory() -
                                             memory_reserved_memory_bytes.get_value();
 
-    all_tracked_mem_sum += MemInfo::allocator_cache_mem();
+    all_tracked_mem_sum += JemallocControl::je_cache_bytes();
     COUNTER_SET(_jemalloc_cache_usage_counter,
-                static_cast<int64_t>(MemInfo::allocator_cache_mem()));
-    all_tracked_mem_sum += MemInfo::allocator_metadata_mem();
+                static_cast<int64_t>(JemallocControl::je_cache_bytes()));
+    all_tracked_mem_sum += JemallocControl::je_metadata_mem();
     COUNTER_SET(_jemalloc_metadata_usage_counter,
-                static_cast<int64_t>(MemInfo::allocator_metadata_mem()));
+                static_cast<int64_t>(JemallocControl::je_metadata_mem()));
     COUNTER_SET(_jemalloc_memory_usage_counter,
                 _jemalloc_cache_usage_counter->current_value() +
                         _jemalloc_metadata_usage_counter->current_value());

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -48,30 +48,10 @@
 
 namespace doris {
 
-static bvar::Adder<int64_t> memory_jemalloc_cache_bytes("memory_jemalloc_cache_bytes");
-static bvar::Adder<int64_t> memory_jemalloc_dirty_pages_bytes("memory_jemalloc_dirty_pages_bytes");
-static bvar::Adder<int64_t> memory_jemalloc_metadata_bytes("memory_jemalloc_metadata_bytes");
-static bvar::Adder<int64_t> memory_jemalloc_virtual_bytes("memory_jemalloc_virtual_bytes");
-static bvar::Adder<int64_t> memory_cgroup_usage_bytes("memory_cgroup_usage_bytes");
-static bvar::Adder<int64_t> memory_sys_available_bytes("memory_sys_available_bytes");
-static bvar::Adder<int64_t> memory_arbitrator_sys_available_bytes(
-        "memory_arbitrator_sys_available_bytes");
-static bvar::Adder<int64_t> memory_arbitrator_process_usage_bytes(
-        "memory_arbitrator_process_usage_bytes");
-static bvar::Adder<int64_t> memory_arbitrator_reserve_memory_bytes(
-        "memory_arbitrator_reserve_memory_bytes");
-static bvar::Adder<int64_t> memory_arbitrator_refresh_interval_growth_bytes(
-        "memory_arbitrator_refresh_interval_growth_bytes");
-
 bool MemInfo::_s_initialized = false;
 std::atomic<int64_t> MemInfo::_s_physical_mem = std::numeric_limits<int64_t>::max();
 std::atomic<int64_t> MemInfo::_s_mem_limit = std::numeric_limits<int64_t>::max();
 std::atomic<int64_t> MemInfo::_s_soft_mem_limit = std::numeric_limits<int64_t>::max();
-
-std::atomic<int64_t> MemInfo::_s_allocator_cache_mem = 0;
-std::atomic<int64_t> MemInfo::_s_allocator_metadata_mem = 0;
-std::atomic<int64_t> MemInfo::_s_je_dirty_pages_mem = std::numeric_limits<int64_t>::min();
-std::atomic<int64_t> MemInfo::_s_virtual_memory_used = 0;
 
 std::atomic<int64_t> MemInfo::_s_cgroup_mem_limit = std::numeric_limits<int64_t>::max();
 std::atomic<int64_t> MemInfo::_s_cgroup_mem_usage = std::numeric_limits<int64_t>::min();
@@ -84,84 +64,6 @@ int64_t MemInfo::_s_sys_mem_available_low_water_mark = std::numeric_limits<int64
 int64_t MemInfo::_s_sys_mem_available_warning_water_mark = std::numeric_limits<int64_t>::min();
 std::atomic<int64_t> MemInfo::_s_process_minor_gc_size = -1;
 std::atomic<int64_t> MemInfo::_s_process_full_gc_size = -1;
-std::mutex MemInfo::je_purge_dirty_pages_lock;
-std::atomic<bool> MemInfo::je_purge_dirty_pages_notify {false};
-std::mutex MemInfo::je_reset_dirty_decay_lock;
-std::atomic<bool> MemInfo::je_enable_dirty_page {true};
-std::condition_variable MemInfo::je_reset_dirty_decay_cv;
-std::atomic<bool> MemInfo::je_reset_dirty_decay_notify {false};
-
-void MemInfo::refresh_allocator_mem() {
-#if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
-#elif defined(USE_JEMALLOC)
-    // jemalloc mallctl refer to : https://jemalloc.net/jemalloc.3.html
-    // https://www.bookstack.cn/read/aliyun-rds-core/4a0cdf677f62feb3.md
-    //  Check the Doris BE web page `http://ip:webserver_port/memory` to get the Jemalloc Profile.
-
-    // 'epoch' is a special mallctl -- it updates the statistics. Without it, all
-    // the following calls will return stale values. It increments and returns
-    // the current epoch number, which might be useful to log as a sanity check.
-    uint64_t epoch = 0;
-    size_t sz = sizeof(epoch);
-    jemallctl("epoch", &epoch, &sz, &epoch, sz);
-
-    // Number of extents of the given type in this arena in the bucket corresponding to page size index.
-    // Large size class starts at 16384, the extents have three sizes before 16384: 4096, 8192, and 12288, so + 3
-    int64_t dirty_pages_bytes = 0;
-    for (unsigned i = 0; i < get_jemallctl_value<unsigned>("arenas.nlextents") + 3; i++) {
-        dirty_pages_bytes += get_je_all_arena_extents_metrics(i, "dirty_bytes");
-    }
-    _s_je_dirty_pages_mem.store(dirty_pages_bytes, std::memory_order_relaxed);
-
-    // Doris uses Jemalloc as default Allocator, Jemalloc Cache consists of two parts:
-    // - Thread Cache, cache a specified number of Pages in Thread Cache.
-    // - Dirty Page, memory Page that can be reused in all Arenas.
-    _s_allocator_cache_mem.store(get_je_all_arena_metrics("tcache_bytes") + dirty_pages_bytes,
-                                 std::memory_order_relaxed);
-    // Total number of bytes dedicated to metadata, which comprise base allocations used
-    // for bootstrap-sensitive allocator metadata structures.
-    _s_allocator_metadata_mem.store(get_jemallctl_value<int64_t>("stats.metadata"),
-                                    std::memory_order_relaxed);
-    _s_virtual_memory_used.store(get_jemallctl_value<int64_t>("stats.mapped"),
-                                 std::memory_order_relaxed);
-#else
-    _s_allocator_cache_mem.store(get_tc_metrics("tcmalloc.pageheap_free_bytes") +
-                                         get_tc_metrics("tcmalloc.central_cache_free_bytes") +
-                                         get_tc_metrics("tcmalloc.transfer_cache_free_bytes") +
-                                         get_tc_metrics("tcmalloc.thread_cache_free_bytes"),
-                                 std::memory_order_relaxed);
-    _s_virtual_memory_used.store(get_tc_metrics("generic.total_physical_bytes") +
-                                         get_tc_metrics("tcmalloc.pageheap_unmapped_bytes"),
-                                 std::memory_order_relaxed);
-#endif
-}
-
-void MemInfo::refresh_memory_bvar() {
-    memory_jemalloc_cache_bytes << MemInfo::allocator_cache_mem() -
-                                           memory_jemalloc_cache_bytes.get_value();
-    memory_jemalloc_dirty_pages_bytes
-            << MemInfo::je_dirty_pages_mem() - memory_jemalloc_dirty_pages_bytes.get_value();
-    memory_jemalloc_metadata_bytes
-            << MemInfo::allocator_metadata_mem() - memory_jemalloc_metadata_bytes.get_value();
-    memory_jemalloc_virtual_bytes << MemInfo::allocator_virtual_mem() -
-                                             memory_jemalloc_virtual_bytes.get_value();
-
-    memory_cgroup_usage_bytes << _s_cgroup_mem_usage - memory_cgroup_usage_bytes.get_value();
-    memory_sys_available_bytes << _s_sys_mem_available - memory_sys_available_bytes.get_value();
-
-    memory_arbitrator_sys_available_bytes
-            << GlobalMemoryArbitrator::sys_mem_available() -
-                       memory_arbitrator_sys_available_bytes.get_value();
-    memory_arbitrator_process_usage_bytes
-            << GlobalMemoryArbitrator::process_memory_usage() -
-                       memory_arbitrator_process_usage_bytes.get_value();
-    memory_arbitrator_reserve_memory_bytes
-            << GlobalMemoryArbitrator::process_reserved_memory() -
-                       memory_arbitrator_reserve_memory_bytes.get_value();
-    memory_arbitrator_refresh_interval_growth_bytes
-            << GlobalMemoryArbitrator::refresh_interval_memory_growth -
-                       memory_arbitrator_refresh_interval_growth_bytes.get_value();
-}
 
 #ifndef __APPLE__
 void MemInfo::refresh_proc_meminfo() {

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -20,11 +20,9 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <atomic>
-#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 
 #if !defined(__APPLE__) || !defined(_POSIX_C_SOURCE)
@@ -33,25 +31,18 @@
 #include <mach/vm_page_size.h>
 #endif
 
-#include "common/logging.h"
-#ifdef USE_JEMALLOC
-#include "jemalloc/jemalloc.h"
-#endif
-#if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
-        !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
-#include <gperftools/malloc_extension.h>
-#endif
 #include "common/config.h"
+#include "common/logging.h"
 #include "util/perf_counters.h"
 #include "util/pretty_printer.h"
 
 namespace doris {
 
-class RuntimeProfile;
-
-// Provides the amount of physical memory available.
-// Populated from /proc/meminfo.
-// TODO: Combine mem-info, cpu-info and disk-info into hardware-info/perf_counters ?
+// Provides the amount of physical memory available and memory limit.
+// Populated from /proc/meminfo and other system attributes.
+// Note: The memory values ​​in MemInfo are original values,
+// usually you should use the memory values ​​in GlobalMemoryArbitrator,
+// which are corrected values ​​that better meet your needs.
 class MemInfo {
 public:
     // Initialize MemInfo.
@@ -75,8 +66,6 @@ public:
 
     static void refresh_proc_meminfo();
 
-    static void refresh_memory_bvar();
-
     static inline int64_t sys_mem_available_low_water_mark() {
         return _s_sys_mem_available_low_water_mark;
     }
@@ -89,158 +78,6 @@ public:
     static inline int64_t process_full_gc_size() {
         return _s_process_full_gc_size.load(std::memory_order_relaxed);
     }
-
-    static inline int64_t get_tc_metrics(const std::string& name) {
-#if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
-        !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
-        size_t value = 0;
-        MallocExtension::instance()->GetNumericProperty(name.c_str(), &value);
-        return value;
-#endif
-        return 0;
-    }
-
-    template <typename T>
-    static inline T get_jemallctl_value(const std::string& name) {
-#ifdef USE_JEMALLOC
-        T value;
-        size_t value_size = sizeof(T);
-        if (jemallctl(name.c_str(), &value, &value_size, nullptr, 0) == 0) {
-            return value;
-        } else {
-            LOG(WARNING) << fmt::format("Failed, jemallctl get {}", name);
-        }
-#endif
-        return 0;
-    }
-
-    template <typename T>
-    static inline void set_jemallctl_value(const std::string& name, T value) {
-#ifdef USE_JEMALLOC
-        T old_value;
-        size_t old_value_size = sizeof(T);
-        try {
-            int err = jemallctl(name.c_str(), &old_value, &old_value_size,
-                                reinterpret_cast<void*>(&value), sizeof(T));
-            if (err) {
-                LOG(WARNING) << fmt::format("Failed, jemallctl value for {} set to {} (old {})",
-                                            name, value, old_value);
-            }
-        } catch (...) {
-            LOG(WARNING) << fmt::format("Exception, jemallctl value for {} set to {} (old {})",
-                                        name, value, old_value);
-        }
-#endif
-    }
-
-    static inline void action_jemallctl(const std::string& name) {
-#ifdef USE_JEMALLOC
-        try {
-            int err = jemallctl(name.c_str(), nullptr, nullptr, nullptr, 0);
-            if (err) {
-                LOG(WARNING) << fmt::format("Failed, jemallctl action {}", name);
-            }
-        } catch (...) {
-            LOG(WARNING) << fmt::format("Exception, jemallctl action {}", name);
-        }
-#endif
-    }
-
-    static inline int64_t get_je_all_arena_metrics(const std::string& name) {
-#ifdef USE_JEMALLOC
-        return get_jemallctl_value<int64_t>(
-                fmt::format("stats.arenas.{}.{}", MALLCTL_ARENAS_ALL, name));
-#endif
-        return 0;
-    }
-
-    static inline int64_t get_je_all_arena_extents_metrics(int64_t page_size_index,
-                                                           const std::string& extent_type) {
-#ifdef USE_JEMALLOC
-        return get_jemallctl_value<int64_t>(fmt::format(
-                "stats.arenas.{}.extents.{}.{}", MALLCTL_ARENAS_ALL, page_size_index, extent_type));
-#endif
-        return 0;
-    }
-
-    static inline void je_purge_all_arena_dirty_pages() {
-#ifdef USE_JEMALLOC
-        // https://github.com/jemalloc/jemalloc/issues/2470
-        // If there is a core dump here, it may cover up the real stack, if stack trace indicates heap corruption
-        // (which led to invalid jemalloc metadata), like double free or use-after-free in the application.
-        // Try sanitizers such as ASAN, or build jemalloc with --enable-debug to investigate further.
-        action_jemallctl(fmt::format("arena.{}.purge", MALLCTL_ARENAS_ALL));
-#endif
-    }
-
-    static inline void je_reset_all_arena_dirty_decay_ms(ssize_t dirty_decay_ms) {
-#ifdef USE_JEMALLOC
-        // Each time this interface is set, all currently unused dirty pages are considered
-        // to have fully decayed, which causes immediate purging of all unused dirty pages unless
-        // the decay time is set to -1
-        //
-        // NOTE: Using "arena.MALLCTL_ARENAS_ALL.dirty_decay_ms" to modify all arenas will fail or even crash,
-        // which may be a bug.
-        for (unsigned i = 0; i < get_jemallctl_value<unsigned>("arenas.narenas"); i++) {
-            set_jemallctl_value<ssize_t>(fmt::format("arena.{}.dirty_decay_ms", i), dirty_decay_ms);
-        }
-#endif
-    }
-
-    static inline void je_decay_all_arena_dirty_pages() {
-#ifdef USE_JEMALLOC
-        // Trigger decay-based purging of unused dirty/muzzy pages for arena <i>, or for all arenas if <i> equals
-        // MALLCTL_ARENAS_ALL. The proportion of unused dirty/muzzy pages to be purged depends on the
-        // current time; see opt.dirty_decay_ms and opt.muzy_decay_ms for details.
-        action_jemallctl(fmt::format("arena.{}.decay", MALLCTL_ARENAS_ALL));
-#endif
-    }
-
-    // the limit of `tcache` is the number of pages, not the total number of page bytes.
-    // `tcache` has two cleaning opportunities: 1. the number of memory alloc and releases reaches a certain number,
-    // recycle pages that has not been used for a long time; 2. recycle all `tcache` when the thread exits.
-    // here add a total size limit.
-    // only free the thread cache of the current thread, which will be fast.
-    static inline void je_thread_tcache_flush() {
-#ifdef USE_JEMALLOC
-        constexpr size_t TCACHE_LIMIT = (1ULL << 30); // 1G
-        if (allocator_cache_mem() - je_dirty_pages_mem() > TCACHE_LIMIT) {
-            action_jemallctl("thread.tcache.flush");
-        }
-#endif
-    }
-
-    static std::mutex je_purge_dirty_pages_lock;
-    static std::atomic<bool> je_purge_dirty_pages_notify;
-    static void notify_je_purge_dirty_pages() {
-        je_purge_dirty_pages_notify.store(true, std::memory_order_relaxed);
-    }
-
-    static std::mutex je_reset_dirty_decay_lock;
-    static std::atomic<bool> je_enable_dirty_page;
-    static std::condition_variable je_reset_dirty_decay_cv;
-    static std::atomic<bool> je_reset_dirty_decay_notify;
-    static void notify_je_reset_dirty_decay() {
-        je_reset_dirty_decay_notify.store(true, std::memory_order_relaxed);
-        je_reset_dirty_decay_cv.notify_all();
-    }
-
-    static inline size_t allocator_virtual_mem() {
-        return _s_virtual_memory_used.load(std::memory_order_relaxed);
-    }
-    static inline size_t allocator_cache_mem() {
-        return _s_allocator_cache_mem.load(std::memory_order_relaxed);
-    }
-    static inline size_t allocator_metadata_mem() {
-        return _s_allocator_metadata_mem.load(std::memory_order_relaxed);
-    }
-    static inline int64_t je_dirty_pages_mem() {
-        return _s_je_dirty_pages_mem.load(std::memory_order_relaxed);
-    }
-
-    // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
-    // obtained by the process malloc, not the physical memory actually used by the process in the OS.
-    static void refresh_allocator_mem();
 
     static inline int64_t mem_limit() {
         DCHECK(_s_initialized);
@@ -282,16 +119,13 @@ private:
     static std::atomic<int64_t> _s_mem_limit;
     static std::atomic<int64_t> _s_soft_mem_limit;
 
-    static std::atomic<int64_t> _s_allocator_cache_mem;
-    static std::atomic<int64_t> _s_allocator_metadata_mem;
-    static std::atomic<int64_t> _s_je_dirty_pages_mem;
-    static std::atomic<int64_t> _s_virtual_memory_used;
-
     static std::atomic<int64_t> _s_cgroup_mem_limit;
     static std::atomic<int64_t> _s_cgroup_mem_usage;
     static std::atomic<bool> _s_cgroup_mem_refresh_state;
     static int64_t _s_cgroup_mem_refresh_wait_times;
 
+    // If you need use system available memory size, use GlobalMemoryArbitrator::sys_mem_available(),
+    // this value in MemInfo is the original value.
     static std::atomic<int64_t> _s_sys_mem_available;
     static int64_t _s_sys_mem_available_low_water_mark;
     static int64_t _s_sys_mem_available_warning_water_mark;

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -33,8 +33,8 @@
 
 #include "gutil/strings/split.h" // for string split
 #include "gutil/strtoint.h"      //  for atoi64
+#include "runtime/memory/jemalloc_control.h"
 #include "util/cgroup_util.h"
-#include "util/mem_info.h"
 #include "util/perf_counters.h"
 
 namespace doris {
@@ -490,44 +490,44 @@ void SystemMetrics::update_allocator_metrics() {
     LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
 #elif defined(USE_JEMALLOC)
     _memory_metrics->memory_jemalloc_allocated_bytes->set_value(
-            MemInfo::get_jemallctl_value<int64_t>("stats.allocated"));
+            JemallocControl::get_jemallctl_value<int64_t>("stats.allocated"));
     _memory_metrics->memory_jemalloc_active_bytes->set_value(
-            MemInfo::get_jemallctl_value<int64_t>("stats.active"));
+            JemallocControl::get_jemallctl_value<int64_t>("stats.active"));
     _memory_metrics->memory_jemalloc_metadata_bytes->set_value(
-            MemInfo::get_jemallctl_value<int64_t>("stats.metadata"));
+            JemallocControl::get_jemallctl_value<int64_t>("stats.metadata"));
     _memory_metrics->memory_jemalloc_resident_bytes->set_value(
-            MemInfo::get_jemallctl_value<int64_t>("stats.resident"));
+            JemallocControl::get_jemallctl_value<int64_t>("stats.resident"));
     _memory_metrics->memory_jemalloc_mapped_bytes->set_value(
-            MemInfo::get_jemallctl_value<int64_t>("stats.mapped"));
+            JemallocControl::get_jemallctl_value<int64_t>("stats.mapped"));
     _memory_metrics->memory_jemalloc_retained_bytes->set_value(
-            MemInfo::get_jemallctl_value<int64_t>("stats.retained"));
+            JemallocControl::get_jemallctl_value<int64_t>("stats.retained"));
     _memory_metrics->memory_jemalloc_tcache_bytes->set_value(
-            MemInfo::get_je_all_arena_metrics("tcache_bytes"));
+            JemallocControl::get_je_all_arena_metrics("tcache_bytes"));
     _memory_metrics->memory_jemalloc_pactive_num->set_value(
-            MemInfo::get_je_all_arena_metrics("pactive"));
+            JemallocControl::get_je_all_arena_metrics("pactive"));
     _memory_metrics->memory_jemalloc_pdirty_num->set_value(
-            MemInfo::get_je_all_arena_metrics("pdirty"));
+            JemallocControl::get_je_all_arena_metrics("pdirty"));
     _memory_metrics->memory_jemalloc_pmuzzy_num->set_value(
-            MemInfo::get_je_all_arena_metrics("pmuzzy"));
+            JemallocControl::get_je_all_arena_metrics("pmuzzy"));
     _memory_metrics->memory_jemalloc_dirty_purged_num->set_value(
-            MemInfo::get_je_all_arena_metrics("dirty_purged"));
+            JemallocControl::get_je_all_arena_metrics("dirty_purged"));
     _memory_metrics->memory_jemalloc_muzzy_purged_num->set_value(
-            MemInfo::get_je_all_arena_metrics("muzzy_purged"));
+            JemallocControl::get_je_all_arena_metrics("muzzy_purged"));
 #else
     _memory_metrics->memory_tcmalloc_allocated_bytes->set_value(
-            MemInfo::get_tc_metrics("generic.total_physical_bytes"));
+            JemallocControl::get_tc_metrics("generic.total_physical_bytes"));
     _memory_metrics->memory_tcmalloc_total_thread_cache_bytes->set_value(
-            MemInfo::allocator_cache_mem());
+            JemallocControl::je_cache_bytes());
     _memory_metrics->memory_tcmalloc_central_cache_free_bytes->set_value(
-            MemInfo::get_tc_metrics("tcmalloc.central_cache_free_bytes"));
+            JemallocControl::get_tc_metrics("tcmalloc.central_cache_free_bytes"));
     _memory_metrics->memory_tcmalloc_transfer_cache_free_bytes->set_value(
-            MemInfo::get_tc_metrics("tcmalloc.transfer_cache_free_bytes"));
+            JemallocControl::get_tc_metrics("tcmalloc.transfer_cache_free_bytes"));
     _memory_metrics->memory_tcmalloc_thread_cache_free_bytes->set_value(
-            MemInfo::get_tc_metrics("tcmalloc.thread_cache_free_bytes"));
+            JemallocControl::get_tc_metrics("tcmalloc.thread_cache_free_bytes"));
     _memory_metrics->memory_tcmalloc_pageheap_free_bytes->set_value(
-            MemInfo::get_tc_metrics("tcmalloc.pageheap_free_bytes"));
+            JemallocControl::get_tc_metrics("tcmalloc.pageheap_free_bytes"));
     _memory_metrics->memory_tcmalloc_pageheap_unmapped_bytes->set_value(
-            MemInfo::get_tc_metrics("tcmalloc.pageheap_unmapped_bytes"));
+            JemallocControl::get_tc_metrics("tcmalloc.pageheap_unmapped_bytes"));
 #endif
 }
 

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -31,6 +31,7 @@
 #include "common/compiler_util.h"
 #include "common/status.h"
 #include "runtime/memory/global_memory_arbitrator.h"
+#include "runtime/memory/jemalloc_control.h"
 #include "runtime/memory/memory_reclamation.h"
 #include "runtime/memory/thread_mem_tracker_mgr.h"
 #include "runtime/process_profile.h"
@@ -118,7 +119,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
 
             // only task thread exceeded memory limit for the first time and wait_gc is true.
             // TODO, in the future, try to free memory and waiting for memory to be freed in pipeline scheduling.
-            doris::MemInfo::je_thread_tcache_flush();
+            doris::JemallocControl::je_thread_tcache_flush();
             doris::MemoryReclamation::je_purge_dirty_pages();
 
             if (!doris::config::disable_memory_gc) {


### PR DESCRIPTION
### What problem does this PR solve?

After a long period of code iteration, the content of the `MemInfo` class is getting more and more, so `MemInfo` is split into `JemallocControl` and `GlobalMemoryArbitrator`.

`MemInfo` provides the amount of physical memory available and memory limit, populated from /proc/meminfo and other system attributes. The memory values ​​​​in `MemInfo` are original values, usually you should use the memory values ​​​​in GlobalMemoryArbitrator.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

