### PR TITLE
[fix](nereids) derive sum() column stats as UNKNOWN

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -353,7 +353,7 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
         Expression child = min.child();
         ColumnStatistic columnStat = child.accept(this, context);
         if (columnStat.isUnKnown) {
-            return ColumnStatistic.UNKNOWN;
+            return ColumnStatistic.UNKNOWN.withAvgSizeByte(min.getDataType().width());
         }
         // if this is scalar agg, we will update count and ndv to 1 when visiting group clause
         return new ColumnStatisticBuilder(columnStat).build();
@@ -364,7 +364,7 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
         Expression child = max.child();
         ColumnStatistic columnStat = child.accept(this, context);
         if (columnStat.isUnKnown) {
-            return ColumnStatistic.UNKNOWN;
+            return ColumnStatistic.UNKNOWN.withAvgSizeByte(max.getDataType().width());
         }
         // if this is scalar agg, we will update count and ndv to 1 when visiting group clause
         return new ColumnStatisticBuilder(columnStat).build();
@@ -374,19 +374,20 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
     public ColumnStatistic visitCount(Count count, Statistics context) {
         double width = count.getDataType().width();
         // for scalar agg, ndv and row count will be normalized by 1 in StatsCalculator.computeAggregate()
-        return new ColumnStatisticBuilder(ColumnStatistic.UNKNOWN).setAvgSizeByte(width).build();
+        return ColumnStatistic.UNKNOWN.withAvgSizeByte(width);
     }
 
     // TODO: return a proper estimated stat after supports histogram
     @Override
     public ColumnStatistic visitSum(Sum sum, Statistics context) {
-        return ColumnStatistic.UNKNOWN;
+        // estimate size as BIGINT
+        return ColumnStatistic.UNKNOWN.withAvgSizeByte(sum.getDataType().width());
     }
 
     // TODO: return a proper estimated stat after supports histogram
     @Override
     public ColumnStatistic visitAvg(Avg avg, Statistics context) {
-        return avg.child().accept(this, context);
+        return ColumnStatistic.UNKNOWN.withAvgSizeByte(avg.getDataType().width());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -380,7 +380,7 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
     // TODO: return a proper estimated stat after supports histogram
     @Override
     public ColumnStatistic visitSum(Sum sum, Statistics context) {
-        return sum.child().accept(this, context);
+        return ColumnStatistic.UNKNOWN;
     }
 
     // TODO: return a proper estimated stat after supports histogram

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -365,4 +365,8 @@ public class ColumnStatistic {
     public boolean isUnKnown() {
         return isUnKnown;
     }
+
+    public ColumnStatistic withAvgSizeByte(double avgSizeByte) {
+        return new ColumnStatisticBuilder(this).setAvgSizeByte(avgSizeByte).build();
+    }
 }

--- a/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.out
+++ b/regression-test/data/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.out
@@ -226,12 +226,13 @@ PhysicalResultSink
 ------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
-------------PhysicalOlapScan[sum_t_one_side]
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
 ----------------PhysicalOlapScan[sum_t_one_side]
+--------hashAgg[GLOBAL]
+----------hashAgg[LOCAL]
+------------filter((t2.score < 100))
+--------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -284,12 +285,12 @@ PhysicalResultSink
 ------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
-------------PhysicalOlapScan[sum_t_one_side]
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
 ----------------PhysicalOlapScan[sum_t_one_side]
+--------hashAgg[GLOBAL]
+----------hashAgg[LOCAL]
+------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -398,12 +399,12 @@ PhysicalResultSink
 --------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ----------hashAgg[GLOBAL]
 ------------hashAgg[LOCAL]
---------------PhysicalOlapScan[sum_t_one_side]
-----------hashAgg[GLOBAL]
-------------hashAgg[LOCAL]
 --------------hashAgg[GLOBAL]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalOlapScan[sum_t_one_side]
+----------hashAgg[GLOBAL]
+------------hashAgg[LOCAL]
+--------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -432,20 +433,20 @@ PhysicalResultSink
 ------hashJoin[INNER_JOIN] hashCondition=((t1.name = t3.name)) otherCondition=()
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
-------------PhysicalOlapScan[sum_t_one_side]
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
 ----------------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ------------------hashAgg[GLOBAL]
 --------------------hashAgg[LOCAL]
-----------------------PhysicalOlapScan[sum_t_one_side]
-------------------hashAgg[GLOBAL]
---------------------hashAgg[LOCAL]
 ----------------------hashAgg[GLOBAL]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalOlapScan[sum_t_one_side]
+------------------hashAgg[GLOBAL]
+--------------------hashAgg[LOCAL]
+----------------------PhysicalOlapScan[sum_t_one_side]
+--------hashAgg[GLOBAL]
+----------hashAgg[LOCAL]
+------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -461,12 +462,12 @@ PhysicalResultSink
 ----------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
-----------------PhysicalOlapScan[sum_t_one_side]
-------------hashAgg[GLOBAL]
---------------hashAgg[LOCAL]
 ----------------hashAgg[GLOBAL]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalOlapScan[sum_t_one_side]
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -480,12 +481,12 @@ PhysicalResultSink
 ------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id) and (t1.name = t2.name)) otherCondition=()
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
-------------PhysicalOlapScan[sum_t_one_side]
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
 ----------------PhysicalOlapScan[sum_t_one_side]
+--------hashAgg[GLOBAL]
+----------hashAgg[LOCAL]
+------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -516,12 +517,12 @@ PhysicalResultSink
 ------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id) and (t1.name = t2.name)) otherCondition=()
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
-------------PhysicalOlapScan[sum_t_one_side]
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
 ----------------PhysicalOlapScan[sum_t_one_side]
+--------hashAgg[GLOBAL]
+----------hashAgg[LOCAL]
+------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -591,12 +592,12 @@ PhysicalResultSink
 ----------hashJoin[INNER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
-----------------PhysicalOlapScan[sum_t_one_side]
-------------hashAgg[GLOBAL]
---------------hashAgg[LOCAL]
 ----------------hashAgg[GLOBAL]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalOlapScan[sum_t_one_side]
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side
@@ -610,12 +611,12 @@ PhysicalResultSink
 ------hashJoin[INNER_JOIN] hashCondition=((t1_alias.id = t2_alias.id) and (t1_alias.name = t2_alias.name)) otherCondition=()
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
-------------PhysicalOlapScan[sum_t_one_side]
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
 ----------------PhysicalOlapScan[sum_t_one_side]
+--------hashAgg[GLOBAL]
+----------hashAgg[LOCAL]
+------------PhysicalOlapScan[sum_t_one_side]
 
 Hint log:
 Used: use_push_down_agg_through_join_one_side

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query31.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query31.out
@@ -42,17 +42,17 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF7 ca_county->[ca_county,ca_county,ca_county]
 --------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF6 ca_county->[ca_county,ca_county]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
+------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county]
+--------------------------PhysicalProject
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=() build RFs:RF4 ca_county->[ca_county]
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF5 RF6 RF7 RF8
+--------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF6 RF7 RF8
 ----------------------------PhysicalProject
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6 RF7 RF8
---------------------------PhysicalProject
-----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF6 RF7 RF8
 ----------------------PhysicalProject
 ------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF7 RF8

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query47.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=()
+--------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=() build RFs:RF8 i_category->[i_category];RF9 i_brand->[i_brand];RF10 s_store_name->[s_store_name];RF11 s_company_name->[s_company_name];RF12 rn->[(rn - 1)]
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF8 RF9 RF10 RF11 RF12
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=() build RFs:RF3 i_category->[i_category];RF4 i_brand->[i_brand];RF5 s_store_name->[s_store_name];RF6 s_company_name->[s_company_name];RF7 rn->[(rn + 1)]
 --------------------PhysicalProject
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF5 RF6 RF7
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 2001))
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query59.out
@@ -16,27 +16,27 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk) and (y.s_store_id1 = x.s_store_id2)) otherCondition=()
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF6 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))) otherCondition=()
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF4 s_store_id2->[s_store_id];RF5 expr_(d_week_seq2 - 52)->[cast(d_week_seq as BIGINT)]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
+----------------------PhysicalProject
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF5 RF6
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[store] apply RFs: RF4
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3
+----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[store]
 ----------------------PhysicalProject
 ------------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
 --------------------------PhysicalOlapScan[date_dim]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
-----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1
-----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
---------------------------PhysicalOlapScan[date_dim]
 --------------PhysicalProject
-----------------PhysicalOlapScan[store]
+----------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
+------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query81.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query81.out
@@ -22,20 +22,20 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE)))
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
+----------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE)))
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ctr_customer_sk]
 ----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF3
-------------------PhysicalProject
---------------------filter((customer_address.ca_state = 'CA'))
-----------------------PhysicalOlapScan[customer_address]
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------hashAgg[LOCAL]
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------PhysicalOlapScan[customer] apply RFs: RF4
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute[DistributionSpecHash]
+----------------------hashAgg[LOCAL]
+------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------PhysicalProject
+----------------filter((customer_address.ca_state = 'CA'))
+------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query31.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query31.out
@@ -42,17 +42,17 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF7 ca_county->[ca_county,ca_county,ca_county]
 --------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF6 ca_county->[ca_county,ca_county]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
+------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county]
+--------------------------PhysicalProject
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=() build RFs:RF4 ca_county->[ca_county]
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF5 RF6 RF7 RF8
+--------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF6 RF7 RF8
 ----------------------------PhysicalProject
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
---------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6 RF7 RF8
---------------------------PhysicalProject
-----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF6 RF7 RF8
 ----------------------PhysicalProject
 ------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
 --------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF7 RF8

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query47.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=() build RFs:RF8 i_category->[i_category,i_category];RF9 i_brand->[i_brand,i_brand];RF10 s_store_name->[s_store_name,s_store_name];RF11 s_company_name->[s_company_name,s_company_name];RF12 expr_(rn - 1)->[(rn + 1),rn]
+--------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=() build RFs:RF8 i_category->[i_category];RF9 i_brand->[i_brand];RF10 s_store_name->[s_store_name];RF11 s_company_name->[s_company_name];RF12 rn->[(rn - 1)]
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF8 RF9 RF10 RF11 RF12
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=() build RFs:RF3 i_category->[i_category];RF4 i_brand->[i_brand];RF5 s_store_name->[s_store_name];RF6 s_company_name->[s_company_name];RF7 rn->[(rn + 1)]
 --------------------PhysicalProject
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF5 RF6 RF7 RF8 RF9 RF10 RF11 RF12
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF5 RF6 RF7
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 2001))
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF8 RF9 RF10 RF11 RF12
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query59.out
@@ -16,27 +16,27 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF4 s_store_id1->[s_store_id];RF5 s_store_sk->[ss_store_sk]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF6 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))) otherCondition=()
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF4 s_store_id2->[s_store_id];RF5 expr_(d_week_seq2 - 52)->[cast(d_week_seq as BIGINT)]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF5 RF6
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[store] apply RFs: RF4
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 --------------------------PhysicalProject
-----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF3
+----------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1 RF2
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store] apply RFs: RF4
+----------------------------PhysicalOlapScan[store]
 ----------------------PhysicalProject
 ------------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
 --------------------------PhysicalOlapScan[date_dim]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
-----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1 RF5
-----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
---------------------------PhysicalOlapScan[date_dim]
 --------------PhysicalProject
-----------------PhysicalOlapScan[store]
+----------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
+------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query81.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query81.out
@@ -22,20 +22,20 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))) build RFs:RF4 ctr_state->[ctr_state]
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
+----------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))) build RFs:RF3 ctr_state->[ctr_state]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ctr_customer_sk]
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF4
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF3
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF3
-------------------PhysicalProject
---------------------filter((customer_address.ca_state = 'CA'))
-----------------------PhysicalOlapScan[customer_address]
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------hashAgg[LOCAL]
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------PhysicalOlapScan[customer] apply RFs: RF4
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute[DistributionSpecHash]
+----------------------hashAgg[LOCAL]
+------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------PhysicalProject
+----------------filter((customer_address.ca_state = 'CA'))
+------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query30.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query30.out
@@ -24,15 +24,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE)))
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ctr_customer_sk]
-------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 ctr_customer_sk->[c_customer_sk]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------PhysicalProject
-------------------------filter((customer_address.ca_state = 'IN'))
---------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalOlapScan[customer] apply RFs: RF2 RF3
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------PhysicalProject
+--------------------filter((customer_address.ca_state = 'IN'))
+----------------------PhysicalOlapScan[customer_address]
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query31.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query31.out
@@ -42,13 +42,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------filter((ws3.d_qoy = 3) and (ws3.d_year = 2000))
 --------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF8
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF7 ca_county->[ca_county]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF7 ca_county->[ca_county]
 --------------------PhysicalProject
-----------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF7
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF6 ca_county->[ca_county,ca_county,ca_county]
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
+----------------------filter((ws2.d_qoy = 2) and (ws2.d_year = 2000))
+------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF7
+--------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF6 ca_county->[ca_county,ca_county]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=() build RFs:RF4 ca_county->[ca_county]
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
@@ -57,9 +57,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6
 --------------------------PhysicalProject
-----------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF6
-------------------------PhysicalProject
---------------------------filter((ws2.d_qoy = 2) and (ws2.d_year = 2000))
-----------------------------PhysicalCteConsumer ( cteId=CTEId#1 )
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------PhysicalProject
+------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#1 )
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query46.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query46.out
@@ -5,34 +5,34 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN shuffle] hashCondition=((dn.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (ca_city = bought_city)))
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city)))
 ------------PhysicalProject
---------------hashAgg[LOCAL]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((dn.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=()
+------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[ss_hdemo_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF1 hd_demo_sk->[ss_hdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2
+------------------------------------PhysicalProject
+--------------------------------------filter(d_dow IN (0, 6) and d_year IN (1999, 2000, 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
-----------------------------------filter(d_dow IN (0, 6) and d_year IN (1999, 2000, 2001))
-------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------filter(OR[(household_demographics.hd_dep_count = 6),(household_demographics.hd_vehicle_count = 0)])
+------------------------------------PhysicalOlapScan[household_demographics]
 ----------------------------PhysicalProject
-------------------------------filter(OR[(household_demographics.hd_dep_count = 6),(household_demographics.hd_vehicle_count = 0)])
---------------------------------PhysicalOlapScan[household_demographics]
+------------------------------filter(s_city IN ('Centerville', 'Fairview', 'Five Points', 'Liberty', 'Oak Grove'))
+--------------------------------PhysicalOlapScan[store]
 ------------------------PhysicalProject
---------------------------filter(s_city IN ('Centerville', 'Fairview', 'Five Points', 'Liberty', 'Oak Grove'))
-----------------------------PhysicalOlapScan[store]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[customer_address]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=()
+--------------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer]
-----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------PhysicalProject
+--------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query58.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query58.out
@@ -5,17 +5,19 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = cs_items.item_id)) otherCondition=((cast(cs_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE))) build RFs:RF13 item_id->[i_item_id]
+----------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = ws_items.item_id)) otherCondition=((cast(cs_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE))) build RFs:RF13 item_id->[i_item_id]
 ------------PhysicalProject
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 i_item_sk->[cs_item_sk]
+----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 ws_item_sk->[i_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[cs_sold_date_sk]
+--------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF11 RF12
+------------------------------PhysicalOlapScan[web_sales] apply RFs: RF11
 ----------------------------PhysicalProject
 ------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF10 d_date->[d_date]
 --------------------------------PhysicalProject
@@ -29,20 +31,18 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_date = '2001-03-24'))
 --------------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item] apply RFs: RF13
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = ws_items.item_id)) otherCondition=((cast(ss_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE))) build RFs:RF8 item_id->[i_item_id]
+--------------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = cs_items.item_id)) otherCondition=((cast(cs_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE))) build RFs:RF8 item_id->[i_item_id]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[cs_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF6 RF7
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF5 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -63,13 +63,11 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 ws_item_sk->[i_item_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF3
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -83,4 +81,6 @@ PhysicalResultSink
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((date_dim.d_date = '2001-03-24'))
 ------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query59.out
@@ -18,25 +18,25 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF4 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
 ----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store] apply RFs: RF5
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store] apply RFs: RF5
+--------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
+----------------------PhysicalOlapScan[date_dim]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=()
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2
 ----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store]
+--------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query65.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query65.out
@@ -5,37 +5,37 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=()
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF4 ss_store_sk->[s_store_sk,ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=()
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF2 ss_store_sk->[ss_store_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=()
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF4
 ------------------------------PhysicalProject
 --------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))
 ----------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[item]
+----------------PhysicalProject
+------------------PhysicalOlapScan[store] apply RFs: RF4
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashAgg[GLOBAL]
-------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------hashAgg[LOCAL]
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
---------------------------------------PhysicalProject
-----------------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))
-------------------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalProject
-------------------PhysicalOlapScan[item]
-------------PhysicalProject
---------------PhysicalOlapScan[store]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))
+----------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query79.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query79.out
@@ -5,7 +5,7 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN shuffle] hashCondition=((ms.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((ms.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------PhysicalProject
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query81.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query81.out
@@ -24,15 +24,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE)))
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ctr_customer_sk]
-------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ctr_customer_sk]
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------PhysicalProject
-------------------------filter((customer_address.ca_state = 'CA'))
---------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalOlapScan[customer] apply RFs: RF3
+------------------PhysicalProject
+--------------------filter((customer_address.ca_state = 'CA'))
+----------------------PhysicalOlapScan[customer_address]
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query83.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query83.out
@@ -5,44 +5,44 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = cr_items.item_id)) otherCondition=() build RFs:RF13 item_id->[i_item_id]
+----------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = wr_items.item_id)) otherCondition=() build RFs:RF13 item_id->[i_item_id,i_item_id]
 ------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 cr_item_sk->[i_item_sk]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[cr_returned_date_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF11
-----------------------------PhysicalProject
-------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF10 d_date->[d_date]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[date_dim] apply RFs: RF10
---------------------------------PhysicalProject
-----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF9 d_week_seq->[d_week_seq]
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF9
-------------------------------------PhysicalProject
---------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
-----------------------------------------PhysicalOlapScan[date_dim]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = wr_items.item_id)) otherCondition=() build RFs:RF8 item_id->[i_item_id]
+--------------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = cr_items.item_id)) otherCondition=() build RFs:RF12 item_id->[i_item_id]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 sr_item_sk->[i_item_sk]
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 sr_item_sk->[i_item_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF7 RF8
+------------------------------PhysicalOlapScan[item] apply RFs: RF11 RF12 RF13
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF10 d_date_sk->[sr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF6
+----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10
+--------------------------------PhysicalProject
+----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF9 d_date->[d_date]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF9
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF8 d_week_seq->[d_week_seq]
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF8
+----------------------------------------PhysicalProject
+------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
+--------------------------------------------PhysicalOlapScan[date_dim]
+----------------PhysicalProject
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute[DistributionSpecHash]
+----------------------hashAgg[LOCAL]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 cr_item_sk->[i_item_sk]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item] apply RFs: RF7 RF13
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[cr_returned_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF6
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF5 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -54,27 +54,27 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
 --------------------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalProject
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute[DistributionSpecHash]
-----------------------hashAgg[LOCAL]
+------------PhysicalProject
+--------------hashAgg[GLOBAL]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------hashAgg[LOCAL]
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
+--------------------------PhysicalOlapScan[item] apply RFs: RF3
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[wr_returned_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF3
+------------------------------PhysicalOlapScan[web_returns] apply RFs: RF2
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[wr_returned_date_sk]
+------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_returns] apply RFs: RF2
+----------------------------------PhysicalOlapScan[date_dim] apply RFs: RF1
 --------------------------------PhysicalProject
-----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
+----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF0 d_week_seq->[d_week_seq]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF1
+--------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF0
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF0 d_week_seq->[d_week_seq]
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF0
-----------------------------------------PhysicalProject
-------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
---------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
+----------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query30.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query30.out
@@ -24,15 +24,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))) build RFs:RF4 ctr_state->[ctr_state]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ctr_customer_sk]
-------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 ctr_customer_sk->[c_customer_sk]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------PhysicalProject
-------------------------filter((customer_address.ca_state = 'IN'))
---------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalOlapScan[customer] apply RFs: RF2 RF3
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4
+------------------PhysicalProject
+--------------------filter((customer_address.ca_state = 'IN'))
+----------------------PhysicalOlapScan[customer_address]
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query31.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query31.out
@@ -42,13 +42,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------filter((ws3.d_qoy = 3) and (ws3.d_year = 2000))
 --------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF8
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF7 ca_county->[ca_county]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF7 ca_county->[ca_county]
 --------------------PhysicalProject
-----------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF7
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF6 ca_county->[ca_county,ca_county,ca_county]
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
+----------------------filter((ws2.d_qoy = 2) and (ws2.d_year = 2000))
+------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF7
+--------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF6 ca_county->[ca_county,ca_county]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=() build RFs:RF4 ca_county->[ca_county]
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 2000))
@@ -57,9 +57,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 2000))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6
 --------------------------PhysicalProject
-----------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF6
-------------------------PhysicalProject
---------------------------filter((ws2.d_qoy = 2) and (ws2.d_year = 2000))
-----------------------------PhysicalCteConsumer ( cteId=CTEId#1 )
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 2000))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------PhysicalProject
+------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 2000))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#1 )
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query46.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query46.out
@@ -5,34 +5,34 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN shuffle] hashCondition=((dn.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_customer_sk->[ss_customer_sk]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 ------------PhysicalProject
---------------hashAgg[LOCAL]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((dn.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->[ss_customer_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[ss_addr_sk]
+------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[ss_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[ss_hdemo_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF1 hd_demo_sk->[ss_hdemo_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3 RF4 RF5
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3 RF4
+------------------------------------PhysicalProject
+--------------------------------------filter(d_dow IN (0, 6) and d_year IN (1999, 2000, 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalProject
-----------------------------------filter(d_dow IN (0, 6) and d_year IN (1999, 2000, 2001))
-------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------filter(OR[(household_demographics.hd_dep_count = 6),(household_demographics.hd_vehicle_count = 0)])
+------------------------------------PhysicalOlapScan[household_demographics]
 ----------------------------PhysicalProject
-------------------------------filter(OR[(household_demographics.hd_dep_count = 6),(household_demographics.hd_vehicle_count = 0)])
---------------------------------PhysicalOlapScan[household_demographics]
+------------------------------filter(s_city IN ('Centerville', 'Fairview', 'Five Points', 'Liberty', 'Oak Grove'))
+--------------------------------PhysicalOlapScan[store]
 ------------------------PhysicalProject
---------------------------filter(s_city IN ('Centerville', 'Fairview', 'Five Points', 'Liberty', 'Oak Grove'))
-----------------------------PhysicalOlapScan[store]
---------------------PhysicalProject
-----------------------PhysicalOlapScan[customer_address]
+--------------------------PhysicalOlapScan[customer_address]
+----------------PhysicalProject
+------------------PhysicalOlapScan[customer] apply RFs: RF5
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
-----------------PhysicalProject
-------------------PhysicalOlapScan[customer] apply RFs: RF0
-----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+--------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query58.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query58.out
@@ -5,17 +5,19 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = cs_items.item_id)) otherCondition=((cast(cs_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE))) build RFs:RF13 item_id->[i_item_id]
+----------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = ws_items.item_id)) otherCondition=((cast(cs_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE))) build RFs:RF13 item_id->[i_item_id]
 ------------PhysicalProject
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 i_item_sk->[cs_item_sk]
+----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 ws_item_sk->[i_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[cs_sold_date_sk]
+--------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF11 RF12
+------------------------------PhysicalOlapScan[web_sales] apply RFs: RF11
 ----------------------------PhysicalProject
 ------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF10 d_date->[d_date]
 --------------------------------PhysicalProject
@@ -29,20 +31,18 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_date = '2001-03-24'))
 --------------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item] apply RFs: RF13
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = ws_items.item_id)) otherCondition=((cast(ss_item_rev as DOUBLE) <= cast((1.1 * ws_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * ws_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(ws_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE))) build RFs:RF8 item_id->[i_item_id]
+--------------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = cs_items.item_id)) otherCondition=((cast(cs_item_rev as DOUBLE) <= cast((1.1 * ss_item_rev) as DOUBLE)) and (cast(cs_item_rev as DOUBLE) >= cast((0.9 * ss_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) <= cast((1.1 * cs_item_rev) as DOUBLE)) and (cast(ss_item_rev as DOUBLE) >= cast((0.9 * cs_item_rev) as DOUBLE))) build RFs:RF8 item_id->[i_item_id]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[cs_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF6 RF7
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF5 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -63,13 +63,11 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 ws_item_sk->[i_item_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF3
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ws_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -83,4 +81,6 @@ PhysicalResultSink
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((date_dim.d_date = '2001-03-24'))
 ------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query59.out
@@ -18,25 +18,25 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF4 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
 ----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store] apply RFs: RF5
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store] apply RFs: RF5
+--------------------filter((d.d_month_seq <= 1207) and (d.d_month_seq >= 1196))
+----------------------PhysicalOlapScan[date_dim]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1 RF2
 ----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store]
+--------------------filter((d.d_month_seq <= 1219) and (d.d_month_seq >= 1208))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query65.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query65.out
@@ -5,11 +5,11 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk,ss_store_sk]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF4 ss_store_sk->[s_store_sk,ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF2 ss_store_sk->[ss_store_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[ss_item_sk]
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
@@ -20,22 +20,22 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))
 ----------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[item]
+----------------PhysicalProject
+------------------PhysicalOlapScan[store] apply RFs: RF4
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashAgg[GLOBAL]
-------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------hashAgg[LOCAL]
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF4
---------------------------------------PhysicalProject
-----------------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))
-------------------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalProject
-------------------PhysicalOlapScan[item]
-------------PhysicalProject
---------------PhysicalOlapScan[store]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_month_seq <= 1232) and (date_dim.d_month_seq >= 1221))
+----------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query79.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query79.out
@@ -5,7 +5,7 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN shuffle] hashCondition=((ms.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((ms.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ------------PhysicalProject
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query81.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query81.out
@@ -24,15 +24,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))) build RFs:RF4 ctr_state->[ctr_state]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ctr_customer_sk]
-------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ctr_customer_sk]
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF4
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------PhysicalProject
-------------------------filter((customer_address.ca_state = 'CA'))
---------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalOlapScan[customer] apply RFs: RF3
+------------------PhysicalProject
+--------------------filter((customer_address.ca_state = 'CA'))
+----------------------PhysicalOlapScan[customer_address]
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query83.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query83.out
@@ -5,44 +5,44 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = cr_items.item_id)) otherCondition=() build RFs:RF13 item_id->[i_item_id]
+----------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = wr_items.item_id)) otherCondition=() build RFs:RF13 item_id->[i_item_id,i_item_id]
 ------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 cr_item_sk->[i_item_sk]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[cr_returned_date_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF11
-----------------------------PhysicalProject
-------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF10 d_date->[d_date]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[date_dim] apply RFs: RF10
---------------------------------PhysicalProject
-----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF9 d_week_seq->[d_week_seq]
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF9
-------------------------------------PhysicalProject
---------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
-----------------------------------------PhysicalOlapScan[date_dim]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = wr_items.item_id)) otherCondition=() build RFs:RF8 item_id->[i_item_id]
+--------------hashJoin[INNER_JOIN colocated] hashCondition=((sr_items.item_id = cr_items.item_id)) otherCondition=() build RFs:RF12 item_id->[i_item_id]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 sr_item_sk->[i_item_sk]
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 sr_item_sk->[i_item_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF7 RF8
+------------------------------PhysicalOlapScan[item] apply RFs: RF11 RF12 RF13
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[sr_returned_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF10 d_date_sk->[sr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF6
+----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10
+--------------------------------PhysicalProject
+----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF9 d_date->[d_date]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF9
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF8 d_week_seq->[d_week_seq]
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF8
+----------------------------------------PhysicalProject
+------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
+--------------------------------------------PhysicalOlapScan[date_dim]
+----------------PhysicalProject
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute[DistributionSpecHash]
+----------------------hashAgg[LOCAL]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 cr_item_sk->[i_item_sk]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item] apply RFs: RF7 RF13
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[cr_returned_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF6
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF5 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -54,27 +54,27 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
 --------------------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalProject
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute[DistributionSpecHash]
-----------------------hashAgg[LOCAL]
+------------PhysicalProject
+--------------hashAgg[GLOBAL]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------hashAgg[LOCAL]
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
+--------------------------PhysicalOlapScan[item] apply RFs: RF3
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[wr_returned_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF3
+------------------------------PhysicalOlapScan[web_returns] apply RFs: RF2
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[wr_returned_date_sk]
+------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_returns] apply RFs: RF2
+----------------------------------PhysicalOlapScan[date_dim] apply RFs: RF1
 --------------------------------PhysicalProject
-----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
+----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF0 d_week_seq->[d_week_seq]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF1
+--------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF0
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_week_seq = date_dim.d_week_seq)) otherCondition=() build RFs:RF0 d_week_seq->[d_week_seq]
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF0
-----------------------------------------PhysicalProject
-------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
---------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
+----------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query65.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query65.out
@@ -5,11 +5,11 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ss_item_sk]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF4 ss_store_sk->[s_store_sk,ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk,ss_store_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF2 ss_store_sk->[ss_store_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalDistribute[DistributionSpecHash]
@@ -21,24 +21,24 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------filter((date_dim.d_month_seq <= 1187) and (date_dim.d_month_seq >= 1176))
 ------------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[store] apply RFs: RF4
+----------------PhysicalProject
+------------------PhysicalOlapScan[item]
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashAgg[GLOBAL]
-------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------hashAgg[LOCAL]
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
---------------------------------------PhysicalProject
-----------------------------------------filter((date_dim.d_month_seq <= 1187) and (date_dim.d_month_seq >= 1176))
-------------------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalProject
-------------------PhysicalOlapScan[store]
-------------PhysicalProject
---------------PhysicalOlapScan[item]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_month_seq <= 1187) and (date_dim.d_month_seq >= 1176))
+----------------------------------PhysicalOlapScan[date_dim]
 
 Hint log:
 Used: leading(store_sales date_dim )

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query30.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query30.out
@@ -24,15 +24,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))) build RFs:RF4 ctr_state->[ctr_state]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ctr_customer_sk]
-------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 ctr_customer_sk->[c_customer_sk]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------PhysicalProject
-------------------------filter((customer_address.ca_state = 'AR'))
---------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalOlapScan[customer] apply RFs: RF2 RF3
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4
+------------------PhysicalProject
+--------------------filter((customer_address.ca_state = 'AR'))
+----------------------PhysicalOlapScan[customer_address]
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query31.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query31.out
@@ -42,13 +42,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------filter((ws3.d_qoy = 3) and (ws3.d_year = 1999))
 --------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF8
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF7 ca_county->[ca_county]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF7 ca_county->[ca_county]
 --------------------PhysicalProject
-----------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 1999))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF7
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF6 ca_county->[ca_county,ca_county,ca_county]
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
+----------------------filter((ws2.d_qoy = 2) and (ws2.d_year = 1999))
+------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF7
+--------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF6 ca_county->[ca_county,ca_county]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
 --------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=() build RFs:RF4 ca_county->[ca_county]
 ----------------------------PhysicalProject
 ------------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 1999))
@@ -57,9 +57,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 1999))
 --------------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6
 --------------------------PhysicalProject
-----------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 1999))
-------------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF6
-------------------------PhysicalProject
---------------------------filter((ws2.d_qoy = 2) and (ws2.d_year = 1999))
-----------------------------PhysicalCteConsumer ( cteId=CTEId#1 )
+----------------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 1999))
+------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------PhysicalProject
+------------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 1999))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#1 )
 

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query58.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query58.out
@@ -38,11 +38,11 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[ss_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[ss_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->[cs_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF6 RF7
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF5 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -63,11 +63,11 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[cs_item_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF1 d_date->[d_date]
 ------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query59.out
@@ -18,25 +18,25 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF4 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
 ----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1206) and (d.d_month_seq >= 1195))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store] apply RFs: RF5
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store] apply RFs: RF5
+--------------------filter((d.d_month_seq <= 1206) and (d.d_month_seq >= 1195))
+----------------------PhysicalOlapScan[date_dim]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF1 RF2
 ----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1218) and (d.d_month_seq >= 1207))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[store]
+--------------------filter((d.d_month_seq <= 1218) and (d.d_month_seq >= 1207))
+----------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query65.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query65.out
@@ -5,11 +5,11 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ss_item_sk]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF4 ss_store_sk->[s_store_sk,ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk,ss_store_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = sc.ss_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ss_item_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((sb.ss_store_sk = sc.ss_store_sk)) otherCondition=((cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))) build RFs:RF2 ss_store_sk->[ss_store_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = sc.ss_store_sk)) otherCondition=() build RFs:RF2 s_store_sk->[ss_store_sk]
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
@@ -20,22 +20,22 @@ PhysicalResultSink
 ------------------------------PhysicalProject
 --------------------------------filter((date_dim.d_month_seq <= 1187) and (date_dim.d_month_seq >= 1176))
 ----------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[store] apply RFs: RF4
+----------------PhysicalProject
+------------------PhysicalOlapScan[item]
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute[DistributionSpecHash]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashAgg[GLOBAL]
-------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------hashAgg[LOCAL]
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
---------------------------------------PhysicalProject
-----------------------------------------filter((date_dim.d_month_seq <= 1187) and (date_dim.d_month_seq >= 1176))
-------------------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalProject
-------------------PhysicalOlapScan[store]
-------------PhysicalProject
---------------PhysicalOlapScan[item]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_month_seq <= 1187) and (date_dim.d_month_seq >= 1176))
+----------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query81.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query81.out
@@ -24,15 +24,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN broadcast] hashCondition=((ctr1.ctr_state = ctr2.ctr_state)) otherCondition=((cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))) build RFs:RF4 ctr_state->[ctr_state]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ctr_customer_sk]
-------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ctr1.ctr_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ctr_customer_sk]
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF2 RF4
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------PhysicalProject
-------------------------filter((customer_address.ca_state = 'TN'))
---------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalOlapScan[customer] apply RFs: RF3
+------------------PhysicalProject
+--------------------filter((customer_address.ca_state = 'TN'))
+----------------------PhysicalOlapScan[customer_address]
 --------------hashAgg[GLOBAL]
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query2.out
@@ -21,18 +21,18 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq1->[d_week_seq]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 53))) otherCondition=()
 ------------------PhysicalProject
---------------------filter((date_dim.d_year = 1998))
-----------------------PhysicalOlapScan[date_dim] apply RFs: RF2
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 53))) otherCondition=() build RFs:RF1 expr_(d_week_seq2 - 53)->[cast(d_week_seq as BIGINT)]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
 ----------------------PhysicalProject
 ------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF3
+------------------------filter((date_dim.d_year = 1998))
+--------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalProject
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
 --------------PhysicalProject
 ----------------filter((date_dim.d_year = 1999))
 ------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query31.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query31.out
@@ -39,17 +39,17 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ws1.ca_county = ws2.ca_county)) otherCondition=((if((web_sales > 0.00), (cast(web_sales as DECIMALV3(38, 8)) / web_sales), NULL) > if((store_sales > 0.00), (cast(store_sales as DECIMALV3(38, 8)) / store_sales), NULL))) build RFs:RF7 ca_county->[ca_county,ca_county,ca_county]
 --------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss1.ca_county = ws1.ca_county)) otherCondition=() build RFs:RF6 ca_county->[ca_county,ca_county]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county,ca_county]
+------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((ss2.ca_county = ss3.ca_county)) otherCondition=() build RFs:RF5 ca_county->[ca_county]
+--------------------PhysicalProject
+----------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 1999))
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((ss1.ca_county = ss2.ca_county)) otherCondition=() build RFs:RF4 ca_county->[ca_county]
 ----------------------PhysicalProject
 ------------------------filter((ss1.d_qoy = 1) and (ss1.d_year = 1999))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF5 RF6 RF7 RF8
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF6 RF7 RF8
 ----------------------PhysicalProject
 ------------------------filter((ss2.d_qoy = 2) and (ss2.d_year = 1999))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6 RF7 RF8
---------------------PhysicalProject
-----------------------filter((ss3.d_qoy = 3) and (ss3.d_year = 1999))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF6 RF7 RF8
 ----------------PhysicalProject
 ------------------filter((ws1.d_qoy = 1) and (ws1.d_year = 1999))
 --------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF7 RF8

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query47.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query47.out
@@ -33,13 +33,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=() build RFs:RF8 i_category->[i_category,i_category];RF9 i_brand->[i_brand,i_brand];RF10 s_store_name->[s_store_name,s_store_name];RF11 s_company_name->[s_company_name,s_company_name];RF12 expr_(rn - 1)->[(rn + 1),rn]
+--------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((v1.i_brand = v1_lead.i_brand) and (v1.i_category = v1_lead.i_category) and (v1.rn = expr_(rn - 1)) and (v1.s_company_name = v1_lead.s_company_name) and (v1.s_store_name = v1_lead.s_store_name)) otherCondition=() build RFs:RF8 i_category->[i_category];RF9 i_brand->[i_brand];RF10 s_store_name->[s_store_name];RF11 s_company_name->[s_company_name];RF12 rn->[(rn - 1)]
+----------------PhysicalProject
+------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF8 RF9 RF10 RF11 RF12
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((v1.i_brand = v1_lag.i_brand) and (v1.i_category = v1_lag.i_category) and (v1.rn = expr_(rn + 1)) and (v1.s_company_name = v1_lag.s_company_name) and (v1.s_store_name = v1_lag.s_store_name)) otherCondition=() build RFs:RF3 i_category->[i_category];RF4 i_brand->[i_brand];RF5 s_store_name->[s_store_name];RF6 s_company_name->[s_company_name];RF7 rn->[(rn + 1)]
 --------------------PhysicalProject
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF5 RF6 RF7 RF8 RF9 RF10 RF11 RF12
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF5 RF6 RF7
 --------------------filter((if((avg_monthly_sales > 0.0000), (cast(abs((sum_sales - cast(avg_monthly_sales as DECIMALV3(38, 2)))) as DECIMALV3(38, 10)) / avg_monthly_sales), NULL) > 0.100000) and (v2.avg_monthly_sales > 0.0000) and (v2.d_year = 1999))
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF8 RF9 RF10 RF11 RF12
-----------------PhysicalProject
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query74.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query74.out
@@ -38,20 +38,20 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=((if((year_total > 0.00), (cast(year_total as DECIMALV3(38, 8)) / year_total), NULL) > if((year_total > 0.00), (cast(year_total as DECIMALV3(38, 8)) / year_total), NULL))) build RFs:RF6 customer_id->[customer_id,customer_id,customer_id]
+------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=((if((year_total > 0.00), (cast(year_total as DECIMALV3(38, 8)) / year_total), NULL) > if((year_total > 0.00), (cast(year_total as DECIMALV3(38, 8)) / year_total), NULL))) build RFs:RF6 customer_id->[customer_id]
+--------------PhysicalProject
+----------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 1999))
+------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF6
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=() build RFs:RF5 customer_id->[customer_id,customer_id]
 ------------------hashJoin[INNER_JOIN shuffle] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=() build RFs:RF4 customer_id->[customer_id]
 --------------------PhysicalProject
 ----------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 1999))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF5 RF6
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF4 RF5
 --------------------PhysicalProject
 ----------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1998) and (t_s_firstyear.year_total > 0.00))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5 RF6
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF5
 ------------------PhysicalProject
 --------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1998) and (t_w_firstyear.year_total > 0.00))
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF6
---------------PhysicalProject
-----------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 1999))
-------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/shape_check/tpch_sf1000/rf_prune/q15.out
+++ b/regression-test/data/shape_check/tpch_sf1000/rf_prune/q15.out
@@ -5,11 +5,11 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalQuickSort[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 supplier_no->[s_suppkey]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
 ------------PhysicalProject
---------------PhysicalOlapScan[supplier] apply RFs: RF0
-------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 supplier_no->[s_suppkey]
+----------------PhysicalProject
+------------------PhysicalOlapScan[supplier] apply RFs: RF0
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
@@ -17,14 +17,14 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
 ----------------------------PhysicalOlapScan[lineitem]
-----------------hashAgg[GLOBAL]
-------------------PhysicalDistribute[DistributionSpecGather]
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------hashAgg[GLOBAL]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------hashAgg[LOCAL]
-------------------------------PhysicalProject
---------------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
-----------------------------------PhysicalOlapScan[lineitem]
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute[DistributionSpecGather]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------hashAgg[GLOBAL]
+----------------------PhysicalDistribute[DistributionSpecHash]
+------------------------hashAgg[LOCAL]
+--------------------------PhysicalProject
+----------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
+------------------------------PhysicalOlapScan[lineitem]
 

--- a/regression-test/data/shape_check/tpch_sf1000/rf_prune/q18.out
+++ b/regression-test/data/shape_check/tpch_sf1000/rf_prune/q18.out
@@ -10,9 +10,7 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------PhysicalOlapScan[lineitem] apply RFs: RF2
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_custkey = orders.o_custkey)) otherCondition=() build RFs:RF1 o_custkey->[c_custkey]
-------------------PhysicalProject
---------------------PhysicalOlapScan[customer] apply RFs: RF1
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_custkey = orders.o_custkey)) otherCondition=()
 ------------------hashJoin[LEFT_SEMI_JOIN colocated] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=() build RFs:RF0 l_orderkey->[o_orderkey]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[orders] apply RFs: RF0
@@ -21,4 +19,6 @@ PhysicalResultSink
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[lineitem]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[customer]
 

--- a/regression-test/data/shape_check/tpch_sf1000/shape/q15.out
+++ b/regression-test/data/shape_check/tpch_sf1000/shape/q15.out
@@ -5,11 +5,11 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalQuickSort[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 supplier_no->[s_suppkey]
+----------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
 ------------PhysicalProject
---------------PhysicalOlapScan[supplier] apply RFs: RF0
-------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 supplier_no->[s_suppkey]
+----------------PhysicalProject
+------------------PhysicalOlapScan[supplier] apply RFs: RF0
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
@@ -17,14 +17,14 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
 ----------------------------PhysicalOlapScan[lineitem]
-----------------hashAgg[GLOBAL]
-------------------PhysicalDistribute[DistributionSpecGather]
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------hashAgg[GLOBAL]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------hashAgg[LOCAL]
-------------------------------PhysicalProject
---------------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
-----------------------------------PhysicalOlapScan[lineitem]
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute[DistributionSpecGather]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------hashAgg[GLOBAL]
+----------------------PhysicalDistribute[DistributionSpecHash]
+------------------------hashAgg[LOCAL]
+--------------------------PhysicalProject
+----------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
+------------------------------PhysicalOlapScan[lineitem]
 

--- a/regression-test/data/shape_check/tpch_sf1000/shape/q18.out
+++ b/regression-test/data/shape_check/tpch_sf1000/shape/q18.out
@@ -10,15 +10,15 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------PhysicalOlapScan[lineitem] apply RFs: RF2
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_custkey = orders.o_custkey)) otherCondition=() build RFs:RF1 o_custkey->[c_custkey]
-------------------PhysicalProject
---------------------PhysicalOlapScan[customer] apply RFs: RF1
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_custkey = orders.o_custkey)) otherCondition=() build RFs:RF1 c_custkey->[o_custkey]
 ------------------hashJoin[LEFT_SEMI_JOIN colocated] hashCondition=((orders.o_orderkey = lineitem.l_orderkey)) otherCondition=() build RFs:RF0 l_orderkey->[o_orderkey]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[orders] apply RFs: RF0
+----------------------PhysicalOlapScan[orders] apply RFs: RF0 RF1
 --------------------PhysicalProject
 ----------------------filter((sum(l_quantity) > 300.00))
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[lineitem]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[customer]
 

--- a/regression-test/suites/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.groovy
+++ b/regression-test/suites/nereids_rules_p0/eager_aggregate/push_down_sum_through_join_one_side.groovy
@@ -155,7 +155,7 @@ suite("push_down_sum_through_join_one_side") {
     """
 
     qt_with_hint_groupby_pushdown_basic """
-        explain shape plan select /*+ USE_CBO_RULE(push_down_agg_through_join_one_side) */  sum(t1.score) from sum_t_one_side t1, sum_t_one_side t2 where t1.id = t2.id group by t1.name;
+        explain shape plan select /*+ USE_CBO_RULE(push_down_agg_through_join_one_side) */  sum(t1.score) from sum_t_one_side t1, sum_t_one_side t2 where t1.id = t2.id and t2.score < 100 group by t1.name;
     """
 
     qt_with_hint_groupby_pushdown_left_join """


### PR DESCRIPTION
### What problem does this PR solve?

in current version, column stats of sum() is derived as that of its child. This is not reasonable.
it will be derived as UNKNOWN

test on tpcds 1T: improved from 277.55 sec to 265.28 sec

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

