### PR TITLE
[fix](exchange) Fix mismatch columns in merging-exchange node

### DIFF
--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -51,7 +51,7 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
           _col_unique_id(tdesc.col_unique_id),
           _slot_idx(tdesc.slotIdx),
           _field_idx(-1),
-          _is_materialized(tdesc.isMaterialized || tdesc.need_materialize),
+          _is_materialized(tdesc.isMaterialized && tdesc.need_materialize),
           _is_key(tdesc.is_key),
           _column_paths(tdesc.column_paths),
           _is_auto_increment(tdesc.__isset.is_auto_increment ? tdesc.is_auto_increment : false),


### PR DESCRIPTION
### What problem does this PR solve?

Introduced by https://github.com/apache/doris/pull/47702

F20250218 08:55:18.762200 10135 assert_cast.h:57] Bad cast from type:doris::vectorized::ColumnNullable to doris::vectorized::ColumnStr
*** Check failure stack trace: ***
@ 0x55bad64c6436 google::LogMessage::SendToLog()
@ 0x55bad64c2e80 google::LogMessage::Flush()
@ 0x55bad64c6c79 google::LogMessageFatal::~LogMessageFatal()
@ 0x55bacb081956 ZZ11assert_castIRKN5doris10vectorized9ColumnStrIjEEL18TypeCheckOnRelease1ERKNS1_7IColumnEET_OT1_ENKUlOSA_E_clIS9_EES5_SD
@ 0x55bacb081797 assert_cast<>()
@ 0x55bacb07f4ef doris::vectorized::ColumnStr<>::insert_from()
@ 0x55bad00b7317 doris::vectorized::IColumn::insert_from_multi_column()
@ 0x55bad5555bc1 doris::vectorized::VSortedRunMerger::get_next()::$_1::operator()()
@ 0x55bad55551ef doris::vectorized::VSortedRunMerger::get_next()
@ 0x55bad552fbc8 doris::vectorized::VDataStreamRecvr::get_next()
@ 0x55bad626bf83 doris::pipeline::ExchangeSourceOperatorX::get_block()
@ 0x55bad55fba4e doris::pipeline::OperatorXBase::get_block_after_projects()
@ 0x55bad63ea221 doris::pipeline::PipelineTask::execute()
@ 0x55bad63fa3fd doris::pipeline::TaskScheduler::_do_work()
@ 0x55bacbffc90a doris::ThreadPool::dispatch_thread()
@ 0x55bacbff0ea1 doris::Thread::supervise_thread()
@ 0x7f945ba99ac3 (unknown)
@ 0x7f945bb2b850 (unknown)
@ (nil) (unknown)
*** Query id: dac13a78b39642cb-9218eca2d5a11638 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1739840118 (unix time) try "date -d @1739840118" if you are using GNU date ***
*** Current BE git commitID: https://github.com/apache/doris/commit/a8e18b0a8653e1b67acd6922b6f31e9d58e2d892 ***
*** SIGABRT unknown detail explain (@0x1cb6) received by PID 7350 (TID 10135 OR 0x7f909bbf6640) from PID 7350; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/signal_handler.h:421
1# 0x00007F945BA47520 in /lib/x86_64-linux-gnu/libc.so.6
2# pthread_kill at ./nptl/pthread_kill.c:89
3# raise at ../sysdeps/posix/raise.c:27
4# abort at ./stdlib/abort.c:81
5# 0x000055BAD64D0D0D in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
6# 0x000055BAD64C334A in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
7# google::LogMessage::SendToLog() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
8# google::LogMessage::Flush() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
10# doris::vectorized::ColumnStr const& assert_cast const&, (TypeCheckOnRelease)1, doris::vectorized::IColumn const&>(doris::vectorized::IColumn const&)::{lambda(auto:1&&)https://github.com/apache/doris/issues/1}::operator()(doris::vectorized::IColumn const&) const at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/common/assert_cast.h:57
11# doris::vectorized::ColumnStr const& assert_cast const&, (TypeCheckOnRelease)1, doris::vectorized::IColumn const&>(doris::vectorized::IColumn const&) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/common/assert_cast.h:72
12# doris::vectorized::ColumnStr::insert_from(doris::vectorized::IColumn const&, unsigned long) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/columns/column_string.h:174
13# doris::vectorized::IColumn::insert_from_multi_column(std::vector > const&, std::vector >) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/columns/column.cpp:51
14# doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*)::$_1::operator()() const at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/runtime/vsorted_run_merger.cpp:172
15# doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
16# doris::vectorized::VDataStreamRecvr::get_next(doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
17# doris::pipeline::ExchangeSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/pipeline/exec/exchange_source_operator.cpp:160
18# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
19# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/pipeline/pipeline_task.cpp:376
20# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/pipeline/task_scheduler.cpp:138
21# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/compatibility-deploy/be/lib/doris_be
22# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/thread.cpp:499
23# start_thread at ./nptl/pthread_create.c:442
24# 0x00007F945BB2B850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

