### PR TITLE
branch-3.0: [fix](java) should use JAVA_OPTS_FOR_JDK_17 instead of JAVA_OPTS #48170 #48335

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -46,6 +46,7 @@ namespace doris {
 namespace {
 JavaVM* g_vm;
 [[maybe_unused]] std::once_flag g_vm_once;
+[[maybe_unused]] std::once_flag g_jvm_conf_once;
 
 const std::string GetDorisJNIDefaultClasspath() {
     const auto* doris_home = getenv("DORIS_HOME");
@@ -265,7 +266,7 @@ Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     }
 #else
     // the hadoop libhdfs will do all the stuff
-    SetEnvIfNecessary();
+    std::call_once(g_jvm_conf_once, SetEnvIfNecessary);
     tls_env_ = getJNIEnv();
 #endif
     *env = tls_env_;

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -93,22 +93,11 @@ const std::string GetDorisJNIClasspathOption() {
 }
 
 [[maybe_unused]] void SetEnvIfNecessary() {
-    const auto* doris_home = getenv("DORIS_HOME");
-    DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
-
-    // CLASSPATH
-    const std::string original_classpath = getenv("CLASSPATH") ? getenv("CLASSPATH") : "";
-    static const std::string classpath = fmt::format(
-            "{}/conf:{}:{}", doris_home, GetDorisJNIDefaultClasspath(), original_classpath);
-    setenv("CLASSPATH", classpath.c_str(), 0);
-
-    // LIBHDFS_OPTS
-    const std::string java_opts = getenv("JAVA_OPTS") ? getenv("JAVA_OPTS") : "";
-    std::string libhdfs_opts =
-            fmt::format("{} -Djava.library.path={}/lib/hadoop_hdfs/native:{}", java_opts,
-                        getenv("DORIS_HOME"), getenv("DORIS_HOME") + std::string("/lib"));
-
-    setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 0);
+    std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
+    CHECK(libhdfs_opts != "") << "LIBHDFS_OPTS is not set";
+    libhdfs_opts += fmt::format(" {} ", GetKerb5ConfPath());
+    setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);
+    LOG(INFO) << "set final LIBHDFS_OPTS: " << libhdfs_opts;
 }
 
 // Only used on non-x86 platform

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -92,6 +92,10 @@ const std::string GetDorisJNIClasspathOption() {
     }
 }
 
+const std::string GetKerb5ConfPath() {
+    return "-Djava.security.krb5.conf=" + config::kerberos_krb5_conf_path;
+}
+
 [[maybe_unused]] void SetEnvIfNecessary() {
     std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     CHECK(libhdfs_opts != "") << "LIBHDFS_OPTS is not set";
@@ -127,6 +131,7 @@ const std::string GetDorisJNIClasspathOption() {
                                                std::istream_iterator<std::string>());
             options.push_back(GetDorisJNIClasspathOption());
         }
+        options.push_back(GetKerb5ConfPath());
         std::unique_ptr<JavaVMOption[]> jvm_options(new JavaVMOption[options.size()]);
         for (int i = 0; i < options.size(); ++i) {
             jvm_options[i] = {const_cast<char*>(options[i].c_str()), nullptr};

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -403,6 +403,7 @@ fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
 export LIBHDFS_OPTS="${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # log "CLASSPATH: ${CLASSPATH}"
 # log "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -204,6 +204,7 @@ else
 fi
 log "Using Java version ${java_version}"
 log "${final_java_opt}"
+export JAVA_OPTS="${final_java_opt}"
 
 # add libs to CLASSPATH
 DORIS_FE_JAR=


### PR DESCRIPTION
bp #48170 and #48335
and also pick part of #47299, only related to `jni-util.cpp`.
To pass the krb5.conf config to Jni env