### PR TITLE
[fix](group commit)Fix replay wal fail problem on agg state type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -352,6 +352,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
             for (int i = 0; i < tableColumns.size(); i++) {
                 Column column = new Column(tableColumns.get(i).getName(), tableColumns.get(i).getType(), true);
                 column.setUniqueId(tableColumns.get(i).getUniqueId());
+                column.setIsAllowNull(true);
                 fileColumns.add(column);
             }
             return fileColumns;


### PR DESCRIPTION
When replay wal on test regression-test/suites/mv_p0/dis_26495/dis_26495.groovy, be will core, this pr fix it.
*** Query id: 764ad7ba18485829-63a6eb98dcea4981 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1740808023 (unix time) try "date -d @1740808023" if you are using GNU date ***
*** Current BE git commitID: a386e8bb19 ***
*** SIGSEGV address not mapped to object (@0xd9) received by PID 8864 (TID 23505 OR 0x7f6aa893c640) from PID 217; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F76D2AD4520 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::vectorized::ColumnNullable::insert_range_from_not_nullable(doris::vectorized::IColumn const&, unsigned long, unsigned long) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/columns/column_nullable.cpp:340
 5# doris::vectorized::VScanner::_do_projections(doris::vectorized::Block*, doris::vectorized::Block*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/exec/scan/vscanner.cpp:204
 6# doris::vectorized::VScanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/exec/scan/vscanner.cpp:84
 7# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr, std::shared_ptr) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:221
 8# std::_Function_handler, std::shared_ptr)::$_1::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 9# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/doris-deploy-branch-3.0-local/be/lib/doris_be
10# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-3.0/doris/be/src/util/thread.cpp:499
11# start_thread at ./nptl/pthread_create.c:442
12# 0x00007F76D2BB8850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
172.20.48.99 last coredump sql: 
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

