### PR TITLE
branch-3.0: [fix](paimon) avoid get paimon table when replay

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
@@ -61,12 +61,11 @@ public class PaimonExternalTable extends ExternalTable implements MvccTable {
 
     private static final Logger LOG = LogManager.getLogger(PaimonExternalTable.class);
 
-    private final Table paimonTable;
+    private Table paimonTable;
 
     public PaimonExternalTable(long id, String name, String remoteName, PaimonExternalCatalog catalog,
             PaimonExternalDatabase db) {
         super(id, name, remoteName, catalog, db, TableType.PAIMON_EXTERNAL_TABLE);
-        this.paimonTable = catalog.getPaimonTable(dbName, name);
     }
 
     public String getPaimonCatalogType() {
@@ -76,11 +75,13 @@ public class PaimonExternalTable extends ExternalTable implements MvccTable {
     protected synchronized void makeSureInitialized() {
         super.makeSureInitialized();
         if (!objectCreated) {
+            this.paimonTable = ((PaimonExternalCatalog) catalog).getPaimonTable(dbName, name);
             objectCreated = true;
         }
     }
 
     public Table getPaimonTable(Optional<MvccSnapshot> snapshot) {
+        makeSureInitialized();
         return paimonTable.copy(
                 Collections.singletonMap(CoreOptions.SCAN_VERSION.key(),
                         String.valueOf(getOrFetchSnapshotCacheValue(snapshot).getSnapshot().getSnapshotId())));

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -30,9 +30,9 @@ set -eo pipefail
 build_version_prefix="doris"
 build_version_major=3
 build_version_minor=0
-build_version_patch=4
+build_version_patch=5
 build_version_hotfix=0
-build_version_rc_version="rc02"
+build_version_rc_version="rc01"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -32,7 +32,7 @@ build_version_major=3
 build_version_minor=0
 build_version_patch=4
 build_version_hotfix=0
-build_version_rc_version="rc01"
+build_version_rc_version="rc02"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then


### PR DESCRIPTION
### What problem does this PR solve?

`catalog.getPaimonTable(dbName, name);` will try forward request to master FE.
When in replay logic, forwarding will fail, cause fe failed to start.
Introduced from #43959

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

