### PR TITLE
[fix](mtmv) Fix materialized rewrite oom when the num of relation mapping is too large

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -185,21 +185,16 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                     () -> String.format("matchMode is %s", matchMode));
             return rewriteResults;
         }
+        SessionVariable sessionVariable = cascadesContext.getConnectContext().getSessionVariable();
+        int materializedViewRelationMappingMaxCount = sessionVariable.getMaterializedViewRelationMappingMaxCount();
         List<RelationMapping> queryToViewTableMappings = RelationMapping.generate(queryStructInfo.getRelations(),
-                viewStructInfo.getRelations());
+                viewStructInfo.getRelations(), materializedViewRelationMappingMaxCount);
         // if any relation in query and view can not map, bail out.
         if (queryToViewTableMappings == null) {
             materializationContext.recordFailReason(queryStructInfo,
                     "Query to view table mapping is null", () -> "");
             return rewriteResults;
         }
-        SessionVariable sessionVariable = cascadesContext.getConnectContext().getSessionVariable();
-        int materializedViewRelationMappingMaxCount = sessionVariable.getMaterializedViewRelationMappingMaxCount();
-        if (queryToViewTableMappings.size() > materializedViewRelationMappingMaxCount) {
-            LOG.warn("queryToViewTableMappings is over limit and be intercepted");
-            queryToViewTableMappings = queryToViewTableMappings.subList(0, materializedViewRelationMappingMaxCount);
-        }
-
         for (RelationMapping queryToViewTableMapping : queryToViewTableMappings) {
             SlotMapping queryToViewSlotMapping =
                     materializationContext.getSlotMappingFromCache(queryToViewTableMapping);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/Mapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/Mapping.java
@@ -102,7 +102,9 @@ public abstract class Mapping {
 
         @Override
         public String toString() {
-            return "MappedRelation{" + "relationId=" + relationId + ", slotNameToSlotMap=" + slotNameToSlotMap + '}';
+            String relationTableName = belongedRelation.getTable().getNameWithFullQualifiers();
+            return "MappedRelation{" + "relationId=" + relationId + ", relationTableName="
+                    + relationTableName + ", slotNameToSlotMap=" + slotNameToSlotMap + '}';
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/RelationMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/RelationMapping.java
@@ -199,7 +199,9 @@ public class RelationMapping extends Mapping {
             boolean[] used, MappedRelation[] current, List<Pair<MappedRelation[], MappedRelation[]>> results,
             int maxMappingCount) {
         if (results.size() >= maxMappingCount) {
-            LOG.warn("queryToViewTableMappings is over limit and be intercepted");
+            LOG.warn(String.format("queryToViewTableMappings is over limit and be intercepted, "
+                            + "results size is %s,\n MappedRelation left is %s,\n MappedRelation right is %s \n",
+                    results.size(), Arrays.toString(left), Arrays.toString(right)));
             return;
         }
         if (index == left.length) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/RelationMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/RelationMapping.java
@@ -29,6 +29,8 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableBiMap.Builder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,6 +46,7 @@ import java.util.Set;
  */
 public class RelationMapping extends Mapping {
 
+    private static final Logger LOG = LogManager.getLogger(RelationMapping.class);
     private final ImmutableBiMap<MappedRelation, MappedRelation> mappedRelationMap;
 
     public RelationMapping(ImmutableBiMap<MappedRelation, MappedRelation> mappedRelationMap) {
@@ -61,7 +64,8 @@ public class RelationMapping extends Mapping {
     /**
      * Generate mapping according to source and target relation
      */
-    public static List<RelationMapping> generate(List<CatalogRelation> sources, List<CatalogRelation> targets) {
+    public static List<RelationMapping> generate(List<CatalogRelation> sources, List<CatalogRelation> targets,
+            int relationMappingMaxCount) {
         // Construct tmp map, key is the table qualifier, value is the corresponding catalog relations
         HashMultimap<TableIdentifier, MappedRelation> sourceTableRelationIdMap = HashMultimap.create();
         for (CatalogRelation relation : sources) {
@@ -100,8 +104,8 @@ public class RelationMapping extends Mapping {
             // query is select * from tableA0, tableA1, tableA4
             List<BiMap<MappedRelation, MappedRelation>> relationMappingPowerList = new ArrayList<>();
             List<Pair<MappedRelation[], MappedRelation[]>> combinations = getUniquePermutation(
-                    sourceMappedRelations.toArray(sourceMappedRelations.toArray(new MappedRelation[0])),
-                    targetMappedRelations.toArray(new MappedRelation[0]));
+                    sourceMappedRelations.toArray(new MappedRelation[0]),
+                    targetMappedRelations.toArray(new MappedRelation[0]), relationMappingMaxCount);
             for (Pair<MappedRelation[], MappedRelation[]> combination : combinations) {
                 BiMap<MappedRelation, MappedRelation> combinationBiMap = HashBiMap.create();
                 MappedRelation[] key = combination.key();
@@ -168,8 +172,8 @@ public class RelationMapping extends Mapping {
      * [(1, 195) (4, 194) (5, 191)]
      * ]
      * */
-    private static List<Pair<MappedRelation[], MappedRelation[]>> getUniquePermutation(
-            MappedRelation[] left, MappedRelation[] right) {
+    public static List<Pair<MappedRelation[], MappedRelation[]>> getUniquePermutation(
+            MappedRelation[] left, MappedRelation[] right, int maxMappingCount) {
         boolean needSwap = left.length > right.length;
         if (needSwap) {
             MappedRelation[] temp = left;
@@ -180,7 +184,7 @@ public class RelationMapping extends Mapping {
         boolean[] used = new boolean[right.length];
         MappedRelation[] current = new MappedRelation[left.length];
         List<Pair<MappedRelation[], MappedRelation[]>> results = new ArrayList<>();
-        backtrack(left, right, 0, used, current, results);
+        backtrack(left, right, 0, used, current, results, maxMappingCount);
         if (needSwap) {
             List<Pair<MappedRelation[], MappedRelation[]>> tmpResults = results;
             results = new ArrayList<>();
@@ -192,9 +196,14 @@ public class RelationMapping extends Mapping {
     }
 
     private static void backtrack(MappedRelation[] left, MappedRelation[] right, int index,
-            boolean[] used, MappedRelation[] current, List<Pair<MappedRelation[], MappedRelation[]>> results) {
+            boolean[] used, MappedRelation[] current, List<Pair<MappedRelation[], MappedRelation[]>> results,
+            int maxMappingCount) {
+        if (results.size() >= maxMappingCount) {
+            LOG.warn("queryToViewTableMappings is over limit and be intercepted");
+            return;
+        }
         if (index == left.length) {
-            results.add(Pair.of(Arrays.copyOf(left, left.length), Arrays.copyOf(current, current.length)));
+            results.add(Pair.of(left, Arrays.copyOf(current, current.length)));
             return;
         }
 
@@ -202,7 +211,7 @@ public class RelationMapping extends Mapping {
             if (!used[i]) {
                 used[i] = true;
                 current[index] = right[i];
-                backtrack(left, right, index + 1, used, current, results);
+                backtrack(left, right, index + 1, used, current, results, maxMappingCount);
                 used[i] = false;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/RelationMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/RelationMapping.java
@@ -199,9 +199,9 @@ public class RelationMapping extends Mapping {
             boolean[] used, MappedRelation[] current, List<Pair<MappedRelation[], MappedRelation[]>> results,
             int maxMappingCount) {
         if (results.size() >= maxMappingCount) {
-            LOG.warn(String.format("queryToViewTableMappings is over limit and be intercepted, "
-                            + "results size is %s,\n MappedRelation left is %s,\n MappedRelation right is %s \n",
-                    results.size(), Arrays.toString(left), Arrays.toString(right)));
+            LOG.warn("queryToViewTableMappings is over limit and be intercepted, "
+                            + "results size is {}, MappedRelation left is {}, MappedRelation right is {}",
+                    results.size(), Arrays.toString(left), Arrays.toString(right));
             return;
         }
         if (index == left.length) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/RelationMappingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/RelationMappingTest.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.mv;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.rules.exploration.mv.mapping.Mapping.MappedRelation;
+import org.apache.doris.nereids.rules.exploration.mv.mapping.RelationMapping;
+import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RelationMappingTest {
+
+    @Mocked
+    public CatalogRelation catalogRelation;
+
+    /**
+     * Permutation and remove duplicated element
+     * For example:
+     * Given [1, 4, 5] and [191, 194, 195]
+     * This would return
+     * [
+     * [(1, 191) (4, 194) (5, 195)],
+     * [(1, 191) (4, 195) (5, 194)],
+     * [(1, 194) (4, 191) (5, 195)],
+     * [(1, 194) (4, 195) (5, 191)],
+     * [(1, 195) (4, 191) (5, 194)],
+     * [(1, 195) (4, 194) (5, 191)]
+     * ]
+     * */
+    @Test
+    public void testGetPermutation() {
+
+        MappedRelation mr1 = MappedRelation.of(new RelationId(1), catalogRelation);
+        MappedRelation mr4 = MappedRelation.of(new RelationId(4), catalogRelation);
+        MappedRelation mr5 = MappedRelation.of(new RelationId(5), catalogRelation);
+
+        MappedRelation mr191 = MappedRelation.of(new RelationId(191), catalogRelation);
+        MappedRelation mr194 = MappedRelation.of(new RelationId(194), catalogRelation);
+        MappedRelation mr195 = MappedRelation.of(new RelationId(195), catalogRelation);
+
+        MappedRelation[] left = new MappedRelation[] {mr1, mr4, mr5};
+        MappedRelation[] right = new MappedRelation[] {mr191, mr194, mr195};
+
+        List<Pair<MappedRelation[], MappedRelation[]>> uniquePermutation = RelationMapping.getUniquePermutation(left,
+                right, 10);
+        Set<BiMap<Integer, Integer>> generatedMappedSet = generateDirectPermutations(uniquePermutation);
+
+        Set<BiMap<Integer, Integer>> exceptedSet = new HashSet<>();
+        BiMap<Integer, Integer> eachMap = HashBiMap.create();
+        eachMap.put(1, 195);
+        eachMap.put(4, 194);
+        eachMap.put(5, 191);
+        exceptedSet.add(eachMap);
+        eachMap = HashBiMap.create();
+        eachMap.put(1, 194);
+        eachMap.put(4, 191);
+        eachMap.put(5, 195);
+        exceptedSet.add(eachMap);
+        eachMap = HashBiMap.create();
+        eachMap.put(1, 194);
+        eachMap.put(4, 195);
+        eachMap.put(5, 191);
+        exceptedSet.add(eachMap);
+        eachMap = HashBiMap.create();
+        eachMap.put(1, 195);
+        eachMap.put(4, 191);
+        eachMap.put(5, 194);
+        exceptedSet.add(eachMap);
+        eachMap = HashBiMap.create();
+        eachMap.put(1, 191);
+        eachMap.put(4, 194);
+        eachMap.put(5, 195);
+        exceptedSet.add(eachMap);
+        eachMap = HashBiMap.create();
+        eachMap.put(1, 191);
+        eachMap.put(4, 195);
+        eachMap.put(5, 194);
+        exceptedSet.add(eachMap);
+
+        Assert.assertEquals(exceptedSet, generatedMappedSet);
+    }
+
+    /**
+     * Permutation and remove duplicated element
+     * For example:
+     * Given [1, 4, 5] and [191, 194, 195]
+     * This would return
+     * [
+     * [(1, 191) (4, 194) (5, 195)],
+     * [(1, 191) (4, 195) (5, 194)],
+     * [(1, 194) (4, 191) (5, 195)],
+     * [(1, 194) (4, 195) (5, 191)],
+     * [(1, 195) (4, 191) (5, 194)],
+     * [(1, 195) (4, 194) (5, 191)]
+     * ]
+     * */
+    @Test
+    public void testGetPermutationWithLimit() {
+
+        MappedRelation mr1 = MappedRelation.of(new RelationId(1), catalogRelation);
+        MappedRelation mr4 = MappedRelation.of(new RelationId(4), catalogRelation);
+        MappedRelation mr5 = MappedRelation.of(new RelationId(5), catalogRelation);
+
+        MappedRelation mr191 = MappedRelation.of(new RelationId(191), catalogRelation);
+        MappedRelation mr194 = MappedRelation.of(new RelationId(194), catalogRelation);
+        MappedRelation mr195 = MappedRelation.of(new RelationId(195), catalogRelation);
+
+        MappedRelation[] left = new MappedRelation[] {mr1, mr4, mr5};
+        MappedRelation[] right = new MappedRelation[] {mr191, mr194, mr195};
+
+        List<Pair<MappedRelation[], MappedRelation[]>> uniquePermutation = RelationMapping.getUniquePermutation(left,
+                right, 5);
+
+        Assert.assertEquals(5, uniquePermutation.size());
+    }
+
+    private Set<BiMap<Integer, Integer>> generateDirectPermutations(
+            List<Pair<MappedRelation[], MappedRelation[]>> uniquePermutation) {
+        Set<BiMap<Integer, Integer>> relationMappingPowerSet = new HashSet<>();
+        for (Pair<MappedRelation[], MappedRelation[]> combination : uniquePermutation) {
+            BiMap<Integer, Integer> combinationBiMap = HashBiMap.create();
+            MappedRelation[] key = combination.key();
+            MappedRelation[] value = combination.value();
+            int length = Math.min(key.length, value.length);
+            for (int i = 0; i < length; i++) {
+                combinationBiMap.put(key[i].getRelationId().asInt(), value[i].getRelationId().asInt());
+            }
+            relationMappingPowerSet.add(combinationBiMap);
+        }
+        return relationMappingPowerSet;
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/RelationMappingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/RelationMappingTest.java
@@ -26,8 +26,8 @@ import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import mockit.Mocked;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -102,7 +102,7 @@ public class RelationMappingTest {
         eachMap.put(5, 194);
         exceptedSet.add(eachMap);
 
-        Assert.assertEquals(exceptedSet, generatedMappedSet);
+        Assertions.assertEquals(exceptedSet, generatedMappedSet);
     }
 
     /**
@@ -136,7 +136,7 @@ public class RelationMappingTest {
         List<Pair<MappedRelation[], MappedRelation[]>> uniquePermutation = RelationMapping.getUniquePermutation(left,
                 right, 5);
 
-        Assert.assertEquals(5, uniquePermutation.size());
+        Assertions.assertEquals(5, uniquePermutation.size());
     }
 
     private Set<BiMap<Integer, Integer>> generateDirectPermutations(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphAggTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphAggTest.java
@@ -93,7 +93,8 @@ class HyperGraphAggTest extends SqlTestBase {
                 null, new BitSet()).get(0);
         StructInfo st2 = MaterializedViewUtils.extractStructInfo(p2, p2,
                 null, new BitSet()).get(0);
-        RelationMapping rm = RelationMapping.generate(st1.getRelations(), st2.getRelations()).get(0);
+        RelationMapping rm = RelationMapping.generate(st1.getRelations(), st2.getRelations(), 8)
+                .get(0);
         SlotMapping sm = SlotMapping.generate(rm);
         return LogicalCompatibilityContext.from(rm, sm, st1, st2);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MappingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MappingTest.java
@@ -107,7 +107,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(1, generateRelationMapping.size());
 
@@ -156,7 +157,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(1, generateRelationMapping.size());
 
@@ -202,7 +204,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(1, generateRelationMapping.size());
 
@@ -248,7 +251,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(2, generateRelationMapping.size());
 
@@ -308,7 +312,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(2, generateRelationMapping.size());
 
@@ -377,7 +382,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(6, generateRelationMapping.size());
 
@@ -465,7 +471,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(6, generateRelationMapping.size());
 
@@ -547,7 +554,8 @@ public class MappingTest extends TestWithFeService {
         List<CatalogRelation> targetRelations = new ArrayList<>();
         targetPlan.accept(RelationCollector.INSTANCE, targetRelations);
 
-        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations);
+        List<RelationMapping> generateRelationMapping = RelationMapping.generate(sourceRelations, targetRelations,
+                8);
         Assertions.assertNotNull(generateRelationMapping);
         Assertions.assertEquals(6, generateRelationMapping.size());
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
@@ -108,7 +108,8 @@ public abstract class SqlTestBase extends TestWithFeService implements MemoPatte
                 context, new BitSet()).get(0);
         StructInfo st2 = MaterializedViewUtils.extractStructInfo(p2, p2,
                 context, new BitSet()).get(0);
-        RelationMapping rm = RelationMapping.generate(st1.getRelations(), st2.getRelations()).get(0);
+        RelationMapping rm = RelationMapping.generate(st1.getRelations(), st2.getRelations(), 8)
+                .get(0);
         SlotMapping sm = SlotMapping.generate(rm);
         return LogicalCompatibilityContext.from(rm, sm, st1, st2);
     }

--- a/regression-test/suites/nereids_rules_p0/mv/many_self_join/many_self_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/many_self_join/many_self_join.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("relation_map_cross_join_test") {
+suite("many_self_join") {
 
     def db_name = context.config.getDbNameByFile(context.file)
     def tb_name = db_name + "_tb"

--- a/regression-test/suites/nereids_rules_p0/mv/relation_map_cross_join_test/relation_map_cross_join_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/relation_map_cross_join_test/relation_map_cross_join_test.groovy
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("relation_map_cross_join_test") {
+
+    def db_name = context.config.getDbNameByFile(context.file)
+    def tb_name = db_name + "_tb"
+    def mv_name = db_name + "_mtmv"
+    sql """drop table if exists ${tb_name}"""
+    sql """
+        CREATE TABLE ${tb_name} (
+            employee_id INT,
+            employee_name VARCHAR(100),
+            manager_id INT
+        ) ENGINE=OLAP
+        DUPLICATE KEY(employee_id)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`employee_id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        );
+        """
+    sql """
+        INSERT INTO ${tb_name} (employee_id, employee_name, manager_id) VALUES
+            (1, 'CEO', 1),
+            (2, 'Manager1', 1),
+            (3, 'Manager2', 1)
+        """
+
+    sql """drop MATERIALIZED VIEW if exists ${mv_name};"""
+    def mtmv_sql = """SELECT 
+            e1.employee_name AS employee,
+            e2.employee_name AS manager_1,
+            e3.employee_name AS manager_2,
+            e4.employee_name AS manager_3,
+            e5.employee_name AS manager_4,
+            e6.employee_name AS manager_5,
+            e7.employee_name AS manager_6,
+            e8.employee_name AS manager_7,
+            e9.employee_name AS manager_8,
+            e10.employee_name AS manager_9
+        FROM 
+            ${tb_name} e1
+        LEFT JOIN 
+            ${tb_name} e2 ON e1.manager_id = e2.employee_id
+        LEFT JOIN 
+            ${tb_name} e3 ON e2.manager_id = e3.employee_id
+        LEFT JOIN 
+            ${tb_name} e4 ON e3.manager_id = e4.employee_id
+        LEFT JOIN 
+            ${tb_name} e5 ON e4.manager_id = e5.employee_id
+        LEFT JOIN 
+            ${tb_name} e6 ON e5.manager_id = e6.employee_id
+        LEFT JOIN 
+            ${tb_name} e7 ON e6.manager_id = e7.employee_id
+        LEFT JOIN 
+            ${tb_name} e8 ON e7.manager_id = e8.employee_id
+        LEFT JOIN 
+            ${tb_name} e9 ON e8.manager_id = e9.employee_id
+        LEFT JOIN 
+            ${tb_name} e10 ON e9.manager_id = e10.employee_id"""
+
+    create_async_mv(db_name, mv_name, mtmv_sql)
+
+    def mark = true
+    sql """USE ${db_name}"""
+    sql """set enable_nereids_timeout = true;"""
+    try {
+        mv_rewrite_success(mtmv_sql, mv_name)
+    } catch (Exception e) {
+        log.info("e.getMessage(): " + e.getMessage())
+        mark = false
+    }
+
+    assertTrue(mark)
+
+}
+


### PR DESCRIPTION
### What problem does this PR solve?

Fix materialized rewrite oom when the num of relation mapping is two large

In a database query with 10 self-joins on the same table, there would be 10! = 3,628,800 unique permutation combinations. These need to be pruned in advance through query optimization to avoid excessive memory consumption

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

Fix materialized rewrite oom when the num of relation mapping is two large

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

