### PR TITLE
[Fix](function) Fix wrong FE fold constant implementation of function date_format

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -295,14 +295,14 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter().format(
+        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
                 java.time.LocalDate.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()))));
     }
 
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateTimeLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter().format(
+        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
                 java.time.LocalDateTime.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()),
                         ((int) date.getHour()), ((int) date.getMinute()), ((int) date.getSecond()))));
     }
@@ -310,14 +310,14 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateV2Literal date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter().format(
+        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
                 java.time.LocalDate.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()))));
     }
 
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateTimeV2Literal date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter().format(
+        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
                 java.time.LocalDateTime.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()),
                         ((int) date.getHour()), ((int) date.getMinute()), ((int) date.getSecond()))));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
@@ -74,7 +74,7 @@ public class DateUtils {
                         break;
                     case 'h': // %h Hour (01..12)
                     case 'I': // %I Hour (01..12)
-                        builder.appendValue(ChronoField.HOUR_OF_AMPM, 2);
+                        builder.appendValue(ChronoField.CLOCK_HOUR_OF_AMPM, 2);
                         break;
                     case 'i': // %i Minutes, numeric (00..59)
                         builder.appendValue(ChronoField.MINUTE_OF_HOUR, 2);
@@ -86,7 +86,7 @@ public class DateUtils {
                         builder.appendValue(ChronoField.HOUR_OF_DAY);
                         break;
                     case 'l': // %l Hour (1..12)
-                        builder.appendValue(ChronoField.HOUR_OF_AMPM);
+                        builder.appendValue(ChronoField.CLOCK_HOUR_OF_AMPM);
                         break;
                     case 'M': // %M Month name (January..December)
                         builder.appendText(ChronoField.MONTH_OF_YEAR, TextStyle.FULL);
@@ -98,8 +98,10 @@ public class DateUtils {
                         builder.appendText(ChronoField.AMPM_OF_DAY);
                         break;
                     case 'r': // %r Time, 12-hour (hh:mm:ss followed by AM or PM)
-                        builder.appendValue(ChronoField.HOUR_OF_AMPM, 2)
+                        builder.appendValue(ChronoField.CLOCK_HOUR_OF_AMPM, 2)
+                                .appendLiteral(':')
                                 .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+                                .appendLiteral(':')
                                 .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
                                 .appendLiteral(' ')
                                 .appendText(ChronoField.AMPM_OF_DAY, TextStyle.FULL)

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_date_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_date_arithmatic.groovy
@@ -29,4 +29,13 @@ suite("fold_constant_date_arithmatic") {
     testFoldConst("select substr(current_date(), 1, 10);")
     testFoldConst("select substr(current_timestamp(), 1, 10);")
     testFoldConst("select substr(current_timestamp(3), 1, 10);")
+
+    testFoldConst("SELECT date_format('2020-12-01 00:00:30.01', '%h');")
+    testFoldConst("SELECT date_format('2020-12-01 00:00:30.01', '%I');")
+    testFoldConst("SELECT date_format('2020-12-01 00:00:30.01', '%l');")
+    testFoldConst("SELECT date_format('2020-12-01 00:00:30.01', '%r');")
+    testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%h');")
+    testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%I');")
+    testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%l');")
+    testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%r');")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before, the FE fold impl is wrong for format string `%h`, `%I`, `%l`, `%r` in sometime.

### Release note

Fix wrong constant folding result of function `date_format` in sometime.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

