### PR TITLE
[fix](regression-test) Fix unstable regression test case due to trigger compaction failed

### DIFF
--- a/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
@@ -48,7 +48,7 @@ suite ("test_dup_keys_schema_change") {
                     `min_dwell_time` INT DEFAULT "99999" COMMENT "用户最小停留时间")
                 DUPLICATE KEY(`user_id`, `date`, `city`, `age`, `sex`) DISTRIBUTED BY HASH(`user_id`)
                 BUCKETS 8
-                PROPERTIES ( "replication_num" = "1", "light_schema_change" = "false" );
+                PROPERTIES ( "replication_num" = "1", "light_schema_change" = "false", "disable_auto_compaction" = "true");
             """
 
         sql """ INSERT INTO ${tableName} VALUES

--- a/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_keys_schema_change.groovy
@@ -44,7 +44,7 @@ suite ("test_uniq_keys_schema_change") {
                     `min_dwell_time` INT DEFAULT "99999" COMMENT "用户最小停留时间")
                 UNIQUE KEY(`user_id`, `date`, `city`, `age`, `sex`) DISTRIBUTED BY HASH(`user_id`)
                 BUCKETS 8
-                PROPERTIES ( "replication_num" = "1", "light_schema_change" = "false");
+                PROPERTIES ( "replication_num" = "1", "light_schema_change" = "false", "disable_auto_compaction" = "true");
             """
 
         sql """ INSERT INTO schema_change_uniq_keys_regression_test VALUES


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

test_dup_keys_schema_change and test_uniq_keys_schema_change.groovy often fail due to waiting for compaction sucess. Disable auto compaction to ensure trigger compaction successfully.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

