### PR TITLE
[opt](iceberg)Optimize count* in batch mode

### DIFF
--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_optimize_count.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_optimize_count.groovy
@@ -55,21 +55,76 @@ suite("test_iceberg_optimize_count", "p0,external,doris,external_docker,external
         qt_q03 """${sqlstr3}""" 
         qt_q04 """${sqlstr4}""" 
 
+        // traditional mode
+        sql """set num_partitions_in_batch_mode=1"""
+        explain {
+            sql("""select * from sample_cow_orc""")
+            notContains "approximate"
+        }
         explain {
             sql("""${sqlstr1}""")
             contains """pushdown agg=COUNT (1000)"""
+        }
+        explain {
+            sql("""select * from sample_cow_parquet""")
+            notContains "approximate"
         }
         explain {
             sql("""${sqlstr2}""")
             contains """pushdown agg=COUNT (1000)"""
         }
         explain {
+            sql("""select * from sample_mor_orc""")
+            notContains "approximate"
+        }
+        explain {
             sql("""${sqlstr3}""")
             contains """pushdown agg=COUNT (1000)"""
         }
+        // because it has dangling delete
         explain {
             sql("""${sqlstr4}""")
             contains """pushdown agg=COUNT (-1)"""
+        }
+
+        // batch mode
+        sql """set num_partitions_in_batch_mode=1025"""
+        explain {
+            sql("""select * from sample_cow_orc""")
+            contains "approximate"
+        }
+        explain {
+            sql("""${sqlstr1}""")
+            contains """pushdown agg=COUNT (1000)"""
+            notContains "approximate"
+        }
+        explain {
+            sql("""select * from sample_cow_parquet""")
+            contains "approximate"
+        }
+        explain {
+            sql("""${sqlstr2}""")
+            contains """pushdown agg=COUNT (1000)"""
+            notContains "approximate"
+        }
+        explain {
+            sql("""select * from sample_mor_orc""")
+            contains "approximate"
+        }
+        explain {
+            sql("""${sqlstr3}""")
+            contains """pushdown agg=COUNT (1000)"""
+            notContains "approximate"
+        }
+        explain {
+            sql("""select * from sample_mor_parquet""")
+            contains "approximate"
+        }
+        // because it has dangling delete
+        explain {
+            sql("""${sqlstr4}""")
+            contains """pushdown agg=COUNT (-1)"""
+            contains "approximate"
         }
 
         // don't use push down count
@@ -110,6 +165,7 @@ suite("test_iceberg_optimize_count", "p0,external,doris,external_docker,external
 
     } finally {
         sql """ set enable_count_push_down_for_external_table=true; """
+        sql """set num_partitions_in_batch_mode=1024"""
         // sql """drop catalog if exists ${catalog_name}"""
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When using batch mode, if count* optimization is available, the traditional mode will be used.
Otherwise, it is impossible to calculate how many counts should be assigned to each split because we do not know how many splits there are.

Related #46398

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

