### PR TITLE
branch-2.1-pick: [Fix](SC) Prevent the values of `__DORIS_VERSION_COL__` be wrongly replaced by fake version when merging tmp rowset in sort SC #49193

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -586,7 +586,7 @@ Status VSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset_rea
         }
 
         auto [rowset, guard] = DORIS_TRY(_internal_sorting(
-                blocks, Version(_temp_delta_versions.second, _temp_delta_versions.second),
+                blocks, Version(_temp_delta_versions.second, _temp_delta_versions.second + 1),
                 newest_write_timestamp, new_tablet, BETA_ROWSET, segments_overlap,
                 new_tablet_schema));
         src_rowsets.push_back(std::move(rowset));
@@ -597,7 +597,7 @@ Status VSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset_rea
         blocks.clear();
 
         // increase temp version
-        _temp_delta_versions.second++;
+        _temp_delta_versions.second += 2;
         return Status::OK();
     };
 


### PR DESCRIPTION
pick https://github.com/apache/doris/pull/49193