### PR TITLE
[feature](Nereids) support turn off ONLY_FULL_GROUP_BY sql mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -54,6 +54,7 @@ import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.agg.AnyValue;
 import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
@@ -61,6 +62,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.StructElement
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitors;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -96,9 +98,11 @@ import org.apache.doris.nereids.types.StructField;
 import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.PlanUtils;
+import org.apache.doris.nereids.util.PlanUtils.CollectNonWindowedAggFuncs;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SqlModeHelper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
@@ -107,6 +111,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -387,7 +392,41 @@ public class BindExpression implements AnalysisRuleFactory {
         Supplier<Scope> childChildrenOutput = Suppliers.memoize(() ->
                 toScope(cascadesContext, PlanUtils.fastGetChildrenOutputs(childPlan.children()))
         );
-        return bindHavingByScopes(having, cascadesContext, childOutput, childChildrenOutput);
+        LogicalHaving<Plan> boundHaving = bindHavingByScopes(having, having.child(),
+                cascadesContext, childOutput, childChildrenOutput);
+        if (!SqlModeHelper.hasOnlyFullGroupBy() && childPlan instanceof LogicalProject) {
+            // ATTN: process having(project) that have aggregate function in having
+            LogicalProject<?> project = (LogicalProject<?>) childPlan;
+            List<AggregateFunction> aggFuncs = CollectNonWindowedAggFuncs.collect(boundHaving.getConjuncts());
+            if (!aggFuncs.isEmpty()) {
+                Map<Expression, Expression> replaceMap = Maps.newHashMap();
+                for (AggregateFunction aggFunc : aggFuncs) {
+                    // ATTN: this is a little trick here. since replace check replace successful with equal operator
+                    //  see: org.apache.doris.nereids.trees.TreeNode.rewriteDownShortCircuit
+                    //  here, we generate a new aggFunc to replace to avoid rewrite its child.
+                    //  because we do not want to replace agg func agg(child) to agg(any_value(child))
+                    replaceMap.put(aggFunc, aggFunc.withChildren(aggFunc.children()));
+                }
+                Builder<NamedExpression> boundProjectionsBuilder
+                        = ImmutableList.builderWithExpectedSize(project.getProjects().size());
+                for (NamedExpression expr : project.getProjects()) {
+                    if (expr instanceof SlotReference) {
+                        Alias alias = new Alias(new AnyValue(expr), expr.getName());
+                        boundProjectionsBuilder.add(alias);
+                        replaceMap.put(expr, alias);
+                    } else {
+                        boundProjectionsBuilder.add(expr);
+                    }
+                }
+                Plan newChildPlan = project.withProjects(boundProjectionsBuilder.build());
+                ImmutableSet.Builder<Expression> newConjunctsBuilder = ImmutableSet.builder();
+                for (Expression conjunct : boundHaving.getConjuncts()) {
+                    newConjunctsBuilder.add(ExpressionUtils.replace(conjunct, replaceMap));
+                }
+                boundHaving = boundHaving.withConjunctsAndChild(newConjunctsBuilder.build(), newChildPlan);
+            }
+        }
+        return boundHaving;
     }
 
     private LogicalHaving<Plan> bindHavingAggregate(
@@ -486,9 +525,8 @@ public class BindExpression implements AnalysisRuleFactory {
     }
 
     private LogicalHaving<Plan> bindHavingByScopes(
-            LogicalHaving<? extends Plan> having,
+            LogicalHaving<? extends Plan> having, Plan child,
             CascadesContext cascadesContext, Scope defaultScope, Supplier<Scope> backupScope) {
-        Plan child = having.child();
 
         SimpleExprAnalyzer analyzer = buildCustomSlotBinderAnalyzer(
                 having, cascadesContext, defaultScope, false, true,
@@ -508,7 +546,7 @@ public class BindExpression implements AnalysisRuleFactory {
         }
         checkIfOutputAliasNameDuplicatedForGroupBy(boundConjuncts.build(),
                 child instanceof LogicalProject ? ((LogicalProject<?>) child).getOutputs() : child.getOutput());
-        return new LogicalHaving<>(boundConjuncts.build(), having.child());
+        return new LogicalHaving<>(boundConjuncts.build(), child);
     }
 
     private LogicalSort<LogicalSetOperation> bindSortWithSetOperation(
@@ -635,12 +673,13 @@ public class BindExpression implements AnalysisRuleFactory {
         SimpleExprAnalyzer analyzer = buildSimpleExprAnalyzer(
                 project, cascadesContext, project.children(), true, true);
 
-        Builder<NamedExpression> boundProjections = ImmutableList.builderWithExpectedSize(project.getProjects().size());
+        Builder<NamedExpression> boundProjectionsBuilder
+                = ImmutableList.builderWithExpectedSize(project.getProjects().size());
         StatementContext statementContext = ctx.statementContext;
         for (Expression expression : project.getProjects()) {
             Expression expr = analyzer.analyze(expression);
             if (!(expr instanceof BoundStar)) {
-                boundProjections.add((NamedExpression) expr);
+                boundProjectionsBuilder.add((NamedExpression) expr);
             } else {
                 UnboundStar unboundStar = (UnboundStar) expression;
                 List<NamedExpression> excepts = unboundStar.getExceptedSlots();
@@ -675,7 +714,7 @@ public class BindExpression implements AnalysisRuleFactory {
                         if (s != e) {
                             replaced.add(s);
                         }
-                        boundProjections.add((NamedExpression) e);
+                        boundProjectionsBuilder.add((NamedExpression) e);
                     }
 
                     if (replaced.size() != replaceMap.size()) {
@@ -683,7 +722,7 @@ public class BindExpression implements AnalysisRuleFactory {
                         throw new AnalysisException("Invalid replace column name: " + replaceMap.keySet());
                     }
                 } else {
-                    boundProjections.addAll(slots);
+                    boundProjectionsBuilder.addAll(slots);
                 }
 
                 // for create view stmt expand star
@@ -693,7 +732,24 @@ public class BindExpression implements AnalysisRuleFactory {
                 });
             }
         }
-        return project.withProjects(boundProjections.build());
+        List<NamedExpression> boundProjections = boundProjectionsBuilder.build();
+        if (!SqlModeHelper.hasOnlyFullGroupBy()) {
+            boolean hasAggregation = boundProjections
+                    .stream()
+                    .anyMatch(e -> e.accept(ExpressionVisitors.CONTAINS_AGGREGATE_CHECKER, null));
+            if (hasAggregation) {
+                boundProjectionsBuilder
+                        = ImmutableList.builderWithExpectedSize(project.getProjects().size());
+                for (NamedExpression expr : boundProjections) {
+                    if (expr instanceof SlotReference) {
+                        expr = new Alias(expr, expr.getName());
+                    }
+                    boundProjectionsBuilder.add(expr);
+                }
+                boundProjections = boundProjectionsBuilder.build();
+            }
+        }
+        return project.withProjects(boundProjections);
     }
 
     private Plan bindLoadProject(MatchingContext<LogicalLoadProject<Plan>> ctx) {
@@ -1027,7 +1083,7 @@ public class BindExpression implements AnalysisRuleFactory {
                 buildAggOutputScopeWithoutAggFun(boundProjections, cascadesContext);
         List<Expression> boundGroupBy = bindGroupBy(
                 agg, agg.getGroupByExpressions(), boundProjections, aggOutputScopeWithoutAggFun, cascadesContext);
-        return agg.withGroupByAndOutput(boundGroupBy, boundProjections);
+        return agg.withGroupByAndOutput(boundGroupBy, processNonStandardAggregate(boundProjections, boundGroupBy));
     }
 
     private Plan bindRepeat(MatchingContext<LogicalRepeat<Plan>> ctx) {
@@ -1042,10 +1098,12 @@ public class BindExpression implements AnalysisRuleFactory {
 
         Builder<List<Expression>> boundGroupingSetsBuilder =
                 ImmutableList.builderWithExpectedSize(repeat.getGroupingSets().size());
+        Set<Expression> flatBoundGroupingSet = Sets.newHashSet();
         for (List<Expression> groupingSet : repeat.getGroupingSets()) {
             List<Expression> boundGroupingSet = bindGroupBy(
                     repeat, groupingSet, boundRepeatOutput, aggOutputScopeWithoutAggFun, cascadesContext);
             boundGroupingSetsBuilder.add(boundGroupingSet);
+            flatBoundGroupingSet.addAll(boundGroupingSet);
         }
         List<List<Expression>> boundGroupingSets = boundGroupingSetsBuilder.build();
         List<NamedExpression> nullableOutput = PlanUtils.adjustNullableForRepeat(boundGroupingSets, boundRepeatOutput);
@@ -1055,7 +1113,7 @@ public class BindExpression implements AnalysisRuleFactory {
 
         // check all GroupingScalarFunction inputSlots must be from groupingExprs
         Set<Slot> groupingExprs = boundGroupingSets.stream()
-                .flatMap(Collection::stream).map(expr -> expr.getInputSlots())
+                .flatMap(Collection::stream).map(Expression::getInputSlots)
                 .flatMap(Collection::stream).collect(Collectors.toSet());
         Set<GroupingScalarFunction> groupingScalarFunctions = ExpressionUtils
                 .collect(nullableOutput, GroupingScalarFunction.class::isInstance);
@@ -1065,7 +1123,44 @@ public class BindExpression implements AnalysisRuleFactory {
                         + " does not exist in GROUP BY clause.");
             }
         }
-        return repeat.withGroupSetsAndOutput(boundGroupingSets, nullableOutput);
+
+        return repeat.withGroupSetsAndOutput(boundGroupingSets,
+                processNonStandardAggregate(nullableOutput, flatBoundGroupingSet));
+    }
+
+    /**
+     * for support non-standard aggregate, such as SELECT c1, c2 FROM t GROUP BY c1.
+     * we around an extra Alias on SlotReference in output expression list
+     * to avoid ExprId conflict. Because we will do a transform later like:
+     * <p>
+     * Repeat([c1#1, c2#2 as c2#3], [[c1#1], [c3#4]])
+     * ---
+     * Project(c1#1, c2#3)
+     * +-- Aggregate([c1#1, any_value(c2#2) as c2#3], [c1#1])
+     *     +-- Project(c1#1, c2#2)
+     *
+     * @param originalProjections original projections in aggregation
+     * @param groupingExprs all expressions for group by key
+     *
+     * @return output with wrapped scalar slots
+     */
+    private List<NamedExpression> processNonStandardAggregate(
+            List<NamedExpression> originalProjections, Collection<Expression> groupingExprs) {
+        if (SqlModeHelper.hasOnlyFullGroupBy()) {
+            return originalProjections;
+        } else {
+
+            ImmutableList.Builder<NamedExpression> finalProjectionsBuilder = ImmutableList.builder();
+            for (NamedExpression projection : originalProjections) {
+                // we do a trick here
+                if (projection instanceof SlotReference && !groupingExprs.contains(projection)) {
+                    finalProjectionsBuilder.add(new Alias(projection, projection.getName()));
+                } else {
+                    finalProjectionsBuilder.add(projection);
+                }
+            }
+            return finalProjectionsBuilder.build();
+        }
     }
 
     private List<Expression> bindGroupBy(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterBind.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterBind.java
@@ -25,7 +25,6 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.InSubquery;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
-import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -60,9 +59,6 @@ public class CheckAfterBind implements AnalysisRuleFactory {
                 if (((InSubquery) predicate).getListQuery().getDataType().isObjectType()) {
                     throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
                 }
-            }
-            if (ExpressionUtils.hasOnlyMetricType(predicate.getArguments())) {
-                throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlots.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlots.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.agg.AnyValue;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Aggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
@@ -37,6 +38,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.qe.SqlModeHelper;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -307,9 +309,17 @@ public class FillUpMissingSlots implements AnalysisRuleFactory {
                 // We couldn't find the equivalent expression in output expressions and group-by expressions,
                 // so we should check whether the expression is valid.
                 if (expression instanceof SlotReference) {
-                    if (checkSlot && (!outerScope.isPresent()
+                    if ((!outerScope.isPresent()
                             || !outerScope.get().getCorrelatedSlots().contains(expression))) {
-                        throw new AnalysisException(expression.toSql() + " should be grouped by.");
+                        if (!SqlModeHelper.hasOnlyFullGroupBy()) {
+                            // ATTN: we should add any_value to agg's output here, but not add slot directly.
+                            //   because normalize agg cannot replace upper slot with new output.
+                            Alias alias = new Alias(new AnyValue(expression));
+                            newOutputSlots.add(alias);
+                            substitution.put(expression, alias.toSlot());
+                        } else if (checkSlot) {
+                            throw new AnalysisException(expression.toSql() + " should be grouped by.");
+                        }
                     }
                 } else if (expression instanceof AggregateFunction) {
                     if (checkWhetherNestedAggregateFunctionsExist((AggregateFunction) expression)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeAggregate.java
@@ -36,6 +36,7 @@ import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.agg.AnyValue;
 import org.apache.doris.nereids.trees.expressions.functions.agg.MultiDistinction;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
@@ -47,10 +48,12 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.PlanUtils.CollectNonWindowedAggFuncs;
 import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.qe.SqlModeHelper;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
@@ -218,14 +221,6 @@ public class NormalizeAggregate implements RewriteRuleFactory, NormalizeToSlot {
         Set<NamedExpression> bottomProjects = Sets.union(pushedGroupByExprs,
                 Sets.union(pushedTrivialAggChildren, pushedTrivialAggInputSlots));
 
-        // create bottom project
-        Plan bottomPlan;
-        if (!bottomProjects.isEmpty()) {
-            bottomPlan = new LogicalProject<>(ImmutableList.copyOf(bottomProjects), aggregate.child());
-        } else {
-            bottomPlan = aggregate.child();
-        }
-
         // use group by context to normalize agg functions to process
         //   sql like: select sum(a + 1) from t group by a + 1
         //
@@ -275,8 +270,6 @@ public class NormalizeAggregate implements RewriteRuleFactory, NormalizeToSlot {
             newAggOutputBuilder.add((NamedExpression) rewrittenExpr);
         }
         ImmutableList<NamedExpression> normalizedAggOutput = newAggOutputBuilder.build();
-        LogicalAggregate<?> newAggregate =
-                aggregate.withNormalized(normalizedGroupExprs, normalizedAggOutput, bottomPlan);
 
         // create upper projects by normalize all output exprs in old LogicalAggregate
         // In aggregateOutput, the expressions inside the agg function can be rewritten
@@ -286,36 +279,58 @@ public class NormalizeAggregate implements RewriteRuleFactory, NormalizeToSlot {
         List<NamedExpression> upperProjects = normalizeOutput(aggregateOutput,
                 groupByExprContext, argsOfAggFuncNeedPushDownContext, normalizedAggFuncsToSlotContext);
 
+        // verify project used slots are all coming from agg's output
+        List<Slot> slotsUsedInUpperProject = collectAllUsedSlots(upperProjects);
+        if (!slotsUsedInUpperProject.isEmpty()) {
+            Set<ExprId> aggOutputExprIds = new HashSet<>(slotsUsedInUpperProject.size());
+            for (NamedExpression expression : normalizedAggOutput) {
+                aggOutputExprIds.add(expression.getExprId());
+            }
+            Set<Slot> missingSlotsInAggregate = new HashSet<>(slotsUsedInUpperProject.size());
+            for (Slot slot : slotsUsedInUpperProject) {
+                if (!aggOutputExprIds.contains(slot.getExprId()) && !(slot instanceof SlotNotFromChildren)) {
+                    missingSlotsInAggregate.add(slot);
+                }
+            }
+            if (!missingSlotsInAggregate.isEmpty()) {
+                if (SqlModeHelper.hasOnlyFullGroupBy()) {
+                    throw new AnalysisException(String.format("%s not in aggregate's output", missingSlotsInAggregate
+                            .stream().map(NamedExpression::getName).collect(Collectors.joining(", "))));
+                } else {
+                    // for any slots missing in aggregate's output, we should add a any_value(slot) into
+                    // aggregate's output list and slot itself into bottom project's output list
+                    bottomProjects = Sets.union(bottomProjects, missingSlotsInAggregate);
+                    Map<Expression, Expression> replaceMap = Maps.newHashMap();
+                    for (Slot slot : missingSlotsInAggregate) {
+                        Alias anyValue = new Alias(new AnyValue(slot), slot.getName());
+                        replaceMap.put(slot, anyValue.toSlot());
+                        newAggOutputBuilder.add(anyValue);
+                    }
+                    upperProjects = upperProjects.stream()
+                            .map(e -> (NamedExpression) ExpressionUtils.replace(e, replaceMap))
+                            .collect(ImmutableList.toImmutableList());
+                }
+            }
+        }
+        // create normalized plan
+        Plan bottomPlan;
+        if (!bottomProjects.isEmpty()) {
+            bottomPlan = new LogicalProject<>(ImmutableList.copyOf(bottomProjects), aggregate.child());
+        } else {
+            bottomPlan = aggregate.child();
+        }
+        // NOTICE: we must call newAggOutputBuilder.build() here, newAggOutputBuilder could be updated if we need
+        //  to process non-standard aggregate: SELECT c1, c2 FROM t GROUP BY c1
+        LogicalAggregate<?> newAggregate =
+                aggregate.withNormalized(normalizedGroupExprs, newAggOutputBuilder.build(), bottomPlan);
         ExpressionRewriteContext rewriteContext = new ExpressionRewriteContext(ctx);
         LogicalProject<Plan> project = eliminateGroupByConstant(groupByExprContext, rewriteContext,
                 normalizedGroupExprs, normalizedAggOutput, bottomProjects, aggregate, upperProjects, newAggregate);
 
-        // verify project used slots are all coming from agg's output
-        List<Slot> slots = collectAllUsedSlots(upperProjects);
-        if (!slots.isEmpty()) {
-            Set<ExprId> aggOutputExprIds = new HashSet<>(slots.size());
-            for (NamedExpression expression : normalizedAggOutput) {
-                aggOutputExprIds.add(expression.getExprId());
-            }
-            List<Slot> errorSlots = new ArrayList<>(slots.size());
-            for (Slot slot : slots) {
-                if (!aggOutputExprIds.contains(slot.getExprId()) && !(slot instanceof SlotNotFromChildren)) {
-                    errorSlots.add(slot);
-                }
-            }
-            if (!errorSlots.isEmpty()) {
-                throw new AnalysisException(String.format("%s not in aggregate's output", errorSlots
-                        .stream().map(NamedExpression::getName).collect(Collectors.joining(", "))));
-            }
-        }
         if (having.isPresent()) {
-            Set<Slot> havingUsedSlots = ExpressionUtils.getInputSlotSet(having.get().getExpressions());
-            Set<ExprId> havingUsedExprIds = new HashSet<>(havingUsedSlots.size());
-            for (Slot slot : havingUsedSlots) {
-                havingUsedExprIds.add(slot.getExprId());
-            }
-            Set<ExprId> aggOutputExprIds = newAggregate.getOutputExprIdSet();
-            if (aggOutputExprIds.containsAll(havingUsedExprIds)) {
+            Set<Slot> havingUsedSlots = having.get().getInputSlots();
+            Set<Slot> aggOutputExprIds = newAggregate.getOutputSet();
+            if (aggOutputExprIds.containsAll(havingUsedSlots)) {
                 // when having just use output slots from agg, we push down having as parent of agg
                 return project.withChildren(ImmutableList.of(
                         new LogicalHaving<>(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
@@ -300,7 +300,7 @@ public class ExpressionRewrite implements RewriteRuleFactory {
                 if (newConjuncts.equals(having.getConjuncts())) {
                     return having;
                 }
-                return having.withExpressions(newConjuncts);
+                return having.withConjuncts(newConjuncts);
             }).toRule(RuleType.REWRITE_HAVING_EXPRESSION);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
@@ -69,7 +69,7 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     @Override
-    public Plan withChildren(List<Plan> children) {
+    public LogicalHaving<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
         return new LogicalHaving<>(conjuncts, children.get(0));
     }
@@ -91,9 +91,13 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
         return new LogicalHaving<>(conjuncts, groupExpression, logicalProperties, children.get(0));
     }
 
-    public Plan withExpressions(Set<Expression> expressions) {
-        return new LogicalHaving<Plan>(expressions, Optional.empty(),
+    public LogicalHaving<Plan> withConjuncts(Set<Expression> conjuncts) {
+        return new LogicalHaving<>(conjuncts, Optional.empty(),
                 Optional.of(getLogicalProperties()), child());
+    }
+
+    public LogicalHaving<Plan> withConjunctsAndChild(Set<Expression> conjuncts, Plan child) {
+        return new LogicalHaving<>(conjuncts, child);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -858,7 +858,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // Set sqlMode to empty string
     @VariableMgr.VarAttr(name = SQL_MODE, needForward = true)
-    public long sqlMode = SqlModeHelper.MODE_DEFAULT;
+    public long sqlMode = SqlModeHelper.MODE_ONLY_FULL_GROUP_BY;
 
     @VariableMgr.VarAttr(name = WORKLOAD_VARIABLE, needForward = true)
     public String workloadGroup = "";

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SqlModeHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SqlModeHelper.java
@@ -225,4 +225,12 @@ public class SqlModeHelper {
                 & MODE_PIPES_AS_CONCAT) != 0;
     }
 
+    public static boolean hasOnlyFullGroupBy() {
+        SessionVariable sessionVariable = ConnectContext.get() == null
+                ? VariableMgr.newSessionVariable()
+                : ConnectContext.get().getSessionVariable();
+        return ((sessionVariable.getSqlMode() & MODE_ALLOWED_MASK)
+                & MODE_ONLY_FULL_GROUP_BY) != 0;
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -945,57 +945,66 @@ public class VariableMgr {
 
     public static void forceUpdateVariables() {
         int currentVariableVersion = GlobalVariable.variableVersion;
+        String updateInfo = currentVariableVersion + "to" + GlobalVariable.CURRENT_VARIABLE_VERSION;
         if (currentVariableVersion == GlobalVariable.VARIABLE_VERSION_0) {
             // update from 2.0.15 or below to 2.0.16 or higher
             if (VariableMgr.newSessionVariable().nereidsTimeoutSecond == 5) {
-                VariableMgr.refreshDefaultSessionVariables("update variable version",
+                VariableMgr.refreshDefaultSessionVariables(updateInfo,
                         SessionVariable.NEREIDS_TIMEOUT_SECOND, "30");
             }
         }
         if (currentVariableVersion < GlobalVariable.VARIABLE_VERSION_100) {
             // update from 2.1.6 or below to 2.1.7 or higher
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_NEREIDS_DML,
                     String.valueOf(true));
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_NEREIDS_DML_WITH_PIPELINE,
                     String.valueOf(true));
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_NEREIDS_PLANNER,
                     String.valueOf(true));
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_FALLBACK_TO_ORIGINAL_PLANNER,
                     String.valueOf(true));
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_PIPELINE_X_ENGINE,
                     String.valueOf(true));
         }
         if (currentVariableVersion < GlobalVariable.VARIABLE_VERSION_101) {
             if (StatisticsUtil.getAutoAnalyzeTableWidthThreshold()
                     < StatisticConstants.AUTO_ANALYZE_TABLE_WIDTH_THRESHOLD) {
-                VariableMgr.refreshDefaultSessionVariables("update variable version",
+                VariableMgr.refreshDefaultSessionVariables(updateInfo,
                         SessionVariable.AUTO_ANALYZE_TABLE_WIDTH_THRESHOLD,
                         String.valueOf(StatisticConstants.AUTO_ANALYZE_TABLE_WIDTH_THRESHOLD));
             }
             if (StatisticsUtil.getTableStatsHealthThreshold()
                     < StatisticConstants.TABLE_STATS_HEALTH_THRESHOLD) {
-                VariableMgr.refreshDefaultSessionVariables("update variable version",
+                VariableMgr.refreshDefaultSessionVariables(updateInfo,
                         SessionVariable.TABLE_STATS_HEALTH_THRESHOLD,
                         String.valueOf(StatisticConstants.TABLE_STATS_HEALTH_THRESHOLD));
             }
         }
         if (currentVariableVersion < GlobalVariable.VARIABLE_VERSION_200) {
             // update from 3.0.2 or below to 3.0.3 or higher
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_FALLBACK_TO_ORIGINAL_PLANNER,
                     String.valueOf(false));
         }
         if (currentVariableVersion < GlobalVariable.VARIABLE_VERSION_300) {
             // update to master
-            // do nothing
+            long sqlMode = defaultSessionVariable.sqlMode;
+            // remove mode_default flag
+            if ((sqlMode & SqlModeHelper.MODE_DEFAULT) != 0) {
+                sqlMode ^= SqlModeHelper.MODE_DEFAULT;
+            }
+            sqlMode |= SqlModeHelper.MODE_ONLY_FULL_GROUP_BY;
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
+                    SessionVariable.SQL_MODE,
+                    String.valueOf(sqlMode));
         }
         if (currentVariableVersion < GlobalVariable.CURRENT_VARIABLE_VERSION) {
-            VariableMgr.refreshDefaultSessionVariables("update variable version",
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     GlobalVariable.VARIABLE_VERSION,
                     String.valueOf(GlobalVariable.CURRENT_VARIABLE_VERSION));
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetVariableTest.java
@@ -45,14 +45,14 @@ public class SetVariableTest {
 
     @Test
     public void testSqlMode() throws Exception {
-        String setStr = "set sql_mode = concat(@@sql_mode, 'STRICT_TRANS_TABLES');";
+        String setStr = "set sql_mode = concat_ws(',', @@sql_mode, 'STRICT_TRANS_TABLES');";
         connectContext.getState().reset();
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, setStr);
         stmtExecutor.execute();
-        Assert.assertEquals("STRICT_TRANS_TABLES",
-                SqlModeHelper.decode(connectContext.getSessionVariable().getSqlMode()));
+        Assert.assertNotEquals(0,
+                connectContext.getSessionVariable().getSqlMode() & SqlModeHelper.MODE_STRICT_TRANS_TABLES);
 
-        String selectStr = "explain select /*+ SET_VAR(enable_nereids_planner=false) */ @@sql_mode;";
+        String selectStr = "explain select @@sql_mode;";
         connectContext.getState().reset();
         stmtExecutor = new StmtExecutor(connectContext, selectStr);
         stmtExecutor.execute();

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -82,7 +82,7 @@ public class VariableMgrTest {
             } else if (row.get(0).equalsIgnoreCase("query_timeout")) {
                 Assert.assertEquals(String.valueOf(originQueryTimeOut), row.get(1));
             } else if (row.get(0).equalsIgnoreCase("sql_mode")) {
-                Assert.assertEquals("", row.get(1));
+                Assert.assertEquals("ONLY_FULL_GROUP_BY", row.get(1));
             } else if (row.get(0).equalsIgnoreCase("insert_timeout")) {
                 Assert.assertEquals(String.valueOf(originInsertTimeout), row.get(1));
             }

--- a/regression-test/suites/nereids_p0/aggregate/non_standard_aggregate.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/non_standard_aggregate.groovy
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("non_standard_aggregate") {
+    sql """
+        set sql_mode = "";
+    """
+
+    sql """
+        DROP TABLE IF EXISTS non_standard_aggregate
+    """
+
+    sql """
+        DROP TABLE IF EXISTS non_standard_aggregate_2
+    """
+
+    sql """
+        CREATE TABLE non_standard_aggregate (
+          c1 int,
+          c2 int,
+          c3 string,
+          c4 array<int>
+        )
+        PROPERTIES (
+          'replication_num' = '1'
+        )
+    """
+
+    sql """
+        CREATE TABLE non_standard_aggregate_2 (
+          c5 int,
+          c6 int,
+          c7 string,
+          c8 array<int>
+        )
+        PROPERTIES (
+          'replication_num' = '1'
+        )
+    """
+
+    sql """
+        INSERT INTO non_standard_aggregate VALUES (1, 2, 'hello,world', [1, 2, 3, 4])
+    """
+
+    sql """
+        INSERT INTO non_standard_aggregate_2 VALUES (1, 2, 'hello,world', [1, 2, 3, 4])
+    """
+
+    // simple case
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1"""
+
+    // not group by key
+    sql """SELECT c1, sum(c2) FROM non_standard_aggregate"""
+
+    // use two scalar column as group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 + c2"""
+
+    // both group by key and scalar column in one expression
+    sql """SELECT c1 + c2, c3 FROM non_standard_aggregate GROUP BY c1"""
+
+    // all scalar column not in group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 + 1"""
+
+    // scalar column with function
+    sql """SELECT c1, c2 + 1 FROM non_standard_aggregate GROUP BY c1 + 1"""
+
+    // use two scalar column as group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 + c2 HAVING c1 < 5"""
+
+    // use function with two scalar column as group by key, function with two scalar column in having
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 + c2 HAVING c1 + c2 < 5"""
+
+    // use function with two scalar column as group by key, function with two scalar column in having
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 + c2 HAVING c1 + c3 < 5"""
+
+    // use function with two scalar column as group by key, function with both scalar column and group by key in having
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 + c2 HAVING c1 + c2 + c1 < 10"""
+
+    // both group by key and scalar column in one expression and use it in having
+    sql """SELECT c1 + c2, c3 FROM non_standard_aggregate GROUP BY c1 HAVING c1 + c2 < 5"""
+
+    // having with aggregate function but project not
+    sql """SELECT c1 FROM non_standard_aggregate HAVING max(c1) = c1"""
+    sql """SELECT c2 FROM non_standard_aggregate HAVING max(c1) = c2"""
+
+    // having with both aggregate function and scalar column
+    sql """SELECT max(c1) FROM non_standard_aggregate HAVING c1 = count(c1)"""
+    sql """SELECT max(c1) FROM non_standard_aggregate HAVING c2 = count(c1)"""
+
+    // lateral view, be do not support any_value(array)
+    // sql """SELECT c1, c4, c5 FROM non_standard_aggregate LATERAL VIEW explode(c4) tmp as c5 GROUP BY c1 HAVING c5 < 5"""
+    sql """SELECT c1, c5 FROM non_standard_aggregate LATERAL VIEW explode(c4) tmp as c5 GROUP BY c1 HAVING c5 < 5"""
+
+    // join
+    sql """SELECT c1, c5 FROM non_standard_aggregate JOIN non_standard_aggregate_2 ON c2 = c6 GROUP BY c1"""
+
+    // filter
+    sql """SELECT c1, c2 FROM non_standard_aggregate WHERE c3 = 'hello,world' GROUP BY c2"""
+
+    // window as scalar column
+    sql """SELECT c1 + 1, LAG(c2, 0, NULL) OVER(PARTITION BY c1 ORDER BY c3) FROM non_standard_aggregate GROUP BY c1 + 1"""
+
+    // having to filter group by key
+    sql """SELECT c1, c2 + 1 FROM non_standard_aggregate GROUP BY c1 + 1 HAVING c1 + 1 < 5"""
+
+    // having to filter scalar column
+    sql """SELECT c1, c2 + 1 FROM non_standard_aggregate GROUP BY c1 + 1 HAVING c2 + 1 < 5"""
+
+    // having with neither group by key nor scalar column
+    sql """SELECT c1, c2 + 1 FROM non_standard_aggregate GROUP BY c1 + 1 HAVING c2 + 2 < 5"""
+
+    // having to filter window
+    sql """SELECT c1 + 1, LAG(c2, 0, NULL) OVER(PARTITION BY c1 ORDER BY c3) AS c3 FROM non_standard_aggregate GROUP BY c1 + 1 HAVING c3 < 10"""
+
+    // order by with group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c1"""
+
+    // order by with scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c2"""
+
+    // order by with function of group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c1 + 1"""
+
+    // order by with function of scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c2 + 1"""
+
+    // order by with aggregate function
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY sum(c2)"""
+
+    // top-n with group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c1 LIMIT 10"""
+
+    // top-n with scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c2 LIMIT 10"""
+
+    // top-n with function of group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c1 + 1 LIMIT 10"""
+
+    // top-n with function of scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY c2 + 1 LIMIT 10"""
+
+    // top-n with aggregate function
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 ORDER BY sum(c2) LIMIT 10"""
+
+    // having scalar column + order by aggregate function
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 HAVING c2 < 10 ORDER BY sum(c2)"""
+
+    // having scalar column + order by scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 HAVING c2 < 10 ORDER BY c3"""
+
+    // having aggregate function + order by scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY c1 HAVING sum(c2) < 10 ORDER BY c3"""
+
+
+    // repeat
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY GROUPING SETS((c1), (c1, c2), ())"""
+
+    // repeat with having on group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY GROUPING SETS((c1), (c1, c2), ()) HAVING c1 < 5"""
+
+    // repeat with having on function with group by key
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY GROUPING SETS((c1), (c1, c2), ()) HAVING c1 + 1 < 5"""
+
+    // repeat with having on scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY GROUPING SETS((c1), (c1, c2), ()) HAVING c3 < 5"""
+
+    // repeat with having on function with scalar column
+    sql """SELECT c1, c2, c3 FROM non_standard_aggregate GROUP BY GROUPING SETS((c1), (c1, c2), ()) HAVING c3 + 1 < 5"""
+
+    // repeat with having with neither group by key nor scalar column
+    sql """SELECT c1, c2, c3 + 1 FROM non_standard_aggregate GROUP BY GROUPING SETS((c1), (c1, c2), ()) HAVING c3 < 5"""
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

same as MySQL. Refer to [MySQL's doc](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_only_full_group_by)

This PR:
- add ONLY_FULL_GROUP_BY mode into default sql_mode
- support SQL that the aggregate's output include the column neither from group by key nor from aggregate function when sql_mode does not contain ONLY_FULL_GROUP_BY 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

