### PR TITLE
[improvement](statistics)Support convert ip type to double for column stats.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv4Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv4Literal.java
@@ -50,6 +50,11 @@ public class IPv4Literal extends Literal implements ComparableLiteral {
     }
 
     @Override
+    public double getDouble() {
+        return (double) value;
+    }
+
+    @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitIPv4Literal(this, context);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv6Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IPv6Literal.java
@@ -50,6 +50,11 @@ public class IPv6Literal extends Literal implements ComparableLiteral {
     }
 
     @Override
+    public double getDouble() {
+        return value.toBigInteger().doubleValue();
+    }
+
+    @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitIPv6Literal(this, context);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -60,6 +60,8 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalTable.DLAType;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IPv4Literal;
+import org.apache.doris.nereids.trees.expressions.literal.IPv6Literal;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.qe.AuditLogHelper;
 import org.apache.doris.qe.AutoCloseConnectContext;
@@ -292,6 +294,10 @@ public class StatisticsUtil {
             case VARCHAR:
             case STRING:
                 return new StringLiteral(columnValue);
+            case IPV4:
+                return new org.apache.doris.analysis.IPv4Literal(columnValue);
+            case IPV6:
+                return new org.apache.doris.analysis.IPv6Literal(columnValue);
             case HLL:
             case BITMAP:
             case ARRAY:
@@ -342,6 +348,12 @@ public class StatisticsUtil {
                 case STRING:
                     VarcharLiteral varchar = new VarcharLiteral(columnValue);
                     return varchar.getDouble();
+                case IPV4:
+                    IPv4Literal ipv4 = new IPv4Literal(columnValue);
+                    return ipv4.getDouble();
+                case IPV6:
+                    IPv6Literal ipv6 = new IPv6Literal(columnValue);
+                    return ipv6.getDouble();
                 case HLL:
                 case BITMAP:
                 case ARRAY:

--- a/regression-test/suites/statistics/test_analyze_ip_type.groovy
+++ b/regression-test/suites/statistics/test_analyze_ip_type.groovy
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_analyze_ip_type") {
+
+    sql """drop database if exists test_analyze_ip_type"""
+    sql """create database test_analyze_ip_type"""
+    sql """use test_analyze_ip_type"""
+    sql """set global force_sample_analyze=false"""
+    sql """set global enable_auto_analyze=false"""
+    def tableName = "iptest"
+    sql """drop table if exists ${tableName}"""
+    sql """ 
+        CREATE TABLE ${tableName} (
+          `id` bigint,
+          `ip_v4` ipv4,
+          `ip_v6` ipv6
+        ) ENGINE=OLAP
+        DISTRIBUTED BY HASH(`id`) BUCKETS 4
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        );  
+    """
+    sql """insert into ${tableName} values(-1, NULL, NULL)"""
+    sql """insert into ${tableName} values(0, 0, '::')"""
+    sql """insert into ${tableName} values(1, 1, '::1')"""
+    sql """insert into ${tableName} values(2130706433, 2130706433, '2001:1b70:a1:610::b102:2')"""
+    sql """insert into ${tableName} values(4294967295, 4294967295, 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')"""
+    sql """analyze table ${tableName} with sync"""
+
+    def result = sql """show column stats ${tableName}"""
+    assertEquals(3, result.size())
+    result = sql """show column cached stats ${tableName}"""
+    assertEquals(3, result.size())
+
+    result = sql """show column stats ${tableName} (ip_v6);"""
+    assertEquals("ip_v6", result[0][0])
+    assertEquals("iptest", result[0][1])
+    assertEquals("5.0", result[0][2])
+    assertEquals("4.0", result[0][3])
+    assertEquals("1.0", result[0][4])
+    assertEquals("80.0", result[0][5])
+    assertEquals("16.0", result[0][6])
+    assertEquals("\"::\"", result[0][7])
+    assertEquals("\"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff\"", result[0][8])
+
+    result = sql """show column cached stats ${tableName} (ip_v6);"""
+    assertEquals("ip_v6", result[0][0])
+    assertEquals("iptest", result[0][1])
+    assertEquals("5.0", result[0][2])
+    assertEquals("4.0", result[0][3])
+    assertEquals("1.0", result[0][4])
+    assertEquals("80.0", result[0][5])
+    assertEquals("16.0", result[0][6])
+    assertEquals("\"::\"", result[0][7])
+    assertEquals("\"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff\"", result[0][8])
+
+    result = sql """show column stats ${tableName} (ip_v4);"""
+    assertEquals("ip_v4", result[0][0])
+    assertEquals("iptest", result[0][1])
+    assertEquals("5.0", result[0][2])
+    assertEquals("4.0", result[0][3])
+    assertEquals("1.0", result[0][4])
+    assertEquals("20.0", result[0][5])
+    assertEquals("4.0", result[0][6])
+    assertEquals("\"0.0.0.0\"", result[0][7])
+    assertEquals("\"255.255.255.255\"", result[0][8])
+
+    result = sql """show column cached stats ${tableName} (ip_v4);"""
+    assertEquals("ip_v4", result[0][0])
+    assertEquals("iptest", result[0][1])
+    assertEquals("5.0", result[0][2])
+    assertEquals("4.0", result[0][3])
+    assertEquals("1.0", result[0][4])
+    assertEquals("20.0", result[0][5])
+    assertEquals("4.0", result[0][6])
+    assertEquals("\"0.0.0.0\"", result[0][7])
+    assertEquals("\"255.255.255.255\"", result[0][8])
+
+    sql """drop database if exists test_analyze_ip_type"""
+}
+
+


### PR DESCRIPTION
### What problem does this PR solve?

Support convert ip type to double for column stats so than we can use the collected min/max value for IPv4/IPv6 type.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

