### PR TITLE
[fix](binlog) get table with db lock if the table not exists

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3990,6 +3990,20 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     }
 
                     if (table == null) {
+                        // Since Database.getTableNullable is lock-free, we need to take lock and check again, to ensure the visibility of the table.
+                        db.readLock();
+                        try {
+                            if (getMetaTable.isSetId()) {
+                                table = db.getTableNullable(getMetaTable.getId());
+                            } else {
+                                table = db.getTableNullable(getMetaTable.getName());
+                            }
+                        } finally {
+                            db.readUnlock();
+                        }
+                    }
+
+                    if (table == null) {
                         LOG.warn("table not found {}", getMetaTable);
                         continue;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3990,7 +3990,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     }
 
                     if (table == null) {
-                        // Since Database.getTableNullable is lock-free, we need to take lock and check again, to ensure the visibility of the table.
+                        // Since Database.getTableNullable is lock-free, we need to take lock and check again,
+                        // to ensure the visibility of the table.
                         db.readLock();
                         try {
                             if (getMetaTable.isSetId()) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`Database.getTableNullable` is lock-free, but the `DROP TABLE` stmt is executed in the below order:
1. take db/table write lock
2. unregister table from db
3. release table write lock
4. write editlog
5. release db write lock

Between steps 3-4, a `getMeta` request might see a missing table but the dropped tables are empty.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

