### PR TITLE
[fix](beut) fix "unknown file C++ exception with description "bad_weak_ptr" thrown" in DataStreamRecvrTest

### DIFF
--- a/be/test/testutil/mock/mock_runtime_state.h
+++ b/be/test/testutil/mock/mock_runtime_state.h
@@ -42,7 +42,7 @@ public:
     int batsh_size = 4096;
     bool _enable_shared_exchange_sink_buffer = true;
     std::shared_ptr<MockContext> _mock_context = std::make_shared<MockContext>();
-    std::unique_ptr<MockQueryContext> _query_ctx_uptr = std::make_unique<MockQueryContext>();
+    std::shared_ptr<MockQueryContext> _query_ctx_uptr = std::make_shared<MockQueryContext>();
 };
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

There are conflicts between the following two PRs. 
One PR uses unique_ptr to construct query_ctx, while the other PR uses shared_from_this

https://github.com/apache/doris/pull/48188
https://github.com/apache/doris/pull/47462

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

