### PR TITLE
[fix](function) Percentil  func core when percent args  is non nullable negative number

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -383,6 +383,7 @@ struct PercentileState {
             inited_flag = true;
             vec_counts.resize(1);
             vec_quantile.resize(1);
+            check_quantile(q);
             vec_quantile[0] = q;
         }
         vec_counts[0].increment_batch(source);

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
@@ -299,6 +299,17 @@ suite("test_aggregate_all_functions", "arrow_flight_sql") {
         assert("${ex}".contains("3000"))
     }
 
+    try {
+        sql "select id,percentile(non_nullable(level + 0.1), -1) from ${tableName_13} group by id order by id"
+    } catch (Exception ex) {
+        assert("${ex}".contains("-1"))
+    }
+    try {
+        sql "select id,percentile(non_nullable(level + 0.1), 3000) from ${tableName_13} group by id order by id"
+    } catch (Exception ex) {
+        assert("${ex}".contains("3000"))
+    }
+
     sql "DROP TABLE IF EXISTS ${tableName_13}"
 
     

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
@@ -299,13 +299,24 @@ suite("test_aggregate_all_functions", "arrow_flight_sql") {
         assert("${ex}".contains("3000"))
     }
 
+    sql """
+        drop table if exists percentile_input_no_nullable;
+    """
+    sql """
+        create table percentile_input_no_nullable(a int, b int not null) properties ("replication_num" = "1");
+    """
+    sql """
+        insert into percentile_input_no_nullable values (10, 100), (20,200), (30, 300), (40, 400);
+    """
+
     try {
-        sql "select id,percentile(non_nullable(level + 0.1), -1) from ${tableName_13} group by id order by id"
+        sql " select percentile(b, -1) from percentile_input_no_nullable;"
     } catch (Exception ex) {
         assert("${ex}".contains("-1"))
     }
+
     try {
-        sql "select id,percentile(non_nullable(level + 0.1), 3000) from ${tableName_13} group by id order by id"
+        sql " select percentile(b, 3000) from percentile_input_no_nullable;"
     } catch (Exception ex) {
         assert("${ex}".contains("3000"))
     }


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/apache/doris/pull/47068
In this PR, a check was performed, but it was not comprehensive. If the parameter is for a non-nullable column, the check will be bypassed.

```
drop table if exists t01;
create table t01(a int, b int not null) properties ("replication_num" = "1");
insert into t01 values (10, 100), (20,200), (30, 300), (40, 400);
select percentile(1, -1) from t01;


mysql> select percentile(a, -1) from t01;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]quantile in func percentile should in [0, 1], but real data is:-1.000000
mysql> select percentile(b, -1) from t01;
ERROR 1105 (HY000): RpcException, msg: send fragments failed. io.grpc.StatusRuntimeException: UNAVAILABLE: io exception, host: 127.0.0.1

```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

