### PR TITLE
[fix](webui) add connection context to avoid NPE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
@@ -31,7 +31,9 @@ import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.httpv2.util.streamresponse.JsonStreamResponse;
 import org.apache.doris.httpv2.util.streamresponse.StreamResponseInf;
+import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -250,7 +252,7 @@ public class StatementSubmitter {
 
     public static StatementBase analyzeStmt(String stmtStr) throws Exception {
         SqlParser parser = new SqlParser(new SqlScanner(new StringReader(stmtStr)));
-        try {
+        try (AutoCloseConnectContext a = StatisticsUtil.buildConnectContext(false)) {
             return SqlParserUtils.getFirstStmt(parser);
         } catch (AnalysisException e) {
             String errorMessage = parser.getErrorMsg(stmtStr);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When execute statement using Playgroup in FE webui, the NPE may thrown.
This is because we didn't set connection context when executing sql in StatementSubmmitter.
This PR fix it

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

