### PR TITLE
[fix](ob catalog) fix oceanbase catalog get connection

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOceanBaseClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOceanBaseClient.java
@@ -65,8 +65,12 @@ public class JdbcOceanBaseClient extends JdbcClient {
         throw new UnsupportedOperationException("JdbcOceanBaseClient does not support jdbcTypeToDoris");
     }
 
-    private void setOracleMode() {
+    @Override
+    public String getTestQuery() {
+        return "SELECT 1 FROM DUAL";
+    }
+
+    void setOracleMode() {
         this.dbType = JdbcResource.OCEANBASE_ORACLE;
     }
 }
-


### PR DESCRIPTION
close https://github.com/apache/doris/issues/48484
When Oceanbase is created, the test statement for getting the connection should be 'select 1 from dual', because this is compatible with both Oracle and MySQL modes.