### PR TITLE
[only test now]

### DIFF
--- a/be/src/common/be_mock_util.h
+++ b/be/src/common/be_mock_util.h
@@ -45,6 +45,7 @@ void mock_random_sleep();
 #ifdef BE_TEST
 #define INJECT_MOCK_SLEEP(lock_guard) \
     DEFER(mock_random_sleep());       \
+    mock_random_sleep();              \
     lock_guard;
 #else
 #define INJECT_MOCK_SLEEP(lock_guard) lock_guard

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -152,7 +152,8 @@ Status PartitionSortSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
             local_state._value_places[i]->_blocks.clear();
             RETURN_IF_ERROR(sorter->prepare_for_read());
             // iff one sorter have data, then could set source ready to read
-            std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock);
+            INJECT_MOCK_SLEEP(
+                    std::unique_lock<std::mutex> lc(local_state._shared_state->sink_eos_lock));
             local_state._dependency->set_ready_to_read();
         }
 

--- a/be/src/pipeline/exec/partition_sort_sink_operator.h
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.h
@@ -72,6 +72,13 @@ class PartitionSortSinkOperatorX final : public DataSinkOperatorX<PartitionSortS
 public:
     PartitionSortSinkOperatorX(ObjectPool* pool, int operator_id, int dest_id,
                                const TPlanNode& tnode, const DescriptorTbl& descs);
+#ifdef BE_TEST
+    PartitionSortSinkOperatorX(ObjectPool* pool, int limit, int partition_exprs_num)
+            : _pool(pool),
+              _limit(limit),
+              _partition_exprs_num(partition_exprs_num),
+              _topn_phase(TPartTopNPhase::ONE_PHASE_GLOBAL) {}
+#endif
     Status init(const TDataSink& tsink) override {
         return Status::InternalError("{} should not init with TPlanNode",
                                      DataSinkOperatorX<PartitionSortSinkLocalState>::_name);

--- a/be/src/pipeline/exec/partition_sort_source_operator.h
+++ b/be/src/pipeline/exec/partition_sort_source_operator.h
@@ -52,7 +52,9 @@ public:
     PartitionSortSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode, int operator_id,
                                  const DescriptorTbl& descs)
             : OperatorX<PartitionSortSourceLocalState>(pool, tnode, operator_id, descs) {}
-
+#ifdef BE_TEST
+    PartitionSortSourceOperatorX() = default;
+#endif
     Status get_block(RuntimeState* state, vectorized::Block* block, bool* eos) override;
 
     bool is_source() const override { return true; }

--- a/be/test/pipeline/operator/partition_sort_sink_operator_test.cpp
+++ b/be/test/pipeline/operator/partition_sort_sink_operator_test.cpp
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "pipeline/exec/partition_sort_sink_operator.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+
+#include "pipeline/exec/partition_sort_source_operator.h"
+#include "pipeline/operator/operator_helper.h"
+#include "testutil/column_helper.h"
+#include "testutil/mock/mock_descriptors.h"
+#include "testutil/mock/mock_runtime_state.h"
+#include "testutil/mock/mock_slot_ref.h"
+#include "vec/core/block.h"
+namespace doris::pipeline {
+
+using namespace vectorized;
+
+class PartitionSortOperatorMockOperator : public OperatorXBase {
+public:
+    Status get_block_after_projects(RuntimeState* state, vectorized::Block* block,
+                                    bool* eos) override {
+        return Status::OK();
+    }
+
+    Status get_block(RuntimeState* state, vectorized::Block* block, bool* eos) override {
+        return Status::OK();
+    }
+    Status setup_local_state(RuntimeState* state, LocalStateInfo& info) override {
+        return Status::OK();
+    }
+
+    const RowDescriptor& row_desc() const override { return *_mock_row_desc; }
+
+private:
+    std::unique_ptr<MockRowDescriptor> _mock_row_desc;
+};
+
+struct PartitionSortOperatorTest : public ::testing::Test {
+    void SetUp() override {
+        state = std::make_shared<MockRuntimeState>();
+        state->batsh_size = 10;
+        _child_op = std::make_unique<PartitionSortOperatorMockOperator>();
+    }
+
+    RuntimeProfile profile {"test"};
+    std::unique_ptr<PartitionSortSinkOperatorX> sink;
+    std::unique_ptr<PartitionSortSourceOperatorX> source;
+
+    std::unique_ptr<PartitionSortSinkLocalState> sink_local_state_uptr;
+
+    PartitionSortSinkLocalState* sink_local_state;
+
+    std::unique_ptr<PartitionSortSourceLocalState> source_local_state_uptr;
+    PartitionSortSourceLocalState* source_local_state;
+
+    std::shared_ptr<MockRuntimeState> state;
+
+    std::shared_ptr<PartitionSortOperatorMockOperator> _child_op;
+
+    ObjectPool pool;
+
+    std::shared_ptr<BasicSharedState> shared_state;
+
+    bool is_ready(std::vector<Dependency*> deps) {
+        for (auto* dep : deps) {
+            if (!dep->ready()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void test_for_sink_and_source() {
+        SetUp();
+        sink = std::make_unique<PartitionSortSinkOperatorX>(&pool, -1, 1);
+        sink->_is_asc_order = {true};
+        sink->_nulls_first = {false};
+
+        sink->_vsort_exec_exprs._sort_tuple_slot_expr_ctxs =
+                MockSlotRef::create_mock_contexts(std::make_shared<DataTypeInt64>());
+
+        sink->_vsort_exec_exprs._materialize_tuple = false;
+
+        sink->_vsort_exec_exprs._ordering_expr_ctxs =
+                MockSlotRef::create_mock_contexts(std::make_shared<DataTypeInt64>());
+
+        sink->_partition_expr_ctxs =
+                MockSlotRef::create_mock_contexts(std::make_shared<DataTypeInt64>());
+        _child_op->_mock_row_desc.reset(
+                new MockRowDescriptor {{std::make_shared<vectorized::DataTypeInt64>()}, &pool});
+
+        EXPECT_TRUE(sink->set_child(_child_op));
+
+        source = std::make_unique<PartitionSortSourceOperatorX>();
+
+        shared_state = sink->create_shared_state();
+        {
+            sink_local_state_uptr =
+                    PartitionSortSinkLocalState ::create_unique(sink.get(), state.get());
+            sink_local_state = sink_local_state_uptr.get();
+            LocalSinkStateInfo info {.task_idx = 0,
+                                     .parent_profile = &profile,
+                                     .sender_id = 0,
+                                     .shared_state = shared_state.get(),
+                                     .le_state_map = {},
+                                     .tsink = TDataSink {}};
+            EXPECT_TRUE(sink_local_state_uptr->init(state.get(), info).ok());
+            state->emplace_sink_local_state(0, std::move(sink_local_state_uptr));
+        }
+
+        {
+            source_local_state_uptr =
+                    PartitionSortSourceLocalState::create_unique(state.get(), source.get());
+            source_local_state = source_local_state_uptr.get();
+            LocalStateInfo info {.parent_profile = &profile,
+                                 .scan_ranges = {},
+                                 .shared_state = shared_state.get(),
+                                 .le_state_map = {},
+                                 .task_idx = 0};
+
+            EXPECT_TRUE(source_local_state_uptr->init(state.get(), info).ok());
+            state->resize_op_id_to_local_state(-100);
+            state->emplace_local_state(source->operator_id(), std::move(source_local_state_uptr));
+        }
+
+        { EXPECT_TRUE(sink_local_state->open(state.get()).ok()); }
+        { EXPECT_TRUE(source_local_state->open(state.get()).ok()); }
+
+        auto sink_func = [&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            Block block = ColumnHelper::create_block<DataTypeInt64>({1, 2, 3, 4});
+            EXPECT_TRUE(sink->sink(state.get(), &block, true));
+        };
+
+        auto source_func = [&]() {
+            bool eos = false;
+            while (true) {
+                if (is_ready(source_local_state->dependencies())) {
+                    Block block;
+                    EXPECT_TRUE(source->get_block(state.get(), &block, &eos).ok());
+                    std::cout << "source block\n" << block.dump_data() << std::endl;
+                    if (eos) {
+                        break;
+                    }
+                }
+            }
+        };
+
+        std::thread sink_thread(sink_func);
+        std::thread source_thread(source_func);
+        sink_thread.join();
+        source_thread.join();
+    }
+};
+
+TEST_F(PartitionSortOperatorTest, test) {
+    for (int i = 0; i < 100; i++) {
+        test_for_sink_and_source();
+    }
+}
+
+} // namespace doris::pipeline


### PR DESCRIPTION
### What problem does this PR solve?
```
==3953416==ERROR: AddressSanitizer: heap-use-after-free on address 0x5140000e0708 at pc 0x561e5c2ccfa8 bp 0x7f4a3dcf29b0 sp 0x7f4a3dcf29a8
READ of size 8 at 0x5140000e0708 thread T15
    #0 0x561e5c2ccfa7 in std::vector<doris::vectorized::SortColumnDescription, std::allocator<doris::vectorized::SortColumnDescription>>::size() const /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:990:40
    #1 0x561e5c2d4220 in std::vector<doris::vectorized::SortColumnDescription, std::allocator<doris::vectorized::SortColumnDescription>>::_M_default_append(unsigned long) /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/vector.tcc:639:29
    #2 0x561e5c2cd0b7 in std::vector<doris::vectorized::SortColumnDescription, std::allocator<doris::vectorized::SortColumnDescription>>::resize(unsigned long) /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:1013:4
    #3 0x561e5c2dac07 in doris::vectorized::Sorter::partial_sort(doris::vectorized::Block&, doris::vectorized::Block&) /mnt/disk12/yanxuecheng/doris/be/src/vec/common/sort/sorter.cpp:183:23
    #4 0x561e76fb0899 in doris::vectorized::PartitionSorter::append_block(doris::vectorized::Block*) /mnt/disk12/yanxuecheng/doris/be/src/vec/common/sort/partition_sorter.cpp:62:5
    #5 0x561e76ea3f8a in doris::pipeline::PartitionSortSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) /mnt/disk12/yanxuecheng/doris/be/src/pipeline/exec/partition_sort_sink_operator.cpp:152:17
    #6 0x561e3a8e4890 in doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()::operator()() const /mnt/disk12/yanxuecheng/doris/be/test/pipeline/operator/partition_sort_sink_operator_test.cpp:150:13
    #7 0x561e3a8e43c6 in void std::__invoke_impl<void, doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()>(std::__invoke_other, doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()&&) /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #8 0x561e3a8e4366 in std::__invoke_result<doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()>::type std::__invoke<doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()>(doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()&&) /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14
    #9 0x561e3a8e432e in void std::thread::_Invoker<std::tuple<doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:292:13
    #10 0x561e3a8e42f6 in std::thread::_Invoker<std::tuple<doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()>>::operator()() /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:299:11
    #11 0x561e3a8e41da in std::thread::_State_impl<std::thread::_Invoker<std::tuple<doris::pipeline::PartitionSortOperatorTest::test_for_sink_and_source()::'lambda'()>>>::_M_run() /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:244:13
    #12 0x561e7ab3f87e in execute_native_thread_routine pthread_atfork.c
    #13 0x561e38a74e0a in asan_thread_start(void*) crtstuff.c
    #14 0x7f4a532131c9 in start_thread (/lib64/libpthread.so.0+0x81c9) (BuildId: 7c4add5c7a885e6ff4ce17867d6a2286e4420eec)
  


```
Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

