### PR TITLE
[enhance](mtmv)When calculating whether partitions are synchronized, first filter based on the partitions used in the query

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
 import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
-import org.apache.doris.nereids.rules.exploration.mv.PartitionCompensator;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
@@ -136,8 +135,7 @@ public class MTMVRewriteUtilTest {
         // currentTimeMills is 3, grace period is 2, and partition getVisibleVersionTime is 1
         // if forceConsistent this should get 0 partitions which mtmv can use.
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
-                .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, true,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, true, null);
         Assert.assertEquals(0, mtmvCanRewritePartitions.size());
     }
 
@@ -145,7 +143,7 @@ public class MTMVRewriteUtilTest {
     public void testGetMTMVCanRewritePartitionsNormal() {
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
     }
 
@@ -167,7 +165,7 @@ public class MTMVRewriteUtilTest {
 
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
     }
 
@@ -189,7 +187,7 @@ public class MTMVRewriteUtilTest {
 
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(0, mtmvCanRewritePartitions.size());
     }
 
@@ -204,7 +202,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         // getMTMVCanRewritePartitions only check the partition is valid or not, it doesn't care the
         // isEnableMaterializedViewRewriteWhenBaseTableUnawareness
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
@@ -223,7 +221,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(0, mtmvCanRewritePartitions.size());
     }
 
@@ -242,7 +240,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
     }
 
@@ -261,7 +259,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         // getMTMVCanRewritePartitions only check the partition is valid or not, it doesn't care the
         // isEnableMaterializedViewRewriteWhenBaseTableUnawareness
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
@@ -278,7 +276,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(0, mtmvCanRewritePartitions.size());
     }
 
@@ -293,7 +291,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(1, mtmvCanRewritePartitions.size());
     }
 
@@ -308,7 +306,7 @@ public class MTMVRewriteUtilTest {
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
-                        PartitionCompensator.getQueryUsedPartitions(ctx));
+                        null);
         Assert.assertEquals(0, mtmvCanRewritePartitions.size());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
When calculating whether partitions are synchronized, first filter based on the partitions used in the query
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When calculating whether partitions are synchronized, first filter based on the partitions used in the query
### Release note
When calculating whether partitions are synchronized, first filter based on the partitions used in the query

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

