### PR TITLE
[feat](nereids) revert #23421: add between predicate back

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -52,6 +52,7 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
 import org.apache.doris.nereids.trees.expressions.CaseWhen;
 import org.apache.doris.nereids.trees.expressions.Cast;
@@ -381,6 +382,11 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
             }
         }
         return results.pop();
+    }
+
+    @Override
+    public Expr visitBetween(Between between, PlanTranslatorContext context) {
+        throw new RuntimeException("Unexpected invocation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -386,7 +386,9 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
     @Override
     public Expr visitBetween(Between between, PlanTranslatorContext context) {
-        throw new RuntimeException("Unexpected invocation");
+        And and = new And(new GreaterThanEqual(between.getCompareExpr(), between.getLowerBound()),
+                new LessThanEqual(between.getCompareExpr(), between.getUpperBound()));
+        return and.accept(this, context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -416,6 +416,7 @@ import org.apache.doris.nereids.trees.TableSample;
 import org.apache.doris.nereids.trees.expressions.Add;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.BitAnd;
 import org.apache.doris.nereids.trees.expressions.BitNot;
 import org.apache.doris.nereids.trees.expressions.BitOr;
@@ -3846,9 +3847,10 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     if (lower.equals(upper)) {
                         outExpression = new EqualTo(valueExpression, lower);
                     } else {
-                        outExpression = new And(
-                                new GreaterThanEqual(valueExpression, getExpression(ctx.lower)),
-                                new LessThanEqual(valueExpression, getExpression(ctx.upper))
+                        outExpression = new Between(
+                                valueExpression,
+                                getExpression(ctx.lower),
+                                getExpression(ctx.upper)
                         );
                     }
                     break;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -42,6 +42,7 @@ import org.apache.doris.nereids.rules.expression.rules.FoldConstantRuleOnFE;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
 import org.apache.doris.nereids.trees.expressions.BitNot;
 import org.apache.doris.nereids.trees.expressions.BoundStar;
@@ -677,6 +678,14 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
                 .map(e -> e.accept(this, context)).collect(Collectors.toList());
         InPredicate newInPredicate = inPredicate.withChildren(rewrittenChildren);
         return TypeCoercionUtils.processInPredicate(newInPredicate);
+    }
+
+    @Override
+    public Expression visitBetween(Between between, ExpressionRewriteContext context) {
+        List<Expression> rewrittenChildren = between.children().stream()
+                .map(e -> e.accept(this, context)).collect(Collectors.toList());
+        Between newBetween = between.withChildren(rewrittenChildren);
+        return TypeCoercionUtils.processBetween(newBetween);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionNormalization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionNormalization.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.rules.expression;
 
 import org.apache.doris.nereids.rules.expression.check.CheckCast;
+import org.apache.doris.nereids.rules.expression.rules.BetweenToCompound;
 import org.apache.doris.nereids.rules.expression.rules.ConvertAggStateCast;
 import org.apache.doris.nereids.rules.expression.rules.DigitalMaskingConvert;
 import org.apache.doris.nereids.rules.expression.rules.FoldConstantRule;
@@ -47,6 +48,7 @@ public class ExpressionNormalization extends ExpressionRewrite {
             bottomUp(
                 SupportJavaDateFormatter.INSTANCE,
                 NormalizeBinaryPredicatesRule.INSTANCE,
+                BetweenToCompound.INSTANCE,
                 InPredicateDedup.INSTANCE,
                 InPredicateExtractNonConstant.INSTANCE,
                 InPredicateToEqualToRule.INSTANCE,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRuleType.java
@@ -23,6 +23,7 @@ package org.apache.doris.nereids.rules.expression;
 public enum ExpressionRuleType {
     ADD_MIN_MAX,
     ARRAY_CONTAIN_TO_ARRAY_OVERLAP,
+    BETWEEN_TO_COMPOUND,
     BETWEEN_TO_EQUAL,
     CASE_WHEN_TO_IF,
     CHECK_CAST,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/BetweenToCompound.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/BetweenToCompound.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.expression.rules;
+
+import org.apache.doris.nereids.rules.expression.ExpressionPatternMatcher;
+import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
+import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
+import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
+import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Between;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Rewrites BetweenPredicates into an equivalent conjunctive CompoundPredicate,
+ * "not between" is first processed by the BetweenToCompoundRule and then by the SimplifyNotExprRule.
+ * Examples:
+ * A BETWEEN X AND Y ==> A >= X AND A <= Y
+ */
+public class BetweenToCompound implements ExpressionPatternRuleFactory {
+
+    public static BetweenToCompound INSTANCE = new BetweenToCompound();
+
+    @Override
+    public List<ExpressionPatternMatcher<? extends Expression>> buildRules() {
+        return ImmutableList.of(
+                matchesTopType(Between.class)
+                        .thenApply(ctx -> rewrite(ctx.expr, ctx.rewriteContext))
+                        .toRule(ExpressionRuleType.BETWEEN_TO_COMPOUND)
+        );
+    }
+
+    public Expression rewrite(Between expr, ExpressionRewriteContext context) {
+        Expression left = new GreaterThanEqual(expr.getCompareExpr(), expr.getLowerBound());
+        Expression right = new LessThanEqual(expr.getCompareExpr(), expr.getUpperBound());
+        return new And(left, right);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/BetweenToCompound.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/BetweenToCompound.java
@@ -44,7 +44,7 @@ public class BetweenToCompound implements ExpressionPatternRuleFactory {
     @Override
     public List<ExpressionPatternMatcher<? extends Expression>> buildRules() {
         return ImmutableList.of(
-                matchesTopType(Between.class)
+                matchesType(Between.class)
                         .thenApply(ctx -> rewrite(ctx.expr, ctx.rewriteContext))
                         .toRule(ExpressionRuleType.BETWEEN_TO_COMPOUND)
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -34,6 +34,7 @@ import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Match;
@@ -193,7 +194,8 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
 
     private static void collectConst(Expression expr, Map<String, Expression> constMap,
             Map<String, TExpr> tExprMap, IdGenerator<ExprId> idGenerator) {
-        if (expr.isConstant() && !expr.isLiteral() && !expr.anyMatch(e -> shouldSkipFold((Expression) e))) {
+        if (expr.isConstant() && !expr.isLiteral() && !(expr instanceof Between)
+                && !expr.anyMatch(e -> shouldSkipFold((Expression) e))) {
             String id = idGenerator.getNextId().toString();
             constMap.put(id, expr);
             Expr staleExpr;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -194,6 +194,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
 
     private static void collectConst(Expression expr, Map<String, Expression> constMap,
             Map<String, TExpr> tExprMap, IdGenerator<ExprId> idGenerator) {
+        // skip BetweenPredicate need to be rewrite to CompoundPredicate
         if (expr.isConstant() && !expr.isLiteral() && !(expr instanceof Between)
                 && !expr.anyMatch(e -> shouldSkipFold((Expression) e))) {
             String id = idGenerator.getNextId().toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -30,7 +30,6 @@ import org.apache.doris.nereids.rules.expression.rules.OneRangePartitionEvaluato
 import org.apache.doris.nereids.rules.expression.rules.OneRangePartitionEvaluator.EvaluateRangeResult;
 import org.apache.doris.nereids.rules.expression.rules.PartitionRangeExpander.PartitionSlotType;
 import org.apache.doris.nereids.trees.expressions.And;
-import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -375,15 +374,6 @@ public class OneRangePartitionEvaluator<K>
         }
         result = result.withRejectNot(false);
         return result;
-    }
-
-    @Override
-    public EvaluateRangeResult visitBetween(Between between, EvaluateRangeInput context) {
-        return visitAnd(
-                new And(
-                        new GreaterThanEqual(between.getCompareExpr(), between.getLowerBound()),
-                        new LessThanEqual(between.getCompareExpr(), between.getUpperBound())),
-                context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.rules.expression.rules.OneRangePartitionEvaluato
 import org.apache.doris.nereids.rules.expression.rules.OneRangePartitionEvaluator.EvaluateRangeResult;
 import org.apache.doris.nereids.rules.expression.rules.PartitionRangeExpander.PartitionSlotType;
 import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -374,6 +375,15 @@ public class OneRangePartitionEvaluator<K>
         }
         result = result.withRejectNot(false);
         return result;
+    }
+
+    @Override
+    public EvaluateRangeResult visitBetween(Between between, EvaluateRangeInput context) {
+        return visitAnd(
+                new And(
+                        new GreaterThanEqual(between.getCompareExpr(), between.getLowerBound()),
+                        new LessThanEqual(between.getCompareExpr(), between.getUpperBound())),
+                context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Between.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Between.java
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions;
+
+import org.apache.doris.nereids.exceptions.UnboundException;
+import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.BooleanType;
+import org.apache.doris.nereids.types.DataType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Between predicate expression.
+ */
+public class Between extends Expression implements TernaryExpression {
+
+    private final Expression compareExpr;
+    private final Expression lowerBound;
+    private final Expression upperBound;
+    /**
+     * Constructor of ComparisonPredicate.
+     *
+     * @param compareExpr    compare of expression
+     * @param lowerBound     left child of between predicate
+     * @param upperBound     right child of between predicate
+     */
+
+    public Between(Expression compareExpr, Expression lowerBound,
+                   Expression upperBound) {
+        super(ImmutableList.of(compareExpr, lowerBound, upperBound));
+        this.compareExpr = compareExpr;
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+    }
+
+    public Between(List<Expression> children) {
+        super(children);
+        this.compareExpr = children.get(0);
+        this.lowerBound = children.get(1);
+        this.upperBound = children.get(2);
+    }
+
+    @Override
+    public DataType getDataType() throws UnboundException {
+        return BooleanType.INSTANCE;
+    }
+
+    @Override
+    public boolean nullable() throws UnboundException {
+        return lowerBound.nullable() || upperBound.nullable();
+    }
+
+    @Override
+    public String computeToSql() {
+        return compareExpr.toSql() + " BETWEEN " + lowerBound.toSql() + " AND " + upperBound.toSql();
+    }
+
+    @Override
+    public String toString() {
+        return compareExpr + " BETWEEN " + lowerBound + " AND " + upperBound;
+    }
+
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitBetween(this, context);
+    }
+
+    public Expression getCompareExpr() {
+        return compareExpr;
+    }
+
+    public Expression getLowerBound() {
+        return lowerBound;
+    }
+
+    public Expression getUpperBound() {
+        return upperBound;
+    }
+
+    @Override
+    public Between withChildren(List<Expression> children) {
+        Preconditions.checkArgument(children.size() == 3);
+        return new Between(children);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Between that = (Between) o;
+        return Objects.equals(compareExpr, that.compareExpr)
+                && Objects.equals(lowerBound, that.lowerBound)
+                && Objects.equals(upperBound, that.upperBound)
+                && Objects.equals(children, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(compareExpr, lowerBound, upperBound);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.Any;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
 import org.apache.doris.nereids.trees.expressions.BinaryOperator;
 import org.apache.doris.nereids.trees.expressions.BitAnd;
@@ -331,6 +332,10 @@ public abstract class ExpressionVisitor<R, C>
 
     public R visitStructLiteral(StructLiteral structLiteral, C context) {
         return visitLiteral(structLiteral, context);
+    }
+
+    public R visitBetween(Between between, C context) {
+        return visit(between, context);
     }
 
     public R visitCompoundPredicate(CompoundPredicate compoundPredicate, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -1226,6 +1226,14 @@ public class TypeCoercionUtils {
                         .map(Expression::getDataType)
                         .collect(Collectors.toList()));
 
+        if (optionalCommonType.isPresent()) {
+            optionalCommonType = Optional.of(downgradeDecimalAndDateLikeType(
+                    optionalCommonType.get(),
+                    between.getCompareExpr(),
+                    between.getLowerBound(),
+                    between.getUpperBound()));
+        }
+
         return optionalCommonType
                 .map(commonType -> {
                     List<Expression> newChildren = between.children().stream()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.annotation.Developing;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Add;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
 import org.apache.doris.nereids.trees.expressions.BinaryOperator;
 import org.apache.doris.nereids.trees.expressions.BitAnd;
@@ -1206,6 +1207,33 @@ public class TypeCoercionUtils {
                     return caseWhen.withChildren(newChildren);
                 })
                 .orElseThrow(() -> new AnalysisException("Cannot find common type for case when " + caseWhen));
+    }
+
+    /**
+     * process between type coercion.
+     */
+    public static Expression processBetween(Between between) {
+        // check
+        between.checkLegalityBeforeTypeCoercion();
+
+        if (between.getLowerBound().getDataType().equals(between.getCompareExpr().getDataType())
+                && between.getUpperBound().getDataType().equals(between.getCompareExpr().getDataType())) {
+            return between;
+        }
+        Optional<DataType> optionalCommonType = TypeCoercionUtils.findWiderCommonTypeForComparison(
+                between.children()
+                        .stream()
+                        .map(Expression::getDataType)
+                        .collect(Collectors.toList()));
+
+        return optionalCommonType
+                .map(commonType -> {
+                    List<Expression> newChildren = between.children().stream()
+                            .map(e -> TypeCoercionUtils.castIfNotMatchType(e, commonType))
+                            .collect(Collectors.toList());
+                    return between.withChildren(newChildren);
+                })
+                .orElse(between);
     }
 
     private static boolean canCompareDate(DataType t1, DataType t2) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/BetweenTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/BetweenTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.nereids.parser;
 
-import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
@@ -35,6 +35,6 @@ public class BetweenTest {
 
         expression = "A between 1 and 2";
         result = PARSER.parseExpression(expression);
-        Assertions.assertInstanceOf(And.class, result);
+        Assertions.assertInstanceOf(Between.class, result);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.rules.expression;
 
 import org.apache.doris.nereids.rules.expression.rules.AddMinMax;
+import org.apache.doris.nereids.rules.expression.rules.BetweenToCompound;
 import org.apache.doris.nereids.rules.expression.rules.DistinctPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rules.ExtractCommonFactorRule;
 import org.apache.doris.nereids.rules.expression.rules.InPredicateDedup;
@@ -241,6 +242,19 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
     }
 
     @Test
+    void testBetweenToCompoundRule() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(
+                        BetweenToCompound.INSTANCE,
+                        SimplifyNotExprRule.INSTANCE)
+        ));
+
+        assertRewrite("a between c and d", "(a >= c) and (a <= d)");
+        assertRewrite("a not between c and d)", "(a < c) or (a > d)");
+
+    }
+
+    @Test
     void testSimplifyCastRule() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
                 bottomUp(SimplifyCastRule.INSTANCE)
@@ -310,7 +324,8 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
     void testAddMinMax() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
             bottomUp(
-                AddMinMax.INSTANCE
+                    AddMinMax.INSTANCE,
+                    BetweenToCompound.INSTANCE
             )
         ));
 
@@ -376,7 +391,8 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
                 bottomUp(
                         SimplifyRange.INSTANCE,
-                        AddMinMax.INSTANCE
+                        AddMinMax.INSTANCE,
+                        BetweenToCompound.INSTANCE
                 )
         ));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTest.java
@@ -250,7 +250,7 @@ class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
         ));
 
         assertRewrite("a between c and d", "(a >= c) and (a <= d)");
-        assertRewrite("a not between c and d)", "(a < c) or (a > d)");
+        assertRewrite("a not between c and d", "(a < c) or (a > d)");
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.rules.analysis.ExpressionAnalyzer;
+import org.apache.doris.nereids.rules.expression.rules.BetweenToCompound;
 import org.apache.doris.nereids.rules.expression.rules.RangeInference;
 import org.apache.doris.nereids.rules.expression.rules.RangeInference.EmptyValue;
 import org.apache.doris.nereids.rules.expression.rules.RangeInference.RangeValue;
@@ -95,7 +96,10 @@ public class SimplifyRangeTest extends ExpressionRewrite {
     @Test
     public void testSimplify() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
-            bottomUp(SimplifyRange.INSTANCE)
+            bottomUp(
+                    SimplifyRange.INSTANCE,
+                    BetweenToCompound.INSTANCE
+            )
         ));
         assertRewrite("TA", "TA");
         assertRewrite("TA > 3 or TA > null", "TA > 3 OR NULL");
@@ -109,7 +113,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewrite("TA > 3 or TA <=> null", "TA > 3 or TA <=> null");
         assertRewrite("(TA < 1 or TA > 2) or (TA >= 0 and TA <= 3)", "TA IS NOT NULL OR NULL");
         assertRewrite("TA between 10 and 20 or TA between 100 and 120 or TA between 15 and 25 or TA between 115 and 125",
-                "TA between 10 and 25 or TA between 100 and 125");
+                "TA >= 10 and TA <= 25 or TA >= 100 and TA <= 125");
         assertRewriteNotNull("TA > 3 and TA > null", "TA > 3 and NULL");
         assertRewriteNotNull("TA > 3 and TA < null", "TA > 3 and NULL");
         assertRewriteNotNull("TA > 3 and TA = null", "TA > 3 and NULL");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -244,6 +244,11 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         // random is non-foldable, so the two random(1, 10) are distinct, cann't merge range for them.
         Expression expr = rewrite("TA + random(1, 10) > 10 AND  TA + random(1, 10) < 1", Maps.newHashMap());
         Assertions.assertEquals("AND[((TA + random(1, 10)) > 10),((TA + random(1, 10)) < 1)]", expr.toSql());
+
+        expr = rewrite("TA + random(1, 10) between 10 and 20", Maps.newHashMap());
+        Assertions.assertEquals("AND[((TA + random(1, 10)) >= 10),((TA + random(1, 10)) <= 20)]", expr.toSql());
+        expr = rewrite("TA + random(1, 10) between 20 and 10", Maps.newHashMap());
+        Assertions.assertEquals("AND[(TA + random(1, 10)) IS NULL,NULL]", expr.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionEqualsTest.java
@@ -84,6 +84,14 @@ public class ExpressionEqualsTest {
     }
 
     @Test
+    public void testBetween() {
+        Between between1 = new Between(child1, left1, right1);
+        Between between2 = new Between(child2, left2, right2);
+        Assertions.assertEquals(between1, between2);
+        Assertions.assertEquals(between1.hashCode(), between2.hashCode());
+    }
+
+    @Test
     public void testNot() {
         Not not1 = new Not(child1);
         Not not2 = new Not(child2);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionParserTest.java
@@ -84,9 +84,10 @@ public class ExpressionParserTest extends ParserTestBase {
     public void testExprBetweenPredicate() {
         parseExpression("c BETWEEN a AND b")
                 .assertEquals(
-                        new And(
-                                new GreaterThanEqual(new UnboundSlot("c"), new UnboundSlot("a")),
-                                new LessThanEqual(new UnboundSlot("c"), new UnboundSlot("b"))
+                        new Between(
+                                new UnboundSlot("c"),
+                                new UnboundSlot("a"),
+                                new UnboundSlot("b")
                         )
                 );
     }

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_date_function_prune_mono.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_date_function_prune_mono.groovy
@@ -124,9 +124,9 @@ suite("test_date_prune_mono") {
     for (int i = 0; i < 2; i++) {
         if (i == 0) {
             // forbid rewrite not a>1 to a<=1
-            sql "set disable_nereids_rules = 'REWRITE_FILTER_EXPRESSION'"
+            sql "set disable_nereids_expression_rules = 'SIMPLIFY_NOT_EXPR'"
         } else {
-            sql "set disable_nereids_rules = ''"
+            sql "set disable_nereids_expression_rules = ''"
         }
         explain {
             sql """select * from mal_test_partition_range5_date_mono where not date(b)<="2020-01-14" """

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_date_function_prune_mono.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_date_function_prune_mono.groovy
@@ -124,9 +124,9 @@ suite("test_date_prune_mono") {
     for (int i = 0; i < 2; i++) {
         if (i == 0) {
             // forbid rewrite not a>1 to a<=1
-            sql "set disable_nereids_expression_rules = 'SIMPLIFY_NOT_EXPR'"
+            sql "set disable_nereids_rules = 'REWRITE_FILTER_EXPRESSION'"
         } else {
-            sql "set disable_nereids_expression_rules = ''"
+            sql "set disable_nereids_rules = ''"
         }
         explain {
             sql """select * from mal_test_partition_range5_date_mono where not date(b)<="2020-01-14" """

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
@@ -124,9 +124,9 @@ suite("test_date_trunc_prune") {
     for (int i = 0; i < 2; i++) {
         if (i == 0) {
             // forbid rewrite not a>1 to a<=1
-            sql "set disable_nereids_expression_rules = 'SIMPLIFY_NOT_EXPR'"
+            sql "set disable_nereids_rules = 'REWRITE_FILTER_EXPRESSION'"
         } else {
-            sql "set disable_nereids_expression_rules = ''"
+            sql "set disable_nereids_rules = ''"
         }
         explain {
             sql """select * from mal_test_partition_range5 where not date_trunc(b,'day')<="2020-01-14" """

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_date_trunc_prune.groovy
@@ -124,9 +124,9 @@ suite("test_date_trunc_prune") {
     for (int i = 0; i < 2; i++) {
         if (i == 0) {
             // forbid rewrite not a>1 to a<=1
-            sql "set disable_nereids_rules = 'REWRITE_FILTER_EXPRESSION'"
+            sql "set disable_nereids_expression_rules = 'SIMPLIFY_NOT_EXPR'"
         } else {
-            sql "set disable_nereids_rules = ''"
+            sql "set disable_nereids_expression_rules = ''"
         }
         explain {
             sql """select * from mal_test_partition_range5 where not date_trunc(b,'day')<="2020-01-14" """


### PR DESCRIPTION
### What problem does this PR solve?

When parse SQL  `random(1, 10)  between 2 and 8`,  it will rewrite as `random(1, 10) >= 2 and random(1, 10) <= 8`. But at the  rewritten moment, the random is still an unbound function, and it can't be known that it's a non-foldable function.  Then  it will bound it to RANDOM function,  but since it contains two unbound random functions,  so it will got two distinct bounded RANDOM function,  and the expression will evaluate random two times. It's wrong, so at the parse phase, BETWEEN shold not rewrite to AND. Only after had bounded functions, can rewrite BETWEEN to AND. 

So we need to add between predicate back.  Just revert #23421.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

