### PR TITLE
[fix](memory) Fix `SwitchResourceContext` when  thread context no attach task

### DIFF
--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -58,20 +58,30 @@ AttachTask::~AttachTask() {
 SwitchResourceContext::SwitchResourceContext(const std::shared_ptr<ResourceContext>& rc) {
     DCHECK(rc != nullptr);
     doris::ThreadLocalHandle::create_thread_local_if_not_exits();
-    if (rc != thread_context()->resource_ctx()) {
-        signal::set_signal_task_id(rc->task_controller()->task_id());
+    if (thread_context()->is_attach_task()) {
         old_resource_ctx_ = thread_context()->resource_ctx();
-        thread_context()->resource_ctx_ = rc;
-        thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
-                rc->memory_context()->mem_tracker(), rc->workload_group());
+        if (rc != old_resource_ctx_) {
+            signal::set_signal_task_id(rc->task_controller()->task_id());
+            thread_context()->resource_ctx_ = rc;
+            thread_context()->thread_mem_tracker_mgr->attach_limiter_tracker(
+                    rc->memory_context()->mem_tracker(), rc->workload_group());
+        }
+    } else {
+        signal::set_signal_task_id(rc->task_controller()->task_id());
+        thread_context()->attach_task(rc);
     }
 }
 
 SwitchResourceContext::~SwitchResourceContext() {
-    if (old_resource_ctx_ != nullptr) {
-        signal::set_signal_task_id(old_resource_ctx_->task_controller()->task_id());
-        thread_context()->resource_ctx_ = old_resource_ctx_;
-        thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker();
+    if (old_resource_ctx_ != thread_context()->resource_ctx()) {
+        if (old_resource_ctx_ != nullptr) {
+            signal::set_signal_task_id(old_resource_ctx_->task_controller()->task_id());
+            thread_context()->resource_ctx_ = old_resource_ctx_;
+            thread_context()->thread_mem_tracker_mgr->detach_limiter_tracker();
+        } else {
+            signal::set_signal_task_id(TUniqueId());
+            thread_context()->detach_task();
+        }
     }
     doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
 }

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -20,6 +20,7 @@
 #include <bthread/bthread.h>
 #include <bthread/types.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -323,7 +324,9 @@ static ThreadContext* thread_context(bool allow_return_null = false) {
 
 class ScopedPeakMem {
 public:
-    explicit ScopedPeakMem(int64* peak_mem) : _peak_mem(peak_mem), _mem_tracker("ScopedPeakMem") {
+    explicit ScopedPeakMem(int64* peak_mem)
+            : _peak_mem(peak_mem),
+              _mem_tracker("ScopedPeakMem:" + UniqueId::gen_uid().to_string()) {
         ThreadLocalHandle::create_thread_local_if_not_exits();
         thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(&_mem_tracker);
     }

--- a/be/test/runtime/thread_context_test.cpp
+++ b/be/test/runtime/thread_context_test.cpp
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/thread_context.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
+#include "runtime/memory/mem_tracker_limiter.h"
+
+namespace doris {
+
+class ThreadContextTest : public testing::Test {
+public:
+    ThreadContextTest() = default;
+    ~ThreadContextTest() override = default;
+
+    void SetUp() override {
+        tracker1 = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
+                                                    "UT-ThreadContextTest1");
+        tracker2 = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
+                                                    "UT-ThreadContextTest2");
+        tracker3 = std::make_unique<MemTracker>("UT-ThreadContextTest3");
+        rc1 = ResourceContext::create_shared();
+        rc1->memory_context()->set_mem_tracker(tracker1);
+
+        query_id1.hi = 1;
+        query_id1.lo = 1;
+        rc1->task_controller()->set_task_id(query_id1);
+        rc2 = ResourceContext::create_shared();
+        rc2->memory_context()->set_mem_tracker(tracker2);
+        query_id2.hi = 2;
+        query_id2.lo = 2;
+        rc2->task_controller()->set_task_id(query_id2);
+    }
+
+protected:
+    std::shared_ptr<MemTrackerLimiter> tracker1;
+    std::shared_ptr<MemTrackerLimiter> tracker2;
+    std::shared_ptr<MemTracker> tracker3;
+    TUniqueId query_id1;
+    TUniqueId query_id2;
+    std::shared_ptr<ResourceContext> rc1;
+    std::shared_ptr<ResourceContext> rc2;
+    std::shared_ptr<WorkloadGroup> workload_group;
+};
+
+TEST_F(ThreadContextTest, SingleScoped) {
+    // AttachTask
+    EXPECT_FALSE(thread_context()->is_attach_task());
+    {
+        auto scoped = AttachTask(rc1);
+        EXPECT_TRUE(thread_context()->is_attach_task());
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest1");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id1);
+    }
+    EXPECT_FALSE(thread_context()->is_attach_task());
+    EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(), "BE-UT");
+    EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), TUniqueId());
+
+    // SwitchResourceContext
+    {
+        auto scoped = SwitchResourceContext(rc2);
+        EXPECT_TRUE(thread_context()->is_attach_task());
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest2");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id2);
+    }
+    EXPECT_FALSE(thread_context()->is_attach_task());
+    EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(), "BE-UT");
+    EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), TUniqueId());
+
+    // SwitchThreadMemTrackerLimiter
+    {
+        auto scoped = SwitchThreadMemTrackerLimiter(tracker1);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest1");
+    }
+    EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(), "BE-UT");
+
+    // AddThreadMemTrackerConsumer
+    EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(), "");
+    {
+        auto scoped = AddThreadMemTrackerConsumer(tracker3);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(),
+                  "UT-ThreadContextTest3");
+    }
+    EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(), "");
+
+    // ScopedPeakMem
+    int64_t peak_mem = 0;
+    {
+        auto scoped = ScopedPeakMem(&peak_mem);
+        thread_context()->thread_mem_tracker_mgr->consume(4 * 1024);
+        EXPECT_TRUE(
+                thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label().starts_with(
+                        "ScopedPeakMem"));
+    }
+    EXPECT_EQ(peak_mem, 4 * 1024);
+    EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(), "");
+}
+
+TEST_F(ThreadContextTest, MixedScoped) {
+    EXPECT_FALSE(thread_context()->is_attach_task());
+    int64_t peak_mem1 = 0;
+    int64_t peak_mem2 = 0;
+    {
+        auto scoped1 = AttachTask(rc1);
+        auto scoped2 = SwitchResourceContext(rc2);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest2");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id2);
+
+        auto scoped3 = SwitchResourceContext(rc2);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest2");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id2);
+        EXPECT_TRUE(thread_context()->is_attach_task());
+
+        auto scoped4 = SwitchThreadMemTrackerLimiter(tracker1);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest1");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id2);
+
+        auto scoped5 = AddThreadMemTrackerConsumer(tracker3);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(),
+                  "UT-ThreadContextTest3");
+
+        auto scoped6 = ScopedPeakMem(&peak_mem1);
+        thread_context()->thread_mem_tracker_mgr->consume(4 * 1024);
+        EXPECT_TRUE(
+                thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label().starts_with(
+                        "ScopedPeakMem"));
+
+        auto scoped7 = ScopedPeakMem(&peak_mem2);
+        thread_context()->thread_mem_tracker_mgr->consume(4 * 1024);
+        EXPECT_TRUE(
+                thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label().starts_with(
+                        "ScopedPeakMem"));
+
+        auto scoped8 = AddThreadMemTrackerConsumer(tracker3);
+        thread_context()->thread_mem_tracker_mgr->consume(4 * 1024);
+        // tracker3 already exists, will not be added again.
+        EXPECT_TRUE(
+                thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label().starts_with(
+                        "ScopedPeakMem"));
+
+        auto scoped9 = SwitchResourceContext(rc1);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest1");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id1);
+
+        auto scoped10 = SwitchThreadMemTrackerLimiter(tracker2);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest2");
+
+        auto scoped11 = SwitchResourceContext(rc2);
+        EXPECT_EQ(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                  "UT-ThreadContextTest2");
+        EXPECT_EQ(thread_context()->resource_ctx()->task_controller()->task_id(), query_id2);
+        EXPECT_TRUE(thread_context()->is_attach_task());
+    }
+    EXPECT_FALSE(thread_context()->is_attach_task());
+    EXPECT_EQ(peak_mem1, 4 * 1024 * 3);
+    EXPECT_EQ(peak_mem2, 4 * 1024 * 2);
+}
+
+} // end namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

#48429 not completely fixed

fix:
```
thread_context.h:201] Check failed: is_attach_task() *** Check failure stack trace: ***    @     0x55baa6559996  google::LogMessage::SendToLog()    @     0x55baa65563e0  google::LogMessage::Flush()    @     0x55baa655a1d9  google::LogMessageFatal::~LogMessageFatal()    @     0x55ba9c250f71  doris::SwitchResourceContext::SwitchResourceContext()    @     0x55ba9bb983e9  doris::MemTableWriter::flush_async()    @     0x55ba9bb90040  doris::MemTableMemoryLimiter::_flush_active_memtables()    @     0x55ba9bb8eea3  doris::MemTableMemoryLimiter::_handle_memtable_flush()    @     0x55ba9bb8e63c  doris::MemTableMemoryLimiter::handle_workload_group_memtable_flush()    @     0x55ba9c15780e  doris::LoadChannelMgr::add_batch()    @     0x55ba9c2ce9a1  std::_Function_handler<>::_M_invoke()    @     0x55ba9c2e8b2b  doris::WorkThreadPool<>::work_thread()    @     0x55baa957fed0  execute_native_thread_routine    @     0x7ff33bc91ac3  (unknown)    @     0x7ff33bd23850  (unknown)    @              (nil)  (unknown)*** Query id: 7427761ba9d1470d-91c666c0d5bb756e ****** is nereids: 0 ****** tablet id: 0 ****** Aborted at 1741115991 (unix time) try "date -d @1741115991" if you are using GNU date ****** Current BE git commitID: 09cbc482fb ****** SIGABRT unknown detail explain (@0x765d) received by PID 30301 (TID 31028 OR 0x7ff1a0242640) from PID 30301; stack trace: *** 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421 1# 0x00007FF33BC3F520 in /lib/x86_64-linux-gnu/libc.so.6 2# pthread_kill at ./nptl/pthread_kill.c:89 3# raise at ../sysdeps/posix/raise.c:27 4# abort at ./stdlib/abort.c:81 5# 0x000055BAA656426D in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 6# 0x000055BAA65568AA in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be10# doris::SwitchResourceContext::SwitchResourceContext(std::shared_ptr<doris::ResourceContext> const&) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be11# doris::MemTableWriter::flush_async() at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_writer.cpp:16012# doris::MemTableMemoryLimiter::_flush_active_memtables(unsigned long, long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:26213# doris::MemTableMemoryLimiter::_handle_memtable_flush(std::shared_ptr<doris::WorkloadGroup>) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:17814# doris::MemTableMemoryLimiter::handle_workload_group_memtable_flush(std::shared_ptr<doris::WorkloadGroup>) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_memory_limiter.cpp:13615# 
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

