### PR TITLE
[fix](sql cache) fix prepare statement with sql cache throw NullPointerException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
@@ -32,6 +32,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.privilege.DataMaskPolicy;
 import org.apache.doris.mysql.privilege.RowFilterPolicy;
 import org.apache.doris.nereids.CascadesContext;
@@ -130,6 +131,13 @@ public class NereidsSqlCacheManager {
      * tryAddFeCache
      */
     public void tryAddFeSqlCache(ConnectContext connectContext, String sql) {
+        switch (connectContext.getCommand()) {
+            case COM_STMT_EXECUTE:
+            case COM_STMT_PREPARE:
+                return;
+            default: {}
+        }
+
         Optional<SqlCacheContext> sqlCacheContextOpt = connectContext.getStatementContext().getSqlCacheContext();
         if (!sqlCacheContextOpt.isPresent()) {
             return;
@@ -149,6 +157,12 @@ public class NereidsSqlCacheManager {
      * tryAddBeCache
      */
     public void tryAddBeCache(ConnectContext connectContext, String sql, CacheAnalyzer analyzer) {
+        switch (connectContext.getCommand()) {
+            case COM_STMT_EXECUTE:
+            case COM_STMT_PREPARE:
+                return;
+            default: {}
+        }
         Optional<SqlCacheContext> sqlCacheContextOpt = connectContext.getStatementContext().getSqlCacheContext();
         if (!sqlCacheContextOpt.isPresent()) {
             return;
@@ -180,6 +194,12 @@ public class NereidsSqlCacheManager {
      * tryParseSql
      */
     public Optional<LogicalSqlCache> tryParseSql(ConnectContext connectContext, String sql) {
+        switch (connectContext.getCommand()) {
+            case COM_STMT_EXECUTE:
+            case COM_STMT_PREPARE:
+                return Optional.empty();
+            default: {}
+        }
         String key = generateCacheKey(connectContext, normalizeSql(sql.trim()));
         SqlCacheContext sqlCacheContext = sqlCaches.getIfPresent(key);
         if (sqlCacheContext == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
@@ -32,7 +32,6 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.metric.MetricRepo;
-import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.privilege.DataMaskPolicy;
 import org.apache.doris.mysql.privilege.RowFilterPolicy;
 import org.apache.doris.nereids.CascadesContext;
@@ -135,7 +134,7 @@ public class NereidsSqlCacheManager {
             case COM_STMT_EXECUTE:
             case COM_STMT_PREPARE:
                 return;
-            default: {}
+            default: { }
         }
 
         Optional<SqlCacheContext> sqlCacheContextOpt = connectContext.getStatementContext().getSqlCacheContext();
@@ -161,7 +160,7 @@ public class NereidsSqlCacheManager {
             case COM_STMT_EXECUTE:
             case COM_STMT_PREPARE:
                 return;
-            default: {}
+            default: { }
         }
         Optional<SqlCacheContext> sqlCacheContextOpt = connectContext.getStatementContext().getSqlCacheContext();
         if (!sqlCacheContextOpt.isPresent()) {
@@ -198,7 +197,7 @@ public class NereidsSqlCacheManager {
             case COM_STMT_EXECUTE:
             case COM_STMT_PREPARE:
                 return Optional.empty();
-            default: {}
+            default: { }
         }
         String key = generateCacheKey(connectContext, normalizeSql(sql.trim()));
         SqlCacheContext sqlCacheContext = sqlCaches.getIfPresent(key);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -166,7 +166,7 @@ public class StatementContext implements Closeable {
     private final Stack<CloseableResource> plannerResources = new Stack<>();
 
     // placeholder params for prepared statement
-    private List<Placeholder> placeholders;
+    private List<Placeholder> placeholders = new ArrayList<>();
 
     // all tables in query
     private boolean needLockTables = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -107,9 +107,11 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
         if (ctx.propertyClause() != null) {
             List<DorisParser.PropertyClauseContext> propertyClauseContexts = ctx.propertyClause();
             for (DorisParser.PropertyClauseContext propertyClauseContext : propertyClauseContexts) {
-                encryptProperty(visitPropertyClause(propertyClauseContext),
-                        propertyClauseContext.fileProperties.start.getStartIndex(),
-                        propertyClauseContext.fileProperties.stop.getStopIndex());
+                if (propertyClauseContext != null) {
+                    encryptProperty(visitPropertyClause(propertyClauseContext),
+                            propertyClauseContext.fileProperties.start.getStartIndex(),
+                            propertyClauseContext.fileProperties.stop.getStopIndex());
+                }
             }
         }
         return super.visitCreateTable(ctx);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExecuteCommand.java
@@ -25,6 +25,8 @@ import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapGroupCommitInsertExecutor;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.planner.GroupCommitPlanner;
 import org.apache.doris.qe.ConnectContext;
@@ -68,9 +70,13 @@ public class ExecuteCommand extends Command {
             throw new AnalysisException(
                     "prepare statement " + stmtName + " not found,  maybe expired");
         }
-        PrepareCommand prepareCommand = (PrepareCommand) preparedStmtCtx.command;
-        LogicalPlanAdapter planAdapter = new LogicalPlanAdapter(prepareCommand.getLogicalPlan(), executor.getContext()
-                .getStatementContext());
+        PrepareCommand prepareCommand = preparedStmtCtx.command;
+        LogicalPlan logicalPlan = prepareCommand.getLogicalPlan();
+        if (logicalPlan instanceof LogicalSqlCache) {
+            throw new AnalysisException("Unsupported sql cache for server prepared statement");
+        }
+        LogicalPlanAdapter planAdapter = new LogicalPlanAdapter(
+                logicalPlan, executor.getContext().getStatementContext());
         executor.setParsedStmt(planAdapter);
         // If it's not a short circuit query or schema version is different(indicates schema changed) or
         // has nondeterministic functions in statement, then need to do reanalyze and plan

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -393,6 +393,17 @@ public abstract class ConnectProcessor {
     private List<StatementBase> parseFromSqlCache(String originStmt) {
         StatementContext statementContext = new StatementContext(ctx, new OriginStatement(originStmt, 0));
         ctx.setStatementContext(statementContext);
+
+        // the mysql protocol has different between COM_QUERY and COM_STMT_EXECUTE,
+        // the sql cache use the result of COM_QUERY, so we can not provide the
+        // result of sql cache for COM_STMT_EXECUTE/COM_STMT_PREPARE
+        switch (ctx.getCommand()) {
+            case COM_STMT_EXECUTE:
+            case COM_STMT_PREPARE:
+                return null;
+            default: {}
+        }
+
         try {
             Optional<Pair<ExplainOptions, String>> explainPlan = NereidsParser.tryParseExplainPlan(originStmt);
             String cacheSqlKey = originStmt;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -401,7 +401,7 @@ public abstract class ConnectProcessor {
             case COM_STMT_EXECUTE:
             case COM_STMT_PREPARE:
                 return null;
-            default: {}
+            default: { }
         }
 
         try {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/TestAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/TestAction.groovy
@@ -68,7 +68,7 @@ class TestAction implements SuiteAction {
             } else {
                 if (exception != null || result.exception != null) {
                     def msg = result.exception?.toString()
-                    log.info("Exception: ${msg}")
+                    log.error("Exception: ${msg}", exception != null ? exception : result.exception)
                     Assert.assertTrue("Expect exception msg contains '${exception}', but meet '${msg}'",
                             msg != null && exception != null && msg.contains(exception))
                 }

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -33,12 +33,7 @@ suite("parse_sql_from_sql_cache") {
     }
 
     def dbName = (sql "select database()")[0][0].toString()
-    foreachFrontends { fe ->
-        def url = "jdbc:mysql://${fe.Host}:${fe.QueryPort}/${dbName}"
-        connect(context.config.jdbcUser, context.config.jdbcPassword, url) {
-            sql "ADMIN SET FRONTEND CONFIG ('cache_last_version_interval_second' = '10')"
-        }
-    }
+    sql "ADMIN SET ALL FRONTENDS CONFIG ('cache_last_version_interval_second' = '10')"
 
     // make sure if the table has been dropped, the cache should invalidate,
     // so we should retry multiple times to check

--- a/regression-test/suites/nereids_p0/cache/prepare_stmt_with_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/prepare_stmt_with_sql_cache.groovy
@@ -15,17 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import com.mysql.cj.ServerPreparedQuery
-import com.mysql.cj.jdbc.ConnectionImpl
-import com.mysql.cj.jdbc.JdbcStatement
-import com.mysql.cj.jdbc.ServerPreparedStatement
-import com.mysql.cj.jdbc.StatementImpl
 import org.apache.doris.regression.util.JdbcUtils
 
-import java.lang.reflect.Field
 import java.sql.PreparedStatement
 import java.sql.ResultSet
-import java.util.concurrent.CopyOnWriteArrayList
 
 suite("prepare_stmt_with_sql_cache") {
 
@@ -38,11 +31,13 @@ suite("prepare_stmt_with_sql_cache") {
         insert into test_prepare_stmt_with_sql_cache select * from numbers('number'='100');
         """
 
+    sql "ADMIN SET ALL FRONTENDS CONFIG ('cache_last_version_interval_second' = '10')"
+
     def db = (sql "select database()")[0][0].toString()
 
-    def url = getServerPrepareJdbcUrl(context.config.jdbcUrl, db)
+    def serverPrepareUrl = getServerPrepareJdbcUrl(context.config.jdbcUrl, db)
 
-    connect(context.config.jdbcUser, context.config.jdbcPassword, url) {
+    connect(context.config.jdbcUser, context.config.jdbcPassword, serverPrepareUrl) {
         sql "set enable_sql_cache=true"
         for (def i in 0..<10) {
             try (PreparedStatement pstmt = prepareStatement("select * from test_prepare_stmt_with_sql_cache where id=?")) {
@@ -52,6 +47,30 @@ suite("prepare_stmt_with_sql_cache") {
                     logger.info("result: {}", result)
                 }
             }
+        }
+    }
+
+    sleep(10 * 1000)
+
+    connect(context.config.jdbcUser, context.config.jdbcPassword, context.config.jdbcUrl) {
+        sql "use ${db}"
+        sql "set enable_sql_cache=true"
+        test {
+            sql "select * from test_prepare_stmt_with_sql_cache where id=10"
+            result([[10]])
+        }
+        test {
+            sql "select * from test_prepare_stmt_with_sql_cache where id=10"
+            result([[10]])
+        }
+    }
+
+    connect(context.config.jdbcUser, context.config.jdbcPassword, serverPrepareUrl) {
+        sql "use ${db}"
+        sql "set enable_sql_cache=true"
+        test {
+            sql "select * from test_prepare_stmt_with_sql_cache where id=10"
+            result(([[10]]))
         }
     }
 }

--- a/regression-test/suites/nereids_p0/cache/prepare_stmt_with_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/prepare_stmt_with_sql_cache.groovy
@@ -59,10 +59,6 @@ suite("prepare_stmt_with_sql_cache") {
             sql "select * from test_prepare_stmt_with_sql_cache where id=10"
             result([[10]])
         }
-        test {
-            sql "select * from test_prepare_stmt_with_sql_cache where id=10"
-            result([[10]])
-        }
     }
 
     connect(context.config.jdbcUser, context.config.jdbcPassword, serverPrepareUrl) {


### PR DESCRIPTION
### What problem does this PR solve?

fix prepare statement with sql cache throw NullPointerException, introduced by #33262.

forbid sql cache when useServerPrepStmts=true, the mysql protocol has different between COM_QUERY and COM_STMT_EXECUTE, the sql cache use the result of COM_QUERY, so we can not provide the result of sql cache for COM_STMT_EXECUTE

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

