### PR TITLE
[feat](ci) enable enable_parquet_page_index in pipeline

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -42,3 +42,6 @@ enable_brpc_connection_check=true
 enable_write_index_searcher_cache=true
 
 sys_log_verbose_modules=query_context,runtime_query_statistics_mgr
+
+# So feature has bug, so by default is false, only open it in pipeline to observe
+enable_parquet_page_index=true

--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -68,3 +68,6 @@ KRB5_CONFIG=/keytabs/krb5.conf
 kerberos_krb5_conf_path=/keytabs/krb5.conf
 pipeline_task_leakage_detect_period_sec=1
 crash_in_memory_tracker_inaccurate = true
+
+# So feature has bug, so by default is false, only open it in pipeline to observe
+enable_parquet_page_index=true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -77,3 +77,6 @@ enable_write_index_searcher_cache=true
 
 # enable download small files in batch, see apache/doris#45061 for details
 enable_batch_download = true
+
+# So feature has bug, so by default is false, only open it in pipeline to observe
+enable_parquet_page_index=true

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -69,3 +69,6 @@ enable_write_index_searcher_cache=true
 
 # enable download small files in batch, see apache/doris#45061 for details
 enable_batch_download = true
+
+# So feature has bug, so by default is false, only open it in pipeline to observe
+enable_parquet_page_index=true

--- a/regression-test/pipeline/performance/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/conf/be_custom.conf
@@ -21,3 +21,6 @@ priority_networks=127.0.0.1/24
 storage_root_path=/data/doris-storage-${branch_name}
 
 streaming_load_max_mb=102400
+
+# So feature has bug, so by default is false, only open it in pipeline to observe
+enable_parquet_page_index=true


### PR DESCRIPTION
### What problem does this PR solve?

There are some unknown bugs with `enable_parquet_page_index` enabled.
So by default it is false, only enable it in ci pipeline for debugging.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

