### PR TITLE
[fix](function) Global buffer overflow in sub_replace

### DIFF
--- a/be/test/testutil/column_helper.h
+++ b/be/test/testutil/column_helper.h
@@ -105,6 +105,15 @@ public:
     }
 
     template <typename DataType>
+    static ColumnWithTypeAndName create_const_column_with_name(typename DataType::FieldType value,
+                                                               size_t size) {
+        auto column = create_column<DataType>({value});
+        auto const_column = ColumnConst::create(column, size);
+        auto data_type = std::make_shared<DataType>();
+        return ColumnWithTypeAndName(std::move(const_column), data_type, "column");
+    }
+
+    template <typename DataType>
     static ColumnWithTypeAndName create_nullable_column_with_name(
             const std::vector<typename DataType::FieldType>& datas,
             const std::vector<typename NullMap::value_type>& null_map) {


### PR DESCRIPTION
### What problem does this PR solve?

```
==8578==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5612d9af6be0 at pc 0x56130d816170 bp 0x7f1d4400bcb0 sp 0x7f1d4400bca8
READ of size 1 at 0x5612d9af6be0 thread T2081 (Scan_normal [wo)
    #0 0x56130d81616f in doris::validate_ascii_fast_avx(char const*, unsigned long) /root/doris/be/src/util/simd/vstring_function.h:92:27
    #1 0x56130d96dd9b in doris::simd::VStringFunctions::is_ascii(doris::StringRef const&) /root/doris/be/src/util/simd/vstring_function.h:210:16
    #2 0x56130d96dd9b in auto doris::vectorized::SubReplaceImpl::replace_execute(doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long)::'lambda'(auto, auto, auto, auto)::operator(), std::integral_constant, std::integral_constant, std::integral_constant>(auto, auto, auto, auto) const /root/doris/be/src/vec/functions/function_string.h:3474:25
    #3 0x56130d95d64e in decltype(auto) std::visit> const&, unsigned long, unsigned long)::'lambda'(auto, auto, auto, auto), std::variant, std::integral_constant>, std::variant, std::integral_constant>, std::variant, std::integral_constant>, std::variant, std::integral_constant>>(auto&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&, std::variant, std::integral_constant>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1769:9
    #4 0x56130d95d64e in doris::vectorized::SubReplaceImpl::replace_execute(doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long) /root/doris/be/src/vec/functions/function_string.h:3472:9
    #5 0x56130d95be14 in doris::vectorized::SubReplaceThreeImpl::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long) /root/doris/be/src/vec/functions/function_string.h:3596:16
    #6 0x56130d959f97 in doris::vectorized::FunctionSubReplace::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long) const /root/doris/be/src/vec/functions/function_string.h:3449:16
    #7 0x5613046320fa in doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long) const /root/doris/be/src/vec/functions/function.h:464:26
    #8 0x561308ff0ce0 in doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool) const /root/doris/be/src/vec/functions/function.cpp
    #9 0x561308fe36ae in doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool) const /root/doris/be/src/vec/functions/function.cpp:245:12
    #10 0x561308fe2b2c in doris::vectorized::PreparedFunctionImpl::default_implementation_for_nulls(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool, bool*) const /root/doris/be/src/vec/functions/function.cpp:217:9
    #11 0x561308ff0b2e in doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool) const /root/doris/be/src/vec/functions/function.cpp:111:5
    #12 0x561308fe36ae in doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool) const /root/doris/be/src/vec/functions/function.cpp:245:12
    #13 0x561308fe3922 in doris::vectorized::PreparedFunctionImpl::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool) const /root/doris/be/src/vec/functions/function.cpp:251:12
    #14 0x56130462f8f8 in doris::vectorized::IFunctionBase::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector> const&, unsigned long, unsigned long, bool) const /root/doris/be/src/vec/functions/function.h:195:19
    #15 0x56130462173c in doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector>&) /root/doris/be/src/vec/exprs/vectorized_fn_call.cpp:190:5
    #16 0x561304622255 in doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) /root/doris/be/src/vec/exprs/vectorized_fn_call.cpp:205:12
    #17 0x5613046e569c in doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) /root/doris/be/src/vec/exprs/vexpr_context.cpp:55:5
    #18 0x5613045cab0f in doris::vectorized::VScanner::_do_projections(doris::vectorized::Block*, doris::vectorized::Block*) /root/doris/be/src/vec/exec/scan/vscanner.cpp:197:9
    #19 0x5613045c701e in doris::vectorized::VScanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) /root/doris/be/src/vec/exec/scan/vscanner.cpp:83:16
    #20 0x561304584d3b in doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr, std::shared_ptr) /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:221:5
    #21 0x561304588c8e in doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_1::operator()() const::'lambda'()::operator()() const::'lambda'()::operator()() const /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:154:21
    #22 0x561304588c8e in doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_1::operator()() const::'lambda'()::operator()() const /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:153:31
    #23 0x561304588c8e in void std::__invoke_impl, std::shared_ptr)::$_1::operator()() const::'lambda'()&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_1::operator()() const::'lambda'()&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #24 0x561304588c8e in std::enable_if, std::shared_ptr)::$_1::operator()() const::'lambda'()&>, void>::type std::__invoke_r, std::shared_ptr)::$_1::operator()() const::'lambda'()&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr, std::shared_ptr)::$_1::operator()() const::'lambda'()&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #25 0x561304588c8e in std::_Function_handler, std::shared_ptr)::$_1::operator()() const::'lambda'()>::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #26 0x5612e924be29 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:599:24
    #27 0x5612e92227b7 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #28 0x7f2722294ac2 in start_thread nptl/pthread_create.c:442:8
    #29 0x7f272232684f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

