### PR TITLE
[fix](jdbc catalog) ensure initialization before fetching row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalTable.java
@@ -199,6 +199,7 @@ public class JdbcExternalTable extends ExternalTable {
 
     @Override
     public long fetchRowCount() {
+        makeSureInitialized();
         Map<String, String> params = new HashMap<>();
         params.put("ctlName", catalog.getName());
         params.put("dbName", this.db.getRemoteName());


### PR DESCRIPTION
We must add makeSureInitialized() in the fetchRowCount() method to ensure the initialization of catalog related resources.