### PR TITLE
[fix](nereids)show user friendly error message when meet unsupported subquery

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -63,7 +63,6 @@ import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Placeholder;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.expressions.TimestampArithmetic;
 import org.apache.doris.nereids.trees.expressions.Variable;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
@@ -82,6 +81,7 @@ import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInputTypes;
 import org.apache.doris.nereids.trees.plans.PlaceholderId;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.BigIntType;
@@ -300,6 +300,11 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
                 Expression firstBound = bounded.get(0);
                 if (!foundInThisScope && firstBound instanceof Slot
                         && !outerScope.get().getCorrelatedSlots().contains(firstBound)) {
+                    if (currentPlan instanceof LogicalJoin) {
+                        throw new AnalysisException(
+                                "Unsupported correlated subquery with correlated slot in join conjuncts "
+                                        + currentPlan);
+                    }
                     outerScope.get().getCorrelatedSlots().add((Slot) firstBound);
                 }
                 return firstBound;
@@ -651,15 +656,6 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
         // Used to replace expression in ShortCircuit plan
         registerPlaceholderIdToSlot(cp, context, left, right);
         cp = (ComparisonPredicate) cp.withChildren(left, right);
-        if (cp.containsType(SubqueryExpr.class) && getScope().getOuterScope().isPresent()) {
-            Scope outerScope = getScope().getOuterScope().get();
-            for (Slot slot : cp.getInputSlots()) {
-                if (outerScope.getCorrelatedSlots().contains(slot)) {
-                    throw new AnalysisException(
-                            String.format("access outer query column %s in expression %s is not supported", slot, cp));
-                }
-            }
-        }
         return TypeCoercionUtils.processComparisonPredicate(cp);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
@@ -105,6 +105,11 @@ public class SubqueryTest extends AnalyzeCheckTestBase {
                 + "(select sum(t1.k1) from t1 where t0.k1 = t1.k1) "
                 + "and t0.k2 = (select sum(t2.k1) from t2 where t0.v1 = t2.v2)";
         checkAnalyze(sql4);
+
+        String sql5 = "select * from t0 where t0.id = "
+                + "(select sum(t1.k1) from t1 where t0.k1 = "
+                + "(select sum(t2.k1) from t2 where t1.id = t2.v2))";
+        checkAnalyze(sql5);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
@@ -105,11 +105,6 @@ public class SubqueryTest extends AnalyzeCheckTestBase {
                 + "(select sum(t1.k1) from t1 where t0.k1 = t1.k1) "
                 + "and t0.k2 = (select sum(t2.k1) from t2 where t0.v1 = t2.v2)";
         checkAnalyze(sql4);
-
-        String sql5 = "select * from t0 where t0.id = "
-                + "(select sum(t1.k1) from t1 where t0.k1 = "
-                + "(select sum(t2.k1) from t2 where t1.id = t2.v2))";
-        checkAnalyze(sql5);
     }
 
     @Test

--- a/regression-test/suites/nereids_p0/subquery/correlated_scalar_subquery.groovy
+++ b/regression-test/suites/nereids_p0/subquery/correlated_scalar_subquery.groovy
@@ -220,4 +220,18 @@ suite("correlated_scalar_subquery") {
         """
         exception "access outer query's column before two agg nodes is not supported"
     }
+
+    test {
+        sql """
+              select * from correlated_scalar_t1 where correlated_scalar_t1.c1 = (select c2 from correlated_scalar_t2 where correlated_scalar_t1.c1 in (select c1 from correlated_scalar_t3));
+        """
+        exception "access outer query column"
+    }
+
+    test {
+        sql """
+              select * from correlated_scalar_t1 where correlated_scalar_t1.c1 = (select c2 from correlated_scalar_t2 where correlated_scalar_t1.c1 = (select c1 from correlated_scalar_t3));
+        """
+        exception "access outer query column"
+    }
 }

--- a/regression-test/suites/nereids_p0/subquery/correlated_scalar_subquery.groovy
+++ b/regression-test/suites/nereids_p0/subquery/correlated_scalar_subquery.groovy
@@ -176,7 +176,7 @@ suite("correlated_scalar_subquery") {
         sql """
               select c1 from correlated_scalar_t1 where correlated_scalar_t1.c2 > (select correlated_scalar_t2.c1 from correlated_scalar_t2 join correlated_scalar_t3 on correlated_scalar_t1.c1 = correlated_scalar_t3.c2 );
         """
-        exception "access outer query's column in join is not supported"
+        exception "Unsupported correlated subquery with correlated slot in join conjuncts"
     }
 
     test {
@@ -224,13 +224,6 @@ suite("correlated_scalar_subquery") {
     test {
         sql """
               select * from correlated_scalar_t1 where correlated_scalar_t1.c1 = (select c2 from correlated_scalar_t2 where correlated_scalar_t1.c1 in (select c1 from correlated_scalar_t3));
-        """
-        exception "access outer query column"
-    }
-
-    test {
-        sql """
-              select * from correlated_scalar_t1 where correlated_scalar_t1.c1 = (select c2 from correlated_scalar_t2 where correlated_scalar_t1.c1 = (select c1 from correlated_scalar_t3));
         """
         exception "access outer query column"
     }

--- a/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
+++ b/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
@@ -648,6 +648,32 @@ suite ("sub_query_correlated") {
         exception "Unsupported correlated subquery with grouping and/or aggregation";
     }
 
+    test {
+        sql """
+                SELECT *
+                    FROM sub_query_correlated_subquery1
+                    WHERE sub_query_correlated_subquery1.k1 IN 
+                        (SELECT sub_query_correlated_subquery2.k2
+                        FROM sub_query_correlated_subquery2
+                        JOIN sub_query_correlated_subquery3
+                            ON sub_query_correlated_subquery2.k2 = sub_query_correlated_subquery3.k1
+                                AND sub_query_correlated_subquery1.k2 = sub_query_correlated_subquery3.k3); """
+        exception "Unsupported correlated subquery with correlated slot in join conjuncts";
+    }
+
+    test {
+        sql """
+                SELECT *
+                    FROM sub_query_correlated_subquery1
+                    WHERE EXISTS 
+                        (SELECT sub_query_correlated_subquery2.k2
+                        FROM sub_query_correlated_subquery2
+                        JOIN sub_query_correlated_subquery3
+                            ON sub_query_correlated_subquery2.k2 = sub_query_correlated_subquery3.k1
+                                AND sub_query_correlated_subquery1.k2 = sub_query_correlated_subquery3.k3); """
+        exception "Unsupported correlated subquery with correlated slot in join conjuncts";
+    }
+
     qt_doris_7643 """
         SELECT sub_query_correlated_subquery6.*
         FROM sub_query_correlated_subquery6


### PR DESCRIPTION
```
SELECT *
    FROM t1
    WHERE t1.k1 IN 
        (SELECT t2.k2
            FROM t2 JOIN t3
                ON t2.k2 = t3.k1
                    AND t1.k2 = t3.k3); -- access t1.k2 in join conjuncts is not suppported

SELECT * 
    FROM t1 
    WHERE t1.c1 = 
        (SELECT c2 
            FROM t2 
               WHERE t1.c1 in (SELECT c1 FROM t3)-- access t1.c1 as compare expr of in-subquery is not supported
        );
```

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

