### PR TITLE
[test](beut) add case when beut to test execute_short_circuit

### DIFF
--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -125,6 +125,12 @@ template <bool has_case, bool has_else>
 class FunctionCase : public IFunction {
 public:
     static constexpr auto name = FunctionCaseName<has_case, has_else>::name;
+#ifdef BE_TEST
+    static constexpr auto use_short_circuit_count = 3;
+#else
+    static constexpr auto use_short_circuit_count = UINT8_MAX;
+#endif
+
     static FunctionPtr create() { return std::make_shared<FunctionCase>(); }
     String get_name() const override { return name; }
     size_t get_number_of_arguments() const override { return 0; }
@@ -192,7 +198,7 @@ public:
     template <typename ColumnType, bool when_null, bool then_null>
     Status execute_impl(const DataTypePtr& data_type, Block& block, uint32_t result,
                         CaseWhenColumnHolder column_holder) const {
-        if (column_holder.pair_count > UINT8_MAX) {
+        if (column_holder.pair_count > use_short_circuit_count) {
             return execute_short_circuit<ColumnType, when_null, then_null>(data_type, block, result,
                                                                            column_holder);
         }

--- a/be/test/vec/function/function_case_test.cpp
+++ b/be/test/vec/function/function_case_test.cpp
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/functions/function_case.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "function_test_util.h"
+#include "testutil/column_helper.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/functions/simple_function_factory.h"
+
+namespace doris::vectorized {
+using namespace ut_type;
+
+TEST(VFunctionCase, test_case) {
+    auto function = FunctionCase<false, true>();
+    auto arguments = {
+            /*
+            CASE  
+            WHEN false THEN 1
+            WHEN false THEN 2
+            WHEN false THEN 3
+            WHEN true THEN 4
+            else 5
+            END
+        */
+            ColumnHelper::create_column_with_name<DataTypeUInt8>({false}),
+            ColumnHelper::create_column_with_name<DataTypeInt32>({1}),
+            ColumnHelper::create_column_with_name<DataTypeUInt8>({false}),
+            ColumnHelper::create_column_with_name<DataTypeInt32>({2}),
+            ColumnHelper::create_column_with_name<DataTypeUInt8>({false}),
+            ColumnHelper::create_column_with_name<DataTypeInt32>({3}),
+            ColumnHelper::create_column_with_name<DataTypeUInt8>({true}),
+            ColumnHelper::create_column_with_name<DataTypeInt32>({4}),
+            ColumnHelper::create_column_with_name<DataTypeInt32>({5}),
+    };
+    Block block = arguments;
+    uint32_t num_columns_without_result = block.columns();
+    block.insert({nullptr, std::make_shared<DataTypeInt32>(), "result"});
+    auto st = function.execute(nullptr, block, {0, 1, 2, 3, 4, 5, 6, 7, 8},
+                               num_columns_without_result, block.rows(), false);
+    EXPECT_TRUE(st.ok()) << st.msg();
+
+    std::cout << block.dump_data() << std::endl;
+
+    EXPECT_TRUE(ColumnHelper::column_equal(block.get_by_position(num_columns_without_result).column,
+                                           ColumnHelper::create_column<DataTypeInt32>({4})));
+}
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?
This PR(https://github.com/apache/doris/pull/47179) fixes a bug in the CASE WHEN statement. (When there are more than 255 conditions, it follows the execute_short_circuit path). 
Here, this case is added to the beut.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

