### PR TITLE
[opt](nereids) catch all exceptions in StatsCalculator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -309,7 +309,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().feDebug) {
                 throw e;
             }
-            LOG.warn("stats calculation failed, plan " + plan.treeString(), e);
+            LOG.warn("stats calculation failed, plan " + plan.toString(), e);
             // use unknown stats or the first child's stats
             if (plan.children().isEmpty() || !(plan.child(0) instanceof GroupPlan)) {
                 Map<Expression, ColumnStatistic> columnStatisticMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -309,6 +309,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().feDebug) {
                 throw e;
             }
+            LOG.warn("stats calculation failed, plan " + plan.treeString(), e);
             // use unknown stats or the first child's stats
             if (plan.children().isEmpty() || !(plan.child(0) instanceof GroupPlan)) {
                 Map<Expression, ColumnStatistic> columnStatisticMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -301,13 +301,32 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
 
     private void estimate() {
         Plan plan = groupExpression.getPlan();
-        Statistics newStats = plan.accept(this, null);
+        Statistics newStats;
+        try {
+            newStats = plan.accept(this, null);
+        } catch (Exception e) {
+            // throw exception in debug mode
+            if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().feDebug) {
+                throw e;
+            }
+            // use unknown stats or the first child's stats
+            if (plan.children().isEmpty() || !(plan.child(0) instanceof GroupPlan)) {
+                Map<Expression, ColumnStatistic> columnStatisticMap = new HashMap<>();
+                for (Slot slot : plan.getOutput()) {
+                    columnStatisticMap.put(slot, ColumnStatistic.createUnknownByDataType(slot.getDataType()));
+                }
+                newStats = new Statistics(1, 1, columnStatisticMap);
+            } else {
+                newStats = ((GroupPlan) plan.child(0)).getStats();
+            }
+        }
         newStats.normalizeColumnStatistics();
 
         // We ensure that the rowCount remains unchanged in order to make the cost of each plan comparable.
+        final Statistics tmpStats = newStats;
         if (groupExpression.getOwnerGroup().getStatistics() == null) {
             boolean isReliable = groupExpression.getPlan().getExpressions().stream()
-                    .noneMatch(e -> newStats.isInputSlotsUnknown(e.getInputSlots()));
+                    .noneMatch(e -> tmpStats.isInputSlotsUnknown(e.getInputSlots()));
             groupExpression.getOwnerGroup().setStatsReliable(isReliable);
             groupExpression.getOwnerGroup().setStatistics(newStats);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/GroupPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/GroupPlan.java
@@ -62,7 +62,7 @@ public class GroupPlan extends LogicalLeaf implements BlockFuncDepsPropagation {
 
     @Override
     public Statistics getStats() {
-        throw new IllegalStateException("GroupPlan can not invoke getStats()");
+        return group.getStatistics();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2271,7 +2271,8 @@ public class SessionVariable implements Serializable, Writable {
                 "use other health replica when the use_fix_replica meet error" })
     public boolean fallbackOtherReplicaWhenFixedCorrupt = false;
 
-    @VariableMgr.VarAttr(name = "FE_DEBUG", needForward = true, fuzzy = true,
+    public static final String FE_DEBUG = "fe_debug";
+    @VariableMgr.VarAttr(name = FE_DEBUG, needForward = true, fuzzy = true,
             description = {"when set true, FE will throw exceptions instead swallow them. This is used for test",
                     "when set true, FE will throw exceptions instead swallow them. This is used for test"})
     public boolean feDebug = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2271,6 +2271,11 @@ public class SessionVariable implements Serializable, Writable {
                 "use other health replica when the use_fix_replica meet error" })
     public boolean fallbackOtherReplicaWhenFixedCorrupt = false;
 
+    @VariableMgr.VarAttr(name = "FE_DEBUG", needForward = true, fuzzy = true,
+            description = {"when set true, FE will throw exceptions instead swallow them. This is used for test",
+                    "when set true, FE will throw exceptions instead swallow them. This is used for test"})
+    public boolean feDebug = false;
+
     @VariableMgr.VarAttr(name = SHOW_ALL_FE_CONNECTION,
             description = {"when it's true show processlist statement list all fe's connection",
                     "当变量为true时，show processlist命令展示所有fe的连接"})
@@ -2505,6 +2510,7 @@ public class SessionVariable implements Serializable, Writable {
     @SuppressWarnings("checkstyle:Indentation")
     public void initFuzzyModeVariables() {
         Random random = new SecureRandom();
+        this.feDebug = true;
         this.parallelPipelineTaskNum = random.nextInt(8);
         this.parallelPrepareThreshold = random.nextInt(32) + 1;
         this.enableCommonExprPushdown = random.nextBoolean();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -374,14 +374,24 @@ public class ColumnStatistic {
 
     public static ColumnStatistic createUnknownByDataType(DataType dataType) {
         if (dataType instanceof CharacterType) {
-            return new ColumnStatisticBuilder(1).setAvgSizeByte(CharacterType.DEFAULT_PRECISION).setNdv(1)
-                    .setNumNulls(1).setMaxValue(Double.POSITIVE_INFINITY).setMinValue(Double.NEGATIVE_INFINITY)
-                    .setIsUnknown(true).setUpdatedTime("")
+            return new ColumnStatisticBuilder(1)
+                    .setAvgSizeByte(Math.max(1, Math.min(dataType.width(), CharacterType.DEFAULT_WIDTH)))
+                    .setNdv(1)
+                    .setNumNulls(1)
+                    .setMaxValue(Double.POSITIVE_INFINITY)
+                    .setMinValue(Double.NEGATIVE_INFINITY)
+                    .setIsUnknown(true)
+                    .setUpdatedTime("")
                     .build();
         } else {
-            return new ColumnStatisticBuilder(1).setAvgSizeByte(dataType.width()).setNdv(1)
-                    .setNumNulls(1).setMaxValue(Double.POSITIVE_INFINITY).setMinValue(Double.NEGATIVE_INFINITY)
-                    .setIsUnknown(true).setUpdatedTime("")
+            return new ColumnStatisticBuilder(1)
+                    .setAvgSizeByte(dataType.width())
+                    .setNdv(1)
+                    .setNumNulls(1)
+                    .setMaxValue(Double.POSITIVE_INFINITY)
+                    .setMinValue(Double.NEGATIVE_INFINITY)
+                    .setIsUnknown(true)
+                    .setUpdatedTime("")
                     .build();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -22,6 +22,8 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.coercion.CharacterType;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -368,5 +370,19 @@ public class ColumnStatistic {
 
     public ColumnStatistic withAvgSizeByte(double avgSizeByte) {
         return new ColumnStatisticBuilder(this).setAvgSizeByte(avgSizeByte).build();
+    }
+
+    public static ColumnStatistic createUnknownByDataType(DataType dataType) {
+        if (dataType instanceof CharacterType) {
+            return new ColumnStatisticBuilder(1).setAvgSizeByte(CharacterType.DEFAULT_PRECISION).setNdv(1)
+                    .setNumNulls(1).setMaxValue(Double.POSITIVE_INFINITY).setMinValue(Double.NEGATIVE_INFINITY)
+                    .setIsUnknown(true).setUpdatedTime("")
+                    .build();
+        } else {
+            return new ColumnStatisticBuilder(1).setAvgSizeByte(dataType.width()).setNdv(1)
+                    .setNumNulls(1).setMaxValue(Double.POSITIVE_INFINITY).setMinValue(Double.NEGATIVE_INFINITY)
+                    .setIsUnknown(true).setUpdatedTime("")
+                    .build();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
@@ -447,4 +447,13 @@ class ExpressionEstimationTest {
         Assertions.assertEquals(est.avgSizeByte, 1);
         Assertions.assertEquals(est.numNulls, 1);
     }
+
+    @Test
+    public void testThrowException() {
+        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        Cast cast = new Cast(a, DateType.INSTANCE);
+        // do not throw any exception
+        ColumnStatistic est = ExpressionEstimation.estimate(cast, null);
+        Assertions.assertTrue(est.isUnKnown());
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?
catch all exceptions in ExpressionEstimation so that any error in ExpressionEstimation  does not break the query.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

