### PR TITLE
branch-2.1: [fix](java) should use JAVA_OPTS_FOR_JDK_17 instead of JAVA_OPTS #48170

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -96,23 +96,11 @@ const std::string GetKerb5ConfPath() {
 }
 
 [[maybe_unused]] void SetEnvIfNecessary() {
-    const auto* doris_home = getenv("DORIS_HOME");
-    DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
-
-    // CLASSPATH
-    const std::string original_classpath = getenv("CLASSPATH") ? getenv("CLASSPATH") : "";
-    static const std::string classpath = fmt::format(
-            "{}/conf:{}:{}", doris_home, GetDorisJNIDefaultClasspath(), original_classpath);
-    setenv("CLASSPATH", classpath.c_str(), 0);
-
-    // LIBHDFS_OPTS
-    const std::string java_opts = getenv("JAVA_OPTS") ? getenv("JAVA_OPTS") : "";
-    std::string libhdfs_opts =
-            fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{} ", java_opts,
-                        getenv("DORIS_HOME"), getenv("DORIS_HOME") + std::string("/lib"));
-    libhdfs_opts += fmt::format("{} ", GetKerb5ConfPath());
-
+    std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
+    CHECK(libhdfs_opts != "") << "LIBHDFS_OPTS is not set";
+    libhdfs_opts += fmt::format(" {} ", GetKerb5ConfPath());
     setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);
+    LOG(INFO) << "set final LIBHDFS_OPTS: " << libhdfs_opts;
 }
 
 // Only used on non-x86 platform

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -358,6 +358,7 @@ fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -207,6 +207,7 @@ elif [[ "${java_version}" -gt 8 ]]; then
 fi
 log "using java version ${java_version}"
 log "${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # add libs to CLASSPATH
 DORIS_FE_JAR=


### PR DESCRIPTION
bp #48170
So that when user using jdk17 to run Doris 2.1, it will get the right JAVA_OPTS