### PR TITLE
[Fix](compaction) Fix full compaction error when compaction size is too large

### DIFF
--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -181,6 +181,8 @@ Status RowSourcesBuffer::_create_buffer_file() {
     } else if (_reader_type == ReaderType::READER_CUMULATIVE_COMPACTION ||
                _reader_type == ReaderType::READER_SEGMENT_COMPACTION) {
         file_path_ss << "_cumu";
+    } else if (_reader_type == ReaderType::READER_FULL_COMPACTION) {
+        file_path_ss << "_full";
     } else if (_reader_type == ReaderType::READER_COLD_DATA_COMPACTION) {
         file_path_ss << "_cold";
     } else {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

```
W20250311 19:24:08.770080  1257 cloud_full_compaction.cpp:158] fail to do CloudFullCompaction. res=[INTERNAL_ERROR]unknown reader type

        0#  doris::vectorized::RowSourcesBuffer::_create_buffer_file() at /root/tools/ldb-16/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/1
1/sstream:1054
        1#  doris::vectorized::RowSourcesBuffer::append(std::vector<doris::vectorized::RowSource, std::allocator<doris::vectorized::RowSource> > const&) 
at /root/selectdb-core/be/src/common/status.h:501
        2#  doris::vectorized::VerticalHeapMergeIterator::next_batch(doris::vectorized::Block*) at /root/selectdb-core/be/src/common/status.h:501
        3#  doris::vectorized::VerticalBlockReader::_unique_key_next_block(doris::vectorized::Block*, bool*) at /root/selectdb-core/be/src/common/status.
h:501
        4#  doris::vectorized::VerticalBlockReader::next_block_with_aggregation(doris::vectorized::Block*, bool*) at /root/tools/ldb-16/bin/../lib/gcc/x8
6_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:907
        5#  doris::Merger::vertical_compact_one_group(std::shared_ptr<doris::BaseTablet>, doris::ReaderType, doris::TabletSchema const&, bool, std::vecto
r<unsigned int, std::allocator<unsigned int> > const&, doris::vectorized::RowSourcesBuffer*, std::vector<std::shared_ptr<doris::RowsetReader>, std::alloc
ator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, long, doris::Merger::Statistics*, std::vector<unsigned int, std::allocator<un
signed int> >, long, doris::CompactionSampleInfo*) at /root/selectdb-core/be/src/olap/merger.cpp:0
        6#  doris::Merger::vertical_merge_rowsets(std::shared_ptr<doris::BaseTablet>, doris::ReaderType, doris::TabletSchema const&, std::vector<std::sha
red_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, long, long, doris::Merger::Statistics
*) at /root/selectdb-core/be/src/olap/merger.cpp:454
        7#  doris::Compaction::merge_input_rowsets() at /root/selectdb-core/be/src/olap/compaction.cpp:191
        8#  doris::CloudCompactionMixin::execute_compact_impl(long) at /root/selectdb-core/be/src/common/status.h:501
        9#  doris::CloudCompactionMixin::execute_compact() at /root/selectdb-core/be/src/common/status.h:501
        10# doris::CloudFullCompaction::execute_compact() at /root/selectdb-core/be/src/common/status.h:501
        11# std::_Function_handler<void (), doris::CloudStorageEngine::_submit_full_compaction_task(std::shared_ptr<doris::CloudTablet> const&)::$_0>::_M
_invoke(std::_Any_data const&) at /root/selectdb-core/be/src/common/status.h:501
        12# doris::ThreadPool::dispatch_thread() at /root/selectdb-core/be/src/util/threadpool.cpp:0
        13# doris::Thread::supervise_thread(void*) at /root/tools/ldb-16/bin/../usr/include/pthread.h:562
        14# ?
        15# clone
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

