### PR TITLE
[improve](cloud)(transaction) do not execute afterVisible if commit transaction fail in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -608,7 +608,10 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                 LOG.info("commitTxn, run txn callback, transactionId:{} callbackId:{}, txnState:{}",
                         transactionId, callbackId, txnState);
                 cb.afterCommitted(txnState, txnOperated);
-                cb.afterVisible(txnState, txnOperated);
+                // do not exectue afterVisible if commit txn fail in cloud mode
+                if (txnOperated) {
+                    cb.afterVisible(txnState, txnOperated);
+                }
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

When committing a transaction fails, the error message is difficult to understand:

```
mysql> show routine load\G;

1. row ***************************
Id: 1737888537744
Name: lineitem_mow_persistent_label
CreateTime: 2025-01-27 10:08:54
PauseTime: NULL
EndTime: NULL
DbName: regression_test_stress_load_release_routine_load
TableName: lineitem_mow_persistent
IsMultiTable: false
State: RUNNING
DataSourceType: KAFKA
CurrentTaskNum: 16
JobProperties: {"max_batch_rows":"300000","timezone":"Asia/Shanghai","send_batch_parallelism":"1","load_to_single_tablet":"false","column_separator":"','","line_delimiter":"\n","current_concurrent_number":"16","delete":"","partial_columns":"false","merge_type":"APPEND","exec_mem_limit":"2147483648","strict_mode":"false","jsonpaths":"","max_batch_interval":"5","max_batch_size":"209715200","fuzzy_parse":"false","escape":"0","enclose":"0","partitions":"","columnToColumnExpr":"","whereExpr":"","desired_concurrent_number":"256","precedingFilter":"","format":"csv","max_error_number":"0","max_filter_ratio":"1.0","json_root":"","strip_outer_array":"false","num_as_string":"false"}
DataSourceProperties: {"topic":"test-release-mow-topic-persistent","currentKafkaPartitions":"0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15","brokerList":"172.20.48.94:9092"}
CustomProperties: {"group.id":"test-consumer-group","kafka_default_offsets":"OFFSET_BEGINNING","client.id":"test-client-id"}
Statistic:

{"receivedBytes":2354664774,"runningTxns":[429816543801345,429918945479680,429959949536256,429837189331968,429918980583432,429888224712705,429837030172683,429898466490368,429888240318465,429959934614528,429853033613312,429816559634432,429844701694976,429908791357441,429826474905600,429908706769920,429959919939585,429826798930944,429888254461953,429908722637824,429856848327680,429908772813824,429816574341120,429846679480320,429826783170560,429929185043456,429908737931264,429908754749440,429898495263744,429888269763584,429837131176960,429918961759242,429860108133376,429849127204864,429837081730048,429959905823745],"errorRows":0,"committedTaskNum":140,"loadedRows":12320899,"loadRowsRate":2204,"abortedTaskNum":120,"errorRowsAfterResumed":0,"totalRows":12320899,"unselectedRows":0,"receivedBytesRate":421293,"taskExecuteTimeMs":5589130}

Progress: {"0":"781664","1":"786801","2":"628823","3":"871308","4":"780769","5":"839093","6":"613342","7":"708207","8":"783686","9":"692121","10":"783018","11":"853209","12":"732847","13":"845036","14":"848547","15":"772412"}
Lag: {"0":10282,"1":16796,"2":256,"3":12460,"4":15437,"5":11465,"6":1346,"7":11647,"8":12285,"9":15834,"10":12916,"11":12750,"12":13712,"13":16845,"14":11884,"15":9546}
ReasonOfStateChanged:
ErrorLogUrls:
OtherMsg: 2025-01-27 11:41:50:[INTERNAL_ERROR]TStatus: Cannot invoke "org.apache.doris.transaction.TransactionState.getTransactionId()" because "txnState" is null
 
0# doris::Status doris::Status::create<true>(doris::TStatus const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
1# doris::StreamLoadExecutor::commit_txn(doris::StreamLoadContext*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/status.h:511
2# doris::CloudStreamLoadExecutor::commit_txn(doris::StreamLoadContext*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/status.h:390
3# doris::RoutineLoadTaskExecutor::exec_task(std::shared_ptr<doris::StreamLoadContext>, doris::DataConsumerPool*, std::function<void (std::shared_ptr<doris::StreamLoadContext>)>) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/status.h:511
4# std::_Function_handler<void (), std::_Bind_result<void, void (doris::RoutineLoadTaskExecutor::(doris::RoutineLoadTaskExecutor, std::shared_ptr<doris::StreamLoadContext>, doris::DataConsumerPool*, doris::RoutineLoadTaskExecutor::submit_task(doris::TRoutineLoadTask const&)::$_0))(std::shared_ptr<doris::StreamLoadContext>, doris::DataConsumerPool*, std::function<void (std::shared_ptr<doris::StreamLoadContext>)>)> >::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:244
5# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/threadpool.cpp:0
6# doris::Thread::supervise_thread(void*) at /var/local/ldb-toolchain/bin/../usr/include/pthread.h:562
7# ?
8# ?
 
User: root
Comment:
1 row in set (0.01 sec)
```

The reason is `txnState.getTransactionId()` will be executed in `afterVisible`. It is possible to determine whether `txnState` is null before executing logic `txnState.getTransactionId()`, but it is more reasonable to do not execute `afterVisible` if commit transaction fail in cloud mode.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

