### PR TITLE
[fix](multi table load) error URL does not depend on the value of _number_filtered_rows

### DIFF
--- a/be/src/io/fs/multi_table_pipe.cpp
+++ b/be/src/io/fs/multi_table_pipe.cpp
@@ -271,7 +271,7 @@ Status MultiTablePipe::exec_plans(ExecEnv* exec_env, std::vector<ExecParam> para
                     _number_loaded_rows += state->num_rows_load_success();
                     _number_filtered_rows += state->num_rows_load_filtered();
                     _number_unselected_rows += state->num_rows_load_unselected();
-
+                    _ctx->error_url = to_load_error_http_path(state->get_error_log_file_path());
                     // check filtered ratio for this plan fragment
                     int64_t num_selected_rows =
                             state->num_rows_load_total() - state->num_rows_load_unselected();
@@ -279,9 +279,6 @@ Status MultiTablePipe::exec_plans(ExecEnv* exec_env, std::vector<ExecParam> para
                         (double)state->num_rows_load_filtered() / num_selected_rows >
                                 _ctx->max_filter_ratio) {
                         *status = Status::DataQualityError("too many filtered rows");
-                    }
-                    if (_number_filtered_rows > 0 && !state->get_error_log_file_path().empty()) {
-                        _ctx->error_url = to_load_error_http_path(state->get_error_log_file_path());
                     }
 
                     // if any of the plan fragment exec failed, set the status to the first failed plan


### PR DESCRIPTION
### What problem does this PR solve?

The error URL does not depend on the value of _number_filtered_rows for it may not be correct.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

