### PR TITLE
[fix] (streamload) fixed the issue of data loss due to concurrency wh…

### DIFF
--- a/be/src/vec/sink/writer/async_result_writer.cpp
+++ b/be/src/vec/sink/writer/async_result_writer.cpp
@@ -130,42 +130,44 @@ void AsyncResultWriter::process_block(RuntimeState* state, RuntimeProfile* profi
     }
 
     DCHECK(_dependency);
-    if (_writer_status.ok()) {
-        while (true) {
-            ThreadCpuStopWatch cpu_time_stop_watch;
-            cpu_time_stop_watch.start();
-            Defer defer {[&]() {
-                if (state && state->get_query_ctx()) {
-                    state->get_query_ctx()->resource_ctx()->cpu_context()->update_cpu_cost_ms(
-                            cpu_time_stop_watch.elapsed_time());
-                }
-            }};
-            if (!_eos && _data_queue.empty() && _writer_status.ok()) {
-                std::unique_lock l(_m);
-                while (!_eos && _data_queue.empty() && _writer_status.ok()) {
-                    // Add 1s to check to avoid lost signal
-                    _cv.wait_for(l, std::chrono::seconds(1));
-                }
+    while (_writer_status.ok()) {
+        ThreadCpuStopWatch cpu_time_stop_watch;
+        cpu_time_stop_watch.start();
+        Defer defer {[&]() {
+            if (state && state->get_query_ctx()) {
+                state->get_query_ctx()->resource_ctx()->cpu_context()->update_cpu_cost_ms(
+                        cpu_time_stop_watch.elapsed_time());
+            }
+        }};
+
+        //1) wait scan operator write data
+        {
+            std::unique_lock l(_m);
+            while (!_eos && _data_queue.empty() && _writer_status.ok()) {
+                // Add 1s to check to avoid lost signal
+                _cv.wait_for(l, std::chrono::seconds(1));
             }
 
+            //check if eos or writer error
             if ((_eos && _data_queue.empty()) || !_writer_status.ok()) {
                 _data_queue.clear();
                 break;
             }
-
-            auto block = _get_block_from_queue();
-            auto status = write(state, *block);
-            if (!status.ok()) [[unlikely]] {
-                std::unique_lock l(_m);
-                _writer_status.update(status);
-                if (_is_finished()) {
-                    _dependency->set_ready();
-                }
-                break;
-            }
-
-            _return_free_block(std::move(block));
         }
+
+        //2) get the block from  data queue and write to downstream
+        auto block = _get_block_from_queue();
+        auto status = write(state, *block);
+        if (!status.ok()) [[unlikely]] {
+            std::unique_lock l(_m);
+            _writer_status.update(status);
+            if (_is_finished()) {
+                _dependency->set_ready();
+            }
+            break;
+        }
+
+        _return_free_block(std::move(block));
     }
 
     bool need_finish = false;


### PR DESCRIPTION
…en importing data from streamload

### What problem does this PR solve?

This is mainly to solve the multithreading problem caused by inconsistent visible order of EOS and data_queue variables in doris's streamload function and asyn_result_writer in the process_block process due to the compilation reordering of the ARM system or the weak memory order problem, which leads to data loss.

Problem Summary:

Mainly in the arm architecture, streamload has data loss problems. The transaction of importing data can be executed and submitted normally, but the NumberTotalRowshe NumberFilterRows in the returned load result are both zero
[Uploading stream_load_lost_data.docx…]()
((https://github.com/user-attachments/files/19201955/stream_load.docx))


