### PR TITLE
[Enhancement](Log) Reduce usage of DCHECK

### DIFF
--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -152,3 +152,29 @@ inline const std::string& Exception::to_string() const {
             return Status::Error<false>(e.code(), e.to_string());                                \
         }                                                                                        \
     } while (0);
+
+#define DORIS_CHECK(condition, ...)                                                           \
+    do {                                                                                      \
+        if (!(condition)) {                                                                   \
+            throw doris::Exception(doris::Status::FatalError(                                 \
+                    "Check failed: {} {}", #condition __VA_OPT__(, fmt::format(__VA_ARGS__)), \
+                    ""));                                                                     \
+        }                                                                                     \
+    } while (0)
+
+template <typename T>
+T* DorisCheckNotNull(const char* expr, T* ptr) {
+    if (ptr == nullptr) {
+        throw doris::Exception(
+                doris::Status::FatalError("Check failed: '{}' must be not null", expr));
+    }
+    return ptr;
+}
+
+#define DORIS_CHECK_LT(a, b, ...) DORIS_CHECK(a < b, __VA_ARGS__)
+#define DORIS_CHECK_LE(a, b, ...) DORIS_CHECK(a <= b, __VA_ARGS__)
+#define DORIS_CHECK_GT(a, b, ...) DORIS_CHECK(a > b, __VA_ARGS__)
+#define DORIS_CHECK_GE(a, b, ...) DORIS_CHECK(a >= b, __VA_ARGS__)
+#define DORIS_CHECK_EQ(a, b, ...) DORIS_CHECK(a == b, __VA_ARGS__)
+#define DORIS_CHECK_NE(a, b, ...) DORIS_CHECK(a != b, __VA_ARGS__)
+#define DORIS_CHECK_NOTNULL(a) DorisCheckNotNull(#a, (a))

--- a/be/src/exprs/block_bloom_filter_impl.cc
+++ b/be/src/exprs/block_bloom_filter_impl.cc
@@ -132,7 +132,7 @@ void BlockBloomFilter::bucket_insert(const uint32_t bucket_idx, const uint32_t h
     for (int i = 0; i < 2; ++i) {
         __m128i new_bucket_sse = _mm_load_si128(reinterpret_cast<__m128i*>(new_bucket + 4 * i));
         __m128i* existing_bucket =
-                reinterpret_cast<__m128i*>(&DCHECK_NOTNULL(_directory)[bucket_idx][4 * i]);
+                reinterpret_cast<__m128i*>(&DORIS_CHECK_NOTNULL(_directory)[bucket_idx][4 * i]);
         *existing_bucket = _mm_or_si128(*existing_bucket, new_bucket_sse);
     }
 }
@@ -163,7 +163,7 @@ bool BlockBloomFilter::bucket_find(const uint32_t bucket_idx, const uint32_t has
     uint32_t masks[kBucketWords];
     make_find_mask(hash, masks);
     for (int i = 0; i < kBucketWords; ++i) {
-        if ((DCHECK_NOTNULL(_directory)[bucket_idx][i] & masks[i]) == 0) {
+        if ((DORIS_CHECK_NOTNULL(_directory)[bucket_idx][i] & masks[i]) == 0) {
             return false;
         }
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -193,7 +193,8 @@ public:
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena*,
                                  size_t num_rows) const override {
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
+        DORIS_CHECK(col.size() >= num_rows, "source column's size should greater than num_rows");
+
         auto* data = col.get_data().data();
         memcpy(places, data, sizeof(Data) * num_rows);
     }
@@ -228,7 +229,7 @@ public:
                                            Arena*) const override {
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         const size_t num_rows = column.size();
-        DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
+        DORIS_CHECK(col.size() >= num_rows, "source column's size should greater than num_rows");
         auto* data = reinterpret_cast<const Data*>(col.get_data().data());
 
         for (size_t i = 0; i != num_rows; ++i) {
@@ -240,8 +241,8 @@ public:
     void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
                                                  const IColumn& column, size_t begin, size_t end,
                                                  Arena*) const override {
-        DCHECK(end <= column.size() && begin <= end)
-                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+        DORIS_CHECK(end <= column.size() && begin <= end, "begin:{}, end:{}, column.size():{}",
+                    begin, end, column.size());
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         auto* data = reinterpret_cast<const Data*>(col.get_data().data());
         for (size_t i = begin; i <= end; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -200,8 +200,8 @@ public:
     void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
                                                  const IColumn& column, size_t begin, size_t end,
                                                  Arena*) const override {
-        DCHECK(end <= column.size() && begin <= end)
-                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+        DORIS_CHECK(end <= column.size() && begin <= end, "begin:{}, end:{}, column.size():{}",
+                    begin, end, column.size());
         auto& col = assert_cast<const ColumnBitmap&>(column);
         auto* data = col.get_data().data();
         for (size_t i = begin; i <= end; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
@@ -74,7 +74,7 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena*) const override {
-        DCHECK_LT(row_num, columns[0]->size());
+        DORIS_CHECK_LT(row_num, columns[0]->size());
         if constexpr (arg_nullable) {
             auto& nullable_col =
                     assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*columns[0]);
@@ -147,7 +147,7 @@ public:
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena*,
                                  size_t num_rows) const override {
         auto& col = assert_cast<const ColumnBitmap&>(column);
-        DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
+        DORIS_CHECK(col.size() >= num_rows, "source column's size should greater than num_rows");
         auto* src = col.get_data().data();
         auto* data = &(this->data(places));
         for (size_t i = 0; i != num_rows; ++i) {
@@ -179,8 +179,8 @@ public:
     void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
                                                  const IColumn& column, size_t begin, size_t end,
                                                  Arena*) const override {
-        DCHECK(end <= column.size() && begin <= end)
-                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+        DORIS_CHECK(end <= column.size() && begin <= end, "begin:{}, end:{}, column.size():{}",
+                    begin, end, column.size());
         auto& col = assert_cast<const ColumnBitmap&>(column);
         auto* data = col.get_data().data();
         for (size_t i = begin; i <= end; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.cpp
@@ -56,7 +56,7 @@ public:
     AggregateFunctionPtr transform_aggregate_function(
             const AggregateFunctionPtr& nested_function, const DataTypes& arguments,
             const bool result_is_nullable) const override {
-        DCHECK(nested_function != nullptr);
+        DORIS_CHECK(nested_function != nullptr);
         if (nested_function == nullptr) {
             return nullptr;
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -569,7 +569,7 @@ public:
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena*) const override {
         if constexpr (Data::IS_ANY) {
-            DCHECK_GT(batch_size, 0);
+            DORIS_CHECK_GT(batch_size, 0);
             this->data(place).change_if_better(*columns[0], 0, nullptr);
         } else {
             Base::add_batch_single_place(batch_size, place, columns, nullptr);
@@ -656,8 +656,8 @@ public:
                                                  const IColumn& column, size_t begin, size_t end,
                                                  Arena*) const override {
         if constexpr (Data::IsFixedLength) {
-            DCHECK(end <= column.size() && begin <= end) << ", begin:" << begin << ", end:" << end
-                                                         << ", column.size():" << column.size();
+            DORIS_CHECK(end <= column.size() && begin <= end, "begin: {}, end:{}, column.size():{}",
+                        begin, end, column.size());
             auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
             auto* data = reinterpret_cast<const Data*>(col.get_data().data());
             for (size_t i = begin; i <= end; ++i) {

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -76,7 +76,7 @@ public:
                                     const DataTypes& arguments)
             : IAggregateFunctionHelper<Derived>(arguments),
               nested_function {assert_cast<NestFunction*>(nested_function_)} {
-        DCHECK(nested_function_ != nullptr);
+        DORIS_CHECK(nested_function_ != nullptr);
         if (result_is_nullable) {
             prefix_size = nested_function->align_of_data();
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -465,7 +465,7 @@ struct WindowFunctionFirstImpl : Data {
             (!arg_ignore_null || (arg_ignore_null && !this->is_null()))) {
             return;
         }
-        DCHECK_LE(frame_start, frame_end);
+        DORIS_CHECK_LE(frame_start, frame_end);
         if (frame_start >= partition_end || frame_end <= partition_start) {
             this->set_is_null();
             return;
@@ -492,7 +492,7 @@ template <typename Data, bool arg_ignore_null = false>
 struct WindowFunctionLastImpl : Data {
     void add_range_single_place(int64_t partition_start, int64_t partition_end, int64_t frame_start,
                                 int64_t frame_end, const IColumn** columns) {
-        DCHECK_LE(frame_start, frame_end);
+        DORIS_CHECK_LE(frame_start, frame_end);
         if ((frame_end <= partition_start) ||
             (frame_start >= partition_end)) { //beyond or under partition, set null
             this->set_is_null();

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -295,7 +295,7 @@ void ColumnArray::update_crcs_with_value(uint32_t* __restrict hash, PrimitiveTyp
                                          uint32_t rows, uint32_t offset,
                                          const uint8_t* __restrict null_data) const {
     auto s = rows;
-    DCHECK(s == size());
+    DORIS_CHECK(s == size());
 
     if (null_data) {
         for (size_t i = 0; i < s; ++i) {
@@ -326,7 +326,7 @@ void ColumnArray::insert(const Field& x) {
 }
 
 void ColumnArray::insert_from(const IColumn& src_, size_t n) {
-    DCHECK_LT(n, src_.size());
+    DORIS_CHECK_LT(n, src_.size());
     const ColumnArray& src = assert_cast<const ColumnArray&>(src_);
     size_t size = src.size_at(n);
     size_t offset = src.offset_at(n);
@@ -354,7 +354,7 @@ void ColumnArray::insert_default() {
 
 void ColumnArray::pop_back(size_t n) {
     auto& offsets_data = get_offsets();
-    DCHECK(n <= offsets_data.size()) << " n:" << n << " with offsets size: " << offsets_data.size();
+    DORIS_CHECK(n <= offsets_data.size(), "n:{} with offsets size: {}", n, offsets_data.size());
     size_t nested_n = offsets_data.back() - offset_at(offsets_data.size() - n);
     if (nested_n) get_data().pop_back(nested_n);
     offsets_data.resize_assume_reserved(offsets_data.size() - n);

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -58,7 +58,7 @@ public:
     Container& get_data() { return _data; }
 
     void resize(size_t n) override {
-        DCHECK_GT(_item_size, 0) << "_item_size should be greater than 0";
+        DORIS_CHECK_GT(_item_size, 0, "_item_size should be greater than 0");
         _data.resize(n * _item_size);
         _item_count = n;
     }
@@ -90,7 +90,8 @@ public:
         if (_item_size == 0) {
             _item_size = src_vec._item_size;
         }
-        DCHECK_EQ(_item_size, src_vec._item_size) << "dst and src should have the same _item_size";
+        DORIS_CHECK_EQ(_item_size, src_vec._item_size,
+                       "dst and src should have the same _item_size");
         resize(origin_size + new_size);
 
         for (uint32_t i = 0; i < new_size; ++i) {
@@ -146,8 +147,9 @@ public:
 
     void insert_from(const IColumn& src, size_t n) override {
         const auto& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
-        DCHECK(_item_size == src_col._item_size) << "dst and src should have the same _item_size  "
-                                                 << _item_size << " " << src_col._item_size;
+        DORIS_CHECK(_item_size == src_col._item_size,
+                    "dst and src should have the same _item_size  {} {}", _item_size,
+                    src_col.item_size());
         insert_data((const char*)(&src_col._data[n * _item_size]), _item_size);
     }
 
@@ -164,7 +166,7 @@ public:
     }
 
     void pop_back(size_t n) override {
-        DCHECK_GE(_item_count, n);
+        DORIS_CHECK_GE(_item_count, n);
         resize(_item_count - n);
     }
 
@@ -260,8 +262,8 @@ public:
     size_t item_size() const { return _item_size; }
 
     void set_item_size(size_t size) {
-        DCHECK(_item_count == 0 || size == _item_size)
-                << "cannot reset _item_size of ColumnFixedLengthObject";
+        DORIS_CHECK(_item_count == 0 || size == _item_size,
+                    "cannot reset _item_size of ColumnFixedLengthObject");
         _item_size = size;
     }
 
@@ -275,9 +277,9 @@ public:
     //NOTICE: here is replace: this[self_row] = rhs[row]
     //But column string is replaced all when self_row = 0
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
-        DCHECK(size() > self_row);
-        DCHECK(_item_size == assert_cast<const Self&>(rhs)._item_size)
-                << _item_size << " " << assert_cast<const Self&>(rhs)._item_size;
+        DORIS_CHECK(size() > self_row);
+        DORIS_CHECK(_item_size == assert_cast<const Self&>(rhs)._item_size, "_item_size ;{}",
+                    assert_cast<const Self&>(rhs)._item_size);
         auto obj = assert_cast<const Self&>(rhs).get_data_at(row);
         memcpy(&_data[self_row * _item_size], obj.data, _item_size);
     }

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -53,4 +53,23 @@ TEST_F(ExceptionTest, NestedError) {
     }
 }
 
+TEST_F(ExceptionTest, DorisCheckCrash) {
+#ifndef NDEBUG
+    ASSERT_DEATH({ DORIS_CHECK(1 == 2); }, "Check failed: 1 == 2 ");
+#endif
+}
+
+TEST_F(ExceptionTest, ComparionMarcoCrash) {
+#ifndef NDEBUG
+    ASSERT_DEATH({ DORIS_CHECK_GT(1, 2); }, "Check failed: 1 > 2 ");
+#endif
+}
+
+TEST_F(ExceptionTest, NotNullCrash) {
+#ifndef NDEBUG
+    int* ptr = nullptr;
+    ASSERT_DEATH({ DORIS_CHECK_NOTNULL(ptr); }, "Check failed: .* must be not null");
+#endif
+}
+
 } // namespace doris


### PR DESCRIPTION

Introduce a new macro `DORIS_CHECK` to encapsulate the behavior of `throw FatalError`, and use it to replace `DCHECK`