### PR TITLE
[fix](regression) Avoid defined global variables in backup-restore case script

### DIFF
--- a/regression-test/suites/backup_restore/test_backup_store_with_db_properties.groovy
+++ b/regression-test/suites/backup_restore/test_backup_store_with_db_properties.groovy
@@ -96,7 +96,7 @@ suite("test_backup_store_with_db_properties","backup_restore") {
     assertEquals(result_kv_restore, result_kv_origin);
 
     for (def tableName in tables) {
-        result = sql "SELECT * FROM ${dbName}.${tableName}"
+        def result = sql "SELECT * FROM ${dbName}.${tableName}"
         assertEquals(result.size(), numRows);
         sql "DROP TABLE ${dbName}.${tableName} FORCE"
     }

--- a/regression-test/suites/backup_restore/test_backup_store_with_db_properties_kv.groovy
+++ b/regression-test/suites/backup_restore/test_backup_store_with_db_properties_kv.groovy
@@ -101,7 +101,7 @@ suite("test_backup_store_with_db_properties_kv","backup_restore") {
     assertEquals(result_restore, result_origin);
 
     for (def tableName in tables) {
-        result = sql "SELECT * FROM ${dbName}.${tableName}"
+        def result = sql "SELECT * FROM ${dbName}.${tableName}"
         assertEquals(result.size(), numRows);
         sql "DROP TABLE ${dbName}.${tableName} FORCE"
     }


### PR DESCRIPTION
### What problem does this PR solve?

Avoid defined global variables in backup-restore case script

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

