### PR TITLE
[fix](memory) Fix LRUCachePolicy initialization and registration order

### DIFF
--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -27,7 +27,6 @@ CachePolicy::CachePolicy(CacheType type, size_t capacity, uint32_t stale_sweep_t
           _initial_capacity(capacity),
           _stale_sweep_time_s(stale_sweep_time_s),
           _enable_prune(enable_prune) {
-    CacheManager::instance()->register_cache(this);
     init_profile();
 }
 

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -47,6 +47,7 @@ public:
             _cache = std::make_shared<doris::DummyLRUCache>();
         }
         _init_mem_tracker(lru_cache_type_string(lru_cache_type));
+        CacheManager::instance()->register_cache(this);
     }
 
     LRUCachePolicy(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
@@ -66,6 +67,7 @@ public:
             _cache = std::make_shared<doris::DummyLRUCache>();
         }
         _init_mem_tracker(lru_cache_type_string(lru_cache_type));
+        CacheManager::instance()->register_cache(this);
     }
 
     void reset_cache() { _cache.reset(); }


### PR DESCRIPTION
### What problem does this PR solve?

Register with CacheManager after LRUCachePolicy is initialized.
Fixed:
```
 F20250311 18:53:15.664247 2308247 lru_cache_policy.h:103] Check failed: _mem_tracker != nullptr
19:01:20 
  *** Check failure stack trace: ***
19:01:20 
   @ 0x556d5b6951c6 google::LogMessageFatal::~LogMessageFatal()
19:01:20 
   @ 0x556d2409bcea doris::LRUCachePolicy::mem_consumption()
19:01:20 
   @ 0x556d24097d83 doris::LRUCachePolicy::exceed_prune_limit()
19:01:20 
   @ 0x556d24090d1d doris::LRUCachePolicy::prune_stale()
19:01:20 
   @ 0x556d253c54a4 doris::CacheManager::for_each_cache_prune_stale_wrap()
19:01:20 
   @ 0x556d253c5fc5 doris::CacheManager::for_each_cache_prune_stale()
19:01:20 
   @ 0x556d214b0a95 doris::Daemon::cache_prune_stale_thread()
19:01:20 
   @ 0x556d25c7f5ef doris::Thread::supervise_thread()
19:01:20 
```

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

