### PR TITLE
[fix](partition) Incorrectly add partition to non-partitioned table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1608,6 +1608,11 @@ public class InternalCatalog implements CatalogIf<Database> {
                 }
             }
 
+            if (partitionInfo.getType() != PartitionType.RANGE && partitionInfo.getType() != PartitionType.LIST
+                    && !isTempPartition) {
+                throw new DdlException("Alter table [" + olapTable.getName() + "] failed. Not a partitioned table");
+            }
+
             Map<String, String> properties = singlePartitionDesc.getProperties();
 
             /*

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AddExistsPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AddExistsPartitionTest.java
@@ -43,13 +43,14 @@ public class AddExistsPartitionTest extends TestWithFeService {
     public void testAddExistsPartition() throws Exception {
         DebugPointUtil.addDebugPoint("InternalCatalog.addPartition.noCheckExists", new DebugPoint());
         createDatabase("test");
-        createTable("CREATE TABLE test.tbl (k INT) DISTRIBUTED BY HASH(k) "
+        createTable("CREATE TABLE test.tbl (k INT) PARTITION BY LIST(`k`) ( PARTITION tbl values in ((1)) ) "
+                + "DISTRIBUTED BY HASH(k) "
                 + " BUCKETS 5 PROPERTIES ( \"replication_num\" = \"" + backendNum() + "\" )");
         List<Long> backendIds = Env.getCurrentSystemInfo().getAllBackendIds();
         Map<Long, Set<Long>> oldBackendTablets = Maps.newHashMap();
         for (long backendId : backendIds) {
             Set<Long> tablets = Sets.newHashSet(Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId));
-            Assertions.assertEquals(5,  tablets.size());
+            Assertions.assertEquals(5, tablets.size());
             oldBackendTablets.put(backendId, tablets);
         }
 
@@ -58,7 +59,7 @@ public class AddExistsPartitionTest extends TestWithFeService {
         Assertions.assertNotNull(getSqlStmtExecutor(addPartitionSql));
         for (long backendId : backendIds) {
             Set<Long> tablets = Sets.newHashSet(Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId));
-            Assertions.assertEquals(5,  tablets.size());
+            Assertions.assertEquals(5, tablets.size());
             Assertions.assertEquals(oldBackendTablets.get(backendId), tablets);
         }
     }

--- a/regression-test/suites/partition_p0/no_partition/test_add_partition_exception.groovy
+++ b/regression-test/suites/partition_p0/no_partition/test_add_partition_exception.groovy
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_add_partition_exception") {
+    sql "drop table if exists test_add_partition_exception_tbl"
+    sql """
+        CREATE TABLE IF NOT EXISTS test_add_partition_exception_tbl (
+            k1 int NOT NULL, 
+            k2 bigint NOT NULL
+        ) 
+        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")
+        """
+
+	test{
+		sql """ alter table test_add_partition_exception_tbl add partition p0 values in (("1"))"""
+		exception "Alter table [test_add_partition_exception_tbl] failed. Not a partitioned table"
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/apache/doris/issues/48111

Related PR: #xxx

```
mysql> CREATE TABLE t (
    ->     id int null,
    ->     k largeint null
    -> )
    -> DISTRIBUTED BY HASH(`k`, `id`) BUCKETS 16
    -> PROPERTIES (
    ->     "replication_num" = "1"
    -> );
Query OK, 0 rows affected (0.03 sec)

mysql> alter table t add partition p1 values in ((1));
Query OK, 0 rows affected (0.03 sec)

mysql> alter table t drop partition p1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Alter table [t] failed. Not a partitioned table
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

