### PR TITLE
[fix](regression)Fix insert p2 cases.

### DIFF
--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_client.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_client.groovy
@@ -50,7 +50,8 @@ suite("test_group_commit_insert_into_lineitem_multiple_client") {
         }
     }
     def insert_table = "test_insert_into_lineitem_multiple_client"
-    def batch = 100;
+    // Set batch to 90 to avoid JDBC driver bug. Larger batch size may trigger JDBC send COM_STMT_FETCH command.
+    def batch = 90;
     def total = 0;
     def rwLock = new ReentrantReadWriteLock();
     def wlock = rwLock.writeLock();
@@ -114,6 +115,9 @@ PROPERTIES (
                 break
             } catch (Exception e) {
                 logger.info("got exception:" + e)
+                Thread.sleep(2000)
+                context.reconnectFe()
+                sql """ set group_commit = async_mode; """
             }
             i++;
             if (i >= 30) {

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_table.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_multiple_table.groovy
@@ -49,7 +49,8 @@ suite("test_group_commit_insert_into_lineitem_multiple_table") {
         }
     }
     def insert_table_base = "test_insert_into_lineitem_multiple_table"
-    def batch = 100;
+    // Set batch to 90 to avoid JDBC driver bug. Larger batch size may trigger JDBC send COM_STMT_FETCH command.
+    def batch = 90;
     def total = 0;
     def rwLock = new ReentrantReadWriteLock();
     def wlock = rwLock.writeLock();
@@ -113,6 +114,9 @@ PROPERTIES (
                 break
             } catch (Exception e) {
                 logger.info("got exception:" + e)
+                Thread.sleep(2000)
+                context.reconnectFe()
+                sql """ set group_commit = async_mode; """
             }
             i++;
             if (i >= 30) {

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_normal.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_normal.groovy
@@ -46,7 +46,8 @@ suite("test_group_commit_insert_into_lineitem_normal") {
         }
     }
     def insert_table = "test_insert_into_lineitem_normal"
-    def batch = 100;
+    // Set batch to 90 to avoid JDBC driver bug. Larger batch size may trigger JDBC send COM_STMT_FETCH command.
+    def batch = 90;
     def count = 0;
     def total = 0;
 

--- a/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
+++ b/regression-test/suites/insert_p2/test_group_commit_insert_into_lineitem_scheme_change.groovy
@@ -81,7 +81,8 @@ suite("test_group_commit_insert_into_lineitem_scheme_change") {
         }
     }
     def insert_table = "test_lineitem_scheme_change"
-    def batch = 100;
+    // Set batch to 90 to avoid JDBC driver bug. Larger batch size may trigger JDBC send COM_STMT_FETCH command.
+    def batch = 90;
     def count = 0;
     def total = 0;
 
@@ -181,6 +182,9 @@ PROPERTIES (
                 if (e.getMessage().contains("is blocked on schema change")) {
                     Thread.sleep(10000)
                 }
+                Thread.sleep(2000)
+                context.reconnectFe()
+                sql """ set group_commit = async_mode; """
             }
             i++;
             if (i >= 30) {


### PR DESCRIPTION
### What problem does this PR solve?

Fix insert p2 cases.
Seems JDBC driver has bug. When executing insert into values SQL, it may send unexpected command such as COM_STMT_FETCH to Doris. This pr change the insert batch from 100 to 90, this could make it success to insert data and test the load function. Will fix the JDBC related issue later.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

