### PR TITLE
[improve](binlog) Download binlogs with persistent connection

### DIFF
--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -188,7 +188,7 @@ private:
         _written_size += write_size;
         if (_written_size == _file_size) {
             // This file has been downloaded, switch to the next one.
-            switchToNextFile();
+            switch_to_next_file();
         }
 
         return write_size;
@@ -196,7 +196,7 @@ private:
 
     Status finish_inner() {
         if (!_is_reading_header && _written_size == _file_size) {
-            switchToNextFile();
+            switch_to_next_file();
         }
 
         if (_fd >= 0) {
@@ -219,7 +219,7 @@ private:
         return Status::OK();
     }
 
-    void switchToNextFile() {
+    void switch_to_next_file() {
         DCHECK(_fd >= 0);
         DCHECK(_written_size == _file_size);
 
@@ -511,6 +511,29 @@ const char* HttpClient::_get_url() const {
         url = "<unknown>";
     }
     return url;
+}
+
+// execute remote call action with retry
+Status HttpClient::execute(int retry_times, int sleep_time,
+                           const std::function<Status(HttpClient*)>& callback) {
+    Status status;
+    for (int i = 0; i < retry_times; ++i) {
+        status = callback(this);
+        if (status.ok()) {
+            auto http_status = get_http_status();
+            if (http_status == 200) {
+                return status;
+            } else {
+                std::string url = mask_token(_get_url());
+                auto error_msg = fmt::format("http status code is not 200, code={}, url={}",
+                                             http_status, url);
+                LOG(WARNING) << error_msg;
+                return Status::HttpError(error_msg);
+            }
+        }
+        sleep(sleep_time);
+    }
+    return status;
 }
 
 Status HttpClient::execute_with_retry(int retry_times, int sleep_time,

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -157,6 +157,10 @@ public:
     // execute remote call action
     Status execute(const std::function<bool(const void* data, size_t length)>& callback = {});
 
+    // execute remote call action with retry, like execute_with_retry but keep the http client instance
+    Status execute(int retry_times, int sleep_time,
+                   const std::function<Status(HttpClient*)>& callback);
+
     size_t on_response_data(const void* data, size_t length);
 
     // The file name of the variant column with the inverted index contains %


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

curl_easy_cleanup will recycle the underlying connections, keep the HttpClient, and reuse it to reduce the established overheads.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

