### PR TITLE
[fix](schema scan) Fix invalid pointer access

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -117,12 +117,12 @@ Status SchemaScanner::get_next_block_async(RuntimeState* state) {
     auto task_ctx = state->get_task_execution_context();
     RETURN_IF_ERROR(ExecEnv::GetInstance()->fragment_mgr()->get_thread_pool()->submit_func(
             [this, task_ctx, state]() {
-                DCHECK(_async_thread_running == false);
                 auto task_lock = task_ctx.lock();
                 if (task_lock == nullptr) {
                     _scanner_status.update(Status::InternalError("Task context not exists!"));
                     return;
                 }
+                DCHECK(_async_thread_running == false);
                 SCOPED_ATTACH_TASK(state);
                 _async_thread_running = true;
                 if (!_opened) {


### PR DESCRIPTION
### What problem does this PR solve?

Schema scanner runs on a separate thread which is executed asynchronously. We should make sure all context used not be freed once it is scheduled.

ERROR: AddressSanitizer: heap-buffer-overflow on address 0x613002f33eb2 at pc 0x55e085dccbe3 bp 0x7f345c0e1f10 sp 0x7f345c0e1f08
READ of size 1 at 0x613002f33eb2 thread T2776 (FragmentMgrAsyn)
    #0 0x55e085dccbe2 in std::__atomic_base::load(std::memory_order) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:481:9
    #1 0x55e085dccbe2 in std::atomic::operator bool() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/atomic:87:22
    #2 0x55e085dccbe2 in doris::SchemaScanner::get_next_block_async(doris::RuntimeState*)::$_0::operator()() const /home/zcp/repo_center/doris_master/doris/be/src/exec/schema_scanner.cpp:118:5
    #3 0x55e085dccbe2 in void std::__invoke_impl(std::__invoke_other, doris::SchemaScanner::get_next_block_async(doris::RuntimeState*)::$_0&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #4 0x55e085dccbe2 in std::enable_if, void>::type std::__invoke_r(doris::SchemaScanner::get_next_block_async(doris::RuntimeState*)::$_0&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #5 0x55e085dccbe2 in std::_Function_handler::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #6 0x55e050f081ca in doris::ThreadPool::dispatch_thread() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:608:24
    #7 0x55e050ede467 in doris::Thread::supervise_thread(void*) /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:498:5
    #8 0x7f376ef5aac2 in start_thread nptl/pthread_create.c:442:8
    #9 0x7f376efec84f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

