### PR TITLE
[fix](schema-change) Nested types should only support enlarging varchar length with light schema change (#49452)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColumnType.java
@@ -100,6 +100,7 @@ public abstract class ColumnType {
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.DATEV2.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.STRING.ordinal()] = true;
         schemaChangeMatrix[PrimitiveType.VARCHAR.ordinal()][PrimitiveType.JSONB.ordinal()] = true;
+        // could not change varchar to char cuz varchar max length is larger than char
 
         schemaChangeMatrix[PrimitiveType.STRING.ordinal()][PrimitiveType.JSONB.ordinal()] = true;
 
@@ -192,7 +193,10 @@ public abstract class ColumnType {
     // return true if the checkType and other are both char-type otherwise return false,
     // which used in checkSupportSchemaChangeForComplexType
     private static boolean checkSupportSchemaChangeForCharType(Type checkType, Type other) throws DdlException {
-        if (checkType.isStringType() && other.isStringType()) {
+        if (checkType.getPrimitiveType() == PrimitiveType.VARCHAR
+                && other.getPrimitiveType() == PrimitiveType.VARCHAR) {
+            // currently nested types only support light schema change for internal fields, for string types,
+            // only varchar can do light schema change
             checkForTypeLengthChange(checkType, other);
             return true;
         } else {
@@ -230,7 +234,8 @@ public abstract class ColumnType {
             // only support char-type schema change behavior for nested complex type
             // if nested is false, we do not check return value.
             if (nested && !checkSupportSchemaChangeForCharType(checkType, other)) {
-                throw new DdlException("Cannot change " + checkType.toSql() + " to " + other.toSql());
+                throw new DdlException(
+                        "Cannot change " + checkType.toSql() + " to " + other.toSql() + " in nested types");
             }
         }
     }

--- a/regression-test/suites/schema_change_p0/test_type_length_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_type_length_change.groovy
@@ -25,7 +25,7 @@ suite("test_type_length_change", "p0") {
             c0 CHAR(5),
             c1 VARCHAR(5)
         ) DUPLICATE KEY (k)
-	DISTRIBUTED BY HASH(k) BUCKETS 1
+        DISTRIBUTED BY HASH(k) BUCKETS 1
         PROPERTIES ( "replication_allocation" = "tag.location.default: 1");
     """
 
@@ -75,4 +75,9 @@ suite("test_type_length_change", "p0") {
     sql """  INSERT INTO ${tableName} VALUES(4, "abcde", "abcde") """
     qt_master_sql """ SELECT * FROM ${tableName} ORDER BY k"""
     qt_master_sql """ DESC ${tableName} """
+
+    test {
+        sql """ ALTER TABLE ${tableName} MODIFY COLUMN c1 CHAR(10) """
+        exception "Can not change VARCHAR to CHAR"
+    }
 }

--- a/regression-test/suites/schema_change_p0/test_varchar_sc_in_complex.groovy
+++ b/regression-test/suites/schema_change_p0/test_varchar_sc_in_complex.groovy
@@ -476,6 +476,61 @@ suite ("test_varchar_sc_in_complex") {
 //            """
 //        qt_sc_after " select * from there_level_nested_type order by c0; "
 
+        // case7. do not support enlarge char length in nested types
+        def tableName2 = "test_enlarge_char_length_nested"
+        sql """ DROP TABLE IF EXISTS ${tableName2} """
+        sql """
+            CREATE TABLE IF NOT EXISTS ${tableName2}
+            (
+                k BIGINT NOT NULL,
+                c1 ARRAY<CHAR(10)>,
+                c2 MAP<CHAR(10), CHAR(10)>,
+                c3 STRUCT<col:CHAR(10)>,
+                c4 ARRAY<VARCHAR(10)>,
+                c5 MAP<VARCHAR(10), VARCHAR(10)>,
+                c6 STRUCT<col:VARCHAR(10)>
+            ) DISTRIBUTED BY HASH(k) BUCKETS 1
+              PROPERTIES ( "replication_num" = "1", "light_schema_change" = "true" );
+        """
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c1 ARRAY<CHAR(20)> """
+            exception "Cannot change char(10) to char(20) in nested types"
+        }
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c2 MAP<CHAR(20), CHAR(20)> """
+            exception "Cannot change char(10) to char(20) in nested types"
+        }
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c3 STRUCT<col:CHAR(20)> """
+            exception "Cannot change char(10) to char(20) in nested types"
+        }
+
+        // case8. do not support convert from char to varchar and varchar to char in nested types
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c1 ARRAY<VARCHAR(20)> """
+            exception "Cannot change char(10) to varchar(20) in nested types"
+        }
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c2 MAP<VARCHAR(20), VARCHAR(20)> """
+            exception "Cannot change char(10) to varchar(20) in nested types"
+        }
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c3 STRUCT<col:VARCHAR(20)> """
+            exception "Cannot change char(10) to varchar(20) in nested types"
+        }
+
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c4 ARRAY<CHAR(20)> """
+            exception "Cannot change varchar(10) to char(20) in nested types"
+        }
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c5 MAP<CHAR(20), CHAR(20)> """
+            exception "Cannot change varchar(10) to char(20) in nested types"
+        }
+        test {
+            sql """ ALTER TABLE ${tableName2} MODIFY COLUMN c6 STRUCT<col:CHAR(20)> """
+            exception "Cannot change varchar(10) to char(20) in nested types"
+        }
     } finally {
          try_sql("DROP TABLE IF EXISTS ${tableName}")
     }


### PR DESCRIPTION
### What problem does this PR solve?

cherry-pick: #49452

Problem Summary:

Currently nested types only support light schema change for internal fields, for string types, only varchar can do light schema change.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

