### PR TITLE
[feat](storage vault) Add object storage op check when creating resource

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
@@ -116,7 +116,7 @@ public class AzureResource extends Resource {
                             newProperties, "=", true, false, true, false));
         }
 
-        status = azureObjStorage.multiPartPutObject(testObj,
+        status = azureObjStorage.multipartUpload(testObj,
                 new ByteArrayInputStream(contentData), contentData.length);
         if (!Status.OK.equals(status)) {
             throw new DdlException(

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
@@ -19,11 +19,12 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.backup.Status;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.datasource.property.constants.S3Properties;
-import org.apache.doris.fs.remote.AzureFileSystem;
+import org.apache.doris.fs.obj.AzureObjStorage;
+import org.apache.doris.fs.obj.ObjStorage;
+import org.apache.doris.fs.obj.RemoteObjects;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -31,11 +32,13 @@ import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public class AzureResource extends Resource {
     private static final Logger LOG = LogManager.getLogger(AzureResource.class);
@@ -78,21 +81,56 @@ public class AzureResource extends Resource {
         this.properties = newProperties;
     }
 
-    private static void pingAzure(String bucketName, String rootPath,
+    protected static void pingAzure(String bucketName, String rootPath,
             Map<String, String> newProperties) throws DdlException {
-        if (FeConstants.runningUnitTest) {
-            return;
+
+        String testFile = "azure://" + bucketName + "/" + rootPath + "/"
+                + UUID.randomUUID().toString() + "/test-object-valid.txt";
+
+        byte[] contentData = new byte[2 * ObjStorage.CHUNK_SIZE];
+        Arrays.fill(contentData, (byte) 'A');
+        AzureObjStorage azureObjStorage = new AzureObjStorage(newProperties);
+
+        Status status = azureObjStorage.putObject(testFile, new ByteArrayInputStream(contentData), contentData.length);
+        if (!Status.OK.equals(status)) {
+            throw new DdlException(
+                    "ping azure failed(put), status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false));
         }
 
-        String testFile = "azure://" + bucketName + "/" + rootPath + "/test-object-valid.txt";
-        AzureFileSystem fileSystem = new AzureFileSystem(newProperties);
-        Status status = fileSystem.exists(testFile);
-        if (status != Status.OK && status.getErrCode() != Status.ErrCode.NOT_FOUND) {
+        status = azureObjStorage.headObject(testFile);
+        if (!Status.OK.equals(status)) {
             throw new DdlException(
                     "ping azure failed(head), status: " + status + ", properties: " + new PrintableMap<>(
                             newProperties, "=", true, false, true, false));
         }
-        LOG.info("success to ping azure");
+
+        RemoteObjects remoteObjects = azureObjStorage.listObjects(testFile, null);
+        LOG.info("remoteObjects: {}", remoteObjects);
+        Preconditions.checkArgument(remoteObjects.getObjectList().size() == 1, "remoteObjects.size() must equal 1");
+
+        status = azureObjStorage.deleteObject(testFile);
+        if (!Status.OK.equals(status)) {
+            throw new DdlException(
+                    "ping azure failed(delete), status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false));
+        }
+
+        status = azureObjStorage.multiPartPutObject(testFile,
+                new ByteArrayInputStream(contentData), contentData.length);
+        if (!Status.OK.equals(status)) {
+            throw new DdlException(
+                    "ping azure failed(multiPartPut), status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false));
+        }
+
+        status = azureObjStorage.deleteObject(testFile);
+        if (!Status.OK.equals(status)) {
+            throw new DdlException(
+                    "ping azure failed(delete), status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false));
+        }
+        LOG.info("Success to ping azure blob storage.");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -128,33 +128,41 @@ public class S3Resource extends Resource {
 
         Status status = s3ObjStorage.putObject(testObj, new ByteArrayInputStream(contentData), contentData.length);
         if (!Status.OK.equals(status)) {
-            throw new DdlException(
-                    "pingS3 failed(put), status: " + status + ", properties: " + new PrintableMap<>(
-                            newProperties, "=", true, false, true, false));
+            String errMsg = "pingS3 failed(put),"
+                    + " please check your endpoint, ak/sk or permissions(put/head/delete/list/multipartUpload),"
+                    + " status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false);
+            throw new DdlException(errMsg);
         }
 
         status = s3ObjStorage.headObject(testObj);
         if (!Status.OK.equals(status)) {
-            throw new DdlException(
-                    "pingS3 failed(head), status: " + status + ", properties: " + new PrintableMap<>(
-                            newProperties, "=", true, false, true, false));
+            String errMsg = "pingS3 failed(head),"
+                    + " please check your endpoint, ak/sk or permissions(put/head/delete/list/multipartUpload),"
+                    + " status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false);
+            throw new DdlException(errMsg);
         }
 
         RemoteObjects remoteObjects = s3ObjStorage.listObjects(testObj, null);
         LOG.info("remoteObjects: {}", remoteObjects);
 
-        status = s3ObjStorage.multiPartPutObject(testObj, new ByteArrayInputStream(contentData), contentData.length);
+        status = s3ObjStorage.multipartUpload(testObj, new ByteArrayInputStream(contentData), contentData.length);
         if (!Status.OK.equals(status)) {
-            throw new DdlException(
-                    "pingS3 failed(multiPartPut), status: " + status + ", properties: " + new PrintableMap<>(
-                            newProperties, "=", true, false, true, false));
+            String errMsg = "pingS3 failed(multipartUpload),"
+                    + " please check your endpoint, ak/sk or permissions(put/head/delete/list/multipartUpload),"
+                    + " status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false);
+            throw new DdlException(errMsg);
         }
 
         status = s3ObjStorage.deleteObject(testObj);
         if (!Status.OK.equals(status)) {
-            throw new DdlException(
-                    "pingS3 failed(delete), status: " + status + ", properties: " + new PrintableMap<>(
-                            newProperties, "=", true, false, true, false));
+            String errMsg = "pingS3 failed(delete),"
+                    + " please check your endpoint, ak/sk or permissions(put/head/delete/list/multipartUpload),"
+                    + " status: " + status + ", properties: " + new PrintableMap<>(
+                            newProperties, "=", true, false, true, false);
+            throw new DdlException(errMsg);
         }
 
         LOG.info("success to ping s3");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * S3 resource
@@ -119,8 +118,9 @@ public class S3Resource extends Resource {
     protected static void pingS3(String bucketName, String rootPath, Map<String, String> newProperties)
             throws DdlException {
 
-        String prefix = "s3://" + bucketName + "/" + rootPath + "/" + UUID.randomUUID().toString();
-        String testObj = prefix + "/test-object-valid.txt";
+        Long timestamp = System.currentTimeMillis();
+        String prefix = "s3://" + bucketName + "/" + rootPath;
+        String testObj = prefix + "/doris-test-object-valid-" + timestamp.toString() + ".txt";
 
         byte[] contentData = new byte[2 * ObjStorage.CHUNK_SIZE];
         Arrays.fill(contentData, (byte) 'A');
@@ -140,9 +140,8 @@ public class S3Resource extends Resource {
                             newProperties, "=", true, false, true, false));
         }
 
-        RemoteObjects remoteObjects = s3ObjStorage.listObjects(prefix, null);
+        RemoteObjects remoteObjects = s3ObjStorage.listObjects(testObj, null);
         LOG.info("remoteObjects: {}", remoteObjects);
-        Preconditions.checkArgument(remoteObjects.getObjectList().size() == 1, "remoteObjects.size() must equal 1");
 
         status = s3ObjStorage.multiPartPutObject(testObj, new ByteArrayInputStream(contentData), contentData.length);
         if (!Status.OK.equals(status)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -418,7 +418,7 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
     }
 
 
-    public Status multiPartPutObject(String remotePath, @Nullable InputStream inputStream, long totalBytes) {
+    public Status multipartUpload(String remotePath, @Nullable InputStream inputStream, long totalBytes) {
         Status st = Status.OK;
         long uploadedBytes = 0;
         int bytesRead = 0;
@@ -440,14 +440,14 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
             blockBlobClient.commitBlockList(blockIds);
         } catch (Exception e) {
             LOG.warn("remotePath:{}, ", remotePath, e);
-            st = new Status(Status.ErrCode.COMMON_ERROR, "Failed to multiPartPutObject " + remotePath
+            st = new Status(Status.ErrCode.COMMON_ERROR, "Failed to multipartUpload " + remotePath
                     + " reason: " + e.getMessage());
 
             if (blockBlobClient != null) {
                 try {
                     blockBlobClient.delete();
                 } catch (Exception e1) {
-                    LOG.warn("abort multiPartPutObject failed", e1);
+                    LOG.warn("abort multipartUpload failed", e1);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -42,6 +42,7 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.http.HttpStatus;
@@ -49,16 +50,19 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.UUID;
 
 public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
     private static final Logger LOG = LogManager.getLogger(AzureObjStorage.class);
@@ -165,10 +169,12 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
             LOG.info("get file " + remoteFilePath + " success: " + properties.toString());
             return Status.OK;
         } catch (BlobStorageException e) {
+            LOG.warn("{} getObject exception:", remoteFilePath, e);
             return new Status(
                     Status.ErrCode.COMMON_ERROR,
                     "get file from azure error: " + e.getServiceMessage());
         } catch (UserException e) {
+            LOG.warn("{} getObject exception:", remoteFilePath, e);
             return new Status(Status.ErrCode.COMMON_ERROR, "getObject "
                     + remoteFilePath + " failed: " + e.getMessage());
         }
@@ -182,10 +188,12 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
             blobClient.upload(content, contentLength);
             return Status.OK;
         } catch (BlobStorageException e) {
+            LOG.warn("{} putObject exception:", remotePath, e);
             return new Status(
                     Status.ErrCode.COMMON_ERROR,
                     "Error occurred while copying the blob:: " + e.getServiceMessage());
         } catch (UserException e) {
+            LOG.warn("{} putObject exception:", remotePath, e);
             return new Status(Status.ErrCode.COMMON_ERROR, "putObject "
                     + remotePath + " failed: " + e.getMessage());
         }
@@ -276,8 +284,8 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
     @Override
     public RemoteObjects listObjects(String remotePath, String continuationToken) throws DdlException {
         try {
-            ListBlobsOptions options = new ListBlobsOptions().setPrefix(remotePath);
             S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            ListBlobsOptions options = new ListBlobsOptions().setPrefix(uri.getKey());
             PagedIterable<BlobItem> pagedBlobs = getClient().getBlobContainerClient(uri.getBucket())
                     .listBlobs(options, continuationToken, null);
             PagedResponse<BlobItem> pagedResponse = pagedBlobs.iterableByPage().iterator().next();
@@ -407,5 +415,32 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
                                                      String newContinuationToken) {
         PagedIterable<BlobItem> pagedBlobs = client.listBlobs(options, newContinuationToken, null);
         return pagedBlobs.iterableByPage().iterator().next();
+    }
+
+
+    public Status multiPartPutObject(String remotePath, @Nullable InputStream inputStream, long totalBytes) {
+        Status st = Status.OK;
+        try {
+            long uploadedBytes = 0;
+            int bytesRead = 0;
+            byte[] buffer = new byte[CHUNK_SIZE];
+            List<String> blockIds = new ArrayList<>();
+
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            BlockBlobClient blockBlobClient = getClient().getBlobContainerClient(uri.getBucket())
+                    .getBlobClient(uri.getKey()).getBlockBlobClient();
+            while (uploadedBytes < totalBytes && (bytesRead = inputStream.read(buffer)) != -1) {
+                String blockId = Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
+                blockIds.add(blockId);
+                blockBlobClient.stageBlock(blockId, new ByteArrayInputStream(buffer, 0, bytesRead), bytesRead);
+                uploadedBytes += bytesRead;
+            }
+            blockBlobClient.commitBlockList(blockIds);
+        } catch (Exception e) {
+            LOG.warn("remotePath:{}, ", remotePath, e);
+            st = new Status(Status.ErrCode.COMMON_ERROR, "Failed to multiPartPutObject " + remotePath
+                    + " reason: " + e.getMessage());
+        }
+        return st;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
@@ -32,6 +32,8 @@ import java.io.InputStream;
  * @param <C> cloud SDK Client
  */
 public interface ObjStorage<C> {
+
+    // CHUNK_SIZE for multi part upload
     public static final int CHUNK_SIZE = 5 * 1024 * 1024;
 
     C getClient() throws UserException;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
@@ -32,6 +32,8 @@ import java.io.InputStream;
  * @param <C> cloud SDK Client
  */
 public interface ObjStorage<C> {
+    public static final int CHUNK_SIZE = 5 * 1024 * 1024;
+
     C getClient() throws UserException;
 
     Triple<String, String, String> getStsToken() throws DdlException;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -265,6 +265,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             LOG.info("total delete {} objects for dir {}", totalObjects, absolutePath);
             return Status.OK;
         } catch (DdlException e) {
+            LOG.warn("deleteObjects:", e);
             return new Status(Status.ErrCode.COMMON_ERROR, "list objects for delete objects failed: " + e.getMessage());
         } catch (Exception e) {
             LOG.warn(String.format("delete objects %s failed", absolutePath), e);
@@ -320,7 +321,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         }
     }
 
-    public Status multiPartPutObject(String remotePath, @Nullable InputStream inputStream, long totalBytes) {
+    public Status multipartUpload(String remotePath, @Nullable InputStream inputStream, long totalBytes) {
         Status st = Status.OK;
         long uploadedBytes = 0;
         int bytesRead = 0;
@@ -378,7 +379,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             getClient().completeMultipartUpload(completeMultipartUploadRequest);
         } catch (Exception e) {
             LOG.warn("remotePath:{}, ", remotePath, e);
-            st = new Status(Status.ErrCode.COMMON_ERROR, "Failed to multiPartPutObject " + remotePath
+            st = new Status(Status.ErrCode.COMMON_ERROR, "Failed to multipartUpload " + remotePath
                     + " reason: " + e.getMessage());
 
             if (uri != null && uploadId != null) {
@@ -390,7 +391,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                             .build();
                     getClient().abortMultipartUpload(abortMultipartUploadRequest);
                 } catch (Exception e1) {
-                    LOG.warn("Failed to abort multiPartPutObject " + remotePath, e1);
+                    LOG.warn("Failed to abort multipartUpload " + remotePath, e1);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/AzureResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/AzureResourceTest.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.DdlException;
+
+import com.google.common.base.Strings;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AzureResourceTest {
+    private static final Logger LOG = LogManager.getLogger(AzureResourceTest.class);
+
+    @Test
+    public void testPingAzure() {
+        try {
+            String azureAccoutName = System.getenv("AZURE_ACCOUNT_NAME");
+            String azureAccoutKey = System.getenv("AZURE_ACCOUNT_KEY");
+            String azureContainerName = System.getenv("AZURE_CONTAINER_NAME");
+
+            Assumptions.assumeTrue(!Strings.isNullOrEmpty(azureAccoutName), "AZURE_ACCOUNT_NAME isNullOrEmpty.");
+            Assumptions.assumeTrue(!Strings.isNullOrEmpty(azureAccoutKey), "AZURE_ACCOUNT_KEY isNullOrEmpty.");
+            Assumptions.assumeTrue(!Strings.isNullOrEmpty(azureContainerName), "AZURE_CONTAINER_NAME isNullOrEmpty.");
+
+            Map<String, String> properties = new HashMap<>();
+            properties.put("s3.endpoint", "endpoint");
+            properties.put("s3.region", "region");
+            properties.put("s3.access_key", azureAccoutName);
+            properties.put("s3.secret_key", azureAccoutKey);
+            AzureResource.pingAzure(azureContainerName, "fe_ut_prefix", properties);
+        } catch (DdlException e) {
+            LOG.info("testPingAzure exception:", e);
+            Assertions.assertTrue(false, e.getMessage());
+        }
+    }
+}

--- a/regression-test/pipeline/vault_p0/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/vault_p0/conf/regression-conf-custom.groovy
@@ -44,5 +44,4 @@ extMinioSk = "minioadmin"
 extMinioRegion = "us-east-1"
 extMinioBucket = "test-bucket"
 
-s3Source = "aliyun"
 s3Endpoint = "oss-cn-hongkong-internal.aliyuncs.com"


### PR DESCRIPTION
* When creating `S3Resource/AzureResource`, we will check if it can be accessed with `put/multiPartPut/list/head/delete` operator

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

