### PR TITLE
[fix] Fixed length error in compress.cpp

### DIFF
--- a/be/src/common/kerberos/kerberos_ticket_mgr.cpp
+++ b/be/src/common/kerberos/kerberos_ticket_mgr.cpp
@@ -17,6 +17,7 @@
 
 #include "common/kerberos/kerberos_ticket_mgr.h"
 
+#include <chrono>
 #include <iomanip>
 #include <sstream>
 
@@ -112,7 +113,8 @@ Status KerberosTicketMgr::get_or_set_ticket_cache(
     new_ticket_cache->start_periodic_refresh();
 
     // Insert into _ticket_caches
-    KerberosTicketEntry entry {.cache = new_ticket_cache};
+    KerberosTicketEntry entry {.cache = new_ticket_cache,
+                               .last_access_time = std::chrono::steady_clock::now()};
     auto [inserted_it, success] = _ticket_caches.emplace(key, std::move(entry));
     if (!success) {
         return Status::InternalError("Failed to insert ticket cache into map");

--- a/be/src/vec/functions/function_compress.cpp
+++ b/be/src/vec/functions/function_compress.cpp
@@ -185,7 +185,8 @@ public:
             col_data.resize(col_data.size() + length.value);
             uncompressed_slice = Slice(col_data.data() + idx, length.value);
 
-            Slice compressed_data(data.data + compressed_str_length, data.size - compressed_str_length);
+            Slice compressed_data(data.data + compressed_str_length,
+                                  data.size - compressed_str_length);
             auto st = compression_codec->decompress(compressed_data, &uncompressed_slice);
 
             if (!st.ok()) {                                      // is not a legal compressed string

--- a/be/src/vec/functions/function_compress.cpp
+++ b/be/src/vec/functions/function_compress.cpp
@@ -52,6 +52,8 @@ class FunctionContext;
 
 namespace doris::vectorized {
 
+static constexpr size_t compressed_str_length = 4;
+
 class FunctionCompress : public IFunction {
 public:
     static constexpr auto name = "compress";
@@ -103,17 +105,17 @@ public:
 
             // Z_MEM_ERROR and Z_BUF_ERROR are already handled in compress, making sure st is always Z_OK
             RETURN_IF_ERROR(compression_codec->compress(data, &compressed_str));
-            col_data.resize(col_data.size() + 4 + compressed_str.size());
+            col_data.resize(col_data.size() + compressed_str_length + compressed_str.size());
 
             std::memcpy(col_data.data() + idx, &length, sizeof(length));
-            idx += 4;
+            idx += compressed_str_length;
 
             // The length of compress_str is not known in advance, so it cannot be compressed directly into col_data
             unsigned char* src = compressed_str.data();
             for (size_t i = 0; i < compressed_str.size(); idx++, i++, src++) {
                 col_data[idx] = *src;
             }
-            col_offset[row] = col_offset[row - 1] + 10 + compressed_str.size();
+            col_offset[row] = col_offset[row - 1] + compressed_str_length + compressed_str.size();
         }
 
         block.replace_by_position(result, std::move(result_column));
@@ -174,16 +176,16 @@ public:
             }
 
             union {
-                char bytes[4];
+                char bytes[compressed_str_length];
                 uint32_t value;
             } length;
-            std::memcpy(length.bytes, data.data, 4);
+            std::memcpy(length.bytes, data.data, compressed_str_length);
 
             size_t idx = col_data.size();
             col_data.resize(col_data.size() + length.value);
             uncompressed_slice = Slice(col_data.data() + idx, length.value);
 
-            Slice compressed_data(data.data + 4, data.size - 4);
+            Slice compressed_data(data.data + compressed_str_length, data.size - compressed_str_length);
             auto st = compression_codec->decompress(compressed_data, &uncompressed_slice);
 
             if (!st.ok()) {                                      // is not a legal compressed string

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_compress_uncompress.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_compress_uncompress.out
@@ -36,3 +36,10 @@ Hello, world!
 -- !compress_numeric_direct --
 12345
 
+-- !compress_multiple_samples --
+Quick brown fox jumps over the lazy dog
+Lorem ipsum dolor sit amet
+数据压缩测试
+xxxxxxxxxxxxxxxxxxxx
+1234567890
+

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_compress_uncompress.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_compress_uncompress.groovy
@@ -136,4 +136,16 @@ suite("test_compress_uncompress") {
             UNCOMPRESS(COMPRESS('12345')) AS decompressed_data
         LIMIT 1;
     """
+
+	// Test 13: Verify that multiple compressions and uncompressions return correct outputs
+	order_qt_compress_multiple_samples """
+		SELECT 
+			UNCOMPRESS(COMPRESS('Quick brown fox jumps over the lazy dog')) AS decompressed_data_1,
+			UNCOMPRESS(COMPRESS('Lorem ipsum dolor sit amet')) AS decompressed_data_2,
+			UNCOMPRESS(COMPRESS('数据压缩测试')) AS decompressed_data_3,
+			UNCOMPRESS(COMPRESS(REPEAT('x', 20))) AS decompressed_data_4,
+			UNCOMPRESS(COMPRESS('1234567890')) AS decompressed_data_5,
+			UNCOMPRESS(COMPRESS(''))) AS decompressed_data_6
+		LIMIT 1;
+	"""
 }

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_compress_uncompress.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_compress_uncompress.groovy
@@ -137,15 +137,23 @@ suite("test_compress_uncompress") {
         LIMIT 1;
     """
 
-	// Test 13: Verify that multiple compressions and uncompressions return correct outputs
-	order_qt_compress_multiple_samples """
-		SELECT 
-			UNCOMPRESS(COMPRESS('Quick brown fox jumps over the lazy dog')) AS decompressed_data_1,
-			UNCOMPRESS(COMPRESS('Lorem ipsum dolor sit amet')) AS decompressed_data_2,
-			UNCOMPRESS(COMPRESS('数据压缩测试')) AS decompressed_data_3,
-			UNCOMPRESS(COMPRESS(REPEAT('x', 20))) AS decompressed_data_4,
-			UNCOMPRESS(COMPRESS('1234567890')) AS decompressed_data_5,
-			UNCOMPRESS(COMPRESS(''))) AS decompressed_data_6
-		LIMIT 1;
-	"""
+	// Test 12: 多个 COMPRESS 调用，直接从表中对 text_col 字段进行多次 COMPRESS
+    order_qt_compress_multiple_calls_from_table """
+        SELECT
+            k0,
+            COMPRESS(text_col) AS comp1,
+            binary_col AS comp2,
+        FROM test_compression
+        ORDER BY k0;
+    """
+
+    // Test 13: 多个 COMPRESS 与 UNCOMPRESS 调用，直接从表中对 text_col 字段先 COMPRESS 再 UNCOMPRESS
+    order_qt_compress_uncompress_multiple_calls_from_table """
+        SELECT
+            k0,
+            text_col AS result1,
+            UNCOMPRESS(binary_col) AS result2
+        FROM test_compression
+        ORDER BY k0;
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?
Fixed length error in compress.cpp

Issue Number: close #xxx

Related PR: #47307 

Problem Summary:
The compressed string length should be represented by 4 bytes instead of 10, and I replaced the magic value with a constant. And I've added examples of multi-line queries

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

