### PR TITLE
[fix](fe-ut) make SetVariableTest::testExecMemLimit more reasonable

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
@@ -65,8 +65,10 @@ public class SetVariableTest {
     public void testExecMemLimit() throws Exception {
         String setStr = "set exec_mem_limit = @@exec_mem_limit * 10";
         connectContext.getState().reset();
+        long previousValue = connectContext.getSessionVariable().getMaxExecMemByte();
+        long expectedValue = previousValue * 10;
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, setStr);
         stmtExecutor.execute();
-        Assert.assertEquals(21474836480L, connectContext.getSessionVariable().getMaxExecMemByte());
+        Assert.assertEquals(expectedValue, connectContext.getSessionVariable().getMaxExecMemByte());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupTest.java
@@ -38,7 +38,7 @@ public class WorkloadGroupTest {
         String name1 = "g1";
         WorkloadGroup group1 = WorkloadGroup.create(name1, properties1);
         Assert.assertEquals(name1, group1.getName());
-        Assert.assertEquals(5, group1.getProperties().size());
+        Assert.assertEquals(7, group1.getProperties().size());
         Assert.assertTrue(group1.getProperties().containsKey(WorkloadGroup.CPU_SHARE));
         Assert.assertTrue(Math.abs(group1.getMemoryLimitPercent() - 30) < 1e-6);
     }


### PR DESCRIPTION
### What problem does this PR solve?

And also fix the WorkloadGroupTest::testCreateNormal
    
After merged the spill and reserve code(#47462), the properties of `WorkloadGroup` was changed.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

