### PR TITLE
[fix](nereids)  fix to_monday('1970-01-04 23:59:59')

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -463,7 +463,7 @@ public class DateTimeExtractAndTransform {
     }
 
     private static LocalDateTime toMonday(LocalDateTime dateTime) {
-        LocalDateTime specialUpperBound = LocalDateTime.of(1970, 1, 4, 0, 0, 0);
+        LocalDateTime specialUpperBound = LocalDateTime.of(1970, 1, 4, 23, 59, 59, 999_999_999);
         LocalDateTime specialLowerBound = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
         if (dateTime.isAfter(specialUpperBound) || dateTime.isBefore(specialLowerBound)) {
             return dateTime.plusDays(-dateTime.getDayOfWeek().getValue() + 1);

--- a/regression-test/suites/nereids_syntax_p0/test_cast_datetime.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_cast_datetime.groovy
@@ -461,6 +461,34 @@ suite("test_cast_datetime") {
         }
 
         test {
+            sql "select to_monday('1969-12-31')"
+            result([[Date.valueOf('1969-12-29')]])
+        }
+
+        test {
+            sql "select to_monday('1969-12-31 23:59:59.999999')"
+            result([[Date.valueOf('1969-12-29')]])
+        }
+
+        // to_monday(1970-01-01 ~ 170-01-04) will return 1970-01-01
+        for (def s : ['1970-01-01', '1970-01-01 00:00:00.000001', '1970-01-02 12:00:00', '1970-01-01', '1970-01-04 23:59:59.999999']) {
+            test {
+                sql "select to_monday('${s}')"
+                result([[Date.valueOf('1970-01-01')]])
+            }
+        }
+
+        test {
+            sql "select to_monday('1970-01-05')"
+            result([[Date.valueOf('1970-01-05')]])
+        }
+
+        test {
+            sql "select to_monday('1970-01-05 00:00:00.000001')"
+            result([[Date.valueOf('1970-01-05')]])
+        }
+
+        test {
             sql "select cast('123.123' as datetime)"
             result([[LocalDateTime.parse('2012-03-12T03:00:00')]])
         }
@@ -544,6 +572,5 @@ suite("test_cast_datetime") {
             sql "select date_add('2023-11-05 01:30:00 America/New_York', INTERVAL 1 DAY)"
             result([[LocalDateTime.parse('2023-11-06T01:30:00')]])
         }
-
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

As doc [to-monday](https://doris.apache.org/docs/2.0/sql-manual/sql-functions/date-time-functions/to-monday) said,  for date between 1970-01-01 and 1970-01-04,  to_monday(date) = '1970-01-01',   this PR fix this.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

