### PR TITLE
[fix](java) should use JAVA_OPTS_FOR_JDK_17 instead of JAVA_OPTS

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -114,6 +114,7 @@ const std::string GetKerb5ConfPath() {
     libhdfs_opts += fmt::format("{} ", GetKerb5ConfPath());
 
     setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);
+    LOG(INFO) << "set final LIBHDFS_OPTS: " << libhdfs_opts;
 }
 
 // Only used on non-x86 platform

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -97,7 +97,7 @@ const std::string GetKerb5ConfPath() {
 }
 
 [[maybe_unused]] void SetEnvIfNecessary() {
-    const std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
+    std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     CHECK(libhdfs_opts != "") << "LIBHDFS_OPTS is not set";
     libhdfs_opts += fmt::format(" {} ", GetKerb5ConfPath());
     setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -96,9 +96,11 @@ const std::string GetKerb5ConfPath() {
     return "-Djava.security.krb5.conf=" + config::kerberos_krb5_conf_path;
 }
 
-[[maybe_unused]] void CheckJniEnv() {
+[[maybe_unused]] void SetEnvIfNecessary() {
     const std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     CHECK(libhdfs_opts != "") << "LIBHDFS_OPTS is not set";
+    libhdfs_opts += fmt::format(" {} ", GetKerb5ConfPath());
+    setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);
     LOG(INFO) << "set final LIBHDFS_OPTS: " << libhdfs_opts;
 }
 
@@ -263,7 +265,7 @@ Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     }
 #else
     // the hadoop libhdfs will do all the stuff
-    CheckJniEnv();
+    SetEnvIfNecessary();
     tls_env_ = getJNIEnv();
 #endif
     *env = tls_env_;

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -419,7 +419,7 @@ fi
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
 export JAVA_OPTS="${final_java_opt}"
-n
+
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
 # log "LIBHDFS_OPTS: ${LIBHDFS_OPTS}"

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -418,7 +418,8 @@ fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
-
+export JAVA_OPTS="${final_java_opt}"
+n
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
 # log "LIBHDFS_OPTS: ${LIBHDFS_OPTS}"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -204,6 +204,7 @@ else
 fi
 log "Using Java version ${java_version}"
 log "${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # add libs to CLASSPATH
 DORIS_FE_JAR=

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -20,9 +20,6 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # Log dir
 LOG_DIR="${DORIS_HOME}/log/"
 
-# For jdk 8
-JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx2048m -DlogPath=$LOG_DIR/jni.log -Xloggc:$LOG_DIR/be.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
-
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djol.skipHotspotSAAttach=true -Xmx2048m -DlogPath=$LOG_DIR/jni.log -Xlog:gc*:$LOG_DIR/be.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Djavax.security.auth.useSubjectCredsOnly=false -Dsun.security.krb5.debug=true -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED -Darrow.enable_null_check_for_get=false"
 

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -26,9 +26,6 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 # Log dir
 LOG_DIR = ${DORIS_HOME}/log
 
-# For jdk 8
-JAVA_OPTS="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xss4m -Xmx8192m -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintClassHistogramAfterFullGC -Xloggc:$LOG_DIR/log/fe.gc.log.$CUR_DATE -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=50M -Dlog4j2.formatMsgNoLookups=true"
-
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR -Xlog:gc*,classhisto*=trace:$LOG_DIR/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
 


### PR DESCRIPTION
### What problem does this PR solve?

1. no need to set `CLASSPATH` and `LIBHDFS_OPTS` again in BE code, this is all done in `start_be.sh`
2. Print the final `LIBHDFS_OPT` env var in be.INFO, so that we can easily know the real JAVA OPTS for jni

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

