### PR TITLE
[Enhancement] (nereids) Optimize Plan children traversal logic to reduce code duplication

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteBottomUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteBottomUpJob.java
@@ -123,32 +123,11 @@ public class PlanTreeRewriteBottomUpJob extends PlanTreeRewriteJob {
 
     private void pushChildrenJobs(Plan plan) {
         List<Plan> children = plan.children();
-        switch (children.size()) {
-            case 0: return;
-            case 1:
-                Plan child = children.get(0);
-                RewriteJobContext childRewriteJobContext = new RewriteJobContext(
-                        child, rewriteJobContext, 0, false, batchId);
-                pushJob(new PlanTreeRewriteBottomUpJob(childRewriteJobContext, context, isTraverseChildren, rules));
-                return;
-            case 2:
-                Plan right = children.get(1);
-                RewriteJobContext rightRewriteJobContext = new RewriteJobContext(
-                        right, rewriteJobContext, 1, false, batchId);
-                pushJob(new PlanTreeRewriteBottomUpJob(rightRewriteJobContext, context, isTraverseChildren, rules));
-
-                Plan left = children.get(0);
-                RewriteJobContext leftRewriteJobContext = new RewriteJobContext(
-                        left, rewriteJobContext, 0, false, batchId);
-                pushJob(new PlanTreeRewriteBottomUpJob(leftRewriteJobContext, context, isTraverseChildren, rules));
-                return;
-            default:
-                for (int i = children.size() - 1; i >= 0; i--) {
-                    child = children.get(i);
-                    childRewriteJobContext = new RewriteJobContext(
-                            child, rewriteJobContext, i, false, batchId);
-                    pushJob(new PlanTreeRewriteBottomUpJob(childRewriteJobContext, context, isTraverseChildren, rules));
-                }
+        for (int i = children.size() - 1; i >= 0; i--) {
+            Plan child = children.get(i);
+            RewriteJobContext childRewriteJobContext = new RewriteJobContext(
+                child, rewriteJobContext, i, false, batchId);
+            pushJob(new PlanTreeRewriteBottomUpJob(childRewriteJobContext, context, isTraverseChildren, rules));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteTopDownJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteTopDownJob.java
@@ -73,28 +73,10 @@ public class PlanTreeRewriteTopDownJob extends PlanTreeRewriteJob {
 
     private void pushChildrenJobs(RewriteJobContext rewriteJobContext) {
         List<Plan> children = rewriteJobContext.plan.children();
-        switch (children.size()) {
-            case 0: return;
-            case 1:
-                RewriteJobContext childRewriteJobContext = new RewriteJobContext(
-                        children.get(0), rewriteJobContext, 0, false, this.rewriteJobContext.batchId);
-                pushJob(new PlanTreeRewriteTopDownJob(childRewriteJobContext, context, isTraverseChildren, rules));
-                return;
-            case 2:
-                RewriteJobContext rightRewriteJobContext = new RewriteJobContext(
-                        children.get(1), rewriteJobContext, 1, false, this.rewriteJobContext.batchId);
-                pushJob(new PlanTreeRewriteTopDownJob(rightRewriteJobContext, context, isTraverseChildren, rules));
-
-                RewriteJobContext leftRewriteJobContext = new RewriteJobContext(
-                        children.get(0), rewriteJobContext, 0, false, this.rewriteJobContext.batchId);
-                pushJob(new PlanTreeRewriteTopDownJob(leftRewriteJobContext, context, isTraverseChildren, rules));
-                return;
-            default:
-                for (int i = children.size() - 1; i >= 0; i--) {
-                    childRewriteJobContext = new RewriteJobContext(
-                            children.get(i), rewriteJobContext, i, false, this.rewriteJobContext.batchId);
-                    pushJob(new PlanTreeRewriteTopDownJob(childRewriteJobContext, context, isTraverseChildren, rules));
-                }
+        for (int i = children.size() - 1; i >= 0; i--) {
+            RewriteJobContext childRewriteJobContext = new RewriteJobContext(
+                children.get(i), rewriteJobContext, i, false, this.rewriteJobContext.batchId);
+            pushJob(new PlanTreeRewriteTopDownJob(childRewriteJobContext, context, isTraverseChildren, rules));
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
The current pushChildrenJobs method handles Plan child nodes using a switch-case structure. The logic in case 1 and case 2 is redundant, and the default branch performs the same operation.

This change does not alter PlanTreeRewriteBottomUpJob logic but only improves code structure.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

