### PR TITLE
[fix](Outfile) add two fields to `SELECT INTO OUTFILE`

### DIFF
--- a/be/src/vec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/vec/sink/writer/vfile_result_writer.cpp
@@ -275,12 +275,12 @@ Status VFileResultWriter::_send_result() {
     _is_result_sent = true;
 
     // The final stat result include:
-    // | FileNumber | Int     |
-    // | TotalRows  | Bigint  |
-    // | FileSize   | Bigint  |
-    // | URL        | Varchar |
-    // | WriteTime  | Varchar |
-    // | WriteSpeed | Varchar |
+    // | FileNumber      | Int     |
+    // | TotalRows       | Bigint  |
+    // | FileSize        | Bigint  |
+    // | URL             | Varchar |
+    // | WriteTimeSec    | Varchar |
+    // | WriteSpeedKB    | Varchar |
     // The type of these field should be consistent with types defined in OutFileClause.java of FE.
     MysqlRowBuffer<> row_buffer;
     row_buffer.push_int(_file_idx);                         // FileNumber
@@ -295,12 +295,12 @@ Status VFileResultWriter::_send_result() {
     double write_time = _file_write_timer->value() / nons_to_second;
     std::string formatted_write_time = fmt::format("{:.3f}", write_time);
     row_buffer.push_string(formatted_write_time.c_str(),
-                           formatted_write_time.length()); // WriteTime
+                           formatted_write_time.length()); // WriteTimeSec
 
     double write_speed = _get_write_speed(_written_data_bytes->value(), _file_write_timer->value());
     std::string formatted_write_speed = fmt::format("{:.2f}", write_speed);
     row_buffer.push_string(formatted_write_speed.c_str(),
-                           formatted_write_speed.length()); // WriteSpeed
+                           formatted_write_speed.length()); // WriteSpeedKB
 
     std::unique_ptr<TFetchDataResult> result = std::make_unique<TFetchDataResult>();
     result->result_batch.rows.resize(1);
@@ -312,8 +312,8 @@ Status VFileResultWriter::_send_result() {
             std::make_pair("TotalRows", std::to_string(_written_rows_counter->value())));
     attach_infos.insert(std::make_pair("FileSize", std::to_string(_written_data_bytes->value())));
     attach_infos.insert(std::make_pair("URL", file_url));
-    attach_infos.insert(std::make_pair("WriteTime", formatted_write_time));
-    attach_infos.insert(std::make_pair("WriteSpeed", formatted_write_speed));
+    attach_infos.insert(std::make_pair("WriteTimeSec", formatted_write_time));
+    attach_infos.insert(std::make_pair("WriteSpeedKB", formatted_write_speed));
 
     result->result_batch.__set_attached_infos(attach_infos);
     RETURN_NOT_OK_STATUS_WITH_WARN(_sinker->add_batch(_state, result),

--- a/be/src/vec/sink/writer/vfile_result_writer.h
+++ b/be/src/vec/sink/writer/vfile_result_writer.h
@@ -21,6 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <string>
@@ -99,6 +100,7 @@ private:
     Status _fill_result_block();
     // delete the dir of file_path
     Status _delete_dir();
+    double _get_write_speed(int64_t write_bytes, int64_t write_time);
 
     RuntimeState* _state; // not owned, set when init
     const pipeline::ResultFileOptions* _file_opts = nullptr;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -79,17 +79,23 @@ public class OutFileClause {
     public static final String TOTAL_ROWS = "TotalRows";
     public static final String FILE_SIZE = "FileSize";
     public static final String URL = "URL";
+    public static final String WRITE_TIME = "WriteTime";
+    public static final String WRITE_SPEED = "WriteSpeed";
 
     static {
         RESULT_COL_NAMES.add(FILE_NUMBER);
         RESULT_COL_NAMES.add(TOTAL_ROWS);
         RESULT_COL_NAMES.add(FILE_SIZE);
         RESULT_COL_NAMES.add(URL);
+        RESULT_COL_NAMES.add(WRITE_TIME);
+        RESULT_COL_NAMES.add(WRITE_SPEED);
 
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.INT));
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.VARCHAR));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.DOUBLE));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.DOUBLE));
 
         PARQUET_REPETITION_TYPE_MAP.put("required", TParquetRepetitionType.REQUIRED);
         PARQUET_REPETITION_TYPE_MAP.put("repeated", TParquetRepetitionType.REPEATED);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -79,16 +79,16 @@ public class OutFileClause {
     public static final String TOTAL_ROWS = "TotalRows";
     public static final String FILE_SIZE = "FileSize";
     public static final String URL = "URL";
-    public static final String WRITE_TIME = "WriteTime";
-    public static final String WRITE_SPEED = "WriteSpeed";
+    public static final String WRITE_TIME_SEC = "WriteTimeSec";
+    public static final String WRITE_SPEED_KB = "WriteSpeedKB";
 
     static {
         RESULT_COL_NAMES.add(FILE_NUMBER);
         RESULT_COL_NAMES.add(TOTAL_ROWS);
         RESULT_COL_NAMES.add(FILE_SIZE);
         RESULT_COL_NAMES.add(URL);
-        RESULT_COL_NAMES.add(WRITE_TIME);
-        RESULT_COL_NAMES.add(WRITE_SPEED);
+        RESULT_COL_NAMES.add(WRITE_TIME_SEC);
+        RESULT_COL_NAMES.add(WRITE_SPEED_KB);
 
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.INT));
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -94,8 +94,8 @@ public class OutFileClause {
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));
         RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.VARCHAR));
-        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.DOUBLE));
-        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.DOUBLE));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.VARCHAR));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.VARCHAR));
 
         PARQUET_REPETITION_TYPE_MAP.put("required", TParquetRepetitionType.REQUIRED);
         PARQUET_REPETITION_TYPE_MAP.put("repeated", TParquetRepetitionType.REPEATED);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
@@ -215,6 +215,8 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
             outfileInfoOneRow.setTotalRows(row.get(OutFileClause.TOTAL_ROWS));
             outfileInfoOneRow.setFileSize(row.get(OutFileClause.FILE_SIZE));
             outfileInfoOneRow.setUrl(row.get(OutFileClause.URL));
+            outfileInfo.setWriteTime(row.get(OutFileClause.WRITE_TIME));
+            outfileInfo.setWriteSpeed(row.get(OutFileClause.WRITE_SPEED));
             outfileInfo.add(outfileInfoOneRow);
         }
         return outfileInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
@@ -215,8 +215,8 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
             outfileInfoOneRow.setTotalRows(row.get(OutFileClause.TOTAL_ROWS));
             outfileInfoOneRow.setFileSize(row.get(OutFileClause.FILE_SIZE));
             outfileInfoOneRow.setUrl(row.get(OutFileClause.URL));
-            outfileInfo.setWriteTime(row.get(OutFileClause.WRITE_TIME_SEC));
-            outfileInfo.setWriteSpeed(row.get(OutFileClause.WRITE_SPEED_KB));
+            outfileInfoOneRow.setWriteTime(row.get(OutFileClause.WRITE_TIME_SEC));
+            outfileInfoOneRow.setWriteSpeed(row.get(OutFileClause.WRITE_SPEED_KB));
             outfileInfo.add(outfileInfoOneRow);
         }
         return outfileInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportTaskExecutor.java
@@ -215,8 +215,8 @@ public class ExportTaskExecutor implements TransientTaskExecutor {
             outfileInfoOneRow.setTotalRows(row.get(OutFileClause.TOTAL_ROWS));
             outfileInfoOneRow.setFileSize(row.get(OutFileClause.FILE_SIZE));
             outfileInfoOneRow.setUrl(row.get(OutFileClause.URL));
-            outfileInfo.setWriteTime(row.get(OutFileClause.WRITE_TIME));
-            outfileInfo.setWriteSpeed(row.get(OutFileClause.WRITE_SPEED));
+            outfileInfo.setWriteTime(row.get(OutFileClause.WRITE_TIME_SEC));
+            outfileInfo.setWriteSpeed(row.get(OutFileClause.WRITE_SPEED_KB));
             outfileInfo.add(outfileInfoOneRow);
         }
         return outfileInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/OutfileInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/OutfileInfo.java
@@ -34,4 +34,10 @@ public class OutfileInfo {
 
     @SerializedName("url")
     private String url;
+
+    @SerializedName("writeTime")
+    private String writeTime;
+
+    @SerializedName("writeSpeed")
+    private String writeSpeed;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ResultFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ResultFileSink.java
@@ -24,8 +24,6 @@ import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.util.FileFormatConstants;
 import org.apache.doris.thrift.TDataSink;
 import org.apache.doris.thrift.TDataSinkType;
@@ -149,56 +147,22 @@ public class ResultFileSink extends DataSink {
      * | TotalRows  | Bigint  |
      * | FileSize   | Bigint  |
      * | URL        | Varchar |
-     * | WriteTime  | Double |
-     * | WriteSpeed | Double |
+     * | WriteTime  | Varchar |
+     * | WriteSpeed | Varchar |
      */
     public static TupleDescriptor constructFileStatusTupleDesc(DescriptorTable descriptorTable) {
         TupleDescriptor resultFileStatusTupleDesc =
                 descriptorTable.createTupleDescriptor("result_file_status");
         resultFileStatusTupleDesc.setIsMaterialized(true);
-        // | FileNumber | Int     |
-        SlotDescriptor fileNumber = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        fileNumber.setLabel(OutFileClause.FILE_NUMBER);
-        fileNumber.setType(ScalarType.createType(PrimitiveType.INT));
-        fileNumber.setColumn(new Column(OutFileClause.FILE_NUMBER, ScalarType.createType(PrimitiveType.INT)));
-        fileNumber.setIsMaterialized(true);
-        fileNumber.setIsNullable(false);
-        // | TotalRows  | Bigint  |
-        SlotDescriptor totalRows = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        totalRows.setLabel(OutFileClause.TOTAL_ROWS);
-        totalRows.setType(ScalarType.createType(PrimitiveType.BIGINT));
-        totalRows.setColumn(new Column(OutFileClause.TOTAL_ROWS, ScalarType.createType(PrimitiveType.BIGINT)));
-        totalRows.setIsMaterialized(true);
-        totalRows.setIsNullable(false);
-        // | FileSize   | Bigint  |
-        SlotDescriptor fileSize = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        fileSize.setLabel(OutFileClause.FILE_SIZE);
-        fileSize.setType(ScalarType.createType(PrimitiveType.BIGINT));
-        fileSize.setColumn(new Column(OutFileClause.FILE_SIZE, ScalarType.createType(PrimitiveType.BIGINT)));
-        fileSize.setIsMaterialized(true);
-        fileSize.setIsNullable(false);
-        // | URL        | Varchar |
-        SlotDescriptor url = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        url.setLabel(OutFileClause.URL);
-        url.setType(ScalarType.createType(PrimitiveType.VARCHAR));
-        url.setColumn(new Column(OutFileClause.URL, ScalarType.createType(PrimitiveType.VARCHAR)));
-        url.setIsMaterialized(true);
-        url.setIsNullable(false);
-        // | WriteTime   | Double  |
-        SlotDescriptor writeTime = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        writeTime.setLabel(OutFileClause.WRITE_TIME);
-        writeTime.setType(ScalarType.createType(PrimitiveType.DOUBLE));
-        writeTime.setColumn(new Column(OutFileClause.WRITE_TIME, ScalarType.createType(PrimitiveType.DOUBLE)));
-        writeTime.setIsMaterialized(true);
-        writeTime.setIsNullable(false);
-        // | WriteSpeed   | Double  |
-        SlotDescriptor writeSpeed = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        writeSpeed.setLabel(OutFileClause.WRITE_SPEED);
-        writeSpeed.setType(ScalarType.createType(PrimitiveType.DOUBLE));
-        writeSpeed.setColumn(new Column(OutFileClause.WRITE_SPEED, ScalarType.createType(PrimitiveType.DOUBLE)));
-        writeSpeed.setIsMaterialized(true);
-        writeSpeed.setIsNullable(false);
-
+        for (int i = 0; i < OutFileClause.RESULT_COL_NAMES.size(); ++i) {
+            SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
+            slotDescriptor.setLabel(OutFileClause.RESULT_COL_NAMES.get(i));
+            slotDescriptor.setType(OutFileClause.RESULT_COL_TYPES.get(i));
+            slotDescriptor.setColumn(new Column(OutFileClause.RESULT_COL_NAMES.get(i),
+                    OutFileClause.RESULT_COL_TYPES.get(i)));
+            slotDescriptor.setIsMaterialized(true);
+            slotDescriptor.setIsNullable(false);
+        }
         resultFileStatusTupleDesc.computeStatAndMemLayout();
         return resultFileStatusTupleDesc;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ResultFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ResultFileSink.java
@@ -143,12 +143,12 @@ public class ResultFileSink extends DataSink {
 
     /**
      * Construct a tuple for file status, the tuple schema as following:
-     * | FileNumber | Int     |
-     * | TotalRows  | Bigint  |
-     * | FileSize   | Bigint  |
-     * | URL        | Varchar |
-     * | WriteTime  | Varchar |
-     * | WriteSpeed | Varchar |
+     * | FileNumber    | Int     |
+     * | TotalRows     | Bigint  |
+     * | FileSize      | Bigint  |
+     * | URL           | Varchar |
+     * | WriteTimeSec  | Varchar |
+     * | WriteSpeedKB  | Varchar |
      */
     public static TupleDescriptor constructFileStatusTupleDesc(DescriptorTable descriptorTable) {
         TupleDescriptor resultFileStatusTupleDesc =

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ResultFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ResultFileSink.java
@@ -149,35 +149,56 @@ public class ResultFileSink extends DataSink {
      * | TotalRows  | Bigint  |
      * | FileSize   | Bigint  |
      * | URL        | Varchar |
+     * | WriteTime  | Double |
+     * | WriteSpeed | Double |
      */
     public static TupleDescriptor constructFileStatusTupleDesc(DescriptorTable descriptorTable) {
         TupleDescriptor resultFileStatusTupleDesc =
                 descriptorTable.createTupleDescriptor("result_file_status");
         resultFileStatusTupleDesc.setIsMaterialized(true);
+        // | FileNumber | Int     |
         SlotDescriptor fileNumber = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        fileNumber.setLabel("FileNumber");
+        fileNumber.setLabel(OutFileClause.FILE_NUMBER);
         fileNumber.setType(ScalarType.createType(PrimitiveType.INT));
-        fileNumber.setColumn(new Column("FileNumber", ScalarType.createType(PrimitiveType.INT)));
+        fileNumber.setColumn(new Column(OutFileClause.FILE_NUMBER, ScalarType.createType(PrimitiveType.INT)));
         fileNumber.setIsMaterialized(true);
         fileNumber.setIsNullable(false);
+        // | TotalRows  | Bigint  |
         SlotDescriptor totalRows = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        totalRows.setLabel("TotalRows");
+        totalRows.setLabel(OutFileClause.TOTAL_ROWS);
         totalRows.setType(ScalarType.createType(PrimitiveType.BIGINT));
-        totalRows.setColumn(new Column("TotalRows", ScalarType.createType(PrimitiveType.BIGINT)));
+        totalRows.setColumn(new Column(OutFileClause.TOTAL_ROWS, ScalarType.createType(PrimitiveType.BIGINT)));
         totalRows.setIsMaterialized(true);
         totalRows.setIsNullable(false);
+        // | FileSize   | Bigint  |
         SlotDescriptor fileSize = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        fileSize.setLabel("FileSize");
+        fileSize.setLabel(OutFileClause.FILE_SIZE);
         fileSize.setType(ScalarType.createType(PrimitiveType.BIGINT));
-        fileSize.setColumn(new Column("FileSize", ScalarType.createType(PrimitiveType.BIGINT)));
+        fileSize.setColumn(new Column(OutFileClause.FILE_SIZE, ScalarType.createType(PrimitiveType.BIGINT)));
         fileSize.setIsMaterialized(true);
         fileSize.setIsNullable(false);
+        // | URL        | Varchar |
         SlotDescriptor url = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
-        url.setLabel("URL");
+        url.setLabel(OutFileClause.URL);
         url.setType(ScalarType.createType(PrimitiveType.VARCHAR));
-        url.setColumn(new Column("URL", ScalarType.createType(PrimitiveType.VARCHAR)));
+        url.setColumn(new Column(OutFileClause.URL, ScalarType.createType(PrimitiveType.VARCHAR)));
         url.setIsMaterialized(true);
         url.setIsNullable(false);
+        // | WriteTime   | Double  |
+        SlotDescriptor writeTime = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
+        writeTime.setLabel(OutFileClause.WRITE_TIME);
+        writeTime.setType(ScalarType.createType(PrimitiveType.DOUBLE));
+        writeTime.setColumn(new Column(OutFileClause.WRITE_TIME, ScalarType.createType(PrimitiveType.DOUBLE)));
+        writeTime.setIsMaterialized(true);
+        writeTime.setIsNullable(false);
+        // | WriteSpeed   | Double  |
+        SlotDescriptor writeSpeed = descriptorTable.addSlotDescriptor(resultFileStatusTupleDesc);
+        writeSpeed.setLabel(OutFileClause.WRITE_SPEED);
+        writeSpeed.setType(ScalarType.createType(PrimitiveType.DOUBLE));
+        writeSpeed.setColumn(new Column(OutFileClause.WRITE_SPEED, ScalarType.createType(PrimitiveType.DOUBLE)));
+        writeSpeed.setIsMaterialized(true);
+        writeSpeed.setIsNullable(false);
+
         resultFileStatusTupleDesc.computeStatAndMemLayout();
         return resultFileStatusTupleDesc;
     }


### PR DESCRIPTION
Problem Summary:

To better monitor the performance of Outfile, we've added two new fields to the Outfile return results: WriteTime and WriteSpeed. 
WriteTime is the time each writer takes to write data, measured in seconds. 
WriteSpeed is the average data write speed for each writer, measured in KB/s.


```sql
mysql> SELECT * FROM demo.hits
    -> into outfile "file:///mnt/disk2/ftw/export/exp_"
    -> format as orc
    -> properties(
    ->     "max_file_size" = "1024MB"
    -> );
+------------+-----------+-----------+--------------------------------------------------------------------------------+-----------+------------+
| FileNumber | TotalRows | FileSize  | URL                                                                            | WriteTime | WriteSpeed |
+------------+-----------+-----------+--------------------------------------------------------------------------------+-----------+------------+
|          1 |    640721 | 351061353 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb933_* | 16.630    | 20615.85   |
|          1 |    655339 | 359181194 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb934_* | 17.309    | 20264.83   |
|          1 |    655930 | 359413876 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb938_* | 17.603    | 19939.38   |
|          1 |    641538 | 351456753 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb935_* | 18.382    | 18671.70   |
|          1 |    669839 | 367119669 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb937_* | 18.725    | 19146.36   |
|          1 |    645864 | 353741902 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb936_* | 18.654    | 18519.36   |
|          1 |    641066 | 351242312 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb932_* | 18.873    | 18175.12   |
|          1 |    650703 | 356569972 | file:///127.0.0.1/mnt/disk2/ftw/export/exp_7b9033d6384340db-92b53a1c9bcfb939_* | 19.480    | 17874.95   |
+------------+-----------+-----------+--------------------------------------------------------------------------------+-----------+------------+
8 rows in set (19.79 sec)
```

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

