### PR TITLE
[fix](regression)Turn auto analyze off before run analyze test.

### DIFF
--- a/regression-test/suites/statistics/test_update_rows_mv.groovy
+++ b/regression-test/suites/statistics/test_update_rows_mv.groovy
@@ -37,6 +37,8 @@ suite("test_update_rows_mv", "p0") {
         DROP TABLE IF EXISTS `${tbl}`
     """
 
+    sql """set global enable_auto_analyze=false"""
+
     sql """
           CREATE TABLE IF NOT EXISTS `${tbl}` (
             `analyzetestlimitedk3` int(11) null comment "",


### PR DESCRIPTION
### What problem does this PR solve?

Turn auto analyze off before run analyze test. Because auto analyze result may overwrite manual analyze.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

