### PR TITLE
[fix](schema-change) Nested types should only support enlarging varchar length with light schema change

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -103,6 +103,7 @@ public abstract class ColumnType {
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.DATEV2.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.STRING.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.JSONB.ordinal()] = true;
+        // could not change varchar to char cuz varchar max length is larger than char
 
         schemaChangeMatrix[PrimitiveType.STRING.ordinal()][PrimitiveType.JSONB.ordinal()] = true;
 
@@ -196,7 +197,8 @@ public abstract class ColumnType {
     // return true if the checkType and other are both char-type otherwise return false,
     // which used in checkSupportSchemaChangeForComplexType
     private static boolean checkSupportSchemaChangeForCharType(Type checkType, Type other) throws DdlException {
-        if (Type.VARCHAR.equals(checkType) && Type.VARCHAR.equals(other)) {
+        if (checkType.getPrimitiveType() == PrimitiveType.VARCHAR
+                && other.getPrimitiveType() == PrimitiveType.VARCHAR) {
             // currently nested type only support light schema change, for string types,
             // only varchar can do light schema change
             checkForTypeLengthChange(checkType, other);
@@ -275,7 +277,8 @@ public abstract class ColumnType {
             // only support char-type schema change behavior for nested complex type
             // if nested is false, we do not check return value.
             if (nested && !checkSupportSchemaChangeForCharType(checkType, other)) {
-                throw new DdlException("Cannot change " + checkType.toSql() + " to " + other.toSql());
+                throw new DdlException(
+                        "Cannot change " + checkType.toSql() + " to " + other.toSql() + " in nested types");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -199,7 +199,7 @@ public abstract class ColumnType {
     private static boolean checkSupportSchemaChangeForCharType(Type checkType, Type other) throws DdlException {
         if (checkType.getPrimitiveType() == PrimitiveType.VARCHAR
                 && other.getPrimitiveType() == PrimitiveType.VARCHAR) {
-            // currently nested type only support light schema change, for string types,
+            // currently nested types only support light schema change, for string types,
             // only varchar can do light schema change
             checkForTypeLengthChange(checkType, other);
             return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -196,7 +196,9 @@ public abstract class ColumnType {
     // return true if the checkType and other are both char-type otherwise return false,
     // which used in checkSupportSchemaChangeForComplexType
     private static boolean checkSupportSchemaChangeForCharType(Type checkType, Type other) throws DdlException {
-        if (checkType.isStringType() && other.isStringType()) {
+        if (Type.VARCHAR.equals(checkType) && Type.VARCHAR.equals(other)) {
+            // currently nested type only support light schema change, for string types,
+            // only varchar can do light schema change
             checkForTypeLengthChange(checkType, other);
             return true;
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -199,7 +199,7 @@ public abstract class ColumnType {
     private static boolean checkSupportSchemaChangeForCharType(Type checkType, Type other) throws DdlException {
         if (checkType.getPrimitiveType() == PrimitiveType.VARCHAR
                 && other.getPrimitiveType() == PrimitiveType.VARCHAR) {
-            // currently nested types only support light schema change, for string types,
+            // currently nested types only support light schema change for internal fields, for string types,
             // only varchar can do light schema change
             checkForTypeLengthChange(checkType, other);
             return true;

--- a/regression-test/data/schema_change_p0/test_type_length_change.out
+++ b/regression-test/data/schema_change_p0/test_type_length_change.out
@@ -16,6 +16,6 @@
 
 -- !master_sql --
 k	int	Yes	true	\N	
-c0	varchar(6)	Yes	true	\N	
-c1	varchar(6)	Yes	true	\N	
+c0	varchar(6)	Yes	false	\N	NONE
+c1	varchar(6)	Yes	false	\N	NONE
 

--- a/regression-test/suites/schema_change_p0/test_type_length_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_type_length_change.groovy
@@ -24,7 +24,8 @@ suite("test_type_length_change", "p0") {
             k INT,
             c0 CHAR(5),
             c1 VARCHAR(5)
-        )
+        ) DUPLICATE KEY (k)
+        DISTRIBUTED BY HASH(k) BUCKETS 1
         PROPERTIES ( "replication_allocation" = "tag.location.default: 1");
     """
 

--- a/regression-test/suites/schema_change_p0/test_type_length_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_type_length_change.groovy
@@ -74,4 +74,9 @@ suite("test_type_length_change", "p0") {
     sql """  INSERT INTO ${tableName} VALUES(4, "abcde", "abcde") """
     qt_master_sql """ SELECT * FROM ${tableName} ORDER BY k"""
     qt_master_sql """ DESC ${tableName} """
+
+    test {
+        sql """ ALTER TABLE ${tableName} MODIFY COLUMN c1 CHAR(10) """
+        exception "Can not change VARCHAR to CHAR"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Introduce: #48607, #46639

Problem Summary:

Currently nested types only support light schema change for internal fields, for string types, only varchar can do light schema change.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

