### PR TITLE
[fix](udf) alias udf skip check enable_java_udf

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -171,7 +171,7 @@ public class FunctionRegistry {
                             || fb instanceof JavaUdtfBuilder))
                     .collect(Collectors.toList());
             if (candidateBuilders.isEmpty()) {
-                throw new org.apache.doris.nereids.exceptions.AnalysisException("java_udf has been disabled.");
+                throw new AnalysisException("java_udf has been disabled.");
             }
         }
         if (candidateBuilders.size() > 1) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -171,7 +171,7 @@ public class FunctionRegistry {
                             || fb instanceof JavaUdtfBuilder))
                     .collect(Collectors.toList());
             if (candidateBuilders.isEmpty()) {
-                FunctionUtil.checkEnableJavaUdfForNereids();
+                throw new org.apache.doris.nereids.exceptions.AnalysisException("java_udf has been disabled.");
             }
         }
         if (candidateBuilders.size() > 1) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.BuiltinFunctionBuilder;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.udf.AliasUdfBuilder;
 import org.apache.doris.nereids.trees.expressions.functions.udf.UdfBuilder;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.qe.ConnectContext;
@@ -213,7 +214,9 @@ public class FunctionRegistry {
                 List<FunctionBuilder> candidate = name2UdfBuilders.getOrDefault(scope, ImmutableMap.of())
                         .get(name.toLowerCase());
                 if (candidate != null && !candidate.isEmpty()) {
-                    FunctionUtil.checkEnableJavaUdfForNereids();
+                    if (candidate.stream().anyMatch(builder -> !(builder instanceof AliasUdfBuilder))) {
+                        FunctionUtil.checkEnableJavaUdfForNereids();
+                    }
                     return candidate;
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
@@ -259,9 +259,4 @@ public class FunctionUtil {
         }
     }
 
-    public static void checkEnableJavaUdfForNereids() {
-        if (!Config.enable_java_udf) {
-            throw new org.apache.doris.nereids.exceptions.AnalysisException("java_udf has been disabled.");
-        }
-    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/UdfTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/UdfTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateFormat;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateTrunc;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DayOfMonth;
@@ -59,10 +60,13 @@ public class UdfTest extends TestWithFeService implements PlanPatternMatchSuppor
     @Override
     protected void runBeforeEach() throws Exception {
         connectContext.setDatabase("test");
+        Config.enable_java_udf = true;
     }
 
     @Test
     public void testSimpleAliasFunction() throws Exception {
+        // alias udf should not check java_udf
+        Config.enable_java_udf = false;
         createFunction("create global alias function f(int) with parameter(n) as hours_add(now(3), n)");
         createFunction("create alias function f(int) with parameter(n) as hours_sub(now(3), n)");
 


### PR DESCRIPTION
### What problem does this PR solve?

if set Config.enable_java_udf = false,  execute fe alias function will throw exception:

```
MySQL root@127.0.0.1:(none)> create global alias function foo3(STRING) with parameter(s) as concat(s, "hello");
Query OK, 0 rows affected
Time: 7.590s
MySQL root@127.0.0.1:(none)> select foo3("tt");
(1105, 'errCode = 2, detailMessage = java_udf has been disabled.')
```

fix this, alias function no check enable_java_udf.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

