### PR TITLE
[feat](nereids) simplify comparison for cast from smaller int type to bigger int type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
@@ -107,7 +107,7 @@ public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule i
         Expression result;
 
         // process type coercion
-        if (left.getDataType().isIntegerLikeType() && right.getDataType().isIntegerLikeType()) {
+        if (left.getDataType().isIntegralType() && right.getDataType().isIntegralType()) {
             result = processIntegerLikeTypeCoercion(cp, left, right);
         } else if (left.getDataType().isFloatLikeType() && right.getDataType().isFloatLikeType()) {
             result = processFloatLikeTypeCoercion(cp, left, right);
@@ -134,8 +134,8 @@ public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule i
         // then will have cast(a as bigint) > cast(500000 + 100000).
         // After fold constant, will have cast(a as bigint) > big int(600000),
         // since 600000 can represent as an int type, will rewrite as a > int(600000).
-        if (left instanceof Cast && left.getDataType().isIntegerLikeType()
-                && ((Cast) left).child().getDataType().isIntegerLikeType()
+        if (left instanceof Cast && left.getDataType().isIntegralType()
+                && ((Cast) left).child().getDataType().isIntegralType()
                 && right instanceof IntegerLikeLiteral) {
             DataType castDataType = left.getDataType();
             DataType childDataType = ((Cast) left).child().getDataType();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
@@ -51,12 +51,16 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NumericLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
+import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DateType;
 import org.apache.doris.nereids.types.DateV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.SmallIntType;
+import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.coercion.DateLikeType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
@@ -103,7 +107,9 @@ public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule i
         Expression result;
 
         // process type coercion
-        if (left.getDataType().isFloatLikeType() && right.getDataType().isFloatLikeType()) {
+        if (left.getDataType().isIntegerLikeType() && right.getDataType().isIntegerLikeType()) {
+            result = processIntegerLikeTypeCoercion(cp, left, right);
+        } else if (left.getDataType().isFloatLikeType() && right.getDataType().isFloatLikeType()) {
             result = processFloatLikeTypeCoercion(cp, left, right);
         } else if (left.getDataType() instanceof DecimalV3Type && right.getDataType() instanceof DecimalV3Type) {
             result = processDecimalV3TypeCoercion(cp, left, right);
@@ -119,6 +125,56 @@ public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule i
         }
 
         return result;
+    }
+
+    private static Expression processIntegerLikeTypeCoercion(ComparisonPredicate cp,
+            Expression left, Expression right) {
+        // Suppose a is integer type, for expression `a > 500000 + 100000`,
+        // since right type is big int (int plus int is big int),
+        // then will have cast(a as bigint) > cast(500000 + 100000).
+        // After fold constant, will have cast(a as bigint) > big int(600000),
+        // since 600000 can represent as an int type, will rewrite as a > int(600000).
+        if (left instanceof Cast && left.getDataType().isIntegerLikeType()
+                && ((Cast) left).child().getDataType().isIntegerLikeType()
+                && right instanceof IntegerLikeLiteral) {
+            DataType castDataType = left.getDataType();
+            DataType childDataType = ((Cast) left).child().getDataType();
+            boolean castDataTypeWider = false;
+            for (DataType type : TypeCoercionUtils.NUMERIC_PRECEDENCE) {
+                if (type.equals(childDataType)) {
+                    break;
+                }
+                if (type.equals(castDataType)) {
+                    castDataTypeWider = true;
+                    break;
+                }
+            }
+            if (castDataTypeWider) {
+                Optional<Pair<BigDecimal, BigDecimal>> minMaxOpt =
+                        TypeCoercionUtils.getDataTypeMinMaxValue(childDataType);
+                if (minMaxOpt.isPresent()) {
+                    BigDecimal childTypeMinValue = minMaxOpt.get().first;
+                    BigDecimal childTypeMaxValue = minMaxOpt.get().second;
+                    BigDecimal rightValue = ((IntegerLikeLiteral) right).getBigDecimalValue();
+                    if (rightValue.compareTo(childTypeMinValue) >= 0 && rightValue.compareTo(childTypeMaxValue) <= 0) {
+                        Expression newRight = null;
+                        if (childDataType.equals(BigIntType.INSTANCE)) {
+                            newRight = new BigIntLiteral(rightValue.longValue());
+                        } else if (childDataType.equals(IntegerType.INSTANCE)) {
+                            newRight = new IntegerLiteral(rightValue.intValue());
+                        } else if (childDataType.equals(SmallIntType.INSTANCE)) {
+                            newRight = new SmallIntLiteral(rightValue.shortValue());
+                        } else if (childDataType.equals(TinyIntType.INSTANCE)) {
+                            newRight = new TinyIntLiteral(rightValue.byteValue());
+                        }
+                        if (newRight != null) {
+                            return cp.withChildren(((Cast) left).child(), newRight);
+                        }
+                    }
+                }
+            }
+        }
+        return cp;
     }
 
     private static Expression processDateLikeTypeCoercion(ComparisonPredicate cp, Expression left, Expression right) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
@@ -52,7 +52,7 @@ public class DecimalLiteral extends FractionalLiteral {
     }
 
     @Override
-    protected BigDecimal getBigDecimalValue() {
+    public BigDecimal getBigDecimalValue() {
         return value;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
@@ -78,7 +78,7 @@ public class DecimalV3Literal extends FractionalLiteral {
     }
 
     @Override
-    protected BigDecimal getBigDecimalValue() {
+    public BigDecimal getBigDecimalValue() {
         return value;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
@@ -38,7 +38,7 @@ public class DoubleLiteral extends FractionalLiteral {
     }
 
     @Override
-    protected BigDecimal getBigDecimalValue() {
+    public BigDecimal getBigDecimalValue() {
         return new BigDecimal(String.valueOf(value));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/FloatLiteral.java
@@ -37,7 +37,7 @@ public class FloatLiteral extends FractionalLiteral {
     }
 
     @Override
-    protected BigDecimal getBigDecimalValue() {
+    public BigDecimal getBigDecimalValue() {
         return new BigDecimal(String.valueOf(value));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IntegerLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IntegerLikeLiteral.java
@@ -41,7 +41,7 @@ public abstract class IntegerLikeLiteral extends NumericLiteral {
     }
 
     @Override
-    protected BigDecimal getBigDecimalValue() {
+    public BigDecimal getBigDecimalValue() {
         return new BigDecimal(getLongValue());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/LargeIntLiteral.java
@@ -64,7 +64,7 @@ public class LargeIntLiteral extends IntegerLikeLiteral {
     }
 
     @Override
-    protected BigDecimal getBigDecimalValue() {
+    public BigDecimal getBigDecimalValue() {
         return new BigDecimal(value);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
@@ -68,5 +68,5 @@ public abstract class NumericLiteral extends Literal implements ComparableLitera
                 + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
     }
 
-    protected abstract BigDecimal getBigDecimalValue();
+    public abstract BigDecimal getBigDecimalValue();
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
@@ -122,6 +122,27 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
     }
 
     @Test
+    void testIntCompIntLiteral() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(
+                        SimplifyCastRule.INSTANCE,
+                        SimplifyComparisonPredicate.INSTANCE
+                )
+        ));
+
+        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE);
+        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE);
+        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE);
+
+        assertRewrite(new LessThan(new Cast(intSlot, BigIntType.INSTANCE), new BigIntLiteral(10L)),
+                new LessThan(intSlot, new IntegerLiteral(10)));
+        assertRewrite(new LessThan(new Cast(smallIntSlot, BigIntType.INSTANCE), new BigIntLiteral(10L)),
+                new LessThan(smallIntSlot, new SmallIntLiteral((short) 10)));
+        assertRewrite(new LessThan(new Cast(tinyIntSlot, BigIntType.INSTANCE), new BigIntLiteral(10L)),
+                new LessThan(tinyIntSlot, new TinyIntLiteral((byte) 10)));
+    }
+
+    @Test
     void testDateTimeV2CmpDateTimeV2() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
                 bottomUp(
@@ -861,8 +882,8 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
                         Pair.of(new DoubleLiteral(-128.1), new DecimalV3Literal(new BigDecimal("-128.1")))),
                 ImmutableList.of(
                         Pair.of(new TinyIntLiteral((byte) -128), null),
-                        Pair.of(new SmallIntLiteral((short) -128), null),
-                        Pair.of(new IntegerLiteral(-128), null),
+                        Pair.of(new SmallIntLiteral((short) -128), new TinyIntLiteral((byte) -128)),
+                        Pair.of(new IntegerLiteral(-128), new TinyIntLiteral((byte) -128)),
                         Pair.of(new DecimalV3Literal(new BigDecimal("-128")), new TinyIntLiteral((byte) -128)),
                         Pair.of(new DoubleLiteral(-128.0), new TinyIntLiteral((byte) -128))),
                 ImmutableList.of(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
@@ -58,6 +58,7 @@ import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.LargeIntType;
 import org.apache.doris.nereids.types.SmallIntType;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.util.ExpressionUtils;
@@ -130,10 +131,13 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
                 )
         ));
 
+        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE);
         Expression intSlot = new SlotReference("a", IntegerType.INSTANCE);
         Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE);
         Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE);
 
+        assertRewrite(new LessThan(new Cast(bigIntSlot, LargeIntType.INSTANCE), new LargeIntLiteral(new BigInteger("10"))),
+                new LessThan(bigIntSlot, new BigIntLiteral(10L)));
         assertRewrite(new LessThan(new Cast(intSlot, BigIntType.INSTANCE), new BigIntLiteral(10L)),
                 new LessThan(intSlot, new IntegerLiteral(10)));
         assertRewrite(new LessThan(new Cast(smallIntSlot, BigIntType.INSTANCE), new BigIntLiteral(10L)),

--- a/regression-test/data/nereids_rules_p0/filter_push_down/push_down_filter_other_condition.out
+++ b/regression-test/data/nereids_rules_p0/filter_push_down/push_down_filter_other_condition.out
@@ -173,7 +173,7 @@ PhysicalResultSink
 -- !pushdown_inner_join_subquery --
 PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((expr_cast(id as BIGINT) = sum(id))) otherCondition=()
-----filter((cast(id as BIGINT) = 1) and (t1.id = 1))
+----filter((t1.id = 1))
 ------PhysicalOlapScan[t1]
 ----filter((sum(id) = 1))
 ------hashAgg[GLOBAL]

--- a/regression-test/data/nereids_rules_p0/filter_push_down/push_filter_through.out
+++ b/regression-test/data/nereids_rules_p0/filter_push_down/push_filter_through.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 
 -- !filter_project_arithmetic --
 PhysicalResultSink
---filter((cast(id as BIGINT) = 1))
+--filter((t1.id = 1))
 ----PhysicalOlapScan[t1]
 
 -- !filter_order_by --

--- a/regression-test/data/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.out
@@ -227,7 +227,7 @@ PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((t1.d_int = expr_cast(d_tinyint as INT))) otherCondition=()
 ----filter((t1.d_int < 10))
 ------PhysicalOlapScan[extend_infer_t1]
-----filter((cast(d_tinyint as INT) < 10) and (t2.d_tinyint < 10))
+----filter((t2.d_tinyint < 10))
 ------PhysicalOlapScan[extend_infer_t1]
 
 -- !test_int_downcast --
@@ -318,7 +318,7 @@ PhysicalResultSink
 -- !test_cast_and_func3 --
 PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((expr_cast(cast(d_int as TINYINT) as SMALLINT) = expr_abs(d_tinyint))) otherCondition=()
-----filter((cast(cast(d_int as TINYINT) as SMALLINT) < 10))
+----filter((cast(d_int as TINYINT) < 10))
 ------PhysicalOlapScan[extend_infer_t1]
 ----filter((abs(d_tinyint) < 10))
 ------PhysicalOlapScan[extend_infer_t1]
@@ -603,12 +603,12 @@ PhysicalResultSink
 -- !not_equal_semi_semi_with_cast --
 PhysicalResultSink
 --hashJoin[LEFT_SEMI_JOIN] hashCondition=((expr_cast(d_smallint as INT) = t.c1)) otherCondition=()
-----filter(( not (cast(d_smallint as INT) = 10)) and ( not (d_smallint = 10)))
+----filter(( not (d_smallint = 10)))
 ------PhysicalOlapScan[extend_infer_t1]
 ----hashJoin[LEFT_SEMI_JOIN] hashCondition=((c1 = expr_cast(d_tinyint as INT))) otherCondition=()
 ------filter(( not (d_int = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
-------filter(( not (cast(d_tinyint as INT) = 10)))
+------filter(( not (d_tinyint = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
 
 -- !not_equal_anti_anti_with_cast --
@@ -619,7 +619,7 @@ PhysicalResultSink
 ----hashJoin[LEFT_ANTI_JOIN] hashCondition=((c1 = expr_cast(d_tinyint as INT))) otherCondition=()
 ------filter(( not (d_int = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
-------filter(( not (cast(d_tinyint as INT) = 10)))
+------filter(( not (d_tinyint = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
 
 -- !not_equal_anti_left_with_cast --
@@ -630,18 +630,18 @@ PhysicalResultSink
 ----hashJoin[LEFT_OUTER_JOIN] hashCondition=((c1 = expr_cast(d_tinyint as INT))) otherCondition=()
 ------filter(( not (d_int = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
-------filter(( not (cast(d_tinyint as INT) = 10)))
+------filter(( not (d_tinyint = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
 
 -- !not_equal_semi_anti_with_cast --
 PhysicalResultSink
 --hashJoin[LEFT_SEMI_JOIN] hashCondition=((expr_cast(d_smallint as INT) = t.c1)) otherCondition=()
-----filter(( not (cast(d_smallint as INT) = 10)) and ( not (d_smallint = 10)))
+----filter(( not (d_smallint = 10)))
 ------PhysicalOlapScan[extend_infer_t1]
 ----hashJoin[LEFT_ANTI_JOIN] hashCondition=((c1 = expr_cast(d_tinyint as INT))) otherCondition=()
 ------filter(( not (d_int = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
-------filter(( not (cast(d_tinyint as INT) = 10)))
+------filter(( not (d_tinyint = 10)))
 --------PhysicalOlapScan[extend_infer_t1]
 
 -- !in_subquery_to_semi_join --

--- a/regression-test/data/nereids_rules_p0/infer_predicate/infer_intersect_except.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/infer_intersect_except.out
@@ -49,7 +49,7 @@ PhysicalResultSink
 --PhysicalIntersect
 ----filter((infer_intersect_except1.a > 0))
 ------PhysicalOlapScan[infer_intersect_except1]
-----filter((cast(a as BIGINT) < -1))
+----filter((infer_intersect_except2.a < -1))
 ------PhysicalOlapScan[infer_intersect_except2]
 
 -- !except_and_intersect_except_predicate_to_right --

--- a/regression-test/data/nereids_rules_p0/max_min_filter_push_down/max_min_filter_push_down.out
+++ b/regression-test/data/nereids_rules_p0/max_min_filter_push_down/max_min_filter_push_down.out
@@ -24,7 +24,7 @@ PhysicalResultSink
 PhysicalResultSink
 --hashAgg[GLOBAL]
 ----hashAgg[LOCAL]
-------filter((cast(value1 as BIGINT) < 19))
+------filter((max_min_filter_push_down1.value1 < 19))
 --------PhysicalOlapScan[max_min_filter_push_down1]
 
 -- !max_expr --

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query66.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query66.out
@@ -29,7 +29,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------filter(sm_carrier IN ('GREAT EASTERN', 'LATVIAN'))
@@ -54,7 +54,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------filter(sm_carrier IN ('GREAT EASTERN', 'LATVIAN'))

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query84.out
@@ -26,6 +26,6 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject
-------------------filter((cast(ib_upper_bound as BIGINT) <= 55806) and (income_band.ib_lower_bound >= 5806))
+------------------filter((income_band.ib_lower_bound >= 5806) and (income_band.ib_upper_bound <= 55806))
 --------------------PhysicalOlapScan[income_band]
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query66.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query66.out
@@ -29,7 +29,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------filter(sm_carrier IN ('GREAT EASTERN', 'LATVIAN'))
@@ -54,7 +54,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------filter(sm_carrier IN ('GREAT EASTERN', 'LATVIAN'))

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query84.out
@@ -26,6 +26,6 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject
-------------------filter((cast(ib_upper_bound as BIGINT) <= 55806) and (income_band.ib_lower_bound >= 5806))
+------------------filter((income_band.ib_lower_bound >= 5806) and (income_band.ib_upper_bound <= 55806))
 --------------------PhysicalOlapScan[income_band]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query66.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query66.out
@@ -30,7 +30,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]
@@ -55,7 +55,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query84.out
@@ -26,6 +26,6 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[household_demographics] apply RFs: RF0
 ------------------------PhysicalProject
---------------------------filter((cast(ib_upper_bound as BIGINT) <= 55806) and (income_band.ib_lower_bound >= 5806))
+--------------------------filter((income_band.ib_lower_bound >= 5806) and (income_band.ib_upper_bound <= 55806))
 ----------------------------PhysicalOlapScan[income_band]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query66.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query66.out
@@ -30,7 +30,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]
@@ -55,7 +55,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 1998))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 77621) and (time_dim.t_time >= 48821))
+------------------------------------filter((time_dim.t_time <= 77621) and (time_dim.t_time >= 48821))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query84.out
@@ -26,6 +26,6 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[household_demographics] apply RFs: RF0
 ------------------------PhysicalProject
---------------------------filter((cast(ib_upper_bound as BIGINT) <= 55806) and (income_band.ib_lower_bound >= 5806))
+--------------------------filter((income_band.ib_lower_bound >= 5806) and (income_band.ib_upper_bound <= 55806))
 ----------------------------PhysicalOlapScan[income_band]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query66.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query66.out
@@ -30,7 +30,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 71770) and (time_dim.t_time >= 42970))
+------------------------------------filter((time_dim.t_time <= 71770) and (time_dim.t_time >= 42970))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]
@@ -55,7 +55,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 71770) and (time_dim.t_time >= 42970))
+------------------------------------filter((time_dim.t_time <= 71770) and (time_dim.t_time >= 42970))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query84.out
@@ -26,7 +26,7 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[household_demographics] apply RFs: RF0
 ------------------------PhysicalProject
---------------------------filter((cast(ib_upper_bound as BIGINT) <= 110306) and (income_band.ib_lower_bound >= 60306))
+--------------------------filter((income_band.ib_lower_bound >= 60306) and (income_band.ib_upper_bound <= 110306))
 ----------------------------PhysicalOlapScan[income_band]
 
 Hint log:

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query66.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query66.out
@@ -30,7 +30,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 71770) and (time_dim.t_time >= 42970))
+------------------------------------filter((time_dim.t_time <= 71770) and (time_dim.t_time >= 42970))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]
@@ -55,7 +55,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter((cast(t_time as BIGINT) <= 71770) and (time_dim.t_time >= 42970))
+------------------------------------filter((time_dim.t_time <= 71770) and (time_dim.t_time >= 42970))
 --------------------------------------PhysicalOlapScan[time_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[warehouse]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query84.out
@@ -26,6 +26,6 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[household_demographics] apply RFs: RF0
 ------------------------PhysicalProject
---------------------------filter((cast(ib_upper_bound as BIGINT) <= 110306) and (income_band.ib_lower_bound >= 60306))
+--------------------------filter((income_band.ib_lower_bound >= 60306) and (income_band.ib_upper_bound <= 110306))
 ----------------------------PhysicalOlapScan[income_band]
 

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query84.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query84.out
@@ -26,6 +26,6 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[household_demographics] apply RFs: RF3
 ----------------PhysicalProject
-------------------filter((cast(ib_upper_bound as BIGINT) <= 87855) and (income_band.ib_lower_bound >= 37855))
+------------------filter((income_band.ib_lower_bound >= 37855) and (income_band.ib_upper_bound <= 87855))
 --------------------PhysicalOlapScan[income_band]
 


### PR DESCRIPTION
### What problem does this PR solve?

simplify comparison for cast from smaller int type to bigger int type.

for example:

suppose a is integer type,  for expression `a >  500000 + 100000`,  because `500000` and `100000` are int type,  int + int is big int type, so the right side is big int type, then will rewrite as `cast(a as bigint) > bigint(500000 + 100000)`,  after fold constant, will got `cast(a as bigint) > bigint(600000)`,  but since `600000` can represent as a int type,  we can simplify this predicate as `a > int(600000)`

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

