### PR TITLE
[improvement](statistics)Improve analyze partition column and key column corner case.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -25,6 +25,10 @@ import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.RangePartitionItem;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
@@ -36,6 +40,8 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import org.apache.commons.text.StringSubstitutor;
 
@@ -63,6 +69,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
     private boolean partitionColumnSampleTooManyRows = false;
     private boolean scanFullTable = false;
     private static final long MAXIMUM_SAMPLE_ROWS = 1_000_000_000;
+    public static final long NO_SKIP_TABLET_ID = -1;
 
     @VisibleForTesting
     public OlapAnalysisTask() {
@@ -172,6 +179,8 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         // Sort the partitions to get stable result.
         List<Partition> sortedPartitions = olapTable.getPartitions().stream().sorted(
                 Comparator.comparing(Partition::getName)).collect(Collectors.toList());
+        long largeTabletId = 0;
+        long largeTabletRows = Long.MAX_VALUE;
         for (Partition p : sortedPartitions) {
             MaterializedIndex materializedIndex = info.indexId == -1 ? p.getBaseIndex() : p.getIndex(info.indexId);
             if (materializedIndex == null) {
@@ -190,8 +199,20 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             for (int i = 0; i < tabletCounts; i++) {
                 int seekTid = (int) ((i + seek) % ids.size());
                 long tabletId = ids.get(seekTid);
-                sampleTabletIds.add(tabletId);
                 long tabletRows = materializedIndex.getTablet(tabletId).getMinReplicaRowCount(p.getVisibleVersion());
+                if (tabletRows > MAXIMUM_SAMPLE_ROWS) {
+                    LOG.debug("Found one large tablet id {} in table {}, rows {}",
+                            largeTabletId, tbl.getName(), largeTabletRows);
+                    // Skip very large tablet and record the smallest large tablet id and row count.
+                    if (tabletRows < largeTabletRows) {
+                        LOG.debug("Current smallest large tablet id {} in table {}, rows {}",
+                                largeTabletId, tbl.getName(), largeTabletRows);
+                        largeTabletId = tabletId;
+                        largeTabletRows = tabletRows;
+                    }
+                    continue;
+                }
+                sampleTabletIds.add(tabletId);
                 if (tabletRows > 0) {
                     selectedRows += tabletRows;
                     // For regular column, will stop adding more tablets when selected tablets'
@@ -208,6 +229,13 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
                 break;
             }
         }
+        // If we skipped some large tablets and this cause the sampled rows is not enough, we add the large tablet back.
+        if (!enough && largeTabletId != 0) {
+            sampleTabletIds.add(largeTabletId);
+            selectedRows += largeTabletRows;
+            LOG.info("Add large tablet {} in table {} back, with rows {}",
+                    largeTabletId, tbl.getName(), largeTabletRows);
+        }
         if (selectedRows < targetSampleRows) {
             scanFullTable = true;
         } else if (forPartitionColumn && selectedRows > MAXIMUM_SAMPLE_ROWS) {
@@ -215,7 +243,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             partitionColumnSampleTooManyRows = true;
             sampleTabletIds.clear();
             Collections.shuffle(sortedPartitions);
-            selectedRows = pickSamplePartition(sortedPartitions, sampleTabletIds);
+            selectedRows = pickSamplePartition(sortedPartitions, sampleTabletIds, getSkipPartitionId(sortedPartitions));
         } else if (col.isKey() && selectedRows > MAXIMUM_SAMPLE_ROWS) {
             // For key column, if a single tablet contains too many rows, need to use limit to control rows to read.
             // In most cases, a single tablet shouldn't contain more than MAXIMUM_SAMPLE_ROWS, in this case, we
@@ -372,12 +400,65 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         }
     }
 
-    protected long pickSamplePartition(List<Partition> partitions, List<Long> pickedTabletIds) {
-        long averageRowsPerPartition = tbl.getRowCount() / partitions.size();
+    // For partition tables with single time type partition column, we'd better to skip sampling the partition
+    // that contains all the history data. Because this partition may contain many old data which is not
+    // visited by most queries. To sample this partition may cause the statistics not accurate.
+    // For example, one table has 366 partitions, partition 1 ~ 365 store date for each day of the year from now.
+    // Partition 0 stores all the history data earlier than 1 year. We want to skip sampling partition 0.
+    protected long getSkipPartitionId(List<Partition> partitions) {
+        if (partitions == null || partitions.size() < StatisticsUtil.getPartitionSampleCount()) {
+            return NO_SKIP_TABLET_ID;
+        }
+        PartitionInfo partitionInfo = ((OlapTable) tbl).getPartitionInfo();
+        if (!PartitionType.RANGE.equals(partitionInfo.getType())) {
+            return NO_SKIP_TABLET_ID;
+        }
+        if (partitionInfo.getPartitionColumns().size() != 1) {
+            return NO_SKIP_TABLET_ID;
+        }
+        Column column = partitionInfo.getPartitionColumns().get(0);
+        if (!column.getType().isDateType()) {
+            return NO_SKIP_TABLET_ID;
+        }
+        PartitionKey lowestKey = PartitionKey.createMaxPartitionKey();
+        long lowestPartitionId = -1;
+        for (Partition p : partitions) {
+            RangePartitionItem item = (RangePartitionItem) partitionInfo.getItem(p.getId());
+            Range<PartitionKey> items = item.getItems();
+            if (!items.hasLowerBound()) {
+                lowestPartitionId = p.getId();
+                break;
+            }
+            if (items.lowerEndpoint().compareTo(lowestKey) < 0) {
+                lowestKey = items.lowerEndpoint();
+                lowestPartitionId = p.getId();
+            }
+        }
+        return lowestPartitionId;
+    }
+
+    protected long pickSamplePartition(List<Partition> partitions, List<Long> pickedTabletIds, long skipPartitionId) {
+        Partition partition = ((OlapTable) tbl).getPartition(skipPartitionId);
+        long averageRowsPerPartition;
+        if (partition != null) {
+            LOG.debug("Going to skip partition {} in table {}", skipPartitionId, tbl.getName());
+            // If we want to skip the oldest partition, calculate the average rows per partition value without
+            // the oldest partition, otherwise if the oldest partition is very large, we may skip all partitions.
+            // Because we only pick partitions which meet partitionRowCount >= averageRowsPerPartition.
+            Preconditions.checkNotNull(partitions, "Partition list of table " + tbl.getName() + " is null");
+            Preconditions.checkState(partitions.size() > 1, "Too few partitions in " + tbl.getName());
+            averageRowsPerPartition = (tbl.getRowCount() - partition.getRowCount()) / (partitions.size() - 1);
+        } else {
+            averageRowsPerPartition = tbl.getRowCount() / partitions.size();
+        }
         long indexId = info.indexId == -1 ? ((OlapTable) tbl).getBaseIndexId() : info.indexId;
         long pickedRows = 0;
         int pickedPartitionCount = 0;
         for (Partition p : partitions) {
+            if (skipPartitionId == p.getId()) {
+                LOG.info("Partition {} in table {} skipped", skipPartitionId, tbl.getName());
+                continue;
+            }
             long partitionRowCount = p.getRowCount();
             if (partitionRowCount >= averageRowsPerPartition) {
                 pickedRows += partitionRowCount;


### PR DESCRIPTION
### What problem does this PR solve?

Improve 2 corner cases:
1. When we pick the tablets for sample analyze, skip the very large tablets.
2. When sample analyze for partition column that choose more than 1,000,000,000 rows, we switch to randomly choose some partitions to analyze. In this case, we don't want to choose the oldest partition with all the history data. 

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

