### PR TITLE
[fix](mtmv) Fix nest mtmv rewrite fail when bottom mtmv cache is invalid

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -332,10 +332,6 @@ public class MTMV extends OlapTable {
         }
     }
 
-    public MTMVCache getCache() {
-        return cache;
-    }
-
     public Map<String, String> getMvProperties() {
         readMvLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mtmv.MTMVCache;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DataTrait;
@@ -48,6 +49,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -63,6 +66,8 @@ import java.util.Set;
  * Logical OlapScan.
  */
 public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan {
+
+    private static final Logger LOG = LogManager.getLogger(LogicalOlapScan.class);
 
     ///////////////////////////////////////////////////////////////////////////
     // Members for materialized index.
@@ -529,9 +534,15 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
         Set<Slot> outputSet = Utils.fastToImmutableSet(getOutputSet());
         if (getTable() instanceof MTMV) {
             MTMV mtmv = (MTMV) getTable();
-            MTMVCache cache = mtmv.getCache();
+            MTMVCache cache;
+            try {
+                cache = mtmv.getOrGenerateCache(ConnectContext.get());
+            } catch (AnalysisException e) {
+                LOG.warn(String.format("LogicalOlapScan computeUnique fail, mv name is %s", mtmv.getName()), e);
+                return;
+            }
             // Maybe query specified index, should not calc, such as select count(*) from t1 index col_index
-            if (cache == null || this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
+            if (this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
                 return;
             }
             Plan originalPlan = cache.getOriginalPlan();
@@ -562,9 +573,15 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
     public void computeUniform(DataTrait.Builder builder) {
         if (getTable() instanceof MTMV) {
             MTMV mtmv = (MTMV) getTable();
-            MTMVCache cache = mtmv.getCache();
+            MTMVCache cache;
+            try {
+                cache = mtmv.getOrGenerateCache(ConnectContext.get());
+            } catch (AnalysisException e) {
+                LOG.warn(String.format("LogicalOlapScan computeUniform fail, mv name is %s", mtmv.getName()), e);
+                return;
+            }
             // Maybe query specified index, should not calc, such as select count(*) from t1 index col_index
-            if (cache == null || this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
+            if (this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
                 return;
             }
             Plan originalPlan = cache.getOriginalPlan();
@@ -577,9 +594,15 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
     public void computeEqualSet(DataTrait.Builder builder) {
         if (getTable() instanceof MTMV) {
             MTMV mtmv = (MTMV) getTable();
-            MTMVCache cache = mtmv.getCache();
+            MTMVCache cache;
+            try {
+                cache = mtmv.getOrGenerateCache(ConnectContext.get());
+            } catch (AnalysisException e) {
+                LOG.warn(String.format("LogicalOlapScan computeEqualSet fail, mv name is %s", mtmv.getName()), e);
+                return;
+            }
             // Maybe query specified index, should not calc, such as select count(*) from t1 index col_index
-            if (cache == null || this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
+            if (this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
                 return;
             }
             Plan originalPlan = cache.getOriginalPlan();
@@ -592,9 +615,15 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
     public void computeFd(DataTrait.Builder builder) {
         if (getTable() instanceof MTMV) {
             MTMV mtmv = (MTMV) getTable();
-            MTMVCache cache = mtmv.getCache();
+            MTMVCache cache;
+            try {
+                cache = mtmv.getOrGenerateCache(ConnectContext.get());
+            } catch (AnalysisException e) {
+                LOG.warn(String.format("LogicalOlapScan computeFd fail, mv name is %s", mtmv.getName()), e);
+                return;
+            }
             // Maybe query specified index, should not calc, such as select count(*) from t1 index col_index
-            if (cache == null || this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
+            if (this.getSelectedIndexId() != this.getTable().getBaseIndexId()) {
                 return;
             }
             Plan originalPlan = cache.getOriginalPlan();
@@ -607,7 +636,14 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
         Map<Slot, Slot> replaceMap = new HashMap<>();
         // Need remove invisible column, and then mapping them
         List<Slot> originOutputs = new ArrayList<>();
-        for (Slot originSlot : mtmv.getCache().getOriginalPlan().getOutput()) {
+        MTMVCache cache;
+        try {
+            cache = mtmv.getOrGenerateCache(ConnectContext.get());
+        } catch (AnalysisException e) {
+            LOG.warn(String.format("LogicalOlapScan constructReplaceMap fail, mv name is %s", mtmv.getName()), e);
+            return replaceMap;
+        }
+        for (Slot originSlot : cache.getOriginalPlan().getOutput()) {
             if (!(originSlot instanceof SlotReference) || (((SlotReference) originSlot).isVisible())) {
                 originOutputs.add(originSlot);
             }


### PR DESCRIPTION
### What problem does this PR solve?
Fix nest mtmv rewrite fail when bottom mtmv cache is invalid

such as bottom mv is mv_1 and mv_2 as following：
```sql
    **mv_1**
        select l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, cast(sum(IFNULL(o_orderkey, 0) * IFNULL(o_custkey, 0)) as decimal(28, 8)) as agg1,
        sum(o_totalprice) as sum_total, 
        max(o_totalprice) as max_total, 
        min(o_totalprice) as min_total, 
        count(*) as count_all, 
        bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (1, 3) then o_custkey else null end)) cnt_1, 
        bitmap_union(to_bitmap(case when o_shippriority > 2 and o_orderkey IN (2) then o_custkey else null end)) as cnt_2 
        from lineitem_1
        inner join orders_1
        on lineitem_1.l_orderkey = orders_1.o_orderkey
        where lineitem_1.l_shipdate >= "2023-10-17"
        group by l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey
 
    **mv_2**
        select l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, ps_partkey, ps_suppkey,
        t.agg1 as agg1, 
        t.sum_total as agg3,
        t.max_total as agg4,
        t.min_total as agg5,
        t.count_all as agg6,
        cast(sum(IFNULL(ps_suppkey, 0) * IFNULL(ps_partkey, 0)) as decimal(28, 8)) as agg2
        from ${mv_1} as t
        inner join partsupp_1
        on t.l_partkey = partsupp_1.ps_partkey and t.l_suppkey = partsupp_1.ps_suppkey
        where partsupp_1.ps_suppkey > 1
        group by l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, ps_partkey, ps_suppkey, agg1, agg3, agg4, agg5, agg6

   **mv_3**

select t1.l_orderkey, t2.l_partkey, t1.l_suppkey, t2.o_orderkey, t1.o_custkey, t2.ps_partkey, t1.ps_suppkey, t2.agg1, t1.agg2, t2.agg3, t1.agg4, t2.agg5, t1.agg6 
        from ${mv_2} as t1
        left join ${mv_2} as t2
        on t1.l_orderkey = t2.l_orderkey
        where t1.l_orderkey > 1
        group by t1.l_orderkey, t2.l_partkey, t1.l_suppkey, t2.o_orderkey, t1.o_custkey, t2.ps_partkey, t1.ps_suppkey, t2.agg1, t1.agg2, t2.agg3, t1.agg4, t2.agg5, t1.agg6
        
```

query as following would fail if mtmvCache invalid in mv_1 and mv_2, the pr fix this

```sql
select t1.l_orderkey, t2.l_partkey, t1.l_suppkey, t2.o_orderkey, t1.o_custkey, t2.ps_partkey, t1.ps_suppkey, t2.agg1, t1.agg2, t2.agg3, t1.agg4, t2.agg5, t1.agg6 
        from (
            select l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, ps_partkey, ps_suppkey, 
            t.agg1 as agg1, 
            t.sum_total as agg3,
            t.max_total as agg4,
            t.min_total as agg5,
            t.count_all as agg6,
            cast(sum(IFNULL(ps_suppkey, 0) * IFNULL(ps_partkey, 0)) as decimal(28, 8)) as agg2
            from (
                select l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, cast(sum(IFNULL(o_orderkey, 0) * IFNULL(o_custkey, 0)) as decimal(28, 8)) as agg1,
                sum(o_totalprice) as sum_total, 
                max(o_totalprice) as max_total, 
                min(o_totalprice) as min_total, 
                count(*) as count_all, 
                bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (1, 3) then o_custkey else null end)) cnt_1, 
                bitmap_union(to_bitmap(case when o_shippriority > 2 and o_orderkey IN (2) then o_custkey else null end)) as cnt_2 
                from lineitem_1
                inner join orders_1
                on lineitem_1.l_orderkey = orders_1.o_orderkey
                where lineitem_1.l_shipdate >= "2023-10-17"
                group by l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey
            ) as t
            inner join partsupp_1
            on t.l_partkey = partsupp_1.ps_partkey and t.l_suppkey = partsupp_1.ps_suppkey
            where partsupp_1.ps_suppkey > 1
            group by l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, ps_partkey, ps_suppkey, agg1, agg3, agg4, agg5, agg6
        ) as t1
        left join (
            select l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, ps_partkey, ps_suppkey, 
            t.agg1 as agg1, 
            t.sum_total as agg3,
            t.max_total as agg4,
            t.min_total as agg5,
            t.count_all as agg6,
            cast(sum(IFNULL(ps_suppkey, 0) * IFNULL(ps_partkey, 0)) as decimal(28, 8)) as agg2
            from (
                select l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, cast(sum(IFNULL(o_orderkey, 0) * IFNULL(o_custkey, 0)) as decimal(28, 8)) as agg1,
                sum(o_totalprice) as sum_total, 
                max(o_totalprice) as max_total, 
                min(o_totalprice) as min_total, 
                count(*) as count_all, 
                bitmap_union(to_bitmap(case when o_shippriority > 1 and o_orderkey IN (1, 3) then o_custkey else null end)) cnt_1, 
                bitmap_union(to_bitmap(case when o_shippriority > 2 and o_orderkey IN (2) then o_custkey else null end)) as cnt_2 
                from lineitem_1
                inner join orders_1
                on lineitem_1.l_orderkey = orders_1.o_orderkey
                where lineitem_1.l_shipdate >= "2023-10-17"
                group by l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey
            ) as t
            inner join partsupp_1
            on t.l_partkey = partsupp_1.ps_partkey and t.l_suppkey = partsupp_1.ps_suppkey
            where partsupp_1.ps_suppkey > 1
            group by l_orderkey, l_partkey, l_suppkey, o_orderkey, o_custkey, ps_partkey, ps_suppkey, agg1, agg3, agg4, agg5, agg6
        ) as t2
        on t1.l_orderkey = t2.l_orderkey
        where t1.l_orderkey > 1
        group by t1.l_orderkey, t2.l_partkey, t1.l_suppkey, t2.o_orderkey, t1.o_custkey, t2.ps_partkey, t1.ps_suppkey, t2.agg1, t1.agg2, t2.agg3, t1.agg4, t2.agg5, t1.agg6
        
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

Fix nest mtmv rewrite fail when bottom mtmv cache is invalid

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

