### PR TITLE
[fix](mv) Fix fail when drop table column when sync mv which not use the dropped column exits on table 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -943,9 +943,10 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     public String toSqlWithoutTbl() {
+        boolean originalTag = disableTableName;
         setDisableTableName(true);
         String result = toSql();
-        setDisableTableName(false);
+        setDisableTableName(originalTag);
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
@@ -171,6 +171,10 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
         return originStatement;
     }
 
+    public MVColumnItem getWhereClauseItem() {
+        return whereClauseItem;
+    }
+
     public Column getWhereClauseItemColumn(OlapTable olapTable) throws DdlException {
         if (whereClauseItem == null) {
             return null;
@@ -178,7 +182,10 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
         return whereClauseItem.toMVColumn(olapTable);
     }
 
-    private void validate(ConnectContext ctx) throws Exception {
+    /**
+     * Valid create mv info
+     */
+    public void validate(ConnectContext ctx) throws Exception {
         name.analyze(ctx);
         Pair<LogicalPlan, CascadesContext> result = analyzeAndRewriteLogicalPlan(logicalPlan, ctx);
         PlanValidator planValidator = new PlanValidator();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -18,23 +18,16 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.CreateMaterializedViewStmt;
-import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FunctionCallExpr;
-import org.apache.doris.analysis.FunctionName;
 import org.apache.doris.analysis.SlotRef;
-import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -43,81 +36,101 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 
-public class MaterializedIndexMetaTest {
+public class MaterializedIndexMetaTest extends SqlTestBase {
 
-    private static String fileName = "./MaterializedIndexMetaSerializeTest";
-    private static Path path = Paths.get(fileName);
+    private static final String fileName = "./MaterializedIndexMetaSerializeTest";
+    private static final Path path = Paths.get(fileName);
 
-    @After
-    public void tearDown() throws IOException {
+    @Override
+    protected void runBeforeAll() throws Exception {
+        Files.deleteIfExists(path);
+        super.runBeforeAll();
+        createTables("CREATE TABLE IF NOT EXISTS basic_test_table (\n"
+                + "    `k1` TINYINT COMMENT \"abc\",\n"
+                + "    `k2` SMALLINT COMMENT \"debug\",\n"
+                + "    `k3` INT,\n"
+                + "    `k4` BIGINT COMMENT \"**\",\n"
+                + "    `k5` LARGEINT,\n"
+                + "    `k6` DOUBLE,\n"
+                + "    `k7` FLOAT,\n"
+                + "    `k8` DATE,\n"
+                + "    `k9` DATETIME,\n"
+                + "    `k10` VARCHAR(255),\n"
+                + "    `k11` DECIMAL(27,9),\n"
+                + "    `k12` INT,\n"
+                + "    `v1` INT COMMENT \"sum_aggregate\",\n"
+                + ")\n"
+                + "ENGINE=OLAP\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 10\n"
+                + "PROPERTIES (\n"
+                + "    \"replication_num\" = \"1\"\n"
+                + ");");
+    }
+
+    @Override
+    protected void runAfterAll() throws Exception {
+        super.runAfterAll();
         Files.deleteIfExists(path);
     }
 
     @Test
-    public void testSerializeMaterializedIndexMeta(@Mocked CreateMaterializedViewStmt stmt)
+    public void testSerializeMaterializedIndexMeta()
             throws IOException, AnalysisException {
         // 1. Write objects to file
         Files.createFile(path);
         DataOutputStream out = new DataOutputStream(Files.newOutputStream(path));
 
-        String mvColumnName = CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + FunctionSet.BITMAP_UNION + "_" + "k1";
         List<Column> schema = Lists.newArrayList();
-        schema.add(new Column("k1", Type.TINYINT, true, null, true, "1", "abc"));
-        schema.add(new Column("k2", Type.SMALLINT, true, null, true, "1", "debug"));
-        schema.add(new Column("k3", Type.INT, true, null, true, "1", ""));
-        schema.add(new Column("k4", Type.BIGINT, true, null, true, "1", "**"));
-        schema.add(new Column("k5", Type.LARGEINT, true, null, true, null, ""));
-        schema.add(new Column("k6", Type.DOUBLE, true, null, true, "1.1", ""));
-        schema.add(new Column("k7", Type.FLOAT, true, null, true, "1", ""));
-        schema.add(new Column("k8", Type.DATE, true, null, true, "1", ""));
-        schema.add(new Column("k9", Type.DATETIME, true, null, true, "1", ""));
-        schema.add(new Column("k10", Type.VARCHAR, true, null, true, "1", ""));
-        schema.add(new Column("k11", Type.DECIMALV2, true, null, true, "1", ""));
-        schema.add(new Column("k12", Type.INT, true, null, true, "1", ""));
-        schema.add(new Column("v1", Type.INT, false, AggregateType.SUM, true, "1", ""));
-        schema.add(new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k1", Type.TINYINT, true, null, true, "1", "abc"));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k2", Type.SMALLINT, true, null, true, "1", "debug"));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k3", Type.INT, true, null, true, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k4", Type.BIGINT, true, null, true, "1", "**"));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k5", Type.LARGEINT, true, null, true, null, ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k6", Type.DOUBLE, true, null, true, "1.1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k7", Type.FLOAT, true, null, true, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k8", Type.DATE, true, null, true, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k9", Type.DATETIME, true, null, true, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k10", Type.VARCHAR, true, null, true, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k11", Type.DECIMALV2, true, null, true, "1", ""));
+        schema.add(new Column(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX + "k12", Type.INT, true, null, true, "1", ""));
+        schema.add(new Column("mva_SUM__CAST(`v1` AS bigint)", Type.INT, false, AggregateType.SUM, true, "1", ""));
+        schema.add(new Column("mva_BITMAP_UNION__to_bitmap_with_check(CAST(`k1` AS bigint))", Type.BITMAP, false, AggregateType.BITMAP_UNION, false, "1", ""));
         short shortKeyColumnCount = 1;
         MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, schema, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.DUP_KEYS, new OriginStatement(
-                "create materialized view test as select k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, sum(v1), "
-                        + "bitmap_union(to_bitmap(k1)) from test group by k1, k2, k3, k4, k5, "
+                "create materialized view test_mv as select k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, sum(v1), "
+                        + "bitmap_union(to_bitmap(k1)) from basic_test_table group by k1, k2, k3, k4, k5, "
                         + "k6, k7, k8, k9, k10, k11, k12",
-                0));
+                0), null, "test");
         indexMeta.write(out);
         out.flush();
         out.close();
-
-        List<Expr> params = Lists.newArrayList();
-        SlotRef param1 = new SlotRef(new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, null, "test"), "c1");
-        params.add(param1);
-        Map<String, Expr> columnNameToDefineExpr = Maps.newHashMap();
-        columnNameToDefineExpr.put(mvColumnName, new FunctionCallExpr(new FunctionName("to_bitmap"), params));
-        new Expectations() {
-            {
-                stmt.parseDefineExpr(null);
-                result = columnNameToDefineExpr;
-            }
-        };
 
 
         // 2. Read objects from file
         DataInputStream in = new DataInputStream(Files.newInputStream(path));
         MaterializedIndexMeta readIndexMeta = MaterializedIndexMeta.read(in);
         readIndexMeta.parseStmt(null);
-        Assert.assertEquals(1, readIndexMeta.getIndexId());
+        Assertions.assertEquals(1, readIndexMeta.getIndexId());
         List<Column> resultColumns = readIndexMeta.getSchema();
-        for (Column column : resultColumns) {
-            if (column.getName().equals(mvColumnName)) {
-                Assert.assertTrue(column.getDefineExpr() instanceof FunctionCallExpr);
-                Assert.assertEquals(Type.BITMAP, column.getType());
-                Assert.assertEquals(AggregateType.BITMAP_UNION, column.getAggregationType());
-                Assert.assertEquals("to_bitmap", ((FunctionCallExpr) column.getDefineExpr()).getFnName().getFunction());
+        for (int i = 0; i < resultColumns.size(); i++) {
+            Column column = resultColumns.get(i);
+            if (column.getName().equals("mva_BITMAP_UNION__to_bitmap_with_check(CAST(`k1` AS bigint))")) {
+                Assertions.assertTrue(column.getDefineExpr() instanceof FunctionCallExpr);
+                Assertions.assertEquals(Type.BITMAP, column.getType());
+                Assertions.assertEquals(AggregateType.BITMAP_UNION, column.getAggregationType());
+                Assertions.assertEquals("to_bitmap_with_check",
+                        ((FunctionCallExpr) column.getDefineExpr()).getFnName().getFunction());
+            } else if (column.getName().equals("mva_SUM__CAST(`v1` AS bigint)")) {
+                Assertions.assertEquals("v1", ((SlotRef) column.getDefineExpr().getChild(0)).getColumn().getName());
             } else {
-                Assert.assertEquals(null, column.getDefineExpr());
+                Assertions.assertEquals(column.getName(),
+                        CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX
+                                + ((SlotRef) column.getDefineExpr()).getColumn().getName());
             }
         }
+
         // 3.close
         in.close();
     }

--- a/regression-test/suites/mv_p0/drop_with_or_not_db_qualifier/drop_with_or_not_db_qualifier.groovy
+++ b/regression-test/suites/mv_p0/drop_with_or_not_db_qualifier/drop_with_or_not_db_qualifier.groovy
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite ("drop_with_or_not_db_qualifier") {
+    sql "set enable_fallback_to_original_planner = false"
+
+    String db = context.config.getDbNameByFile(context.file)
+
+    sql"""drop database if exists ${db} """
+    sql """create database ${db}"""
+
+    sql """drop database if exists ${db}_another"""
+    sql """create database ${db}_another"""
+    sql "use ${db}_another"
+
+    sql """drop table if exists ${db}.t;"""
+    sql """drop table if exists ${db}.t1;"""
+
+
+    sql """
+    CREATE TABLE ${db}.t (
+        id int null,
+        k largeint null,
+        d date null,
+        k1 int
+    )
+    PARTITION BY RANGE (`id`) (
+        partition p1 values [(1), (2))
+    )
+    DISTRIBUTED BY HASH(`k`, `id`) BUCKETS 16
+    PROPERTIES (
+        "replication_num" = "1"
+    );
+    """
+
+    sql "create materialized view ${db}.mv_t as select d from ${db}.t;"
+    Thread.sleep(2000)
+
+    // drop column should success when create and drop in another db
+    sql """alter table ${db}.t drop column k1;"""
+
+    //
+    sql """use ${db}"""
+
+    sql """
+    CREATE TABLE t1 (
+        id int null,
+        k largeint null,
+        d date null,
+        k1 int
+    )
+    PARTITION BY RANGE (`id`) (
+        partition p1 values [(1), (2))
+    )
+    DISTRIBUTED BY HASH(`k`, `id`) BUCKETS 16
+    PROPERTIES (
+        "replication_num" = "1"
+    );
+    """
+
+    sql """alter table ${db}.t1 ADD ROLLUP mv_t1(d); """
+
+    Thread.sleep(2000)
+    sql """use ${db}_another"""
+
+    // should success when create in one db and drop in another db
+    sql """ alter table ${db}.t1 drop column k1;"""
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

this is brought by https://github.com/apache/doris/pull/4014

schema is as following:

```sql
drop database db;

create database db;

CREATE TABLE db.t (
    id int null,
    k largeint null,
    d date null,
    k1 int
)
PARTITION BY RANGE (`id`) (
    partition p1 values [(1), (2))
)
DISTRIBUTED BY HASH(`k`, `id`) BUCKETS 16
PROPERTIES (
    "replication_num" = "1"
);

create materialized view db.mv_t as select d from db.t;

```

if run drop sql as following  would fail with message `OriginStatement{originStmt='create materialized view db.mv_t as select d from db.t', idx=0}`, the pr fix this

```sql

alter table db.t drop column k1;
```


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

Fix fail when drop table column when sync mv exits on table

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

