### PR TITLE
[opt](cloud) Add config to control sync_rowsets parallelism when init scanners

### DIFF
--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -38,6 +38,7 @@ DEFINE_mInt32(meta_service_brpc_timeout_ms, "10000");
 DEFINE_Int64(tablet_cache_capacity, "100000");
 DEFINE_Int64(tablet_cache_shards, "16");
 DEFINE_mInt32(tablet_sync_interval_s, "1800");
+DEFINE_mInt32(init_scanner_sync_rowsets_parallelism, "10");
 
 DEFINE_mInt64(min_compaction_failure_interval_ms, "5000");
 DEFINE_mInt64(base_compaction_freeze_interval_s, "7200");

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -68,6 +68,8 @@ DECLARE_mInt32(meta_service_brpc_timeout_ms);
 DECLARE_Int64(tablet_cache_capacity);
 DECLARE_Int64(tablet_cache_shards);
 DECLARE_mInt32(tablet_sync_interval_s);
+// parallelism for scanner init where may issue RPCs to sync rowset meta from MS
+DECLARE_mInt32(init_scanner_sync_rowsets_parallelism);
 
 // Cloud compaction config
 DECLARE_mInt64(min_compaction_failure_interval_ms);

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -449,7 +449,8 @@ Status OlapScanLocalState::hold_tablets() {
                             ->sync_rowsets(cur_version);
                 });
             }
-            RETURN_IF_ERROR(cloud::bthread_fork_join(tasks, 10));
+            RETURN_IF_ERROR(
+                    cloud::bthread_fork_join(tasks, config::init_scanner_sync_rowsets_parallelism));
         }
         _sync_rowset_timer->update(duration_ns);
     }


### PR DESCRIPTION
### What problem does this PR solve?

It may take long time where there are a lot of tablets in a single scanner, because we need to sync rowsets from MS to BE side before preceeding scanning procedure.

be.conf init_scanner_sync_rowsets_parallelism default 10

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

