### PR TITLE
[fix](group commit) fix wal reader handle empty block

### DIFF
--- a/be/src/olap/wal/wal_reader.h
+++ b/be/src/olap/wal/wal_reader.h
@@ -35,6 +35,7 @@ public:
     Status read_header(uint32_t& version, std::string& col_ids);
 
 private:
+    Status _deserialize(PBlock& block, const std::string& buf, size_t block_len, size_t bytes_read);
     Status _check_checksum(const char* binary, size_t size, uint32_t checksum);
 
     std::string _file_name;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

If kill BE, wal writer may write block length and does not write block data. Then when replay wal, will get: 
```
failed to replay wal...st=[INTERNAL_ERROR]cur path: . failed to deserialize row
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

