### PR TITLE
[fix](cloud) dup FDCache reset before FileCache dtor causing crash

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -720,7 +720,6 @@ void ExecEnv::destroy() {
     _memtable_memory_limiter.reset();
     _delta_writer_v2_pool.reset();
     _load_stream_map_pool.reset();
-    _file_cache_open_fd_cache.reset();
     SAFE_STOP(_write_cooldown_meta_executors);
 
     // StorageEngine must be destoried before _cache_manager destory


### PR DESCRIPTION
There is another FDCache reset near line 788, and this previous dup one deconstruct its mutex before BlockFileCache destory in FileCacheFactory thus causing BE crash on following stack:

SIGSEGV address not mapped to object (@0x68) received by PID 222738 (TID 222917 OR 0x7505dc800640) from PID 104; stack trace: *** 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/common/signal_handler.h:421 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /home/qatest/jdk/java-17-openjdk-amd64/lib/server/libjvm.so 2# JVM_handle_linux_signal in /home/qatest/jdk/java-17-openjdk-amd64/lib/server/libjvm.so 3# 0x0000750666842520 in /lib/x86_64-linux-gnu/libc.so.6 4# __pthread_rwlock_wrlock at ./nptl/pthread_rwlock_wrlock.c:26 5# doris::io::FDCache::remove_file_reader(std::pair<doris::io::UInt128Wrapper, unsigned long> const&) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/io/cache/fs_file_cache_storag e.cpp:86
6# doris::io::FSFileCacheStorage::remove(doris::io::FileCacheKey const&) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/io/cache/fs_file_cache_storage.cpp:203


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

