### PR TITLE
[fix](Nereids) fix str_to_date date value out of range

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -302,8 +302,7 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateTimeLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue())
-                .withResolverStyle(ResolverStyle.STRICT).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue()).format(
                 java.time.LocalDateTime.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()),
                         ((int) date.getHour()), ((int) date.getMinute()), ((int) date.getSecond()))));
     }
@@ -311,16 +310,14 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateV2Literal date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue())
-                .withResolverStyle(ResolverStyle.STRICT).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue()).format(
                 java.time.LocalDate.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()))));
     }
 
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateTimeV2Literal date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue())
-                .withResolverStyle(ResolverStyle.STRICT).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue()).format(
                 java.time.LocalDateTime.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()),
                         ((int) date.getHour()), ((int) date.getMinute()), ((int) date.getSecond()))));
     }
@@ -542,8 +539,7 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "unix_timestamp")
     public static Expression unixTimestamp(StringLikeLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        DateTimeFormatter formatter = DateUtils.dateTimeFormatter(format.getValue())
-                .withResolverStyle(ResolverStyle.STRICT);
+        DateTimeFormatter formatter = DateUtils.dateTimeFormatter(format.getValue());
         LocalDateTime dateObj;
         try {
             dateObj = LocalDateTime.parse(date.getValue(), formatter);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -295,14 +295,15 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue()).format(
                 java.time.LocalDate.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()))));
     }
 
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateTimeLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue())
+                .withResolverStyle(ResolverStyle.STRICT).format(
                 java.time.LocalDateTime.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()),
                         ((int) date.getHour()), ((int) date.getMinute()), ((int) date.getSecond()))));
     }
@@ -310,14 +311,16 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateV2Literal date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue())
+                .withResolverStyle(ResolverStyle.STRICT).format(
                 java.time.LocalDate.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()))));
     }
 
     @ExecFunction(name = "date_format")
     public static Expression dateFormat(DateTimeV2Literal date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        return new VarcharLiteral(DateUtils.formatBuilder(format.getValue()).toFormatter(Locale.US).format(
+        return new VarcharLiteral(DateUtils.dateTimeFormatter(format.getValue())
+                .withResolverStyle(ResolverStyle.STRICT).format(
                 java.time.LocalDateTime.of(((int) date.getYear()), ((int) date.getMonth()), ((int) date.getDay()),
                         ((int) date.getHour()), ((int) date.getMinute()), ((int) date.getSecond()))));
     }
@@ -539,7 +542,8 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "unix_timestamp")
     public static Expression unixTimestamp(StringLikeLiteral date, StringLikeLiteral format) {
         format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-        DateTimeFormatter formatter = DateUtils.formatBuilder(format.getValue()).toFormatter();
+        DateTimeFormatter formatter = DateUtils.dateTimeFormatter(format.getValue())
+                .withResolverStyle(ResolverStyle.STRICT);
         LocalDateTime dateObj;
         try {
             dateObj = LocalDateTime.parse(date.getValue(), formatter);
@@ -630,20 +634,20 @@ public class DateTimeExtractAndTransform {
             if (returnType instanceof DateTimeV2Type) {
                 boolean hasMicroPart = org.apache.doris.analysis.DateLiteral
                         .hasMicroSecondPart(format.getStringValue());
-                return DateTimeV2Literal.fromJavaDateType(DateUtils.getTime(DateUtils.formatBuilder(format.getValue())
-                        .toFormatter(), str.getValue()), hasMicroPart ? 6 : 0);
+                return DateTimeV2Literal.fromJavaDateType(DateUtils.getTime(DateUtils
+                        .dateTimeFormatter(format.getValue()), str.getValue()), hasMicroPart ? 6 : 0);
             } else {
-                return DateTimeLiteral.fromJavaDateType(DateUtils.getTime(DateUtils.formatBuilder(format.getValue())
-                        .toFormatter(), str.getValue()));
+                return DateTimeLiteral.fromJavaDateType(DateUtils.getTime(DateUtils
+                        .dateTimeFormatter(format.getValue()), str.getValue()));
             }
         } else {
             DataType returnType = DataType.fromCatalogType(ScalarType.getDefaultDateType(Type.DATE));
             if (returnType instanceof DateV2Type) {
-                return DateV2Literal.fromJavaDateType(DateUtils.getTime(DateUtils.formatBuilder(format.getValue())
-                        .toFormatter(), str.getValue()));
+                return DateV2Literal.fromJavaDateType(DateUtils.getTime(DateUtils.dateTimeFormatter(format.getValue()),
+                        str.getValue()));
             } else {
-                return DateLiteral.fromJavaDateType(DateUtils.getTime(DateUtils.formatBuilder(format.getValue())
-                        .toFormatter(), str.getValue()));
+                return DateLiteral.fromJavaDateType(DateUtils.getTime(DateUtils.dateTimeFormatter(format.getValue()),
+                        str.getValue()));
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
@@ -27,12 +27,14 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.WeekFields;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -47,7 +49,7 @@ public class DateUtils {
     /**
      * format builder.
      */
-    public static DateTimeFormatterBuilder formatBuilder(String pattern) throws AnalysisException {
+    public static DateTimeFormatter dateTimeFormatter(String pattern) throws AnalysisException {
         DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
         boolean escaped = false;
         for (int i = 0; i < pattern.length(); i++) {
@@ -159,7 +161,7 @@ public class DateUtils {
                 builder.appendLiteral(character);
             }
         }
-        return builder;
+        return builder.toFormatter(Locale.US).withResolverStyle(ResolverStyle.STRICT);
     }
 
     /**

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_date_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_date_arithmatic.groovy
@@ -38,4 +38,14 @@ suite("fold_constant_date_arithmatic") {
     testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%I');")
     testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%l');")
     testFoldConst("SELECT date_format('2020-12-01 12:00:30.01', '%r');")
+    
+    testFoldConst("select str_to_date('2023-02-29', '%Y-%m-%d') AS result;")
+    testFoldConst("select str_to_date('1900-02-29', '%Y-%m-%d') AS result;")
+    testFoldConst("select str_to_date('2025-04-31', '%Y-%m-%d') AS result;")
+    testFoldConst("select str_to_date('31-12-2020 23:59:59', '%d-%m-%Y %H:%i:%s');")
+    testFoldConst("select str_to_date('2020-12-31T23:59:59', '%Y-%m-%dT%H:%i:%s');")
+    testFoldConst("select str_to_date('20201231235959', '%Y%m%d%H%i%s');")
+    testFoldConst("select str_to_date('31/12/2020 23:59', '%d/%m/%Y %H:%i');")
+    testFoldConst("select str_to_date('31/12/2020 11:59 PM', '%d/%m/%Y %h:%i %p');")
+    testFoldConst("select str_to_date('20201231T235959', '%Y%m%dT%H%i%s');")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #18209

Problem Summary:

SELECT STR_TO_DATE('2025-04-31', '%Y-%m-%d') AS result; 
would be changed to result 2025-04-30 in smart mode by mistake

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

