### PR TITLE
[fix](backup) make snapshot task with unique signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -210,17 +210,19 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             }
 
             //clear old task
-            AgentTaskQueue.removeTaskOfType(TTaskType.MAKE_SNAPSHOT, task.getTabletId());
-            unfinishedTaskIds.remove(task.getTabletId());
-            taskProgress.remove(task.getTabletId());
-            taskErrMsg.remove(task.getTabletId());
+            AgentTaskQueue.removeTaskOfType(TTaskType.MAKE_SNAPSHOT, task.getSignature());
+            unfinishedTaskIds.remove(task.getSignature());
+            taskProgress.remove(task.getSignature());
+            taskErrMsg.remove(task.getSignature());
 
-            SnapshotTask newTask = new SnapshotTask(null, replica.getBackendIdWithoutException(), task.getTabletId(),
+            long signature = env.getNextId();
+            long beId = replica.getBackendIdWithoutException();
+            SnapshotTask newTask = new SnapshotTask(null, beId, signature,
                     task.getJobId(), task.getDbId(), tbl.getId(), task.getPartitionId(),
                     task.getIndexId(), task.getTabletId(),
                     task.getVersion(),
                     task.getSchemaHash(), timeoutMs, false /* not restore task */);
-            unfinishedTaskIds.put(tablet.getId(), replica.getBackendIdWithoutException());
+            unfinishedTaskIds.put(signature, beId);
 
             //send task
             AgentBatchTask batchTask = new AgentBatchTask(newTask);
@@ -277,9 +279,9 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 request.getSnapshotFiles());
 
         snapshotInfos.put(task.getTabletId(), info);
-        taskProgress.remove(task.getTabletId());
-        Long oldValue = unfinishedTaskIds.remove(task.getTabletId());
-        taskErrMsg.remove(task.getTabletId());
+        taskProgress.remove(task.getSignature());
+        taskErrMsg.remove(task.getSignature());
+        Long oldValue = unfinishedTaskIds.remove(task.getSignature());
         if (LOG.isDebugEnabled()) {
             LOG.debug("get finished snapshot info: {}, unfinished tasks num: {}, remove result: {}. {}",
                     info, unfinishedTaskIds.size(), (oldValue != null), this);
@@ -637,13 +639,15 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                                         + ". visible version: " + visibleVersion);
                         return;
                     }
-                    SnapshotTask task = new SnapshotTask(null, replica.getBackendIdWithoutException(), tablet.getId(),
+                    long signature = env.getNextId();
+                    long beId = replica.getBackendIdWithoutException();
+                    SnapshotTask task = new SnapshotTask(null, beId, signature,
                             jobId, dbId, olapTable.getId(), partition.getId(),
                             index.getId(), tablet.getId(),
                             visibleVersion,
                             schemaHash, timeoutMs, false /* not restore task */);
                     batchTask.addTask(task);
-                    unfinishedTaskIds.put(tablet.getId(), replica.getBackendIdWithoutException());
+                    unfinishedTaskIds.put(signature, beId);
                 }
             }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -234,7 +234,7 @@ public class BackupJobTest {
         Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames),
                             ((OlapTable) db.getTableNullable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames));
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
-        AgentTask task = AgentTaskQueue.getTask(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
+        AgentTask task = AgentTaskQueue.getTask(backendId, TTaskType.MAKE_SNAPSHOT, id.get() - 1);
         Assert.assertTrue(task instanceof SnapshotTask);
         SnapshotTask snapshotTask = (SnapshotTask) task;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

PR #47416 already filters the staled responses by the job ID. But the task is getting by `(backendId, taskType, signature)`, so some staled responses might not be able to be filtered, if the two signatures are equal.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

