### PR TITLE
[fix](Nereids) divide const folding for decimalv3 return type is not correct

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
@@ -642,11 +642,12 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "divide")
     public static Expression divideDecimalV3(DecimalV3Literal first, DecimalV3Literal second) {
-        if (second.getValue().compareTo(BigDecimal.ZERO) == 0) {
-            return new NullLiteral(first.getDataType());
-        }
         DecimalV3Type t1 = (DecimalV3Type) first.getDataType();
         DecimalV3Type t2 = (DecimalV3Type) second.getDataType();
+        if (second.getValue().compareTo(BigDecimal.ZERO) == 0) {
+            return new NullLiteral(DecimalV3Type.createDecimalV3TypeLooseCheck(
+                    t1.getPrecision(), t1.getScale() - t2.getScale()));
+        }
         BigDecimal result = first.getValue().divide(second.getValue());
         return new DecimalV3Literal(DecimalV3Type.createDecimalV3TypeLooseCheck(
                 t1.getPrecision(), t1.getScale() - t2.getScale()), result);

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
@@ -467,4 +467,7 @@ suite("fold_constant_numeric_arithmatic") {
     testFoldConst("SELECT 0 ^ 1 AS xor_case_2") //0 XOR 1 = 1
     testFoldConst("SELECT 255 ^ 128 AS xor_case_3") //255 XOR 128
 
+    // ensure divide for decimal v3 could return correct type when divider is 0
+    sql """ select if(random() > 0.5, cast(random() as decimal(38,10)), cast(0 as decimal(30, 10)) / cast(0 as decimal(30,10)))"""
+
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #17393

Problem Summary:

divide const folding for decimalv3 return type is not correct. return scale should be dividend's scale - divider's scale.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

