### PR TITLE
[fix](build) Fix compilation error on MacOS caused by unsupported include

### DIFF
--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#if !defined(__APPLE__)
 #include <experimental/bits/simd.h>
+#endif
 #include <glog/logging.h>
 
 #include <algorithm>


### PR DESCRIPTION
#include <experimental/bits/simd.h> is not used on MacOS and it will cause compilation errors, so we can just ignore it on MacOS