### PR TITLE
[opt](meta) Add strict field synchronization checks for cloud/non-cloud mode metadata conversions to prevent inconsistent PB bugs

### DIFF
--- a/be/src/cloud/pb_convert.h
+++ b/be/src/cloud/pb_convert.h
@@ -24,14 +24,10 @@ RowsetMetaCloudPB doris_rowset_meta_to_cloud(const RowsetMetaPB&);
 RowsetMetaCloudPB doris_rowset_meta_to_cloud(RowsetMetaPB&&);
 void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in);
 void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in);
-RowsetMetaPB cloud_rowset_meta_to_doris(const RowsetMetaCloudPB&,
-                                        const SchemaCloudDictionary* dict = nullptr);
-RowsetMetaPB cloud_rowset_meta_to_doris(RowsetMetaCloudPB&&,
-                                        const SchemaCloudDictionary* dict = nullptr);
-void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in,
-                                const SchemaCloudDictionary* dict = nullptr);
-void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in,
-                                const SchemaCloudDictionary* dict = nullptr);
+RowsetMetaPB cloud_rowset_meta_to_doris(const RowsetMetaCloudPB&);
+RowsetMetaPB cloud_rowset_meta_to_doris(RowsetMetaCloudPB&&);
+void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in);
+void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in);
 
 // TabletSchemaPB <=> TabletSchemaCloudPB
 TabletSchemaCloudPB doris_tablet_schema_to_cloud(const TabletSchemaPB&);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -325,7 +325,7 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id
     }
 
     if (tablet_schema.__isset.variant_enable_flatten_nested) {
-        schema->set_variant_enable_flatten_nested(tablet_schema.variant_enable_flatten_nested);
+        schema->set_enable_variant_flatten_nested(tablet_schema.variant_enable_flatten_nested);
     }
 
     if (tablet_schema.__isset.enable_single_replica_compaction) {

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -1069,7 +1069,7 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema, bool ignore_extrac
 
     _row_store_column_unique_ids.assign(schema.row_store_column_unique_ids().begin(),
                                         schema.row_store_column_unique_ids().end());
-    _variant_enable_flatten_nested = schema.variant_enable_flatten_nested();
+    _enable_variant_flatten_nested = schema.enable_variant_flatten_nested();
     _vl_field_mem_size += _row_store_column_unique_ids.capacity() * sizeof(int32_t);
     update_metadata_size();
 }
@@ -1139,7 +1139,7 @@ void TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t version
     _sort_col_num = ori_tablet_schema.sort_col_num();
     _row_store_page_size = ori_tablet_schema.row_store_page_size();
     _storage_page_size = ori_tablet_schema.storage_page_size();
-    _variant_enable_flatten_nested = ori_tablet_schema.variant_flatten_nested();
+    _enable_variant_flatten_nested = ori_tablet_schema.variant_flatten_nested();
 
     // copy from table_schema_param
     _schema_version = version;
@@ -1304,7 +1304,7 @@ void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_schema_pb) const {
     tablet_schema_pb->set_inverted_index_storage_format(_inverted_index_storage_format);
     tablet_schema_pb->mutable_row_store_column_unique_ids()->Assign(
             _row_store_column_unique_ids.begin(), _row_store_column_unique_ids.end());
-    tablet_schema_pb->set_variant_enable_flatten_nested(_variant_enable_flatten_nested);
+    tablet_schema_pb->set_enable_variant_flatten_nested(_enable_variant_flatten_nested);
 }
 
 size_t TabletSchema::row_size() const {
@@ -1573,7 +1573,7 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
     if (a._row_store_page_size != b._row_store_page_size) return false;
     if (a._storage_page_size != b._storage_page_size) return false;
     if (a._skip_write_index_on_load != b._skip_write_index_on_load) return false;
-    if (a._variant_enable_flatten_nested != b._variant_enable_flatten_nested) return false;
+    if (a._enable_variant_flatten_nested != b._enable_variant_flatten_nested) return false;
     return true;
 }
 

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -371,10 +371,10 @@ public:
         _disable_auto_compaction = disable_auto_compaction;
     }
     bool disable_auto_compaction() const { return _disable_auto_compaction; }
-    void set_variant_enable_flatten_nested(bool flatten_nested) {
-        _variant_enable_flatten_nested = flatten_nested;
+    void set_enable_variant_flatten_nested(bool flatten_nested) {
+        _enable_variant_flatten_nested = flatten_nested;
     }
-    bool variant_flatten_nested() const { return _variant_enable_flatten_nested; }
+    bool variant_flatten_nested() const { return _enable_variant_flatten_nested; }
     void set_enable_single_replica_compaction(bool enable_single_replica_compaction) {
         _enable_single_replica_compaction = enable_single_replica_compaction;
     }
@@ -594,7 +594,7 @@ private:
     // Contains column ids of which columns should be encoded into row store.
     // ATTN: For compability reason empty cids means all columns of tablet schema are encoded to row column
     std::vector<int32_t> _row_store_column_unique_ids;
-    bool _variant_enable_flatten_nested = false;
+    bool _enable_variant_flatten_nested = false;
     int64_t _vl_field_mem_size {0}; // variable length field
 };
 

--- a/be/test/olap/pb_convert_test.cpp
+++ b/be/test/olap/pb_convert_test.cpp
@@ -1,0 +1,443 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "cloud/pb_convert.h"
+
+#include <gen_cpp/olap_file.pb.h>
+
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "google/protobuf/message.h"
+#include "gtest/gtest.h"
+
+namespace doris {
+
+using namespace doris::cloud;
+using namespace google::protobuf;
+
+// RowsetMetaPB <=> RowsetMetaCloudPB
+// TabletSchemaPB <=> TabletSchemaCloudPB
+// TabletMetaPB <=> TabletMetaCloudPB
+
+// test if 2 PBs have the same declared fields: count and names.
+// note that reserved fields are not considered
+bool have_same_fields(const google::protobuf::Descriptor* desc1,
+                      const google::protobuf::Descriptor* desc2) {
+    if (desc1->field_count() != desc2->field_count()) {
+        return false;
+    }
+    std::set<std::string> fields1;
+    for (int i = 0; i < desc1->field_count(); ++i) {
+        fields1.insert(desc1->field(i)->name());
+    }
+    std::set<std::string> fields2;
+    for (int i = 0; i < desc2->field_count(); ++i) {
+        fields2.insert(desc2->field(i)->name());
+    }
+    return fields1 == fields2;
+}
+
+// traverse all fields of the given message clear them and set them to a default
+// value, after which, all has_xxx() function will return true;
+void set_all_fields_to_default(Message* message) {
+    const Descriptor* descriptor = message->GetDescriptor();
+    const Reflection* reflection = message->GetReflection();
+
+    // set scalar value to the field
+    auto set_scalar_type = [](Message* m, const FieldDescriptor* f, const Reflection* r) {
+        switch (f->cpp_type()) {
+        case FieldDescriptor::CPPTYPE_INT32:
+            r->SetInt32(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_INT64:
+            r->SetInt64(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_UINT32:
+            r->SetUInt32(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_UINT64:
+            r->SetUInt64(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_DOUBLE:
+            r->SetDouble(m, f, 0.0);
+            break;
+        case FieldDescriptor::CPPTYPE_FLOAT:
+            r->SetFloat(m, f, 0.0f);
+            break;
+        case FieldDescriptor::CPPTYPE_BOOL:
+            r->SetBool(m, f, false);
+            break;
+        case FieldDescriptor::CPPTYPE_ENUM:
+            r->SetEnum(m, f, f->enum_type()->value(0));
+            break;
+        case FieldDescriptor::CPPTYPE_STRING: {
+            const std::string empty_str;
+            r->SetString(m, f, empty_str);
+            break;
+        }
+        default:
+            EXPECT_TRUE(false) << "unexpected branch reached";
+            break;
+        }
+    };
+
+    // add a scalar value to the repeated field
+    auto add_scalar_type = [](Message* m, const FieldDescriptor* f, const Reflection* r) {
+        switch (f->cpp_type()) {
+        case FieldDescriptor::CPPTYPE_INT32:
+            r->AddInt32(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_INT64:
+            r->AddInt64(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_UINT32:
+            r->AddUInt32(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_UINT64:
+            r->AddUInt64(m, f, 0);
+            break;
+        case FieldDescriptor::CPPTYPE_DOUBLE:
+            r->AddDouble(m, f, 0.0);
+            break;
+        case FieldDescriptor::CPPTYPE_FLOAT:
+            r->AddFloat(m, f, 0.0f);
+            break;
+        case FieldDescriptor::CPPTYPE_BOOL:
+            r->AddBool(m, f, false);
+            break;
+        case FieldDescriptor::CPPTYPE_ENUM:
+            r->AddEnum(m, f, f->enum_type()->value(0));
+            break;
+        case FieldDescriptor::CPPTYPE_STRING: {
+            const std::string empty_str;
+            r->AddString(m, f, empty_str);
+            break;
+        }
+        default:
+            EXPECT_TRUE(false) << "unexpected branch reached";
+            break;
+        }
+    };
+
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const FieldDescriptor* field = descriptor->field(i);
+        if (field->is_repeated()) { // add an element
+            reflection->ClearField(message, field);
+            if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
+                [[maybe_unused]] Message* sub_message = reflection->AddMessage(message, field);
+                // the following has memory issue, however it is no need to set vaule
+                // set_all_fields_to_default(sub_message);
+            } else {
+                add_scalar_type(message, field, reflection);
+            }
+        } else if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
+            Message* sub_message = reflection->MutableMessage(message, field);
+            set_all_fields_to_default(sub_message);
+        } else {
+            set_scalar_type(message, field, reflection);
+        }
+    }
+}
+
+// get all names of fields that are set, despite of the vaules, of the msg
+std::set<std::string> get_set_fields(const google::protobuf::Message& msg) {
+    std::set<std::string> set_fields;
+    const auto* descriptor = msg.GetDescriptor();
+    const auto* reflection = msg.GetReflection();
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const auto* field = descriptor->field(i);
+        if (field->is_repeated()) {
+            if (reflection->FieldSize(msg, field) > 0) {
+                set_fields.insert(field->name());
+            }
+        } else {
+            if (reflection->HasField(msg, field)) {
+                set_fields.insert(field->name());
+            }
+        }
+    }
+    return set_fields;
+}
+
+// clang-format off
+
+auto print = [](auto v) { std::stringstream s; for (auto& i : v) s << i << " "; return s.str(); };
+auto set_diff = [](auto a, auto b) {
+    std::set<std::string> r;
+    std::set_difference(a.begin(), a.end(), b.begin(), b.end(), std::inserter(r, r.end()));
+    return r;
+};
+
+// ensure that PBs need to be converted have identical fields, so that they can
+// be inter-converted
+TEST(PbConvert, ensure_identical_fields) {
+    EXPECT_EQ(RowsetMetaPB::GetDescriptor()->field_count(), RowsetMetaCloudPB::GetDescriptor()->field_count());
+    EXPECT_EQ(TabletSchemaPB::GetDescriptor()->field_count(), TabletSchemaCloudPB::GetDescriptor()->field_count());
+    EXPECT_EQ(TabletMetaPB::GetDescriptor()->field_count(), TabletMetaCloudPB::GetDescriptor()->field_count());
+
+    EXPECT_TRUE(have_same_fields(RowsetMetaPB::GetDescriptor(), RowsetMetaCloudPB::GetDescriptor()));
+    EXPECT_TRUE(have_same_fields(TabletMetaPB::GetDescriptor(), TabletMetaCloudPB::GetDescriptor()));
+    EXPECT_TRUE(have_same_fields(TabletSchemaPB::GetDescriptor(), TabletSchemaCloudPB::GetDescriptor()));
+}
+
+TEST(PbConvert, ensure_all_fields_converted_correctly) {
+    // rowset meta
+    RowsetMetaPB rs;
+    set_all_fields_to_default(&rs);
+    auto rowset_meta_set_fields = get_set_fields(rs);
+    EXPECT_EQ(rowset_meta_set_fields.size(), RowsetMetaPB::GetDescriptor()->field_count()) << print(rowset_meta_set_fields);
+
+    RowsetMetaCloudPB rs_cloud;
+    set_all_fields_to_default(&rs_cloud);
+    auto rowset_meta_cloud_set_fields = get_set_fields(rs_cloud);
+    EXPECT_EQ(rowset_meta_cloud_set_fields.size(), RowsetMetaCloudPB::GetDescriptor()->field_count()) << print(rowset_meta_cloud_set_fields);
+    EXPECT_EQ(rowset_meta_set_fields.size(), rowset_meta_cloud_set_fields.size());
+
+    RowsetMetaCloudPB rowset_meta_cloud_out;
+    doris_rowset_meta_to_cloud(&rowset_meta_cloud_out, rs);
+    auto rowset_meta_cloud_out_set_fields = get_set_fields(rowset_meta_cloud_out);
+    EXPECT_EQ(rowset_meta_set_fields.size(), rowset_meta_cloud_out_set_fields.size())
+        << "doris_rowset_meta_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(rowset_meta_set_fields)
+        << "\n output_fields=" << print(rowset_meta_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(rowset_meta_set_fields, rowset_meta_cloud_out_set_fields));
+
+    RowsetMetaPB rowset_meta_out;
+    cloud_rowset_meta_to_doris(&rowset_meta_out, rs_cloud);
+    auto rowset_meta_out_set_fields = get_set_fields(rowset_meta_out);
+    EXPECT_EQ(rowset_meta_cloud_set_fields.size(), rowset_meta_out_set_fields.size())
+        << "cloud_rowset_meta_to_doris() missing output fields,"
+        << "\n input_fields=" << print(rowset_meta_cloud_set_fields)
+        << "\n output_fields=" << print(rowset_meta_out_set_fields)
+        << "\n diff=" << print(set_diff(rowset_meta_cloud_set_fields, rowset_meta_out_set_fields));
+
+    // tablet schema
+    TabletSchemaPB tablet_schema;
+    set_all_fields_to_default(&tablet_schema);
+    auto tablet_schema_set_fields = get_set_fields(tablet_schema);
+    EXPECT_EQ(tablet_schema_set_fields.size(), TabletSchemaPB::GetDescriptor()->field_count()) << print(tablet_schema_set_fields);
+
+    TabletSchemaCloudPB tablet_schema_cloud;
+    set_all_fields_to_default(&tablet_schema_cloud);
+    auto tablet_schema_cloud_set_fields = get_set_fields(tablet_schema_cloud);
+    EXPECT_EQ(tablet_schema_cloud_set_fields.size(), TabletSchemaCloudPB::GetDescriptor()->field_count()) << print(tablet_schema_cloud_set_fields);
+    EXPECT_EQ(tablet_schema_set_fields.size(), tablet_schema_cloud_set_fields.size());
+
+    TabletSchemaCloudPB tablet_schema_cloud_out;
+    doris_tablet_schema_to_cloud(&tablet_schema_cloud_out, tablet_schema);
+    auto tablet_schema_cloud_out_set_fields = get_set_fields(tablet_schema_cloud_out);
+    EXPECT_EQ(tablet_schema_set_fields.size(), tablet_schema_cloud_out_set_fields.size())
+        << "doris_tablet_schema_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(tablet_schema_set_fields)
+        << "\n output_fields=" << print(tablet_schema_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_schema_set_fields, tablet_schema_cloud_out_set_fields));
+
+    TabletSchemaPB tablet_schema_out;
+    cloud_tablet_schema_to_doris(&tablet_schema_out, tablet_schema_cloud);
+    auto tablet_schema_out_set_fields = get_set_fields(tablet_schema_out);
+    EXPECT_EQ(tablet_schema_cloud_set_fields.size(), tablet_schema_out_set_fields.size())
+        << "cloud_tablet_schema_to_doris() missing output fields,"
+        << "\n input_fields=" << print(tablet_schema_cloud_set_fields)
+        << "\n output_fields=" << print(tablet_schema_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_schema_cloud_set_fields, tablet_schema_out_set_fields));
+
+    // tablet meta
+    TabletMetaPB tablet_meta;
+    set_all_fields_to_default(&tablet_meta);
+    auto tablet_meta_set_fields = get_set_fields(tablet_meta);
+    EXPECT_EQ(tablet_meta_set_fields.size(), TabletMetaPB::GetDescriptor()->field_count()) << print(tablet_meta_set_fields);
+    TabletMetaCloudPB tablet_meta_cloud;
+    set_all_fields_to_default(&tablet_meta_cloud);
+    auto tablet_meta_cloud_set_fields = get_set_fields(tablet_meta_cloud);
+    EXPECT_EQ(tablet_meta_cloud_set_fields.size(), TabletMetaCloudPB::GetDescriptor()->field_count()) << print(tablet_meta_cloud_set_fields);
+    EXPECT_EQ(tablet_meta_set_fields.size(), tablet_meta_cloud_set_fields.size());
+
+    TabletMetaCloudPB tablet_meta_cloud_out;
+    doris_tablet_meta_to_cloud(&tablet_meta_cloud_out, tablet_meta);
+    auto tablet_meta_cloud_out_set_fields = get_set_fields(tablet_meta_cloud_out);
+    EXPECT_EQ(tablet_meta_set_fields.size(), tablet_meta_cloud_out_set_fields.size())
+        << "doris_tablet_meta_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(tablet_meta_set_fields)
+        << "\n output_fields=" << print(tablet_meta_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_meta_set_fields, tablet_meta_cloud_out_set_fields));
+
+    TabletMetaPB tablet_meta_out;
+    cloud_tablet_meta_to_doris(&tablet_meta_out, tablet_meta_cloud);
+    auto tablet_meta_out_set_fields = get_set_fields(tablet_meta_out);
+    EXPECT_EQ(tablet_meta_cloud_set_fields.size(), tablet_meta_out_set_fields.size())
+        << "cloud_tablet_meta_to_doris() missing output fields,"
+        << "\n input_fields=" << print(tablet_meta_cloud_set_fields)
+        << "\n output_fields=" << print(tablet_meta_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_meta_cloud_set_fields, tablet_meta_out_set_fields));
+}
+
+TEST(PbConvert, test_rvalue_overloads) {
+    // rowset meta
+    RowsetMetaPB rs;
+    set_all_fields_to_default(&rs);
+    auto rs_set_fields = get_set_fields(rs);
+
+    RowsetMetaCloudPB rs_cloud;
+    set_all_fields_to_default(&rs_cloud);
+    auto rs_cloud_set_fields = get_set_fields(rs_cloud);
+    EXPECT_EQ(rs_set_fields.size(), rs_cloud_set_fields.size());
+
+    RowsetMetaCloudPB rs_cloud_out;
+    rs_cloud_out = doris_rowset_meta_to_cloud(std::move(rs));
+    auto rs_cloud_out_set_fields = get_set_fields(rs_cloud_out);
+    EXPECT_EQ(rs_set_fields.size(), rs_cloud_out_set_fields.size())
+        << "doris_rowset_meta_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(rs_set_fields)
+        << "\n output_fields=" << print(rs_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(rs_set_fields, rs_cloud_out_set_fields));
+
+    RowsetMetaPB rs_out;
+    rs_out = cloud_rowset_meta_to_doris(std::move(rs_cloud));
+    auto rs_out_set_fields = get_set_fields(rs_out);
+    EXPECT_EQ(rs_cloud_set_fields.size(), rs_out_set_fields.size())
+        << "cloud_rowset_meta_to_doris() missing output fields,"
+        << "\n input_fields=" << print(rs_cloud_set_fields)
+        << "\n output_fields=" << print(rs_out_set_fields)
+        << "\n diff=" << print(set_diff(rs_cloud_set_fields, rs_out_set_fields));
+
+    // tablet schema
+    TabletSchemaPB tablet_schema;
+    set_all_fields_to_default(&tablet_schema);
+    auto tablet_schema_set_fields = get_set_fields(tablet_schema);
+
+    TabletSchemaCloudPB tablet_schema_cloud;
+    set_all_fields_to_default(&tablet_schema_cloud);
+    auto tablet_schema_cloud_set_fields = get_set_fields(tablet_schema_cloud);
+    EXPECT_EQ(tablet_schema_set_fields.size(), tablet_schema_cloud_set_fields.size());
+
+    TabletSchemaCloudPB tablet_schema_cloud_out;
+    tablet_schema_cloud_out = doris_tablet_schema_to_cloud(std::move(tablet_schema));
+    auto tablet_schema_cloud_out_set_fields = get_set_fields(tablet_schema_cloud_out);
+    EXPECT_EQ(tablet_schema_set_fields.size(), tablet_schema_cloud_out_set_fields.size())
+        << "doris_tablet_schema_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(tablet_schema_set_fields)
+        << "\n output_fields=" << print(tablet_schema_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_schema_set_fields, tablet_schema_cloud_out_set_fields));
+
+    TabletSchemaPB tablet_schema_out;
+    tablet_schema_out = cloud_tablet_schema_to_doris(std::move(tablet_schema_cloud));
+    auto tablet_schema_out_set_fields = get_set_fields(tablet_schema_out);
+    EXPECT_EQ(tablet_schema_cloud_set_fields.size(), tablet_schema_out_set_fields.size())
+        << "cloud_tablet_schema_to_doris() missing output fields,"
+        << "\n input_fields=" << print(tablet_schema_cloud_set_fields)
+        << "\n output_fields=" << print(tablet_schema_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_schema_cloud_set_fields, tablet_schema_out_set_fields));
+
+    // tablet meta
+    TabletMetaPB tablet_meta;
+    set_all_fields_to_default(&tablet_meta);
+    auto tablet_meta_set_fields = get_set_fields(tablet_meta);
+
+    TabletMetaCloudPB tablet_meta_cloud;
+    set_all_fields_to_default(&tablet_meta_cloud);
+    auto tablet_meta_cloud_set_fields = get_set_fields(tablet_meta_cloud);
+    EXPECT_EQ(tablet_meta_set_fields.size(), tablet_meta_cloud_set_fields.size());
+
+    TabletMetaCloudPB tablet_meta_cloud_out;
+    tablet_meta_cloud_out = doris_tablet_meta_to_cloud(std::move(tablet_meta));
+    auto tablet_meta_cloud_out_set_fields = get_set_fields(tablet_meta_cloud_out);
+    EXPECT_EQ(tablet_meta_set_fields.size(), tablet_meta_cloud_out_set_fields.size())
+        << "doris_tablet_meta_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(tablet_meta_set_fields)
+        << "\n output_fields=" << print(tablet_meta_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_meta_set_fields, tablet_meta_cloud_out_set_fields));
+
+    TabletMetaPB tablet_meta_out;
+    tablet_meta_out = cloud_tablet_meta_to_doris(std::move(tablet_meta_cloud));
+    auto tablet_meta_out_set_fields = get_set_fields(tablet_meta_out);
+    EXPECT_EQ(tablet_meta_cloud_set_fields.size(), tablet_meta_out_set_fields.size())
+        << "cloud_tablet_meta_to_doris() missing output fields,"
+        << "\n input_fields=" << print(tablet_meta_cloud_set_fields)
+        << "\n output_fields=" << print(tablet_meta_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_meta_cloud_set_fields, tablet_meta_out_set_fields));
+}
+
+TEST(PbConvert, test_return_value_overloads) {
+    // rowset meta
+    RowsetMetaPB rs;
+    set_all_fields_to_default(&rs);
+    auto rs_set_fields = get_set_fields(rs);
+    EXPECT_EQ(rs_set_fields.size(), RowsetMetaPB::GetDescriptor()->field_count());
+
+    RowsetMetaCloudPB rs_cloud;
+    set_all_fields_to_default(&rs_cloud);
+    auto rs_cloud_set_fields = get_set_fields(rs_cloud);
+    EXPECT_EQ(rs_cloud_set_fields.size(), RowsetMetaCloudPB::GetDescriptor()->field_count());
+    EXPECT_EQ(rs_set_fields.size(), rs_cloud_set_fields.size());
+
+    RowsetMetaCloudPB rs_cloud_out;
+    rs_cloud_out = doris_rowset_meta_to_cloud(std::move(rs));
+    auto rs_cloud_out_set_fields = get_set_fields(rs_cloud_out);
+    EXPECT_EQ(rs_set_fields.size(), rs_cloud_out_set_fields.size())
+        << "doris_rowset_meta_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(rs_set_fields)
+        << "\n output_fields=" << print(rs_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(rs_set_fields, rs_cloud_out_set_fields));
+
+    RowsetMetaPB rs_out;
+    rs_out = cloud_rowset_meta_to_doris(std::move(rs_cloud));
+    auto rs_out_set_fields = get_set_fields(rs_out);
+    EXPECT_EQ(rs_cloud_set_fields.size(), rs_out_set_fields.size())
+        << "cloud_rowset_meta_to_doris() missing output fields,"
+        << "\n input_fields=" << print(rs_cloud_set_fields)
+        << "\n output_fields=" << print(rs_out_set_fields)
+        << "\n diff=" << print(set_diff(rs_cloud_set_fields, rs_out_set_fields));
+
+    // tablet schema
+    TabletSchemaPB tablet_schema;
+    set_all_fields_to_default(&tablet_schema);
+    auto tablet_schema_set_fields = get_set_fields(tablet_schema);
+    EXPECT_EQ(tablet_schema_set_fields.size(), TabletSchemaPB::GetDescriptor()->field_count());
+
+    TabletSchemaCloudPB tablet_schema_cloud;
+    set_all_fields_to_default(&tablet_schema_cloud);
+    auto tablet_schema_cloud_set_fields = get_set_fields(tablet_schema_cloud);
+    EXPECT_EQ(tablet_schema_cloud_set_fields.size(), TabletSchemaCloudPB::GetDescriptor()->field_count());
+    EXPECT_EQ(tablet_schema_set_fields.size(), tablet_schema_cloud_set_fields.size());
+
+    TabletSchemaCloudPB tablet_schema_cloud_out;
+    tablet_schema_cloud_out = doris_tablet_schema_to_cloud(std::move(tablet_schema));
+    auto tablet_schema_cloud_out_set_fields = get_set_fields(tablet_schema_cloud_out);
+    EXPECT_EQ(tablet_schema_set_fields.size(), tablet_schema_cloud_out_set_fields.size())
+        << "doris_tablet_schema_to_cloud() missing output fields,"
+        << "\n input_fields=" << print(tablet_schema_set_fields)
+        << "\n output_fields=" << print(tablet_schema_cloud_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_schema_set_fields, tablet_schema_cloud_out_set_fields));
+
+    TabletSchemaPB tablet_schema_out;
+    tablet_schema_out = cloud_tablet_schema_to_doris(std::move(tablet_schema_cloud));
+    auto tablet_schema_out_set_fields = get_set_fields(tablet_schema_out);
+    EXPECT_EQ(tablet_schema_cloud_set_fields.size(), tablet_schema_out_set_fields.size())
+        << "cloud_tablet_schema_to_doris() missing output fields,"
+        << "\n input_fields=" << print(tablet_schema_cloud_set_fields)
+        << "\n output_fields=" << print(tablet_schema_out_set_fields)
+        << "\n diff=" << print(set_diff(tablet_schema_cloud_set_fields, tablet_schema_out_set_fields));
+}
+
+// clang-format on
+
+} // namespace doris
+
+// vim: et tw=80 ts=4 sw=4 cc=80:

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -750,10 +750,6 @@ void MetaServiceImpl::update_tablet(::google::protobuf::RpcController* controlle
             tablet_meta.set_is_persistent(tablet_meta_info.is_persistent());
         } else if (tablet_meta_info.has_ttl_seconds()) {
             tablet_meta.set_ttl_seconds(tablet_meta_info.ttl_seconds());
-        } else if (tablet_meta_info.has_group_commit_interval_ms()) {
-            tablet_meta.set_group_commit_interval_ms(tablet_meta_info.group_commit_interval_ms());
-        } else if (tablet_meta_info.has_group_commit_data_bytes()) {
-            tablet_meta.set_group_commit_data_bytes(tablet_meta_info.group_commit_data_bytes());
         } else if (tablet_meta_info.has_compaction_policy()) {
             tablet_meta.set_compaction_policy(tablet_meta_info.compaction_policy());
         } else if (tablet_meta_info.has_time_series_compaction_goal_size_mbytes()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
@@ -230,7 +230,7 @@ public class CloudRollupJobV2 extends RollupJobV2 {
                                     tbl.getTimeSeriesCompactionLevelThreshold(),
                                     tbl.disableAutoCompaction(),
                                     tbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
-                                    tbl.getEnableMowLightDelete(), null,
+                                    null,
                                     tbl.rowStorePageSize(),
                                     tbl.variantEnableFlattenNested(), null,
                                     tbl.storagePageSize());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
@@ -274,7 +274,6 @@ public class CloudSchemaChangeJobV2 extends SchemaChangeJobV2 {
                                             tbl.getTimeSeriesCompactionLevelThreshold(),
                                             tbl.disableAutoCompaction(),
                                             tbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
-                                            tbl.getEnableMowLightDelete(),
                                             tbl.getInvertedIndexFileStorageFormat(),
                                             tbl.rowStorePageSize(),
                                             tbl.variantEnableFlattenNested(), clusterKeyUids,

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -179,7 +179,6 @@ public class CloudInternalCatalog extends InternalCatalog {
                         tbl.getTimeSeriesCompactionLevelThreshold(),
                         tbl.disableAutoCompaction(),
                         tbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
-                        tbl.getEnableMowLightDelete(),
                         tbl.getInvertedIndexFileStorageFormat(),
                         tbl.rowStorePageSize(),
                         tbl.variantEnableFlattenNested(), clusterKeyUids,
@@ -213,7 +212,7 @@ public class CloudInternalCatalog extends InternalCatalog {
             Long timeSeriesCompactionGoalSizeMbytes, Long timeSeriesCompactionFileCountThreshold,
             Long timeSeriesCompactionTimeThresholdSeconds, Long timeSeriesCompactionEmptyRowsetsThreshold,
             Long timeSeriesCompactionLevelThreshold, boolean disableAutoCompaction,
-            List<Integer> rowStoreColumnUniqueIds, boolean enableMowLightDelete,
+            List<Integer> rowStoreColumnUniqueIds,
             TInvertedIndexFileStorageFormat invertedIndexFileStorageFormat, long pageSize,
             boolean variantEnableFlattenNested, List<Integer> clusterKeyUids,
             long storagePageSize) throws DdlException {
@@ -338,7 +337,6 @@ public class CloudInternalCatalog extends InternalCatalog {
             schemaBuilder.addAllRowStoreColumnUniqueIds(rowStoreColumnUniqueIds);
         }
         schemaBuilder.setDisableAutoCompaction(disableAutoCompaction);
-        schemaBuilder.setEnableMowLightDelete(enableMowLightDelete);
 
         if (invertedIndexFileStorageFormat != null) {
             if (invertedIndexFileStorageFormat == TInvertedIndexFileStorageFormat.V1) {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -137,6 +137,7 @@ message RowsetMetaPB {
 
     optional bool enable_inverted_index_file_info = 1006;
     repeated InvertedIndexFileInfo inverted_index_file_info = 1007;
+    optional SchemaDictKeyList schema_dict_key_list = 1008; // align to cloud rowset
 }
 
 message SchemaDictKeyList {
@@ -383,6 +384,7 @@ message TabletSchemaPB {
     optional CompressKind compress_kind = 5; // OLAPHeaderMessage.compress_kind
     optional double bf_fpp = 6; // OLAPHeaderMessage.bf_fpp
     optional uint32 next_column_unique_id = 7; // OLAPHeaderMessage.next_column_unique_id
+    // FIXME(gavin): deprecate and remove in the future
     optional bool is_in_memory = 8 [default=false];
     optional int32 delete_sign_idx = 9 [default = -1];
     optional int32 sequence_col_idx = 10 [default= -1];
@@ -395,8 +397,8 @@ message TabletSchemaPB {
     optional int32 version_col_idx = 17 [default = -1];
     optional bool store_row_column = 18 [default=false]; // store tuplerow oriented column
     optional bool is_dynamic_schema = 19 [default=false]; // deprecated
-    optional bool is_partial_update = 20 [default=false]; // deprecated
-    repeated string partial_update_input_columns = 21; // deprecated
+    reserved 20; // deprecated is_partial_update
+    reserved 21; // deprecated partial_update_input_columns
     optional bool enable_single_replica_compaction = 22 [default=false];
     optional bool skip_write_index_on_load = 23 [default=false];
     repeated int32 cluster_key_uids = 24;
@@ -405,7 +407,7 @@ message TabletSchemaPB {
     repeated int32 row_store_column_unique_ids = 26;
     optional int64 row_store_page_size = 27 [default=16384];
 
-    optional bool variant_enable_flatten_nested = 28 [default=false];
+    optional bool enable_variant_flatten_nested = 28 [default=false];
     optional int32 skip_bitmap_col_idx = 29 [default = -1];
     optional int64 storage_page_size = 30 [default=65536];
 }
@@ -437,12 +439,15 @@ message TabletSchemaCloudPB {
     // column unique ids for row store columns
     repeated int32 row_store_column_unique_ids = 26;
     optional int64 row_store_page_size = 27 [default=16384];
-    optional bool enable_mow_light_delete = 28 [default=false];
+    reserved 28; // deprecated enable_mow_light_delete
     optional bool enable_variant_flatten_nested = 29 [default=false];
     optional int32 skip_bitmap_col_idx = 30 [default = -1];
     optional int64 storage_page_size = 31 [default=65536];
 
     optional bool is_dynamic_schema = 100 [default=false];
+
+    // FIXME(gavin): deprecate and remove in the future
+    optional bool is_in_memory = 200 [default=false]; // unused, just keep align to TabletSchemaPB
 }
 
 enum TabletStatePB {
@@ -578,8 +583,8 @@ message TabletMetaCloudPB {
     optional int64 time_series_compaction_goal_size_mbytes = 32 [default = 1024];
     optional int64 time_series_compaction_file_count_threshold = 33 [default = 2000];
     optional int64 time_series_compaction_time_threshold_seconds = 34 [default = 3600];
-    optional int64 group_commit_interval_ms = 35 [default = 10000];
-    optional int64 group_commit_data_bytes = 36 [default = 134217728];
+    reserved 35; // deprecated group_commit_interval_ms
+    reserved 36; // deprecated group_commit_data_bytes
     optional int64 time_series_compaction_empty_rowsets_threshold = 37 [default = 5];
     optional int64 time_series_compaction_level_threshold = 38 [default = 1];
 


### PR DESCRIPTION
### What problem does this PR solve?

Before this PR, there were no unit tests for the interconversion between cloud and non-cloud modes of rowset meta, tablet schema, and tablet meta. Additionally, there was no strict validation mechanism to ensure synchronization across Protocol Buffer (PB) definitions, posing risks of critical bugs.
With this PR, the aforementioned issues have been rigorously addressed through comprehensive unit test coverage and strict field synchronization checks.

* Fix some missing fields for pb_convert
* Add UT to prevent future missing fields
* Add mechanism for cloud/non-cloud PB interconversion


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

