### PR TITLE
[fix](Nereids) cse extract wrong expression from lambda expressions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/CommonSubExpressionOpt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/CommonSubExpressionOpt.java
@@ -66,7 +66,7 @@ public class CommonSubExpressionOpt extends PlanPostProcessor {
         List<List<NamedExpression>> multiLayers = Lists.newArrayList();
         CommonSubExpressionCollector collector = new CommonSubExpressionCollector();
         for (Expression expr : projects) {
-            expr.accept(collector, null);
+            collector.collect(expr);
         }
         // use linkedHashMap to make projects order stable
         Map<Expression, Alias> aliasMap = new LinkedHashMap<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/CommonSubExpressionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/CommonSubExpressionTest.java
@@ -20,14 +20,24 @@ package org.apache.doris.nereids.postprocess;
 import org.apache.doris.nereids.processor.post.CommonSubExpressionCollector;
 import org.apache.doris.nereids.processor.post.CommonSubExpressionOpt;
 import org.apache.doris.nereids.rules.expression.ExpressionRewriteTestHelper;
+import org.apache.doris.nereids.trees.expressions.Add;
 import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.ArrayItemReference;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.ArrayMap;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewriter;
+import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.IntegerType;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,25 +47,38 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class CommonSubExpressionTest extends ExpressionRewriteTestHelper {
     @Test
     public void testExtractCommonExpr() {
         List<NamedExpression> exprs = parseProjections("a+b, a+b+1, abs(a+b+1), a");
-        CommonSubExpressionCollector collector =
-                new CommonSubExpressionCollector();
+        CommonSubExpressionCollector collector = new CommonSubExpressionCollector();
         exprs.forEach(expr -> collector.visit(expr, null));
-        System.out.println(collector.commonExprByDepth);
         Assertions.assertEquals(2, collector.commonExprByDepth.size());
-        List<Expression> l1 = collector.commonExprByDepth.get(Integer.valueOf(1))
-                .stream().collect(Collectors.toList());
-        List<Expression> l2 = collector.commonExprByDepth.get(Integer.valueOf(2))
-                .stream().collect(Collectors.toList());
+        List<Expression> l1 = new ArrayList<>(collector.commonExprByDepth.get(1));
+        List<Expression> l2 = new ArrayList<>(collector.commonExprByDepth.get(2));
         Assertions.assertEquals(1, l1.size());
         assertExpression(l1.get(0), "a+b");
         Assertions.assertEquals(1, l2.size());
         assertExpression(l2.get(0), "a+b+1");
+    }
+
+    @Test
+    void testLambdaExpression() {
+        ArrayItemReference ref = new ArrayItemReference("x", new SlotReference(new ExprId(1), "y",
+                ArrayType.of(IntegerType.INSTANCE), true, ImmutableList.of()));
+        Expression add = new Add(ref.toSlot(), Literal.of(1));
+        Expression and = new And(add, add);
+        ArrayMap arrayMap = new ArrayMap(new Lambda(ImmutableList.of("x"), and, ImmutableList.of(ref)));
+        List<NamedExpression> exprs = Lists.newArrayList(
+                new Alias(new ExprId(10000), arrayMap, "c1"),
+                new Alias(new ExprId(10001), arrayMap, "c2")
+        );
+        CommonSubExpressionCollector collector = new CommonSubExpressionCollector();
+        exprs.forEach(expr -> collector.visit(expr, false));
+        Assertions.assertEquals(1, collector.commonExprByDepth.size());
+        Assertions.assertEquals(1, collector.commonExprByDepth.get(4).size());
+        Assertions.assertEquals(arrayMap, collector.commonExprByDepth.get(4).iterator().next());
     }
 
     @Test
@@ -68,15 +91,14 @@ public class CommonSubExpressionTest extends ExpressionRewriteTestHelper {
         computeMultLayerProjectionsMethod.setAccessible(true);
         List<List<NamedExpression>> multiLayers = (List<List<NamedExpression>>) computeMultLayerProjectionsMethod
                 .invoke(opt, inputSlots, exprs);
-        System.out.println(multiLayers);
         Assertions.assertEquals(3, multiLayers.size());
         List<NamedExpression> l0 = multiLayers.get(0);
         Assertions.assertEquals(2, l0.size());
         Assertions.assertTrue(l0.contains(ExprParser.INSTANCE.parseExpression("a")));
-        Assertions.assertTrue(l0.get(1) instanceof Alias);
+        Assertions.assertInstanceOf(Alias.class, l0.get(1));
         assertExpression(l0.get(1).child(0), "a+b");
-        Assertions.assertEquals(multiLayers.get(1).size(), 3);
-        Assertions.assertEquals(multiLayers.get(2).size(), 5);
+        Assertions.assertEquals(3, multiLayers.get(1).size());
+        Assertions.assertEquals(5, multiLayers.get(2).size());
         List<NamedExpression> l2 = multiLayers.get(2);
         for (int i = 0; i < 5; i++) {
             Assertions.assertEquals(exprs.get(i).getExprId().asInt(), l2.get(i).getExprId().asInt());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #33087

Problem Summary:

CSE should not extract ArrayItemSlot and ArrayItemReference. Because they could not be computed out of Lambda expression.
NOTICE: currently, we could not extract common expression from Lambda, because ArrayItemSlot in Lambda are not same.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

