### PR TITLE
[fix](Export) change the export logical

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2632,11 +2632,6 @@ public class Config extends ConfigBase {
     public static int maximum_parallelism_of_export_job = 50;
 
     @ConfField(mutable = true, description = {
-            "ExportExecutorTask任务中一个OutFile语句允许的最大tablets数量",
-            "The maximum number of tablets allowed by an OutfileStatement in an ExportExecutorTask"})
-    public static int maximum_tablets_of_outfile_in_export = 10;
-
-    @ConfField(mutable = true, description = {
             "是否用 mysql 的 bigint 类型来返回 Doris 的 largeint 类型",
             "Whether to use mysql's bigint type to return Doris's largeint type"})
     public static boolean use_mysql_bigint_for_largeint = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -106,8 +106,6 @@ public class ExportJob implements Writable {
 
     private static final String BROKER_PROPERTY_PREFIXES = "broker.";
 
-    private static final int MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT = Config.maximum_tablets_of_outfile_in_export;
-
     public static final String CONSISTENT_NONE = "none";
     public static final String CONSISTENT_PARTITION = "partition";
 
@@ -189,10 +187,9 @@ public class ExportJob implements Writable {
     /**
      * Each parallel has an associated Outfile list
      * which are organized into a two-dimensional list.
-     * Therefore, we can access the selectStmtListPerParallel
      * to get the outfile logical plans list responsible for each parallel task.
      */
-    private List<List<StatementBase>> selectStmtListPerParallel = Lists.newArrayList();
+    private List<Optional<StatementBase>> selectStmtPerParallel = Lists.newArrayList();
 
     private List<String> exportColumns = Lists.newArrayList();
 
@@ -255,8 +252,6 @@ public class ExportJob implements Writable {
      * according to the 'parallelism' set by the user.
      * The tablets which will be exported by this ExportJob are divided into 'parallelism' copies,
      * and each ExportTaskExecutor is responsible for a list of tablets.
-     * The tablets responsible for an ExportTaskExecutor will be assigned to multiple OutfileStmt
-     * according to the 'TABLETS_NUM_PER_OUTFILE_IN_EXPORT'.
      *
      * @throws UserException
      */
@@ -282,14 +277,10 @@ public class ExportJob implements Writable {
 
             // debug LOG output
             if (LOG.isDebugEnabled()) {
-                for (int i = 0; i < selectStmtListPerParallel.size(); ++i) {
+                for (int i = 0; i < selectStmtPerParallel.size(); ++i) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("ExportTaskExecutor {} is responsible for outfile:", i);
-                    }
-                    for (StatementBase outfile : selectStmtListPerParallel.get(i)) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("outfile sql: [{}]", outfile.toSql());
-                        }
+                        LOG.debug("outfile sql: [{}]", selectStmtPerParallel.get(i).get().toSql());
                     }
                 }
             }
@@ -312,21 +303,16 @@ public class ExportJob implements Writable {
         }
 
         // get all tablets
-        List<List<List<Long>>> tabletsListPerParallel = splitTablets();
+        List<List<Long>> tabletsListPerParallel = splitTablets();
 
         // Each Outfile clause responsible for MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT tablets
-        for (List<List<Long>> tabletsList : tabletsListPerParallel) {
-            List<StatementBase> logicalPlanAdapters = Lists.newArrayList();
-            for (List<Long> tabletIds : tabletsList) {
-                // generate LogicalPlan
-                LogicalPlan plan = generateOneLogicalPlan(qualifiedTableName, tabletIds,
-                        this.partitionNames, selectLists);
-                // generate  LogicalPlanAdapter
-                StatementBase statementBase = generateLogicalPlanAdapter(plan);
-
-                logicalPlanAdapters.add(statementBase);
-            }
-            selectStmtListPerParallel.add(logicalPlanAdapters);
+        for (List<Long> tabletsList : tabletsListPerParallel) {
+            // generate LogicalPlan
+            LogicalPlan plan = generateOneLogicalPlan(qualifiedTableName, tabletsList,
+                    this.partitionNames, selectLists);
+            // generate  LogicalPlanAdapter
+            StatementBase statementBase = generateLogicalPlanAdapter(plan);
+            selectStmtPerParallel.add(Optional.of(statementBase));
         }
     }
 
@@ -352,16 +338,13 @@ public class ExportJob implements Writable {
             });
         }
 
-        List<StatementBase> logicalPlanAdapters = Lists.newArrayList();
-
         // generate LogicalPlan
         LogicalPlan plan = generateOneLogicalPlan(qualifiedTableName, ImmutableList.of(),
                 ImmutableList.of(), selectLists);
         // generate  LogicalPlanAdapter
         StatementBase statementBase = generateLogicalPlanAdapter(plan);
 
-        logicalPlanAdapters.add(statementBase);
-        selectStmtListPerParallel.add(logicalPlanAdapters);
+        selectStmtPerParallel.add(Optional.of(statementBase));
     }
 
     private LogicalPlan generateOneLogicalPlan(List<String> qualifiedTableName, List<Long> tabletIds,
@@ -402,15 +385,15 @@ public class ExportJob implements Writable {
 
     private void generateExportJobExecutor() {
         jobExecutorList = Lists.newArrayList();
-        for (List<StatementBase> selectStmts : selectStmtListPerParallel) {
-            ExportTaskExecutor executor = new ExportTaskExecutor(selectStmts, this);
+        for (Optional<StatementBase> selectStmt : selectStmtPerParallel) {
+            ExportTaskExecutor executor = new ExportTaskExecutor(selectStmt, this);
             jobExecutorList.add(executor);
         }
 
         // add empty task to make export job could be finished finally if jobExecutorList is empty
         // which means that export table without data
         if (jobExecutorList.isEmpty()) {
-            ExportTaskExecutor executor = new ExportTaskExecutor(Lists.newArrayList(), this);
+            ExportTaskExecutor executor = new ExportTaskExecutor(Optional.empty(), this);
             jobExecutorList.add(executor);
         }
     }
@@ -434,77 +417,59 @@ public class ExportJob implements Writable {
             }
         }
 
-        List<List<TableRef>> tableRefListPerParallel = getTableRefListPerParallel();
-        LOG.info("Export Job [{}] is split into {} Export Task Executor.", id, tableRefListPerParallel.size());
+        List<TableRef> tableRefPerParallel = getTableRefListPerParallel();
+        LOG.info("Export Job [{}] is split into {} Export Task Executor.", id, tableRefPerParallel.size());
 
         // debug LOG output
         if (LOG.isDebugEnabled()) {
-            for (int i = 0; i < tableRefListPerParallel.size(); i++) {
+            for (int i = 0; i < tableRefPerParallel.size(); i++) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("ExportTaskExecutor {} is responsible for tablets:", i);
-                }
-                for (TableRef tableRef : tableRefListPerParallel.get(i)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Tablet id: [{}]", tableRef.getSampleTabletIds());
-                    }
+                    LOG.debug("Tablet id: [{}]", tableRefPerParallel.get(i).getSampleTabletIds());
                 }
             }
         }
 
         // generate 'select..outfile..' statement
-        for (List<TableRef> tableRefList : tableRefListPerParallel) {
-            List<StatementBase> selectStmtLists = Lists.newArrayList();
-            for (TableRef tableRef : tableRefList) {
-                List<TableRef> tmpTableRefList = Lists.newArrayList(tableRef);
-                FromClause fromClause = new FromClause(tmpTableRefList);
-                // generate outfile clause
-                OutFileClause outfile = new OutFileClause(this.exportPath, this.format, convertOutfileProperties());
-                SelectStmt selectStmt = new SelectStmt(list, fromClause, this.whereExpr, null,
-                        null, null, LimitElement.NO_LIMIT);
-                selectStmt.setOutFileClause(outfile);
-                selectStmt.setOrigStmt(new OriginStatement(selectStmt.toSql(), 0));
-                selectStmtLists.add(selectStmt);
-            }
-            selectStmtListPerParallel.add(selectStmtLists);
+        for (TableRef tableReferences : tableRefPerParallel) {
+            FromClause fromClause = new FromClause(Lists.newArrayList(tableReferences));
+            // generate outfile clause
+            OutFileClause outfile = new OutFileClause(this.exportPath, this.format, convertOutfileProperties());
+            SelectStmt selectStmt = new SelectStmt(list, fromClause, this.whereExpr, null,
+                    null, null, LimitElement.NO_LIMIT);
+            selectStmt.setOutFileClause(outfile);
+            selectStmt.setOrigStmt(new OriginStatement(selectStmt.toSql(), 0));
+            selectStmtPerParallel.add(Optional.of(selectStmt));
         }
 
         // debug LOG output
         if (LOG.isDebugEnabled()) {
-            for (int i = 0; i < selectStmtListPerParallel.size(); ++i) {
+            for (int i = 0; i < selectStmtPerParallel.size(); ++i) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("ExportTaskExecutor {} is responsible for outfile:", i);
-                }
-                for (StatementBase outfile : selectStmtListPerParallel.get(i)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("outfile sql: [{}]", outfile.toSql());
-                    }
+                    LOG.debug("outfile sql: [{}]", selectStmtPerParallel.get(i).get().toSql());
                 }
             }
         }
     }
 
-    private List<List<TableRef>> getTableRefListPerParallel() throws UserException {
-        List<List<List<Long>>> tabletsListPerParallel = splitTablets();
-
-        List<List<TableRef>> tableRefListPerParallel = Lists.newArrayList();
-        for (List<List<Long>> tabletsList : tabletsListPerParallel) {
-            List<TableRef> tableRefList = Lists.newArrayList();
-            for (List<Long> tablets : tabletsList) {
-                // Since export does not support the alias, here we pass the null value.
-                // we can not use this.tableRef.getAlias(),
-                // because the constructor of `Tableref` will convert this.tableRef.getAlias()
-                // into lower case when lower_case_table_names = 1
-                TableRef tblRef = new TableRef(this.tableRef.getName(), null,
-                        this.tableRef.getPartitionNames(), (ArrayList) tablets,
-                        this.tableRef.getTableSample(), this.tableRef.getCommonHints());
-                tableRefList.add(tblRef);
-            }
-            tableRefListPerParallel.add(tableRefList);
+    private List<TableRef> getTableRefListPerParallel() throws UserException {
+        List<List<Long>> tabletsListPerParallel = splitTablets();
+        List<TableRef> tableRefPerParallel = Lists.newArrayList();
+        for (List<Long> tabletsList : tabletsListPerParallel) {
+            // Since export does not support the alias, here we pass the null value.
+            // we can not use this.tableRef.getAlias(),
+            // because the constructor of `Tableref` will convert this.tableRef.getAlias()
+            // into lower case when lower_case_table_names = 1
+            TableRef tblRef = new TableRef(this.tableRef.getName(), null,
+                    this.tableRef.getPartitionNames(), (ArrayList) tabletsList,
+                    this.tableRef.getTableSample(), this.tableRef.getCommonHints());
+            tableRefPerParallel.add(tblRef);
         }
-        return tableRefListPerParallel;
+        return tableRefPerParallel;
     }
 
-    private List<List<List<Long>>> splitTablets() throws UserException {
+    private List<List<Long>> splitTablets() throws UserException {
         // get tablets
         Database db = Env.getCurrentEnv().getInternalCatalog().getDbOrAnalysisException(this.tableName.getDb());
         OlapTable table = db.getOlapTableOrAnalysisException(this.tableName.getTbl());
@@ -561,7 +526,7 @@ public class ExportJob implements Writable {
                             + "set parallelism to partition num.", id, totalPartitions, this.parallelism);
             }
             int start = 0;
-            List<List<List<Long>>> tabletsListPerParallel = new ArrayList<>();
+            List<List<Long>> tabletsListPerParallel = new ArrayList<>();
             for (int i = 0; i < realParallelism; ++i) {
                 int partitionNum = numPerParallel;
                 if (numPerQueryRemainder > 0) {
@@ -569,8 +534,9 @@ public class ExportJob implements Writable {
                     --numPerQueryRemainder;
                 }
                 List<List<Long>> tablets = new ArrayList<>(tabletIdList.subList(start, start + partitionNum));
+                List<Long> flatTablets = tablets.stream().flatMap(List::stream).collect(Collectors.toList());
                 start += partitionNum;
-                tabletsListPerParallel.add(tablets);
+                tabletsListPerParallel.add(flatTablets);
             }
             return tabletsListPerParallel;
         }
@@ -584,7 +550,7 @@ public class ExportJob implements Writable {
         Integer tabletsNumPerParallel = tabletsAllNum / this.parallelism;
         Integer tabletsNumPerQueryRemainder = tabletsAllNum - tabletsNumPerParallel * this.parallelism;
 
-        List<List<List<Long>>> tabletsListPerParallel = Lists.newArrayList();
+        List<List<Long>> tabletsListPerParallel = Lists.newArrayList();
         Integer realParallelism = this.parallelism;
         if (tabletsAllNum < this.parallelism) {
             realParallelism = tabletsAllNum;
@@ -600,14 +566,8 @@ public class ExportJob implements Writable {
                 --tabletsNumPerQueryRemainder;
             }
             List<Long> tabletsList = new ArrayList<>(flatTabletIdList.subList(start, start + tabletsNum));
-            List<List<Long>> tablets = new ArrayList<>();
-            for (int i = 0; i < tabletsList.size(); i += MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT) {
-                int end = Math.min(i + MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT, tabletsList.size());
-                tablets.add(new ArrayList<>(tabletsList.subList(i, end)));
-            }
-
             start += tabletsNum;
-            tabletsListPerParallel.add(tablets);
+            tabletsListPerParallel.add(tabletsList);
         }
         return tabletsListPerParallel;
     }
@@ -703,7 +663,7 @@ public class ExportJob implements Writable {
         finishTimeMs = System.currentTimeMillis();
         failMsg = new ExportFailMsg(type, msg);
         jobExecutorList.clear();
-        selectStmtListPerParallel.clear();
+        selectStmtPerParallel.clear();
         allOutfileInfo.clear();
         partitionToVersion.clear();
         if (FeConstants.runningUnitTest) {
@@ -753,7 +713,7 @@ public class ExportJob implements Writable {
         outfileInfo = GsonUtils.GSON.toJson(allOutfileInfo);
         // Clear the jobExecutorList to release memory.
         jobExecutorList.clear();
-        selectStmtListPerParallel.clear();
+        selectStmtPerParallel.clear();
         allOutfileInfo.clear();
         partitionToVersion.clear();
         Env.getCurrentEnv().getEditLog().logExportUpdateState(this, ExportJobState.FINISHED);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
@@ -54,7 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ExportTaskExecutor implements TransientTaskExecutor {
     private static final Logger LOG = LogManager.getLogger(ExportTaskExecutor.class);
 
-    List<StatementBase> selectStmtLists;
+    Optional<StatementBase> selectStmt;
 
     ExportJob exportJob;
 
@@ -66,9 +66,9 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
 
     private AtomicBoolean isFinished;
 
-    ExportTaskExecutor(List<StatementBase> selectStmtLists, ExportJob exportJob) {
+    ExportTaskExecutor(Optional<StatementBase> selectStmt, ExportJob exportJob) {
         this.taskId = UUID.randomUUID().getMostSignificantBits();
-        this.selectStmtLists = selectStmtLists;
+        this.selectStmt = selectStmt;
         this.exportJob = exportJob;
         this.isCanceled = new AtomicBoolean(false);
         this.isFinished = new AtomicBoolean(false);
@@ -89,16 +89,14 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
         LOG.debug("[Export Task] taskId: {} updating state to EXPORTING", taskId);
         exportJob.updateExportJobState(ExportJobState.EXPORTING, taskId, null, null, null);
         List<OutfileInfo> outfileInfoList = Lists.newArrayList();
-        for (int idx = 0; idx < selectStmtLists.size(); ++idx) {
-            LOG.debug("[Export Task] taskId: {} processing statement {}/{}",
-                    taskId, idx + 1, selectStmtLists.size());
+        if (selectStmt.isPresent()) {
             if (isCanceled.get()) {
-                LOG.debug("[Export Task] taskId: {} canceled during execution at statement {}", taskId, idx + 1);
+                LOG.debug("[Export Task] taskId: {} canceled during execution", taskId);
                 throw new JobException("Export executor has been canceled, task id: {}", taskId);
             }
             // check the version of tablets, skip if the consistency is in partition level.
             if (exportJob.getExportTable().isManagedTable() && !exportJob.isPartitionConsistency()) {
-                LOG.debug("[Export Task] taskId: {} checking tablet versions for statement {}", taskId, idx + 1);
+                LOG.debug("[Export Task] taskId: {} checking tablet versions", taskId);
                 try {
                     Database db = Env.getCurrentEnv().getInternalCatalog().getDbOrAnalysisException(
                             exportJob.getTableName().getDb());
@@ -109,7 +107,7 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
                     LOG.debug("[Export Lock] taskId: {}, table: {} acquired readLock", taskId, table.getName());
                     try {
                         List<Long> tabletIds;
-                        LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) selectStmtLists.get(idx);
+                        LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) selectStmt.get();
                         Optional<UnboundRelation> unboundRelation = findUnboundRelation(
                                 logicalPlanAdapter.getLogicalPlan());
                         tabletIds = unboundRelation.get().getTabletIds();
@@ -150,8 +148,8 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
             }
 
             try (AutoCloseConnectContext r = buildConnectContext()) {
-                LOG.debug("[Export Task] taskId: {} executing statement {}", taskId, idx + 1);
-                stmtExecutor = new StmtExecutor(r.connectContext, selectStmtLists.get(idx));
+                LOG.debug("[Export Task] taskId: {} executing", taskId);
+                stmtExecutor = new StmtExecutor(r.connectContext, selectStmt.get());
                 stmtExecutor.execute();
                 if (r.connectContext.getState().getStateType() == MysqlStateType.ERR) {
                     LOG.debug("[Export Task] taskId: {} failed with MySQL error: {}", taskId,
@@ -160,16 +158,11 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
                             ExportFailMsg.CancelType.RUN_FAIL, r.connectContext.getState().getErrorMessage());
                     return;
                 }
-                LOG.debug("[Export Task] taskId: {} statement {} executed successfully", taskId, idx + 1);
-                OutfileInfo outfileInfo = getOutFileInfo(r.connectContext.getResultAttachedInfo());
-                LOG.debug("[Export Task] taskId: {} got outfile info for statement {}:"
-                                + "fileNumber={}, totalRows={}, fileSize={}",
-                        taskId, idx + 1, outfileInfo.getFileNumber(),
-                        outfileInfo.getTotalRows(), outfileInfo.getFileSize());
-                outfileInfoList.add(outfileInfo);
+                LOG.debug("[Export Task] taskId: {} executed successfully", taskId);
+                outfileInfoList = getOutFileInfo(r.connectContext.getResultAttachedInfo());
             } catch (Exception e) {
-                LOG.debug("[Export Task] taskId: {} failed with exception during statement {}: {}",
-                        taskId, idx + 1, e.getMessage(), e);
+                LOG.debug("[Export Task] taskId: {} failed with exception: {}",
+                        taskId, e.getMessage(), e);
                 exportJob.updateExportJobState(ExportJobState.CANCELLED, taskId, null,
                         ExportFailMsg.CancelType.RUN_FAIL, e.getMessage());
                 throw new JobException(e);
@@ -213,12 +206,16 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
         return new AutoCloseConnectContext(connectContext);
     }
 
-    private OutfileInfo getOutFileInfo(Map<String, String> resultAttachedInfo) {
-        OutfileInfo outfileInfo = new OutfileInfo();
-        outfileInfo.setFileNumber(resultAttachedInfo.get(OutFileClause.FILE_NUMBER));
-        outfileInfo.setTotalRows(resultAttachedInfo.get(OutFileClause.TOTAL_ROWS));
-        outfileInfo.setFileSize(resultAttachedInfo.get(OutFileClause.FILE_SIZE));
-        outfileInfo.setUrl(resultAttachedInfo.get(OutFileClause.URL));
+    private List<OutfileInfo> getOutFileInfo(List<Map<String, String>> resultAttachedInfo) {
+        List<OutfileInfo> outfileInfo = Lists.newArrayList();
+        for (Map<String, String> row : resultAttachedInfo) {
+            OutfileInfo outfileInfoOneRow = new OutfileInfo();
+            outfileInfoOneRow.setFileNumber(row.get(OutFileClause.FILE_NUMBER));
+            outfileInfoOneRow.setTotalRows(row.get(OutFileClause.TOTAL_ROWS));
+            outfileInfoOneRow.setFileSize(row.get(OutFileClause.FILE_SIZE));
+            outfileInfoOneRow.setUrl(row.get(OutFileClause.URL));
+            outfileInfo.add(outfileInfoOneRow);
+        }
         return outfileInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -227,7 +227,7 @@ public class ConnectContext {
 
     private StatsErrorEstimator statsErrorEstimator;
 
-    private Map<String, String> resultAttachedInfo = Maps.newHashMap();
+    private List<Map<String, String>> resultAttachedInfo = Lists.newArrayList();
 
     private String workloadGroupName = "";
     private boolean isGroupCommit;
@@ -1095,11 +1095,11 @@ public class ConnectContext {
         return env.getAuth().getExecMemLimit(getQualifiedUser());
     }
 
-    public void setResultAttachedInfo(Map<String, String> resultAttachedInfo) {
-        this.resultAttachedInfo = resultAttachedInfo;
+    public void addResultAttachedInfo(Map<String, String> resultAttachedInfo) {
+        this.resultAttachedInfo.add(resultAttachedInfo);
     }
 
-    public Map<String, String> getResultAttachedInfo() {
+    public List<Map<String, String>> getResultAttachedInfo() {
         return resultAttachedInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2070,7 +2070,7 @@ public class StmtExecutor {
                     }
                     profile.getSummaryProfile().freshWriteResultConsumeTime();
                     context.updateReturnRows(batch.getBatch().getRows().size());
-                    context.setResultAttachedInfo(batch.getBatch().getAttachedInfos());
+                    context.addResultAttachedInfo(batch.getBatch().getAttachedInfos());
                 }
                 if (batch.isEos()) {
                     break;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExportToOutfileLogicalPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExportToOutfileLogicalPlanTest.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The `Export` sql finally generates the `Outfile` sql.
@@ -93,31 +94,18 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
                 + ");";
 
         List<Long> currentTablets1 = Arrays.asList(10010L, 10012L, 10014L, 10016L, 10018L, 10020L, 10022L, 10024L,
-                10026L, 10028L);
-        List<Long> currentTablets2 = Arrays.asList(10030L, 10032L, 10034L, 10036L, 10038L, 10040L, 10042L, 10044L,
-                10046L, 10048L);
-        List<Long> currentTablets3 = Arrays.asList(10050L, 10052L, 10054L, 10056L, 10058L, 10060L, 10062L, 10064L,
-                10066L, 10068L);
-        List<Long> currentTablets4 = Arrays.asList(10070L, 10072L, 10074L, 10076L, 10078L, 10080L, 10082L, 10084L,
+                10026L, 10028L, 10030L, 10032L, 10034L, 10036L, 10038L, 10040L, 10042L, 10044L,
+                10046L, 10048L, 10050L, 10052L, 10054L, 10056L, 10058L, 10060L, 10062L, 10064L,
+                10066L, 10068L, 10070L, 10072L, 10074L, 10076L, 10078L, 10080L, 10082L, 10084L,
                 10086L, 10088L);
         // generate outfile
-        List<List<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
+        List<Optional<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
 
         // check
         Assert.assertEquals(1, outfileSqlPerParallel.size());
-        Assert.assertEquals(4, outfileSqlPerParallel.get(0).size());
 
-        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(0)).getLogicalPlan();
+        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan1, false), Lists.newArrayList(), currentTablets1);
-
-        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(1)).getLogicalPlan();
-        checkPartitionsAndTablets(getUnboundRelation(plan2, false), Lists.newArrayList(), currentTablets2);
-
-        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(2)).getLogicalPlan();
-        checkPartitionsAndTablets(getUnboundRelation(plan3, false), Lists.newArrayList(), currentTablets3);
-
-        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(3)).getLogicalPlan();
-        checkPartitionsAndTablets(getUnboundRelation(plan4, false), Lists.newArrayList(), currentTablets4);
     }
 
     /**
@@ -153,25 +141,21 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
                 10086L, 10088L);
 
         // generate outfile
-        List<List<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
+        List<Optional<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
 
         // check
         Assert.assertEquals(4, outfileSqlPerParallel.size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(0).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(1).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(2).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(3).size());
 
-        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(0)).getLogicalPlan();
+        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan1, false), Lists.newArrayList(), currentTablets1);
 
-        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get(0)).getLogicalPlan();
+        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan2, false), Lists.newArrayList(), currentTablets2);
 
-        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get(0)).getLogicalPlan();
+        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan3, false), Lists.newArrayList(), currentTablets3);
 
-        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get(0)).getLogicalPlan();
+        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan4, false), Lists.newArrayList(), currentTablets4);
     }
 
@@ -199,41 +183,27 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
         // This export sql should generate 4 array, and there should be 1 outfile sql in per array.
         // The only difference between them is the TABLET(). They are:
         List<Long> currentTablets1 = Arrays.asList(10010L, 10012L, 10014L, 10016L, 10018L, 10020L, 10022L, 10024L,
-                10026L, 10028L);
-        List<Long> currentTablets12 = Arrays.asList(10030L, 10032L, 10034L, 10036L);
+                10026L, 10028L, 10030L, 10032L, 10034L, 10036L);
         List<Long> currentTablets2 = Arrays.asList(10038L, 10040L, 10042L, 10044L, 10046L, 10048L, 10050L, 10052L,
-                10054L, 10056L);
-        List<Long> currentTablets22 = Arrays.asList(10058L, 10060L, 10062L);
+                10054L, 10056L, 10058L, 10060L, 10062L);
         List<Long> currentTablets3 = Arrays.asList(10064L, 10066L, 10068L, 10070L, 10072L, 10074L, 10076L, 10078L,
-                10080L, 10082L);
-        List<Long> currentTablets32 = Arrays.asList(10084L, 10086L, 10088L);
+                10080L, 10082L, 10084L, 10086L, 10088L);
 
         // generate outfile
-        List<List<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
+        List<Optional<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
 
         // check
         Assert.assertEquals(3, outfileSqlPerParallel.size());
-        Assert.assertEquals(2, outfileSqlPerParallel.get(0).size());
-        Assert.assertEquals(2, outfileSqlPerParallel.get(1).size());
-        Assert.assertEquals(2, outfileSqlPerParallel.get(2).size());
 
-        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(0)).getLogicalPlan();
+        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan1, false), Lists.newArrayList(), currentTablets1);
 
-        LogicalPlan plan12 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(1)).getLogicalPlan();
-        checkPartitionsAndTablets(getUnboundRelation(plan12, false), Lists.newArrayList(), currentTablets12);
-
-        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get(0)).getLogicalPlan();
+        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan2, false), Lists.newArrayList(), currentTablets2);
 
-        LogicalPlan plan22 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get(1)).getLogicalPlan();
-        checkPartitionsAndTablets(getUnboundRelation(plan22, false), Lists.newArrayList(), currentTablets22);
 
-        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get(0)).getLogicalPlan();
+        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan3, false), Lists.newArrayList(), currentTablets3);
-
-        LogicalPlan plan32 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get(1)).getLogicalPlan();
-        checkPartitionsAndTablets(getUnboundRelation(plan32, false), Lists.newArrayList(), currentTablets32);
     }
 
     /**
@@ -267,26 +237,22 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
         List<String> currentPartitions = Arrays.asList("p1");
 
         // generate outfile
-        List<List<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
+        List<Optional<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
 
         // check
         Assert.assertEquals(4, outfileSqlPerParallel.size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(0).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(1).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(2).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(3).size());
 
 
-        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(0)).getLogicalPlan();
+        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan1, false), currentPartitions, currentTablets1);
 
-        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get(0)).getLogicalPlan();
+        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan2, false), currentPartitions, currentTablets2);
 
-        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get(0)).getLogicalPlan();
+        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan3, false), currentPartitions, currentTablets3);
 
-        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get(0)).getLogicalPlan();
+        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan4, false), currentPartitions, currentTablets4);
     }
 
@@ -320,25 +286,21 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
         List<String> currentPartitions = Arrays.asList("p1", "p4");
 
         // generate outfile
-        List<List<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
+        List<Optional<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
 
         // check
         Assert.assertEquals(4, outfileSqlPerParallel.size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(0).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(1).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(2).size());
-        Assert.assertEquals(1, outfileSqlPerParallel.get(3).size());
 
-        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(0)).getLogicalPlan();
+        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan1, false), currentPartitions, currentTablets1);
 
-        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get(0)).getLogicalPlan();
+        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan2, false), currentPartitions, currentTablets2);
 
-        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get(0)).getLogicalPlan();
+        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan3, false), currentPartitions, currentTablets3);
 
-        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get(0)).getLogicalPlan();
+        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan4, false), currentPartitions, currentTablets4);
     }
 
@@ -380,42 +342,39 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
         List<String> currentPartitions = Arrays.asList("p1");
 
         // generate outfile
-        List<List<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
+        List<Optional<StatementBase>> outfileSqlPerParallel = getOutfileSqlPerParallel(exportSql);
 
         // check
         Assert.assertEquals(10, outfileSqlPerParallel.size());
-        for (int i = 0; i < 10; ++i) {
-            Assert.assertEquals(1, outfileSqlPerParallel.get(i).size());
-        }
 
-        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get(0)).getLogicalPlan();
+        LogicalPlan plan1 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(0).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan1, false), currentPartitions, currentTablets1);
 
-        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get(0)).getLogicalPlan();
+        LogicalPlan plan2 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(1).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan2, false), currentPartitions, currentTablets2);
 
-        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get(0)).getLogicalPlan();
+        LogicalPlan plan3 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(2).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan3, false), currentPartitions, currentTablets3);
 
-        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get(0)).getLogicalPlan();
+        LogicalPlan plan4 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(3).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan4, false), currentPartitions, currentTablets4);
 
-        LogicalPlan plan5 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(4).get(0)).getLogicalPlan();
+        LogicalPlan plan5 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(4).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan5, false), currentPartitions, currentTablets5);
 
-        LogicalPlan plan6 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(5).get(0)).getLogicalPlan();
+        LogicalPlan plan6 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(5).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan6, false), currentPartitions, currentTablets6);
 
-        LogicalPlan plan7 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(6).get(0)).getLogicalPlan();
+        LogicalPlan plan7 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(6).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan7, false), currentPartitions, currentTablets7);
 
-        LogicalPlan plan8 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(7).get(0)).getLogicalPlan();
+        LogicalPlan plan8 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(7).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan8, false), currentPartitions, currentTablets8);
 
-        LogicalPlan plan9 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(8).get(0)).getLogicalPlan();
+        LogicalPlan plan9 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(8).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan9, false), currentPartitions, currentTablets9);
 
-        LogicalPlan plan10 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(9).get(0)).getLogicalPlan();
+        LogicalPlan plan10 = ((LogicalPlanAdapter) outfileSqlPerParallel.get(9).get()).getLogicalPlan();
         checkPartitionsAndTablets(getUnboundRelation(plan10, false), currentPartitions, currentTablets10);
     }
 
@@ -425,9 +384,9 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
     }
 
     // need open EnableNereidsPlanner
-    private List<List<StatementBase>> getOutfileSqlPerParallel(String exportSql) throws UserException {
+    private List<Optional<StatementBase>> getOutfileSqlPerParallel(String exportSql) throws UserException {
         ExportCommand exportCommand = (ExportCommand) parseSql(exportSql);
-        List<List<StatementBase>> selectStmtListPerParallel = Lists.newArrayList();
+        List<Optional<StatementBase>> selectStmtPerParallel = Lists.newArrayList();
         try {
             Method checkAllParameters = exportCommand.getClass().getDeclaredMethod("checkAllParameters",
                     ConnectContext.class, TableName.class, Map.class);
@@ -445,7 +404,7 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
 
             ExportJob job = (ExportJob) generateExportJob.invoke(
                     exportCommand, connectContext, exportCommand.getFileProperties(), tblName);
-            selectStmtListPerParallel = job.getSelectStmtListPerParallel();
+            selectStmtPerParallel = job.getSelectStmtPerParallel();
         } catch (NoSuchMethodException e) {
             throw new UserException(e);
         } catch (InvocationTargetException e) {
@@ -453,7 +412,7 @@ public class ExportToOutfileLogicalPlanTest extends TestWithFeService {
         } catch (IllegalAccessException e) {
             throw new UserException(e);
         }
-        return selectStmtListPerParallel;
+        return selectStmtPerParallel;
     }
 
     private void checkPartitionsAndTablets(UnboundRelation relation, List<String> currentPartitionNames,


### PR DESCRIPTION
Problem Summary:

Previously, Export would split the task into multiple threads, and each thread would further split the task into multiple outfiles, which were executed sequentially.
Each thread will decide how many outfiles to split into according to `maximum_tablets_of_outfile_in_export` and the actual number of partitions/buckets of the data.
Each thread executes multiple outfiles sequentially, with each Outfile task waiting for the previous one to complete before starting. This not only reduces export performance but also worsens the user experience, as users cannot clearly determine the actual concurrency performance of an Export Job.

Now, this logic has been simplified, and each thread will only handle one outfile without splitting it into multiple Outfile tasks. The parallelism value specified by the user in the `EXPORT` statement corresponds to the number of threads, with each thread handling one Outfile statement. This not only improves the user experience but also increases CPU utilization.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

