### PR TITLE
[Fix](remote-fs)Change closed Field to Instance-Level to Avoid Global Shutdown Issues in RemoteFileSystem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFileSystem.java
@@ -43,7 +43,7 @@ public abstract class RemoteFileSystem extends PersistentFileSystem implements C
     // this field will be visited by multi-threads, better use volatile qualifier
     protected volatile org.apache.hadoop.fs.FileSystem dfsFileSystem = null;
     private final ReentrantLock fsLock = new ReentrantLock();
-    protected static final AtomicBoolean closed = new AtomicBoolean(false);
+    protected AtomicBoolean closed = new AtomicBoolean(false);
 
     public RemoteFileSystem(String name, StorageBackend.StorageType type) {
         super(name, type);


### PR DESCRIPTION

### PR Description:
Change Background:
The closed field in the current RemoteFileSystem class is static, meaning it is shared globally across all instances of the class. This design leads to issues when multiple parts of the application use RemoteFileSystem and attempt to close it. Once one instance is closed, the static closed field is set to true, causing other instances to incorrectly report that the file system is unavailable. This can cause confusion and inconsistent behavior, especially when multiple threads are involved.

### Change Details:
closed Field: The closed field has been moved from a static field to an instance-level field. This ensures that each RemoteFileSystem instance maintains its own shutdown status, eliminating the problem of shared state between instances.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

