### PR TITLE
[fix](pipeline) The sink operator should not be set to ready when closing the source operator

### DIFF
--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -513,11 +513,6 @@ Status PipelineXLocalState<SharedStateArg>::close(RuntimeState* state) {
         COUNTER_SET(_wait_for_dependency_timer, _dependency->watcher_elapse_time());
     }
     _closed = true;
-    // Some kinds of source operators has a 1-1 relationship with a sink operator (such as AnalyticOperator).
-    // We must ensure AnalyticSinkOperator will not be blocked if AnalyticSourceOperator already closed.
-    if (_shared_state && _shared_state->sink_deps.size() == 1) {
-        _shared_state->sink_deps.front()->set_always_ready();
-    }
     return Status::OK();
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

For broadcast join with shared hash table, if the building hash table instance is closed early, the other instances will receive incomplete `SharedHashTableContext`(`signaled` is true, but `hash_table_variants` is nullptr).

Related PR: #xxx

Problem Summary:
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:602:27 in 
/root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:602:27: runtime error: reference binding to null pointer of type 'HashTableVariants' (aka 'variant<std::monostate, MethodSerialized<JoinHashTable<doris::StringRef, DefaultHash<doris::StringRef>>>, MethodOneNumber<unsigned char, JoinHashTable<unsigned char, HashCRC32<doris::vectorized::UInt8>>>, MethodOneNumber<unsigned short, JoinHashTable<unsigned short, HashCRC32<doris::vectorized::UInt16>>>, MethodOneNumber<unsigned int, JoinHashTable<unsigned int, HashCRC32<doris::vectorized::UInt32>>>, MethodOneNumber<unsigned long, JoinHashTable<unsigned long, HashCRC32<doris::vectorized::UInt64>>>, MethodOneNumber<wide::integer<128, unsigned int>, JoinHashTable<wide::integer<128, unsigned int>, HashCRC32<doris::vectorized::UInt128>>>, MethodOneNumber<wide::integer<256, unsigned int>, JoinHashTable<wide::integer<256, unsigned int>, HashCRC32<doris::vectorized::UInt256>>>, MethodKeysFixed<JoinHashTable<unsigned long, HashCRC32<doris::vectorized::UInt64>>>, MethodKeysFixed<JoinHashTable<wide::integer<128, unsigned int>, HashCRC32<doris::vectorized::UInt128>>>, MethodKeysFixed<JoinHashTable<doris::vectorized::UInt136, HashCRC32<doris::vectorized::UInt136>>>, MethodKeysFixed<JoinHashTable<wide::integer<256, unsigned int>, HashCRC32<doris::vectorized::UInt256>>>, MethodStringNoCache<JoinHashTable<doris::StringRef, DefaultHash<doris::StringRef>>>>')
    #0 0x56030b6f6711 in doris::pipeline::HashJoinBuildSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:591:9
    #1 0x56030e0c7d33 in doris::pipeline::PipelineTask::execute(bool*) /root/doris/be/src/pipeline/pipeline_task.cpp:372:36
    #2 0x56030e11ab2a in doris::pipeline::TaskScheduler::_do_work(int) /root/doris/be/src/pipeline/task_scheduler.cpp:136:9
    #3 0x5602da0eb039 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:608:24
    #4 0x5602da0c1c7e in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #5 0x5602da0c1c7e in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #6 0x7f6b57315608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #7 0x7f6b575c2132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:602:27 in 
*** Query id: 2dd9d71557654cff-b00860f34cee21de ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1739696168 (unix time) try "date -d @1739696168" if you are using GNU date ***
*** Current BE git commitID: a9b13ff93a ***
*** SIGSEGV address not mapped to object (@0xf0) received by PID 15014 (TID 18813 OR 0x7f6098827700) from PID 240; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F6B574E6090 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::pipeline::HashJoinBuildSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:591
 5# doris::pipeline::PipelineTask::execute(bool*) at /root/doris/be/src/pipeline/pipeline_task.cpp:374
 6# doris::pipeline::TaskScheduler::_do_work(int) at /root/doris/be/src/pipeline/task_scheduler.cpp:136
 7# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:615
 8# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
 9# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
10# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

