### PR TITLE
[improve](function) memory reuse in array_map fucntion

### DIFF
--- a/be/src/vec/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_map_function.cpp
@@ -200,7 +200,9 @@ public:
         while (args_info.current_row_idx < block->rows()) {
             bool mem_reuse = lambda_block.mem_reuse();
             for (int i = 0; i < column_size; i++) {
-                if (!mem_reuse) {
+                if (mem_reuse) {
+                    columns[i] = lambda_block.get_by_position(i).column->assume_mutable();
+                } else {
                     if (_contains_column_id(output_slot_ref_indexs, i) || i >= gap) {
                         // TODO: maybe could create const column, so not insert_many_from when extand data
                         // but now here handle batch_size of array nested data every time, so maybe have different rows

--- a/be/src/vec/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_map_function.cpp
@@ -200,9 +200,7 @@ public:
         while (args_info.current_row_idx < block->rows()) {
             bool mem_reuse = lambda_block.mem_reuse();
             for (int i = 0; i < column_size; i++) {
-                if (mem_reuse) {
-                    columns[i] = lambda_block.get_by_position(i).column->assume_mutable();
-                } else {
+                if (!mem_reuse) {
                     if (_contains_column_id(output_slot_ref_indexs, i) || i >= gap) {
                         // TODO: maybe could create const column, so not insert_many_from when extand data
                         // but now here handle batch_size of array nested data every time, so maybe have different rows


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
support memory reuse in array_map, so no need to alloc memory every time. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

