### PR TITLE
[Enhancement-2.1](log) Reduce INFO log size by changing some routine query log to VLOG

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -703,7 +703,8 @@ void FragmentMgr::_exec_actual(std::shared_ptr<PlanFragmentExecutor> fragment_ex
     {
         _fragment_instance_map.erase(fragment_executor->fragment_instance_id());
 
-        LOG_INFO("Instance {} finished", print_id(fragment_executor->fragment_instance_id()));
+        VLOG(10) << fmt::format("Instance {} finished",
+                                print_id(fragment_executor->fragment_instance_id()));
     }
     if (all_done && query_ctx) {
         _query_ctx_map.erase(query_ctx->query_id());
@@ -808,7 +809,7 @@ Status FragmentMgr::start_query_execution(const PExecPlanFragmentStartRequest* r
         }
     }
     q_ctx->set_ready_to_execute(false);
-    LOG_INFO("Query {} start execution", print_id(query_id));
+    VLOG(10) << fmt::format("Query {} start execution", print_id(query_id));
     return Status::OK();
 }
 
@@ -822,13 +823,14 @@ void FragmentMgr::remove_pipeline_context(
         f_context->instance_ids(ins_ids);
         all_done = q_context->countdown(ins_ids.size());
         for (const auto& ins_id : ins_ids) {
-            LOG_INFO("Removing query {} instance {}, all done? {}", print_id(query_id),
-                     print_id(ins_id), all_done);
+            VLOG(10) << fmt::format("Removing query {} instance {}, all done? {}",
+                                    print_id(query_id), print_id(ins_id), all_done);
             _pipeline_map.erase(ins_id);
             g_pipeline_fragment_instances_count << -1;
         }
     }
     if (all_done) {
+        // the only one log when query finished.
         _query_ctx_map.erase(query_id);
         LOG_INFO("Query {} finished", print_id(query_id));
     }
@@ -864,13 +866,13 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
                         current_connect_fe_addr = params.coord;
                     }
 
-                    LOG(INFO) << "query_id: " << print_id(query_id)
-                              << ", coord_addr: " << params.coord
-                              << ", total fragment num on current host: "
-                              << params.fragment_num_on_host
-                              << ", fe process uuid: " << params.query_options.fe_process_uuid
-                              << ", query type: " << params.query_options.query_type
-                              << ", report audit fe:" << current_connect_fe_addr;
+                    VLOG(10) << "query_id: " << print_id(query_id)
+                             << ", coord_addr: " << params.coord
+                             << ", total fragment num on current host: "
+                             << params.fragment_num_on_host
+                             << ", fe process uuid: " << params.query_options.fe_process_uuid
+                             << ", query type: " << params.query_options.query_type
+                             << ", report audit fe:" << current_connect_fe_addr;
 
                     // This may be a first fragment request of the query.
                     // Create the query fragments context.
@@ -909,21 +911,21 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
                             _exec_env->runtime_query_statistics_mgr()->set_workload_group_id(
                                     print_id(query_id), tg_id);
 
-                            LOG(INFO) << "Query/load id: " << print_id(query_ctx->query_id())
-                                      << ", use workload group: "
-                                      << workload_group_ptr->debug_string()
-                                      << ", is pipeline: " << ((int)is_pipeline);
+                            VLOG(10) << "Query/load id: " << print_id(query_ctx->query_id())
+                                     << ", use workload group: "
+                                     << workload_group_ptr->debug_string()
+                                     << ", is pipeline: " << ((int)is_pipeline);
                         } else {
-                            LOG(INFO) << "Query/load id: " << print_id(query_ctx->query_id())
-                                      << " carried group info but can not find group in be";
+                            VLOG(10) << "Query/load id: " << print_id(query_ctx->query_id())
+                                     << " carried group info but can not find group in be";
                         }
                     }
                     // There is some logic in query ctx's dctor, we could not check if exists and delete the
                     // temp query ctx now. For example, the query id maybe removed from workload group's queryset.
                     map.insert({query_id, query_ctx});
-                    LOG(INFO) << "Register query/load memory tracker, query/load id: "
-                              << print_id(query_ctx->query_id()) << " limit: "
-                              << PrettyPrinter::print(query_ctx->mem_limit(), TUnit::BYTES);
+                    VLOG(10) << "Register query/load memory tracker, query/load id: "
+                             << print_id(query_ctx->query_id()) << " limit: "
+                             << PrettyPrinter::print(query_ctx->mem_limit(), TUnit::BYTES);
                     return Status::OK();
                 }));
     }
@@ -1444,8 +1446,7 @@ void FragmentMgr::cancel_worker() {
                                     queries_pipeline_task_leak.push_back(q_ctx->query_id());
                                     LOG_INFO(
                                             "Query {}, type {} is not found on any frontends, "
-                                            "maybe it "
-                                            "is leaked.",
+                                            "maybe it is leaked.",
                                             print_id(q_ctx->query_id()),
                                             toString(q_ctx->get_query_source()));
                                     continue;

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -154,7 +154,6 @@ QueryContext::~QueryContext() {
     }
 
     _exec_env->runtime_query_statistics_mgr()->set_query_finished(print_id(_query_id));
-    VLOG(10) << fmt::format("Query {} deconstructed, {}", print_id(_query_id), mem_tracker_msg);
     // Not release the the thread token in query context's dector method, because the query
     // conext may be dectored in the thread token it self. It is very dangerous and may core.
     // And also thread token need shutdown, it may take some time, may cause the thread that
@@ -187,8 +186,8 @@ QueryContext::~QueryContext() {
     _exec_env->spill_stream_mgr()->async_cleanup_query(_query_id);
     DorisMetrics::instance()->query_ctx_cnt->increment(-1);
     // the only one msg shows query's end. any other msg should append to it if need.
-    VLOG(10) << fmt::format("Query {} deconstructed, mem_tracker: {}", print_id(this->_query_id),
-                            mem_tracker_msg);
+    LOG(INFO) << fmt::format("Query {} deconstructed, mem_tracker: {}", print_id(this->_query_id),
+                             mem_tracker_msg);
 }
 
 void QueryContext::set_ready_to_execute(bool is_cancelled) {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -154,7 +154,7 @@ QueryContext::~QueryContext() {
     }
 
     _exec_env->runtime_query_statistics_mgr()->set_query_finished(print_id(_query_id));
-    LOG_INFO("Query {} deconstructed, {}", print_id(_query_id), mem_tracker_msg);
+    VLOG(10) << fmt::format("Query {} deconstructed, {}", print_id(_query_id), mem_tracker_msg);
     // Not release the the thread token in query context's dector method, because the query
     // conext may be dectored in the thread token it self. It is very dangerous and may core.
     // And also thread token need shutdown, it may take some time, may cause the thread that
@@ -187,7 +187,8 @@ QueryContext::~QueryContext() {
     _exec_env->spill_stream_mgr()->async_cleanup_query(_query_id);
     DorisMetrics::instance()->query_ctx_cnt->increment(-1);
     // the only one msg shows query's end. any other msg should append to it if need.
-    LOG_INFO("Query {} deconstructed, mem_tracker: {}", print_id(this->_query_id), mem_tracker_msg);
+    VLOG(10) << fmt::format("Query {} deconstructed, mem_tracker: {}", print_id(this->_query_id),
+                            mem_tracker_msg);
 }
 
 void QueryContext::set_ready_to_execute(bool is_cancelled) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

They are only useful when there's a query hanging in BE. When it occurs, we can dynamically change the vlog level.

### Release note

Reduce query-side INFO log quantity

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

