### PR TITLE
[Fix](Error) missing field initializer

### DIFF
--- a/be/src/common/kerberos/kerberos_ticket_mgr.cpp
+++ b/be/src/common/kerberos/kerberos_ticket_mgr.cpp
@@ -112,7 +112,7 @@ Status KerberosTicketMgr::get_or_set_ticket_cache(
     new_ticket_cache->start_periodic_refresh();
 
     // Insert into _ticket_caches
-    KerberosTicketEntry entry {.cache = new_ticket_cache};
+    KerberosTicketEntry entry {.cache = new_ticket_cache, .last_access_time {}};
     auto [inserted_it, success] = _ticket_caches.emplace(key, std::move(entry));
     if (!success) {
         return Status::InternalError("Failed to insert ticket cache into map");


### PR DESCRIPTION
## Proposed changes
Issue Number: close #xxx

Compiling with -Werror turns a warning into an error , clang-18 now compiles correctly