### PR TITLE
[feature](metrics)Add statistics prometheus metrics.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -272,6 +272,7 @@ import org.apache.doris.statistics.StatisticsAutoCollector;
 import org.apache.doris.statistics.StatisticsCache;
 import org.apache.doris.statistics.StatisticsCleaner;
 import org.apache.doris.statistics.StatisticsJobAppender;
+import org.apache.doris.statistics.StatisticsMetricCollector;
 import org.apache.doris.statistics.query.QueryStats;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
@@ -562,6 +563,8 @@ public class Env {
 
     private FollowerColumnSender followerColumnSender;
 
+    private StatisticsMetricCollector statisticsMetricCollector;
+
     private HiveTransactionMgr hiveTransactionMgr;
 
     private TopicPublisherThread topicPublisherThread;
@@ -809,6 +812,7 @@ public class Env {
         this.statisticsCleaner = new StatisticsCleaner();
         this.statisticsAutoCollector = new StatisticsAutoCollector();
         this.statisticsJobAppender = new StatisticsJobAppender();
+        this.statisticsMetricCollector = new StatisticsMetricCollector();
         this.globalFunctionMgr = new GlobalFunctionMgr();
         this.workloadGroupMgr = new WorkloadGroupMgr();
         this.workloadSchedPolicyMgr = new WorkloadSchedPolicyMgr();
@@ -1891,6 +1895,7 @@ public class Env {
         statisticsCleaner.start();
         statisticsAutoCollector.start();
         statisticsJobAppender.start();
+        statisticsMetricCollector.start();
     }
 
     // start threads that should run on all FE
@@ -6790,6 +6795,10 @@ public class Env {
 
     public StatisticsAutoCollector getStatisticsAutoCollector() {
         return statisticsAutoCollector;
+    }
+
+    public StatisticsMetricCollector getStatisticsMetricCollector() {
+        return statisticsMetricCollector;
     }
 
     public MasterDaemon getTabletStatMgr() {

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -157,6 +157,21 @@ public final class MetricRepo {
     public static GaugeMetric<Integer> GAUGE_INTERNAL_DATABASE_NUM;
     public static GaugeMetric<Integer> GAUGE_INTERNAL_TABLE_NUM;
 
+    // Statistics
+    public static GaugeMetric<Double> GAUGE_UNHEALTHY_TABLE_RATE;
+    public static GaugeMetric<Double> GAUGE_UNHEALTHY_COLUMN_RATE;
+    public static GaugeMetric<Integer> GAUGE_UNHEALTHY_TABLE_NUM;
+    public static GaugeMetric<Integer> GAUGE_UNHEALTHY_COLUMN_NUM;
+    public static GaugeMetric<Integer> GAUGE_HIGH_PRIORITY_QUEUE_LENGTH;
+    public static GaugeMetric<Integer> GAUGE_MID_PRIORITY_QUEUE_LENGTH;
+    public static GaugeMetric<Integer> GAUGE_LOW_PRIORITY_QUEUE_LENGTH;
+    public static GaugeMetric<Integer> GAUGE_VERY_LOW_PRIORITY_QUEUE_LENGTH;
+    public static GaugeMetric<Integer> GAUGE_NOT_ANALYZED_TABLE_NUM;
+    public static GaugeMetric<Integer> GAUGE_EMPTY_TABLE_NUM;
+    public static GaugeMetric<Integer> GAUGE_EMPTY_TABLE_COLUMN_NUM;
+    public static LongCounterMetric COUNTER_FAILED_ANALYZE_TASK;
+    public static LongCounterMetric COUNTER_INVALID_STATS;
+
     private static Map<Pair<EtlJobType, JobState>, Long> loadJobNum = Maps.newHashMap();
 
     private static ScheduledThreadPoolExecutor metricTimer = ThreadPoolManager.newDaemonScheduledThreadPool(1,
@@ -581,6 +596,8 @@ public final class MetricRepo {
         };
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_CATALOG_NUM);
 
+
+
         GAUGE_INTERNAL_DATABASE_NUM = new GaugeMetric<Integer>("internal_database_num",
                 MetricUnit.NOUNIT, "total internal database num") {
             @Override
@@ -599,6 +616,115 @@ public final class MetricRepo {
             }
         };
         DORIS_METRIC_REGISTER.addMetrics(GAUGE_INTERNAL_TABLE_NUM);
+
+        // statistics
+        String labelKey = "module";
+        String labelValue = "statistics";
+        COUNTER_FAILED_ANALYZE_TASK = new LongCounterMetric("failed_analyze_task", MetricUnit.NOUNIT, "");
+        COUNTER_FAILED_ANALYZE_TASK.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_FAILED_ANALYZE_TASK);
+        COUNTER_INVALID_STATS = new LongCounterMetric("invalid_stats", MetricUnit.NOUNIT, "");
+        COUNTER_INVALID_STATS.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_INVALID_STATS);
+        GAUGE_UNHEALTHY_TABLE_RATE = new GaugeMetric<Double>("unhealthy_table_rate",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Double getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getUnhealthyTableRate();
+            }
+        };
+        GAUGE_UNHEALTHY_TABLE_RATE.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_UNHEALTHY_TABLE_RATE);
+        GAUGE_UNHEALTHY_COLUMN_RATE = new GaugeMetric<Double>("unhealthy_column_rate",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Double getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getUnhealthyColumnRate();
+            }
+        };
+        GAUGE_UNHEALTHY_COLUMN_RATE.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_UNHEALTHY_COLUMN_RATE);
+        GAUGE_UNHEALTHY_TABLE_NUM = new GaugeMetric<Integer>("unhealthy_table_num",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getUnhealthyTableCount();
+            }
+        };
+        GAUGE_UNHEALTHY_TABLE_NUM.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_UNHEALTHY_TABLE_NUM);
+        GAUGE_UNHEALTHY_COLUMN_NUM = new GaugeMetric<Integer>("unhealthy_column_num",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getUnhealthyColumnCount();
+            }
+        };
+        GAUGE_UNHEALTHY_COLUMN_NUM.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_UNHEALTHY_COLUMN_NUM);
+        GAUGE_NOT_ANALYZED_TABLE_NUM = new GaugeMetric<Integer>("not_analyzed_table_num",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getNotAnalyzedTableCount();
+            }
+        };
+        GAUGE_NOT_ANALYZED_TABLE_NUM.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_NOT_ANALYZED_TABLE_NUM);
+        GAUGE_EMPTY_TABLE_NUM = new GaugeMetric<Integer>("empty_table_num",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getEmptyTableCount();
+            }
+        };
+        GAUGE_EMPTY_TABLE_NUM.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_EMPTY_TABLE_NUM);
+        GAUGE_EMPTY_TABLE_COLUMN_NUM = new GaugeMetric<Integer>("empty_table_column_num",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getStatisticsMetricCollector().getEmptyTableColumnCount();
+            }
+        };
+        GAUGE_EMPTY_TABLE_COLUMN_NUM.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_EMPTY_TABLE_COLUMN_NUM);
+        GAUGE_HIGH_PRIORITY_QUEUE_LENGTH = new GaugeMetric<Integer>("high_priority_queue_length",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getAnalysisManager().highPriorityJobs.size();
+            }
+        };
+        GAUGE_HIGH_PRIORITY_QUEUE_LENGTH.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_HIGH_PRIORITY_QUEUE_LENGTH);
+        GAUGE_MID_PRIORITY_QUEUE_LENGTH = new GaugeMetric<Integer>("mid_priority_queue_length",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getAnalysisManager().midPriorityJobs.size();
+            }
+        };
+        GAUGE_MID_PRIORITY_QUEUE_LENGTH.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_MID_PRIORITY_QUEUE_LENGTH);
+        GAUGE_LOW_PRIORITY_QUEUE_LENGTH = new GaugeMetric<Integer>("low_priority_queue_length",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getAnalysisManager().lowPriorityJobs.size();
+            }
+        };
+        GAUGE_LOW_PRIORITY_QUEUE_LENGTH.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_LOW_PRIORITY_QUEUE_LENGTH);
+        GAUGE_VERY_LOW_PRIORITY_QUEUE_LENGTH = new GaugeMetric<Integer>("very_low_priority_queue_length",
+                MetricUnit.NOUNIT, "") {
+            @Override
+            public Integer getValue() {
+                return Env.getCurrentEnv().getAnalysisManager().veryLowPriorityJobs.size();
+            }
+        };
+        GAUGE_VERY_LOW_PRIORITY_QUEUE_LENGTH.addLabel(new MetricLabel(labelKey, labelValue));
+        DORIS_METRIC_REGISTER.addMetrics(GAUGE_VERY_LOW_PRIORITY_QUEUE_LENGTH);
 
         // init system metrics
         initSystemMetrics();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
@@ -19,6 +19,7 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -74,6 +75,9 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
             if (!task.killed) {
                 if (except != null) {
                     LOG.warn("Analyze {} failed.", task.toString(), except);
+                    if (MetricRepo.isInit) {
+                        MetricRepo.COUNTER_FAILED_ANALYZE_TASK.increase(1L);
+                    }
                     task.job.taskFailed(task, Util.getRootCauseMessage(except));
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.qe.AuditLogHelper;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.QueryState;
@@ -486,6 +487,9 @@ public abstract class BaseAnalysisTask {
             stmtExecutor = new StmtExecutor(a.connectContext, sql);
             ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0));
             if (!colStatsData.isValid()) {
+                if (MetricRepo.isInit) {
+                    MetricRepo.COUNTER_INVALID_STATS.increase(1L);
+                }
                 String message = String.format("ColStatsData is invalid, skip analyzing. %s", colStatsData.toSQL(true));
                 LOG.warn(message);
                 throw new RuntimeException(message);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsMetricCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsMetricCollector.java
@@ -1,0 +1,146 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.statistics.util.StatisticsUtil;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Daemon thread to collect statistics related metrics.
+ */
+public class StatisticsMetricCollector extends MasterDaemon {
+
+    public static final Logger LOG = LogManager.getLogger(StatisticsMetricCollector.class);
+
+    public static final long INTERVAL = 300;
+
+    private volatile int unhealthyTableCount;
+    private volatile int unhealthyColumnCount;
+    private volatile int notAnalyzedTableCount;
+    private volatile int totalTableCount;
+    private volatile int totalColumnCount;
+    private volatile int emptyTableCount;
+    private volatile int emptyTableColumnCount;
+
+    public StatisticsMetricCollector() {
+        super("Statistics Metric Collector", TimeUnit.SECONDS.toMillis(INTERVAL));
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        InternalCatalog catalog = Env.getCurrentInternalCatalog();
+        AnalysisManager analysisManager = Env.getCurrentEnv().getAnalysisManager();
+        int tmpUnhealthyTableCount = 0;
+        int tmpUnhealthyColumnCount = 0;
+        int tmpNotAnalyzedTableCount = 0;
+        int tmpTotalTableCount = 0;
+        int tmpTotalColumnCount = 0;
+        int tmpEmptyTableCount = 0;
+        int tmpEmptyTableColumnCount = 0;
+        for (DatabaseIf<? extends TableIf> db : catalog.getAllDbs()) {
+            try {
+                if (StatisticConstants.SYSTEM_DBS.contains(db.getFullName())) {
+                    continue;
+                }
+                for (TableIf table : db.getTables()) {
+                    try {
+                        if (!(table instanceof OlapTable)) {
+                            continue;
+                        }
+                        tmpTotalTableCount += 1;
+                        // Get all supported columns, including all indexes.
+                        Set<String> columns = table.getSchemaAllIndexes(false)
+                                .stream()
+                                .filter(c -> !StatisticsUtil.isUnsupportedType(c.getType()))
+                                .map(Column::getName)
+                                .collect(Collectors.toSet());
+                        tmpTotalColumnCount += columns.size();
+                        if (table.getRowCount() == 0) {
+                            tmpEmptyTableCount += 1;
+                            tmpEmptyTableColumnCount += columns.size();
+                        }
+                        if (analysisManager.findTableStatsStatus(table.getId()) == null) {
+                            tmpNotAnalyzedTableCount += 1;
+                        }
+                        // Get all unhealthy columns.
+                        Set<Pair<String, String>> columnIndexPairs = table.getColumnIndexPairs(columns)
+                                .stream().filter(p -> StatisticsUtil.needAnalyzeColumn(table, p))
+                                .collect(Collectors.toSet());
+                        if (!columnIndexPairs.isEmpty()) {
+                            tmpUnhealthyTableCount += 1;
+                            tmpUnhealthyColumnCount += columnIndexPairs.size();
+                        }
+                    } catch (Exception e) {
+                        LOG.info("Failed to get metrics for table {}. Reason {}", table.getName(), e.getMessage());
+                    }
+                }
+            } catch (Exception e) {
+                LOG.info("Failed to get metrics for db {}. Reason {}", db.getFullName(), e.getMessage());
+            }
+        }
+        unhealthyTableCount = tmpUnhealthyTableCount;
+        unhealthyColumnCount = tmpUnhealthyColumnCount;
+        notAnalyzedTableCount = tmpNotAnalyzedTableCount;
+        totalTableCount = tmpTotalTableCount;
+        totalColumnCount = tmpTotalColumnCount;
+        emptyTableCount = tmpEmptyTableCount;
+        emptyTableColumnCount = tmpEmptyTableColumnCount;
+    }
+
+    public int getUnhealthyTableCount() {
+        return unhealthyTableCount;
+    }
+
+    public double getUnhealthyTableRate() {
+        return (totalTableCount == 0 ? 0 : (double) unhealthyTableCount / totalTableCount) * 100;
+    }
+
+    public int getUnhealthyColumnCount() {
+        return unhealthyColumnCount;
+    }
+
+    public double getUnhealthyColumnRate() {
+        return (totalColumnCount == 0 ? 0 : (double) unhealthyColumnCount / totalColumnCount) * 100;
+    }
+
+    public int getNotAnalyzedTableCount() {
+        return notAnalyzedTableCount;
+    }
+
+    public int getEmptyTableCount() {
+        return emptyTableCount;
+    }
+
+    public int getEmptyTableColumnCount() {
+        return emptyTableColumnCount;
+    }
+}

--- a/regression-test/suites/metrics_p0/test_fe_metrics.groovy
+++ b/regression-test/suites/metrics_p0/test_fe_metrics.groovy
@@ -25,6 +25,19 @@ suite("test_fe_metrics") {
             assertEquals(200, code)
             assertTrue(body.contains("jvm_heap_size_bytes"))
             assertTrue(body.contains("jvm_gc"))
+            assertTrue(body.contains("unhealthy_table_num"))
+            assertTrue(body.contains("unhealthy_column_num"))
+            assertTrue(body.contains("unhealthy_table_rate"))
+            assertTrue(body.contains("unhealthy_column_rate"))
+            assertTrue(body.contains("empty_table_num"))
+            assertTrue(body.contains("empty_table_column_num"))
+            assertTrue(body.contains("failed_analyze_task"))
+            assertTrue(body.contains("invalid_stats"))
+            assertTrue(body.contains("high_priority_queue_length"))
+            assertTrue(body.contains("mid_priority_queue_length"))
+            assertTrue(body.contains("low_priority_queue_length"))
+            assertTrue(body.contains("very_low_priority_queue_length"))
+            assertTrue(body.contains("not_analyzed_table_num"))
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Support prometheus metrics for statistics. 
Add a Daemon StatisticsMetricCollector to collect metrics for statistics, such as unhealthy table count, unhealthy column count and so on.
PrometheusMetricVisitor could get the statistics metric values stored in StatisticsMetricCollector.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

