### PR TITLE
[fix](column) fix ColumnWithTypeAndName::get_nested use-after-free when input Const(Nullable) column

### DIFF
--- a/be/src/vec/core/column_with_type_and_name.cpp
+++ b/be/src/vec/core/column_with_type_and_name.cpp
@@ -95,8 +95,9 @@ ColumnWithTypeAndName ColumnWithTypeAndName::get_nested(bool replace_null_data_t
         auto nested_type = assert_cast<const DataTypeNullable*>(type.get())->get_nested_type();
         ColumnPtr nested_column = column;
         if (column) {
-            nested_column = nested_column->convert_to_full_column_if_const();
-            const auto* source_column = assert_cast<const ColumnNullable*>(nested_column.get());
+            // A column_ptr is needed here to ensure that the column in convert_to_full_column_if_const is not released.
+            auto column_ptr = nested_column->convert_to_full_column_if_const();
+            const auto* source_column = assert_cast<const ColumnNullable*>(column_ptr.get());
             nested_column = source_column->get_nested_column_ptr();
 
             if (replace_null_data_to_default) {

--- a/be/test/vec/core/column_with_type_and_name_test.cpp
+++ b/be/test/vec/core/column_with_type_and_name_test.cpp
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/core/column_with_type_and_name.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/column_helper.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+
+namespace doris::vectorized {
+
+TEST(ColumnWithTypeAndNameTest, get_nested_test) {
+    ColumnWithTypeAndName column_with_type_and_name;
+    auto null_column = ColumnNullable::create(ColumnHelper::create_column<DataTypeInt32>({1}),
+                                              ColumnHelper::create_column<DataTypeUInt8>({true}));
+    column_with_type_and_name.column = ColumnConst::create(null_column, 3);
+    column_with_type_and_name.type =
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>());
+    column_with_type_and_name.name = "column_with_type_and_name";
+    column_with_type_and_name.get_nested(true);
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

error code 
```
        ColumnPtr nested_column = column;
        if (column) {
            nested_column = nested_column->convert_to_full_column_if_const();
            const auto* source_column = assert_cast<const ColumnNullable*>(nested_column.get());
            nested_column = source_column->get_nested_column_ptr();
```

If column is a const(nullable) column, 
execute: nested_column = nested_column->convert_to_full_column_if_const(); 
nested_column points to a new nullable column. 
Execute: const auto* source_column = assert_cast<const ColumnNullable*>(nested_column.get()); 
source_column, this raw pointer, points to the new nullable column (but does not have ownership). 
Execute: nested_column = source_column->get_nested_column_ptr(); 
nested_column points to the nested column of the new nullable column, and the original nullable column is released.




### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

