### PR TITLE
[fix](set variable)Set local session variable when set global variable on Observer.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -309,27 +309,11 @@ public class VariableMgr {
         return joiner.toString();
     }
 
-    // The only difference between setVar and setVarForNonMasterFE
-    // is that setVarForNonMasterFE will just return if "checkUpdate" throw exception.
-    // This is because, when setting global variables from Non Master FE, Doris will do following step:
-    //      1. forward this SetStmt to Master FE to execute.
-    //      2. Change this SetStmt to "SESSION" level, and execute it again on this Non Master FE.
-    // But for "GLOBAL only" variable, such ash "password_history", it doesn't allow to set on SESSION level.
-    // So when doing step 2, "set password_history=xxx" without "GLOBAL" keywords will throw exception.
-    // So in this case, we should just ignore this exception and return.
     public static void setVarForNonMasterFE(SessionVariable sessionVariable, SetVar setVar)
             throws DdlException {
         VarContext varCtx = getVarContext(setVar.getVariable());
         if (varCtx == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable());
-        }
-        try {
-            checkUpdate(setVar, varCtx.getFlag());
-        } catch (DdlException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("no need to set var for non master fe: {}", setVar.getVariable(), e);
-            }
-            return;
         }
         setVarInternal(sessionVariable, setVar, varCtx);
     }


### PR DESCRIPTION
### What problem does this PR solve?

When set global var in Observer, after forward the op to Master, it doesn't set local session variable in Observer. Because checkUpdate function doesn't allow set global var in Observer. This pr is to remove the checkUpdate so that local var in Observer could be set. Here we don't need to do checkUpdate, because we only change the local variable, not change the default value nor write any edit log.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

