### PR TITLE
[fix](cancel) Fix cancel failure

### DIFF
--- a/be/src/pipeline/pipeline_x/pipeline_x_task.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.h
@@ -139,7 +139,6 @@ public:
     int task_id() const { return _index; };
 
     void clear_blocking_state() override {
-        _state->get_query_ctx()->get_execution_dependency()->set_always_ready();
         // We use a lock to assure all dependencies are not deconstructed here.
         std::unique_lock<std::mutex> lc(_dependency_lock);
         if (!_finished) {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -250,6 +250,7 @@ void QueryContext::cancel(std::string msg, Status new_status, int fragment_id) {
 
 void QueryContext::cancel_all_pipeline_context(const PPlanFragmentCancelReason& reason,
                                                const std::string& msg) {
+    set_execution_dependency_ready();
     std::vector<std::weak_ptr<pipeline::PipelineFragmentContext>> ctx_to_cancel;
     {
         std::lock_guard<std::mutex> lock(_pipeline_map_write_lock);
@@ -267,6 +268,7 @@ void QueryContext::cancel_all_pipeline_context(const PPlanFragmentCancelReason& 
 Status QueryContext::cancel_pipeline_context(const int fragment_id,
                                              const PPlanFragmentCancelReason& reason,
                                              const std::string& msg) {
+    set_execution_dependency_ready();
     std::weak_ptr<pipeline::PipelineFragmentContext> ctx_to_cancel;
     {
         std::lock_guard<std::mutex> lock(_pipeline_map_write_lock);


### PR DESCRIPTION
### What problem does this PR solve?

If a query is canceled before fragment contexts are prepared, no fragment context will be found. So we should set execution ready to ensure tasks will not be blocked.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

