### PR TITLE
[style](properties)(log) Optimize invalid property alert words

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/property/PropertiesSet.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/property/PropertiesSet.java
@@ -80,7 +80,7 @@ public class PropertiesSet<T extends PropertySchema.SchemaGroup> {
             throws IllegalArgumentException {
         rawProperties.forEach(entry -> {
             if (!schemaGroup.getSchemas().containsKey(entry.toLowerCase())) {
-                throw new IllegalArgumentException("Invalid property " + entry);
+                throw new IllegalArgumentException("Invalid property [" + entry + "]");
             }
         });
     }
@@ -119,7 +119,7 @@ public class PropertiesSet<T extends PropertySchema.SchemaGroup> {
         rawProperties.forEach((key, value) -> {
             String entryKey = key.toLowerCase();
             if (!schemaGroup.getSchemas().containsKey(entryKey)) {
-                throw new IllegalArgumentException("Invalid property " + key);
+                throw new IllegalArgumentException("Invalid property [" + key + "]");
             }
             PropertySchema schema = schemaGroup.getSchemas().get(entryKey);
             properties.put(entryKey, reader.accept(schema, value));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterRoutineLoadStmt.java
@@ -151,7 +151,7 @@ public class AlterRoutineLoadStmt extends DdlStmt implements NotFallbackInParser
         Optional<String> optional = jobProperties.keySet().stream().filter(
                 entity -> !CONFIGURABLE_JOB_PROPERTIES_SET.contains(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         if (jobProperties.containsKey(CreateRoutineLoadStmt.DESIRED_CONCURRENT_NUMBER_PROPERTY)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeProperties.java
@@ -81,7 +81,7 @@ public class AnalyzeProperties {
     }
 
     public void check() throws AnalysisException {
-        String msgTemplate = "%s = %s is invalid property";
+        String msgTemplate = "[%s] = %s is invalid property";
         Optional<String> optional = properties.keySet().stream().filter(
                 entity -> !PROPERTIES_SET.contains(entity)).findFirst();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CopyIntoProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CopyIntoProperties.java
@@ -59,7 +59,7 @@ public class CopyIntoProperties extends CopyProperties {
         analyzeUseDeleteSign();
         for (Entry<String, String> entry : properties.entrySet()) {
             if (!COPY_PROPERTIES.contains(entry.getKey())) {
-                throw new AnalysisException("Property '" + entry.getKey() + "' is invalid");
+                throw new AnalysisException("Property [" + entry.getKey() + "] is invalid");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateFileStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateFileStmt.java
@@ -112,7 +112,7 @@ public class CreateFileStmt extends DdlStmt implements NotFallbackInParser {
         Optional<String> optional = properties.keySet().stream().filter(
                 entity -> !PROPERTIES_SET.contains(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         catalogName = properties.get(PROP_CATALOG);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -521,7 +521,7 @@ public class CreateRoutineLoadStmt extends DdlStmt implements NotFallbackInParse
         Optional<String> optional = jobProperties.keySet().stream().filter(
                 entity -> !PROPERTIES_SET.contains(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         desiredConcurrentNum = ((Long) Util.getLongPropertyOrDefault(

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -155,7 +155,7 @@ public class CreateSqlBlockRuleStmt extends DdlStmt implements NotFallbackInPars
         Optional<String> optional = properties.keySet().stream().filter(entity -> !PROPERTIES_SET.contains(entity))
                 .findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropFileStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropFileStmt.java
@@ -82,7 +82,7 @@ public class DropFileStmt extends DdlStmt implements NotFallbackInParser {
         Optional<String> optional = properties.keySet().stream().filter(
                 entity -> !PROP_CATALOG.equals(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         catalogName = properties.get(PROP_CATALOG);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -247,7 +247,7 @@ public abstract class InsertStmt extends DdlStmt implements NotFallbackInParser 
 
         for (Entry<String, String> entry : properties.entrySet()) {
             if (!InsertStmt.PROPERTIES_MAP.containsKey(entry.getKey())) {
-                throw new DdlException(entry.getKey() + " is invalid property");
+                throw new DdlException("[" + entry.getKey() + "] is invalid property");
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -326,7 +326,7 @@ public class LoadStmt extends DdlStmt implements NotFallbackInParser {
 
         for (Entry<String, String> entry : properties.entrySet()) {
             if (!PROPERTIES_MAP.containsKey(entry.getKey())) {
-                throw new DdlException(entry.getKey() + " is invalid property");
+                throw new DdlException("[" + entry.getKey() + "] is invalid property");
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StageProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StageProperties.java
@@ -85,7 +85,7 @@ public class StageProperties extends CopyProperties {
         analyzeDryRun();
         for (Entry<String, String> entry : properties.entrySet()) {
             if (!STAGE_PROPERTIES.contains(entry.getKey())) {
-                throw new AnalysisException("Property '" + entry.getKey() + "' is invalid");
+                throw new AnalysisException("Property [" + entry.getKey() + "] is invalid");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -472,7 +472,7 @@ public class JdbcResource extends Resource {
     public static void validateProperties(Map<String, String> properties) throws DdlException {
         for (String key : properties.keySet()) {
             if (!ALL_PROPERTIES.contains(key)) {
-                throw new DdlException("JDBC resource Property of " + key + " is unknown");
+                throw new DdlException("JDBC resource Property of [" + key + "] is unknown");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -203,7 +203,7 @@ public class StorageVaultMgr {
                         .filter(key -> !S3StorageVault.ALLOW_ALTER_PROPERTIES.contains(key))
                         .findAny()
                         .ifPresent(key -> {
-                            throw new IllegalArgumentException("Alter property " + key + " is not allowed.");
+                            throw new IllegalArgumentException("Alter property [" + key + "] is not allowed.");
                         });
                 request.setOp(Operation.ALTER_S3_VAULT);
             } else if (type == StorageVaultType.HDFS) {
@@ -213,7 +213,7 @@ public class StorageVaultMgr {
                                 || key.toLowerCase().contains(S3Properties.PROVIDER))
                         .findAny()
                         .ifPresent(key -> {
-                            throw new IllegalArgumentException("Alter property " + key + " is not allowed.");
+                            throw new IllegalArgumentException("Alter property [" + key + "] is not allowed.");
                         });
                 request.setOp(Operation.ALTER_HDFS_VAULT);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -439,7 +439,9 @@ public class DynamicPartitionUtil {
         }
         if (!invalidDynamicPartitionProperties.isEmpty()) {
             throw new DdlException("Invalid dynamic partition properties: "
-                    + String.join(", ", invalidDynamicPartitionProperties));
+                    + invalidDynamicPartitionProperties.stream()
+                    .map(prop -> "[" + prop + "]")
+                    .collect(Collectors.joining(", ")));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFileCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFileCommand.java
@@ -68,7 +68,7 @@ public class CreateFileCommand extends Command implements ForwardWithSync {
         Optional<String> optional = properties.keySet().stream().filter(
                 entity -> !PROPERTIES_SET.contains(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         catalogName = properties.get(PROP_CATALOG);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropFileCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropFileCommand.java
@@ -74,7 +74,7 @@ public class DropFileCommand extends DropCommand {
         Optional<String> optional = properties.keySet().stream().filter(
                 entity -> !PROP_CATALOG.equals(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         catalogName = properties.get(PROP_CATALOG);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/SqlBlockRuleCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/SqlBlockRuleCommand.java
@@ -95,7 +95,7 @@ public abstract class SqlBlockRuleCommand extends Command implements ForwardWith
         Optional<String> optional = properties.keySet().stream().filter(entity -> !PROPERTIES_SET.contains(entity))
                 .findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfo.java
@@ -406,7 +406,7 @@ public class CreateRoutineLoadInfo {
         Optional<String> optional = jobProperties.keySet().stream().filter(
                 entity -> !PROPERTIES_SET.contains(entity)).findFirst();
         if (optional.isPresent()) {
-            throw new AnalysisException(optional.get() + " is invalid property");
+            throw new AnalysisException("[" + optional.get() + "] is invalid property");
         }
 
         desiredConcurrentNum = ((Long) Util.getLongPropertyOrDefault(

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HudiTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HudiTableValuedFunction.java
@@ -82,7 +82,7 @@ public class HudiTableValuedFunction extends MetadataTableValuedFunction {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             // check ctl, db, tbl
             validParams.put(key.toLowerCase(), params.get(key));

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/IcebergTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/IcebergTableValuedFunction.java
@@ -85,7 +85,7 @@ public class IcebergTableValuedFunction extends MetadataTableValuedFunction {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             // check ctl, db, tbl
             validParams.put(key.toLowerCase(), params.get(key));

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/JobsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/JobsTableValuedFunction.java
@@ -52,7 +52,7 @@ public class JobsTableValuedFunction extends MetadataTableValuedFunction {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             validParams.put(key.toLowerCase(), params.get(key));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MvInfosTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MvInfosTableValuedFunction.java
@@ -84,7 +84,7 @@ public class MvInfosTableValuedFunction extends MetadataTableValuedFunction {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             // check ctl, db, tbl
             validParams.put(key.toLowerCase(), params.get(key));

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/PartitionValuesTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/PartitionValuesTableValuedFunction.java
@@ -72,7 +72,7 @@ public class PartitionValuesTableValuedFunction extends MetadataTableValuedFunct
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             // check ctl, db, tbl
             validParams.put(key.toLowerCase(), params.get(key));

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/PartitionsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/PartitionsTableValuedFunction.java
@@ -135,7 +135,7 @@ public class PartitionsTableValuedFunction extends MetadataTableValuedFunction {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             // check ctl, db, tbl
             validParams.put(key.toLowerCase(), params.get(key));

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TasksTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TasksTableValuedFunction.java
@@ -52,7 +52,7 @@ public class TasksTableValuedFunction extends MetadataTableValuedFunction {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
-                throw new AnalysisException("'" + key + "' is invalid property");
+                throw new AnalysisException("[" + key + "] is invalid property");
             }
             validParams.put(key.toLowerCase(), params.get(key));
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -84,6 +84,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -396,10 +397,10 @@ public class SchemaChangeJobV2Test {
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = new LinkedHashMap<>();
         properties.put(DynamicPartitionProperty.ENABLE, "true");
         properties.put(DynamicPartitionProperty.DYNAMIC_PARTITION_PROPERTY_PREFIX + "time_uint", "day");
-        properties.put(DynamicPartitionProperty.DYNAMIC_PARTITION_PROPERTY_PREFIX + "edn", "3");
+        properties.put(DynamicPartitionProperty.DYNAMIC_PARTITION_PROPERTY_PREFIX + "end ", "3");
         properties.put(DynamicPartitionProperty.PREFIX, "p");
         properties.put(DynamicPartitionProperty.BUCKETS, "30");
         properties.put("invalid_property", "invalid_value");
@@ -409,7 +410,7 @@ public class SchemaChangeJobV2Test {
         OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogMocker.TEST_TBL2_ID);
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("errCode = 2,"
-                + " detailMessage = Invalid dynamic partition properties: dynamic_partition.time_uint, dynamic_partition.edn");
+                + " detailMessage = Invalid dynamic partition properties: [dynamic_partition.time_uint], [dynamic_partition.end ]");
         schemaChangeHandler.process(alterClauses, db, olapTable);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterRoutineLoadStmtTest.java
@@ -127,7 +127,7 @@ public class AlterRoutineLoadStmtTest {
                 stmt.analyze(analyzer);
                 Assert.fail();
             } catch (AnalysisException e) {
-                Assert.assertTrue(e.getMessage().contains("format is invalid property"));
+                Assert.assertTrue(e.getMessage().contains("[format] is invalid property"));
             } catch (UserException e) {
                 Assert.fail();
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/StageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/StageTest.java
@@ -241,7 +241,7 @@ public class StageTest extends TestWithFeService {
 
         // with an unknown property
         sql = CREATE_STAGE_SQL + ", 'default.file.type' = 'csv', 'test_key'='test_value')";
-        parseAndAnalyzeWithException(sql, "'test_key' is invalid");
+        parseAndAnalyzeWithException(sql, "[test_key] is invalid");
     }
 
     @Test

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_alter.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_alter.groovy
@@ -51,7 +51,7 @@ suite("test_dynamic_partition_with_alter") {
 
         test {
             sql "alter table ${tbl} set ('dynamic_partition.time_uint' = 'day')"
-            exception "Invalid dynamic partition properties: dynamic_partition.time_uint"
+            exception "Invalid dynamic partition properties: [dynamic_partition.time_uint]"
         }
     } catch (Exception e) {
         sql "drop table if exists ${tbl}"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When executing SQL statements with properties, if some properties are based on valid keys with spaces, the returned exception information may be misleading.

For example, this alter statement
`alter table test_dynamic_partition set ( "dynamic_partition.start " = "-2");`

`[dynamic_partition.start]` is a valid property, but the user may have typed an extra space

Doris returned the following result:

`errCode = 2, detailMessage = Invalid dynamic partition properties: dynamic_partition.start`

Users may find it difficult to identify the issue from the returned information and may consider it a bug

**Optimized return information:**

`errCode = 2, detailMessage = Invalid dynamic partition properties: [dynamic_partition.start ]`

If multiple properties are illegal, they will be returned:

`errCode = 2, detailMessage = Invalid dynamic partition properties: [dynamic_partition.start ], [dynamic_partition.edn]`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

