### PR TITLE
[fix](metrics) max_compaction_score metrics do not update while compaction_num_per_round > 1

### DIFF
--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -837,7 +837,6 @@ std::vector<TabletSharedPtr> TabletManager::find_best_tablets_to_compaction(
                       << ", compaction_score=" << compaction_score
                       << ", highest_score=" << highest_score;
         picked_tablet.emplace_back(std::move(best_tablet));
-        *score = compaction_score;
     }
 
     std::vector<TabletSharedPtr> reverse_top_tablets;
@@ -850,6 +849,7 @@ std::vector<TabletSharedPtr> TabletManager::find_best_tablets_to_compaction(
         picked_tablet.emplace_back(*it);
     }
 
+    *score = highest_score;
     return picked_tablet;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
if we set compaction_num_per_round>1, then max_compaction_score do not update.

come from: https://github.com/apache/doris/pull/46160

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

