### PR TITLE
[fix](exchange) Fix mismatch columns in merging-exchange node

### DIFF
--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -51,8 +51,9 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
           _col_unique_id(tdesc.col_unique_id),
           _slot_idx(tdesc.slotIdx),
           _field_idx(-1),
-          _is_materialized(tdesc.isMaterialized || tdesc.need_materialize),
+          _is_materialized(tdesc.isMaterialized),
           _is_key(tdesc.is_key),
+          _need_materialize(tdesc.need_materialize),
           _column_paths(tdesc.column_paths),
           _is_auto_increment(tdesc.__isset.is_auto_increment ? tdesc.is_auto_increment : false),
           _col_default_value(tdesc.__isset.col_default_value ? tdesc.col_default_value : "") {}
@@ -70,6 +71,7 @@ SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
           _field_idx(-1),
           _is_materialized(pdesc.is_materialized()),
           _is_key(pdesc.is_key()),
+          _need_materialize(true),
           _column_paths(pdesc.column_paths().begin(), pdesc.column_paths().end()),
           _is_auto_increment(pdesc.is_auto_increment()) {}
 
@@ -83,8 +85,9 @@ SlotDescriptor::SlotDescriptor()
           _col_unique_id(0),
           _slot_idx(0),
           _field_idx(-1),
-          _is_materialized(true),
+          _is_materialized(false),
           _is_key(false),
+          _need_materialize(true),
           _is_auto_increment(false) {}
 #endif
 
@@ -531,7 +534,7 @@ int RowDescriptor::get_column_id(int slot_id, bool force_materialize_slot) const
     int column_id_counter = 0;
     for (auto* const tuple_desc : _tuple_desc_map) {
         for (auto* const slot : tuple_desc->slots()) {
-            if (!force_materialize_slot && !slot->is_materialized()) {
+            if (!force_materialize_slot && !slot->need_materialize()) {
                 continue;
             }
             if (slot->id() == slot_id) {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -80,6 +80,7 @@ public:
     int32_t col_unique_id() const { return _col_unique_id; }
 
     bool is_key() const { return _is_key; }
+    bool need_materialize() const { return _need_materialize; }
     const std::vector<std::string>& column_paths() const { return _column_paths; };
 
     bool is_auto_increment() const { return _is_auto_increment; }
@@ -122,6 +123,7 @@ private:
     const bool _is_materialized;
 
     const bool _is_key;
+    const bool _need_materialize;
     const std::vector<std::string> _column_paths;
 
     const bool _is_auto_increment;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -72,7 +72,7 @@ Block::Block(ColumnsWithTypeAndName data_) : data {std::move(data_)} {
 Block::Block(const std::vector<SlotDescriptor*>& slots, size_t block_size,
              bool ignore_trivial_slot) {
     for (auto* const slot_desc : slots) {
-        if (ignore_trivial_slot && !slot_desc->is_materialized()) {
+        if (ignore_trivial_slot && !slot_desc->need_materialize()) {
             continue;
         }
         auto column_ptr = slot_desc->get_empty_mutable_column();
@@ -1006,7 +1006,7 @@ MutableBlock::MutableBlock(const std::vector<TupleDescriptor*>& tuple_descs, int
                            bool ignore_trivial_slot) {
     for (auto* const tuple_desc : tuple_descs) {
         for (auto* const slot_desc : tuple_desc->slots()) {
-            if (ignore_trivial_slot && !slot_desc->is_materialized()) {
+            if (ignore_trivial_slot && !slot_desc->need_materialize()) {
                 continue;
             }
             _data_types.emplace_back(slot_desc->get_data_type_ptr());

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -2343,7 +2343,7 @@ Status OrcReader::on_string_dicts_loaded(
         int dict_pos = -1;
         int index = 0;
         for (const auto slot_desc : _tuple_descriptor->slots()) {
-            if (!slot_desc->is_materialized()) {
+            if (!slot_desc->need_materialize()) {
                 // should be ignored from reading
                 continue;
             }

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -826,7 +826,7 @@ Status RowGroupReader::_rewrite_dict_predicates() {
         int dict_pos = -1;
         int index = 0;
         for (const auto slot_desc : _tuple_descriptor->slots()) {
-            if (!slot_desc->is_materialized()) {
+            if (!slot_desc->need_materialize()) {
                 // should be ignored from reading
                 continue;
             }

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -422,6 +422,9 @@ Status NewOlapScanner::_init_variant_columns() {
         if (!slot->is_materialized()) {
             continue;
         }
+        if (!slot->need_materialize()) {
+            continue;
+        }
         if (slot->type().is_variant_type()) {
             // Such columns are not exist in frontend schema info, so we need to
             // add them into tablet_schema for later column indexing.
@@ -440,6 +443,9 @@ Status NewOlapScanner::_init_variant_columns() {
 Status NewOlapScanner::_init_return_columns() {
     for (auto* slot : _output_tuple_desc->slots()) {
         if (!slot->is_materialized()) {
+            continue;
+        }
+        if (!slot->need_materialize()) {
             continue;
         }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -365,7 +365,7 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
 Status ScannerContext::validate_block_schema(Block* block) {
     size_t index = 0;
     for (auto& slot : _output_tuple_desc->slots()) {
-        if (!slot->is_materialized()) {
+        if (!slot->need_materialize()) {
             continue;
         }
         auto& data = block->get_by_position(index++);

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -217,7 +217,7 @@ void VFileScanner::_init_runtime_filter_partition_prune_ctxs() {
 void VFileScanner::_init_runtime_filter_partition_prune_block() {
     // init block with empty column
     for (auto const* slot_desc : _real_tuple_desc->slots()) {
-        if (!slot_desc->is_materialized()) {
+        if (!slot_desc->need_materialize()) {
             // should be ignored from reading
             continue;
         }
@@ -253,7 +253,7 @@ Status VFileScanner::_process_runtime_filters_partition_prune(bool& can_filter_a
     size_t index = 0;
     bool first_column_filled = false;
     for (auto const* slot_desc : _real_tuple_desc->slots()) {
-        if (!slot_desc->is_materialized()) {
+        if (!slot_desc->need_materialize()) {
             // should be ignored from reading
             continue;
         }

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -93,7 +93,7 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
     int64_t rows_read_threshold = _num_rows_read + config::doris_scanner_row_num;
     if (!block->mem_reuse()) {
         for (auto* const slot_desc : _output_tuple_desc->slots()) {
-            if (!slot_desc->is_materialized()) {
+            if (!slot_desc->need_materialize()) {
                 // should be ignore from reading
                 continue;
             }

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -65,7 +65,7 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
                 state->desc_tbl().debug_string());
     }
     _column_name = &slot_desc->col_name();
-    if (!context->force_materialize_slot() && !slot_desc->is_materialized()) {
+    if (!context->force_materialize_slot() && !slot_desc->need_materialize()) {
         // slot should be ignored manually
         _column_id = -1;
         _prepare_finished = true;

--- a/be/src/vec/utils/util.hpp
+++ b/be/src/vec/utils/util.hpp
@@ -72,7 +72,7 @@ public:
         ColumnsWithTypeAndName columns_with_type_and_name;
         for (const auto& tuple_desc : row_desc.tuple_descriptors()) {
             for (const auto& slot_desc : tuple_desc->slots()) {
-                if (!slot_desc->is_materialized()) {
+                if (!slot_desc->need_materialize()) {
                     continue;
                 }
                 columns_with_type_and_name.emplace_back(nullptr, slot_desc->get_data_type_ptr(),
@@ -86,7 +86,7 @@ public:
         NameAndTypePairs name_with_types;
         for (const auto& tuple_desc : row_desc.tuple_descriptors()) {
             for (const auto& slot_desc : tuple_desc->slots()) {
-                if (!slot_desc->is_materialized()) {
+                if (!slot_desc->need_materialize()) {
                     continue;
                 }
                 name_with_types.emplace_back(slot_desc->col_name(), slot_desc->get_data_type_ptr());
@@ -100,7 +100,7 @@ public:
         ColumnsWithTypeAndName columns_with_type_and_name;
         for (const auto& tuple_desc : row_desc.tuple_descriptors()) {
             for (const auto& slot_desc : tuple_desc->slots()) {
-                if (ignore_trivial_slot && !slot_desc->is_materialized()) {
+                if (ignore_trivial_slot && !slot_desc->need_materialize()) {
                     continue;
                 }
                 columns_with_type_and_name.emplace_back(


### PR DESCRIPTION
### What problem does this PR solve?

Introduced by #47702

F20250218 08:55:18.762200 10135 assert_cast.h:57] Bad cast from type:doris::vectorized::ColumnNullable to doris::vectorized::ColumnStr
*** Check failure stack trace: ***
    @     0x55bad64c6436  google::LogMessage::SendToLog()
    @     0x55bad64c2e80  google::LogMessage::Flush()
    @     0x55bad64c6c79  google::LogMessageFatal::~LogMessageFatal()
    @     0x55bacb081956  _ZZ11assert_castIRKN5doris10vectorized9ColumnStrIjEEL18TypeCheckOnRelease1ERKNS1_7IColumnEET_OT1_ENKUlOSA_E_clIS9_EES5_SD_
    @     0x55bacb081797  assert_cast<>()
    @     0x55bacb07f4ef  doris::vectorized::ColumnStr<>::insert_from()
    @     0x55bad00b7317  doris::vectorized::IColumn::insert_from_multi_column()
    @     0x55bad5555bc1  doris::vectorized::VSortedRunMerger::get_next()::$_1::operator()()
    @     0x55bad55551ef  doris::vectorized::VSortedRunMerger::get_next()
    @     0x55bad552fbc8  doris::vectorized::VDataStreamRecvr::get_next()
    @     0x55bad626bf83  doris::pipeline::ExchangeSourceOperatorX::get_block()
    @     0x55bad55fba4e  doris::pipeline::OperatorXBase::get_block_after_projects()
    @     0x55bad63ea221  doris::pipeline::PipelineTask::execute()
    @     0x55bad63fa3fd  doris::pipeline::TaskScheduler::_do_work()
    @     0x55bacbffc90a  doris::ThreadPool::dispatch_thread()
    @     0x55bacbff0ea1  doris::Thread::supervise_thread()
    @     0x7f945ba99ac3  (unknown)
    @     0x7f945bb2b850  (unknown)
    @              (nil)  (unknown)
*** Query id: dac13a78b39642cb-9218eca2d5a11638 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1739840118 (unix time) try "date -d @1739840118" if you are using GNU date ***
*** Current BE git commitID: a8e18b0a86 ***
*** SIGABRT unknown detail explain (@0x1cb6) received by PID 7350 (TID 10135 OR 0x7f909bbf6640) from PID 7350; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/signal_handler.h:421
 1# 0x00007F945BA47520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055BAD64D0D0D in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 6# 0x000055BAD64C334A in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
10# doris::vectorized::ColumnStr const& assert_cast const&, (TypeCheckOnRelease)1, doris::vectorized::IColumn const&>(doris::vectorized::IColumn const&)::{lambda(auto:1&&)#1}::operator()(doris::vectorized::IColumn const&) const at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/common/assert_cast.h:57
11# doris::vectorized::ColumnStr const& assert_cast const&, (TypeCheckOnRelease)1, doris::vectorized::IColumn const&>(doris::vectorized::IColumn const&) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/common/assert_cast.h:72
12# doris::vectorized::ColumnStr::insert_from(doris::vectorized::IColumn const&, unsigned long) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/columns/column_string.h:174
13# doris::vectorized::IColumn::insert_from_multi_column(std::vector > const&, std::vector >) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/columns/column.cpp:51
14# doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*)::$_1::operator()() const at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/runtime/vsorted_run_merger.cpp:172
15# doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
16# doris::vectorized::VDataStreamRecvr::get_next(doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
17# doris::pipeline::ExchangeSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/pipeline/exec/exchange_source_operator.cpp:160
18# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
19# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/pipeline/pipeline_task.cpp:376
20# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/pipeline/task_scheduler.cpp:138
21# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
22# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/thread.cpp:499
23# start_thread at ./nptl/pthread_create.c:442
24# 0x00007F945BB2B850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

