### PR TITLE
[fix](build) Fix an import error

### DIFF
--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/custom/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/custom/AuditLoaderPlugin.java
@@ -26,7 +26,7 @@ import org.apache.doris.plugin.PluginException;
 import org.apache.doris.plugin.PluginInfo;
 
 import com.google.common.collect.Queues;
-import org.apache.doris.plugin.audit.AuditEvent;
+import org.apache.doris.plugin.AuditEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
Fix an import error:
-import org.apache.doris.plugin.audit.AuditEvent;
+import org.apache.doris.plugin.AuditEvent;