### PR TITLE
[fix](variant) update least common type in ColumnObject::pop_back

### DIFF
--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -735,6 +735,9 @@ void ColumnObject::Subcolumn::pop_back(size_t n) {
     size_t sz = data.size() - num_removed;
     data.resize(sz);
     data_types.resize(sz);
+    // need to update least_common_type when pop_back a column from the last
+    least_common_type = sz > 0 ? LeastCommonType {data_types[sz - 1]}
+                               : LeastCommonType {std::make_shared<DataTypeNothing>()};
     num_of_defaults_in_prefix -= n;
 }
 

--- a/be/test/vec/columns/column_object_test.cpp
+++ b/be/test/vec/columns/column_object_test.cpp
@@ -25,6 +25,7 @@ namespace doris::vectorized {
 
 class ColumnObjectTest : public ::testing::Test {};
 
+// TEST
 TEST_F(ColumnObjectTest, test_pop_back) {
     ColumnObject::Subcolumn subcolumn(0, true /* is_nullable */, false /* is_root */);
 
@@ -37,6 +38,93 @@ TEST_F(ColumnObjectTest, test_pop_back) {
     subcolumn.pop_back(1);
     EXPECT_EQ(subcolumn.size(), 1);
     EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int8)");
+
+    subcolumn.pop_back(1);
+    EXPECT_EQ(subcolumn.size(), 0);
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nothing");
+}
+
+TEST_F(ColumnObjectTest, test_pop_back_multiple_types) {
+    ColumnObject::Subcolumn subcolumn(0, true /* is_nullable */, false /* is_root */);
+
+    Field field_int8(42);
+    subcolumn.insert(field_int8);
+    EXPECT_EQ(subcolumn.size(), 1);
+    EXPECT_EQ(subcolumn.data_types.size(), 1);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int8)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int8)");
+
+    Field field_int16(12345);
+    subcolumn.insert(field_int16);
+    EXPECT_EQ(subcolumn.size(), 2);
+    EXPECT_EQ(subcolumn.data_types.size(), 2);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int8)");
+    EXPECT_EQ(subcolumn.data_types[1]->get_name(), "Nullable(Int16)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int16)");
+
+    Field field_int32(1234567);
+    subcolumn.insert(field_int32);
+    EXPECT_EQ(subcolumn.size(), 3);
+    EXPECT_EQ(subcolumn.data_types.size(), 3);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int8)");
+    EXPECT_EQ(subcolumn.data_types[1]->get_name(), "Nullable(Int16)");
+    EXPECT_EQ(subcolumn.data_types[2]->get_name(), "Nullable(Int32)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int32)");
+
+    subcolumn.pop_back(1);
+    EXPECT_EQ(subcolumn.size(), 2);
+    EXPECT_EQ(subcolumn.data_types.size(), 2);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int8)");
+    EXPECT_EQ(subcolumn.data_types[1]->get_name(), "Nullable(Int16)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int16)");
+
+    subcolumn.pop_back(1);
+    EXPECT_EQ(subcolumn.size(), 1);
+    EXPECT_EQ(subcolumn.data_types.size(), 1);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int8)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int8)");
+
+    subcolumn.pop_back(1);
+    EXPECT_EQ(subcolumn.size(), 0);
+    EXPECT_EQ(subcolumn.data_types.size(), 0);
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nothing");
+
+    subcolumn.insert(field_int32);
+    EXPECT_EQ(subcolumn.size(), 1);
+    EXPECT_EQ(subcolumn.data_types.size(), 1);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int32)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int32)");
+
+    subcolumn.insert(field_int16);
+    EXPECT_EQ(subcolumn.size(), 2);
+    EXPECT_EQ(subcolumn.data_types.size(), 1);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int32)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int32)");
+
+    subcolumn.insert(field_int8);
+    EXPECT_EQ(subcolumn.size(), 3);
+    EXPECT_EQ(subcolumn.data_types.size(), 1);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int32)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int32)");
+
+    subcolumn.pop_back(1);
+    EXPECT_EQ(subcolumn.size(), 2);
+    EXPECT_EQ(subcolumn.data_types.size(), 1);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int32)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int32)");
+
+    Field field_string("hello");
+    subcolumn.insert(field_string);
+    EXPECT_EQ(subcolumn.size(), 3);
+    EXPECT_EQ(subcolumn.data_types.size(), 2);
+    EXPECT_EQ(subcolumn.data_types[0]->get_name(), "Nullable(Int32)");
+    EXPECT_EQ(subcolumn.data_types[1]->get_name(), "Nullable(JSONB)");
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(JSONB)");
+
+    subcolumn.pop_back(3);
+    EXPECT_EQ(subcolumn.size(), 0);
+    EXPECT_EQ(subcolumn.data_types.size(), 0);
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nothing");
 }
 
 } // namespace doris::vectorized

--- a/be/test/vec/columns/column_object_test.cpp
+++ b/be/test/vec/columns/column_object_test.cpp
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/columns/column_object.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
+
+namespace doris::vectorized {
+
+class ColumnObjectTest : public ::testing::Test {};
+
+TEST_F(ColumnObjectTest, test_pop_back) {
+    ColumnObject::Subcolumn subcolumn(0, true /* is_nullable */, false /* is_root */);
+
+    Field field_int(123);
+    Field field_string("hello");
+
+    subcolumn.insert(field_int);
+    subcolumn.insert(field_string);
+
+    subcolumn.pop_back(1);
+    EXPECT_EQ(subcolumn.size(), 1);
+    EXPECT_EQ(subcolumn.get_least_common_type()->get_name(), "Nullable(Int8)");
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. In a subcolumn, each time a different type of column is inserted, the `least_common_type` is updated.
2. Similarly, each time a column is popped back, the `least_common_type` needs to be updated as well.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

