### PR TITLE
[fix](hint) fix leading when use dphyper

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/HyperGraph.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/HyperGraph.java
@@ -211,7 +211,8 @@ public class HyperGraph {
         LogicalJoin<?, ?> join = (LogicalJoin<?, ?>) plan;
         return join.getJoinType() == JoinType.INNER_JOIN
                 && !join.isMarkJoin()
-                && !join.getExpressions().isEmpty();
+                && !join.getExpressions().isEmpty()
+                && !join.isLeadingJoin();
     }
 
     /**

--- a/regression-test/suites/nereids_p0/hint/multi_leading.groovy
+++ b/regression-test/suites/nereids_p0/hint/multi_leading.groovy
@@ -33,6 +33,7 @@ suite("multi_leading") {
     sql "set ignore_shape_nodes='PhysicalProject'"
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set runtime_filter_mode=OFF'
+    sql 'set enable_dphyp_optimizer=true;'
 
     // create tables
     sql """drop table if exists t1;"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
```sql
use test_multi_leading;
set enable_dphyp_optimizer=true;
explain physical plan 
select
	count(*)
from
	(
	select
		/*+ leading(alias2 t1) */
		c1,
		c11
	from
		t1
	join (
		select
			c2,
			c22
		from
			t2
		join t4 on
			c2 = c4) as alias2 on
		c1 = alias2.c2) as alias1
join t3 on
	alias1.c1 = t3.c3;
```
The leading hint in subquery is not used, because in dphyper, the join is reordered. 
This pr fix this problem.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

