### PR TITLE
[fix](memory) Fix `Segcompaction` and `WriteCooldownMeta` and `HttpStreamAction` thread attach task

### DIFF
--- a/be/src/http/action/http_stream.cpp
+++ b/be/src/http/action/http_stream.cpp
@@ -248,7 +248,6 @@ void HttpStreamAction::on_chunk_data(HttpRequest* req) {
 
     int64_t start_read_data_time = MonotonicNanos();
     Status st = ctx->allocate_schema_buffer();
-
     if (!st.ok()) {
         ctx->status = st;
         return;

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -255,7 +255,7 @@ Status SegcompactionWorker::_create_segment_writer_for_segcompaction(
 
 Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPtr segments) {
     DCHECK(_seg_compact_mem_tracker != nullptr);
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_seg_compact_mem_tracker);
+    SCOPED_ATTACH_TASK(_seg_compact_mem_tracker);
     /* throttle segcompaction task if memory depleted */
     if (GlobalMemoryArbitrator::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE)) {
         return Status::Error<FETCH_MEMORY_EXCEEDED>("skip segcompaction due to memory shortage");

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -224,7 +224,7 @@ void WriteCooldownMetaExecutors::WriteCooldownMetaExecutors::submit(TabletShared
             std::unique_lock<std::mutex> lck {_latch};
             _pending_tablets.erase(t->tablet_id());
         }
-        SCOPED_ATTACH_TASK();
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
         auto s = t->write_cooldown_meta();
         if (s.ok()) {
             return;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -224,6 +224,7 @@ void WriteCooldownMetaExecutors::WriteCooldownMetaExecutors::submit(TabletShared
             std::unique_lock<std::mutex> lck {_latch};
             _pending_tablets.erase(t->tablet_id());
         }
+        SCOPED_ATTACH_TASK();
         auto s = t->write_cooldown_meta();
         if (s.ok()) {
             return;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -831,7 +831,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
     std::shared_ptr<QueryContext> query_ctx;
     RETURN_IF_ERROR(
             _get_or_create_query_ctx(params, params.query_id, true, query_source, query_ctx));
-    SCOPED_ATTACH_TASK(query_ctx.get());
+    SCOPED_SWITCH_RESOURCE_CONTEXT(query_ctx.get()->resource_ctx());
     int64_t duration_ns = 0;
     std::shared_ptr<pipeline::PipelineFragmentContext> context =
             std::make_shared<pipeline::PipelineFragmentContext>(

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -30,6 +30,11 @@ void AttachTask::init(const std::shared_ptr<ResourceContext>& rc) {
     thread_context()->attach_task(rc);
 }
 
+AttachTask::AttachTask() {
+    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
+    init(rc);
+}
+
 AttachTask::AttachTask(const std::shared_ptr<ResourceContext>& rc) {
     init(rc);
 }

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -30,16 +30,14 @@ void AttachTask::init(const std::shared_ptr<ResourceContext>& rc) {
     thread_context()->attach_task(rc);
 }
 
-AttachTask::AttachTask() {
-    std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
-    init(rc);
-}
-
 AttachTask::AttachTask(const std::shared_ptr<ResourceContext>& rc) {
     init(rc);
 }
 
 AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
+    // if parameter is `orphan_mem_tracker`, if you do not switch thraed mem tracker afterwards,
+    // alloc or free memory from Allocator will fail DCHECK. unless you know for sure that
+    // the thread will not alloc or free memory from Allocator later.
     std::shared_ptr<ResourceContext> rc = ResourceContext::create_shared();
     rc->memory_context()->set_mem_tracker(mem_tracker);
     init(rc);

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -342,7 +342,8 @@ public:
 
 class AttachTask {
 public:
-    explicit AttachTask();
+    // you must use ResourceCtx or MemTracker initialization.
+    explicit AttachTask() = delete;
 
     explicit AttachTask(const std::shared_ptr<ResourceContext>& rc);
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -342,6 +342,8 @@ public:
 
 class AttachTask {
 public:
+    explicit AttachTask();
+
     explicit AttachTask(const std::shared_ptr<ResourceContext>& rc);
 
     // Shortcut attach task, initialize an empty resource context, and set the memory tracker.


### PR DESCRIPTION
### What problem does this PR solve?

fix 1
```
Check failed: is_attach_task() F20250324 18:14:26.741550 31004 thread_context.h:202] Check failed: is_attach_task() 

*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1742811404 (unix time) try "date -d @1742811404" if you are using GNU date ***
*** Current BE git commitID: 0210cade6a ***
*** SIGABRT unknown detail explain (@0x76ec) received by PID 30444 (TID 31001 OR 0x7f7e08da5640) from PID 30444; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F7FAF8E3520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x00005609821B433D in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# 0x00005609821A697A in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# Allocator<false, false, false, DefaultMemoryAllocator>::sys_memory_check(unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.cpp:189
11# Allocator<false, false, false, DefaultMemoryAllocator>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.h:254
12# doris::faststring::GrowToAtLeast(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/util/faststring.cc:35
13# doris::faststring::append(void const*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/util/faststring.h:114
14# doris::segment_v2::BinaryPrefixPageBuilder::add(unsigned char const*, unsigned long*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp:76
15# doris::segment_v2::IndexedColumnWriter::add(void const*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp:92
16# doris::PrimaryKeyIndexBuilder::add_item(doris::Slice const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/primary_key_index.cpp:59
17# doris::segment_v2::SegmentWriter::_generate_primary_key_index(std::vector<doris::KeyCoder const*, std::allocator<doris::KeyCoder const*> > const&, std::vector<doris::vectorized::IOlapColumnDataAccessor*, std::allocator<doris::vectorized::IOlapColumnDataAccessor*> > const&, doris::vectorized::IOlapColumnDataAccessor*, unsigned long, bool) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/segment_writer.cpp:1281
18# doris::segment_v2::SegmentWriter::append_block(doris::vectorized::Block const*, unsigned long, unsigned long) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
19# doris::Merger::vertical_compact_one_group(long, doris::ReaderType, doris::TabletSchema const&, bool, std::vector<unsigned int, std::allocator<unsigned int> > const&, doris::vectorized::RowSourcesBuffer*, doris::vectorized::VerticalBlockReader&, doris::segment_v2::SegmentWriter&, doris::Merger::Statistics*, unsigned long*, doris::KeyBoundsPB&, doris::SimpleRowIdConversion*) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
20# doris::SegcompactionWorker::_do_compact_segments(std::shared_ptr<std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > >) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segcompaction.cpp:312
21# doris::SegcompactionWorker::compact_segments(std::shared_ptr<std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > >) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segcompaction.cpp:376
22# doris::StorageEngine::_handle_seg_compaction(std::shared_ptr<doris::SegcompactionWorker>, std::shared_ptr<std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > >, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/olap_server.cpp:1125
```

fix 2
```
F20250324 22:23:58.712177  6075 thread_context.h:202] Check failed: is_attach_task() 
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007FD053E89520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055926378A33D in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# 0x000055926377C97A in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# Allocator<false, false, false, DefaultMemoryAllocator>::sys_memory_check(unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.cpp:189
11# Allocator<false, false, false, DefaultMemoryAllocator>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.h:254
12# doris::io::Memory<Allocator<false, false, false, DefaultMemoryAllocator> >::Memory(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:48
13# doris::io::FileBuffer::FileBuffer(doris::io::BufferType, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>, unsigned long, doris::io::OperationState) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:86
14# doris::io::UploadFileBuffer::UploadFileBuffer(std::function<void (doris::io::UploadFileBuffer&)>, doris::io::OperationState, unsigned long, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.h:157
15# decltype (::new ((void*)(0)) doris::io::UploadFileBuffer(std::declval<std::function<void (doris::io::UploadFileBuffer&)> >(), std::declval<doris::io::OperationState>(), std::declval<unsigned long&>(), std::declval<std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()> >())) std::construct_at<doris::io::UploadFileBuffer, std::function<void (doris::io::UploadFileBuffer&)>, doris::io::OperationState, unsigned long&, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()> >(doris::io::UploadFileBuffer*, std::function<void (doris::io::UploadFileBuffer&)>&&, doris::io::OperationState&&, unsigned long&, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97
16# doris::io::FileBufferBuilder::build(std::shared_ptr<doris::io::FileBuffer>*) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:247
17# doris::io::S3FileWriter::_build_upload_buffer() at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:199
18# doris::io::S3FileWriter::appendv(doris::Slice const*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:251
19# doris::Tablet::write_cooldown_meta() at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:2240
20# std::_Function_handler<void (), doris::WriteCooldownMetaExecutors::submit(std::shared_ptr<doris::Tablet>)::$_1>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
21# doris::WorkThreadPool<true>::work_thread(int) at /home/zcp/repo_center/doris_master/doris/be/src/util/work_thread_pool.hpp:159
```

fix 3
```
F20250326 08:38:26.267536 234213 thread_context.h:202] Check failed: is_attach_task() 

 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007FBB36633520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055B829A9C6CD in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# 0x000055B829A8ED0A in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# Allocator<false, false, false, DefaultMemoryAllocator>::sys_memory_check(unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.cpp:189
11# Allocator<false, false, false, DefaultMemoryAllocator>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.h:254
12# doris::ByteBuffer::ByteBuffer(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/util/byte_buffer.h:77
13# doris::ByteBuffer::allocate(unsigned long, std::shared_ptr<doris::ByteBuffer>*) at /home/zcp/repo_center/doris_master/doris/be/src/util/byte_buffer.h:38
14# doris::StreamLoadContext::allocate_schema_buffer() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
15# doris::HttpStreamAction::on_chunk_data(doris::HttpRequest*) at /home/zcp/repo_center/doris_master/doris/be/src/http/action/http_stream.cpp:254
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

