### PR TITLE
[fix](fragment) Remove unused instance ID

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -859,11 +859,6 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
     }
 
     {
-        for (const auto& local_param : params.local_params) {
-            const TUniqueId& fragment_instance_id = local_param.fragment_instance_id;
-            query_ctx->fragment_instance_ids.push_back(fragment_instance_id);
-        }
-
         int64 now = duration_cast<std::chrono::milliseconds>(
                             std::chrono::system_clock::now().time_since_epoch())
                             .count();
@@ -904,13 +899,9 @@ void FragmentMgr::_set_scan_concurrency(const Param& params, QueryContext* query
 
 void FragmentMgr::cancel_query(const TUniqueId query_id, const Status reason) {
     std::shared_ptr<QueryContext> query_ctx = nullptr;
-    std::vector<TUniqueId> all_instance_ids;
     {
         if (auto q_ctx = get_query_ctx(query_id)) {
             query_ctx = q_ctx;
-            // Copy instanceids to avoid concurrent modification.
-            // And to reduce the scope of lock.
-            all_instance_ids = query_ctx->fragment_instance_ids;
         } else {
             LOG(WARNING) << "Query " << print_id(query_id)
                          << " does not exists, failed to cancel it";

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -327,8 +327,6 @@ public:
 
     std::shared_ptr<ResourceContext> resource_ctx() { return _resource_ctx; }
 
-    std::vector<TUniqueId> fragment_instance_ids;
-
     // plan node id -> TFileScanRangeParams
     // only for file scan node
     std::map<int, TFileScanRangeParams> file_scan_range_params_map;


### PR DESCRIPTION
### What problem does this PR solve?

`fragment_instance_ids` is accessed concurrently. Just remote it since it is never used

start BE in local mode
terminate called after throwing an instance of 'std::bad_array_new_length'
  what():  std::bad_array_new_length
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1741912659 (unix time) try "date -d @1741912659" if you are using GNU date ***
*** Current BE git commitID: 1f2257e4b9 ***
*** SIGABRT unknown detail explain (@0x358a0a) received by PID 3508746 (TID 3509523 OR 0x7fb0df8dd640) from PID 3508746; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_variant-sparse/doris/be/src/common/signal_handler.h:421
 1# 0x00007FB255578520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 6# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 7# 0x000055A9CFB751F1 in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
 8# 0x000055A9CFB75344 in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
 9# std::__throw_bad_cast() at ../../../../../libstdc++-v3/src/c++11/functexcept.cc:62
10# doris::ConcurrentContextMap<doris::TUniqueId, std::weak_ptr<doris::QueryContext>, doris::QueryContext>::erase(doris::TUniqueId const&) at /home/zcp/repo_center/doris_variant-sparse/doris/be/src/runtime/fragment_mgr.cpp:283
11# doris::FragmentMgr::cancel_query(doris::TUniqueId, doris::Status) in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
12# std::_Function_handler<void (), doris::PInternalService::cancel_plan_fragment(google::protobuf::RpcController*, doris::PCancelPlanFragmentRequest const*, doris::PCancelPlanFragmentResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
13# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_variant-sparse/doris/be/src/util/work_thread_pool.hpp:159
14# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
15# start_thread at ./nptl/pthread_create.c:442
16# 0x00007FB25565C850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

