### PR TITLE
[feature](Nereids) support standard sql query organization

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -22,7 +22,7 @@ parser grammar DorisParser;
 options { tokenVocab = DorisLexer; }
 
 @members {
-    public boolean doris_legacy_SQL_syntax = true;
+    public boolean ansiSQLSyntax = false;
 }
 
 multiStatements
@@ -1171,7 +1171,7 @@ querySpecification
       aggClause?
       havingClause?
       qualifyClause?
-      {doris_legacy_SQL_syntax}? queryOrganization                         #regularQuerySpecification
+      ({!ansiSQLSyntax}? queryOrganization | {ansiSQLSyntax}?)         #regularQuerySpecification
     ;
 
 cte

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -2101,8 +2101,8 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         return ParserUtils.withOrigin(ctx, () -> {
             // TODO: need to add withQueryResultClauses and withCTE
             LogicalPlan query = plan(ctx.queryTerm());
-            query = withCte(query, ctx.cte());
-            return withQueryOrganization(query, ctx.queryOrganization());
+            query = withQueryOrganization(query, ctx.queryOrganization());
+            return withCte(query, ctx.cte());
         });
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/NereidsParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/NereidsParser.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.plugin.DialectConverterPlugin;
 import org.apache.doris.plugin.PluginMgr;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableMap;
@@ -392,7 +393,7 @@ public class NereidsParser {
     public static ParserRuleContext toAst(
             CommonTokenStream tokenStream, Function<DorisParser, ParserRuleContext> parseFunction) {
         DorisParser parser = new DorisParser(tokenStream);
-
+        parser.ansiSQLSyntax = GlobalVariable.enable_ansi_query_organization_behavior;
         parser.addParseListener(POST_PROCESSOR);
         parser.removeErrorListeners();
         parser.addErrorListener(PARSE_ERROR_LISTENER);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -77,6 +77,9 @@ public final class GlobalVariable {
 
     public static final String ENABLE_FETCH_ICEBERG_STATS = "enable_fetch_iceberg_stats";
 
+    public static final String ENABLE_ANSI_QUERY_ORGANIZATION_BEHAVIOR
+            = "enable_ansi_query_organization_behavior";
+
     @VariableMgr.VarAttr(name = VARIABLE_VERSION, flag = VariableMgr.INVISIBLE
             | VariableMgr.READ_ONLY | VariableMgr.GLOBAL)
     public static int variableVersion = CURRENT_VARIABLE_VERSION;
@@ -191,6 +194,18 @@ public final class GlobalVariable {
                 "当HMS catalog中的Iceberg表没有统计信息时，是否通过Iceberg Api获取统计信息",
                 "Enable fetch stats for HMS Iceberg table when it's not analyzed."})
     public static boolean enableFetchIcebergStats = false;
+
+
+    @VariableMgr.VarAttr(name = ENABLE_ANSI_QUERY_ORGANIZATION_BEHAVIOR, flag = VariableMgr.GLOBAL,
+            description = {
+                    "控制 query organization 的行为。当设置为 true 时使用 ANSI 的 query organization 行为，即作用于整个语句。"
+                            + "当设置为 false 时，使用 Doris 历史版本的行为，"
+                            + "即 order by 默认只作用于 set operation 的最后一个 operand。",
+                    "Controls the behavior of query organization. When set to true, uses the ANSI query"
+                            + " organization behavior, which applies to the entire statement. When set to false,"
+                            + " uses the behavior of Doris's historical versions, where order by by default only"
+                            + " applies to the last operand of the set operation."})
+    public static boolean enable_ansi_query_organization_behavior = true;
 
     // Don't allow creating instance.
     private GlobalVariable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -1002,6 +1002,11 @@ public class VariableMgr {
             VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.SQL_MODE,
                     String.valueOf(sqlMode));
+
+            // update from older version, use legacy behavior.
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
+                    GlobalVariable.ENABLE_ANSI_QUERY_ORGANIZATION_BEHAVIOR,
+                    String.valueOf(false));
         }
         if (currentVariableVersion < GlobalVariable.CURRENT_VARIABLE_VERSION) {
             VariableMgr.refreshDefaultSessionVariables(updateInfo,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/EqualSetTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/EqualSetTest.java
@@ -71,7 +71,7 @@ class EqualSetTest extends TestWithFeService {
         Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));
         plan = PlanChecker.from(connectContext)
-                .analyze("select id, id2 from agg where id2 = id limit 1 order by id")
+                .analyze("(select id, id2 from agg where id2 = id limit 1) order by id")
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isNullSafeEqual(plan.getOutput().get(0), plan.getOutput().get(1)));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniformTest.java
@@ -103,13 +103,13 @@ class UniformTest extends TestWithFeService {
     @Test
     void testSetOp() {
         Plan plan = PlanChecker.from(connectContext)
-                .analyze("select name from agg limit 1 except select name from agg")
+                .analyze("(select name from agg limit 1) except select name from agg")
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties().getTrait()
                 .isUniform(plan.getOutput().get(0)));
         plan = PlanChecker.from(connectContext)
-                .analyze("select id from agg intersect select name from agg limit 1")
+                .analyze("select id from agg intersect (select name from agg limit 1)")
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties().getTrait()

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
@@ -141,7 +141,7 @@ class UniqueTest extends TestWithFeService {
     @Test
     void testSetOp() {
         Plan plan = PlanChecker.from(connectContext)
-                .analyze("select name from agg limit 1 except select name from agg")
+                .analyze("(select name from agg limit 1) except select name from agg")
                 .rewrite()
                 .getPlan();
         Assertions.assertTrue(plan.getLogicalProperties().getTrait()

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
@@ -714,7 +714,7 @@ class InferPredicatesTest extends TestWithFeService implements MemoPatternMatchS
                                 && filter.getPredicate().toSql().contains("sid IN (1, 2)"))
                 );
 
-        String sql2 = "select id,t2.sid from (select 2 id,'abc' b from score limit 0 offset 0  union all select 1 id,'abb' c4) t inner join score t2 on t.id=t2.sid";
+        String sql2 = "select id,t2.sid from ((select 2 id,'abc' b from score limit 0 offset 0)  union all select 1 id,'abb' c4) t inner join score t2 on t.id=t2.sid";
         PlanChecker.from(connectContext).analyze(sql2).rewrite().printlnTree();
         PlanChecker.from(connectContext)
                 .analyze(sql2)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownLimitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownLimitTest.java
@@ -242,8 +242,7 @@ class PushDownLimitTest extends TestWithFeService implements MemoPatternMatchSup
         PlanChecker.from(connectContext)
                 .analyze("select k1 from t1 "
                         + "union all select k2 from t2 "
-                        + "union all select k1 from t3 "
-                        + "limit 10")
+                        + "union all (select k1 from t3 limit 10)")
                 .rewrite()
                 .matches(
                         logicalUnion(

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_pg.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_pg.groovy
@@ -623,7 +623,7 @@ suite("test_jdbc_query_pg", "p0,external,pg,external_docker,external_docker_pg")
         order_qt_sql93 """ SELECT CASE k8 WHEN 1 THEN CAST(1 AS decimal(4,1)) WHEN 2 THEN CAST(1 AS decimal(4,2)) 
                             ELSE CAST(1 AS decimal(4,3)) END FROM $jdbcPg14Table1 limit 3"""
         order_qt_sql95 """ SELECT * from (SELECT k8 FROM $jdbcPg14Table1 UNION (SELECT id as k8 FROM ${dorisExTable1}  UNION SELECT k7 as k8 FROM $jdbcPg14Table1) 
-                            UNION ALL SELECT id as k8 FROM $exMysqlTypeTable ORDER BY id limit 3) as a order by k8 limit 3"""
+                            UNION ALL (SELECT id as k8 FROM $exMysqlTypeTable ORDER BY id limit 3)) as a order by k8 limit 3"""
         order_qt_sql100 """ SELECT COUNT(*) FROM $jdbcPg14Table1 WHERE EXISTS(SELECT max(id) FROM ${dorisExTable1}) """
         order_qt_sql103 """ SELECT count(*) FROM $jdbcPg14Table1 n WHERE (SELECT count(*) FROM ${dorisExTable1} r WHERE n.k8 = r.id) > 1 """
         order_qt_sql105 """ SELECT count(*) AS numwait FROM $jdbcPg14Table1 l1 WHERE

--- a/regression-test/suites/nereids_p0/union/push_limit_with_eliminate_union.groovy
+++ b/regression-test/suites/nereids_p0/union/push_limit_with_eliminate_union.groovy
@@ -17,5 +17,5 @@
 
 suite("push_limit_with_eliminate_union") {
     // this should not failed for [INTERNAL_ERROR]VSlotRef  have invalid slot id
-    sql """(select 1 limit 0 union all select count() + 1) limit 1;"""
+    sql """((select 1 limit 0) union all select count() + 1) limit 1;"""
 }

--- a/regression-test/suites/nereids_rules_p0/adjust_nullable/set_operation.groovy
+++ b/regression-test/suites/nereids_rules_p0/adjust_nullable/set_operation.groovy
@@ -79,7 +79,7 @@ suite("test_set_operation_adjust_nullable") {
     sql """insert into set_operation_t2 values ('1', 1);"""
 
     sql """
-        select
+        (select
             c2,
             c1
         from
@@ -89,6 +89,7 @@ suite("test_set_operation_adjust_nullable") {
             2 asc
         limit
             0
+        )
         union distinct
         select
             c3,

--- a/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.groovy
@@ -163,7 +163,7 @@ suite("pull_up_predicate_set_op") {
     select t.a,t3.b from      (select 3 as a,'aa' as b union all select 2,'dd' ) t inner join test_pull_up_predicate_set_op3 t3
     on t3.a=t.a and t3.b=t.b;"""
 
-    qt_union_all_const_empty_relation """ explain shape plan select t.a,t3.b from (select 3 as a,'aa' as b from test_pull_up_predicate_set_op3 limit 0 offset 0 union all select 2,'dd' ) t 
+    qt_union_all_const_empty_relation """ explain shape plan select t.a,t3.b from ((select 3 as a,'aa' as b from test_pull_up_predicate_set_op3 limit 0 offset 0) union all select 2,'dd' ) t 
     inner join test_pull_up_predicate_set_op3 t3 on t3.a=t.a and t3.b=t.b;"""
 
     qt_union_all_const2_has_cast_to_null_different_type """ explain shape plan
@@ -360,7 +360,7 @@ suite("pull_up_predicate_set_op") {
     qt_union_all_const_tinyint_int_res """select t.a,t3.b from      (select 3 as a,'aa' as b union all select 2,'dd' ) t inner join test_pull_up_predicate_set_op3 t3
     on t3.a=t.a and t3.b=t.b order by 1,2;"""
 
-    qt_union_all_const_empty_relation_res """ select t.a,t3.b from (select 3 as a,'aa' as b from test_pull_up_predicate_set_op3 limit 0 offset 0 union all select 2,'dd' ) t 
+    qt_union_all_const_empty_relation_res """ select t.a,t3.b from ((select 3 as a,'aa' as b from test_pull_up_predicate_set_op3 limit 0 offset 0) union all select 2,'dd' ) t 
     inner join test_pull_up_predicate_set_op3 t3 on t3.a=t.a and t3.b=t.b order by 1,2;"""
 
     qt_union_all_const2_has_cast_to_null_different_type_res """ select t.a,t3.b from (select 3 as a,'aa' as b union all select 'abc','dd' ) t inner join test_pull_up_predicate_set_op3 t3

--- a/regression-test/suites/nereids_rules_p0/infer_set_operator_distinct/infer_set_operator_distinct.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_set_operator_distinct/infer_set_operator_distinct.groovy
@@ -126,7 +126,7 @@ suite("infer_set_operator_distinct") {
     """
 
     qt_union_order_limit """
-        explain shape plan select * from t1 union select * from t2 order by id limit 10;
+        explain shape plan select * from t1 union (select * from t2 order by id limit 10);
     """
 
     qt_union_inner_join_combination """
@@ -218,7 +218,7 @@ suite("infer_set_operator_distinct") {
     """
 
     qt_with_hint_union_order_limit """
-        explain shape plan select /*+ USE_CBO_RULE(INFER_SET_OPERATOR_DISTINCT) */ * from t1 union select * from t2 order by id limit 10;
+        explain shape plan select /*+ USE_CBO_RULE(INFER_SET_OPERATOR_DISTINCT) */ * from t1 union (select * from t2 order by id limit 10);
     """
 
     qt_with_hint_union_inner_join_combination """
@@ -310,7 +310,7 @@ suite("infer_set_operator_distinct") {
     """
 
     qt_with_hint_no_union_order_limit """
-        explain shape plan select /*+ USE_CBO_RULE(NO_INFER_SET_OPERATOR_DISTINCT) */ * from t1 union select * from t2 order by id limit 10;
+        explain shape plan select /*+ USE_CBO_RULE(NO_INFER_SET_OPERATOR_DISTINCT) */ * from t1 union (select * from t2 order by id limit 10);
     """
 
     qt_with_hint_no_union_inner_join_combination """

--- a/regression-test/suites/nereids_rules_p0/limit_push_down/order_push_down.groovy
+++ b/regression-test/suites/nereids_rules_p0/limit_push_down/order_push_down.groovy
@@ -84,7 +84,7 @@ suite("order_push_down") {
     // `LIMIT` with Set Operation and `ORDER BY`:
     qt_limit_outside_order_inside_set_operation """explain shape plan SELECT * FROM (SELECT t1.id FROM t1 UNION ALL SELECT t2.id FROM t2 ORDER BY id) u  LIMIT 1;"""
     // `LIMIT` with Set Operation and `ORDER BY`:
-    qt_limit_inside_set_operation """explain shape plan SELECT * FROM (SELECT t1.id FROM t1 UNION ALL SELECT t2.id FROM t2 ORDER BY id LIMIT 1) u;"""
+    qt_limit_inside_set_operation """explain shape plan SELECT * FROM (SELECT t1.id FROM t1 UNION ALL (SELECT t2.id FROM t2 ORDER BY id LIMIT 1)) u;"""
 
     // `LIMIT` with Set Operation and `OFFSET` with `ORDER BY`:
     qt_limit_offset_set_operation """explain shape plan SELECT * FROM (SELECT t1.id FROM t1 INTERSECT SELECT t2.id FROM t2) u ORDER BY id LIMIT 1 OFFSET 1;"""

--- a/regression-test/suites/nereids_rules_p0/push_down_top_n/push_down_top_n_distinct_through_union.groovy
+++ b/regression-test/suites/nereids_rules_p0/push_down_top_n/push_down_top_n_distinct_through_union.groovy
@@ -68,7 +68,7 @@ suite("push_down_top_n_distinct_through_union") {
     """
 
     qt_push_down_topn_union_with_limit """
-        explain shape plan select * from (select * from table2 t1 limit 5 union select * from table2 t2 limit 5) sub order by id limit 10;
+        explain shape plan select * from ((select * from table2 t1 limit 5) union (select * from table2 t2 limit 5)) sub order by id limit 10;
     """
 
     qt_push_down_topn_union_complex_conditions """

--- a/regression-test/suites/nereids_rules_p0/push_down_top_n/push_down_top_n_through_union.groovy
+++ b/regression-test/suites/nereids_rules_p0/push_down_top_n/push_down_top_n_through_union.groovy
@@ -68,7 +68,7 @@ suite("push_down_top_n_through_union") {
     """
 
     qt_push_down_topn_union_with_limit """
-        explain shape plan select * from (select * from table1 t1 limit 5 union all select * from table1 t2 limit 5) sub order by id limit 10;
+        explain shape plan select * from ((select * from table1 t1 limit 5) union all (select * from table1 t2 limit 5)) sub order by id limit 10;
     """
 
     qt_push_down_topn_union_complex_conditions """

--- a/regression-test/suites/nereids_syntax_p0/cte.groovy
+++ b/regression-test/suites/nereids_syntax_p0/cte.groovy
@@ -306,7 +306,7 @@ suite("cte") {
         notContains "MultiCastDataSinks"
     }
 
-    sql "WITH cte_0 AS ( SELECT 1 AS a ) SELECT * from cte_0 t1 LIMIT 10 UNION SELECT * from cte_0 t1 LIMIT 10"
+    sql "WITH cte_0 AS ( SELECT 1 AS a ) (SELECT * from cte_0 t1 LIMIT 10) UNION (SELECT * from cte_0 t1 LIMIT 10)"
 
     qt_cte_with_repeat """
         with cte_0 as (select lo_orderkey, lo_linenumber, grouping_id(lo_orderkey) as id from lineorder group by cube(lo_orderkey, lo_linenumber))

--- a/regression-test/suites/nereids_syntax_p0/set_operation.groovy
+++ b/regression-test/suites/nereids_syntax_p0/set_operation.groovy
@@ -256,12 +256,12 @@ suite("test_nereids_set_operation") {
     """
 
     order_qt_select43 """
-        SELECT * FROM (select k1, k3 from setOperationTableNotNullable order by k3 union all
+        SELECT * FROM ((select k1, k3 from setOperationTableNotNullable order by k3) union all
             select k1, k5 from setOperationTable) t;
     """
 
     order_qt_select44 """
-    select k1, k3 from setOperationTableNotNullable order by k3 union all
+    (select k1, k3 from setOperationTableNotNullable order by k3) union all
             select k1, k5 from setOperationTable
     """
 
@@ -325,9 +325,9 @@ suite("test_nereids_set_operation") {
 
     sql "sync"
     order_qt_check_child_col_order """
-        select avg(tap), potno from dwd_daytable where potno=3601 and ddate >= '2023-08-01' group by potno limit 10
+        (select avg(tap), potno from dwd_daytable where potno=3601 and ddate >= '2023-08-01' group by potno limit 10)
         union
-        select avg(tap), potno from dwd_daytable where potno=3602 and ddate >= '2023-08-01' group by potno limit 10;
+        (select avg(tap), potno from dwd_daytable where potno=3602 and ddate >= '2023-08-01' group by potno limit 10);
     """
 
     sql "DROP TABLE IF EXISTS table_22_undef_partitions2_keys3_properties4_distributed_by54"

--- a/regression-test/suites/query_p0/cache/sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/sql_cache.groovy
@@ -107,6 +107,7 @@ suite("sql_cache") {
                 """
 
     qt_sql_cache4 """
+                    (
                     select
                         k1,
                         sum(k2) as total_pv 
@@ -118,7 +119,9 @@ suite("sql_cache") {
                         k1 
                     order by
                         k1
+                    )
                     union all
+                    (
                     select
                         k1,
                         sum(k2) as total_pv 
@@ -129,10 +132,12 @@ suite("sql_cache") {
                     group by
                         k1 
                     order by
-                        k1;
+                        k1
+                    )
                 """
     
     qt_sql_cache5 """
+                    (
                     select
                         k1,
                         sum(k2) as total_pv 
@@ -144,7 +149,9 @@ suite("sql_cache") {
                         k1 
                     order by
                         k1
+                    )
                     union all
+                    (
                     select
                         k1,
                         sum(k2) as total_pv 
@@ -155,7 +162,8 @@ suite("sql_cache") {
                     group by
                         k1 
                     order by
-                        k1;
+                        k1
+                    )
                 """
 
     sql "SET enable_nereids_planner=true"


### PR DESCRIPTION
### What problem does this PR solve?

Previously, Doris's query organization defaulted to applying to the last operator of the set operation. Now, a global variable, enable_ansi_query_organization_behavior, has been introduced. The default value is true. When this variable is set to true, query organization remains consistent with the ANSI SQL standard, applying to the entire statement. When this variable is set to false, it maintains the previous behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

