### PR TITLE
[Enhancement](ctas) Support create auto range partition table with CTAS command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/PartitionTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/PartitionTableInfo.java
@@ -329,6 +329,7 @@ public class PartitionTableInfo {
         try {
             identifierPartitionColumns = PartitionDesc.getColNamesFromExpr(exprs,
                     partitionType.equalsIgnoreCase(PartitionType.LIST.name()), isAutoPartition);
+            // check of it will be done in validatePartitionInfo later.
         } catch (Exception e) {
             throw new AnalysisException(e.getMessage(), e.getCause());
         }
@@ -336,5 +337,9 @@ public class PartitionTableInfo {
 
     public boolean inIdentifierPartitions(String columnName) {
         return identifierPartitionColumns != null && identifierPartitionColumns.contains(columnName);
+    }
+
+    public List<String> getIdentifierPartitionColumns() {
+        return identifierPartitionColumns;
     }
 }

--- a/regression-test/suites/nereids_p0/create_table/test_ctas_auto_partition.groovy
+++ b/regression-test/suites/nereids_p0/create_table/test_ctas_auto_partition.groovy
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_ctas_auto_partition") {
+    sql "drop table if exists test_partition__dbt_tmp3"
+    test {
+        sql """
+            create table `test_partition__dbt_tmp3`
+            AUTO PARTITION BY RANGE (date_trunc(`today`, 'day')) ()
+            PROPERTIES ("replication_num" = "1" )
+            as
+            select nullable(current_date()) as today;
+        """
+        exception "AUTO RANGE PARTITION doesn't support NULL column"
+    }
+
+    test {
+        sql """
+            create table `test_partition__dbt_tmp3`
+            AUTO PARTITION BY RANGE (date_trunc(`today`, 'day')) ()
+            PROPERTIES ("replication_num" = "1" )
+            as
+            select cast(null as date) as today;
+        """
+        exception "AUTO RANGE PARTITION doesn't support NULL column"
+    }
+
+    test {
+        sql """
+            create table `test_partition__dbt_tmp3`
+            AUTO PARTITION BY RANGE (date_trunc(`today`, 'day')) ()
+            PROPERTIES ("replication_num" = "1" )
+            as
+            select 1 as today;
+        """
+        exception "partition expr date_trunc is illegal!"
+    }
+
+    test{
+        sql """
+            create table `test_partition__dbt_tmp3`
+            AUTO PARTITION BY RANGE (date_trunc(`today`, 'day'), date_trunc(`today1`, 'day')) ()
+            PROPERTIES ("replication_num" = "1" )
+            as
+            select 1 as today;
+        """
+        exception "auto create partition only support one slotRef in function expr"
+    }
+
+    test{
+        sql """
+            create table `test_partition__dbt_tmp3`
+            AUTO PARTITION BY RANGE (date_trunc(`today`, 'day')) ()
+            PROPERTIES ("replication_num" = "1" )
+            as
+            select current_date() as today, current_date() + 1 as today;
+        """
+        exception "Duplicate column name 'today'"
+    }
+
+    test{
+        sql """
+            create table `test_partition__dbt_tmp3`
+            AUTO PARTITION BY RANGE (date_trunc(`today`, 'day')) ()
+            PROPERTIES ("replication_num" = "1" )
+            as
+            select current_date() as today2, current_date() + 1 as today1;
+        """
+        exception "partition key today is not exists"
+    }
+
+    sql """
+        create table `test_partition__dbt_tmp3`
+        AUTO PARTITION BY RANGE (date_trunc(`today`, 'day')) ()
+        PROPERTIES ("replication_num" = "1" )
+        as
+        select 1 as id, 'cyril' as name, 18 as age, 100 as score, current_date() as today;
+    """
+    assertEquals((sql "select count() from test_partition__dbt_tmp3")[0][0], 1)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

In this case, we do no upgrade of nullable property because user should know they want a non-nullable target column.

### Release note

Don't transform expression to nullable when used to create auto range partition table

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

