### PR TITLE
[fix](Nereids) deep copy for LogicalWindow is wrong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalWindowToPhysicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalWindowToPhysicalWindow.java
@@ -68,7 +68,7 @@ public class LogicalWindowToPhysicalWindow extends OneImplementationRuleFactory 
     public Rule build() {
 
         return RuleType.LOGICAL_WINDOW_TO_PHYSICAL_WINDOW_RULE.build(
-            logicalWindow().when(LogicalWindow::isChecked).then(this::implement)
+            logicalWindow().then(this::implement)
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -149,7 +149,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
         List<NamedExpression> outputExpressions = aggregate.getOutputExpressions().stream()
                 .map(o -> (NamedExpression) ExpressionDeepCopier.INSTANCE.deepCopy(o, context))
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, child);
+        return aggregate.withChildGroupByAndOutput(groupByExpressions, outputExpressions, child);
     }
 
     @Override
@@ -194,7 +194,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
         List<NamedExpression> newProjects = project.getProjects().stream()
                 .map(p -> (NamedExpression) ExpressionDeepCopier.INSTANCE.deepCopy(p, context))
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalProject<>(newProjects, child);
+        return new LogicalProject<>(newProjects, project.isDistinct(), child);
     }
 
     @Override
@@ -353,7 +353,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
         List<Slot> generatorOutput = generate.getGeneratorOutput().stream()
                 .map(o -> (Slot) ExpressionDeepCopier.INSTANCE.deepCopy(o, context))
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalGenerate<>(generators, generatorOutput, child);
+        return new LogicalGenerate<>(generators, generatorOutput, generate.getExpandColumnAlias(), child);
     }
 
     @Override
@@ -362,7 +362,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
         List<NamedExpression> windowExpressions = window.getWindowExpressions().stream()
                 .map(w -> (NamedExpression) ExpressionDeepCopier.INSTANCE.deepCopy(w, context))
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalWindow<>(windowExpressions, child);
+        return new LogicalWindow<>(windowExpressions, window.isChecked(), child);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
@@ -65,10 +65,6 @@ public class LogicalEmptyRelation extends LogicalRelation
         return projects;
     }
 
-    public LogicalEmptyRelation withProjects(List<? extends NamedExpression> projects) {
-        return new LogicalEmptyRelation(relationId, projects);
-    }
-
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalEmptyRelation(relationId, projects,
@@ -84,6 +80,14 @@ public class LogicalEmptyRelation extends LogicalRelation
     @Override
     public LogicalEmptyRelation withRelationId(RelationId relationId) {
         throw new RuntimeException("should not call LogicalEmptyRelation's withRelationId method");
+    }
+
+    public LogicalEmptyRelation withProjects(List<NamedExpression> projects) {
+        return new LogicalEmptyRelation(relationId, projects);
+    }
+
+    public LogicalEmptyRelation withRelationIdAndProjects(RelationId relationId, List<NamedExpression> projects) {
+        return new LogicalEmptyRelation(relationId, projects);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -88,6 +88,10 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
         throw new RuntimeException("should not call LogicalOneRowRelation's withRelationId method");
     }
 
+    public LogicalOneRowRelation withRelationIdAndProjects(RelationId relationId, List<NamedExpression> projects) {
+        return new LogicalOneRowRelation(relationId, projects);
+    }
+
     @Override
     public List<Slot> computeOutput() {
         return projects.stream()

--- a/regression-test/suites/nereids_syntax_p0/transform_outer_join_to_anti.groovy
+++ b/regression-test/suites/nereids_syntax_p0/transform_outer_join_to_anti.groovy
@@ -85,4 +85,3 @@ suite("transform_outer_join_to_anti") {
         contains "ANTI JOIN"
     }
 }
-


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #21727 #14397

Problem Summary:

1. forgot to copy isChecked flag in LogicalWindow when do deep copy
2. implement LogicalWindow To PhyscialWindow should not check isChecked flag

This PR:
1. check deep copy for all plan node
2. remove check isChecked in LogicalWindow To PhyscialWindow

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

