### PR TITLE
[fix](arrow-flight-sql) Modify the default value of `arrow_flight_sql_port` configuration

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -62,7 +62,7 @@ DEFINE_Int32(be_port, "9060");
 // port for brpc
 DEFINE_Int32(brpc_port, "8060");
 
-DEFINE_Int32(arrow_flight_sql_port, "-1");
+DEFINE_Int32(arrow_flight_sql_port, "8181");
 
 // If the external client cannot directly access priority_networks, set public_host to be accessible
 // to external client.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -62,7 +62,7 @@ DEFINE_Int32(be_port, "9060");
 // port for brpc
 DEFINE_Int32(brpc_port, "8060");
 
-DEFINE_Int32(arrow_flight_sql_port, "8181");
+DEFINE_Int32(arrow_flight_sql_port, "8050");
 
 // If the external client cannot directly access priority_networks, set public_host to be accessible
 // to external client.

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -36,7 +36,7 @@ be_port = 9060
 webserver_port = 8040
 heartbeat_service_port = 9050
 brpc_port = 8060
-arrow_flight_sql_port = 8181
+arrow_flight_sql_port = 8050
 
 # HTTPS configures
 enable_https = false

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -36,7 +36,7 @@ be_port = 9060
 webserver_port = 8040
 heartbeat_service_port = 9050
 brpc_port = 8060
-arrow_flight_sql_port = -1
+arrow_flight_sql_port = 8181
 
 # HTTPS configures
 enable_https = false

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -47,7 +47,7 @@ http_port = 8030
 rpc_port = 9020
 query_port = 9030
 edit_log_port = 9010
-arrow_flight_sql_port = -1
+arrow_flight_sql_port = 8081
 
 # Choose one if there are more than one ip except loopback address. 
 # Note that there should at most one ip match this list.

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -47,7 +47,7 @@ http_port = 8030
 rpc_port = 9020
 query_port = 9030
 edit_log_port = 9010
-arrow_flight_sql_port = 8081
+arrow_flight_sql_port = 8070
 
 # Choose one if there are more than one ip except loopback address. 
 # Note that there should at most one ip match this list.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -475,7 +475,7 @@ public class Config extends ConfigBase {
     public static int query_port = 9030;
 
     @ConfField(description = {"FE Arrow-Flight-SQL server 的端口号", "The port of FE Arrow-Flight-SQL server"})
-    public static int arrow_flight_sql_port = -1;
+    public static int arrow_flight_sql_port = 8081;
 
     @ConfField(description = {"MySQL 服务的 IO 线程数", "The number of IO threads in MySQL service"})
     public static int mysql_service_io_threads_num = 4;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -475,7 +475,7 @@ public class Config extends ConfigBase {
     public static int query_port = 9030;
 
     @ConfField(description = {"FE Arrow-Flight-SQL server 的端口号", "The port of FE Arrow-Flight-SQL server"})
-    public static int arrow_flight_sql_port = 8081;
+    public static int arrow_flight_sql_port = 8070;
 
     @ConfField(description = {"MySQL 服务的 IO 线程数", "The number of IO threads in MySQL service"})
     public static int mysql_service_io_threads_num = 4;

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
@@ -112,7 +112,7 @@ public class MockedBackendFactory {
     public static final int BE_DEFAULT_THRIFT_PORT = 9060;
     public static final int BE_DEFAULT_BRPC_PORT = 8060;
     public static final int BE_DEFAULT_HTTP_PORT = 8040;
-    public static final int BE_DEFAULT_ARROW_FLIGHT_SQL_PORT = 8070;
+    public static final int BE_DEFAULT_ARROW_FLIGHT_SQL_PORT = 8181;
 
     // create a mocked backend with customize parameters
     public static MockedBackend createBackend(String host, int heartbeatPort, int thriftPort, int brpcPort,

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
@@ -112,7 +112,7 @@ public class MockedBackendFactory {
     public static final int BE_DEFAULT_THRIFT_PORT = 9060;
     public static final int BE_DEFAULT_BRPC_PORT = 8060;
     public static final int BE_DEFAULT_HTTP_PORT = 8040;
-    public static final int BE_DEFAULT_ARROW_FLIGHT_SQL_PORT = 8181;
+    public static final int BE_DEFAULT_ARROW_FLIGHT_SQL_PORT = 8050;
 
     // create a mocked backend with customize parameters
     public static MockedBackend createBackend(String host, int heartbeatPort, int thriftPort, int brpcPort,

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedFrontend.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedFrontend.java
@@ -79,7 +79,7 @@ public class MockedFrontend {
         MIN_FE_CONF.put("http_port", "8030");
         MIN_FE_CONF.put("rpc_port", "9020");
         MIN_FE_CONF.put("query_port", "9030");
-        MIN_FE_CONF.put("arrow_flight_sql_port", "8081");
+        MIN_FE_CONF.put("arrow_flight_sql_port", "8070");
         MIN_FE_CONF.put("edit_log_port", "9010");
         MIN_FE_CONF.put("priority_networks", "127.0.0.1/24");
         MIN_FE_CONF.put("sys_log_verbose_modules", "org");

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedFrontend.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedFrontend.java
@@ -79,7 +79,7 @@ public class MockedFrontend {
         MIN_FE_CONF.put("http_port", "8030");
         MIN_FE_CONF.put("rpc_port", "9020");
         MIN_FE_CONF.put("query_port", "9030");
-        MIN_FE_CONF.put("arrow_flight_sql_port", "9040");
+        MIN_FE_CONF.put("arrow_flight_sql_port", "8081");
         MIN_FE_CONF.put("edit_log_port", "9010");
         MIN_FE_CONF.put("priority_networks", "127.0.0.1/24");
         MIN_FE_CONF.put("sys_log_verbose_modules", "org");


### PR DESCRIPTION
### What problem does this PR solve?

If your cluster 8050 and 8070 are occupied, FE and BE will not fail to start, but arrow flight server will be unavailable.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

