### PR TITLE
[fix](minor) Reorder incorrect logging

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -856,6 +856,12 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
                         current_connect_fe_addr = params.coord;
                     }
 
+                    // This may be a first fragment request of the query.
+                    // Create the query fragments context.
+                    query_ctx = QueryContext::create_shared(
+                            query_id, params.fragment_num_on_host, _exec_env, params.query_options,
+                            params.coord, pipeline, params.is_nereids, current_connect_fe_addr,
+                            query_source);
                     VLOG(10) << "query_id: " << print_id(query_id)
                              << ", coord_addr: " << params.coord
                              << ", total fragment num on current host: "
@@ -864,13 +870,6 @@ Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, boo
                              << ", query type: " << params.query_options.query_type
                              << ", report audit fe:" << current_connect_fe_addr << ", limit: "
                              << PrettyPrinter::print(query_ctx->mem_limit(), TUnit::BYTES);
-
-                    // This may be a first fragment request of the query.
-                    // Create the query fragments context.
-                    query_ctx = QueryContext::create_shared(
-                            query_id, params.fragment_num_on_host, _exec_env, params.query_options,
-                            params.coord, pipeline, params.is_nereids, current_connect_fe_addr,
-                            query_source);
                     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(query_ctx->query_mem_tracker);
                     RETURN_IF_ERROR(DescriptorTbl::create(&(query_ctx->obj_pool), params.desc_tbl,
                                                           &(query_ctx->desc_tbl)));


### PR DESCRIPTION
### What problem does this PR solve?

*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1741780869 (unix time) try "date -d @1741780869" if you are using GNU date ***
*** Current BE git commitID: e455bceb91 ***
*** SIGSEGV address not mapped to object (@0x1e0) received by PID 5145 (TID 6323 OR 0x7f07c3e83640) from PID 480; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007F09DF269520 in /lib/x86_64-linux-gnu/libc.so.6
 2# doris::FragmentMgr::_get_query_ctx<doris::TPipelineFragmentParams>(doris::TPipelineFragmentParams const&, doris::TUniqueId, bool, doris::QuerySource, std::shared_ptr<doris::QueryContext>&)::{lambda(phmap::flat_hash_map<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, phmap::Hash<doris::TUniqueId>, phmap::EqualTo<doris::TUniqueId>, std::allocator<std::pair<doris::TUniqueId const, std::shared_ptr<doris::QueryContext> > > >&)#1}::operator()(phmap::flat_hash_map<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, phmap::Hash<doris::TUniqueId>, phmap::EqualTo<doris::TUniqueId>, std::allocator<std::pair<doris::TUniqueId const, std::shared_ptr<doris::QueryContext> > > >&) const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:847
 3# std::_Function_handler<doris::Status (phmap::flat_hash_map<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, phmap::Hash<doris::TUniqueId>, phmap::EqualTo<doris::TUniqueId>, std::allocator<std::pair<doris::TUniqueId const, std::shared_ptr<doris::QueryContext> > > >&), doris::FragmentMgr::_get_query_ctx<doris::TPipelineFragmentParams>(doris::TPipelineFragmentParams const&, doris::TUniqueId, bool, doris::QuerySource, std::shared_ptr<doris::QueryContext>&)::{lambda(phmap::flat_hash_map<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, phmap::Hash<doris::TUniqueId>, phmap::EqualTo<doris::TUniqueId>, std::allocator<std::pair<doris::TUniqueId const, std::shared_ptr<doris::QueryContext> > > >&)#1}>::_M_invoke(std::_Any_data const&, phmap::flat_hash_map<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, phmap::Hash<doris::TUniqueId>, phmap::EqualTo<doris::TUniqueId>, std::allocator<std::pair<doris::TUniqueId const, std::shared_ptr<doris::QueryContext> > > >&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 4# doris::ConcurrentContextMap<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, doris::QueryContext>::apply_if_not_exists(doris::TUniqueId const&, std::shared_ptr<doris::QueryContext>&, std::function<doris::Status (phmap::flat_hash_map<doris::TUniqueId, std::shared_ptr<doris::QueryContext>, phmap::Hash<doris::TUniqueId>, phmap::EqualTo<doris::TUniqueId>, std::allocator<std::pair<doris::TUniqueId const, std::shared_ptr<doris::QueryContext> > > >&)>&&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:275
 5# doris::Status doris::FragmentMgr::_get_query_ctx<doris::TPipelineFragmentParams>(doris::TPipelineFragmentParams const&, doris::TUniqueId, bool, doris::QuerySource, std::shared_ptr<doris::QueryContext>&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:847
 6# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, doris::QuerySource, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:1060
 7# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, doris::QuerySource) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/runtime/fragment_mgr.cpp:782
 8# doris::PInternalServiceImpl::_exec_plan_fragment_impl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::PFragmentRequestVersion, bool, std::function<void (doris::RuntimeState*, doris::Status*)> const&) in /mnt/hdd01/dorisTestEnv/NEREIDS_ASAN/be/lib/doris_be
 9# doris::PInternalServiceImpl::_exec_plan_fragment_in_pthread(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/service/internal_service.cpp:356
10# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/work_thread_pool.hpp:159
11# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
12# start_thread at ./nptl/pthread_create.c:442
13# 0x00007F09DF34D850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

