### PR TITLE
[fix](nereids) fix push down non-foldable filter through project

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PushDownFilterThroughProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PushDownFilterThroughProject.java
@@ -18,11 +18,15 @@
 package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
+
+import java.util.Map;
 
 /**
  * merge consecutive projects
@@ -38,9 +42,13 @@ public class PushDownFilterThroughProject extends PlanPostProcessor {
         }
 
         PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) child;
+        Map<Slot, Expression> childAlias = project.getAliasToProducer();
+        if (filter.getInputSlots().stream().map(childAlias::get)
+                .anyMatch(expr -> expr != null && expr.containsNonfoldable())) {
+            return filter;
+        }
         PhysicalFilter<? extends Plan> newFilter = filter.withConjunctsAndChild(
-                ExpressionUtils.replace(filter.getConjuncts(), project.getAliasToProducer()),
-                project.child());
+                ExpressionUtils.replace(filter.getConjuncts(), childAlias), project.child());
         return ((AbstractPhysicalPlan) project.withChildren(newFilter.accept(this, context)))
                 .copyStatsAndGroupIdFrom(project);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PushDownFilterThroughProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PushDownFilterThroughProject.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * merge consecutive projects
@@ -43,8 +44,8 @@ public class PushDownFilterThroughProject extends PlanPostProcessor {
 
         PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) child;
         Map<Slot, Expression> childAlias = project.getAliasToProducer();
-        if (filter.getInputSlots().stream().map(childAlias::get)
-                .anyMatch(expr -> expr != null && expr.containsNonfoldable())) {
+        if (filter.getInputSlots().stream().map(childAlias::get).filter(Objects::nonNull)
+                .anyMatch(Expression::containsNonfoldable)) {
             return filter;
         }
         PhysicalFilter<? extends Plan> newFilter = filter.withConjunctsAndChild(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
@@ -61,19 +61,6 @@ public class Validator extends PlanPostProcessor {
         Preconditions.checkArgument(!filter.getConjuncts().isEmpty()
                 && filter.getPredicate() != BooleanLiteral.TRUE, "Filter predicate can't be empty or true");
 
-        Plan child = filter.child();
-        // Forbidden filter-project, we must make filter-project -> project-filter.
-        // except that the project contains NoneMovableFunction
-        if (child instanceof PhysicalProject) {
-            PhysicalProject<?> project = (PhysicalProject<?>) child;
-            if (!project.containsNoneMovableFunction()
-                    && filter.getInputSlots().stream().map(project.getAliasToProducer()::get).filter(Objects::nonNull)
-                            .noneMatch(Expression::containsNonfoldable)) {
-                throw new AnalysisException(
-                        "Nereids generate a filter-project plan, but backend not support:\n" + filter.treeString());
-            }
-        }
-
         return visit(filter, context);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
@@ -62,7 +62,9 @@ public class Validator extends PlanPostProcessor {
         Plan child = filter.child();
         // Forbidden filter-project, we must make filter-project -> project-filter.
         // except that the project contains NoneMovableFunction
-        if (child instanceof PhysicalProject && !((PhysicalProject<?>) child).containsNoneMovableFunction()) {
+        if (child instanceof PhysicalProject && !((PhysicalProject<?>) child).containsNoneMovableFunction()
+                && filter.getInputSlots().stream().map(((PhysicalProject<?>) child).getAliasToProducer()::get)
+                        .anyMatch(expr -> expr != null && expr.containsNonfoldable())) {
             throw new AnalysisException(
                     "Nereids generate a filter-project plan, but backend not support:\n" + filter.treeString());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
@@ -64,7 +64,7 @@ public class Validator extends PlanPostProcessor {
         // except that the project contains NoneMovableFunction
         if (child instanceof PhysicalProject && !((PhysicalProject<?>) child).containsNoneMovableFunction()
                 && filter.getInputSlots().stream().map(((PhysicalProject<?>) child).getAliasToProducer()::get)
-                        .anyMatch(expr -> expr != null && expr.containsNonfoldable())) {
+                        .noneMatch(expr -> expr != null && expr.containsNonfoldable())) {
             throw new AnalysisException(
                     "Nereids generate a filter-project plan, but backend not support:\n" + filter.treeString());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
-import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotNotFromChildren;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
@@ -33,7 +32,6 @@ import org.apache.doris.nereids.util.Utils;
 import com.google.common.base.Preconditions;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterThroughProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterThroughProject.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Sets;
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -72,6 +73,7 @@ public class PushDownFilterThroughProject implements RewriteRuleFactory {
     private static Plan pushDownFilterThroughProject(LogicalFilter<LogicalProject<Plan>> filter) {
         LogicalProject<? extends Plan> project = filter.child();
         Set<Slot> childOutputs = project.getOutputSet();
+        Map<Slot, Expression> childAlias = project.getAliasToProducer();
         // we need run this rule before subquery unnesting
         // therefore the conjuncts may contain slots from outer query
         // we should only push down conjuncts without any outer query's slot,
@@ -79,23 +81,15 @@ public class PushDownFilterThroughProject implements RewriteRuleFactory {
         // splitConjuncts.first -> conjuncts having outer query slots which should NOT be pushed down
         // splitConjuncts.second -> conjuncts without any outer query slots which should be pushed down
         Pair<Set<Expression>, Set<Expression>> splitConjuncts =
-                splitConjunctsByChildOutput(filter.getConjuncts(), childOutputs);
-        if (splitConjuncts.second.isEmpty()) {
-            // all conjuncts contain outer query's slots, no conjunct can be pushed down
-            // just return unchanged plan
+                splitConjunctsByChildOutput(filter.getConjuncts(), childOutputs, childAlias);
+        Set<Expression> remainPredicates = splitConjuncts.first;
+        Set<Expression> pushDownPredicates = splitConjuncts.second;
+        if (pushDownPredicates.isEmpty()) {
             return null;
         }
-        Set<Expression> conjuncts;
-        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().enableCompressMaterialize) {
-            conjuncts = ExpressionUtils.replace(eliminateDecodeAndEncode(splitConjuncts.second),
-                    project.getAliasToProducer());
-        } else {
-            conjuncts = ExpressionUtils.replace(splitConjuncts.second,
-                    project.getAliasToProducer());
-        }
-        project = (LogicalProject<? extends Plan>) project.withChildren(new LogicalFilter<>(conjuncts,
-                project.child()));
-        return PlanUtils.filterOrSelf(splitConjuncts.first, project);
+        project = (LogicalProject<? extends Plan>) project.withChildren(
+                new LogicalFilter<>(pushDownPredicates, project.child()));
+        return PlanUtils.filterOrSelf(remainPredicates, project);
     }
 
     private static Plan pushDownFilterThroughLimitProject(
@@ -103,37 +97,44 @@ public class PushDownFilterThroughProject implements RewriteRuleFactory {
         LogicalLimit<LogicalProject<Plan>> limit = filter.child();
         LogicalProject<Plan> project = limit.child();
         Set<Slot> childOutputs = project.getOutputSet();
+        Map<Slot, Expression> childAlias = project.getAliasToProducer();
         // split the conjuncts by child's output
         Pair<Set<Expression>, Set<Expression>> splitConjuncts =
-                splitConjunctsByChildOutput(filter.getConjuncts(), childOutputs);
-        if (splitConjuncts.second.isEmpty()) {
+                splitConjunctsByChildOutput(filter.getConjuncts(), childOutputs, childAlias);
+        Set<Expression> remainPredicates = splitConjuncts.first;
+        Set<Expression> pushDownPredicates = splitConjuncts.second;
+        if (pushDownPredicates.isEmpty()) {
             return null;
         }
-        Set<Expression> conjuncts;
-        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().enableCompressMaterialize) {
-            conjuncts = ExpressionUtils.replace(eliminateDecodeAndEncode(splitConjuncts.second),
-                    project.getAliasToProducer());
-        } else {
-            conjuncts = ExpressionUtils.replace(splitConjuncts.second,
-                    project.getAliasToProducer());
-        }
         project = project.withProjectsAndChild(project.getProjects(),
-                new LogicalFilter<>(
-                        conjuncts,
-                        limit.withChildren(project.child())));
-        return PlanUtils.filterOrSelf(splitConjuncts.first, project);
+                new LogicalFilter<>(pushDownPredicates, limit.withChildren(project.child())));
+        return PlanUtils.filterOrSelf(remainPredicates, project);
     }
 
     private static Pair<Set<Expression>, Set<Expression>> splitConjunctsByChildOutput(
-            Set<Expression> conjuncts, Set<Slot> childOutputs) {
+            Set<Expression> conjuncts, Set<Slot> childOutputs, Map<Slot, Expression> childAlias) {
         Set<Expression> pushDownPredicates = Sets.newLinkedHashSet();
         Set<Expression> remainPredicates = Sets.newLinkedHashSet();
         for (Expression conjunct : conjuncts) {
             Set<Slot> conjunctSlots = conjunct.getInputSlots();
-            if (childOutputs.containsAll(conjunctSlots)) {
+            // If filter contains non-foldable expression, it can push down, for example:
+            // `filter(a + random(1, 10) > 1) -> project(a)` => `project(a) -> filter(a + random(1, 10) > 1)`.
+            // If filter slot is alias and its expression contains non-foldable expression, it can't push down, example:
+            // `filter(a > 1) -> project(b + random(1, 10) as a)`, if push down filter, it got
+            // `project(b + random(1, 10) as a) -> filter(b + random(1, 10) > 1)`, it contains two distinct RANDOM.
+            if (childOutputs.containsAll(conjunctSlots)
+                    && conjunctSlots.stream().map(childAlias::get)
+                            .noneMatch(expr -> expr != null && expr.containsNonfoldable())) {
                 pushDownPredicates.add(conjunct);
             } else {
                 remainPredicates.add(conjunct);
+            }
+        }
+        if (!pushDownPredicates.isEmpty()) {
+            if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().enableCompressMaterialize) {
+                pushDownPredicates = ExpressionUtils.replace(eliminateDecodeAndEncode(pushDownPredicates), childAlias);
+            } else {
+                pushDownPredicates = ExpressionUtils.replace(pushDownPredicates, childAlias);
             }
         }
         return Pair.of(remainPredicates, pushDownPredicates);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterThroughProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterThroughProject.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Sets;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -123,8 +124,8 @@ public class PushDownFilterThroughProject implements RewriteRuleFactory {
             // `filter(a > 1) -> project(b + random(1, 10) as a)`, if push down filter, it got
             // `project(b + random(1, 10) as a) -> filter(b + random(1, 10) > 1)`, it contains two distinct RANDOM.
             if (childOutputs.containsAll(conjunctSlots)
-                    && conjunctSlots.stream().map(childAlias::get)
-                            .noneMatch(expr -> expr != null && expr.containsNonfoldable())) {
+                    && conjunctSlots.stream().map(childAlias::get).filter(Objects::nonNull)
+                            .noneMatch(Expression::containsNonfoldable)) {
                 pushDownPredicates.add(conjunct);
             } else {
                 remainPredicates.add(conjunct);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDowFilterThroughProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDowFilterThroughProjectTest.java
@@ -43,8 +43,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 class PushDowFilterThroughProjectTest implements MemoPatternMatchSupported {
     private final LogicalOlapScan scan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
             PlanConstructor.student,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDowFilterThroughProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDowFilterThroughProjectTest.java
@@ -18,14 +18,18 @@
 package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.properties.OrderKey;
+import org.apache.doris.nereids.trees.expressions.Add;
 import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Random;
 import org.apache.doris.nereids.trees.expressions.functions.window.Rank;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.util.LogicalPlanBuilder;
@@ -36,7 +40,10 @@ import org.apache.doris.nereids.util.PlanConstructor;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 class PushDowFilterThroughProjectTest implements MemoPatternMatchSupported {
     private final LogicalOlapScan scan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
@@ -70,7 +77,7 @@ class PushDowFilterThroughProjectTest implements MemoPatternMatchSupported {
         Alias alias = new Alias(new ExprId(1), window, "window");
         ConnectContext context = MemoTestUtils.createConnectContext();
 
-        // filter -> limit -> project(windows)
+        // filter -> project(windows)
         LogicalPlan plan = new LogicalPlanBuilder(scan)
                 .projectExprs(ImmutableList.of(alias))
                 .filter(new IsNull(alias.toSlot()))
@@ -90,6 +97,47 @@ class PushDowFilterThroughProjectTest implements MemoPatternMatchSupported {
         PlanChecker.from(context, plan)
                 .applyTopDown(new PushDownFilterThroughProject())
                 .matches(logicalFilter(logicalLimit(logicalProject())));
+    }
+
+    @Test
+    void notPushDownFilterThroughNonfoldable() {
+        ConnectContext context = MemoTestUtils.createConnectContext();
+        Alias foldableAlias = new Alias(new ExprId(1), scan.getOutput().get(0), "a");
+        Alias nonfoldableAlias = new Alias(new ExprId(2),
+                new Random(new BigIntLiteral(1L), new BigIntLiteral(10L)), "b");
+        Expression nonfoldableAdd = new Add(foldableAlias.toSlot(),
+                new Random(new BigIntLiteral(1L), new BigIntLiteral(2L)));
+        Expression condition = new And(Lists.newArrayList(new IsNull(foldableAlias.toSlot()),
+                new IsNull(nonfoldableAlias.toSlot()), new IsNull(nonfoldableAdd)));
+        LogicalPlan plan = new LogicalPlanBuilder(scan)
+                .projectExprs(ImmutableList.of(foldableAlias, nonfoldableAlias))
+                .filter(condition)
+                .build();
+
+        PlanChecker.from(context, plan)
+                .applyTopDown(new PushDownFilterThroughProject())
+                .matches(
+                        logicalFilter(
+                                logicalProject(
+                                        logicalFilter().when(f -> f.getPredicate().toSql().equals(
+                                                "AND[id IS NULL,(id + random(1, 2)) IS NULL]"))))
+                                .when(f -> f.getPredicate().toSql().equals("b IS NULL")));
+
+        plan = new LogicalPlanBuilder(scan)
+                .projectExprs(ImmutableList.of(foldableAlias, nonfoldableAlias))
+                .limit(1)
+                .filter(condition)
+                .build();
+
+        PlanChecker.from(context, plan)
+                .applyTopDown(new PushDownFilterThroughProject())
+                .matches(
+                        logicalFilter(
+                                logicalProject(
+                                        logicalFilter(logicalLimit())
+                                                .when(f -> f.getPredicate().toSql().equals(
+                                                        "AND[id IS NULL,(id + random(1, 2)) IS NULL]"))))
+                                .when(f -> f.getPredicate().toSql().equals("b IS NULL")));
     }
 
     @Test

--- a/regression-test/data/nereids_rules_p0/filter_push_down/push_filter_through.out
+++ b/regression-test/data/nereids_rules_p0/filter_push_down/push_filter_through.out
@@ -294,7 +294,7 @@ PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
 ------PhysicalUnion
---------filter((cast(random() as INT) = 2))
+--------filter((id = 2))
 ----------PhysicalOneRowRelation
 --------filter((t2.id = 2))
 ----------PhysicalOlapScan[t2]
@@ -302,7 +302,7 @@ PhysicalResultSink
 -- !push_filter_union_all --
 PhysicalResultSink
 --PhysicalUnion
-----filter(cast(random() as INT) IN (2, 3))
+----filter(id IN (2, 3))
 ------PhysicalOneRowRelation
 ----filter(id IN (2, 3))
 ------PhysicalOlapScan[t2]
@@ -310,7 +310,7 @@ PhysicalResultSink
 -- !push_filter_intersect --
 PhysicalResultSink
 --PhysicalIntersect
-----filter(cast(random() as INT) IN (2, 3))
+----filter(id IN (2, 3))
 ------PhysicalOneRowRelation
 ----filter(id IN (2, 3))
 ------PhysicalOlapScan[t2]
@@ -318,8 +318,9 @@ PhysicalResultSink
 -- !push_filter_except --
 PhysicalResultSink
 --PhysicalExcept
-----filter((cast(random() as INT) = 2) and (t1.msg = ''))
-------PhysicalOlapScan[t1]
+----filter((id = 2))
+------filter((t1.msg = ''))
+--------PhysicalOlapScan[t1]
 ----filter((t2.id = 2) and (t2.msg = ''))
 ------PhysicalOlapScan[t2]
 


### PR DESCRIPTION
### What problem does this PR solve?

When the expression contains slots which is an alias and its original expression is non-foldable, then this expression cann't push down through project. For example:  

```filter(b > 1) -> project(a + random(1, 10) as b)```, 

if push down , it will got 

```project(a + random(1, 10) as b) -> filter(a + random(1, 10) > 1)```,

it will contains two distinct RANDOM function. This is an error.

But if the filter expression itself contains non-foldable expression, it can still push down. For example: 

```filter(a + random(1, 10) > 1) -> project(a)```,  

it can still push down the filter, and got 

```project(a) -> filter(a + random(1, 10) > 1)```. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

