### PR TITLE
[opt](nereids) set column stats unkown by default when derive Not expressoin

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -513,14 +513,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                 // 4. not A like XXX
                 // 5. not array_contains([xx, xx], xx)
                 colBuilder.setNumNulls(0);
-                Preconditions.checkArgument(
-                        child instanceof EqualPredicate
-                                || child instanceof InPredicate
-                                || child instanceof IsNull
-                                || child instanceof Like
-                                || child instanceof Match
-                                || child instanceof Function,
-                        "Not-predicate meet unexpected child: %s", child.toSql());
+
                 if (child instanceof Like) {
                     rowCount = context.statistics.getRowCount() - childStats.getRowCount();
                     colBuilder.setNdv(Math.max(1.0, originColStats.ndv - childColStats.ndv));
@@ -545,6 +538,9 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                 } else if (child instanceof Match) {
                     rowCount = context.statistics.getRowCount() - childStats.getRowCount();
                     colBuilder.setNdv(Math.max(1.0, originColStats.ndv - childColStats.ndv));
+                } else {
+                    rowCount = context.statistics.getRowCount() - childStats.getRowCount();
+                    colBuilder.setIsUnknown(true);
                 }
                 if (not.child().getInputSlots().size() == 1 && !(child instanceof IsNull)) {
                     // only consider the single column numNull, otherwise, ignore


### PR DESCRIPTION
### What problem does this PR solve?
The stats derivation of the Not expression needs to consider the type of the Not child expression. Therefore, specific implementations need to be added for each type of child expression, and thus the check for the child expression type is added. An exception is thrown when the check fails. Although this can detect the omitted child types as early as possible, it will cause problems in customer scenarios. This PR will remove this type check.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

