### PR TITLE
[opt](profile) Optimization for profile file format

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -584,7 +584,7 @@ public class Profile {
             }
         }
     }
-    
+
     // remove profile from storage
     public void deleteFromStorage() {
         if (!profileHasBeenStored()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -52,8 +51,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.Deflater;
-import java.util.zip.Inflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -203,7 +200,7 @@ public class Profile {
             byte[] buffer = new byte[1024];
             int readBytes;
             while ((readBytes = zipIn.read(buffer)) != -1) {
-                entryContent.write(buffer, 0, readBytes); 
+                entryContent.write(buffer, 0, readBytes);
             }
 
             // Parse profile data using memory stream
@@ -515,7 +512,7 @@ public class Profile {
             throw t;
         }
     }
-    
+
     public void writeToStorage(String systemProfileStorageDir) {
         if (Strings.isNullOrEmpty(getId())) {
             LOG.warn("store profile failed, name is empty");
@@ -543,14 +540,14 @@ public class Profile {
         try {
             fileOutputStream = new FileOutputStream(profileFilePath);
             zipOut = new ZipOutputStream(fileOutputStream);
-            
+
             // First create memory stream to hold all data
             ByteArrayOutputStream memoryStream = new ByteArrayOutputStream();
             DataOutputStream memoryDataStream = new DataOutputStream(memoryStream);
 
             // Write summary profile and execution profile content to memory
             this.summaryProfile.write(memoryDataStream);
-            
+
             StringBuilder builder = new StringBuilder();
             getChangedSessionVars(builder);
             getExecutionProfileContent(builder);
@@ -574,7 +571,7 @@ public class Profile {
         } finally {
             try {
                 if (zipOut != null) {
-                    zipOut.close(); 
+                    zipOut.close();
                 }
                 if (fileOutputStream != null) {
                     fileOutputStream.close();
@@ -584,6 +581,7 @@ public class Profile {
             }
         }
     }
+
     // remove profile from storage
     public void deleteFromStorage() {
         if (!profileHasBeenStored()) {
@@ -691,7 +689,7 @@ public class Profile {
             if (entry == null || !entry.getName().equals(expectedEntryName)) {
                 throw new IOException("Invalid zip file format - missing entry: " + expectedEntryName);
             }
-            
+
             // Read zip entry content into memory
             ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024 * 1024];
@@ -702,17 +700,17 @@ public class Profile {
 
             // Parse profile data using memory stream
             DataInputStream memoryDataInput = new DataInputStream(
-                new ByteArrayInputStream(entryContent.toByteArray()));
-            
+                    new ByteArrayInputStream(entryContent.toByteArray()));
+
             // Skip summary profile data
             Text.readString(memoryDataInput);
-            
+
             // Read execution profile length and content
             int executionProfileLength = memoryDataInput.readInt();
             byte[] executionProfileBytes = new byte[executionProfileLength];
             memoryDataInput.readFully(executionProfileBytes);
-            
-            // Append execution profile content 
+
+            // Append execution profile content
             builder.append(new String(executionProfileBytes, StandardCharsets.UTF_8));
         } catch (Exception e) {
             LOG.error("Failed to read profile from storage: {}", profileStoragePath, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -151,7 +151,7 @@ public class Profile {
         try {
             profileMetaFileInputStream = new FileInputStream(path);
         } catch (Exception e) {
-            LOG.warn("open profile file {} failed", path, e);
+            LOG.warn("Open profile file {} failed", path, e);
         }
 
         return profileMetaFileInputStream;
@@ -160,6 +160,7 @@ public class Profile {
     // For normal profile, the profile id is a TUniqueId, but for broker load, the profile id is a long.
     public static String[] parseProfileFileName(String profileFileName) {
         if (!profileFileName.endsWith(".zip")) {
+            LOG.warn("Invalid profile name {}", profileFileName);
             return null;
         } else {
             profileFileName = profileFileName.substring(0, profileFileName.length() - 4);
@@ -218,8 +219,6 @@ public class Profile {
 
             String[] parts = path.split(File.separator);
             String filename = parts[parts.length - 1];
-            // Remove .zip extension
-            filename = filename.substring(0, filename.length() - 4);
             String queryFinishTimeStr = parseProfileFileName(filename)[0];
             res.queryFinishTimestamp = Long.valueOf(queryFinishTimeStr);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -201,7 +201,7 @@ public class Profile {
 
             // Read zip entry content into memory
             ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
-            byte[] buffer = new byte[1024];
+            byte[] buffer = new byte[1024 * 50];
             int readBytes;
             while ((readBytes = zipIn.read(buffer)) != -1) {
                 entryContent.write(buffer, 0, readBytes);
@@ -694,7 +694,7 @@ public class Profile {
 
             // Read zip entry content into memory
             ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
-            byte[] buffer = new byte[1024 * 1024];
+            byte[] buffer = new byte[1024 * 50];
             int readBytes;
             while ((readBytes = zipIn.read(buffer)) != -1) {
                 entryContent.write(buffer, 0, readBytes);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -53,6 +54,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Profile is a class to record the execution time of a query. It has the
@@ -79,6 +83,7 @@ public class Profile {
     private static final int MergedProfileLevel = 1;
     // profile file name format: time_id
     private static final String SEPERATOR = "_";
+    private static final String PROFILE_ENTRY_SUFFIX = ".profile";
 
     // summaryProfile will be serialized to storage as JSON, and we can recover it from storage
     // recover of SummaryProfile is important, because it contains the meta information of the profile
@@ -126,7 +131,7 @@ public class Profile {
 
     // check if the profile file is valid and create a file input stream
     // user need to close the file stream.
-    private static FileInputStream createPorfileFileInputStream(String path) {
+    static FileInputStream createPorfileFileInputStream(String path) {
         File profileFile = new File(path);
         if (!profileFile.isFile()) {
             LOG.warn("Profile storage path {} is invalid, its not a file.", profileFile.getAbsolutePath());
@@ -157,6 +162,9 @@ public class Profile {
 
     // For normal profile, the profile id is a TUniqueId, but for broker load, the profile id is a long.
     public static String[] parseProfileFileName(String profileFileName) {
+        if (profileFileName.endsWith(".zip")) {
+            profileFileName = profileFileName.substring(0, profileFileName.length() - 4);
+        }
         String [] timeAndID = profileFileName.split(SEPERATOR);
         if (timeAndID.length != 2) {
             return null;
@@ -165,7 +173,9 @@ public class Profile {
         try {
             DebugUtil.parseTUniqueIdFromString(timeAndID[1]);
         } catch (NumberFormatException e) {
-            if (Long.valueOf(timeAndID[1]) == null) {
+            try {
+                Long.parseLong(timeAndID[1]);
+            } catch (NumberFormatException e2) {
                 return null;
             }
         }
@@ -173,84 +183,63 @@ public class Profile {
         return timeAndID;
     }
 
-    // read method will only read summary profile, and return a Profile object
+
     public static Profile read(String path) {
-        FileInputStream profileFileInputStream = null;
+        FileInputStream fileInputStream = null;
         try {
-            profileFileInputStream = createPorfileFileInputStream(path);
-            // Maybe profile path is invalid
-            if (profileFileInputStream == null) {
-                return null;
-            }
+            fileInputStream = new FileInputStream(path);
             File profileFile = new File(path);
             long fileSize = profileFile.length();
-            // read method will move the cursor to the end of the summary profile
-            DataInput dataInput = new DataInputStream(profileFileInputStream);
+
+            ZipInputStream zipIn = new ZipInputStream(fileInputStream);
+            ZipEntry entry = zipIn.getNextEntry();
+            if (entry == null) {
+                LOG.error("Invalid zip profile file, {}", path);
+                return null;
+            }
+
+            // Read zip entry content into memory
+            ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int readBytes;
+            while ((readBytes = zipIn.read(buffer)) != -1) {
+                entryContent.write(buffer, 0, readBytes); 
+            }
+
+            // Parse profile data using memory stream
+            DataInputStream memoryDataInput = new DataInputStream(
+                new ByteArrayInputStream(entryContent.toByteArray()));
+
             Profile res = new Profile();
-            res.summaryProfile = SummaryProfile.read(dataInput);
+            res.summaryProfile = SummaryProfile.read(memoryDataInput);
             res.profileStoragePath = path;
             res.isQueryFinished = true;
             res.profileSize = fileSize;
+
             String[] parts = path.split(File.separator);
-            String queryFinishTimeStr = parseProfileFileName(parts[parts.length - 1])[0];
-            // queryFinishTime is used for sorting profile by finish time.
+            String filename = parts[parts.length - 1];
+            // Remove .zip extension
+            filename = filename.substring(0, filename.length() - 4);
+            String queryFinishTimeStr = parseProfileFileName(filename)[0];
             res.queryFinishTimestamp = Long.valueOf(queryFinishTimeStr);
+
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Read profile from storage: {}", res.summaryProfile.getProfileId());
             }
             return res;
+
         } catch (Exception exception) {
             LOG.error("read profile failed", exception);
             return null;
         } finally {
-            if (profileFileInputStream != null) {
+            if (fileInputStream != null) {
                 try {
-                    profileFileInputStream.close();
+                    fileInputStream.close();
                 } catch (Exception e) {
                     LOG.warn("close profile file {} failed", path, e);
                 }
             }
         }
-    }
-
-    // Method to compress a string using Deflater
-    public static byte[] compressExecutionProfile(String str) throws IOException {
-        byte[] data = str.getBytes(StandardCharsets.UTF_8);
-        Deflater deflater = new Deflater();
-        deflater.setInput(data);
-        deflater.finish();
-
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
-        byte[] buffer = new byte[1024];
-        while (!deflater.finished()) {
-            int count = deflater.deflate(buffer);
-            outputStream.write(buffer, 0, count);
-        }
-        deflater.end();
-        outputStream.close();
-        return outputStream.toByteArray();
-    }
-
-    // Method to decompress a byte array using Inflater
-    public static String decompressExecutionProfile(byte[] data) throws IOException {
-        Inflater inflater = new Inflater();
-        inflater.setInput(data, 0, data.length);
-
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
-        byte[] buffer = new byte[1024];
-        try {
-            while (!inflater.finished()) {
-                int count = inflater.inflate(buffer);
-                outputStream.write(buffer, 0, count);
-            }
-            inflater.end();
-        } catch (Exception e) {
-            throw new IOException("Failed to decompress data", e);
-        } finally {
-            outputStream.close();
-        }
-
-        return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
     }
 
     // For load task, the profile contains many execution profiles
@@ -526,7 +515,7 @@ public class Profile {
             throw t;
         }
     }
-
+    
     public void writeToStorage(String systemProfileStorageDir) {
         if (Strings.isNullOrEmpty(getId())) {
             LOG.warn("store profile failed, name is empty");
@@ -539,11 +528,9 @@ public class Profile {
         }
 
         final String profileId = this.summaryProfile.getProfileId();
-
-        // queryFinishTimeStamp_ProfileId
         final String profileFilePath = systemProfileStorageDir + File.separator
                                     + String.valueOf(this.queryFinishTimestamp)
-                                    + SEPERATOR + profileId;
+                                    + SEPERATOR + profileId + ".zip";
 
         File profileFile = new File(profileFilePath);
         if (profileFile.exists()) {
@@ -551,34 +538,44 @@ public class Profile {
             profileFile.delete();
         }
 
-        // File structure of profile:
-        /*
-         * Integer: n(size of summary profile)
-         * String: json of summary profile
-         * Integer: m(size of compressed execution profile)
-         * String: compressed binary of execution profile
-        */
         FileOutputStream fileOutputStream = null;
+        ZipOutputStream zipOut = null;
         try {
             fileOutputStream = new FileOutputStream(profileFilePath);
-            DataOutputStream dataOutputStream = new DataOutputStream(fileOutputStream);
-            this.summaryProfile.write(dataOutputStream);
+            zipOut = new ZipOutputStream(fileOutputStream);
+            
+            // First create memory stream to hold all data
+            ByteArrayOutputStream memoryStream = new ByteArrayOutputStream();
+            DataOutputStream memoryDataStream = new DataOutputStream(memoryStream);
 
-            // store execution profiles as string
-            StringBuilder build = new StringBuilder();
-            getChangedSessionVars(build);
-            getExecutionProfileContent(build);
-            byte[] buf = compressExecutionProfile(build.toString());
-            dataOutputStream.writeInt(buf.length);
-            dataOutputStream.write(buf);
-            build = null;
-            dataOutputStream.flush();
+            // Write summary profile and execution profile content to memory
+            this.summaryProfile.write(memoryDataStream);
+            
+            StringBuilder builder = new StringBuilder();
+            getChangedSessionVars(builder);
+            getExecutionProfileContent(builder);
+            byte[] executionProfileBytes = builder.toString().getBytes(StandardCharsets.UTF_8);
+            memoryDataStream.writeInt(executionProfileBytes.length);
+            memoryDataStream.write(executionProfileBytes);
+            memoryDataStream.flush();
+
+            // Create zip entry with profileId based name
+            ZipEntry zipEntry = new ZipEntry(profileId + PROFILE_ENTRY_SUFFIX);
+            zipOut.putNextEntry(zipEntry);
+            zipOut.write(memoryStream.toByteArray());
+            zipOut.closeEntry();
+
             this.profileSize = profileFile.length();
+            this.profileStoragePath = profileFilePath;
+
         } catch (Exception e) {
             LOG.error("write {} summary profile failed", getId(), e);
             return;
         } finally {
             try {
+                if (zipOut != null) {
+                    zipOut.close(); 
+                }
                 if (fileOutputStream != null) {
                     fileOutputStream.close();
                 }
@@ -586,10 +583,7 @@ public class Profile {
                 LOG.warn("close profile file {} failed", profileFilePath, e);
             }
         }
-
-        this.profileStoragePath = profileFilePath;
     }
-
     // remove profile from storage
     public void deleteFromStorage() {
         if (!profileHasBeenStored()) {
@@ -674,37 +668,55 @@ public class Profile {
         builder.append("\n");
     }
 
-    private void getOnStorageProfile(StringBuilder builder) {
+    void getOnStorageProfile(StringBuilder builder) {
         if (!profileHasBeenStored()) {
             return;
         }
 
         LOG.info("Profile {} has been stored to storage, reading it from storage", getId());
-
         FileInputStream fileInputStream = null;
+        ZipInputStream zipIn = null;
 
         try {
             fileInputStream = createPorfileFileInputStream(profileStoragePath);
             if (fileInputStream == null) {
-                builder.append("Failed to read execution profile from " + profileStoragePath);
+                builder.append("Failed to read profile from " + profileStoragePath);
                 return;
             }
 
-            DataInputStream dataInput = new DataInputStream(fileInputStream);
-            // skip summary profile
-            Text.readString(dataInput);
-            // read compressed execution profile
-            int binarySize = dataInput.readInt();
-            byte[] binaryExecutionProfile = new byte[binarySize];
-            dataInput.readFully(binaryExecutionProfile, 0, binarySize);
-            // decompress binary execution profile
-            String textExecutionProfile = decompressExecutionProfile(binaryExecutionProfile);
-            builder.append(textExecutionProfile);
-            return;
+            // Directly create ZipInputStream from file input stream
+            zipIn = new ZipInputStream(fileInputStream);
+            ZipEntry entry = zipIn.getNextEntry();
+            String expectedEntryName = summaryProfile.getProfileId() + PROFILE_ENTRY_SUFFIX;
+            if (entry == null || !entry.getName().equals(expectedEntryName)) {
+                throw new IOException("Invalid zip file format - missing entry: " + expectedEntryName);
+            }
+            
+            // Read zip entry content into memory
+            ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024 * 1024];
+            int readBytes;
+            while ((readBytes = zipIn.read(buffer)) != -1) {
+                entryContent.write(buffer, 0, readBytes);
+            }
+
+            // Parse profile data using memory stream
+            DataInputStream memoryDataInput = new DataInputStream(
+                new ByteArrayInputStream(entryContent.toByteArray()));
+            
+            // Skip summary profile data
+            Text.readString(memoryDataInput);
+            
+            // Read execution profile length and content
+            int executionProfileLength = memoryDataInput.readInt();
+            byte[] executionProfileBytes = new byte[executionProfileLength];
+            memoryDataInput.readFully(executionProfileBytes);
+            
+            // Append execution profile content 
+            builder.append(new String(executionProfileBytes, StandardCharsets.UTF_8));
         } catch (Exception e) {
-            LOG.error("An error occurred while reading execution profile from storage, profile storage path: {}",
-                    profileStoragePath, e);
-            builder.append("Failed to read execution profile from " + profileStoragePath);
+            LOG.error("Failed to read profile from storage: {}", profileStoragePath, e);
+            builder.append("Failed to read profile from " + profileStoragePath);
         } finally {
             if (fileInputStream != null) {
                 try {
@@ -714,8 +726,6 @@ public class Profile {
                 }
             }
         }
-
-        return;
     }
 
     public String debugInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -52,8 +51,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.Deflater;
-import java.util.zip.Inflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -206,12 +203,12 @@ public class Profile {
             byte[] buffer = new byte[1024];
             int readBytes;
             while ((readBytes = zipIn.read(buffer)) != -1) {
-                entryContent.write(buffer, 0, readBytes); 
+                entryContent.write(buffer, 0, readBytes);
             }
 
             // Parse profile data using memory stream
             DataInputStream memoryDataInput = new DataInputStream(
-                new ByteArrayInputStream(entryContent.toByteArray()));
+                    new ByteArrayInputStream(entryContent.toByteArray()));
 
             Profile res = new Profile();
             res.summaryProfile = SummaryProfile.read(memoryDataInput);
@@ -518,7 +515,7 @@ public class Profile {
             throw t;
         }
     }
-    
+
     public void writeToStorage(String systemProfileStorageDir) {
         if (Strings.isNullOrEmpty(getId())) {
             LOG.warn("store profile failed, name is empty");
@@ -546,14 +543,14 @@ public class Profile {
         try {
             fileOutputStream = new FileOutputStream(profileFilePath);
             zipOut = new ZipOutputStream(fileOutputStream);
-            
+
             // First create memory stream to hold all data
             ByteArrayOutputStream memoryStream = new ByteArrayOutputStream();
             DataOutputStream memoryDataStream = new DataOutputStream(memoryStream);
 
             // Write summary profile and execution profile content to memory
             this.summaryProfile.write(memoryDataStream);
-            
+
             StringBuilder builder = new StringBuilder();
             getChangedSessionVars(builder);
             getExecutionProfileContent(builder);
@@ -577,7 +574,7 @@ public class Profile {
         } finally {
             try {
                 if (zipOut != null) {
-                    zipOut.close(); 
+                    zipOut.close();
                 }
                 if (fileOutputStream != null) {
                     fileOutputStream.close();
@@ -587,6 +584,7 @@ public class Profile {
             }
         }
     }
+    
     // remove profile from storage
     public void deleteFromStorage() {
         if (!profileHasBeenStored()) {
@@ -694,7 +692,7 @@ public class Profile {
             if (entry == null || !entry.getName().equals(expectedEntryName)) {
                 throw new IOException("Invalid zip file format - missing entry: " + expectedEntryName);
             }
-            
+
             // Read zip entry content into memory
             ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024 * 1024];
@@ -705,17 +703,17 @@ public class Profile {
 
             // Parse profile data using memory stream
             DataInputStream memoryDataInput = new DataInputStream(
-                new ByteArrayInputStream(entryContent.toByteArray()));
-            
+                    new ByteArrayInputStream(entryContent.toByteArray()));
+
             // Skip summary profile data
             Text.readString(memoryDataInput);
-            
+
             // Read execution profile length and content
             int executionProfileLength = memoryDataInput.readInt();
             byte[] executionProfileBytes = new byte[executionProfileLength];
             memoryDataInput.readFully(executionProfileBytes);
-            
-            // Append execution profile content 
+
+            // Append execution profile content
             builder.append(new String(executionProfileBytes, StandardCharsets.UTF_8));
         } catch (Exception e) {
             LOG.error("Failed to read profile from storage: {}", profileStoragePath, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -152,8 +152,7 @@ public class ProfileManager extends MasterDaemon {
         return INSTANCE;
     }
 
-    // The visibility of ProfileManager() is package level, so that we can write ut for it.
-    ProfileManager() {
+    protected ProfileManager() {
         super("profile-manager", Config.profile_manager_gc_interval_seconds * 1000);
         lock = new ReentrantReadWriteLock(true);
         readLock = lock.readLock();
@@ -483,7 +482,7 @@ public class ProfileManager extends MasterDaemon {
 
     // List PROFILE_STORAGE_PATH and return all dir names
     // string will contain profile id and its storage timestamp
-    List<String> getOnStorageProfileInfos() {
+    protected List<String> getOnStorageProfileInfos() {
         List<String> res = Lists.newArrayList();
         try {
             File profileDir = new File(PROFILE_STORAGE_PATH);
@@ -508,7 +507,7 @@ public class ProfileManager extends MasterDaemon {
     // read profile file on storage
     // deserialize to an object Profile
     // push them to memory structure of ProfileManager for index
-    void loadProfilesFromStorageIfFirstTime(boolean sync) {
+    protected void loadProfilesFromStorageIfFirstTime(boolean sync) {
         if (checkIfProfileLoaded()) {
             return;
         }
@@ -588,7 +587,7 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    void createProfileStorageDirIfNecessary() {
+    protected void createProfileStorageDirIfNecessary() {
         File profileDir = new File(PROFILE_STORAGE_PATH);
         if (profileDir.exists()) {
             return;
@@ -602,7 +601,7 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    List<ProfileElement> getProfilesNeedStore() {
+    protected List<ProfileElement> getProfilesNeedStore() {
         List<ProfileElement> profilesToBeStored = Lists.newArrayList();
 
         queryIdToProfileMap.forEach((queryId, profileElement) -> {
@@ -617,7 +616,7 @@ public class ProfileManager extends MasterDaemon {
     // Collect profiles that need to be stored to storage
     // Store them to storage
     // Release the memory
-    void writeProfileToStorage() {
+    protected void writeProfileToStorage() {
         try {
             if (Strings.isNullOrEmpty(PROFILE_STORAGE_PATH)) {
                 LOG.error("Logical error, PROFILE_STORAGE_PATH is empty");
@@ -671,7 +670,7 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    List<ProfileElement> getProfilesToBeRemoved() {
+    protected List<ProfileElement> getProfilesToBeRemoved() {
         // By order of query finish timestamp
         // The profile with the least storage timestamp will be on the top of heap
         PriorityQueue<ProfileElement> profileDeque = new PriorityQueue<>(Comparator.comparingLong(
@@ -703,7 +702,7 @@ public class ProfileManager extends MasterDaemon {
 
     // We can not store all profiles on storage, because the storage space is limited
     // So we need to remove the outdated profiles
-    void deleteOutdatedProfilesFromStorage() {
+    protected void deleteOutdatedProfilesFromStorage() {
         if (!checkIfProfileLoaded()) {
             return;
         }
@@ -759,7 +758,7 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    List<String> getBrokenProfiles() {
+    protected List<String> getBrokenProfiles() {
         List<String> profilesOnStorage = getOnStorageProfileInfos();
         List<String> brokenProfiles = Lists.newArrayList();
 
@@ -803,7 +802,7 @@ public class ProfileManager extends MasterDaemon {
         return brokenProfiles;
     }
 
-    void deleteBrokenProfiles() {
+    protected void deleteBrokenProfiles() {
         if (!checkIfProfileLoaded()) {
             return;
         }
@@ -840,7 +839,7 @@ public class ProfileManager extends MasterDaemon {
 
     // The init value of query finish time of profile is MAX_VALUE,
     // So a more recent query will be on the top of the heap.
-    PriorityQueue<ProfileElement> getProfileOrderByQueryFinishTimeDesc() {
+    protected PriorityQueue<ProfileElement> getProfileOrderByQueryFinishTimeDesc() {
         readLock.lock();
         try {
             PriorityQueue<ProfileElement> queryIdDeque = new PriorityQueue<>(Comparator.comparingLong(
@@ -858,7 +857,7 @@ public class ProfileManager extends MasterDaemon {
 
     // The init value of query finish time of profile is MAX_VALUE
     // So query finished earlier will be on the top of heap
-    PriorityQueue<ProfileElement> getProfileOrderByQueryFinishTime() {
+    protected PriorityQueue<ProfileElement> getProfileOrderByQueryFinishTime() {
         readLock.lock();
         try {
             PriorityQueue<ProfileElement> queryIdDeque = new PriorityQueue<>(Comparator.comparingLong(
@@ -875,7 +874,7 @@ public class ProfileManager extends MasterDaemon {
     }
 
     // Older query will be on the top of heap
-    PriorityQueue<ProfileElement> getProfileOrderByQueryStartTime() {
+    protected PriorityQueue<ProfileElement> getProfileOrderByQueryStartTime() {
         readLock.lock();
         try {
             PriorityQueue<ProfileElement> queryIdDeque = new PriorityQueue<>(Comparator.comparingLong(
@@ -955,7 +954,7 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    void deleteOutdatedProfilesFromMemory() {
+    protected void deleteOutdatedProfilesFromMemory() {
         StringBuilder stringBuilder = new StringBuilder();
         StringBuilder stringBuilderTTL = new StringBuilder();
         writeLock.lock();
@@ -1019,7 +1018,7 @@ public class ProfileManager extends MasterDaemon {
         }
     }
 
-    String getDebugInfo() {
+    protected String getDebugInfo() {
         StringBuilder stringBuilder = new StringBuilder();
         readLock.lock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -734,6 +734,9 @@ public class ProfileManager extends MasterDaemon {
 
             try {
                 String timeStampAndId = profileDirAbsPath.substring(separatorIdx + 1);
+                if (timeStampAndId.endsWith(".zip")) {
+                    timeStampAndId = timeStampAndId.substring(0, timeStampAndId.length() - 4);
+                }
                 String[] parsed = Profile.parseProfileFileName(timeStampAndId);
                 if (parsed == null) {
                     LOG.warn("Invalid profile directory path: {}", profileDirAbsPath);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileManager.java
@@ -734,9 +734,6 @@ public class ProfileManager extends MasterDaemon {
 
             try {
                 String timeStampAndId = profileDirAbsPath.substring(separatorIdx + 1);
-                if (timeStampAndId.endsWith(".zip")) {
-                    timeStampAndId = timeStampAndId.substring(0, timeStampAndId.length() - 4);
-                }
                 String[] parsed = Profile.parseProfileFileName(timeStampAndId);
                 if (parsed == null) {
                     LOG.warn("Invalid profile directory path: {}", profileDirAbsPath);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -631,7 +631,7 @@ class ProfileManagerTest {
                 profileManager.pushProfile(profile);
 
                 // Create profile file
-                File profileFile = new File(tempDir, System.currentTimeMillis() + "_" + profileId);
+                File profileFile = new File(tempDir, System.currentTimeMillis() + "_" + profileId + ".zip");
                 profileFile.createNewFile();
             }
 
@@ -679,7 +679,7 @@ class ProfileManagerTest {
                 Profile profile = constructProfile(profileId);
                 profileManager.pushProfile(profile);
 
-                File normalFile = new File(tempDir, System.currentTimeMillis() + "_" + profileId);
+                File normalFile = new File(tempDir, System.currentTimeMillis() + "_" + profileId + ".zip");
                 normalFile.createNewFile();
                 normalFiles.add(normalFile);
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfilePersistentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfilePersistentTest.java
@@ -38,11 +38,18 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 public class ProfilePersistentTest {
     private static final Logger LOG = LogManager.getLogger(ProfilePersistentTest.class);
@@ -92,34 +99,6 @@ public class ProfilePersistentTest {
         }
 
         return profile;
-    }
-
-    @Test
-    public void compressBasicTest() {
-        // Initialize StringBuilder for faster string construction
-        StringBuilder executionProfileTextBuilder = new StringBuilder(1024 * 1024);
-        // Populate the StringBuilder with random characters
-        for (int i = 0; i < 1024 * 1024; i++) {
-            executionProfileTextBuilder.append((char) (Math.random() * 26 + 'a'));
-        }
-        // Convert StringBuilder to String
-        String executionProfileText = executionProfileTextBuilder.toString();
-
-        byte[] compressed = null;
-        try {
-            compressed = Profile.compressExecutionProfile(executionProfileText);
-        } catch (IOException e) {
-            LOG.error("Failed to compress execution profile: {}", e.getMessage(), e);
-            Assert.fail();
-        }
-        String executionProfileTextDecompressed = null;
-        try {
-            executionProfileTextDecompressed = Profile.decompressExecutionProfile(compressed);
-        } catch (IOException e) {
-            LOG.error("Failed to decompress execution profile: {}", e.getMessage(), e);
-            Assert.fail();
-        }
-        Assert.assertEquals(executionProfileText, executionProfileTextDecompressed);
     }
 
     @Test
@@ -263,28 +242,17 @@ public class ProfilePersistentTest {
     }
 
     @Test
-    public void profileBasicTest() {
+    public void profileBasicTest() throws IOException {
         final int executionProfileNum = 5;
         Profile profile = constructRandomProfile(executionProfileNum);
 
-        // after profile is stored to disk, futher read will be from disk
-        // so we store the original answer to a string
-        String profileContentString = profile.getProfileByLevel();
-        String currentBinaryWorkingDir = System.getProperty("user.dir");
-        String profileStoragePath = currentBinaryWorkingDir + File.separator + "doris-feut-profile";
-        File profileDir = new File(profileStoragePath);
-        if (!profileDir.exists()) {
-            // create query_id directory
-            if (!profileDir.mkdir()) {
-                LOG.warn("create profile directory {} failed", profileDir.getAbsolutePath());
-                Assert.fail();
-                return;
-            }
-        }
-
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
         try {
-            profile.writeToStorage(profileStoragePath);
+            profile.writeToStorage(tempDir.toString());
 
+            // after profile is stored to disk, futher read will be from disk
+            // so we store the original answer to a string
+            String profileContentString = profile.getProfileByLevel();
             String profileStoragePathTmp = profile.getProfileStoragePath();
             Assert.assertFalse(Strings.isNullOrEmpty(profileStoragePathTmp));
 
@@ -299,14 +267,274 @@ public class ProfilePersistentTest {
             profile.deleteFromStorage();
             File tmpFile = new File(profileStoragePathTmp);
             Assert.assertFalse(tmpFile.exists());
-            FileUtils.deleteQuietly(profileDir);
         } finally {
-            try {
-                FileUtils.deleteDirectory(profileDir);
-            } catch (Exception e) {
-                LOG.warn("delete profile directory {} failed", profileDir.getAbsolutePath());
-                Assert.fail();
-            }
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testWriteAndReadStorage() throws IOException {
+        final int executionProfileNum = 3;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // Test writeToStorage
+            profile.writeToStorage(tempDir.toString());
+            Assert.assertFalse(Strings.isNullOrEmpty(profile.getProfileStoragePath()));
+            Assert.assertTrue(new File(profile.getProfileStoragePath()).exists());
+
+            // Test read
+            Profile readProfile = Profile.read(profile.getProfileStoragePath());
+            Assert.assertNotNull(readProfile);
+            Assert.assertEquals(profile.getId(), readProfile.getId());
+            Assert.assertEquals(profile.getQueryFinishTimestamp(), readProfile.getQueryFinishTimestamp());
+
+            // Verify content is readable
+            StringBuilder builder = new StringBuilder();
+            readProfile.getOnStorageProfile(builder);
+            Assert.assertFalse(Strings.isNullOrEmpty(builder.toString()));
+
+            // Clean up
+            profile.deleteFromStorage();
+            Assert.assertFalse(new File(profile.getProfileStoragePath()).exists());
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testCreateProfileFileInputStream() throws IOException {
+        final int executionProfileNum = 1;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // Write profile first
+            profile.writeToStorage(tempDir.toString());
+            String path = profile.getProfileStoragePath();
+
+            // Test createPorfileFileInputStream
+            FileInputStream fis = Profile.createPorfileFileInputStream(path);
+            Assert.assertNotNull(fis);
+            fis.close();
+
+            // Test with invalid path
+            Assert.assertNull(Profile.createPorfileFileInputStream("/invalid/path"));
+            
+            // Test with directory
+            Assert.assertNull(Profile.createPorfileFileInputStream(tempDir.toString()));
+
+            // Clean up
+            profile.deleteFromStorage();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test 
+    public void testGetOnStorageProfile() throws IOException {
+        final int executionProfileNum = 2;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // First get profile content before storage
+            StringBuilder beforeStorage = new StringBuilder();
+            beforeStorage.append(profile.getProfileByLevel());
+            Assert.assertFalse(Strings.isNullOrEmpty(beforeStorage.toString()));
+
+            // Write to storage
+            profile.writeToStorage(tempDir.toString());
+
+            // Test getOnStorageProfile
+            StringBuilder afterStorage = new StringBuilder();
+            afterStorage.append(profile.getProfileByLevel());
+            Assert.assertFalse(Strings.isNullOrEmpty(afterStorage.toString()));
+
+            // Content should be same
+            Assert.assertEquals(beforeStorage.toString().trim(), afterStorage.toString().trim());
+
+            // Test with corrupted file
+            File profileFile = new File(profile.getProfileStoragePath());
+            FileUtils.writeStringToFile(profileFile, "corrupted content", StandardCharsets.UTF_8);
+            StringBuilder corruptedContent = new StringBuilder();
+            profile.getOnStorageProfile(corruptedContent);
+            Assert.assertTrue(corruptedContent.toString().contains("Failed to read profile"));
+
+            // Clean up
+            profile.deleteFromStorage();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testProfileRead() throws IOException {
+        final int executionProfileNum = 1;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // Write profile
+            profile.writeToStorage(tempDir.toString());
+
+            // Test read with valid path
+            Profile readProfile = Profile.read(profile.getProfileStoragePath());
+            Assert.assertNotNull(readProfile);
+            Assert.assertEquals(profile.getId(), readProfile.getId());
+
+            // Test read with invalid path
+            Assert.assertNull(Profile.read("/invalid/path"));
+
+            // Test read with directory
+            Assert.assertNull(Profile.read(tempDir.toString()));
+
+            // Test read with corrupted file
+            File profileFile = new File(profile.getProfileStoragePath());
+            FileUtils.writeStringToFile(profileFile, "corrupted", StandardCharsets.UTF_8);
+            Assert.assertNull(Profile.read(profile.getProfileStoragePath()));
+
+            // Clean up
+            profile.deleteFromStorage();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testwriteToStorage() throws IOException {
+        final int executionProfileNum = 3;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // Test writeToStorage
+            profile.writeToStorage(tempDir.toString());
+            Assert.assertFalse(Strings.isNullOrEmpty(profile.getProfileStoragePath()));
+            Assert.assertTrue(new File(profile.getProfileStoragePath()).exists());
+            Assert.assertTrue(profile.getProfileStoragePath().endsWith(".zip"));
+
+            // Test write with empty id
+            Profile emptyProfile = new Profile();
+            emptyProfile.writeToStorage(tempDir.toString());
+            Assert.assertTrue(Strings.isNullOrEmpty(emptyProfile.getProfileStoragePath()));
+
+            // Test write already stored profile
+            profile.writeToStorage(tempDir.toString());
+            Assert.assertTrue(profile.getProfileStoragePath().endsWith(".zip"));
+
+            // Clean up
+            profile.deleteFromStorage();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testCreateProfileFileInputStreamWithCorruptedFiles() throws IOException {
+        final int executionProfileNum = 1;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // Write profile first
+            profile.writeToStorage(tempDir.toString());
+            String path = profile.getProfileStoragePath();
+
+            // Test with empty file
+            File emptyFile = new File(tempDir.toString(), "empty_1234567_abcdef.zip");
+            emptyFile.createNewFile();
+            Assert.assertNull(Profile.createPorfileFileInputStream(emptyFile.getAbsolutePath()));
+
+            // Test with invalid filename format
+            File invalidFile = new File(tempDir.toString(), "invalid_name.zip");
+            invalidFile.createNewFile();
+            Assert.assertNull(Profile.createPorfileFileInputStream(invalidFile.getAbsolutePath()));
+
+            // Test with non-existing file
+            Assert.assertNull(Profile.createPorfileFileInputStream(tempDir + "/non_existing.zip"));
+
+            // Clean up
+            profile.deleteFromStorage();
+            emptyFile.delete();
+            invalidFile.delete();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testGetOnStorageProfileComprehensive() throws IOException {
+        final int executionProfileNum = 2;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // First get profile content before storage
+            StringBuilder beforeStorage = new StringBuilder();
+            profile.getExecutionProfileContent(beforeStorage);
+            String originalContent = beforeStorage.toString();
+
+            // Write to storage
+            profile.writeToStorage(tempDir.toString());
+
+            // Test with non-stored profile
+            Profile nonStoredProfile = constructRandomProfile(1);
+            StringBuilder nonStoredBuilder = new StringBuilder();
+            nonStoredProfile.getOnStorageProfile(nonStoredBuilder);
+            Assert.assertEquals("", nonStoredBuilder.toString());
+
+            // Test with invalid zip entry
+            File profileFile = new File(profile.getProfileStoragePath());
+            FileOutputStream fos = new FileOutputStream(profileFile);
+            ZipOutputStream zos = new ZipOutputStream(fos);
+            zos.putNextEntry(new ZipEntry("wrong_entry_name"));
+            zos.write("test data".getBytes());
+            zos.closeEntry();
+            zos.close();
+            fos.close();
+
+            StringBuilder invalidBuilder = new StringBuilder();
+            profile.getOnStorageProfile(invalidBuilder);
+            Assert.assertTrue(invalidBuilder.toString().contains("Failed to read profile"));
+
+            // Clean up
+            profile.deleteFromStorage();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testProfileReadComprehensive() throws IOException {
+        final int executionProfileNum = 1;
+        Profile profile = constructRandomProfile(executionProfileNum);
+
+        Path tempDir = Files.createTempDirectory("profile-persistent-test");
+        try {
+            // Write profile
+            profile.writeToStorage(tempDir.toString());
+
+            // Test read with missing entry in zip
+            File profileFile = new File(profile.getProfileStoragePath());
+            FileOutputStream fos = new FileOutputStream(profileFile);
+            ZipOutputStream zos = new ZipOutputStream(fos);
+            zos.close();
+            Assert.assertNull(Profile.read(profileFile.getAbsolutePath()));
+
+            // Test read with corrupted zip
+            FileUtils.writeStringToFile(profileFile, "not a zip file", StandardCharsets.UTF_8);
+            Assert.assertNull(Profile.read(profileFile.getAbsolutePath()));
+
+            // Test read with empty file
+            FileUtils.writeStringToFile(profileFile, "", StandardCharsets.UTF_8);
+            Assert.assertNull(Profile.read(profileFile.getAbsolutePath()));
+
+            // Clean up
+            profile.deleteFromStorage();
+        } finally {
+            FileUtils.deleteDirectory(tempDir.toFile());
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfilePersistentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfilePersistentTest.java
@@ -321,7 +321,7 @@ public class ProfilePersistentTest {
 
             // Test with invalid path
             Assert.assertNull(Profile.createPorfileFileInputStream("/invalid/path"));
-            
+
             // Test with directory
             Assert.assertNull(Profile.createPorfileFileInputStream(tempDir.toString()));
 
@@ -332,7 +332,7 @@ public class ProfilePersistentTest {
         }
     }
 
-    @Test 
+    @Test
     public void testGetOnStorageProfile() throws IOException {
         final int executionProfileNum = 2;
         Profile profile = constructRandomProfile(executionProfileNum);
@@ -440,7 +440,6 @@ public class ProfilePersistentTest {
         try {
             // Write profile first
             profile.writeToStorage(tempDir.toString());
-            String path = profile.getProfileStoragePath();
 
             // Test with empty file
             File emptyFile = new File(tempDir.toString(), "empty_1234567_abcdef.zip");
@@ -474,7 +473,6 @@ public class ProfilePersistentTest {
             // First get profile content before storage
             StringBuilder beforeStorage = new StringBuilder();
             profile.getExecutionProfileContent(beforeStorage);
-            String originalContent = beforeStorage.toString();
 
             // Write to storage
             profile.writeToStorage(tempDir.toString());


### PR DESCRIPTION
### What problem does this PR solve?

A new profile file format. User could decompress profile file by using unzip directly.

```
[hezhiqiang@VM-10-2-centos log]$ unzip profile/1740745121714_33bf38e988ea4945-b585d2f74d1da3fd.zip
Archive:  profile/1740745121714_33bf38e988ea4945-b585d2f74d1da3fd.zip
  inflating: 33bf38e988ea4945-b585d2f74d1da3fd.profile
[hezhiqiang@VM-10-2-centos log]$ head 33bf38e988ea4945-b585d2f74d1da3fd.profile -n 10
�{"summaryProfile":{"counterTotalTime":{"value":0,"type":5,"level":1},"localTimePercent":0.0,"infoStrings":{"Distributed Plan":"N/A","Task Type":"QUERY","User":"root","Default Catalog":"internal","Total":"9sec745ms","Default Db":"tpch","Profile ID":"33bf38e988ea4945-b585d2f74d1da3fd","Task State":"OK","Sql Statement":"SELECT      c.c_name,      COUNT(o.o_orderkey) AS total_orders,      SUM(o.o_totalprice) AS total_spent FROM      customer c JOIN      orders o ON c.c_custkey \u003d o.o_custkey GROUP BY      c.c_name limit 20","Start Time":"2025-02-28 20:18:31","End Time":"2025-02-28 20:18:41"},"infoStringsDisplayOrder":["Profile ID","Task Type","Start Time","End Time","Total","Task State","User","Default Catalog","Default Db","Sql Statement","Distributed Plan"],"counterMap":{"TotalTime":{"value":0,"type":5,"level":1}},"childCounterMap":{},"childMap":{},"childList":[],"planNodeInfos":[],"name":"Summary","timestamp":-1,"isDone":false,"isCancel":false,"isSinkOperator":false,"nodeid":-1},"executionSummaryProfile":{"counterTotalTime":{"value":0,"type":5,"level":1},"localTimePercent":0.0,"infoStrings":{"Fragment RPC Count":"2","Analysis Time":"6ms","CreateSingleNode Time":"N/A","Get Table Version Count":"N/A","Parse SQL Time":"3ms","Get Partition Files Time":"N/A","Get Partition Version Time":"N/A","Nereids Optimize Time":"11ms","Nereids Lock Table Time":"6ms","Get Partitions Time":"N/A","Get Table Version Time":"N/A","Nereids GarbageCollect Time":"0ms","Wait and Fetch Result Time":"9sec643ms","Is Nereids":"Yes","Is Cached":"No","Workload Group":"normal","Finalize Scan Node Time":"N/A","Fetch Result Time":"9sec641ms","Instances Num Per BE":"10.16.10.2:8261:4","Plan Time":"26ms","Fragment RPC Phase1 Time":"28ms","Create Scan Range Time":"N/A","Fragment Assign Time":"3ms","Nereids BeFoldConst Time":"0ms","JoinReorder Time":"N/A","QueryDistributed Time":"N/A","Get Splits Time":"N/A","Fragment Compressed Size":"22.63 KB","Get Partition Version Count":"N/A","Fragment RPC Phase2 Time":"30ms","Schedule Time Of BE":"{\"phase1\":{\"10.16.10.2: 8261\":{\"RPC Work Time\":\"17ms\",\"RPC Latency From FE To BE\":\"10ms\",\"RPC Work Queue Time\":\"0ms\",\"RPC Latency From BE To FE\":\"1ms\"}},\"phase2\":{\"10.16.10.2: 8261\":{\"RPC Work Time\":\"4ms\",\"RPC Latency From FE To BE\":\"3ms\",\"RPC Work Queue Time\":\"0ms\",\"RPC Latency From BE To FE\":\"23ms\"}}}","Get Partition Version Count (hasData)":"N/A","Fragment Serialize Time":"9ms","Init Scan Node Time":"N/A","Trace ID":"","Nereids Rewrite Time":"10ms","Schedule Time":"70ms","Transaction Commit Time":"N/A","Nereids Translate Time":"2ms","Parallel Fragment Exec Instance Num":"48","Total Instances Num":"4","Doris Version":"e021a6a015","Nereids Distribute Time":"6ms","Nereids Analysis Time":"3ms","Write Result Time":"0ms","System Message":"N/A","Executed By Frontend":"N/A"},"infoStringsDisplayOrder":["Parse SQL Time","Nereids Lock Table Time","Nereids Analysis Time","Nereids Rewrite Time","Nereids Optimize Time","Nereids Translate Time","Nereids Distribute Time","Workload Group","Analysis Time","Plan Time","JoinReorder Time","CreateSingleNode Time","QueryDistributed Time","Init Scan Node Time","Finalize Scan Node Time","Get Splits Time","Get Partitions Time","Get Partition Files Time","Create Scan Range Time","Get Partition Version Time","Get Partition Version Count (hasData)","Get Partition Version Count","Get Table Version Time","Get Table Version Count","Schedule Time","Fragment Assign Time","Fragment Serialize Time","Fragment RPC Phase1 Time","Fragment RPC Phase2 Time","Fragment Compressed Size","Fragment RPC Count","Schedule Time Of BE","Wait and Fetch Result Time","Fetch Result Time","Write Result Time","Doris Version","Is Nereids","Is Cached","Total Instances Num","Instances Num Per BE","Parallel Fragment Exec Instance Num","Trace ID","Transaction Commit Time","System Message","Executed By Frontend","Nereids GarbageCollect Time","Nereids BeFoldConst Time"],"counterMap":{"TotalTime":{"value":0,"type":5,"level":1}},"childCounterMap":{},"childMap":{},"childList":[],"planNodeInfos":[],"name":"Execution Summary","timestamp":-1,"isDone":false,"isCancel":false,"isSinkOperator":false,"nodeid":-1},"parseSqlStartTime":1740745111965,"parseSqlFinishTime":1740745111968,"nereidsLockTableFinishTime":1740745111971,"nereidsAnalysisFinishTime":1740745111974,"nereidsRewriteFinishTime":1740745111984,"nereidsOptimizeFinishTime":1740745111995,"nereidsTranslateFinishTime":1740745111997,"nereidsGarbageCollectionTime":0,"nereidsBeFoldConstTime":0,"queryBeginTime":1740745111968,"queryAnalysisFinishTime":1740745111974,"queryJoinReorderFinishTime":-1,"queryCreateSingleNodeFinishTime":-1,"queryDistributedFinishTime":-1,"initScanNodeStartTime":-1,"initScanNodeFinishTime":-1,"finalizeScanNodeStartTime":-1,"finalizeScanNodeFinishTime":-1,"getSplitsStartTime":-1,"getPartitionsFinishTime":-1,"getPartitionFilesFinishTime":-1,"getSplitsFinishTime":-1,"createScanRangeFinishTime":-1,"queryPlanFinishTime":1740745112000,"assignFragmentTime":1740745112003,"fragmentSerializeTime":1740745112012,"fragmentSendPhase1Time":1740745112040,"fragmentSendPhase2Time":1740745112070,"fragmentCompressedSize":23173,"fragmentRpcCount":2,"queryScheduleFinishTime":1740745112070,"queryFetchResultFinishTime":1740745121713,"tempStarTime":1740745121713,"queryFetchResultConsumeTime":9641,"queryWriteResultConsumeTime":0,"getPartitionVersionTime":0,"getPartitionVersionCount":0,"getPartitionVersionByHasDataCount":0,"getTableVersionTime":0,"getTableVersionCount":0,"transactionCommitBeginTime":-1,"transactionCommitEndTime":-1,"filesystemOptTime":-1,"hmsAddPartitionTime":-1,"hmsAddPartitionCnt":0,"hmsUpdatePartitionTime":-1,"hmsUpdatePartitionCnt":0,"filesystemRenameFileCnt":0,"filesystemRenameDirCnt":0,"filesystemDeleteDirCnt":0,"filesystemDeleteFileCnt":0,"transactionType":"UNKNOWN"}�U
Changed Session Variables:
VarName                       | CurrentValue | DefaultValue
------------------------------|--------------|-------------
insert_visible_timeout_ms     | 10000        | 60000
fetch_splits_max_wait_time_ms | 4000         | 1000
exec_mem_limit                | 2147483648   | 100147483648
profile_level                 | 2            | 1
auto_profile_threshold_ms     | 1            | -1
```

Sometimes, profile could be very large, so this pr changed implementation of `loadProfilesFromStorageIfFirstTime`.
Use a separate thread to handle profile loading after catalog is ready, so that first loading of profile files will not block main thread. And this thread read profile in a batch manner, max concurrency of each bath is 10. By using batch loading, we can reduce peak of memory usage.

According to test, load of 500 profiles from disks costs 800ms(On a x86-64 machine with 8C, HDD).
```
2025-03-02 10:11:17,019 INFO (profile-loader|195) [ProfileManager.lambda$loadProfilesFromStorageIfFirstTime$2():521] Reading 500 profiles from /mnt/datadisk1/Doris-Deploy/20250301070117-doris-master-3ea1b7c5c6/fe/log/profile
2025-03-02 10:11:17,054 INFO (profile-loader|195) [ProfileManager.lambda$loadProfilesFromStorageIfFirstTime$2():560] Processed batch 0 - 10 of 500 profiles
...
2025-03-02 10:11:17,901 INFO (profile-loader|195) [ProfileManager.lambda$loadProfilesFromStorageIfFirstTime$2():563] Load profiles into memory finished, costs 884ms
```
Total size of profile file on disk is 58MB, typical size of single test profile file about 150KB, after decompress, its content ifs about 1.6MB.
```text
root@d1:/mnt/datadisk1/Doris-Deploy/20250301070117-doris-master-3ea1b7c5c6/fe/log# du -h profile/
58M	profile/
```
So max memory usage for the loading is about 16MB(10 * 1.6MB).


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

