### PR TITLE
[fix](trino connector catalog) enable self-attachment for Java agents and adjust settings for Mac systems

### DIFF
--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorPluginLoader.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorPluginLoader.java
@@ -53,6 +53,14 @@ public class TrinoConnectorPluginLoader {
 
         static {
             try {
+                // Allow self-attachment for Java agents,this is required for certain debugging and monitoring functions
+                System.setProperty("jdk.attach.allowAttachSelf", "true");
+                // Get the operating system name
+                String osName = System.getProperty("os.name").toLowerCase();
+                // Skip HotSpot SAAttach for Mac/Darwin systems to avoid potential issues
+                if (osName.contains("mac") || osName.contains("darwin")) {
+                    System.setProperty("jol.skipHotspotSAAttach", "true");
+                }
                 // Trino uses jul as its own log system, so the attributes of JUL are configured here
                 System.setProperty("java.util.logging.SimpleFormatter.format",
                         "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n");

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPluginLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPluginLoader.java
@@ -54,6 +54,14 @@ public class TrinoConnectorPluginLoader {
 
         static {
             try {
+                // Allow self-attachment for Java agents,this is required for certain debugging and monitoring functions
+                System.setProperty("jdk.attach.allowAttachSelf", "true");
+                // Get the operating system name
+                String osName = System.getProperty("os.name").toLowerCase();
+                // Skip HotSpot SAAttach for Mac/Darwin systems to avoid potential issues
+                if (osName.contains("mac") || osName.contains("darwin")) {
+                    System.setProperty("jol.skipHotspotSAAttach", "true");
+                }
                 // Trino uses jul as its own log system, so the attributes of JUL are configured here
                 System.setProperty("java.util.logging.SimpleFormatter.format",
                         "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n");


### PR DESCRIPTION
Added explanatory comments for critical system properties in `TrinoConnectorPluginLoader.java`:

- `jdk.attach.allowAttachSelf`: Required for Java agent functionality in debugging and monitoring
- `jol.skipHotspotSAAttach`: Prevents issues on Mac/Darwin systems with HotSpot Serviceability Agent

These properties are essential for proper plugin loading and debugging capabilities.


![image](https://github.com/user-attachments/assets/eaf4a342-ec30-4f49-a441-c3034c73bc10)
