### PR TITLE
[Opt](checksum) Add an config to skip `__DORIS_VERSION_COL__` when calculate checksum

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1455,6 +1455,8 @@ DEFINE_mBool(enable_prune_delete_sign_when_base_compaction, "true");
 
 DEFINE_mBool(enable_mow_verbose_log, "false");
 
+DEFINE_mBool(skip_version_col_when_calc_check_sum, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1530,6 +1530,8 @@ DECLARE_mBool(enable_prune_delete_sign_when_base_compaction);
 
 DECLARE_mBool(enable_mow_verbose_log);
 
+DECLARE_mBool(skip_version_col_when_calc_check_sum);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -823,11 +823,6 @@ void Block::shuffle_columns(const std::vector<int>& result_column_ids) {
 
 void Block::update_hash(SipHash& hash) const {
     bool skip_version_col = config::skip_version_col_when_calc_check_sum;
-    std::string msg {};
-    for (const auto& name : get_names()) {
-        msg += fmt::format("{},", name);
-    }
-    LOG_INFO("[xxx Block::update_hash] {}", msg);
     for (size_t row_no = 0, num_rows = rows(); row_no < num_rows; ++row_no) {
         for (const auto& col : data) {
             if (skip_version_col && col.name == VERSION_COL) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -822,8 +822,17 @@ void Block::shuffle_columns(const std::vector<int>& result_column_ids) {
 }
 
 void Block::update_hash(SipHash& hash) const {
+    bool skip_version_col = config::skip_version_col_when_calc_check_sum;
+    std::string msg {};
+    for (const auto& name : get_names()) {
+        msg += fmt::format("{},", name);
+    }
+    LOG_INFO("[xxx Block::update_hash] {}", msg);
     for (size_t row_no = 0, num_rows = rows(); row_no < num_rows; ++row_no) {
         for (const auto& col : data) {
+            if (skip_version_col && col.name == VERSION_COL) {
+                continue;
+            }
             col.column->update_hash_with_value(row_no, hash);
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

sometimes there may be confusing but not totally random values in `__DORIS_VERSION_COL__`(such as `2^29, 2^29+1`) on tablets which have schema change before. And this will lead to checksums of tablets inconsistent between replicas. This PR 
1. add a config to skip `__DORIS_VERSION_COL__` column when calculating checksum to avoid this problem.
2. add DCHECK when doing compaction
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

