### PR TITLE
[Fix](txn) Remove `TabletTxnInfo` if version exists when publish version

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -210,6 +210,9 @@ Status EnginePublishVersionTask::execute() {
                 }
                 if (version.first != max_version + 1) {
                     if (tablet->check_version_exist(version)) {
+                        _engine.txn_manager()->remove_txn_tablet_info(partition_id, transaction_id,
+                                                                      tablet->tablet_id(),
+                                                                      tablet->tablet_uid());
                         continue;
                     }
                     auto handle_version_not_continuous = [&]() {

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -245,6 +245,9 @@ public:
     TxnState get_txn_state(TPartitionId partition_id, TTransactionId transaction_id,
                            TTabletId tablet_id, TabletUid tablet_uid);
 
+    void remove_txn_tablet_info(TPartitionId partition_id, TTransactionId transaction_id,
+                                TTabletId tablet_id, TabletUid tablet_uid);
+
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
 
@@ -287,6 +290,11 @@ private:
     // get _txn_map_lock before calling.
     void _insert_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
     void _clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
+
+    void _remove_txn_tablet_info_unlocked(TPartitionId partition_id, TTransactionId transaction_id,
+                                          TTabletId tablet_id, TabletUid tablet_uid,
+                                          std::lock_guard<std::shared_mutex>& txn_lock,
+                                          std::lock_guard<std::shared_mutex>& wrlock);
 
     class TabletVersionCache : public LRUCachePolicy {
     public:


### PR DESCRIPTION
### What problem does this PR solve?

`TabletTxnInfo` should be removed if version exists when publish version. Otherwise, the related txn info will not be deleted and occupy large memories

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

