### PR TITLE
[sort](ut) Test sort merger with single stream

### DIFF
--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -215,12 +215,12 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
                     THROW_IF_ERROR(_ordering_expr[i]->execute(block.get(), &desc[i].column_number));
                 }
             }
-            MergeSortCursorImpl::reset();
         }
+        MergeSortCursorImpl::reset();
     }
 
     Block* block_ptr() override { return block.get(); }
-    bool eof() const override { return is_last() && _is_eof; }
+    bool eof() const override { return is_last(0) && _is_eof; }
 
     VExprContextSPtrs _ordering_expr;
     BlockSupplier _block_supplier {};

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -215,8 +215,11 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
                     THROW_IF_ERROR(_ordering_expr[i]->execute(block.get(), &desc[i].column_number));
                 }
             }
+            MergeSortCursorImpl::reset();
+        } else {
+            pos = 0;
+            rows = block->rows();
         }
-        MergeSortCursorImpl::reset();
     }
 
     Block* block_ptr() override { return block.get(); }

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -192,6 +192,7 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
                 ++merged_rows;
             }
 
+            current->next();
             if (_need_more_data(current)) {
                 do_insert();
                 return Status::OK();
@@ -210,8 +211,7 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
 }
 
 bool VSortedRunMerger::_need_more_data(MergeSortCursor& current) {
-    if (!current->is_last()) {
-        current->next();
+    if (!current->is_last(0)) {
         _priority_queue.push(current);
         return false;
     } else if (current->eof()) {

--- a/be/test/vec/runtime/sort_merger_test.cpp
+++ b/be/test/vec/runtime/sort_merger_test.cpp
@@ -433,4 +433,56 @@ TEST(SortMergerTest, TEST_SMALL_OFFSET_SINGLE_STREAM) {
     }
 }
 
+TEST(SortMergerTest, TEST_SINGLE_STREAM) {
+    /**
+     * in: [([NULL], eos = true)]
+     *     offset = 0, limit = -1, NULL_FIRST, ASC
+     * out: [NULL]
+     */
+    const int num_children = 1;
+    const int batch_size = 5;
+    std::vector<int> round;
+    round.resize(num_children, 0);
+    const int num_round = 1;
+
+    std::unique_ptr<VSortedRunMerger> merger;
+    auto profile = std::make_shared<RuntimeProfile>("");
+    auto ordering_expr = MockSlotRef::create_mock_contexts(
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>()));
+    {
+        std::vector<bool> is_asc_order = {true};
+        std::vector<bool> nulls_first = {true};
+        const int limit = -1;
+        const int offset = 0;
+        merger.reset(new VSortedRunMerger(ordering_expr, is_asc_order, nulls_first, batch_size,
+                                          limit, offset, profile.get()));
+    }
+    {
+        std::vector<vectorized::BlockSupplier> child_block_suppliers;
+        for (int child_idx = 0; child_idx < num_children; child_idx++) {
+            vectorized::BlockSupplier block_supplier =
+                    [&, round_vec = &round, num_round = num_round, id = child_idx](
+                            vectorized::Block* block, bool* eos) {
+                        *block = ColumnHelper::create_nullable_block<DataTypeInt64>({0}, {1});
+                        *eos = ++((*round_vec)[id]) == num_round;
+                        return Status::OK();
+                    };
+            child_block_suppliers.push_back(block_supplier);
+        }
+        EXPECT_TRUE(merger->prepare(child_block_suppliers).ok());
+        EXPECT_EQ(merger->_priority_queue.size(), 1);
+        EXPECT_EQ(merger->_priority_queue.top()->pos, 0);
+        EXPECT_EQ(merger->_priority_queue.top()->rows, 1);
+        EXPECT_EQ(merger->_priority_queue.top()->block_ptr()->rows(), 1);
+    }
+    {
+        vectorized::Block block;
+        bool eos = false;
+        EXPECT_TRUE(merger->get_next(&block, &eos).ok());
+        auto expect_block = ColumnHelper::create_nullable_column<DataTypeInt64>({0}, {1});
+        EXPECT_TRUE(ColumnHelper::column_equal(block.get_by_position(0).column, expect_block));
+        EXPECT_TRUE(eos);
+    }
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Sort merger should support single stream input with a non-empty block with `eos=true`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

