### PR TITLE
[fix](nereids) in predicate extract non-constant exclude non-foldable expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstant.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstant.java
@@ -43,10 +43,13 @@ public class InPredicateExtractNonConstant implements ExpressionPatternRuleFacto
 
     @Override
     public List<ExpressionPatternMatcher<? extends Expression>> buildRules() {
+        // If compare expr contains non-foldable expressions, don't extract it.
+        // For example: `a + random() in (x, x + 10)`, if extracted, `a + random() = x or a + random() = x + 10`,
+        // then the expression will contain RANDOM two times.
         return ImmutableList.of(
                 matchesType(InPredicate.class)
-                        .when(inPredicate -> inPredicate.getOptions().size()
-                                <= InPredicateDedup.REWRITE_OPTIONS_MAX_SIZE)
+                        .when(inPredicate -> !inPredicate.getCompareExpr().containsNonfoldable()
+                                && inPredicate.getOptions().size() <= InPredicateDedup.REWRITE_OPTIONS_MAX_SIZE)
                         .then(this::rewrite)
                         .toRule(ExpressionRuleType.IN_PREDICATE_EXTRACT_NON_CONSTANT)
         );

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstantTest.java
@@ -43,5 +43,14 @@ class InPredicateExtractNonConstantTest extends SqlTestBase {
                         logicalFilter().when(f -> f.getPredicate().toString().equals(
                                 "OR[id#0 IN (10, 20, 30, 300),(id#0 = score#1),(id#0 = (score#1 + 10)),(id#0 = (score#1 + score#1))]"
                 )));
+
+        sql = "select * from T1 where id + random(1, 10) in (score,  score + 10, score + score, score, 10, 20, 30, 100 + 200)";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(
+                        logicalFilter().when(f -> f.getPredicate().toString().equals(
+                                "(id#0 + random(1, 10)) IN (score#1, (score#1 + 10), (score#1 + score#1), 10, 20, 30, 300)"
+                        )));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

for rule InPredicateExtractNonConstant,  if the compare expr contains non-foldable expression, then don't rewrite it. for example:  `a + random() in (id, 1, 2, 3)`, if rewrite to `a + random() = id or a + random() in (1, 2, 3)`,  it will contains RANDOM double times.  There's another solution:   add a project to alias `random() as k`,  and rewrite this expression to `k = id or k in (1, 2, 3)`,  but the backend developer said no need this solution,  InPredicateExtractNonConstant just skip the non-foldable expression is ok.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

