### PR TITLE
[opt](metrics) optimize performance of metrics endpoint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmService.java
@@ -38,11 +38,8 @@ public class JvmService {
 
     private final JvmInfo jvmInfo;
 
-    private JvmStats jvmStats;
-
     public JvmService() {
         this.jvmInfo = JvmInfo.jvmInfo();
-        this.jvmStats = JvmStats.jvmStats();
     }
 
     public JvmInfo info() {
@@ -50,8 +47,7 @@ public class JvmService {
     }
 
     public synchronized JvmStats stats() {
-        jvmStats = JvmStats.jvmStats();
-        return jvmStats;
+        return JvmStats.jvmStats();
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

the `http://<fe_ip>:<fe_http_port>/metrics` maybe made the frontends hung, when the threads num too large, this pr replace `ThreadMXBean.getThreadInfos` to `ThreadMXBean.dumpAllThreads` to optimize performance

see also:
1. https://issues.apache.org/jira/browse/HADOOP-16850
2. https://bugs.openjdk.org/browse/JDK-8185005
3. https://github.com/apache/skywalking/discussions/9190

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

