### PR TITLE
[improve](analytic) refactor the insert into result mode for window function

### DIFF
--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -206,8 +206,7 @@ bool AnalyticSinkLocalState::_get_next_for_sliding_rows(int64_t batch_rows,
         current_row_start = std::min(current_row_start, current_row_end);
         _execute_for_function(_partition_by_pose.start, _partition_by_pose.end, current_row_start,
                               current_row_end);
-        int64_t pos = _current_row_position + _have_removed_rows -
-                      _input_block_first_row_positions[_output_block_index];
+        int64_t pos = current_pos_in_block();
         _insert_result_info(pos, pos + 1);
         _current_row_position++;
         if (_current_row_position - current_block_base_pos >= batch_rows) {

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -225,8 +225,7 @@ bool AnalyticSinkLocalState::_get_next_for_unbounded_rows(int64_t batch_rows,
         // going on calculate, add up data, no need to reset state
         _execute_for_function(_partition_by_pose.start, _partition_by_pose.end,
                               _current_row_position, _current_row_position + 1);
-        int64_t pos = _current_row_position + _have_removed_rows -
-                      _input_block_first_row_positions[_output_block_index];
+        int64_t pos = current_pos_in_block();
         _insert_result_info(pos, pos + 1);
         _current_row_position++;
         if (_current_row_position - current_block_base_pos >= batch_rows) {
@@ -252,8 +251,7 @@ bool AnalyticSinkLocalState::_get_next_for_partition(int64_t batch_rows,
     // should not exceed block batch size
     current_window_frame_width = std::min<int64_t>(current_window_frame_width, batch_rows);
     auto real_deal_with_width = current_window_frame_width - previous_window_frame_width;
-    int64_t pos = _current_row_position + _have_removed_rows -
-                  _input_block_first_row_positions[_output_block_index];
+    int64_t pos = current_pos_in_block();
     _insert_result_info(pos, pos + real_deal_with_width);
     _current_row_position += real_deal_with_width;
     return _current_row_position - current_block_base_pos >= batch_rows;
@@ -271,8 +269,7 @@ bool AnalyticSinkLocalState::_get_next_for_unbounded_range(int64_t batch_rows,
         auto current_window_frame_width = _order_by_pose.end - current_block_base_pos;
         current_window_frame_width = std::min<int64_t>(current_window_frame_width, batch_rows);
         auto real_deal_with_width = current_window_frame_width - previous_window_frame_width;
-        int64_t pos = _current_row_position + _have_removed_rows -
-                      _input_block_first_row_positions[_output_block_index];
+        int64_t pos = current_pos_in_block();
         _insert_result_info(pos, pos + real_deal_with_width);
         _current_row_position += real_deal_with_width;
         if (_current_row_position - current_block_base_pos >= batch_rows) {
@@ -303,8 +300,7 @@ bool AnalyticSinkLocalState::_get_next_for_range_between(int64_t batch_rows,
         }
         _execute_for_function(_partition_by_pose.start, _partition_by_pose.end,
                               _order_by_pose.start, _order_by_pose.end);
-        int64_t pos = _current_row_position + _have_removed_rows -
-                      _input_block_first_row_positions[_output_block_index];
+        int64_t pos = current_pos_in_block();
         _insert_result_info(pos, pos + 1);
         _current_row_position++;
         if (_current_row_position - current_block_base_pos >= batch_rows) {

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -800,11 +800,7 @@ Status AnalyticSinkOperatorX::_add_input_block(doris::RuntimeState* state,
 void AnalyticSinkLocalState::_remove_unused_rows() {
     // test column overflow 4G
     DBUG_EXECUTE_IF("AnalyticSinkLocalState._remove_unused_rows", { return; });
-#ifndef NDEBUG
-    const size_t block_num = 0;
-#else
     const size_t block_num = 256;
-#endif
     if (_removed_block_index + block_num + 1 >= _input_block_first_row_positions.size()) {
         return;
     }

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -340,7 +340,7 @@ Status AnalyticSinkLocalState::_execute_impl() {
                 _output_current_block(&block);
                 _refresh_buffer_and_dependency_state(&block);
             }
-            if (_current_row_position == _partition_by_pose.end && !_streaming_mode) {
+            if (_current_row_position == _partition_by_pose.end && _partition_by_pose.is_ended) {
                 _reset_state_for_next_partition();
             }
         }

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -87,7 +87,7 @@ private:
     void _init_result_columns();
     void _execute_for_function(int64_t partition_start, int64_t partition_end, int64_t frame_start,
                                int64_t frame_end);
-    void _insert_result_info(int64_t real_deal_with_width, int64_t pos = 0);
+    void _insert_result_info(int64_t start, int64_t end);
     void _output_current_block(vectorized::Block* block);
     void _reset_state_for_next_partition();
     void _refresh_buffer_and_dependency_state(vectorized::Block* block);

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -87,7 +87,7 @@ private:
     void _init_result_columns();
     void _execute_for_function(int64_t partition_start, int64_t partition_end, int64_t frame_start,
                                int64_t frame_end);
-    void _insert_result_info(int64_t real_deal_with_width);
+    void _insert_result_info(int64_t real_deal_with_width, int64_t pos = 0);
     void _output_current_block(vectorized::Block* block);
     void _reset_state_for_next_partition();
     void _refresh_buffer_and_dependency_state(vectorized::Block* block);
@@ -137,6 +137,7 @@ private:
     executor _executor;
 
     bool _current_window_empty = false;
+    bool _streaming_mode = false;
     int64_t _current_row_position = 0;
     int64_t _output_block_index = 0;
     std::vector<vectorized::MutableColumnPtr> _result_window_columns;

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -59,6 +59,9 @@ public:
     int64_t _average_size = 0;
 };
 
+// those function cacluate need partition info, so can't be used in streaming mode
+static const std::set<std::string> PARTITION_FUNCTION_SET {"ntile", "cume_dist", "percent_rank"};
+
 class AnalyticSinkLocalState : public PipelineXSinkLocalState<AnalyticSharedState> {
     ENABLE_FACTORY_CREATOR(AnalyticSinkLocalState);
 

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -129,6 +129,7 @@ private:
     std::vector<vectorized::AggFnEvaluator*> _agg_functions;
     std::vector<size_t> _offsets_of_aggregate_states;
     std::vector<bool> _result_column_nullable_flags;
+    std::vector<bool> _result_column_could_resize;
 
     using vectorized_get_next = bool (AnalyticSinkLocalState::*)(int64_t, int64_t);
     struct executor {

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -88,6 +88,10 @@ private:
     void _execute_for_function(int64_t partition_start, int64_t partition_end, int64_t frame_start,
                                int64_t frame_end);
     void _insert_result_info(int64_t start, int64_t end);
+    int64_t current_pos_in_block() {
+        return _current_row_position + _have_removed_rows -
+               _input_block_first_row_positions[_output_block_index];
+    }
     void _output_current_block(vectorized::Block* block);
     void _reset_state_for_next_partition();
     void _refresh_buffer_and_dependency_state(vectorized::Block* block);

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -184,6 +184,11 @@ public:
     /// Inserts results into a column.
     virtual void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const = 0;
 
+    virtual void insert_result_into_pos(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                        size_t pos) const {
+        insert_result_into(place, to);
+    }
+
     virtual void insert_result_into_vec(const std::vector<AggregateDataPtr>& places,
                                         const size_t offset, IColumn& to,
                                         const size_t num_rows) const = 0;

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -184,11 +184,6 @@ public:
     /// Inserts results into a column.
     virtual void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const = 0;
 
-    virtual void insert_result_into_pos(ConstAggregateDataPtr __restrict place, IColumn& to,
-                                        size_t pos) const {
-        insert_result_into(place, to);
-    }
-
     virtual void insert_result_into_vec(const std::vector<AggregateDataPtr>& places,
                                         const size_t offset, IColumn& to,
                                         const size_t num_rows) const = 0;
@@ -237,6 +232,19 @@ public:
     /// Verify function signature
     virtual Status verify_result_type(const bool without_key, const DataTypes& argument_types,
                                       const DataTypePtr result_type) const = 0;
+
+    // agg function is used result column push_back to insert result,
+    // and now want's resize column early and use operator[] to insert result.
+    // but like result column is string column, it's can't resize dirctly with operator[]
+    // need template specialization agg for the string type in insert_result_into_range
+    virtual bool result_column_could_resize() const { return false; }
+
+    virtual void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                          const size_t start, const size_t end) const {
+        for (size_t i = start; i < end; ++i) {
+            insert_result_into(place, to);
+        }
+    }
 
 protected:
     DataTypes argument_types;

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -80,11 +80,14 @@ public:
                 doris::vectorized::WindowFunctionRowNumber::data(place).count);
     }
 
-    void insert_result_into_pos(ConstAggregateDataPtr __restrict place, IColumn& to,
-                                size_t pos) const override {
+    bool result_column_could_resize() const override { return true; }
+
+    void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                  const size_t start, const size_t end) const override {
         auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
-        // column.get_data()[pos] = (doris::vectorized::WindowFunctionRowNumber::data(place).count);
-        column.get_data().push_back(doris::vectorized::WindowFunctionRowNumber::data(place).count);
+        for (size_t i = start; i < end; ++i) {
+            column.get_data()[i] = (doris::vectorized::WindowFunctionRowNumber::data(place).count);
+        }
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}
@@ -129,7 +132,18 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).rank);
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                data(place).rank);
+    }
+
+    bool result_column_could_resize() const override { return true; }
+
+    void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                  const size_t start, const size_t end) const override {
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
+        for (size_t i = start; i < end; ++i) {
+            column.get_data()[i] = (doris::vectorized::WindowFunctionRank::data(place).rank);
+        }
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}
@@ -171,7 +185,18 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).rank);
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                data(place).rank);
+    }
+
+    bool result_column_could_resize() const override { return true; }
+
+    void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                  const size_t start, const size_t end) const override {
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
+        for (size_t i = start; i < end; ++i) {
+            column.get_data()[i] = (doris::vectorized::WindowFunctionDenseRank::data(place).rank);
+        }
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}
@@ -227,7 +252,19 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
         auto percent_rank = _cal_percent(data(place).rank, data(place).partition_size);
-        assert_cast<ColumnFloat64&>(to).get_data().push_back(percent_rank);
+        assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                percent_rank);
+    }
+
+    bool result_column_could_resize() const override { return true; }
+
+    void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                  const size_t start, const size_t end) const override {
+        auto& column = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
+        auto percent_rank = _cal_percent(data(place).rank, data(place).partition_size);
+        for (size_t i = start; i < end; ++i) {
+            column.get_data()[i] = percent_rank;
+        }
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}
@@ -280,7 +317,19 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
         auto cume_dist = (double)data(place).numerator * 1.0 / (double)data(place).denominator;
-        assert_cast<ColumnFloat64&>(to).get_data().push_back(cume_dist);
+        assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                cume_dist);
+    }
+
+    bool result_column_could_resize() const override { return true; }
+
+    void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                  const size_t start, const size_t end) const override {
+        auto& column = assert_cast<ColumnFloat64&, TypeCheckOnRelease::DISABLE>(to);
+        auto cume_dist = (double)data(place).numerator * 1.0 / (double)data(place).denominator;
+        for (size_t i = start; i < end; ++i) {
+            column.get_data()[i] = cume_dist;
+        }
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}
@@ -331,8 +380,18 @@ public:
     void reset(AggregateDataPtr place) const override { WindowFunctionNTile::data(place).rows = 0; }
 
     void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
                 WindowFunctionNTile::data(place).bucket_index);
+    }
+
+    bool result_column_could_resize() const override { return true; }
+
+    void insert_result_into_range(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                  const size_t start, const size_t end) const override {
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
+        for (size_t i = start; i < end; ++i) {
+            column.get_data()[i] = WindowFunctionNTile::data(place).bucket_index;
+        }
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -76,7 +76,15 @@ public:
     }
 
     void insert_result_into(ConstAggregateDataPtr place, IColumn& to) const override {
-        assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).count);
+        assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to).get_data().push_back(
+                doris::vectorized::WindowFunctionRowNumber::data(place).count);
+    }
+
+    void insert_result_into_pos(ConstAggregateDataPtr __restrict place, IColumn& to,
+                                size_t pos) const override {
+        auto& column = assert_cast<ColumnInt64&, TypeCheckOnRelease::DISABLE>(to);
+        // column.get_data()[pos] = (doris::vectorized::WindowFunctionRowNumber::data(place).count);
+        column.get_data().push_back(doris::vectorized::WindowFunctionRowNumber::data(place).count);
     }
 
     void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena*) const override {}


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
add two function interface:  result_column_could_resize/insert_result_into_range
in order to resize the result column early and use operator[i] to assign result value.   
as this could be faster than reverse and push_back to result column.
after refactor the execute time have reduce 10%+
<img width="429" alt="image" src="https://github.com/user-attachments/assets/ae73ad16-80e6-4401-8349-41cd1bc66cf0" />


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

