### PR TITLE
[cherry-pick](branch-2.1) Don't prematurely erase DeleteRows in reading iceberg table with position delete (#47977)

### DIFF
--- a/be/src/vec/exec/format/table/iceberg_reader.cpp
+++ b/be/src/vec/exec/format/table/iceberg_reader.cpp
@@ -302,8 +302,7 @@ Status IcebergTableReader::_position_delete_base(
         const std::string data_file_path, const std::vector<TIcebergDeleteFileDesc>& delete_files) {
     std::vector<DeleteRows*> delete_rows_array;
     int64_t num_delete_rows = 0;
-    std::vector<DeleteFile*> erase_data;
-    for (auto& delete_file : delete_files) {
+    for (const auto& delete_file : delete_files) {
         SCOPED_TIMER(_iceberg_profile.delete_files_read_time);
         Status create_status = Status::OK();
         auto* delete_file_cache = _kv_cache->get<DeleteFile>(
@@ -337,7 +336,6 @@ Status IcebergTableReader::_position_delete_base(
             if (row_ids->size() > 0) {
                 delete_rows_array.emplace_back(row_ids);
                 num_delete_rows += row_ids->size();
-                erase_data.emplace_back(delete_file_cache);
             }
         };
         delete_file_map.if_contains(data_file_path, get_value);
@@ -347,10 +345,6 @@ Status IcebergTableReader::_position_delete_base(
         _sort_delete_rows(delete_rows_array, num_delete_rows);
         this->set_delete_rows();
         COUNTER_UPDATE(_iceberg_profile.num_delete_rows, num_delete_rows);
-    }
-    // the deleted rows are copy out, we can erase them.
-    for (auto& erase_item : erase_data) {
-        erase_item->erase(data_file_path);
     }
     return Status::OK();
 }


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #41460
Problem Summary:
When reading the Iceberg table, previously read `DeleteRows` should not be released immediately, as the Iceberg data file is split into multiple `IcebergSplit`s for execution. These `IcebergSplit`s belong to the same data file, meaning they share the same `DeleteRows`. Therefore, `DeleteRows` in the `DeleteFile` should not be released prematurely. Instead, they should be released when the shared_kv is reset, at which point all `DeleteRows` will be freed along with the cached `DeleteFile`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

