### PR TITLE
Revert "[fix](java) should use JAVA_OPTS_FOR_JDK_17 instead of JAVA_OPTS"

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -107,8 +107,7 @@ const std::string GetKerb5ConfPath() {
     setenv("CLASSPATH", classpath.c_str(), 0);
 
     // LIBHDFS_OPTS
-    const std::string java_opts =
-            getenv("JAVA_OPTS_FOR_JDK_17") ? getenv("JAVA_OPTS_FOR_JDK_17") : "";
+    const std::string java_opts = getenv("JAVA_OPTS") ? getenv("JAVA_OPTS") : "";
     std::string libhdfs_opts =
             fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{} ", java_opts,
                         getenv("DORIS_HOME"), getenv("DORIS_HOME") + std::string("/lib"));
@@ -124,7 +123,7 @@ const std::string GetKerb5ConfPath() {
     if (rv == 0) {
         std::vector<std::string> options;
 
-        char* java_opts = getenv("JAVA_OPTS_FOR_JDK_17");
+        char* java_opts = getenv("JAVA_OPTS");
         if (java_opts == nullptr) {
             options = {
                     GetDorisJNIClasspathOption(), fmt::format("-Xmx{}", "1g"),
@@ -217,7 +216,7 @@ Status JniLocalFrame::push(JNIEnv* env, int max_local_ref) {
 }
 
 void JniUtil::parse_max_heap_memory_size_from_jvm(JNIEnv* env) {
-    // The start_be.sh would set JAVA_OPTS_FOR_JDK_17 inside LIBHDFS_OPTS
+    // The start_be.sh would set JAVA_OPTS inside LIBHDFS_OPTS
     std::string java_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     std::istringstream iss(java_opts);
     std::string opt;

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -384,7 +384,7 @@ if [[ -f "${DORIS_HOME}/conf/hdfs-site.xml" ]]; then
     export LIBHDFS3_CONF="${DORIS_HOME}/conf/hdfs-site.xml"
 fi
 
-# check java version and choose correct JAVA_OPTS_FOR_JDK_17
+# check java version and choose correct JAVA_OPTS
 java_version="$(
     set -e
     jdk_version "${JAVA_HOME}/bin/java"
@@ -412,13 +412,12 @@ if [[ "${MACHINE_OS}" == "Darwin" ]]; then
     fi
 
     if [[ -n "${JAVA_OPTS_FOR_JDK_17}" ]] && ! echo "${JAVA_OPTS_FOR_JDK_17}" | grep "${max_fd_limit/-/\\-}" >/dev/null; then
-        export JAVA_OPTS_FOR_JDK_17="${JAVA_OPTS_FOR_JDK_17} ${max_fd_limit}"
+        export JAVA_OPTS="${JAVA_OPTS_FOR_JDK_17} ${max_fd_limit}"
     fi
 fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
-export JAVA_OPTS="${final_java_opt}"
 
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -91,10 +91,10 @@ export DORIS_HOME
 
 # export env variables from fe.conf
 #
-# JAVA_OPTS_FOR_JDK_17
+# JAVA_OPTS
 # LOG_DIR
 # PID_DIR
-export JAVA_OPTS_FOR_JDK_17="-Xmx1024m"
+export JAVA_OPTS="-Xmx1024m"
 export LOG_DIR="${DORIS_HOME}/log"
 PID_DIR="$(
     cd "${curdir}"
@@ -204,7 +204,6 @@ else
 fi
 log "Using Java version ${java_version}"
 log "${final_java_opt}"
-export JAVA_OPTS="${final_java_opt}"
 
 # add libs to CLASSPATH
 DORIS_FE_JAR=

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -20,6 +20,9 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # Log dir
 LOG_DIR="${DORIS_HOME}/log/"
 
+# For jdk 8
+JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx2048m -DlogPath=$LOG_DIR/jni.log -Xloggc:$LOG_DIR/be.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
+
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djol.skipHotspotSAAttach=true -Xmx2048m -DlogPath=$LOG_DIR/jni.log -Xlog:gc*:$LOG_DIR/be.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED -Darrow.enable_null_check_for_get=false"
 

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -26,6 +26,9 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # Log dir
 LOG_DIR = ${DORIS_HOME}/log
 
+# For jdk 8
+JAVA_OPTS="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintClassHistogramAfterFullGC -Xloggc:$LOG_DIR/log/fe.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Dlog4j2.formatMsgNoLookups=true"
+
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR -Xlog:gc*,classhisto*=trace:$LOG_DIR/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
 


### PR DESCRIPTION
Reverts apache/doris#47913
Before this PR, the BE's JVM heap size does not follow the JAVA_OPTS_FOR_JDK17 in be.conf,
it use default value, which is 1/4 of physical memory.
After this PR, the BE's JVM heap size is set to 2GB, and it cause some test pipeline OOM.
So I revert this PR temporarily to try investigate the usage of BE's JVM first. 