### PR TITLE
[fix](spill) Resource released by wakeup early while spilling running

### DIFF
--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
@@ -577,14 +577,6 @@ Status PartitionedHashJoinProbeOperatorX::push(RuntimeState* state, vectorized::
     return Status::OK();
 }
 
-Status PartitionedHashJoinProbeOperatorX::_setup_internal_operator_for_non_spill(
-        PartitionedHashJoinProbeLocalState& local_state, RuntimeState* state) {
-    DCHECK(local_state._shared_state->inner_runtime_state);
-    local_state._in_mem_shared_state_sptr =
-            std::move(local_state._shared_state->inner_shared_state);
-    return Status::OK();
-}
-
 Status PartitionedHashJoinProbeOperatorX::_setup_internal_operators(
         PartitionedHashJoinProbeLocalState& local_state, RuntimeState* state) const {
     local_state._shared_state->inner_runtime_state = RuntimeState::create_unique(
@@ -876,10 +868,7 @@ Status PartitionedHashJoinProbeOperatorX::get_block(RuntimeState* state, vectori
                 return _revoke_memory(state);
             }
         } else {
-            if (UNLIKELY(!local_state._shared_state->inner_runtime_state)) {
-                RETURN_IF_ERROR(_setup_internal_operator_for_non_spill(local_state, state));
-            }
-
+            DCHECK(local_state._shared_state->inner_runtime_state);
             RETURN_IF_ERROR(_inner_probe_operator->push(
                     local_state._shared_state->inner_runtime_state.get(),
                     local_state._child_block.get(), local_state._child_eos));

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
@@ -167,8 +167,6 @@ private:
 
     [[nodiscard]] Status _setup_internal_operators(PartitionedHashJoinProbeLocalState& local_state,
                                                    RuntimeState* state) const;
-    [[nodiscard]] Status _setup_internal_operator_for_non_spill(
-            PartitionedHashJoinProbeLocalState& local_state, RuntimeState* state);
 
     bool _should_revoke_memory(RuntimeState* state) const;
 

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
@@ -24,6 +24,7 @@
 #include "common/be_mock_util.h"
 #include "common/status.h"
 #include "operator.h"
+#include "pipeline/dependency.h"
 #include "pipeline/exec/hashjoin_build_sink.h"
 #include "pipeline/exec/hashjoin_probe_operator.h"
 #include "pipeline/exec/join_build_sink_operator.h"
@@ -80,6 +81,7 @@ protected:
     std::unique_ptr<vectorized::PartitionerBase> _partitioner;
 
     std::unique_ptr<RuntimeProfile> _internal_runtime_profile;
+    std::shared_ptr<Dependency> _finish_dependency;
 
     RuntimeProfile::Counter* _partition_timer = nullptr;
     RuntimeProfile::Counter* _partition_shuffle_timer = nullptr;


### PR DESCRIPTION
### What problem does this PR solve?

```
#0  0x00007fb52583075b in kill () at ../sysdeps/unix/syscall-template.S:120
#1  0x00005567831c4947 in doris::signal::(anonymous namespace)::InvokeDefaultSignalHandler (signal_number=11) at /root/doris/be/src/common/signal_handler.h:334
#2  doris::signal::(anonymous namespace)::FailureSignalHandler (signal_number=11, signal_info=0x7fb0f2217070, ucontext=<optimized out>) at /root/doris/be/src/common/signal_handler.h:428
#3  0x00007fb5266f37a9 in PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] () from /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
#4  0x00007fb5266f4206 in JVM_handle_linux_signal () from /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
#5  <signal handler called>
#6  doris::vectorized::SpillWriter::get_written_bytes (this=0x0) at /root/doris/be/src/vec/spill/spill_writer.h:57
#7  doris::vectorized::SpillStream::spill_eof (this=0x7fb4f50e7910) at /root/doris/be/src/vec/spill/spill_stream.cpp:148
#8  0x000055678ddfb537 in doris::pipeline::AggSpillPartition::finish_current_spilling (this=0x7fb0f09e70d0, eos=<optimized out>) at /root/doris/be/src/pipeline/dependency.h:494
#9  doris::pipeline::PartitionedAggSinkLocalState::_spill_hash_table<doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > >, PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > > (this=0x7fb10430fb80, state=<optimized out>, context=..., hash_table=..., size_to_revoke=<optimized out>, eos=<optimized out>) at /root/doris/be/src/pipeline/exec/partitioned_aggregation_sink_operator.h:136
#10 0x000055678ddc980c in doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(auto:1&)#1}::operator()<doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > > >(doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > >&) const (this=<optimized out>, agg_method=...) at /root/doris/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp:319
#11 std::__invoke_impl<doris::Status, doris::vectorized::Overload<doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(std::monostate&)#1}, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(auto:1&)#1}>, doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > >&>(std::__invoke_other, doris::vectorized::Overload<doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(std::monostate&)#1}, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(auto:1&)#1}>&&, doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > >&) (__f=..., __args=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#12 std::__invoke<doris::vectorized::Overload<doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(std::monostate&)#1}, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(auto:1&)#1}>, doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > >&>(doris::vectorized::Overload<doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(std::monostate&)#1}, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const::{lambda(auto:1&)#1}>&&, doris::vectorized::MethodKeysFixed<PHHashMap<doris::vectorized::UInt136, char*, HashCRC32<doris::vectorized::UInt136> > >&) (__fn=..., __args=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#13 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIN5doris6StatusEEEONS4_10vectorized8OverloadIJZZNS4_8pipeline28PartitionedAggSinkLocalState13revoke_memoryEPNS4_12RuntimeStateERKSt10shared_ptrINS9_12SpillContextEEENK3$_0clEvEUlRSt9monostateE_ZZNSA_13revoke_memoryESC_SH_ENKSI_clEvEUlRT_E_EEERSt7variantIJSJ_NS7_16MethodSerializedI9PHHashMapINS4_9StringRefEPc11DefaultHashISU_vEEEENS7_15MethodOneNumberIhST_IhSV_9HashCRC32IhEEEENS10_ItST_ItSV_S11_ItEEEENS10_IjST_IjSV_S11_IjEEEENS10_ImST_ImSV_S11_ImEEEENS7_19MethodStringNoCacheINS4_13StringHashMapISV_9AllocatorILb1ELb1ELb0E22DefaultMemoryAllocatorEEEEENS10_IN4wide7integerILm128EjEEST_IS1N_SV_S11_IS1N_EEEENS10_INS1M_ILm256EjEEST_IS1R_SV_S11_IS1R_EEEENS10_IjST_IjSV_14HashMixWrapperIjS18_EEEENS10_ImST_ImSV_S1V_ImS1B_EEEENS7_26MethodSingleNullableColumnINS10_IhNS7_15DataWithNullKeyIS13_EEEEEENS22_INS10_ItNS23_IS16_EEEEEENS22_INS10_IjNS23_IS19_EEEEEENS22_INS10_ImNS23_IS1C_EEEEEENS22_INS10_IjNS23_IS1X_EEEEEENS22_INS10_ImNS23_IS20_EEEEEENS22_INS10_IS1N_NS23_IS1P_EEEEEENS22_INS10_IS1R_NS23_IS1T_EEEEEENS22_INS1E_INS23_IS1J_EEEEEENS7_15MethodKeysFixedIS1C_EENS2V_IS1P_EENS2V_IS1T_EENS2V_IST_INS7_7UInt136ESV_S11_IS2Z_EEEEEEEJEEESt16integer_sequenceImJLm23EEEE14__visit_invokeESQ_S34_ (__visitor=..., __vars=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
#14 0x000055678ddc5f50 in _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIN5doris6StatusEEENS3_10vectorized8OverloadIJZZNS3_8pipeline28PartitionedAggSinkLocalState13revoke_memoryEPNS3_12RuntimeStateERKSt10shared_ptrINS8_12SpillContextEEENK3$_0clEvEUlRSt9monostateE_ZZNS9_13revoke_memoryESB_SG_ENKSH_clEvEUlRT_E_EEEJRSt7variantIJSI_NS6_16MethodSerializedI9PHHashMapINS3_9StringRefEPc11DefaultHashISS_vEEEENS6_15MethodOneNumberIhSR_IhST_9HashCRC32IhEEEENSY_ItSR_ItST_SZ_ItEEEENSY_IjSR_IjST_SZ_IjEEEENSY_ImSR_ImST_SZ_ImEEEENS6_19MethodStringNoCacheINS3_13StringHashMapIST_9AllocatorILb1ELb1ELb0E22DefaultMemoryAllocatorEEEEENSY_IN4wide7integerILm128EjEESR_IS1L_ST_SZ_IS1L_EEEENSY_INS1K_ILm256EjEESR_IS1P_ST_SZ_IS1P_EEEENSY_IjSR_IjST_14HashMixWrapperIjS16_EEEENSY_ImSR_ImST_S1T_ImS19_EEEENS6_26MethodSingleNullableColumnINSY_IhNS6_15DataWithNullKeyIS11_EEEEEENS20_INSY_ItNS21_IS14_EEEEEENS20_INSY_IjNS21_IS17_EEEEEENS20_INSY_ImNS21_IS1A_EEEEEENS20_INSY_IjNS21_IS1V_EEEEEENS20_INSY_ImNS21_IS1Y_EEEEEENS20_INSY_IS1L_NS21_IS1N_EEEEEENS20_INSY_IS1P_NS21_IS1R_EEEEEENS20_INS1C_INS21_IS1H_EEEEEENS6_15MethodKeysFixedIS1A_EENS2T_IS1N_EENS2T_IS1R_EENS2T_ISR_INS6_7UInt136EST_SZ_IS2X_EEEEEEEEDcOT0_DpOT1_ (__visitor=..., __variants=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714
#15 _ZSt5visitIN5doris10vectorized8OverloadIJZZNS0_8pipeline28PartitionedAggSinkLocalState13revoke_memoryEPNS0_12RuntimeStateERKSt10shared_ptrINS3_12SpillContextEEENK3$_0clEvEUlRSt9monostateE_ZZNS4_13revoke_memoryES6_SB_ENKSC_clEvEUlRT_E_EEEJRSt7variantIJSD_NS1_16MethodSerializedI9PHHashMapINS0_9StringRefEPc11DefaultHashISN_vEEEENS1_15MethodOneNumberIhSM_IhSO_9HashCRC32IhEEEENST_ItSM_ItSO_SU_ItEEEENST_IjSM_IjSO_SU_IjEEEENST_ImSM_ImSO_SU_ImEEEENS1_19MethodStringNoCacheINS0_13StringHashMapISO_9AllocatorILb1ELb1ELb0E22DefaultMemoryAllocatorEEEEENST_IN4wide7integerILm128EjEESM_IS1G_SO_SU_IS1G_EEEENST_INS1F_ILm256EjEESM_IS1K_SO_SU_IS1K_EEEENST_IjSM_IjSO_14HashMixWrapperIjS11_EEEENST_ImSM_ImSO_S1O_ImS14_EEEENS1_26MethodSingleNullableColumnINST_IhNS1_15DataWithNullKeyISW_EEEEEENS1V_INST_ItNS1W_ISZ_EEEEEENS1V_INST_IjNS1W_IS12_EEEEEENS1V_INST_ImNS1W_IS15_EEEEEENS1V_INST_IjNS1W_IS1Q_EEEEEENS1V_INST_ImNS1W_IS1T_EEEEEENS1V_INST_IS1G_NS1W_IS1I_EEEEEENS1V_INST_IS1K_NS1W_IS1M_EEEEEENS1V_INS17_INS1W_IS1C_EEEEEENS1_15MethodKeysFixedIS15_EENS2O_IS1I_EENS2O_IS1M_EENS2O_ISM_INS1_7UInt136ESO_SU_IS2S_EEEEEEEEDcOSG_DpOT0_ (__visitor=..., __variants=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1764
#16 doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0::operator()() const (this=0x7fb4f417ef00) at /root/doris/be/src/pipeline/exec/partitioned_aggregation_sink_operator.cpp:312
#17 std::__invoke_impl<doris::Status, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0&>(std::__invoke_other, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0&) (__f=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#18 std::__invoke_r<doris::Status, doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0&>(doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0&) (__fn=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
#19 std::_Function_handler<doris::Status (), doris::pipeline::PartitionedAggSinkLocalState::revoke_memory(doris::RuntimeState*, std::shared_ptr<doris::pipeline::SpillContext> const&)::$_0>::_M_invoke(std::_Any_data const&) (__functor=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#20 0x000055678dd58d61 in std::function<doris::Status ()>::operator()() const (this=0x0) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#21 doris::pipeline::SpillRunnable::run (this=0x7fb154261d10) at /root/doris/be/src/pipeline/exec/spill_utils.h:151
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

