### PR TITLE
[fix](nereids)show user friendly error message if meet unsupported subquery

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
+++ b/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
@@ -648,6 +648,32 @@ suite ("sub_query_correlated") {
         exception "Unsupported correlated subquery with grouping and/or aggregation";
     }
 
+    test {
+        sql """
+                SELECT *
+                    FROM sub_query_correlated_subquery1
+                    WHERE sub_query_correlated_subquery1.k1 IN 
+                        (SELECT sub_query_correlated_subquery2.k2
+                        FROM sub_query_correlated_subquery2
+                        JOIN sub_query_correlated_subquery3
+                            ON sub_query_correlated_subquery2.k2 = sub_query_correlated_subquery3.k1
+                                AND sub_query_correlated_subquery1.k2 = sub_query_correlated_subquery3.k3); """
+        exception "Unsupported correlated subquery with correlated slot in join conjuncts";
+    }
+
+    test {
+        sql """
+                SELECT *
+                    FROM sub_query_correlated_subquery1
+                    WHERE EXISTS 
+                        (SELECT sub_query_correlated_subquery2.k2
+                        FROM sub_query_correlated_subquery2
+                        JOIN sub_query_correlated_subquery3
+                            ON sub_query_correlated_subquery2.k2 = sub_query_correlated_subquery3.k1
+                                AND sub_query_correlated_subquery1.k2 = sub_query_correlated_subquery3.k3); """
+        exception "Unsupported correlated subquery with correlated slot in join conjuncts";
+    }
+
     qt_doris_7643 """
         SELECT sub_query_correlated_subquery6.*
         FROM sub_query_correlated_subquery6


### PR DESCRIPTION
```
SELECT *
    FROM t1
    WHERE t1.k1 IN 
        (SELECT t2.k2
            FROM t2 JOIN t3
                ON t2.k2 = t3.k1
                    AND t1.k2 = t3.k3); -- access t1.k2 in join conjuncts is not suppported
```

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

