### PR TITLE
[fix](catalog)when checkpoint,use cacheThreadPool

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -814,7 +814,7 @@ public class Env {
         this.auditEventProcessor = new AuditEventProcessor(this.pluginMgr);
         this.refreshManager = new RefreshManager();
         this.policyMgr = new PolicyMgr();
-        this.extMetaCacheMgr = new ExternalMetaCacheMgr();
+        this.extMetaCacheMgr = new ExternalMetaCacheMgr(isCheckpointCatalog);
         this.analysisManager = new AnalysisManager();
         this.statisticsCleaner = new StatisticsCleaner();
         this.statisticsAutoCollector = new StatisticsAutoCollector();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -187,16 +187,35 @@ public class ThreadPoolManager {
     }
 
     public static ThreadPoolExecutor newDaemonThreadPool(int corePoolSize,
-                                                         int maximumPoolSize,
-                                                         long keepAliveTime,
-                                                         TimeUnit unit,
-                                                         BlockingQueue<Runnable> workQueue,
-                                                         RejectedExecutionHandler handler,
-                                                         String poolName,
-                                                         boolean needRegisterMetric) {
+            int maximumPoolSize,
+            long keepAliveTime,
+            TimeUnit unit,
+            BlockingQueue<Runnable> workQueue,
+            RejectedExecutionHandler handler,
+            String poolName,
+            boolean needRegisterMetric) {
         ThreadFactory threadFactory = namedThreadFactory(poolName);
-        ThreadPoolExecutor threadPool = new ThreadPoolExecutor(corePoolSize, maximumPoolSize,
-                keepAliveTime, unit, workQueue, threadFactory, handler);
+        ThreadPoolExecutor threadPool = new ThreadPoolExecutor(0, maximumPoolSize,
+                keepAliveTime, unit, workQueue, threadFactory, handler) {
+            @Override
+            protected void beforeExecute(Thread t, Runnable r) {
+                super.beforeExecute(t, r);
+                System.out.println("Thread " + t.getName() + " is about to execute task: " + r);
+            }
+
+            @Override
+            protected void afterExecute(Runnable r, Throwable t) {
+                super.afterExecute(r, t);
+                System.out.println("Thread " + Thread.currentThread().getName() + " has finished executing task: " + r);
+            }
+
+            @Override
+            protected void terminated() {
+                super.terminated();
+                System.out.println("ThreadPool has terminated.");
+            }
+        };
+
         if (needRegisterMetric) {
             nameToThreadPoolMap.put(poolName, threadPool);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -187,35 +187,16 @@ public class ThreadPoolManager {
     }
 
     public static ThreadPoolExecutor newDaemonThreadPool(int corePoolSize,
-            int maximumPoolSize,
-            long keepAliveTime,
-            TimeUnit unit,
-            BlockingQueue<Runnable> workQueue,
-            RejectedExecutionHandler handler,
-            String poolName,
-            boolean needRegisterMetric) {
+                                                         int maximumPoolSize,
+                                                         long keepAliveTime,
+                                                         TimeUnit unit,
+                                                         BlockingQueue<Runnable> workQueue,
+                                                         RejectedExecutionHandler handler,
+                                                         String poolName,
+                                                         boolean needRegisterMetric) {
         ThreadFactory threadFactory = namedThreadFactory(poolName);
-        ThreadPoolExecutor threadPool = new ThreadPoolExecutor(0, maximumPoolSize,
-                keepAliveTime, unit, workQueue, threadFactory, handler) {
-            @Override
-            protected void beforeExecute(Thread t, Runnable r) {
-                super.beforeExecute(t, r);
-                System.out.println("Thread " + t.getName() + " is about to execute task: " + r);
-            }
-
-            @Override
-            protected void afterExecute(Runnable r, Throwable t) {
-                super.afterExecute(r, t);
-                System.out.println("Thread " + Thread.currentThread().getName() + " has finished executing task: " + r);
-            }
-
-            @Override
-            protected void terminated() {
-                super.terminated();
-                System.out.println("ThreadPool has terminated.");
-            }
-        };
-
+        ThreadPoolExecutor threadPool = new ThreadPoolExecutor(corePoolSize, maximumPoolSize,
+                keepAliveTime, unit, workQueue, threadFactory, handler);
         if (needRegisterMetric) {
             nameToThreadPoolMap.put(poolName, threadPool);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -136,6 +136,8 @@ public class ExternalMetaCacheMgr {
             boolean needRegisterMetric) {
         String executorNamePrefix = isCheckpointCatalog ? "Checkpoint" : "NotCheckpoint";
         String realPoolName = executorNamePrefix + poolName;
+        // Business threads require a fixed size thread pool and use queues to store unprocessed tasks.
+        // Checkpoint threads have almost no business and need to be released in a timely manner to avoid thread leakage
         if (isCheckpointCatalog) {
             return ThreadPoolManager.newDaemonCacheThreadPool(numThread, realPoolName, needRegisterMetric);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -99,7 +99,7 @@ public class ExternalMetaCacheMgr {
     private final MaxComputeMetadataCacheMgr maxComputeMetadataCacheMgr;
     private final PaimonMetadataCacheMgr paimonMetadataCacheMgr;
 
-    public ExternalMetaCacheMgr() {
+    public ExternalMetaCacheMgr(boolean isCheckpointCatalog) {
         rowCountRefreshExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 1000,
@@ -108,7 +108,8 @@ public class ExternalMetaCacheMgr {
         commonRefreshExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 10000,
-                "CommonRefreshExecutor", 10, true);
+                isCheckpointCatalog ? "CommonRefreshExecutorCheckpoint" : "CommonRefreshExecutorNotCheckPoint", 10,
+                true);
 
         // The queue size should be large enough,
         // because there may be thousands of partitions being queried at the same time.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -100,25 +100,24 @@ public class ExternalMetaCacheMgr {
     private final PaimonMetadataCacheMgr paimonMetadataCacheMgr;
 
     public ExternalMetaCacheMgr(boolean isCheckpointCatalog) {
-        rowCountRefreshExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+        rowCountRefreshExecutor = newThreadPool(isCheckpointCatalog,
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 1000,
                 "RowCountRefreshExecutor", 0, true);
 
-        commonRefreshExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+        commonRefreshExecutor = newThreadPool(isCheckpointCatalog,
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 10000,
-                isCheckpointCatalog ? "CommonRefreshExecutorCheckpoint" : "CommonRefreshExecutorNotCheckPoint", 10,
-                true);
+                "CommonRefreshExecutor", 10, true);
 
         // The queue size should be large enough,
         // because there may be thousands of partitions being queried at the same time.
-        fileListingExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+        fileListingExecutor = newThreadPool(isCheckpointCatalog,
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 1000,
                 "FileListingExecutor", 10, true);
 
-        scheduleExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+        scheduleExecutor = newThreadPool(isCheckpointCatalog,
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 1000,
                 "scheduleExecutor", 10, true);
@@ -130,6 +129,19 @@ public class ExternalMetaCacheMgr {
         icebergMetadataCacheMgr = new IcebergMetadataCacheMgr(commonRefreshExecutor);
         maxComputeMetadataCacheMgr = new MaxComputeMetadataCacheMgr();
         paimonMetadataCacheMgr = new PaimonMetadataCacheMgr(commonRefreshExecutor);
+    }
+
+    private ExecutorService newThreadPool(boolean isCheckpointCatalog, int numThread, int queueSize,
+            String poolName, int timeoutSeconds,
+            boolean needRegisterMetric) {
+        String executorNamePrefix = isCheckpointCatalog ? "Checkpoint" : "NotCheckpoint";
+        String realPoolName = executorNamePrefix + poolName;
+        if (isCheckpointCatalog) {
+            return ThreadPoolManager.newDaemonCacheThreadPool(numThread, realPoolName, needRegisterMetric);
+        } else {
+            return ThreadPoolManager.newDaemonFixedThreadPool(numThread, queueSize, realPoolName, timeoutSeconds,
+                    needRegisterMetric);
+        }
     }
 
     public ExecutorService getFileListingExecutor() {


### PR DESCRIPTION
### What problem does this PR solve?
when checkpoint,if use fixedThreadPool,will Thread Overflow

The checkpoint thread is a newly created thread pool (without reusing the business thread pool), with a core size and maxSize of 64. During the checkpoint process, if the guava cache reaches its expiration time (10 minutes), it will automatically create a task to clean up the cache. Since four caches are using this thread pool and have expiration times of 10 minutes, four threads are created simultaneously to clean up different caches. Since 4<coteSize (64), threads will not be automatically destroyed.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
when checkpoint,use cacheThreadPool 
### Release note
when checkpoint,use cacheThreadPool 

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

