### PR TITLE
[fix](binlog) avoid adding acqurie_md5 param when enable_download_md5…

### DIFF
--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -296,8 +296,10 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     // Step 5.3: get all segment files
     for (int64_t segment_index = 0; segment_index < num_segments; ++segment_index) {
         auto segment_file_size = segment_file_sizes[segment_index];
-        auto get_segment_file_url =
-                fmt::format("{}&acquire_md5=true", segment_file_urls[segment_index]);
+        auto get_segment_file_url = segment_file_urls[segment_index];
+        if (config::enable_download_md5sum_check) {
+            get_segment_file_url = fmt::format("{}&acquire_md5=true", get_segment_file_url);
+        }
 
         auto segment_path = local_segment_path(local_tablet->tablet_path(),
                                                rowset_meta->rowset_id().to_string(), segment_index);
@@ -312,9 +314,7 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
             download_success_files.push_back(segment_path);
 
             std::string remote_file_md5;
-            if (config::enable_download_md5sum_check) {
-                RETURN_IF_ERROR(client->get_content_md5(&remote_file_md5));
-            }
+            RETURN_IF_ERROR(client->get_content_md5(&remote_file_md5));
             LOG(INFO) << "download segment file to " << segment_path
                       << ", remote md5: " << remote_file_md5
                       << ", remote size: " << segment_file_size;
@@ -470,8 +470,11 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     DCHECK(segment_index_file_names.size() == segment_index_file_urls.size());
     for (int64_t i = 0; i < segment_index_file_urls.size(); ++i) {
         auto segment_index_file_size = segment_index_file_sizes[i];
-        auto get_segment_index_file_url =
-                fmt::format("{}&acquire_md5=true", segment_index_file_urls[i]);
+        auto get_segment_index_file_url = segment_index_file_urls[i];
+        if (config::enable_download_md5sum_check) {
+            get_segment_index_file_url =
+                    fmt::format("{}&acquire_md5=true", get_segment_index_file_url);
+        }
 
         uint64_t estimate_timeout = estimate_download_timeout(segment_index_file_size);
         auto local_segment_index_path = segment_index_file_names[i];
@@ -486,9 +489,7 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
             download_success_files.push_back(local_segment_index_path);
 
             std::string remote_file_md5;
-            if (config::enable_download_md5sum_check) {
-                RETURN_IF_ERROR(client->get_content_md5(&remote_file_md5));
-            }
+            RETURN_IF_ERROR(client->get_content_md5(&remote_file_md5));
 
             std::error_code ec;
             // Check file length


### PR DESCRIPTION
…sum_check is disabled

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When the `acqurie_md5` param is set, the upstream computes the MD5sum and replies in the response headers. To reduce the overhead of computing the MD5sum, the config `enable_download_md5sum_check` is added. However the former PR does not remove the `acquire_md5` param and only skips the md5sum checking, so the computing overhead still exists.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

