### PR TITLE
[fix](Nereids) fix double literal to string literal cast problem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -262,12 +262,18 @@ public abstract class Literal extends Expression implements LeafExpression {
             }
         } else if (targetType.isVarcharType()) {
             if (this.dataType.isDoubleType() || this.dataType.isFloatType()) {
-                return new VarcharLiteral(desc.replaceAll("\\.0+$", ""), ((VarcharType) targetType).getLen());
+                int pointZeroIndex = findPointZeroIndex(desc);
+                if (pointZeroIndex > -1) {
+                    return new VarcharLiteral(desc.substring(0, pointZeroIndex), ((VarcharType) targetType).getLen());
+                }
             }
             return new VarcharLiteral(desc, ((VarcharType) targetType).getLen());
         } else if (targetType instanceof StringType) {
             if (this.dataType.isDoubleType() || this.dataType.isFloatType()) {
-                return new StringLiteral(desc.replaceAll("\\.0+$", ""));
+                int pointZeroIndex = findPointZeroIndex(desc);
+                if (pointZeroIndex > -1) {
+                    return new StringLiteral(desc.substring(0, pointZeroIndex));
+                }
             }
             return new StringLiteral(desc);
         } else if (targetType.isDateType()) {
@@ -290,6 +296,19 @@ public abstract class Literal extends Expression implements LeafExpression {
             return new IPv6Literal(desc);
         }
         throw new AnalysisException("cannot cast " + desc + " from type " + this.dataType + " to type " + targetType);
+    }
+
+    private static int findPointZeroIndex(String str) {
+        int pointIndex = -1;
+        for (int i = 0; i < str.length(); ++i) {
+            char c = str.charAt(i);
+            if (pointIndex > 0 && c != '0') {
+                return -1;
+            } else if (pointIndex == -1 && c == '.') {
+                pointIndex = i;
+            }
+        }
+        return pointIndex;
     }
 
     /** fromLegacyLiteral */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -261,8 +261,14 @@ public abstract class Literal extends Expression implements LeafExpression {
                 return new CharLiteral(desc, ((CharType) targetType).getLen());
             }
         } else if (targetType.isVarcharType()) {
+            if (this.dataType.isDoubleType()) {
+                return new VarcharLiteral(desc.replaceAll("\\.0+$", ""), ((VarcharType) targetType).getLen());
+            }
             return new VarcharLiteral(desc, ((VarcharType) targetType).getLen());
         } else if (targetType instanceof StringType) {
+            if (this.dataType.isDoubleType()) {
+                return new StringLiteral(desc.replaceAll("\\.0+$", ""));
+            }
             return new StringLiteral(desc);
         } else if (targetType.isDateType()) {
             return new DateLiteral(desc);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -261,12 +261,12 @@ public abstract class Literal extends Expression implements LeafExpression {
                 return new CharLiteral(desc, ((CharType) targetType).getLen());
             }
         } else if (targetType.isVarcharType()) {
-            if (this.dataType.isDoubleType()) {
+            if (this.dataType.isDoubleType() || this.dataType.isFloatType()) {
                 return new VarcharLiteral(desc.replaceAll("\\.0+$", ""), ((VarcharType) targetType).getLen());
             }
             return new VarcharLiteral(desc, ((VarcharType) targetType).getLen());
         } else if (targetType instanceof StringType) {
-            if (this.dataType.isDoubleType()) {
+            if (this.dataType.isDoubleType() || this.dataType.isFloatType()) {
                 return new StringLiteral(desc.replaceAll("\\.0+$", ""));
             }
             return new StringLiteral(desc);

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_cast.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_cast.groovy
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("fold_constant_cast") {
+    sql "set enable_nereids_planner=true"
+    sql "set enable_fallback_to_original_planner=false"
+    sql "set enable_fold_constant_by_be=false"
+    // bug_fix
+    testFoldConst("select concat(substr('2025-03-20',1,4)-1,'-01-01')")
+    testFoldConst("select concat(substr('2025-03-20',1,4)-1.0,'-01-01')")
+    testFoldConst("select concat(substr('2025-03-20',1,4)+1.0,'-01-01')")
+    testFoldConst("select concat(substr('2025-03-20',1,4)-0.5,'-01-01')")
+    testFoldConst("select cast(cast(2025.00 as double) as string)")
+    testFoldConst("select cast(cast(2025.00 as float) as string)")
+    testFoldConst("SELECT CAST(CAST(123 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(123.456 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-123.456 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(0.001 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-0.001 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(1e+10 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(1e-10 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-1e+10 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-1e-10 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(123456789.123456789 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-123456789.123456789 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(0 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(0.1 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-0.1 AS DOUBLE) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(123 AS FLOAT) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(123.456 AS FLOAT) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-123.456 AS FLOAT) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(0.001 AS FLOAT) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(-0.001 AS FLOAT) AS STRING)")
+    testFoldConst("SELECT CAST(CAST(1e+10 AS FLOAT) AS STRING)")
+}

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -1726,6 +1726,9 @@ suite("fold_constant_string_arithmatic") {
 
     // bug_fix
     testFoldConst("select concat(substr('2025-03-20',1,4)-1,'-01-01')")
+    testFoldConst("select concat(substr('2025-03-20',1,4)-1.0,'-01-01')")
+    testFoldConst("select concat(substr('2025-03-20',1,4)+1.0,'-01-01')")
+    testFoldConst("select concat(substr('2025-03-20',1,4)-0.5,'-01-01')")
     testFoldConst("select cast(cast(2025.00 as double) as string)")
     testFoldConst("select cast(cast(2025.00 as float) as string)")
 }

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -1726,6 +1726,7 @@ suite("fold_constant_string_arithmatic") {
 
     // bug_fix
     testFoldConst("select concat(substr('2025-03-20',1,4)-1,'-01-01')")
-    testFoldConst("select cast(2025.00 as string)")
+    testFoldConst("select cast(cast(2025.00 as double) as string)")
+    testFoldConst("select cast(cast(2025.00 as float) as string)")
 }
 

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -1723,13 +1723,5 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("select split_by_string('a😁a😁a', '')")
     testFoldConst("select character_length('a😁a😁a')")
     testFoldConst("select replace_empty('a😁a😁a', '', '2')")
-
-    // bug_fix
-    testFoldConst("select concat(substr('2025-03-20',1,4)-1,'-01-01')")
-    testFoldConst("select concat(substr('2025-03-20',1,4)-1.0,'-01-01')")
-    testFoldConst("select concat(substr('2025-03-20',1,4)+1.0,'-01-01')")
-    testFoldConst("select concat(substr('2025-03-20',1,4)-0.5,'-01-01')")
-    testFoldConst("select cast(cast(2025.00 as double) as string)")
-    testFoldConst("select cast(cast(2025.00 as float) as string)")
 }
 

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_string_arithmatic.groovy
@@ -1723,5 +1723,9 @@ suite("fold_constant_string_arithmatic") {
     testFoldConst("select split_by_string('a😁a😁a', '')")
     testFoldConst("select character_length('a😁a😁a')")
     testFoldConst("select replace_empty('a😁a😁a', '', '2')")
+
+    // bug_fix
+    testFoldConst("select concat(substr('2025-03-20',1,4)-1,'-01-01')")
+    testFoldConst("select cast(2025.00 as string)")
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

When cast double like 1.000 to string, it should strip .000 in the trailing of double

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

