### PR TITLE
[opt](paimon)Add suppressed information display

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -658,6 +658,26 @@ public class Util {
         return rootCause;
     }
 
+    public static String getRootCauseWithSuppressedMessage(Throwable t) {
+        String rootCause;
+        Throwable p = t;
+        while (p.getCause() != null) {
+            p = p.getCause();
+        }
+        String message = p.getMessage();
+        if (message == null) {
+            rootCause = p.getClass().getName();
+        } else {
+            rootCause = p.getClass().getName() + ": " + p.getMessage();
+        }
+        StringBuilder msg = new StringBuilder(rootCause);
+        Throwable[] suppressed = p.getSuppressed();
+        for (int i = 0; i < suppressed.length; i++) {
+            msg.append(" With suppressed").append("[").append(i).append("]:").append(suppressed[i].getMessage());
+        }
+        return msg.toString();
+    }
+
     // Return the stack of the root cause
     public static String getRootCauseStack(Throwable t) {
         String rootStack = "unknown";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1172,7 +1172,7 @@ public class StmtExecutor {
         } catch (Exception e) {
             LOG.warn("execute Exception. {}", context.getQueryIdentifier(), e);
             context.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
-                    e.getClass().getSimpleName() + ", msg: " + Util.getRootCauseMessage(e));
+                    e.getClass().getSimpleName() + ", msg: " + Util.getRootCauseWithSuppressedMessage(e));
             if (parsedStmt instanceof KillStmt) {
                 // ignore kill stmt execute err(not monitor it)
                 context.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/UtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/UtilTest.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UtilTest {
+
+    @Test
+    public void getRootCauseWithSuppressedMessageRootCauseWithMessageNoSuppressed() {
+        Exception rootCause = new Exception("Root cause message");
+        Assertions.assertEquals("java.lang.Exception: Root cause message",
+                Util.getRootCauseWithSuppressedMessage(rootCause));
+    }
+
+    @Test
+    public void getRootCauseWithSuppressedMessageRootCauseWithMessageWithSuppressed() {
+        Exception rootCause = new Exception("Root cause message");
+        rootCause.addSuppressed(new Exception("Suppressed message"));
+        Assertions.assertEquals(
+                "java.lang.Exception: Root cause message With suppressed[0]:Suppressed message",
+                Util.getRootCauseWithSuppressedMessage(rootCause));
+    }
+
+    @Test
+    public void getRootCauseWithSuppressedMessageRootCauseWithMessageWithMultiSuppressed() {
+        Exception rootCause = new Exception("Root cause message");
+        rootCause.addSuppressed(new Exception("Suppressed message"));
+        rootCause.addSuppressed(new Exception("Suppressed message2"));
+        Assertions.assertEquals(
+                "java.lang.Exception: Root cause message "
+                            + "With suppressed[0]:Suppressed message"
+                            + "With suppressed[1]:Suppressed message2",
+                Util.getRootCauseWithSuppressedMessage(rootCause));
+    }
+
+    @Test
+    public void getRootCauseWithSuppressedMessageRootCauseWithoutMessageNoSuppressed() {
+        Exception rootCause = new Exception();
+        Assertions.assertEquals("java.lang.Exception", Util.getRootCauseWithSuppressedMessage(rootCause));
+    }
+
+    @Test
+    public void getRootCauseWithSuppressedMessageRootCauseWithoutMessageWithSuppressed() {
+        Exception rootCause = new Exception();
+        rootCause.addSuppressed(new Exception("Suppressed message"));
+        Assertions.assertEquals(
+                "java.lang.Exception With suppressed[0]:Suppressed message",
+                Util.getRootCauseWithSuppressedMessage(rootCause));
+    }
+
+    @Test
+    public void getRootCauseWithSuppressedMessageChainedExceptionWithChainedSuppressed() {
+        Exception rootCause = new Exception("Root cause message");
+        Exception chainedException = new Exception("Chained exception", rootCause);
+        chainedException.addSuppressed(new Exception("Suppressed message"));
+        Assertions.assertEquals("java.lang.Exception: Root cause message",
+                Util.getRootCauseWithSuppressedMessage(chainedException));
+    }
+
+    @Test
+    public void getRootCauseWithSuppressedMessageChainedExceptionWithCauseSuppressed() {
+        Exception rootCause = new Exception("Root cause message");
+        Exception chainedException = new Exception("Chained exception", rootCause);
+        rootCause.addSuppressed(new Exception("Suppressed message"));
+        Assertions.assertEquals(
+                "java.lang.Exception: Root cause message With suppressed[0]:Suppressed message",
+                Util.getRootCauseWithSuppressedMessage(chainedException));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/UtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/UtilTest.java
@@ -44,9 +44,9 @@ public class UtilTest {
         rootCause.addSuppressed(new Exception("Suppressed message"));
         rootCause.addSuppressed(new Exception("Suppressed message2"));
         Assertions.assertEquals(
-                "java.lang.Exception: Root cause message "
-                            + "With suppressed[0]:Suppressed message"
-                            + "With suppressed[1]:Suppressed message2",
+                "java.lang.Exception: Root cause message"
+                            + " With suppressed[0]:Suppressed message"
+                            + " With suppressed[1]:Suppressed message2",
                 Util.getRootCauseWithSuppressedMessage(rootCause));
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Some important error messages may be suppressed after caused. If you only look at the caused information, it may be misleading, so the suppressed information is also displayed so that you can have more error information to locate the problem.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

