### PR TITLE
[fix](cloud) speed up file cache initializtion

### DIFF
--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -309,15 +309,31 @@ std::string FSFileCacheStorage::get_path_in_local_cache(const UInt128Wrapper& va
 }
 
 Status FSFileCacheStorage::upgrade_cache_dir_if_necessary() const {
-    /// version 1.0: cache_base_path / key / offset
-    /// version 2.0: cache_base_path / key_prefix / key / offset
+    /* 
+     * If use version2 but was version 1, do upgrade:
+     *
+     * Action I:
+     *     version 1.0: cache_base_path / key / offset
+     *     version 2.0: cache_base_path / key_prefix / key / offset
+     *
+     * Action II:
+     *     add '_0' to hash dir
+     *
+     * Note: This is a sync operation with tons of IOs, so it may affect BE
+     * boot time heavily. Fortunately, Action I & II will only happen when
+     * upgrading (once in the cluster life time).
+     */
+
     std::string version;
+    std::error_code ec;
+
     RETURN_IF_ERROR(read_file_cache_version(&version));
     if (USE_CACHE_VERSION2 && version != "2.0") {
         // move directories format as version 2.0
-        std::error_code ec;
         std::filesystem::directory_iterator key_it {_cache_base_path, ec};
         if (ec) {
+            LOG(WARNING) << "Failed to list directory: " << _cache_base_path
+                         << ", error: " << ec.message();
             return Status::InternalError("Failed to list dir {}: {}", _cache_base_path,
                                          ec.message());
         }
@@ -328,31 +344,43 @@ Status FSFileCacheStorage::upgrade_cache_dir_if_necessary() const {
                     std::string key_prefix =
                             Path(_cache_base_path) / cache_key.substr(0, KEY_PREFIX_LENGTH);
                     bool exists = false;
-                    RETURN_IF_ERROR(fs->exists(key_prefix, &exists));
-                    if (!exists) {
-                        RETURN_IF_ERROR(fs->create_directory(key_prefix));
+                    auto exists_status = fs->exists(key_prefix, &exists);
+                    if (!exists_status.ok()) {
+                        LOG(WARNING) << "Failed to check directory existence: " << key_prefix
+                                     << ", error: " << exists_status.to_string();
+                        return exists_status;
                     }
-                    RETURN_IF_ERROR(fs->rename(key_it->path(), key_prefix / cache_key));
+                    if (!exists) {
+                        auto create_status = fs->create_directory(key_prefix);
+                        if (!create_status.ok()) {
+                            LOG(WARNING) << "Failed to create directory: " << key_prefix
+                                         << ", error: " << create_status.to_string();
+                            return create_status;
+                        }
+                    }
+                    auto rename_status = fs->rename(key_it->path(), key_prefix / cache_key);
+                    if (!rename_status.ok()) {
+                        LOG(WARNING)
+                                << "Failed to rename directory from " << key_it->path().native()
+                                << " to " << (key_prefix / cache_key).native()
+                                << ", error: " << rename_status.to_string();
+                        return rename_status;
+                    }
                 }
             }
         }
-        if (!write_file_cache_version().ok()) {
-            return Status::InternalError("Failed to write version hints for file cache");
-        }
-    }
 
-    auto rebuild_dir = [&](std::filesystem::directory_iterator& upgrade_key_it) -> Status {
-        for (; upgrade_key_it != std::filesystem::directory_iterator(); ++upgrade_key_it) {
-            if (upgrade_key_it->path().filename().native().find('_') == std::string::npos) {
-                RETURN_IF_ERROR(fs->delete_directory(upgrade_key_it->path().native() + "_0"));
-                RETURN_IF_ERROR(
-                        fs->rename(upgrade_key_it->path(), upgrade_key_it->path().native() + "_0"));
+        auto rebuild_dir = [&](std::filesystem::directory_iterator& upgrade_key_it) -> Status {
+            for (; upgrade_key_it != std::filesystem::directory_iterator(); ++upgrade_key_it) {
+                if (upgrade_key_it->path().filename().native().find('_') == std::string::npos) {
+                    RETURN_IF_ERROR(fs->delete_directory(upgrade_key_it->path().native() + "_0"));
+                    RETURN_IF_ERROR(fs->rename(upgrade_key_it->path(),
+                                               upgrade_key_it->path().native() + "_0"));
+                }
             }
-        }
-        return Status::OK();
-    };
-    std::error_code ec;
-    if constexpr (USE_CACHE_VERSION2) {
+            return Status::OK();
+        };
+
         std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
         if (ec) [[unlikely]] {
             LOG(WARNING) << ec.message();
@@ -374,13 +402,11 @@ Status FSFileCacheStorage::upgrade_cache_dir_if_necessary() const {
             }
             RETURN_IF_ERROR(rebuild_dir(key_it));
         }
-    } else {
-        std::filesystem::directory_iterator key_it {_cache_base_path, ec};
-        if (ec) [[unlikely]] {
-            return Status::IOError(ec.message());
+        if (!write_file_cache_version().ok()) {
+            return Status::InternalError("Failed to write version hints for file cache");
         }
-        RETURN_IF_ERROR(rebuild_dir(key_it));
     }
+
     return Status::OK();
 }
 


### PR DESCRIPTION
The initialization of the file cache involves asynchronous loading logic and synchronous upgrade directories. The latter mainly handles the conversion from version1 to version2 format and some fallback logic for problematic directories, which involves a large number of directory traversals and can be very slow.

Previously, in PR #44429, we changed the initialization of multiple cache directories from parallel to serial to avoid the disorder caused by concurrent initialization, which led to a long cache initialization time and affected the startup speed of the BE.

We found that the upgrade directory is only meaningful during upgrades and does not need to be executed on every restart. Therefore, if we detect that the version file has been successfully written, we consider the cache directory to have completed the upgrade and skip these redundant directory traversals

Of course, we could further optimize the directory traversal process to make it asynchronous and not block the BE startup. However, this would result in three concurrent operations on the file system: asynchronous loading, asynchronous updating, and lazy loading on query. This would increase code complexity, the likelihood of errors, and the difficulty of troubleshooting. Considering that old clusters are not very common and that a cluster only needs to go through such an upgrade once in its lifecycle, we assessed that this optimization would have low cost-effectiveness and decided not to pursue it.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

