### PR TITLE
[opt](Nereids) support more pattern in DeferMaterializeTopNResult

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2076,7 +2076,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                     requiredByProjectSlotIdSet, context);
         } else {
             if (project.child() instanceof PhysicalDeferMaterializeTopN) {
-                inputFragment.setOutputExprs(projectionExprs);
+                inputFragment.setOutputExprs(allProjectionExprs);
             } else {
                 TupleDescriptor tupleDescriptor = generateTupleDesc(slots, null, context);
                 inputPlanNode.setProjectList(projectionExprs);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateOrderByKeyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateOrderByKeyTest.java
@@ -36,7 +36,7 @@ public class EliminateOrderByKeyTest extends TestWithFeService implements MemoPa
         createTable("create table test.test_unique_order_by2(a int not null, b int not null, c int, d int) "
                 + "unique key(a,b) distributed by hash(a) properties('replication_num'='1');");
         connectContext.setDatabase("test");
-        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION,DEFER_MATERIALIZE_TOP_N_RESULT");
     }
 
     @Test

--- a/regression-test/suites/nereids_rules_p0/defer_materialize_topn/lazy_materialize_topn.groovy
+++ b/regression-test/suites/nereids_rules_p0/defer_materialize_topn/lazy_materialize_topn.groovy
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("lazy_materialize_topn") {
+    sql """
+        set enable_two_phase_read_opt = true
+    """
+
+    sql """
+    drop table if exists lazy_materialize_topn;
+    """
+
+    sql """
+        CREATE TABLE `lazy_materialize_topn` (
+          `c1` int NULL,
+          `c2` int NULL,
+          `c3` int NULL,
+          `c4` array<int> NULL
+        )
+        PROPERTIES (
+          "replication_allocation" = "tag.location.default: 1",
+          "light_schema_change" = "true"
+        );
+    """
+
+    sql """
+        insert into lazy_materialize_topn values (1, 1, 1, [1]), (2, 2, 2, [2]), (3, 3, 3, [3]);
+    """
+
+    sql """
+        sync
+    """
+
+    List sqls = [
+            // TopN(Scan)
+            """select * from lazy_materialize_topn order by c1 limit 10""",
+            // TopN(Project(Scan))
+            """select c1, c2 from lazy_materialize_topn order by c1 limit 10""",
+            // Project(TopN(Scan))
+            """select c1, c2, c3, c4 from lazy_materialize_topn order by c1 limit 10""",
+            // Project(TopN(Project(Scan)))
+            """select c1 + 1, c2 + 1 from (select c1, c2 from lazy_materialize_topn order by c1 limit 10) t""",
+            // TopN(Filter(Scan))
+            """select * from lazy_materialize_topn where c2 < 5 order by c1 limit 10;""",
+            // TopN(Project(Filter(Scan)))
+            """select c1, c2, c3 from lazy_materialize_topn where c2 < 5 order by c1 limit 10;""",
+            // Project(TopN(Project(Filter(Scan))))
+            """select c1 + 1, c2 + 1, c3 + 1 from ( select c1, c2, c3 from lazy_materialize_topn where c2 < 5 order by c1 limit 10) t""",
+            // project set is diff with output list
+            """select c1, c1, c2 from (select c1, c2 from lazy_materialize_topn where c3 < 1 order by c2 limit 1)t;"""
+    ]
+
+    for (sqlStr in sqls) {
+        explain {
+            sql """${sqlStr}"""
+            contains """OPT TWO PHASE"""
+        }
+        sql """${sqlStr}"""
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #47661, #22487

Problem Summary:

after this PR we support:

1. TopN(Scan)
2. Project(TopN(Project(Scan)))
3. TopN(Filter(Scan))
4. TopN(Project(Filter(Scan)))
5. Project(TopN(Project(Filter(Scan))))

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

