### PR TITLE
[fix](binlog) Wrong judgment of anyEnable for add binlog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -158,11 +158,7 @@ public class BinlogManager {
         if (tableIds != null) {
             for (long tableId : tableIds) {
                 boolean tableBinlogEnable = binlogConfigCache.isEnableTable(dbId, tableId);
-                if (tableIds.size() > 1) {
-                    anyEnable = anyEnable || tableBinlogEnable;
-                } else {
-                    anyEnable = tableBinlogEnable;
-                }
+                anyEnable = anyEnable || tableBinlogEnable;
                 if (anyEnable) {
                     break;
                 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx
```
if (!(table instanceof OlapTable)) {
    LOG.warn("table is not olap table. db: {}, table id: {}", db.getFullName(), tableId);
    return null;
}
```
View don't have `enable binlog` config cache, so binlog is not enabled by default when a view is created.

Related PR: https://github.com/apache/doris/pull/40680

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

