### PR TITLE
[fix](build) Skip some hdfsBuilder functions when USE_HADOOP_HDFS support is not enabled

### DIFF
--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -227,9 +227,11 @@ Status create_hdfs_builder(const THdfsParams& hdfsParams, const std::string& fs_
         builder->kerberos_login = true;
         builder->hdfs_kerberos_principal = hdfsParams.hdfs_kerberos_principal;
         builder->hdfs_kerberos_keytab = hdfsParams.hdfs_kerberos_keytab;
-        hdfsBuilderSetKerb5Conf(builder->get(), doris::config::kerberos_krb5_conf_path.c_str());
         hdfsBuilderSetPrincipal(builder->get(), builder->hdfs_kerberos_principal.c_str());
+#ifdef USE_HADOOP_HDFS
+        hdfsBuilderSetKerb5Conf(builder->get(), doris::config::kerberos_krb5_conf_path.c_str());
         hdfsBuilderSetKeyTabFile(builder->get(), builder->hdfs_kerberos_keytab.c_str());
+#endif
         hdfsBuilderConfSetStr(builder->get(), "hadoop.kerberos.keytab.login.autorenewal.enabled",
                               "true");
         // RETURN_IF_ERROR(builder->set_kerberos_ticket_cache());


### PR DESCRIPTION
We should check whether the USE_HADOOP_HDFS macro is enabled before deciding whether to use the hdfsBuilderSetKerb5Conf and hdfsBuilderSetKeyTabFile functions. Otherwise, compilation may fail in some environments that do not have HADOOP_HDFS compilation dependencies, such as MacOS.