### PR TITLE
[opt](cloud) Add config enable_meta_service_endpoint_consistency_check (#49264)

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -256,18 +256,19 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         if (config::meta_service_endpoint.empty() && !master_info.meta_service_endpoint.empty()) {
             auto st = config::set_config("meta_service_endpoint", master_info.meta_service_endpoint,
                                          true);
-            LOG(INFO) << "set config meta_service_endpoing " << master_info.meta_service_endpoint
+            LOG(INFO) << "set config meta_service_endpoint " << master_info.meta_service_endpoint
                       << " " << st;
         }
 
-        if (master_info.meta_service_endpoint != config::meta_service_endpoint) {
+        if (master_info.meta_service_endpoint != config::meta_service_endpoint &&
+            config::enable_meta_service_endpoint_consistency_check) {
             LOG(WARNING) << "Detected mismatch in meta_service_endpoint configuration between FE "
                             "and BE. "
                          << "FE meta_service_endpoint: " << master_info.meta_service_endpoint
                          << ", BE meta_service_endpoint: " << config::meta_service_endpoint;
             return Status::InvalidArgument<false>(
-                    "fe and be do not work in same mode, fe meta_service_endpoint: {},"
-                    " be meta_service_endpoint: {}",
+                    "fe and be do not work in same mode or meta_service_endpoint mismatch,"
+                    "fe meta_service_endpoint: {}, be meta_service_endpoint: {}",
                     master_info.meta_service_endpoint, config::meta_service_endpoint);
         }
     }

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -25,6 +25,7 @@ namespace doris::config {
 DEFINE_String(deploy_mode, "");
 DEFINE_mString(cloud_unique_id, "");
 DEFINE_mString(meta_service_endpoint, "");
+DEFINE_mBool(enable_meta_service_endpoint_consistency_check, "true");
 DEFINE_Bool(meta_service_use_load_balancer, "false");
 DEFINE_mInt32(meta_service_rpc_timeout_ms, "10000");
 DEFINE_Bool(meta_service_connection_pooled, "true");

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -44,6 +44,9 @@ static inline bool is_cloud_mode() {
 // separated by a comma, like "host:port,host:port,host:port", then BE will choose a server to connect in randomly.
 // In this mode, The config meta_service_connection_pooled is still useful, but the other two configs will be ignored.
 DECLARE_mString(meta_service_endpoint);
+// Whether check config::meta_service_endpoint is identical to the ms endpoint from FE master heartbeat
+// This may help in some cases that we intend to change the config only FE side or BE side
+DECLARE_mBool(enable_meta_service_endpoint_consistency_check);
 // Set the underlying connection type to pooled.
 DECLARE_Bool(meta_service_connection_pooled);
 DECLARE_mInt64(meta_service_connection_pool_size);


### PR DESCRIPTION
pick #49264

Whether check config::meta_service_endpoint is identical to the ms endpoint from FE master heartbeat This may help in some cases that we intend to change the config only FE side or BE side

