### PR TITLE
[opt](mtmv) Optimize explain materialized view rewrite info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -411,7 +411,7 @@ public abstract class MaterializationContext {
         if (!chosenMaterializationQualifiers.isEmpty()) {
             chosenMaterializationQualifiers.forEach(materializationQualifier ->
                     builder.append("  ")
-                            .append(generateIdentifierName(materializationQualifier)).append(" chose \n"));
+                            .append(generateIdentifierName(materializationQualifier)).append(" chose\n"));
         }
         // rewrite success but not chosen
         builder.append("\nMaterializedViewRewriteSuccessButNotChose:\n");
@@ -423,7 +423,7 @@ public abstract class MaterializationContext {
         if (!rewriteSuccessButNotChoseQualifiers.isEmpty()) {
             rewriteSuccessButNotChoseQualifiers.forEach(materializationQualifier ->
                     builder.append("  ")
-                            .append(generateIdentifierName(materializationQualifier)).append(" not chose \n"));
+                            .append(generateIdentifierName(materializationQualifier)).append(" not chose\n"));
         }
         // rewrite fail
         builder.append("\nMaterializedViewRewriteFail:");
@@ -431,10 +431,15 @@ public abstract class MaterializationContext {
             if (!ctx.isSuccess()) {
                 Set<String> failReasonSet =
                         ctx.getFailReason().values().stream().map(Pair::key).collect(ImmutableSet.toImmutableSet());
+                if (ctx.isEnableRecordFailureDetail()) {
+                    failReasonSet = ctx.getFailReason().values().stream()
+                            .map(Pair::toString)
+                            .collect(ImmutableSet.toImmutableSet());
+                }
                 builder.append("\n")
                         .append("  ")
-                        .append(generateIdentifierName(ctx.generateMaterializationIdentifier())).append(" fail \n")
-                        .append("  FailSummary: ").append(String.join(", ", failReasonSet));
+                        .append(generateIdentifierName(ctx.generateMaterializationIdentifier())).append(" fail\n")
+                        .append("  FailInfo: ").append(String.join(", ", failReasonSet));
             }
         }
         return builder.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -411,9 +411,7 @@ public abstract class MaterializationContext {
         if (!chosenMaterializationQualifiers.isEmpty()) {
             chosenMaterializationQualifiers.forEach(materializationQualifier ->
                     builder.append("  ")
-                            .append(generateIdentifierName(materializationQualifier)).append(" chose, \n"));
-        } else {
-            builder.append("  chose: none, \n");
+                            .append(generateIdentifierName(materializationQualifier)).append(" chose \n"));
         }
         // rewrite success but not chosen
         builder.append("\nMaterializedViewRewriteSuccessButNotChose:\n");
@@ -425,9 +423,7 @@ public abstract class MaterializationContext {
         if (!rewriteSuccessButNotChoseQualifiers.isEmpty()) {
             rewriteSuccessButNotChoseQualifiers.forEach(materializationQualifier ->
                     builder.append("  ")
-                            .append(generateIdentifierName(materializationQualifier)).append(" not chose, \n"));
-        } else {
-            builder.append("  not chose: none, \n");
+                            .append(generateIdentifierName(materializationQualifier)).append(" not chose \n"));
         }
         // rewrite fail
         builder.append("\nMaterializedViewRewriteFail:");
@@ -437,7 +433,7 @@ public abstract class MaterializationContext {
                         ctx.getFailReason().values().stream().map(Pair::key).collect(ImmutableSet.toImmutableSet());
                 builder.append("\n")
                         .append("  ")
-                        .append(generateIdentifierName(ctx.generateMaterializationIdentifier())).append(" fail, \n")
+                        .append(generateIdentifierName(ctx.generateMaterializationIdentifier())).append(" fail \n")
                         .append("  FailSummary: ").append(String.join(", ", failReasonSet));
             }
         }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -2172,8 +2172,11 @@ class Suite implements GroovyInterceptable {
         explain {
             sql(" memo plan ${query_sql}")
             check { result ->
-                boolean success = !result.contains("${mv_name} chose") && !result.contains("${mv_name} not chose")
+                boolean success = !result.contains(".${mv_name} chose") && !result.contains(".${mv_name} not chose")
                 && !result.contains("${mv_name} fail")
+                if (!success) {
+                    logger.info("mv_not_part_in fail =" + result)
+                }
                 Assert.assertEquals(true, success)
             }
         }
@@ -2187,8 +2190,11 @@ class Suite implements GroovyInterceptable {
             check { result ->
                 boolean success = true;
                 for (String mv_name : mv_names) {
-                    success = !result.contains("${mv_name} chose") && !result.contains("${mv_name} not chose")
-                            && !result.contains("${mv_name} fail")
+                    success = !result.contains(".${mv_name} chose") && !result.contains(".${mv_name} not chose")
+                            && !result.contains(".${mv_name} fail")
+                }
+                if (!success) {
+                    logger.info("mv_all_not_part_in fail =" + result)
                 }
                 Assert.assertEquals(true, success)
             }
@@ -2208,7 +2214,7 @@ class Suite implements GroovyInterceptable {
         }
         explain {
             sql(" memo plan ${query_sql}")
-            contains("${mv_name} chose")
+            contains(".${mv_name} chose")
         }
     }
 
@@ -2228,7 +2234,7 @@ class Suite implements GroovyInterceptable {
             check { result ->
                 boolean success = true;
                 for (String mv_name : mv_names) {
-                    def contains = result.contains("${mv_name} chose")
+                    def contains = result.contains(".${mv_name} chose")
                     if (!contains) {
                         logger.info("mv_rewrite_all_success fail =" + result)
                     }
@@ -2254,7 +2260,7 @@ class Suite implements GroovyInterceptable {
             check { result ->
                 boolean success = false;
                 for (String mv_name : mv_names) {
-                    success = success || result.contains("${mv_name} chose")
+                    success = success || result.contains(".${mv_name} chose")
                 }
                 if (!success) {
                     logger.info("mv_rewrite_any_success fail =" + result)
@@ -2272,7 +2278,7 @@ class Suite implements GroovyInterceptable {
             check {result ->
                 boolean success = true
                 for (String mv_name : mv_names) {
-                    boolean stepSuccess = result.contains("${mv_name} chose") || result.contains("${mv_name} not chose")
+                    boolean stepSuccess = result.contains(".${mv_name} chose") || result.contains(".${mv_name} not chose")
                     success = success && stepSuccess
                 }
                 if (!success) {
@@ -2291,7 +2297,7 @@ class Suite implements GroovyInterceptable {
             check { result ->
                 boolean success = false
                 for (String mv_name : mv_names) {
-                    success = success || result.contains("${mv_name} chose") || result.contains("${mv_name} not chose")
+                    success = success || result.contains(".${mv_name} chose") || result.contains(".${mv_name} not chose")
                 }
                 if (!success) {
                     logger.info("mv_rewrite_any_success_without_check_chosen fail =" + result)
@@ -2307,7 +2313,7 @@ class Suite implements GroovyInterceptable {
         explain {
             sql(" memo plan ${query_sql}")
             check { result ->
-                result.contains("${mv_name} chose") || result.contains("${mv_name} not chose")
+                result.contains(".${mv_name} chose") || result.contains(".${mv_name} not chose")
             }
         }
     }
@@ -2317,7 +2323,7 @@ class Suite implements GroovyInterceptable {
         logger.info("query_sql = " + query_sql + ", mv_name = " + mv_name)
         explain {
             sql(" memo plan ${query_sql}")
-            contains("${mv_name} fail")
+            contains(".${mv_name} fail")
         }
     }
 
@@ -2329,7 +2335,7 @@ class Suite implements GroovyInterceptable {
             check {result ->
                 boolean fail = true
                 for (String mv_name : mv_names) {
-                    boolean stepFail = result.contains("${mv_name} fail")
+                    boolean stepFail = result.contains(".${mv_name} fail")
                     fail = fail && stepFail
                 }
                 if (!fail) {
@@ -2348,7 +2354,7 @@ class Suite implements GroovyInterceptable {
             check { result ->
                 boolean fail = false
                 for (String mv_name : mv_names) {
-                    fail = fail || result.contains("${mv_name} fail")
+                    fail = fail || result.contains(".${mv_name} fail")
                 }
                 if (!fail) {
                     logger.info("mv_rewrite_any_fail =" + result)


### PR DESCRIPTION
### What problem does this PR solve?

Optimize explain info is as following

```text
|                                                                                     
| ========== MATERIALIZATIONS ==========                                              
|                                                                                     
| MaterializedView                                                                    
| MaterializedViewRewriteSuccessAndChose:                                             
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv3 chose     
|                                                                                     
| MaterializedViewRewriteSuccessButNotChose:                                          
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv4 not chose 
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv2 not chose 
|                                                                                     
| MaterializedViewRewriteFail:                                                        
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv1 fail      
|   FailInfo: View struct info is invalid, Predicate compensate fail                  
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv fail       
|   FailInfo: View struct info is invalid                                             
|                                                                                     
|                                                                                     
| ========== STATISTICS ==========                                                    
| planed with unknown column statistics                                               
+-------------------------------------------------------------------------------------
58 rows in set (0.06 sec)
```
Optimize explain memo plan info is as following:

```text
| ========== MATERIALIZATIONS ==========                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
| MaterializedView                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
| MaterializedViewRewriteSuccessAndChose:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv3 chose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
| MaterializedViewRewriteSuccessButNotChose:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv4 not chose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv2 not chose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
| MaterializedViewRewriteFail:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv1 fail                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|   FailInfo: View struct info is invalid:view plan is LogicalResultSink[225] ( outputExprs=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2, sum_total#25] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| +--LogicalAggregate[223] ( groupByExpr=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2], outputExpr=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2, sum(o_totalprice#19) AS `sum_total`#25], hasRepeat=false )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
|    +--LogicalProject[221] ( distinct=false, projects=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2, o_totalprice#19] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
|       +--LogicalJoin[219] ( type=LEFT_OUTER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(l_orderkey#0 = o_orderkey#16), (l_shipdate#10 = o_orderdate#20)], otherJoinConjuncts=[], markJoinConjuncts=[] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
|          |--LogicalProject[212] ( distinct=false, projects=[l_orderkey#0, l_partkey#1, l_suppkey#2, l_shipdate#10] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|          |  +--LogicalFilter[210] ( predicates=(l_orderkey#0 = 1) )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|          |     +--LogicalOlapScan ( qualified=internal.regression_test_nereids_rules_p0_mv_availability.lineitem_partition, indexName=<index_not_selected>, selectedIndexId=1749786446788, preAgg=ON, operativeCol=[l_orderkey#0, l_partkey#1, l_suppkey#2, l_shipdate#10] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|          +--LogicalProject[216] ( distinct=false, projects=[o_orderkey#16, o_totalprice#19, o_orderdate#20] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
|             +--LogicalFilter[214] ( predicates=(o_orderkey#16 = 1) )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|                +--LogicalOlapScan ( qualified=internal.regression_test_nereids_rules_p0_mv_availability.orders_partition, indexName=<index_not_selected>, selectedIndexId=1749786446763, preAgg=ON, operativeCol=[o_orderkey#16, o_totalprice#19, o_orderdate#20] ), Predicate compensate fail:query predicates = Predicates ( pulledUpPredicates=[] ),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
|  query equivalenceClass = EquivalenceClass{equivalenceSlotMap={}},                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
| view predicates = Predicates ( pulledUpPredicates=[] ),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
|  query equivalenceClass = EquivalenceClass{equivalenceSlotMap={}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| comparisonResult = valid: true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|  viewExpressions: [(l_orderkey#0 = 1)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
|  queryExpressions :[]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|  viewNoNullableSlot :[]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| queryAllPulledUpExpressions :[]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
|   internal.regression_test_nereids_rules_p0_mv_availability.partition_mv fail                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
|   FailInfo: View struct info is invalid:view plan is LogicalResultSink[93] ( outputExprs=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2, sum_total#25] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
| +--LogicalAggregate[91] ( groupByExpr=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2], outputExpr=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2, sum(o_totalprice#19) AS `sum_total`#25], hasRepeat=false )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|    +--LogicalProject[89] ( distinct=false, projects=[l_shipdate#10, o_orderdate#20, l_partkey#1, l_suppkey#2, o_totalprice#19] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|       +--LogicalJoin[87] ( type=LEFT_OUTER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(l_orderkey#0 = o_orderkey#16), (l_shipdate#10 = o_orderdate#20)], otherJoinConjuncts=[], markJoinConjuncts=[] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|          |--LogicalProject[83] ( distinct=false, projects=[l_orderkey#0, l_partkey#1, l_suppkey#2, l_shipdate#10] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|          |  +--LogicalOlapScan ( qualified=internal.regression_test_nereids_rules_p0_mv_availability.lineitem_partition, indexName=<index_not_selected>, selectedIndexId=1749786446788, preAgg=ON, operativeCol=[l_orderkey#0, l_partkey#1, l_suppkey#2, l_shipdate#10] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
|          +--LogicalProject[84] ( distinct=false, projects=[o_orderkey#16, o_totalprice#19, o_orderdate#20] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|             +--LogicalOlapScan ( qualified=internal.regression_test_nereids_rules_p0_mv_availability.orders_partition, indexName=<index_not_selected>, selectedIndexId=1749786446763, preAgg=ON, operativeCol=[o_orderkey#16, o_totalprice#19, o_orderdate#20] )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
535 rows in set (0.07 sec)
```


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

