### PR TITLE
[fix](java) export JAVA_OPTS at last

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -358,6 +358,7 @@ fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -207,6 +207,7 @@ elif [[ "${java_version}" -gt 8 ]]; then
 fi
 log "using java version ${java_version}"
 log "${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # add libs to CLASSPATH
 DORIS_FE_JAR=


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #47913

Problem Summary:

Export the `JAVA_OPTS` at last in `start_xxx.sh`.
Because user may use different version of java to run Doris, so different JAVA_OPTS
env variable may be used like `JAVA_OPTS` for java8, `JAVA_OPTS_FOR_JDK_17` for java 17.

But in `be/src/util/jni-util.cpp`, it only read `JAVA_OPTS` env variable.
So we need to set this variable at last. 