### PR TITLE
[feat](regression) inject debug points need run in nonConcurrent or docker suites

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -1589,6 +1589,13 @@ class Suite implements GroovyInterceptable {
     }
 
     DebugPoint GetDebugPoint() {
+        def execType = RegressionTest.getGroupExecType(group);
+        if (execType != RegressionTest.GroupExecType.SINGLE
+            && execType != RegressionTest.GroupExecType.DOCKER) {
+            throw new Exception("Debug point must use in nonConcurrent suite or docker suite, "
+                    + "need add 'nonConcurrent' or 'docker' to suite's belong groups, "
+                    + "see example demo_p0/debugpoint_action.groovy.")
+        }
         return debugPoint
     }
 

--- a/regression-test/suites/backup_restore/test_backup_cancelled.groovy
+++ b/regression-test/suites/backup_restore/test_backup_cancelled.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_backup_cancelled", "backup_cancelled") {
+suite("test_backup_cancelled", "backup_cancelled,nonConcurrent") {
     String suiteName = "test_backup_cancelled"
     String repoName = "${suiteName}_repo_" + UUID.randomUUID().toString().replace("-", "")
     String dbName = "${suiteName}_db"
@@ -58,36 +58,37 @@ suite("test_backup_cancelled", "backup_cancelled") {
 
     // test failed to get tablet when truncate or drop table
 
-    GetDebugPoint().enableDebugPointForAllBEs("SnapshotManager::make_snapshot.inject_failure", [tablet_id:"${tabletId}", execute:3]);
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("SnapshotManager::make_snapshot.inject_failure", [tablet_id:"${tabletId}", execute:3]);
 
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${snapshotName}
+            TO `${repoName}`
+            ON (${tableName})
+        """
 
-    sql """
-        BACKUP SNAPSHOT ${dbName}.${snapshotName}
-        TO `${repoName}`
-        ON (${tableName})
-    """
-
-    syncer.waitSnapshotFinish(dbName)
-
-
-    GetDebugPoint().disableDebugPointForAllBEs("SnapshotManager::make_snapshot.inject_failure")
+        syncer.waitSnapshotFinish(dbName)
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("SnapshotManager::make_snapshot.inject_failure")
+    }
 
 
 
 
     // test missing versions when compaction or balance
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("Tablet::capture_consistent_versions.inject_failure", [tablet_id:"${tabletId}", execute:1]);
 
-    GetDebugPoint().enableDebugPointForAllBEs("Tablet::capture_consistent_versions.inject_failure", [tablet_id:"${tabletId}", execute:1]);
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${snapshotName_1}
+            TO `${repoName}`
+            ON (${tableName})
+        """
 
-    sql """
-        BACKUP SNAPSHOT ${dbName}.${snapshotName_1}
-        TO `${repoName}`
-        ON (${tableName})
-    """
-
-    syncer.waitSnapshotFinish(dbName)
-
-    GetDebugPoint().disableDebugPointForAllBEs("Tablet::capture_consistent_versions.inject_failure");
+        syncer.waitSnapshotFinish(dbName)
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("Tablet::capture_consistent_versions.inject_failure");
+    }
 
 
     def snapshot = syncer.getSnapshotTimestamp(repoName, snapshotName)

--- a/regression-test/suites/backup_restore/test_backup_restore_atomic_with_alter.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_atomic_with_alter.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_backup_restore_atomic_with_alter", "backup_restore") {
+suite("test_backup_restore_atomic_with_alter", "backup_restore,nonConcurrent") {
     if (!getFeConfig("enable_debug_points").equals("true")) {
         logger.info("Config.enable_debug_points=true is required")
         return
@@ -96,6 +96,7 @@ suite("test_backup_restore_atomic_with_alter", "backup_restore") {
     sql "DROP TABLE ${dbName}.${tableNamePrefix}_0 FORCE"
 
     // disable restore
+ try {
     GetDebugPoint().enableDebugPointForAllFEs("FE.PAUSE_NON_PENDING_RESTORE_JOB", [value:snapshotName])
 
     sql """
@@ -239,6 +240,9 @@ suite("test_backup_restore_atomic_with_alter", "backup_restore") {
     }
     sql "DROP DATABASE ${dbName} FORCE"
     sql "DROP REPOSITORY `${repoName}`"
+  } finally {
+    GetDebugPoint().disableDebugPointForAllFEs("FE.PAUSE_NON_PENDING_RESTORE_JOB")
+  }
 }
 
 

--- a/regression-test/suites/demo_p0/debugpoint_action.groovy
+++ b/regression-test/suites/demo_p0/debugpoint_action.groovy
@@ -15,6 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.junit.Assert
+
+// This is a good example.
+// Debug point must run in 'nonConcurrent' or 'docker' suites.
+// If not a docker suite, must put nonConcurrent to the groups.
 suite('debugpoint_action', 'nonConcurrent') {
     try {
         GetDebugPoint().enableDebugPointForAllFEs('PublishVersionDaemon.stop_publish', [timeout:1])
@@ -24,4 +29,25 @@ suite('debugpoint_action', 'nonConcurrent') {
         GetDebugPoint().disableDebugPointForAllFEs('PublishVersionDaemon.stop_publish')
         GetDebugPoint().disableDebugPointForAllBEs('Tablet.build_tablet_report_info.version_miss')
     }
+}
+
+// This is a bad example.
+// its group tag not contains nonConcurrent or docker.
+suite('debugpoint_action_bad') {
+    Exception exception = null;
+    try {
+        GetDebugPoint().enableDebugPointForAllFEs('debugpoint_action_bad_xx', [timeout:1])
+    } catch (Exception e) {
+        exception = e
+    } finally {
+        // this is bad example, should disable or clear debug points after end suite
+        // GetDebugPoint().disableDebugPointForAllFEs('debugpoint_action_bad_xx')
+    }
+
+    Assert.assertNotNull(exception)
+    def expectMsg = "Debug point must use in nonConcurrent suite or docker suite"
+    def msg = exception.toString()
+    log.info("meet exception: ${msg}")
+    Assert.assertTrue("Expect exception msg contains '${expectMsg}', but meet '${msg}'",
+            msg.contains(expectMsg))
 }

--- a/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_during_sc.groovy
+++ b/regression-test/suites/fault_injection_p0/partial_update/test_partial_update_during_sc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_partial_update_during_sc') {
+suite('test_partial_update_during_sc', 'nonConcurrent') {
 
     String db = context.config.getDbNameByFile(context.file)
     sql "select 1;" // to create database

--- a/regression-test/suites/query_p0/join/test_inject_send_filter_size_fail/test_inject_send_filter_size_fail.groovy
+++ b/regression-test/suites/query_p0/join/test_inject_send_filter_size_fail/test_inject_send_filter_size_fail.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_inject_send_filter_size_fail") {
+suite("test_inject_send_filter_size_fail", "nonConcurrent") {
     sql "set enable_spill=false"
     sql "set enable_force_spill=false"
     sql "set parallel_pipeline_task_num=3"

--- a/regression-test/suites/query_p0/join/test_slow_close/test_slow_close.groovy
+++ b/regression-test/suites/query_p0/join/test_slow_close/test_slow_close.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_slow_close") {
+suite("test_slow_close", "nonConcurrent") {
     sql "set enable_spill = false"
     sql "set enable_force_spill = false"
     sql "set disable_join_reorder=true;"


### PR DESCRIPTION
### What problem does this PR solve?

debug point suites need add tag 'nonConcurrent' or 'docker'.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

