### PR TITLE
[fix](statistics)Fix replace table doesn't remove table stat meta memory leak bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -832,6 +832,7 @@ public class Alter {
             if (origTable.getType() == TableType.MATERIALIZED_VIEW) {
                 Env.getCurrentEnv().getMtmvService().deregisterMTMV((MTMV) origTable);
             }
+            Env.getCurrentEnv().getAnalysisManager().removeTableStats(origTable.getId());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCleaner.java
@@ -116,19 +116,24 @@ public class StatisticsCleaner extends MasterDaemon {
                 // If ctlName, dbName and tblName exist, it means the table stats is created under new version.
                 // First try to find the table by the given names. If table exists, means the tableMeta is valid,
                 // it should be kept in memory.
+                boolean tableExist = false;
                 try {
-                    StatisticsUtil.findTable(stats.ctlName, stats.dbName, stats.tblName);
-                    continue;
+                    TableIf table = StatisticsUtil.findTable(stats.ctlName, stats.dbName, stats.tblName);
+                    // Tables may have identical names but different id, e.g. replace table.
+                    tableExist = table.getId() == id;
                 } catch (Exception e) {
                     LOG.debug("Table {}.{}.{} not found.", stats.ctlName, stats.dbName, stats.tblName);
                 }
-                // If we couldn't find table by names, try to find it in internal catalog. This is to support older
-                // version which the tableStats object doesn't store the names but only table id.
+                // If we couldn't find table by names, try to find it in internal catalog by id.
+                // This is to support older version which the tableStats object doesn't store the names
+                // but only table id.
                 // We may remove external table's tableStats here, but it's not a big problem.
                 // Because the stats in column_statistics table is still available,
-                // the only disadvantage is auto analyze may be triggered for this table.
-                // But it only happens once, the new table stats object will have all the catalog, db and table names.
-                if (tableExistInInternalCatalog(internalCatalog, id)) {
+                // the only disadvantage is auto analyze may be triggered for this table again.
+                // But it only happens once, the new table stats object will have all the catalog,
+                // db and table names.
+                // Also support REPLACE TABLE
+                if (tableExist || tableExistInInternalCatalog(internalCatalog, id)) {
                     continue;
                 }
                 LOG.info("Table {}.{}.{} with id {} not exist, remove its table stats record.",

--- a/regression-test/suites/statistics/test_replace_table.groovy
+++ b/regression-test/suites/statistics/test_replace_table.groovy
@@ -17,9 +17,9 @@
 
 suite("test_replace_table") {
 
-    sql """drop database if exists test_replace_table"""
-    sql """create database test_replace_table"""
-    sql """use test_replace_table"""
+    sql """drop database if exists test_replace_table_statistics"""
+    sql """create database test_replace_table_statistics"""
+    sql """use test_replace_table_statistics"""
     sql """set global force_sample_analyze=false"""
     sql """set global enable_auto_analyze=false"""
 
@@ -70,12 +70,19 @@ suite("test_replace_table") {
     result = sql """show column cached stats t2"""
     assertEquals(2, result.size())
 
+    def id1 = get_table_id("internal", "test_replace_table_statistics", "t1")
+    def id2 = get_table_id("internal", "test_replace_table_statistics", "t2")
+
     sql """ALTER TABLE t1 REPLACE WITH TABLE t2 PROPERTIES('swap' = 'false');"""
     result = sql """show column stats t1"""
     assertEquals(2, result.size())
     result = sql """show column cached stats t1"""
     assertEquals(2, result.size())
 
-    sql """drop database if exists test_replace_table"""
-}
+    result = sql """show table stats ${id1}"""
+    assertEquals(0, result.size())
+    result = sql """show table stats ${id2}"""
+    assertEquals(1, result.size())
 
+    sql """drop database if exists test_replace_table_statistics"""
+}


### PR DESCRIPTION
### What problem does this PR solve?

Fix replace table doesn't remove table stat meta bug. When doing replace table with property swap=false, the old table is removed. In this case, we need to remove the table stats meta object for that table to avoid memory leak.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

