### PR TITLE
[fix](broker) select broker by hash of file path, instead of always select the first broker

### DIFF
--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -143,7 +143,10 @@ Status FileFactory::create_file_reader(const io::FileSystemProperties& system_pr
         break;
     }
     case TFileType::FILE_BROKER: {
-        RETURN_IF_ERROR(create_broker_reader(system_properties.broker_addresses[0],
+        // select broker by hash of file path
+        auto key = HashUtil::hash(file_description.path.data(), file_description.path.size(), 0);
+        auto index = key % system_properties.broker_addresses.size();
+        RETURN_IF_ERROR(create_broker_reader(system_properties.broker_addresses[index],
                                              system_properties.properties, file_description,
                                              reader_options, file_system, file_reader));
         break;


### PR DESCRIPTION
### What problem does this PR solve?

if we select data from hive, we found all BE read the same broker.
`select count(1) from hive.db.table where part_key='xxxx';`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

