### PR TITLE
[fix](Nereids) nested window function with order by raise exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractAndNormalizeWindowExpression.java
@@ -62,7 +62,7 @@ public class ExtractAndNormalizeWindowExpression extends OneRewriteRuleFactory i
                     if (output instanceof WindowExpression) {
                         WindowExpression windowExpression = (WindowExpression) output;
                         Expression expression = ((WindowExpression) output).getFunction();
-                        if (expression.containsType(OrderExpression.class)) {
+                        if (expression.children().stream().anyMatch(OrderExpression.class::isInstance)) {
                             throw new AnalysisException("order by is not supported in " + expression);
                         }
                         if (expression instanceof NullableAggregateFunction) {

--- a/regression-test/suites/nereids_rules_p0/normalize_window/normalize_window_nullable_agg_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/normalize_window/normalize_window_nullable_agg_test.groovy
@@ -73,6 +73,16 @@ suite("normalize_window_nullable_agg") {
         exception "order by is not supported"
     }
 
+    test {
+        sql "select group_concat(cast(sum(xwhat) over(partition by xwho order by xwhen) as varchar) order by xwhat) over(partition by xwhen) from windowfunnel_test_normalize_window;"
+        exception "order by is not supported"
+    }
+
+    // test only refuse order by in function's direct children
+    sql """
+        select sum(sum(xwhat) over(partition by xwho order by xwhen)) over(partition by xwho) from windowfunnel_test_normalize_window
+    """
+
     sql "set enable_fold_constant_by_be = 1;"
     sql "drop table if exists fold_window1"
     sql """create table fold_window1 (


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #40937

Problem Summary:

We want to provide clearer error messages for window functions with ORDER BY parameters. However, the current error checking incorrectly inspects all child nodes instead of just the immediate/direct child nodes. As a result, when nested window functions are present, this may trigger unexpected error reporting.

```sql
errCode = 2, detailMessage = order by is not supported in max(dense_rank() WindowSpec(PARTITION BY lot_no#0 ORDER BY loading_time#20 asc null first)) 
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

