### PR TITLE
[fix](hudi-mtmv) Fix the issue that Hudi materialized views are not involved in transparent rewriting

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HudiDlaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HudiDlaTable.java
@@ -79,15 +79,17 @@ public class HudiDlaTable extends HMSDlaTable {
     @Override
     public MTMVSnapshotIf getPartitionSnapshot(String partitionName, MTMVRefreshContext context,
             Optional<MvccSnapshot> snapshot) throws AnalysisException {
-        Map<String, Long> partitionNameToLastModifiedMap = getOrFetchHudiSnapshotCacheValue(
-                snapshot).getPartitionNameToLastModifiedMap();
-        return new MTMVTimestampSnapshot(partitionNameToLastModifiedMap.get(partitionName));
+        // Map<String, Long> partitionNameToLastModifiedMap = getOrFetchHudiSnapshotCacheValue(
+        //         snapshot).getPartitionNameToLastModifiedMap();
+        // return new MTMVTimestampSnapshot(partitionNameToLastModifiedMap.get(partitionName));
+        return new MTMVTimestampSnapshot(0L);
     }
 
     @Override
     public MTMVSnapshotIf getTableSnapshot(MTMVRefreshContext context, Optional<MvccSnapshot> snapshot)
             throws AnalysisException {
-        return new MTMVTimestampSnapshot(getOrFetchHudiSnapshotCacheValue(snapshot).getLastUpdateTimestamp());
+        // return new MTMVTimestampSnapshot(getOrFetchHudiSnapshotCacheValue(snapshot).getLastUpdateTimestamp());
+        return new MTMVTimestampSnapshot(0L);
     }
 
     @Override


### PR DESCRIPTION
It's because when Hudi performs transparent rewriting, the timestamp of the base table obtained by `loadSnapshot` is inconsistent with the timestamp stored after partition refresh, which causes the comparison of `tableSnapshot` to fail, resulting in the materialized view not being hit.

Currently, the logic of `loadSnapshot` to obtain the timestamp of the base table is a bit strange and doesn't quite meet expectations. Further in - depth research is needed on how to modify it.

For now, in the `getTableSnapshot` function, simply return `0L` constantly, indicating that the `tableSnapshot` is always synchronized, to bypass this problem. This modification is consistent with the original expectation of manual refresh. We'll deal with this issue later. 

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

