### PR TITLE
[fix](runtime filter) Fix debug string in RuntimeFilterWrapper

### DIFF
--- a/be/src/runtime_filter/runtime_filter_wrapper.cpp
+++ b/be/src/runtime_filter/runtime_filter_wrapper.cpp
@@ -574,11 +574,12 @@ bool RuntimeFilterWrapper::contain_null() const {
     return false;
 }
 
-std::string RuntimeFilterWrapper::debug_string() const {
+std::string RuntimeFilterWrapper::debug_string() {
     auto type_string = _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER
                                ? fmt::format("{}({})", filter_type_to_string(_filter_type),
                                              filter_type_to_string(get_real_type()))
                                : filter_type_to_string(_filter_type);
+    std::shared_lock<std::shared_mutex> rlock(_rwlock);
     auto result = fmt::format("[id: {}, state: {}, type: {}, column_type: {}", _filter_id,
                               states_to_string<RuntimeFilterWrapper>({_state}), type_string,
                               type_to_string(_column_return_type));


### PR DESCRIPTION
### What problem does this PR solve?

*** SIGABRT unknown detail explain (@0x1e11) received by PID 7697 (TID 10382 OR 0x7fe74c2e9640) from PID 7697; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007FE875042520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 6# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 7# 0x00005628EF52D5A1 in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
 8# 0x00005628EF52D6F4 in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
 9# 0x00005628EF52DAE6 in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
10# void fmt::v7::detail::buffer::append(char const*, char const*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
11# char const* fmt::v7::detail::parse_replacement_field, char, fmt::v7::basic_format_context, char> >&>(char const*, char const*, fmt::v7::detail::format_handler, char, fmt::v7::basic_format_context, char> >&) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
12# void fmt::v7::detail::vformat_to(fmt::v7::detail::buffer&, fmt::v7::basic_string_view, fmt::v7::basic_format_args::type>, fmt::v7::type_identity::type> >, fmt::v7::detail::locale_ref) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
13# fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view, fmt::v7::format_args) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
14# doris::RuntimeFilterWrapper::debug_string[abi:cxx11]() const at /home/zcp/repo_center/doris_master/doris/be/src/runtime_filter/runtime_filter_wrapper.cpp:602
15# doris::RuntimeFilter::_debug_string[abi:cxx11]() const at /home/zcp/repo_center/doris_master/doris/be/src/runtime_filter/runtime_filter.cpp:128
16# doris::RuntimeFilterConsumer::debug_string[abi:cxx11]() const at /home/zcp/repo_center/doris_master/doris/be/src/runtime_filter/runtime_filter_consumer.h:61
17# doris::RuntimeFilterConsumer::_set_state(doris::RuntimeFilterConsumer::State) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
18# doris::RuntimeFilterConsumer::acquire_expr(std::vector, std::allocator > >&) at /home/zcp/repo_center/doris_master/doris/be/src/runtime_filter/runtime_filter_consumer.cpp:59
19# doris::RuntimeFilterConsumerHelper::acquire_runtime_filter(std::vector, std::allocator > >&) at /home/zcp/repo_center/doris_master/doris/be/src/runtime_filter/runtime_filter_consumer_helper.cpp:90
20# doris::pipeline::ScanLocalState::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/scan_operator.cpp:100

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

