### PR TITLE
[fix](jdbc catalog) Use factory methods to return mapped types instead 2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -18,7 +18,6 @@
 package org.apache.doris.datasource.jdbc.client;
 
 import org.apache.doris.catalog.ArrayType;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.util.Util;
@@ -383,9 +382,7 @@ public class JdbcMySQLClient extends JdbcClient {
             }
             case "CHAR":
             case "CHARACTER":
-                ScalarType charType = ScalarType.createType(PrimitiveType.CHAR);
-                charType.setLength(fieldSchema.requiredColumnSize());
-                return charType;
+                return ScalarType.createCharType(fieldSchema.requiredColumnSize());
             case "VARCHAR":
                 return ScalarType.createVarcharType(fieldSchema.requiredColumnSize());
             case "STRING":


### PR DESCRIPTION
Related PR: #46623

Problem Summary:

We should use factory methods to create types instead of returning a type directly, because the returned type is static and final, which will cause problems with length setting.

external_table_p0/jdbc/type_test/select/test_doris_all_types_select.groovy
will occasionally fail due to this problem