### PR TITLE
[fix](nereids)TableQueryPlanAction can't work when having empty relation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
@@ -36,6 +36,7 @@ import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.plans.commands.Command;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -239,7 +240,7 @@ public class TableQueryPlanAction extends RestBaseController {
                     PhysicalProperties.GATHER, ExplainCommand.ExplainLevel.REWRITTEN_PLAN);
             if (!rewrittenPlan.allMatch(planTreeNode -> planTreeNode instanceof LogicalOlapScan
                     || planTreeNode instanceof LogicalFilter || planTreeNode instanceof LogicalProject
-                    || planTreeNode instanceof LogicalResultSink)) {
+                    || planTreeNode instanceof LogicalResultSink || planTreeNode instanceof LogicalEmptyRelation)) {
                 throw new DorisHttpException(HttpResponseStatus.BAD_REQUEST,
                         "only support single table filter-prune-scan, but found [ " + sql + "]");
             }
@@ -254,11 +255,12 @@ public class TableQueryPlanAction extends RestBaseController {
             // acquire ScanNode to obtain pruned tablet
             // in this way, just retrieve only one scannode
             List<ScanNode> scanNodes = planner.getScanNodes();
-            if (scanNodes.size() != 1) {
+            if (scanNodes.size() > 1) {
                 throw new DorisHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                         "Planner should plan just only one ScanNode but found [ " + scanNodes.size() + "]");
             }
-            List<TScanRangeLocations> scanRangeLocations = scanNodes.get(0).getScanRangeLocations(0);
+            List<TScanRangeLocations> scanRangeLocations = scanNodes.size() == 1
+                    ? scanNodes.get(0).getScanRangeLocations(0) : new ArrayList<>();
             // acquire the PlanFragment which the executable template
             List<PlanFragment> fragments = planner.getFragments();
             if (fragments.size() != 1) {

--- a/fe/fe-core/src/test/java/org/apache/doris/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/http/TableQueryPlanActionTest.java
@@ -80,6 +80,39 @@ public class TableQueryPlanActionTest extends DorisHttpTestCase {
     }
 
     @Test
+    public void testQueryPlanActionEmptyRelation() throws IOException, TException {
+        RequestBody body = RequestBody.create(
+                "{ \"sql\" :  \" select k1,k2 from " + DB_NAME + "." + TABLE_NAME + " where false \" }", JSON);
+        Request request = new Request.Builder()
+                .post(body)
+                .addHeader("Authorization", rootAuth)
+                .url(URI + PATH_URI)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        Assert.assertNotNull(response.body());
+        String respStr = response.body().string();
+        JSONObject jsonObject = (JSONObject) JSONValue.parse(respStr);
+        Assert.assertEquals(200, (long) ((JSONObject) jsonObject.get("data")).get("status"));
+
+        JSONObject partitionsObject = (JSONObject) ((JSONObject) jsonObject.get("data")).get("partitions");
+        Assert.assertNotNull(partitionsObject);
+        for (Object tabletKey : partitionsObject.keySet()) {
+            JSONObject tabletObject = (JSONObject) partitionsObject.get(tabletKey);
+            Assert.assertNotNull(tabletObject.get("routings"));
+            Assert.assertEquals(3, ((JSONArray) tabletObject.get("routings")).size());
+            Assert.assertEquals(testStartVersion, (long) tabletObject.get("version"));
+        }
+        String queryPlan = (String) ((JSONObject) jsonObject.get("data")).get("opaqued_query_plan");
+        Assert.assertNotNull(queryPlan);
+        byte[] binaryPlanInfo = Base64.getDecoder().decode(queryPlan);
+        TDeserializer deserializer = new TDeserializer();
+        TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
+        deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo);
+        expectThrowsNoException(() -> deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo));
+        System.out.println(tQueryPlanInfo);
+    }
+
+    @Test
     public void testNoSqlFailure() throws IOException {
         RequestBody body = RequestBody.create(JSON, "{}");
         Request request = new Request.Builder()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

the bug is introduced by https://github.com/apache/doris/pull/39627

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

