### PR TITLE
[improvement](fe) trim the start and end whitespace of properties

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3765,11 +3765,11 @@ opt_key_value_map_in_paren ::=
     | STRING_LITERAL:name EQUAL STRING_LITERAL:value
     {:
     RESULT = Maps.newHashMap();
-    RESULT.put(name, value);
+    RESULT.put(name.trim(), value);
     :}
     | opt_key_value_map_in_paren:map COMMA STRING_LITERAL:name EQUAL STRING_LITERAL:value
     {:
-    map.put(name, value);
+    map.put(name.trim(), value);
     RESULT = map;
     :}
     ;
@@ -3778,11 +3778,11 @@ key_value_map ::=
     STRING_LITERAL:name EQUAL STRING_LITERAL:value
     {:
     RESULT = Maps.newHashMap();
-    RESULT.put(name, value);
+    RESULT.put(name.trim(), value);
     :}
     | key_value_map:map COMMA STRING_LITERAL:name EQUAL STRING_LITERAL:value
     {:
-    map.put(name, value);
+    map.put(name.trim(), value);
     RESULT = map;
     :}
     ;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -3985,9 +3985,9 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     private String parsePropertyKey(PropertyKeyContext item) {
         if (item.constant() != null) {
-            return parseConstant(item.constant());
+            return parseConstant(item.constant()).trim();
         }
-        return item.getText();
+        return item.getText().trim();
     }
 
     private String parsePropertyValue(PropertyValueContext item) {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
@@ -182,7 +182,8 @@ public class AlterTest {
                         + "PARTITION BY RANGE(k1)\n" + "(\n"
                         + "    PARTITION p1 values less than('2020-02-01 00:00:00'),\n"
                         + "    PARTITION p2 values less than('2020-03-01 00:00:00')\n" + ")\n"
-                        + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" + "PROPERTIES('replication_num' = '1','enable_unique_key_merge_on_write' = 'false');");
+                        + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
+                        + "PROPERTIES('replication_num' = '1','enable_unique_key_merge_on_write' = 'false');");
 
         createTable("create external table test.odbc_table\n" + "(  `k1` bigint(20) COMMENT \"\",\n"
                 + "  `k2` datetime COMMENT \"\",\n" + "  `k3` varchar(20) COMMENT \"\",\n"
@@ -197,7 +198,8 @@ public class AlterTest {
                         + "   \"AWS_ENDPOINT\" = \"bj\",\n" + "   \"AWS_REGION\" = \"bj\",\n"
                         + "   \"AWS_ROOT_PATH\" = \"/path/to/root\",\n" + "   \"AWS_ACCESS_KEY\" = \"bbb\",\n"
                         + "   \"AWS_SECRET_KEY\" = \"aaaa\",\n" + "   \"AWS_MAX_CONNECTIONS\" = \"50\",\n"
-                        + "   \"AWS_REQUEST_TIMEOUT_MS\" = \"3000\",\n" + "   \"AWS_CONNECTION_TIMEOUT_MS\" = \"1000\",\n"
+                        + "   \"AWS_REQUEST_TIMEOUT_MS\" = \"3000\",\n"
+                        + "   \"AWS_CONNECTION_TIMEOUT_MS\" = \"1000\",\n"
                         + "   \"AWS_BUCKET\" = \"test-bucket\",  \"s3_validity_check\" = \"false\"\n"
                         + ");");
 
@@ -206,7 +208,8 @@ public class AlterTest {
                         + "   \"AWS_ENDPOINT\" = \"bj\",\n" + "   \"AWS_REGION\" = \"bj\",\n"
                         + "   \"AWS_ROOT_PATH\" = \"/path/to/root\",\n" + "   \"AWS_ACCESS_KEY\" = \"bbb\",\n"
                         + "   \"AWS_SECRET_KEY\" = \"aaaa\",\n" + "   \"AWS_MAX_CONNECTIONS\" = \"50\",\n"
-                        + "   \"AWS_REQUEST_TIMEOUT_MS\" = \"3000\",\n" + "   \"AWS_CONNECTION_TIMEOUT_MS\" = \"1000\",\n"
+                        + "   \"AWS_REQUEST_TIMEOUT_MS\" = \"3000\",\n"
+                        + "   \"AWS_CONNECTION_TIMEOUT_MS\" = \"1000\",\n"
                         + "   \"AWS_BUCKET\" = \"test-bucket\", \"s3_validity_check\" = \"false\"\n"
                         + ");");
 
@@ -219,7 +222,8 @@ public class AlterTest {
                         + "  \"cooldown_ttl\" = \"1\"\n" + ");");
 
         createRemoteStoragePolicy(
-                "CREATE STORAGE POLICY testPolicyAnotherResource\n" + "PROPERTIES(\n" + "  \"storage_resource\" = \"remote_s3_1\",\n"
+                "CREATE STORAGE POLICY testPolicyAnotherResource\n" + "PROPERTIES(\n"
+                        + "  \"storage_resource\" = \"remote_s3_1\",\n"
                         + "  \"cooldown_ttl\" = \"1\"\n" + ");");
 
         createTable("CREATE TABLE test.tbl_remote1\n" + "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int sum\n"
@@ -247,7 +251,7 @@ public class AlterTest {
                 + " PROPERTIES (\"replication_num\" = \"1\", \"function_column.sequence_col\" = \"v1\");");
 
         createTable("CREATE TABLE test.tbl_storage(k1 int) ENGINE=OLAP UNIQUE KEY (k1)\n"
-                 + "DISTRIBUTED BY HASH(k1) BUCKETS 3\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 3\n"
                 + "PROPERTIES('replication_num' = '1','enable_unique_key_merge_on_write' = 'true');");
     }
 
@@ -1099,9 +1103,12 @@ public class AlterTest {
     @Test
     public void testAlterDateV2Schema() throws Exception {
         createTable("CREATE TABLE test.unique_partition_datev2\n" + "(\n" + "    k1 date,\n" + "    k2 datetime(3),\n"
-                + "    k3 datetime,\n" + "    v1 date,\n" + "    v2 datetime(3),\n" + "    v3 datetime,\n" + "    v4 int\n"
-                + ")\n" + "UNIQUE KEY(k1, k2, k3)\n" + "PARTITION BY RANGE(k1)\n" + "(\n" + "    PARTITION p1 values less than('2020-02-01'),\n"
-                + "    PARTITION p2 values less than('2020-03-01')\n" + ")\n" + "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" + "PROPERTIES('replication_num' = '1');");
+                + "    k3 datetime,\n" + "    v1 date,\n" + "    v2 datetime(3),\n" + "    v3 datetime,\n"
+                + "    v4 int\n"
+                + ")\n" + "UNIQUE KEY(k1, k2, k3)\n" + "PARTITION BY RANGE(k1)\n" + "(\n"
+                + "    PARTITION p1 values less than('2020-02-01'),\n"
+                + "    PARTITION p2 values less than('2020-03-01')\n" + ")\n" + "DISTRIBUTED BY HASH(k1) BUCKETS 3\n"
+                + "PROPERTIES('replication_num' = '1');");
 
         // partition key can not be changed.
         String changeOrderStmt = "ALTER TABLE test.unique_partition_datev2 modify column k1 int key null";
@@ -1452,5 +1459,39 @@ public class AlterTest {
         List<List<String>> resultRows = executor.execute().getResultRows();
         String createSql = resultRows.get(0).get(1);
         Assert.assertFalse(createSql.contains("storage_policy"));
+    }
+
+    @Test
+    public void alterTableModifyPropertyTrim() throws Exception {
+        createTable("CREATE TABLE test.tbl_trim_property_key (\n"
+                + "`uuid` varchar(255) NULL,\n"
+                + "`action_datetime` date NULL\n"
+                + ")\n"
+                + "DUPLICATE KEY(uuid)\n"
+                + "PARTITION BY RANGE(action_datetime)()\n"
+                + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                + "PROPERTIES\n"
+                + "(\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ");\n");
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException("tbl_trim_property_key");
+        Assert.assertEquals(1, tbl.getTableProperty().getReplicaAllocation().getTotalReplicaNum());
+
+        String sql1 = "alter table test.tbl_trim_property_key set (\n"
+                + "' default.replication_num ' = '2'\n"
+                + " );";
+        AlterTableStmt alterTableStmt1 = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql1, connectContext);
+        Env.getCurrentEnv().alterTable(alterTableStmt1);
+        Assert.assertEquals(2, tbl.getDefaultReplicaAllocation().getTotalReplicaNum());
+
+        String sql2 = "alter table test.tbl_trim_property_key set (\n"
+                + "'default.replication_ num' = '1'\n"
+                + " );";
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "Unknown table property: [default.replication_ num]",
+                () -> Env.getCurrentEnv()
+                        .alterTable((AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, connectContext)));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AdminSetConfigStmtTest.java
@@ -89,5 +89,12 @@ public class AdminSetConfigStmtTest extends TestWithFeService {
         results = ConfigBase.getConfigInfo(matcher);
         Assert.assertEquals(num, results.size());
     }
+
+    @Test
+    public void testTrimPropertyKey() throws Exception {
+        String stmt = "admin set frontend config(\" alter_table_timeout_second \" = \"60\");";
+        AdminSetConfigStmt adminSetConfigStmt = (AdminSetConfigStmt) parseAndAnalyzeStmt(stmt);
+        Assert.assertEquals("60", adminSetConfigStmt.getConfigs().get("alter_table_timeout_second"));
+    }
 }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/StageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/StageTest.java
@@ -315,6 +315,16 @@ public class StageTest extends TestWithFeService {
         Assert.assertEquals("csv", propertiesMap.get("default.file.type"));
     }
 
+    @Test
+    public void testCreateStageTrimPropertyKey() throws Exception {
+        String sql = CREATE_STAGE_SQL + ", ' default.file.type' = 'csv', ' default.file.compression '='gz')";
+        Assert.assertEquals("csv", parseAndAnalyze(sql).getStageProperties().getFileType());
+        Assert.assertEquals("gz", parseAndAnalyze(sql).getStageProperties().getCompression());
+
+        sql = CREATE_STAGE_SQL + ", 'default.file. type' = 'orc')";
+        parseAndAnalyzeWithException(sql, "Property 'default.file. type' is invalid");
+    }
+
     private void parseAndAnalyzeWithException(String sql, String errorMsg) {
         do {
             try {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -752,7 +752,7 @@ public class CreateTableTest extends TestWithFeService {
     }
 
     @Test
-    public void testCreateTableWithStringLen() throws DdlException  {
+    public void testCreateTableWithStringLen() throws DdlException {
         ExceptionChecker.expectThrowsNoException(() -> {
             createTable("create table test.test_strLen(k1 CHAR, k2 CHAR(10) , k3 VARCHAR ,k4 VARCHAR(10))"
                     + " duplicate key (k1) distributed by hash(k1) buckets 1 properties('replication_num' = '1');");
@@ -766,7 +766,7 @@ public class CreateTableTest extends TestWithFeService {
     }
 
     @Test
-    public void testCreateTableWithForceReplica() throws DdlException  {
+    public void testCreateTableWithForceReplica() throws DdlException {
         try {
             Config.force_olap_table_replication_num = 1;
             // no need to specify replication_num, the table can still be created.
@@ -989,5 +989,97 @@ public class CreateTableTest extends TestWithFeService {
                         + "(k1 int, k2 int)\n"
                         + "duplicate key(k1)\n"
                         + "distributed by hash(k1) buckets 1\n", true));
+    }
+
+    @Test
+    public void testCreateTableTrimPropertyKey() throws Exception {
+        String sql = "create table test.tbl_trim_property_key\n"
+                + "(`uuid` varchar(255) NULL,\n"
+                + "`action_datetime` date NULL\n"
+                + ")\n"
+                + "DUPLICATE KEY(uuid)\n"
+                + "PARTITION BY RANGE(action_datetime)()\n"
+                + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                + "PROPERTIES\n"
+                + "(\n"
+                + "\"min_load_replica_num \" = \"1\",\n"
+                + "\" dynamic_partition.enable\" = \"true\",\n"
+                + "\" dynamic_partition.time_unit \" = \"DAY\",\n"
+                + "\"dynamic_partition.end\" = \"3\",\n"
+                + "\"dynamic_partition.prefix\" = \"p\",\n"
+                + "\"dynamic_partition.start\" = \"-3\"\n"
+                + ");";
+        createTable(sql);
+        Database db =
+                Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_trim_property_key");
+        Assert.assertEquals(1, table.getMinLoadReplicaNum());
+        Assert.assertTrue(table.getTableProperty().getDynamicPartitionProperty().getEnable());
+        Assert.assertEquals("DAY", table.getTableProperty().getDynamicPartitionProperty().getTimeUnit());
+        Assert.assertEquals(3, table.getTableProperty().getDynamicPartitionProperty().getEnd());
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Invalid dynamic partition properties: dynamic_partition. enable",
+                () -> createTable("create table test.tbl_trim_property_key_invalid\n"
+                        + "(`uuid` varchar(255) NULL,\n"
+                        + "`action_datetime` date NULL\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(uuid)\n"
+                        + "PARTITION BY RANGE(action_datetime)()\n"
+                        + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                        + "PROPERTIES\n"
+                        + "(\n"
+                        + "\"dynamic_partition. enable\" = \"true\",\n"
+                        + "\"dynamic_partition.time_unit\" = \"DAY\",\n"
+                        + "\"dynamic_partition.end\" = \"3\",\n"
+                        + "\"dynamic_partition.prefix\" = \"p\",\n"
+                        + "\"dynamic_partition.start\" = \"-3\"\n"
+                        + ");"));
+    }
+
+    @Test
+    public void testCreateTableTrimPropertyKeyWithNereids() throws Exception {
+        String sql = "create table test.tbl_trim_property_key\n"
+                + "(`uuid` varchar(255) NULL,\n"
+                + "`action_datetime` date NULL\n"
+                + ")\n"
+                + "DUPLICATE KEY(uuid)\n"
+                + "PARTITION BY RANGE(action_datetime)()\n"
+                + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                + "PROPERTIES\n"
+                + "(\n"
+                + "\"min_load_replica_num \" = \"1\",\n"
+                + "\" dynamic_partition.enable\" = \"true\",\n"
+                + "\" dynamic_partition.time_unit \" = \"DAY\",\n"
+                + "\"dynamic_partition.end\" = \"3\",\n"
+                + "\"dynamic_partition.prefix\" = \"p\",\n"
+                + "\"dynamic_partition.start\" = \"-3\"\n"
+                + ");";
+        createTable(sql, true);
+        Database db =
+                Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_trim_property_key");
+        Assert.assertEquals(1, table.getMinLoadReplicaNum());
+        Assert.assertTrue(table.getTableProperty().getDynamicPartitionProperty().getEnable());
+        Assert.assertEquals("DAY", table.getTableProperty().getDynamicPartitionProperty().getTimeUnit());
+        Assert.assertEquals(3, table.getTableProperty().getDynamicPartitionProperty().getEnd());
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Invalid dynamic partition properties: dynamic_partition. enable",
+                () -> createTable("create table test.tbl_trim_property_key_invalid\n"
+                        + "(`uuid` varchar(255) NULL,\n"
+                        + "`action_datetime` date NULL\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(uuid)\n"
+                        + "PARTITION BY RANGE(action_datetime)()\n"
+                        + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                        + "PROPERTIES\n"
+                        + "(\n"
+                        + "\"dynamic_partition. enable\" = \"true\",\n"
+                        + "\"dynamic_partition.time_unit\" = \"DAY\",\n"
+                        + "\"dynamic_partition.end\" = \"3\",\n"
+                        + "\"dynamic_partition.prefix\" = \"p\",\n"
+                        + "\"dynamic_partition.start\" = \"-3\"\n"
+                        + ");", true));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -1039,7 +1039,7 @@ public class CreateTableTest extends TestWithFeService {
 
     @Test
     public void testCreateTableTrimPropertyKeyWithNereids() throws Exception {
-        String sql = "create table test.tbl_trim_property_key\n"
+        String sql = "create table test.tbl_trim_property_key_with_nereids\n"
                 + "(`uuid` varchar(255) NULL,\n"
                 + "`action_datetime` date NULL\n"
                 + ")\n"
@@ -1058,7 +1058,7 @@ public class CreateTableTest extends TestWithFeService {
         createTable(sql, true);
         Database db =
                 Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
-        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_trim_property_key");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_trim_property_key_with_nereids");
         Assert.assertEquals(1, table.getMinLoadReplicaNum());
         Assert.assertTrue(table.getTableProperty().getDynamicPartitionProperty().getEnable());
         Assert.assertEquals("DAY", table.getTableProperty().getDynamicPartitionProperty().getTimeUnit());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47851

Problem Summary:

trim the start and end whitespace of properties.

When executing SQL statements with properties, if some properties are based on valid keys with spaces, the returned exception information may be misleading:
`errCode = 2, detailMessage = Invalid dynamic partition properties: dynamic_partition.start`

so auto trim the start and end whitespace of properties will be better.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

