### PR TITLE
[opt](connection) add connection num in error msg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/AcceptListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/AcceptListener.java
@@ -97,10 +97,12 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                             connection.setCloseListener(
                                     streamConnection -> connectScheduler.unregisterConnection(context));
                         } else {
-                            context.getState().setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS,
-                                    "Reach limit of connections");
+                            long userConnLimit = context.getEnv().getAuth().getMaxConn(context.getQualifiedUser());
+                            String errMsg = String.format("Reach limit of connections. Total: %, User: %d",
+                                    connectScheduler.getMaxConnections(), userConnLimit);
+                            context.getState().setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, errMsg);
                             MysqlProto.sendResponsePacket(context);
-                            throw new AfterConnectedException("Reach limit of connections");
+                            throw new AfterConnectedException(errMsg);
                         }
                         context.setStartTime();
                         int userQueryTimeout = context.getEnv().getAuth().getQueryTimeout(context.getQualifiedUser());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -92,10 +92,12 @@ public class ConnectScheduler {
     }
 
     // Register one connection with its connection id.
-    public boolean registerConnection(ConnectContext ctx) {
+    // Return -1 means register OK
+    // Return >=0 means register failed, and return value is current connection num.
+    public int registerConnection(ConnectContext ctx) {
         if (numberConnection.incrementAndGet() > maxConnections) {
             numberConnection.decrementAndGet();
-            return false;
+            return numberConnection.get();
         }
         // Check user
         connByUser.putIfAbsent(ctx.getQualifiedUser(), new AtomicInteger(0));
@@ -103,13 +105,13 @@ public class ConnectScheduler {
         if (conns.incrementAndGet() > ctx.getEnv().getAuth().getMaxConn(ctx.getQualifiedUser())) {
             conns.decrementAndGet();
             numberConnection.decrementAndGet();
-            return false;
+            return numberConnection.get();
         }
         connectionMap.put(ctx.getConnectionId(), ctx);
         if (ctx.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL)) {
             flightToken2ConnectionId.put(ctx.getPeerIdentity(), ctx.getConnectionId());
         }
-        return true;
+        return -1;
     }
 
     public void unregisterConnection(ConnectContext ctx) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -208,4 +208,8 @@ public class ConnectScheduler {
     public Map<String, AtomicInteger> getUserConnectionMap() {
         return connByUser;
     }
+
+    public int getMaxConnections() {
+        return maxConnections;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSessionsWithTokenManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSessionsWithTokenManager.java
@@ -20,6 +20,7 @@ package org.apache.doris.service.arrowflight.sessions;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ConnectScheduler;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.arrowflight.tokens.FlightTokenDetails;
 import org.apache.doris.service.arrowflight.tokens.FlightTokenManager;
@@ -65,12 +66,18 @@ public class FlightSessionsWithTokenManager implements FlightSessionsManager {
         flightTokenDetails.setCreatedSession(true);
         ConnectContext connectContext = FlightSessionsManager.buildConnectContext(peerIdentity,
                 flightTokenDetails.getUserIdentity(), flightTokenDetails.getRemoteIp());
-        ExecuteEnv.getInstance().getScheduler().submit(connectContext);
-        if (!ExecuteEnv.getInstance().getScheduler().registerConnection(connectContext)) {
-            String err = "Reach limit of connections, increase `qe_max_connection` in fe.conf, or decrease "
-                    + "`arrow_flight_token_cache_size` to evict unused bearer tokens and it connections faster";
-            connectContext.getState().setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, err);
-            throw new IllegalArgumentException(err);
+        ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+        connectScheduler.submit(connectContext);
+        if (!connectScheduler.registerConnection(connectContext)) {
+            long userConnLimit = connectContext.getEnv().getAuth().getMaxConn(connectContext.getQualifiedUser());
+            String errMsg = String.format(
+                    "Reach limit of connections. Total: %d, User: %d. "
+                            + "Increase `qe_max_connection` in fe.conf or user's `max_user_connections`,"
+                            + " or decrease `arrow_flight_token_cache_size` "
+                            + "to evict unused bearer tokens and it connections faster",
+                    connectScheduler.getMaxConnections(), userConnLimit);
+            connectContext.getState().setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, errMsg);
+            throw new IllegalArgumentException(errMsg);
         }
         return connectContext;
     }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Add the value of `max connection number` and `current connection number`
in error msg when encountering `Reach limit of connections`.
For easy debugging.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

