### PR TITLE
[fix](Nereids) fix substring with only one parameter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/StringArithmetic.java
@@ -83,7 +83,7 @@ public class StringArithmetic {
         if (stringLength == 0) {
             return "";
         }
-        int leftIndex = 0;
+        long leftIndex = 0;
         if (second < (- stringLength)) {
             return "";
         } else if (second < 0) {
@@ -93,7 +93,7 @@ public class StringArithmetic {
         } else {
             return "";
         }
-        int rightIndex = 0;
+        long rightIndex = 0;
         if (third <= 0) {
             return "";
         } else if ((third + leftIndex) > stringLength) {
@@ -101,7 +101,8 @@ public class StringArithmetic {
         } else {
             rightIndex = third + leftIndex;
         }
-        return first.substring(leftIndex, rightIndex);
+        // left index and right index are in integer range because of definition, so we can safely cast it to int
+        return first.substring((int) leftIndex, (int) rightIndex);
     }
 
     /**

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -663,6 +663,9 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("select substr('abcdef',3,-1)")
     testFoldConst("select substr('',3,-1)")
     testFoldConst("select substr('abcdef',3,10)")
+    testFoldConst("select substr('abcdef',-3)")
+    testFoldConst("select substr('abcdef',3)")
+    testFoldConst("select substr('',3)")
 
     // substring
     testFoldConst("select substring('1', 1, 1)")
@@ -689,6 +692,9 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("select substring('Hello World', 1, 5)")
     testFoldConst("select substring('', 1, 5)")
     testFoldConst("select substring('Hello World', 1, 50)")
+    testFoldConst("select substring('abcdef',-3)")
+    testFoldConst("select substring('abcdef',3)")
+    testFoldConst("select substring('',3)")
 
     // substring_index
     testFoldConst("select substring_index('a,b,c', ',', 2)")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

explain select substr('abcd', 2); would failed at fe fold constant because third parameter set to integer max. Should check upper bound when calculating

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

