### PR TITLE
[fix](hudi) Set Hadoop Hudi Jni reader as default

### DIFF
--- a/be/src/vec/exec/format/table/hudi_jni_reader.cpp
+++ b/be/src/vec/exec/format/table/hudi_jni_reader.cpp
@@ -71,14 +71,14 @@ HudiJniReader::HudiJniReader(const TFileScanRangeParams& scan_params,
         }
     }
 
-    if (_hudi_params.hudi_jni_scanner == "hadoop") {
-        _jni_connector = std::make_unique<JniConnector>(
-                "org/apache/doris/hudi/HadoopHudiJniScanner", params, required_fields);
-    } else if (_hudi_params.hudi_jni_scanner == "spark") {
+    if (_hudi_params.hudi_jni_scanner == "spark") {
         _jni_connector = std::make_unique<JniConnector>("org/apache/doris/hudi/HudiJniScanner",
                                                         params, required_fields);
     } else {
-        DCHECK(false) << "Unsupported hudi jni scanner: " << _hudi_params.hudi_jni_scanner;
+        // _hudi_params.hudi_jni_scanner == "hadoop"
+        // and default use hadoop hudi jni scanner
+        _jni_connector = std::make_unique<JniConnector>(
+                "org/apache/doris/hudi/HadoopHudiJniScanner", params, required_fields);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
Related PR: #44267 

Problem Summary:
If we set hudi_jni_scanner to an incorrect value, jni_connector will be null, causing a core dump.
So we set hadoop as default hudi jni scanner.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

