### PR TITLE
[Fix](external catalog) where tables in the information_schema could not be displayed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -305,11 +305,17 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         List<Pair<String, String>> tableNames;
         if (name.equals(InfoSchemaDb.DATABASE_NAME)) {
             tableNames = ExternalInfoSchemaDatabase.listTableNames().stream()
-                    .map(tableName -> Pair.of(tableName, tableName))
+                    .map(tableName -> {
+                        lowerCaseToTableName.put(tableName.toLowerCase(), tableName);
+                        return Pair.of(tableName, tableName);
+                    })
                     .collect(Collectors.toList());
         } else if (name.equals(MysqlDb.DATABASE_NAME)) {
             tableNames = ExternalMysqlDatabase.listTableNames().stream()
-                    .map(tableName -> Pair.of(tableName, tableName))
+                    .map(tableName -> {
+                        lowerCaseToTableName.put(tableName.toLowerCase(), tableName);
+                        return Pair.of(tableName, tableName);
+                    })
                     .collect(Collectors.toList());
         } else {
             tableNames = extCatalog.listTableNames(null, remoteName).stream().map(tableName -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -492,7 +492,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     continue;
                 }
 
-                if (matcher != null && !matcher.match(dbName)) {
+                if (matcher != null && !matcher.match(getMysqlTableSchema(catalog.getName(), dbName))) {
                     continue;
                 }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalTableNameComparedLowercaseMetaCacheFalseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalTableNameComparedLowercaseMetaCacheFalseTest.java
@@ -23,7 +23,9 @@ import org.apache.doris.analysis.RefreshCatalogStmt;
 import org.apache.doris.analysis.SwitchStmt;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.test.TestExternalCatalog;
@@ -100,6 +102,13 @@ public class ExternalTableNameComparedLowercaseMetaCacheFalseTest extends TestWi
         Assertions.assertEquals(2, tableNames.size());
         Assertions.assertTrue(tableNames.contains("TABLE1"));
         Assertions.assertTrue(tableNames.contains("TABLE2"));
+    }
+
+    @Test
+    public void testShowInformationSchemaTables() {
+        Set<String> tableNames = env.getCatalogMgr().getCatalog("test1").getDbNullable(InfoSchemaDb.DATABASE_NAME).getTableNamesWithLock();
+        Assertions.assertTrue(SchemaTable.TABLE_MAP.keySet().containsAll(tableNames));
+        Assertions.assertTrue(tableNames.containsAll(SchemaTable.TABLE_MAP.keySet()));
     }
 
     private void switchTest() throws Exception {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When FE case insensitivity is enabled, tables under the external catalog information_schema cannot be viewed

``` sql
mysql> show catalogs;
+-----------+-------------+----------+-----------+----------------------------+----------------+------------------------+
| CatalogId | CatalogName | Type     | IsCurrent | CreateTime                 | LastUpdateTime | Comment                |
+-----------+-------------+----------+-----------+----------------------------+----------------+------------------------+
|     13007 | b           | hms      | No        | 2025-03-27 16:37:10.188367 | NULL           |                        |
|     13015 | hive        | hms      | No        | 2025-03-27 17:03:45.259390 | NULL           |                        |
|         0 | internal    | internal | Yes       | NULL                       | NULL           | Doris internal catalog |
+-----------+-------------+----------+-----------+----------------------------+----------------+------------------------+
3 rows in set (0.03 sec)

mysql> switch hive;
Query OK, 0 rows affected (0.00 sec)

mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| aaaaaaaa           |
| icebergdb          |
| information_schema |
| mysql              |
+--------------------+
4 rows in set (0.85 sec)

mysql> use information_schema
Database changed

MySQL [information_schema]> show tables;
Empty set (0.00 sec)

```


tables in information_schema should not empty

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

