### PR TITLE
[fix](result sink) Fix empty sender if exists

### DIFF
--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -79,6 +79,7 @@ Status ResultBufferMgr::create_sender(const TUniqueId& query_id, int buffer_size
 
         if (_buffer_map.end() != iter) {
             LOG(WARNING) << "already have buffer control block for this instance " << query_id;
+            *sender = iter->second;
             return Status::OK();
         }
     }

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -46,6 +46,11 @@ TEST_F(ResultBufferMgrTest, create_normal) {
 
     std::shared_ptr<ResultBlockBufferBase> control_block1;
     EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state, false).ok());
+    EXPECT_NE(control_block1, nullptr);
+    control_block1.reset();
+
+    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state, false).ok());
+    EXPECT_NE(control_block1, nullptr);
 }
 
 TEST_F(ResultBufferMgrTest, create_arrow) {


### PR DESCRIPTION
### What problem does this PR solve?

If a sender already exists, we should obtain the previous one when we create senders with the same query ID.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

