### PR TITLE
[fix](jvm) the jvm opt should only be set once

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -46,6 +46,7 @@ namespace doris {
 namespace {
 JavaVM* g_vm;
 [[maybe_unused]] std::once_flag g_vm_once;
+[[maybe_unused]] std::once_flag g_jvm_conf_once;
 
 const std::string GetDorisJNIDefaultClasspath() {
     const auto* doris_home = getenv("DORIS_HOME");
@@ -265,7 +266,7 @@ Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     }
 #else
     // the hadoop libhdfs will do all the stuff
-    SetEnvIfNecessary();
+    std::call_once(g_jvm_conf_once, SetEnvIfNecessary);
     tls_env_ = getJNIEnv();
 #endif
     *env = tls_env_;


### PR DESCRIPTION
### What problem does this PR solve?

Introduced from #47299 
the `SetEnvIfNecessary` may be called multiple times, and in #47299,
we changed `setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 0);` to `setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);`
so it will add `krb5 path` at the end of `LIBHDFS_OPTS` and set it every time,
so `LIBHDFS_OPTS` becomes longer and longer.

This PR fix this issue by calling `SetEnvIfNecessary` only once

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

