### PR TITLE
[fix](inverted index) Added Error Check for Zero File Read Result

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
@@ -221,6 +221,13 @@ void DorisFSDirectory::FSIndexInput::readInternal(uint8_t* b, const int32_t len)
     if (!st.ok()) {
         _CLTHROWA(CL_ERR_IO, "read past EOF");
     }
+    if (bytes_read == 0) {
+        std::string error_msg;
+        error_msg.append("Read 0 bytes at position ");
+        error_msg.append(std::to_string(_pos));
+        error_msg.append(" (expected non-zero data)");
+        _CLTHROWA(CL_ERR_IO, error_msg.c_str());
+    }
     bufferLength = len;
     DBUG_EXECUTE_IF("DorisFSDirectory::FSIndexInput::readInternal_bytes_read_error",
                     { bytes_read = len + 10; })


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

1. "When running the test_index_compound_directory_fault_injection case with HDFS for remote storage, issues may occur. Added error handling for cases where reading a file returns a value of 0."

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

