### PR TITLE
[fix](deps) miss build_jindofs in build-thirdparty.sh

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1868,6 +1868,7 @@ build_jindofs() {
 
 if [[ "${#packages[@]}" -eq 0 ]]; then
     packages=(
+        jindofs
         odbc
         openssl
         libevent
@@ -1936,7 +1937,6 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         dragonbox
         brotli
         icu
-        jindofs
     )
     if [[ "$(uname -s)" == 'Darwin' ]]; then
         read -r -a packages <<<"binutils gettext ${packages[*]}"

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1936,6 +1936,7 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         dragonbox
         brotli
         icu
+        jindofs
     )
     if [[ "$(uname -s)" == 'Darwin' ]]; then
         read -r -a packages <<<"binutils gettext ${packages[*]}"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -611,6 +611,7 @@ export TP_ARCHIVES=(
     'AZURE'
     'DRAGONBOX'
     'ICU'
+    'JINDOFS'
 )
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then


### PR DESCRIPTION
Follow up #49259
Forget to call `build_jindofs` in `build-thirdparty.sh`