### PR TITLE
[fix](load) fix dead lock when write memtable failed

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_memtable_write_failed.groovy
+++ b/regression-test/suites/fault_injection_p0/test_memtable_write_failed.groovy
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_memtable_write_failed", "nonConcurrent") {
+    GetDebugPoint().clearDebugPointsForAllBEs()
+    def testTable = "test_memtable_write_failed"
+    sql """ DROP TABLE IF EXISTS ${testTable}"""
+
+    sql """
+        CREATE TABLE IF NOT EXISTS `${testTable}` (
+          `id` BIGINT NOT NULL AUTO_INCREMENT,
+          `value` int(11) NOT NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        COMMENT "OLAP"
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        )
+    """
+    
+    def run_test = {thread_num, rows, iters -> 
+        def threads = []
+        (1..thread_num).each { id1 -> 
+            threads.add(Thread.start {
+                (1..iters).each { id2 -> 
+                    try {
+                         sql """insert into ${testTable}(value) select number from numbers("number" = "${rows}");"""
+                         String content = ""
+                         (1..4096).each {
+                             content += "${it},${it}\n"
+                         }
+                         content += content
+                         streamLoad {
+                             table "${testTable}"
+                             set 'column_separator', ','
+                             inputStream new ByteArrayInputStream(content.getBytes())
+                             time 30000 // limit inflight 10s
+
+                             check { result, exception, startTime, endTime ->
+                                 if (exception != null) {
+                                     throw exception
+                                 }
+                                 def json = parseJson(result)
+                                 if (json.Status.equalsIgnoreCase("success")) {
+                                     assertEquals(8192, json.NumberTotalRows)
+                                     assertEquals(0, json.NumberFilteredRows)
+                                 } else {
+                                     assertTrue(json.Message.contains("write memtable random failed for debug"))
+                                 }
+                             }
+                         }
+                    } catch (Exception e) {
+                         logger.info(e.getMessage())
+                         assertTrue(e.getMessage().contains("write memtable random failed for debug"))
+                    }
+                }
+            })
+        }
+        threads.each { thread -> thread.join() }
+    }
+
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("MemTableWriter.write.random_insert_error")
+        GetDebugPoint().enableDebugPointForAllBEs("MemTableMemoryLimiter._handle_memtable_flush.limit_reached")
+        GetDebugPoint().enableDebugPointForAllBEs("MemTableMemoryLimiter._need_flush.random_flush")
+        run_test(5, 10000, 10)
+    } catch (Exception e){
+        logger.info(e.getMessage())
+        assertTrue(e.getMessage().contains("write memtable random failed for debug"))
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("MemTableWriter.write.random_insert_error")
+        GetDebugPoint().disableDebugPointForAllBEs("MemTableMemoryLimiter._handle_memtable_flush.limit_reached")
+        GetDebugPoint().disableDebugPointForAllBEs("MemTableMemoryLimiter._need_flush.random_flush")
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #48489 

Problem Summary:

The _mem_table_ptr_lock will be locked in _reset_mem_table, so don't need to be acquired in MemTableWriter::write.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

