### PR TITLE
[fix](statistics)The column name should be case sensitive when inject column stats.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterColumnStatsStmt.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
@@ -26,7 +27,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
-import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.datasource.CatalogIf;
@@ -173,10 +173,9 @@ public class AlterColumnStatsStmt extends DdlStmt implements NotFallbackInParser
             }
             indexId = idxId;
         }
-
-        if (table.getColumn(columnName) == null) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME,
-                    columnName, FeNameFormat.getColumnNameRegex());
+        Column column = table.getColumn(columnName);
+        if (column == null || !column.getName().equals(columnName)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_FIELD_ERROR, columnName, table.getName());
         }
 
         if (optPartitionNames != null && table instanceof OlapTable) {

--- a/regression-test/suites/nereids_rules_p0/mv/grouping_sets/grouping_sets.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/grouping_sets/grouping_sets.groovy
@@ -127,7 +127,7 @@ suite("materialized_view_grouping_sets") {
     sql """analyze table orders with sync;"""
     sql """analyze table partsupp with sync;"""
 
-    sql """alter table orders modify column o_comment set stats ('row_count'='10');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='10');"""
     sql """alter table lineitem modify column l_comment set stats ('row_count'='7');"""
 
     // query has group sets, and mv doesn't

--- a/regression-test/suites/nereids_rules_p0/mv/join/dphyp_outer/outer_join_dphyp.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/dphyp_outer/outer_join_dphyp.groovy
@@ -124,7 +124,7 @@ suite("outer_join_dphyp") {
     sql """analyze table partsupp with sync;"""
 
     sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
-    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
     sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
 
     // without filter

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -285,11 +285,11 @@ suite("outer_join") {
 
     sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
     sql """alter table lineitem_same_col modify column l_comment set stats ('row_count'='5');"""
-    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
-    sql """alter table orders_same_col modify column o_comment set stats ('row_count'='18');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
+    sql """alter table orders_same_col modify column O_COMMENT set stats ('row_count'='18');"""
     sql """alter table partsupp modify column ps_comment set stats ('row_count'='2');"""
     sql """alter table lineitem_null modify column l_comment set stats ('row_count'='5');"""
-    sql """alter table orders_null modify column o_comment set stats ('row_count'='5');"""
+    sql """alter table orders_null modify column O_COMMENT set stats ('row_count'='5');"""
 
 
     // without filter

--- a/regression-test/suites/nereids_rules_p0/mv/same_name/sync_async_same_name.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/same_name/sync_async_same_name.groovy
@@ -57,7 +57,7 @@ suite("sync_async_same_name") {
     (5, 2, 'o', 1.2, '2023-12-12', 'c','d',2, 'mi');  
     """
 
-    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
 
     sql """analyze table orders with sync;"""
 

--- a/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
@@ -55,7 +55,7 @@ suite("single_table_without_aggregate") {
     """
 
     sql "analyze table orders with sync;"
-    sql """alter table orders modify column o_comment set stats ('row_count'='2');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='2');"""
     sql """set enable_stats=false;"""
 
     def check_rewrite = { mv_sql, query_sql, mv_name ->

--- a/regression-test/suites/nereids_rules_p0/mv/unsafe_equals/null_un_safe_equals.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/unsafe_equals/null_un_safe_equals.groovy
@@ -57,7 +57,7 @@ suite("null_unsafe_equals") {
     (5, 2, 'o', 1.2, '2023-12-12', 'c','d', null, 'mi');  
     """
 
-    sql """alter table orders modify column o_comment set stats ('row_count'='8');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='8');"""
 
     def mv1_0 =
             """

--- a/regression-test/suites/nereids_rules_p0/mv/with_auth/with_select_table_auth.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/with_auth/with_select_table_auth.groovy
@@ -112,7 +112,7 @@ suite("with_select_table_auth","p0,auth") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
-    sql """alter table orders modify column o_comment set stats ('row_count'='18');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='18');"""
     sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
 
     sql """grant select_priv on ${db}.orders to ${user_name}"""

--- a/regression-test/suites/nereids_rules_p0/mv/with_sql_limit/query_with_sql_limit.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/with_sql_limit/query_with_sql_limit.groovy
@@ -143,7 +143,7 @@ suite("query_with_sql_limit") {
     sql """analyze table lineitem with sync"""
     sql """analyze table orders with sync"""
 
-    sql """alter table orders modify column o_comment set stats ('row_count'='18');"""
+    sql """alter table orders modify column O_COMMENT set stats ('row_count'='18');"""
     sql """alter table lineitem modify column l_comment set stats ('row_count'='5');"""
  sql """alter table partsupp modify column ps_comment set stats ('row_count'='3');"""
 

--- a/regression-test/suites/statistics/test_alter_table_set_column_stats.groovy
+++ b/regression-test/suites/statistics/test_alter_table_set_column_stats.groovy
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_alter_table_set_column_stats") {
+
+    sql """drop database if exists test_alter_table_set_column_stats"""
+    sql """create database test_alter_table_set_column_stats"""
+    sql """use test_alter_table_set_column_stats"""
+    sql """set global force_sample_analyze=false"""
+    sql """set global enable_auto_analyze=false"""
+    sql """drop table if exists et"""
+    sql """
+        CREATE TABLE `et` (
+        `QTY` DECIMAL(18, 2) NOT NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`QTY`)
+        COMMENT 'st_entry_detail_et'
+        DISTRIBUTED BY HASH(`QTY`) BUCKETS 40
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    sql """alter table et modify column QTY set stats ('row_count'='1690909875', 'ndv'='836', 'min_value'='-893077', 'max_value'='987118080', 'avg_size'='288004948', 'max_size'='288004948' );"""
+    def result = sql """show column stats et"""
+    assertEquals(1, result.size())
+    assertEquals("QTY", result[0][0])
+    assertEquals("et", result[0][1])
+    assertEquals("1.690909875E9", result[0][2])
+    assertEquals("836.0", result[0][3])
+    assertEquals("0.0", result[0][4])
+    assertEquals("0.0", result[0][5])
+    assertEquals("0.0", result[0][6])
+    assertEquals("-893077", result[0][7])
+    assertEquals("987118080", result[0][8])
+
+    test {
+        sql """alter table et modify column qty set stats ('row_count'='1690909875', 'ndv'='836', 'min_value'='-893077', 'max_value'='987118080', 'avg_size'='288004948', 'max_size'='288004948' );"""
+        exception "Unknown column 'qty' in 'et'"
+    }
+    sql """drop database if exists test_alter_table_set_column_stats"""
+}
+


### PR DESCRIPTION
### What problem does this PR solve?

Fix inject column stats column name case insensitive bug. The column name should be case sensitive when inject column stats, otherwise it couldn't be load to the cache.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

