### PR TITLE
[fix](binlog) Replaced partition should be record to Dropped Resources

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
@@ -26,6 +26,7 @@ import org.apache.doris.persist.BarrierLog;
 import org.apache.doris.persist.DropInfo;
 import org.apache.doris.persist.DropPartitionInfo;
 import org.apache.doris.persist.RecoverInfo;
+import org.apache.doris.persist.ReplacePartitionOperationLog;
 import org.apache.doris.persist.ReplaceTableOperationLog;
 import org.apache.doris.thrift.TBinlog;
 import org.apache.doris.thrift.TBinlogType;
@@ -742,6 +743,9 @@ public class DBBinlog {
                 case RECOVER_INFO:
                     raw = RecoverInfo.fromJson(data);
                     break;
+                case REPLACE_PARTITIONS:
+                    raw = ReplacePartitionOperationLog.fromJson(data);
+                    break;
                 default:
                     break;
             }
@@ -802,6 +806,11 @@ public class DBBinlog {
                 droppedPartitions.removeIf(entry -> (entry.first == partitionId));
             } else if (tableId > 0) {
                 droppedTables.removeIf(entry -> (entry.first == tableId));
+            }
+        } else if ((binlogType == TBinlogType.REPLACE_PARTITIONS) && (raw instanceof ReplacePartitionOperationLog)) {
+            ReplacePartitionOperationLog replacePartitionOperationLog = (ReplacePartitionOperationLog) raw;
+            for (Long partitionId : replacePartitionOperationLog.getReplacedPartitionIds()) {
+                droppedPartitions.add(Pair.of(partitionId, commitSeq));
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6232,7 +6232,8 @@ public class Env {
                 throw new DdlException("Temp partition[" + partName + "] does not exist");
             }
         }
-        olapTable.replaceTempPartitions(db.getId(), partitionNames, tempPartitionNames, isStrictRange,
+        List<Long> replacedPartitionIds = olapTable.replaceTempPartitions(db.getId(), partitionNames,
+                tempPartitionNames, isStrictRange,
                 useTempPartitionName, isForceDropOld);
         long version;
         long versionTime = System.currentTimeMillis();
@@ -6255,10 +6256,11 @@ public class Env {
             LOG.warn("produceEvent failed: ", t);
         }
         // write log
-        ReplacePartitionOperationLog info =
-                new ReplacePartitionOperationLog(db.getId(), db.getFullName(), olapTable.getId(), olapTable.getName(),
-                        partitionNames, tempPartitionNames, isStrictRange, useTempPartitionName, version, versionTime,
-                        isForceDropOld);
+        ReplacePartitionOperationLog info = new ReplacePartitionOperationLog(db.getId(), db.getFullName(),
+                olapTable.getId(), olapTable.getName(),
+                partitionNames, tempPartitionNames, replacedPartitionIds, isStrictRange, useTempPartitionName, version,
+                versionTime,
+                isForceDropOld);
         editLog.logReplaceTempPartition(info);
         LOG.info("finished to replace partitions {} with temp partitions {} from table: {}", clause.getPartitionNames(),
                 clause.getTempPartitionNames(), olapTable.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2800,14 +2800,16 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
      *         names are still p1 and p2.
      *
      */
-    public void replaceTempPartitions(long dbId, List<String> partitionNames, List<String> tempPartitionNames,
+    public List<Long> replaceTempPartitions(long dbId, List<String> partitionNames, List<String> tempPartitionNames,
             boolean strictRange, boolean useTempPartitionName, boolean isForceDropOld) throws DdlException {
+        List<Long> replacedPartitionIds = Lists.newArrayList();
         // check partition items
         checkPartition(partitionNames, tempPartitionNames, strictRange);
 
         // begin to replace
         // 1. drop old partitions
         for (String partitionName : partitionNames) {
+            replacedPartitionIds.add(nameToPartition.get(partitionName).getId());
             dropPartition(dbId, partitionName, isForceDropOld);
         }
 
@@ -2828,6 +2830,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
                 renamePartition(tempPartitionNames.get(i), partitionNames.get(i));
             }
         }
+        return replacedPartitionIds;
     }
 
     private void checkPartition(List<String> partitionNames, List<String> tempPartitionNames,

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ReplacePartitionOperationLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ReplacePartitionOperationLog.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
@@ -55,17 +56,20 @@ public class ReplacePartitionOperationLog implements Writable {
     private long versionTime = 0L;
     @SerializedName(value = "force")
     private boolean force = false;
+    @SerializedName(value = "partitionIds")
+    private List<Long> replacedPartitionIds;
 
     public ReplacePartitionOperationLog(long dbId, String dbName, long tblId, String tblName,
-                                        List<String> partitionNames,
-                                        List<String> tempPartitonNames, boolean strictRange,
-                                        boolean useTempPartitionName, long version, long versionTime, boolean force) {
+            List<String> partitionNames,
+            List<String> tempPartitonNames, List<Long> replacedPartitionIds, boolean strictRange,
+            boolean useTempPartitionName, long version, long versionTime, boolean force) {
         this.dbId = dbId;
         this.dbName = dbName;
         this.tblId = tblId;
         this.tblName = tblName;
         this.partitions = partitionNames;
         this.tempPartitions = tempPartitonNames;
+        this.replacedPartitionIds = replacedPartitionIds;
         this.strictRange = strictRange;
         this.useTempPartitionName = useTempPartitionName;
         this.version = version;
@@ -83,6 +87,10 @@ public class ReplacePartitionOperationLog implements Writable {
 
     public List<String> getPartitions() {
         return partitions;
+    }
+
+    public List<Long> getReplacedPartitionIds() {
+        return replacedPartitionIds == null ? Lists.newArrayList() : replacedPartitionIds;
     }
 
     public List<String> getTempPartitions() {
@@ -127,5 +135,9 @@ public class ReplacePartitionOperationLog implements Writable {
     @Override
     public String toString() {
         return toJson();
+    }
+
+    public static RecoverInfo fromJson(String json) {
+        return GsonUtils.GSON.fromJson(json, RecoverInfo.class);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

test: https://github.com/selectdb/ccr-syncer/pull/477 regression-test/suites/db_sync_dep/partition/drop/test_ds_dep_part_drop.groovy

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

