### PR TITLE
[fix](runtime) Avoid merging results into one large result in BufferControlBlock

### DIFF
--- a/be/src/runtime/result_block_buffer.h
+++ b/be/src/runtime/result_block_buffer.h
@@ -102,6 +102,10 @@ protected:
     // protects all subsequent data in this block
     std::mutex _lock;
 
+    // The last batch size in bytes.
+    // Determine whether to merge multiple batches based on the size of each batch to avoid getting an excessively large batch after merging.
+    size_t _last_batch_bytes = 0;
+
     // get arrow flight result is a sync method, need wait for data ready and return result.
     // TODO, waiting for data will block pipeline, so use a request pool to save requests waiting for data.
     std::condition_variable _arrow_data_arrival;


### PR DESCRIPTION
### What problem does this PR solve?

Avoid rpc error: `FLOW_CONTROL_ERROR`

Problem Summary:

Merging into an excessively large batch can cause BRPC transmission failure with error: `FLOW_CONTROL_ERROR`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

