### PR TITLE
[Refactor](beut) Make function be-ut test aware of result's precision

### DIFF
--- a/be/src/util/debug/leak_annotations.h
+++ b/be/src/util/debug/leak_annotations.h
@@ -69,8 +69,7 @@ void __lsan_do_leak_check();
 int __lsan_do_recoverable_leak_check();
 } // extern "C"
 
-namespace doris {
-namespace debug {
+namespace doris::debug {
 
 class ScopedLSANDisabler {
 public:
@@ -78,5 +77,4 @@ public:
     ~ScopedLSANDisabler() { __lsan_enable(); }
 };
 
-} // namespace debug
-} // namespace doris
+} // namespace doris::debug

--- a/be/src/util/quantile_state.h
+++ b/be/src/util/quantile_state.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 
+#include "common/exception.h"
 #include "slice.h"
 
 namespace doris {
@@ -61,6 +62,11 @@ public:
     size_t get_serialized_size();
     double get_value_by_percentile(float percentile) const;
     double get_explicit_value_by_percentile(float percentile) const;
+    #ifdef BE_TEST
+    std::string to_string() const {
+        throw Status::NotSupported("QuantileState::to_string() not implemented");
+    }
+    #endif
     ~QuantileState() = default;
 
 private:

--- a/be/src/util/quantile_state.h
+++ b/be/src/util/quantile_state.h
@@ -62,11 +62,11 @@ public:
     size_t get_serialized_size();
     double get_value_by_percentile(float percentile) const;
     double get_explicit_value_by_percentile(float percentile) const;
-    #ifdef BE_TEST
+#ifdef BE_TEST
     std::string to_string() const {
         throw Status::NotSupported("QuantileState::to_string() not implemented");
     }
-    #endif
+#endif
     ~QuantileState() = default;
 
 private:

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -25,7 +25,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <ostream>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -229,6 +229,14 @@ public:
 
     T& get_element(size_t n) { return data[n]; }
 
+#ifdef BE_TEST
+    int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override {
+        std::string lhs = get_element(n).to_string();
+        std::string rhs = assert_cast<const Self&>(rhs_).get_element(m).to_string();
+        return lhs.compare(rhs);
+    }
+#endif
+
     ColumnPtr replicate(const IColumn::Offsets& replicate_offsets) const override;
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -21,13 +21,13 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <cstdint>
-#include <cstring>
 #include <sys/types.h>
 
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <initializer_list>
 #include <string>
 #include <type_traits>

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -21,8 +21,8 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 #include <sys/types.h>
 
 #include <algorithm>
@@ -39,12 +39,10 @@
 #include "olap/uint24.h"
 #include "runtime/define_primitive_type.h"
 #include "vec/columns/column.h"
-#include "vec/columns/column_impl.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/cow.h"
 #include "vec/common/pod_array_fwd.h"
 #include "vec/common/string_ref.h"
-#include "vec/common/uint128.h"
 #include "vec/common/unaligned.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
@@ -52,12 +50,10 @@
 
 class SipHash;
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
 class Arena;
 class ColumnSorter;
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::vectorized
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -22,15 +22,11 @@
 
 #include <fmt/format.h>
 #include <glog/logging.h>
-#include <stdint.h>
-#include <string.h>
 
 #include <algorithm>
 #include <cassert>
-#include <functional>
+#include <cstring>
 #include <map>
-#include <new>
-#include <ostream>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -154,7 +150,7 @@ DEFINE_FIELD_VECTOR(Tuple);
 DEFINE_FIELD_VECTOR(Map);
 #undef DEFINE_FIELD_VECTOR
 
-using FieldMap = std::map<String, Field, std::less<String>>;
+using FieldMap = std::map<String, Field>;
 #define DEFINE_FIELD_MAP(X)       \
     struct X : public FieldMap {  \
         using FieldMap::FieldMap; \
@@ -197,9 +193,7 @@ public:
     }
 
     JsonbField& operator=(JsonbField&& x) {
-        if (data) {
-            delete[] data;
-        }
+        delete[] data;
         data = x.data;
         size = x.size;
         x.data = nullptr;
@@ -207,11 +201,7 @@ public:
         return *this;
     }
 
-    ~JsonbField() {
-        if (data) {
-            delete[] data;
-        }
-    }
+    ~JsonbField() { delete[] data; }
 
     const char* get_value() const { return data; }
     size_t get_size() const { return size; }
@@ -495,21 +485,23 @@ public:
     template <typename T>
     T& get() {
         using TWithoutRef = std::remove_reference_t<T>;
-        TWithoutRef* MAY_ALIAS ptr = reinterpret_cast<TWithoutRef*>(&storage);
+        auto* MAY_ALIAS ptr = reinterpret_cast<TWithoutRef*>(&storage);
         return *ptr;
     }
 
     template <typename T>
     const T& get() const {
         using TWithoutRef = std::remove_reference_t<T>;
-        const TWithoutRef* MAY_ALIAS ptr = reinterpret_cast<const TWithoutRef*>(&storage);
+        const auto* MAY_ALIAS ptr = reinterpret_cast<const TWithoutRef*>(&storage);
         return *ptr;
     }
 
     template <typename T>
     bool try_get(T& result) {
         const Types::Which requested = TypeToEnum<std::decay_t<T>>::value;
-        if (which != requested) return false;
+        if (which != requested) {
+            return false;
+        }
         result = get<T>();
         return true;
     }
@@ -519,7 +511,9 @@ public:
     template <typename T>
     bool try_get(T& result) const {
         const Types::Which requested = TypeToEnum<std::decay_t<T>>::value;
-        if (which != requested) return false;
+        if (which != requested) {
+            return false;
+        }
         result = get<T>();
         return true;
     }
@@ -702,7 +696,7 @@ private:
     void assign_concrete(T&& x) {
         using JustT = std::decay_t<T>;
         assert(which == TypeToEnum<JustT>::value);
-        JustT* MAY_ALIAS ptr = reinterpret_cast<JustT*>(&storage);
+        auto* MAY_ALIAS ptr = reinterpret_cast<JustT*>(&storage);
         *ptr = std::forward<T>(x);
     }
 

--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -559,7 +559,7 @@ public:
         case Types::Tuple:
         case Types::Map:
         case Types::VariantMap:
-            return std::strong_ordering::equal;
+            return std::strong_ordering::equal; //TODO: throw Exception?
         case Types::UInt64:
             return get<UInt64>() <=> rhs.get<UInt64>();
         case Types::UInt128:

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -548,7 +548,7 @@ struct Decimal {
         return T(value);
     }
 
-    static Decimal double_to_decimal(double value_) {
+    static Decimal double_to_decimalv2(double value_) requires(std::is_same_v<T, Int128>) {
         DecimalV2Value decimal_value;
         decimal_value.assign_from_double(value_);
         return Decimal(binary_cast<DecimalV2Value, T>(decimal_value));

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -548,7 +548,9 @@ struct Decimal {
         return T(value);
     }
 
-    static Decimal double_to_decimalv2(double value_) requires(std::is_same_v<T, Int128>) {
+    static Decimal double_to_decimalv2(double value_)
+        requires(std::is_same_v<T, Int128>)
+    {
         DecimalV2Value decimal_value;
         decimal_value.assign_from_double(value_);
         return Decimal(binary_cast<DecimalV2Value, T>(decimal_value));

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -267,6 +267,8 @@ struct WhichDataType {
     bool is_string_or_fixed_string() const { return is_string() || is_fixed_string(); }
 
     bool is_json() const { return idx == TypeIndex::JSONB; }
+    bool is_bitmap() const { return idx == TypeIndex::BitMap; }
+    bool is_hll() const { return idx == TypeIndex::HLL; }
 
     bool is_array() const { return idx == TypeIndex::Array; }
     bool is_tuple() const { return idx == TypeIndex::Tuple; }

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -256,6 +256,7 @@ struct WhichDataType {
     bool is_date_time_v2() const { return idx == TypeIndex::DateTimeV2; }
     bool is_date_or_datetime() const { return is_date() || is_date_time(); }
     bool is_date_v2_or_datetime_v2() const { return is_date_v2() || is_date_time_v2(); }
+    bool is_time_v2() const { return idx == TypeIndex::TimeV2; }
 
     bool is_ipv4() const { return idx == TypeIndex::IPv4; }
     bool is_ipv6() const { return idx == TypeIndex::IPv6; }

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -24,11 +24,8 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
-#include <limits>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <type_traits>
 
@@ -49,9 +46,7 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_number.h" // IWYU pragma: keep
-#include "vec/data_types/number_traits.h"
 #include "vec/data_types/serde/data_type_serde.h"
-#include "vec/utils/template_helpers.hpp"
 
 namespace doris {
 class DecimalV2Value;

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -21,38 +21,32 @@
 #pragma once
 
 #include <gen_cpp/Types_types.h>
-#include <stddef.h>
+#include <cstddef>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <type_traits>
 
-#include "common/cast_set.h"
 #include "common/status.h"
 #include "runtime/define_primitive_type.h"
 #include "serde/data_type_number_serde.h"
 #include "vec/columns/column_vector.h"
-#include "vec/common/uint128.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/serde/data_type_serde.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
 class BufferWritable;
 class IColumn;
 class ReadBuffer;
 template <typename T>
 struct TypeId;
-} // namespace vectorized
-} // namespace doris
 
-namespace doris::vectorized {
-#include "common/compile_check_begin.h"
 /** Implements part of the IDataType interface, common to all numbers and for Date and DateTime.
   */
 template <typename T>
@@ -69,34 +63,34 @@ public:
     TypeDescriptor get_type_as_type_descriptor() const override {
         // Doris does not support uint8 at present, use uint8 as boolean type
         if constexpr (std::is_same_v<TypeId<T>, TypeId<UInt8>>) {
-            return TypeDescriptor(TYPE_BOOLEAN);
+            return {TYPE_BOOLEAN};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int8>>) {
-            return TypeDescriptor(TYPE_TINYINT);
+            return {TYPE_TINYINT};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int16>> ||
                       std::is_same_v<TypeId<T>, TypeId<UInt16>>) {
-            return TypeDescriptor(TYPE_SMALLINT);
+            return {TYPE_SMALLINT};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int32>> ||
                       std::is_same_v<TypeId<T>, TypeId<UInt32>>) {
-            return TypeDescriptor(TYPE_INT);
+            return {TYPE_INT};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int64>> ||
                       std::is_same_v<TypeId<T>, TypeId<UInt64>>) {
-            return TypeDescriptor(TYPE_BIGINT);
+            return {TYPE_BIGINT};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int128>> ||
                       std::is_same_v<TypeId<T>, TypeId<Int128>>) {
-            return TypeDescriptor(TYPE_LARGEINT);
+            return {TYPE_LARGEINT};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Float32>>) {
-            return TypeDescriptor(TYPE_FLOAT);
+            return {TYPE_FLOAT};
         }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Float64>>) {
-            return TypeDescriptor(TYPE_DOUBLE);
+            return {TYPE_DOUBLE};
         }
-        return TypeDescriptor(INVALID_TYPE);
+        return {INVALID_TYPE};
     }
 
     doris::FieldType get_storage_field_type() const override {

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -21,9 +21,9 @@
 #pragma once
 
 #include <gen_cpp/Types_types.h>
-#include <cstddef>
 
 #include <boost/iterator/iterator_facade.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -881,7 +881,6 @@ struct ConvertImplFromJsonb {
 template <typename ToDataType, typename Name>
 struct ConvertImpl<DataTypeString, ToDataType, Name> {
     template <typename Additions = void*>
-
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           uint32_t result, size_t input_rows_count,
                           Additions additions [[maybe_unused]] = Additions()) {

--- a/be/src/vec/functions/math.cpp
+++ b/be/src/vec/functions/math.cpp
@@ -26,6 +26,7 @@
 #include <type_traits>
 
 #include "common/status.h"
+#include "util/debug/leak_annotations.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
@@ -43,15 +44,12 @@
 #include "vec/functions/function_unary_arithmetic.h"
 #include "vec/functions/simple_function_factory.h"
 
-namespace doris {
-namespace vectorized {
+namespace doris::vectorized {
+
 struct LnImpl;
 struct Log10Impl;
 struct Log2Impl;
-} // namespace vectorized
-} // namespace doris
 
-namespace doris::vectorized {
 struct AcosName {
     static constexpr auto name = "acos";
     // https://dev.mysql.com/doc/refman/8.4/en/mathematical-functions.html#function_acos
@@ -248,6 +246,7 @@ struct UnaryFunctionPlainSin {
     using FuncType = double (*)(double);
 
     static FuncType get_sin_func() {
+#ifndef BE_TEST
         void* handle = dlopen("libm.so.6", RTLD_LAZY);
         if (handle) {
             if (auto sin_func = (double (*)(double))dlsym(handle, "sin"); sin_func) {
@@ -255,6 +254,7 @@ struct UnaryFunctionPlainSin {
             }
             dlclose(handle);
         }
+#endif
         return std::sin;
     }
 

--- a/be/test/testutil/any_type.h
+++ b/be/test/testutil/any_type.h
@@ -28,8 +28,10 @@ struct AnyType : public std::variant<std::any, __int128_t> {
     AnyType() = default;
 
     template <typename T>
-    AnyType(T value) {
+    AnyType(T value, int scale = -1, int precision = -1) {
         this->emplace<std::any>(std::move(value));
+        this->_scale = scale;
+        this->_precision = precision;
     }
 
     AnyType(__int128_t value) { this->emplace<__int128_t>(value); }
@@ -54,6 +56,15 @@ struct AnyType : public std::variant<std::any, __int128_t> {
     friend ValueType any_cast(AnyType& operand);
     template <class ValueType>
     friend ValueType any_cast(AnyType&& operand);
+
+    int _scale = -1;
+    int _precision = -1;
+    int scale_or(int default_value) const {
+        return _scale == -1 ? default_value : _scale;
+    }
+    int precision_or(int default_value) const {
+        return _precision == -1 ? default_value : _precision;
+    }
 };
 
 template <class ValueType>

--- a/be/test/testutil/any_type.h
+++ b/be/test/testutil/any_type.h
@@ -59,9 +59,7 @@ struct AnyType : public std::variant<std::any, __int128_t> {
 
     int _scale = -1;
     int _precision = -1;
-    int scale_or(int default_value) const {
-        return _scale == -1 ? default_value : _scale;
-    }
+    int scale_or(int default_value) const { return _scale == -1 ? default_value : _scale; }
     int precision_or(int default_value) const {
         return _precision == -1 ? default_value : _precision;
     }

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
 
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new TestListener);
-    doris::ExecEnv::GetInstance()->set_tracking_memory(false);
+    doris::ExecEnv::set_tracking_memory(false);
 
     google::ParseCommandLineFlags(&argc, &argv, false);
     int res = RUN_ALL_TESTS();

--- a/be/test/testutil/test_util.h
+++ b/be/test/testutil/test_util.h
@@ -27,9 +27,9 @@
 DECLARE_bool(gen_out);
 
 struct TestCaseInfo {
-    inline static int arg_const_info {};
-    inline static int cur_cast_line {};
-    inline static int arg_size {};
+    inline static thread_local int arg_const_info {};
+    inline static thread_local int cur_cast_line {};
+    inline static thread_local int arg_size {};
 };
 
 //"Rewrite the virtual functions of the gtest framework to enable listening to test events.
@@ -49,7 +49,7 @@ struct TestListener : public ::testing::EmptyTestEventListener {
                     std::cout << "arg" << i + 1 << " ";
                 }
             }
-            std::cout << "\nError occurred in case" << TestCaseInfo::cur_cast_line << std::endl;
+            std::cout << "\nError occurred in row " << TestCaseInfo::cur_cast_line << std::endl;
             std::cout << "\033[0m";
         }
     }

--- a/be/test/vec/columns/column_array_test.cpp
+++ b/be/test/vec/columns/column_array_test.cpp
@@ -630,7 +630,7 @@ TEST_F(ColumnArrayTest, CreateArrayTest) {
     //
     //  so actually according to the semantics of the function, it should not impl in array,
     //  but we should make sure in creation of array, the nested_column && offsets_column should not be const
-    for (auto & array_column : array_columns) {
+    for (auto& array_column : array_columns) {
         const auto* column = check_and_get_column<ColumnArray>(
                 remove_nullable(array_column->assume_mutable()).get());
         auto column_size = column->size();

--- a/be/test/vec/columns/column_array_test.cpp
+++ b/be/test/vec/columns/column_array_test.cpp
@@ -37,119 +37,110 @@ protected:
         // we need to load data from csv file into column_array list
         // step1. create data type for array nested type (const and nullable)
         // array<bool>
-        BaseInputTypeSet array_uint8 = {TypeIndex::Array, TypeIndex::UInt8};
+        InputTypeSet array_uint8 = {TypeIndex::Array, TypeIndex::UInt8};
         // array<tinyint>
-        BaseInputTypeSet array_tinyint = {TypeIndex::Array, TypeIndex::Int8};
+        InputTypeSet array_tinyint = {TypeIndex::Array, TypeIndex::Int8};
         // array<smallint>
-        BaseInputTypeSet array_smallint = {TypeIndex::Array, TypeIndex::Int16};
+        InputTypeSet array_smallint = {TypeIndex::Array, TypeIndex::Int16};
         // array<int>
-        BaseInputTypeSet array_int = {TypeIndex::Array, TypeIndex::Int32};
+        InputTypeSet array_int = {TypeIndex::Array, TypeIndex::Int32};
         // array<bigint>
-        BaseInputTypeSet array_bigint = {TypeIndex::Array, TypeIndex::Int64};
+        InputTypeSet array_bigint = {TypeIndex::Array, TypeIndex::Int64};
         // array<largeint>
-        BaseInputTypeSet array_largeint = {TypeIndex::Array, TypeIndex::Int128};
+        InputTypeSet array_largeint = {TypeIndex::Array, TypeIndex::Int128};
         // array<float>
-        BaseInputTypeSet array_float = {TypeIndex::Array, TypeIndex::Float32};
+        InputTypeSet array_float = {TypeIndex::Array, TypeIndex::Float32};
         // array<double>
-        BaseInputTypeSet array_double = {TypeIndex::Array, TypeIndex::Float64};
+        InputTypeSet array_double = {TypeIndex::Array, TypeIndex::Float64};
         // array<ipv4>
-        BaseInputTypeSet array_ipv4 = {TypeIndex::Array, TypeIndex::IPv4};
+        InputTypeSet array_ipv4 = {TypeIndex::Array, TypeIndex::IPv4};
         // array<ipv6>
-        BaseInputTypeSet array_ipv6 = {TypeIndex::Array, TypeIndex::IPv6};
+        InputTypeSet array_ipv6 = {TypeIndex::Array, TypeIndex::IPv6};
         // array<date>
-        BaseInputTypeSet array_date = {TypeIndex::Array, TypeIndex::Date};
+        InputTypeSet array_date = {TypeIndex::Array, TypeIndex::Date};
         // array<datetime>
-        BaseInputTypeSet array_datetime = {TypeIndex::Array, TypeIndex::DateTime};
+        InputTypeSet array_datetime = {TypeIndex::Array, TypeIndex::DateTime};
         // array<datev2>
-        BaseInputTypeSet array_datev2 = {TypeIndex::Array, TypeIndex::DateV2};
+        InputTypeSet array_datev2 = {TypeIndex::Array, TypeIndex::DateV2};
         // array<datetimev2>
-        BaseInputTypeSet array_datetimev2 = {TypeIndex::Array, TypeIndex::DateTimeV2};
+        InputTypeSet array_datetimev2 = {TypeIndex::Array, TypeIndex::DateTimeV2};
         // array<varchar>
-        BaseInputTypeSet array_varchar = {TypeIndex::Array, TypeIndex::String};
+        InputTypeSet array_varchar = {TypeIndex::Array, TypeIndex::String};
         // array<decimal32(9, 5)> UT
-        BaseInputTypeSet array_decimal = {TypeIndex::Array, TypeIndex::Decimal32};
+        InputTypeSet array_decimal = {TypeIndex::Array, TypeIndex::Decimal32};
         // array<decimal64(18, 9)> UT
-        BaseInputTypeSet array_decimal64 = {TypeIndex::Array, TypeIndex::Decimal64};
+        InputTypeSet array_decimal64 = {TypeIndex::Array, TypeIndex::Decimal64};
         // array<decimal128(38, 20)> UT
-        BaseInputTypeSet array_decimal128 = {TypeIndex::Array, TypeIndex::Decimal128V3};
+        InputTypeSet array_decimal128 = {TypeIndex::Array, TypeIndex::Decimal128V3};
         // array<decimal256(76, 40)> UT
-        BaseInputTypeSet array_decimal256 = {TypeIndex::Array, TypeIndex::Decimal256};
+        InputTypeSet array_decimal256 = {TypeIndex::Array, TypeIndex::Decimal256};
         // array<array<bool>>
-        BaseInputTypeSet array_array_uint8 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::UInt8};
+        InputTypeSet array_array_uint8 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::UInt8};
         // array<array<tinyint>>
-        BaseInputTypeSet array_array_tinyint = {TypeIndex::Array, TypeIndex::Array,
-                                                TypeIndex::Int8};
+        InputTypeSet array_array_tinyint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int8};
         // array<array<smallint>>
-        BaseInputTypeSet array_array_smallint = {TypeIndex::Array, TypeIndex::Array,
-                                                 TypeIndex::Int16};
+        InputTypeSet array_array_smallint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int16};
         // array<array<int>>
-        BaseInputTypeSet array_array_int = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int32};
+        InputTypeSet array_array_int = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int32};
         // array<array<bigint>>
-        BaseInputTypeSet array_array_bigint = {TypeIndex::Array, TypeIndex::Array,
-                                               TypeIndex::Int64};
+        InputTypeSet array_array_bigint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int64};
         // array<array<largeint>>
-        BaseInputTypeSet array_array_largeint = {TypeIndex::Array, TypeIndex::Array,
-                                                 TypeIndex::Int128};
+        InputTypeSet array_array_largeint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int128};
         // array<array<float>>
-        BaseInputTypeSet array_array_float = {TypeIndex::Array, TypeIndex::Array,
-                                              TypeIndex::Float32};
+        InputTypeSet array_array_float = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Float32};
         // array<array<double>>
-        BaseInputTypeSet array_array_double = {TypeIndex::Array, TypeIndex::Array,
-                                               TypeIndex::Float64};
+        InputTypeSet array_array_double = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Float64};
         // array<array<ipv4>>
-        BaseInputTypeSet array_array_ipv4 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv4};
+        InputTypeSet array_array_ipv4 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv4};
         // array<array<ipv6>>
-        BaseInputTypeSet array_array_ipv6 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv6};
+        InputTypeSet array_array_ipv6 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv6};
         // array<array<date>>
-        BaseInputTypeSet array_array_date = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Date};
+        InputTypeSet array_array_date = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Date};
         // array<array<datetime>>
-        BaseInputTypeSet array_array_datetime = {TypeIndex::Array, TypeIndex::Array,
-                                                 TypeIndex::DateTime};
+        InputTypeSet array_array_datetime = {TypeIndex::Array, TypeIndex::Array,
+                                             TypeIndex::DateTime};
         // array<array<datev2>>
-        BaseInputTypeSet array_array_datev2 = {TypeIndex::Array, TypeIndex::Array,
-                                               TypeIndex::DateV2};
+        InputTypeSet array_array_datev2 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::DateV2};
         // array<array<datetimev2>>
-        BaseInputTypeSet array_array_datetimev2 = {TypeIndex::Array, TypeIndex::Array,
-                                                   TypeIndex::DateTimeV2};
+        InputTypeSet array_array_datetimev2 = {TypeIndex::Array, TypeIndex::Array,
+                                               TypeIndex::DateTimeV2};
         // array<array<varchar>>
-        BaseInputTypeSet array_array_varchar = {TypeIndex::Array, TypeIndex::Array,
-                                                TypeIndex::String};
+        InputTypeSet array_array_varchar = {TypeIndex::Array, TypeIndex::Array, TypeIndex::String};
         // array<array<decimal32(9, 5)>> UT
-        BaseInputTypeSet array_array_decimal = {TypeIndex::Array, TypeIndex::Array,
-                                                TypeIndex::Decimal32};
+        InputTypeSet array_array_decimal = {TypeIndex::Array, TypeIndex::Array,
+                                            TypeIndex::Decimal32};
         // array<array<decimal64(18, 9)>> UT
-        BaseInputTypeSet array_array_decimal64 = {TypeIndex::Array, TypeIndex::Array,
-                                                  TypeIndex::Decimal64};
+        InputTypeSet array_array_decimal64 = {TypeIndex::Array, TypeIndex::Array,
+                                              TypeIndex::Decimal64};
         // array<array<decimal128(38, 20)>> UT
-        BaseInputTypeSet array_array_decimal128 = {TypeIndex::Array, TypeIndex::Array,
-                                                   TypeIndex::Decimal128V3};
+        InputTypeSet array_array_decimal128 = {TypeIndex::Array, TypeIndex::Array,
+                                               TypeIndex::Decimal128V3};
         // array<array<decimal256(76, 40)>> UT
-        BaseInputTypeSet array_array_decimal256 = {TypeIndex::Array, TypeIndex::Array,
-                                                   TypeIndex::Decimal256};
+        InputTypeSet array_array_decimal256 = {TypeIndex::Array, TypeIndex::Array,
+                                               TypeIndex::Decimal256};
         // array<map<char,double>>
-        BaseInputTypeSet array_map_char_double = {TypeIndex::Array, TypeIndex::Map,
-                                                  TypeIndex::String, TypeIndex::Float64};
+        InputTypeSet array_map_char_double = {TypeIndex::Array, TypeIndex::Map, TypeIndex::String,
+                                              TypeIndex::Float64};
         // test_array_map<datetime,decimal<76,56>>.csv
-        BaseInputTypeSet array_map_datetime_decimal = {TypeIndex::Array, TypeIndex::Map,
-                                                       TypeIndex::DateTime, TypeIndex::Decimal256};
+        InputTypeSet array_map_datetime_decimal = {TypeIndex::Array, TypeIndex::Map,
+                                                   TypeIndex::DateTime, TypeIndex::Decimal256};
         // test_array_map<ipv4,ipv6>.csv
-        BaseInputTypeSet array_map_ipv4_ipv6 = {TypeIndex::Array, TypeIndex::Map, TypeIndex::IPv4,
-                                                TypeIndex::IPv6};
+        InputTypeSet array_map_ipv4_ipv6 = {TypeIndex::Array, TypeIndex::Map, TypeIndex::IPv4,
+                                            TypeIndex::IPv6};
         // test_array_map<largeInt,string>.csv
-        BaseInputTypeSet array_map_largeint_string = {TypeIndex::Array, TypeIndex::Map,
-                                                      TypeIndex::Int128, TypeIndex::String};
+        InputTypeSet array_map_largeint_string = {TypeIndex::Array, TypeIndex::Map,
+                                                  TypeIndex::Int128, TypeIndex::String};
         // array<struct<f1:int,f2:date,f3:decimal,f4:string,f5:double,f6:ipv4,f7:ipv6>>
-        BaseInputTypeSet array_struct = {
-                TypeIndex::Array,   TypeIndex::Struct,    TypeIndex::Int32,
-                TypeIndex::Date,    TypeIndex::Decimal32, TypeIndex::String,
-                TypeIndex::Float64, TypeIndex::IPv4,      TypeIndex::IPv6};
+        InputTypeSet array_struct = {TypeIndex::Array,   TypeIndex::Struct,    TypeIndex::Int32,
+                                     TypeIndex::Date,    TypeIndex::Decimal32, TypeIndex::String,
+                                     TypeIndex::Float64, TypeIndex::IPv4,      TypeIndex::IPv6};
 
-        std::vector<BaseInputTypeSet> array_typeIndex = {
+        std::vector<InputTypeSet> array_typeIndex = {
                 array_uint8,    array_tinyint,   array_smallint,   array_int,        array_bigint,
                 array_largeint, array_float,     array_double,     array_ipv4,       array_ipv6,
                 array_date,     array_datetime,  array_datev2,     array_datetimev2, array_varchar,
                 array_decimal,  array_decimal64, array_decimal128, array_decimal256};
-        std::vector<BaseInputTypeSet> array_array_typeIndex = {
+        std::vector<InputTypeSet> array_array_typeIndex = {
                 array_array_uint8,     array_array_tinyint,    array_array_smallint,
                 array_array_int,       array_array_bigint,     array_array_largeint,
                 array_array_float,     array_array_double,     array_array_ipv4,
@@ -157,43 +148,43 @@ protected:
                 array_array_datev2,    array_array_datetimev2, array_array_varchar,
                 array_array_decimal,   array_array_decimal64,  array_array_decimal128,
                 array_array_decimal256};
-        std::vector<BaseInputTypeSet> array_map_typeIndex = {
+        std::vector<InputTypeSet> array_map_typeIndex = {
                 array_map_char_double, array_map_datetime_decimal, array_map_ipv4_ipv6,
                 array_map_largeint_string};
-        std::vector<BaseInputTypeSet> array_struct_typeIndex = {array_struct};
+        std::vector<InputTypeSet> array_struct_typeIndex = {array_struct};
 
         vector<ut_type::UTDataTypeDescs> descs;
         descs.reserve(array_typeIndex.size());
         for (int i = 0; i < array_typeIndex.size(); i++) {
-            descs.push_back(ut_type::UTDataTypeDescs());
+            descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_typeIndex[i][0]);
-            input_types.push_back(Nullable {static_cast<TypeIndex>(array_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(array_typeIndex[i][1])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, descs[i]));
         }
 
         for (int i = 0; i < array_array_typeIndex.size(); i++) {
-            descs.push_back(ut_type::UTDataTypeDescs());
+            descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_array_typeIndex[i][0]);
-            input_types.push_back(Nullable {static_cast<TypeIndex>(array_array_typeIndex[i][1])});
-            input_types.push_back(Nullable {static_cast<TypeIndex>(array_array_typeIndex[i][2])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(array_array_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(array_array_typeIndex[i][2])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, descs[i + array_typeIndex.size()]));
         }
 
         for (int i = 0; i < array_map_typeIndex.size(); i++) {
-            descs.push_back(ut_type::UTDataTypeDescs());
+            descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_map_typeIndex[i][0]); // array
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_map_typeIndex[i][1])}); // map
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_map_typeIndex[i][2])}); // key
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_map_typeIndex[i][3])}); // val
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_map_typeIndex[i][1])}); // map
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_map_typeIndex[i][2])}); // key
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_map_typeIndex[i][3])}); // val
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(
@@ -201,25 +192,25 @@ protected:
         }
 
         for (int i = 0; i < array_struct_typeIndex.size(); i++) {
-            descs.push_back(ut_type::UTDataTypeDescs());
+            descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_struct_typeIndex[i][0]); // arr
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][1])}); // struct
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][2])}); // f1
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][3])}); // f2
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][4])}); // f3
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][5])}); // f4
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][6])}); // f5
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][7])}); // f6
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][8])}); // f7
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][1])}); // struct
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][2])}); // f1
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][3])}); // f2
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][4])}); // f3
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][5])}); // f4
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][6])}); // f5
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][7])}); // f6
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][8])}); // f7
 
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(
@@ -369,7 +360,7 @@ TEST_F(ColumnArrayTest, InsertManyDictDataTest) {
 TEST_F(ColumnArrayTest, InsertManyContinuousBinaryDataTest) {
     auto callback = [&](MutableColumns& load_cols, DataTypeSerDeSPtrs serders) {
         for (auto& col : array_columns) {
-            EXPECT_ANY_THROW(col->insert_many_continuous_binary_data(nullptr, 0, 1));
+            EXPECT_ANY_THROW(col->insert_many_continuous_binary_data(nullptr, nullptr, 1));
         }
     };
     assert_insert_many_continuous_binary_data(array_columns, serdes, callback);
@@ -639,9 +630,9 @@ TEST_F(ColumnArrayTest, CreateArrayTest) {
     //
     //  so actually according to the semantics of the function, it should not impl in array,
     //  but we should make sure in creation of array, the nested_column && offsets_column should not be const
-    for (int i = 0; i < array_columns.size(); i++) {
-        auto column = check_and_get_column<ColumnArray>(
-                remove_nullable(array_columns[i]->assume_mutable()).get());
+    for (auto & array_column : array_columns) {
+        const auto* column = check_and_get_column<ColumnArray>(
+                remove_nullable(array_column->assume_mutable()).get());
         auto column_size = column->size();
         LOG(INFO) << "column_type: " << column->get_name();
         // test create_array

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -21,8 +21,8 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <stddef.h>
 
+#include <cstddef>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -30,11 +30,9 @@
 #include <vector>
 
 #include "agent/be_exec_version_manager.h"
-#include "gtest/gtest_pred_impl.h"
 #include "util/bitmap_value.h"
 #include "vec/columns/column.h"
 #include "vec/common/string_ref.h"
-#include "vec/core/block.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
@@ -42,26 +40,6 @@
 #include "vec/data_types/data_type_quantilestate.h"
 
 namespace doris::vectorized {
-TEST(ColumnComplexTest, BasicTest) {
-    using ColumnSTLString = ColumnComplexType<std::string>;
-    auto column = ColumnSTLString::create();
-    EXPECT_EQ(column->size(), 0);
-    std::string val0 = "";
-    std::string val1 = "str-1";
-
-    column->insert_data(reinterpret_cast<const char*>(&val0), sizeof(val0));
-    column->insert_data(reinterpret_cast<const char*>(&val1), sizeof(val1));
-
-    StringRef ref = column->get_data_at(0);
-    EXPECT_EQ((*reinterpret_cast<const std::string*>(ref.data)), "");
-    ref = column->get_data_at(1);
-    EXPECT_EQ((*reinterpret_cast<const std::string*>(ref.data)), val1);
-}
-
-// Test the compile failed
-TEST(ColumnComplexTest, DataTypeBitmapTest) {
-    std::make_shared<DataTypeBitMap>();
-}
 
 TEST(ColumnComplexTest, GetDataAtTest) {
     auto column_bitmap = ColumnBitmap::create();

--- a/be/test/vec/data_types/data_type_array_test.cpp
+++ b/be/test/vec/data_types/data_type_array_test.cpp
@@ -60,157 +60,148 @@ protected:
         // we need to load data from csv file into column_array list
         // step1. create data type for array nested type (const and nullable)
         // array<tinyint>
-        BaseInputTypeSet array_tinyint = {TypeIndex::Array, TypeIndex::Int8};
+        InputTypeSet array_tinyint = {TypeIndex::Array, TypeIndex::Int8};
         // array<smallint>
-        BaseInputTypeSet array_smallint = {TypeIndex::Array, TypeIndex::Int16};
+        InputTypeSet array_smallint = {TypeIndex::Array, TypeIndex::Int16};
         // array<int>
-        BaseInputTypeSet array_int = {TypeIndex::Array, TypeIndex::Int32};
+        InputTypeSet array_int = {TypeIndex::Array, TypeIndex::Int32};
         // array<bigint>
-        BaseInputTypeSet array_bigint = {TypeIndex::Array, TypeIndex::Int64};
+        InputTypeSet array_bigint = {TypeIndex::Array, TypeIndex::Int64};
         // array<largeint>
-        BaseInputTypeSet array_largeint = {TypeIndex::Array, TypeIndex::Int128};
+        InputTypeSet array_largeint = {TypeIndex::Array, TypeIndex::Int128};
         // array<float>
-        BaseInputTypeSet array_float = {TypeIndex::Array, TypeIndex::Float32};
+        InputTypeSet array_float = {TypeIndex::Array, TypeIndex::Float32};
         // array<double>
-        BaseInputTypeSet array_double = {TypeIndex::Array, TypeIndex::Float64};
+        InputTypeSet array_double = {TypeIndex::Array, TypeIndex::Float64};
         // array<ipv4>
-        BaseInputTypeSet array_ipv4 = {TypeIndex::Array, TypeIndex::IPv4};
+        InputTypeSet array_ipv4 = {TypeIndex::Array, TypeIndex::IPv4};
         // array<ipv6>
-        BaseInputTypeSet array_ipv6 = {TypeIndex::Array, TypeIndex::IPv6};
+        InputTypeSet array_ipv6 = {TypeIndex::Array, TypeIndex::IPv6};
         // array<date>
-        BaseInputTypeSet array_date = {TypeIndex::Array, TypeIndex::Date};
+        InputTypeSet array_date = {TypeIndex::Array, TypeIndex::Date};
         // array<datetime>
-        BaseInputTypeSet array_datetime = {TypeIndex::Array, TypeIndex::DateTime};
+        InputTypeSet array_datetime = {TypeIndex::Array, TypeIndex::DateTime};
         // array<datev2>
-        BaseInputTypeSet array_datev2 = {TypeIndex::Array, TypeIndex::DateV2};
+        InputTypeSet array_datev2 = {TypeIndex::Array, TypeIndex::DateV2};
         // array<datetimev2>
-        BaseInputTypeSet array_datetimev2 = {TypeIndex::Array, TypeIndex::DateTimeV2};
+        InputTypeSet array_datetimev2 = {TypeIndex::Array, TypeIndex::DateTimeV2};
         // array<varchar>
-        BaseInputTypeSet array_varchar = {TypeIndex::Array, TypeIndex::String};
+        InputTypeSet array_varchar = {TypeIndex::Array, TypeIndex::String};
         // array<decimal32(9, 5)> UT
-        BaseInputTypeSet array_decimal = {TypeIndex::Array, TypeIndex::Decimal32};
+        InputTypeSet array_decimal = {TypeIndex::Array, TypeIndex::Decimal32};
         // array<decimal64(18, 9)> UT
-        BaseInputTypeSet array_decimal64 = {TypeIndex::Array, TypeIndex::Decimal64};
+        InputTypeSet array_decimal64 = {TypeIndex::Array, TypeIndex::Decimal64};
         // array<decimal128(38, 20)> UT
-        BaseInputTypeSet array_decimal128 = {TypeIndex::Array, TypeIndex::Decimal128V3};
+        InputTypeSet array_decimal128 = {TypeIndex::Array, TypeIndex::Decimal128V3};
         // array<decimal256(76, 40)> UT
-        BaseInputTypeSet array_decimal256 = {TypeIndex::Array, TypeIndex::Decimal256};
-        std::vector<BaseInputTypeSet> array_typeIndex = {
+        InputTypeSet array_decimal256 = {TypeIndex::Array, TypeIndex::Decimal256};
+        std::vector<InputTypeSet> array_typeIndex = {
                 array_tinyint,   array_smallint,   array_int,        array_bigint,  array_largeint,
                 array_float,     array_double,     array_ipv4,       array_ipv6,    array_date,
                 array_datetime,  array_datev2,     array_datetimev2, array_varchar, array_decimal,
                 array_decimal64, array_decimal128, array_decimal256};
         // array<array<tinyint>>
-        BaseInputTypeSet array_array_tinyint = {TypeIndex::Array, TypeIndex::Array,
-                                                TypeIndex::Int8};
+        InputTypeSet array_array_tinyint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int8};
         // array<array<smallint>>
-        BaseInputTypeSet array_array_smallint = {TypeIndex::Array, TypeIndex::Array,
-                                                 TypeIndex::Int16};
+        InputTypeSet array_array_smallint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int16};
         // array<array<int>>
-        BaseInputTypeSet array_array_int = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int32};
+        InputTypeSet array_array_int = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int32};
         // array<array<bigint>>
-        BaseInputTypeSet array_array_bigint = {TypeIndex::Array, TypeIndex::Array,
-                                               TypeIndex::Int64};
+        InputTypeSet array_array_bigint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int64};
         // array<array<largeint>>
-        BaseInputTypeSet array_array_largeint = {TypeIndex::Array, TypeIndex::Array,
-                                                 TypeIndex::Int128};
+        InputTypeSet array_array_largeint = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Int128};
         // array<array<float>>
-        BaseInputTypeSet array_array_float = {TypeIndex::Array, TypeIndex::Array,
-                                              TypeIndex::Float32};
+        InputTypeSet array_array_float = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Float32};
         // array<array<double>>
-        BaseInputTypeSet array_array_double = {TypeIndex::Array, TypeIndex::Array,
-                                               TypeIndex::Float64};
+        InputTypeSet array_array_double = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Float64};
         // array<array<ipv4>>
-        BaseInputTypeSet array_array_ipv4 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv4};
+        InputTypeSet array_array_ipv4 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv4};
         // array<array<ipv6>>
-        BaseInputTypeSet array_array_ipv6 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv6};
+        InputTypeSet array_array_ipv6 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::IPv6};
         // array<array<date>>
-        BaseInputTypeSet array_array_date = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Date};
+        InputTypeSet array_array_date = {TypeIndex::Array, TypeIndex::Array, TypeIndex::Date};
         // array<array<datetime>>
-        BaseInputTypeSet array_array_datetime = {TypeIndex::Array, TypeIndex::Array,
-                                                 TypeIndex::DateTime};
+        InputTypeSet array_array_datetime = {TypeIndex::Array, TypeIndex::Array,
+                                             TypeIndex::DateTime};
         // array<array<datev2>>
-        BaseInputTypeSet array_array_datev2 = {TypeIndex::Array, TypeIndex::Array,
-                                               TypeIndex::DateV2};
+        InputTypeSet array_array_datev2 = {TypeIndex::Array, TypeIndex::Array, TypeIndex::DateV2};
         // array<array<datetimev2>>
-        BaseInputTypeSet array_array_datetimev2 = {TypeIndex::Array, TypeIndex::Array,
-                                                   TypeIndex::DateTimeV2};
+        InputTypeSet array_array_datetimev2 = {TypeIndex::Array, TypeIndex::Array,
+                                               TypeIndex::DateTimeV2};
         // array<array<varchar>>
-        BaseInputTypeSet array_array_varchar = {TypeIndex::Array, TypeIndex::Array,
-                                                TypeIndex::String};
+        InputTypeSet array_array_varchar = {TypeIndex::Array, TypeIndex::Array, TypeIndex::String};
         // array<array<decimal32(9, 5)>> UT
-        BaseInputTypeSet array_array_decimal = {TypeIndex::Array, TypeIndex::Array,
-                                                TypeIndex::Decimal32};
+        InputTypeSet array_array_decimal = {TypeIndex::Array, TypeIndex::Array,
+                                            TypeIndex::Decimal32};
         // array<array<decimal64(18, 9)>> UT
-        BaseInputTypeSet array_array_decimal64 = {TypeIndex::Array, TypeIndex::Array,
-                                                  TypeIndex::Decimal64};
+        InputTypeSet array_array_decimal64 = {TypeIndex::Array, TypeIndex::Array,
+                                              TypeIndex::Decimal64};
         // array<array<decimal128(38, 20)>> UT
-        BaseInputTypeSet array_array_decimal128 = {TypeIndex::Array, TypeIndex::Array,
-                                                   TypeIndex::Decimal128V3};
+        InputTypeSet array_array_decimal128 = {TypeIndex::Array, TypeIndex::Array,
+                                               TypeIndex::Decimal128V3};
         // array<array<decimal256(76, 40)>> UT
-        BaseInputTypeSet array_array_decimal256 = {TypeIndex::Array, TypeIndex::Array,
-                                                   TypeIndex::Decimal256};
+        InputTypeSet array_array_decimal256 = {TypeIndex::Array, TypeIndex::Array,
+                                               TypeIndex::Decimal256};
         // array<map<char,double>>
-        BaseInputTypeSet array_map_char_double = {TypeIndex::Array, TypeIndex::Map,
-                                                  TypeIndex::String, TypeIndex::Float64};
+        InputTypeSet array_map_char_double = {TypeIndex::Array, TypeIndex::Map, TypeIndex::String,
+                                              TypeIndex::Float64};
         // test_array_map<datetime,decimal<76,56>>.csv
-        BaseInputTypeSet array_map_datetime_decimal = {
-                TypeIndex::Array, TypeIndex::Map, TypeIndex::DateTimeV2, TypeIndex::Decimal256};
+        InputTypeSet array_map_datetime_decimal = {TypeIndex::Array, TypeIndex::Map,
+                                                   TypeIndex::DateTimeV2, TypeIndex::Decimal256};
         // test_array_map<ipv4,ipv6>.csv
-        BaseInputTypeSet array_map_ipv4_ipv6 = {TypeIndex::Array, TypeIndex::Map, TypeIndex::IPv4,
-                                                TypeIndex::IPv6};
+        InputTypeSet array_map_ipv4_ipv6 = {TypeIndex::Array, TypeIndex::Map, TypeIndex::IPv4,
+                                            TypeIndex::IPv6};
         // test_array_map<largeInt,string>.csv
-        BaseInputTypeSet array_map_largeint_string = {TypeIndex::Array, TypeIndex::Map,
-                                                      TypeIndex::Int128, TypeIndex::String};
+        InputTypeSet array_map_largeint_string = {TypeIndex::Array, TypeIndex::Map,
+                                                  TypeIndex::Int128, TypeIndex::String};
         // array<struct<f1:int,f2:date,f3:decimal,f4:string,f5:double,f6:ipv4,f7:ipv6>>
-        BaseInputTypeSet array_struct = {
-                TypeIndex::Array,   TypeIndex::Struct,    TypeIndex::Int32,
-                TypeIndex::Date,    TypeIndex::Decimal32, TypeIndex::String,
-                TypeIndex::Float64, TypeIndex::IPv4,      TypeIndex::IPv6};
+        InputTypeSet array_struct = {TypeIndex::Array,   TypeIndex::Struct,    TypeIndex::Int32,
+                                     TypeIndex::Date,    TypeIndex::Decimal32, TypeIndex::String,
+                                     TypeIndex::Float64, TypeIndex::IPv4,      TypeIndex::IPv6};
 
-        std::vector<BaseInputTypeSet> array_array_typeIndex = {
+        std::vector<InputTypeSet> array_array_typeIndex = {
                 array_array_tinyint,    array_array_smallint,   array_array_int,
                 array_array_bigint,     array_array_largeint,   array_array_float,
                 array_array_double,     array_array_ipv4,       array_array_ipv6,
                 array_array_date,       array_array_datetime,   array_array_datev2,
                 array_array_datetimev2, array_array_varchar,    array_array_decimal,
                 array_array_decimal64,  array_array_decimal128, array_array_decimal256};
-        std::vector<BaseInputTypeSet> array_map_typeIndex = {
+        std::vector<InputTypeSet> array_map_typeIndex = {
                 array_map_char_double, array_map_datetime_decimal, array_map_ipv4_ipv6,
                 array_map_largeint_string};
-        std::vector<BaseInputTypeSet> array_struct_typeIndex = {array_struct};
+        std::vector<InputTypeSet> array_struct_typeIndex = {array_struct};
 
         array_descs.reserve(array_typeIndex.size() + array_array_typeIndex.size() +
                             array_map_typeIndex.size() + array_struct_typeIndex.size());
         for (int i = 0; i < array_typeIndex.size(); i++) {
-            array_descs.push_back(ut_type::UTDataTypeDescs());
+            array_descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_typeIndex[i][0]);
-            input_types.push_back(Nullable {static_cast<TypeIndex>(array_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(array_typeIndex[i][1])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, array_descs[i]));
         }
         for (int i = 0; i < array_array_typeIndex.size(); i++) {
-            array_descs.push_back(ut_type::UTDataTypeDescs());
+            array_descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_array_typeIndex[i][0]);
-            input_types.push_back(Nullable {static_cast<TypeIndex>(array_array_typeIndex[i][1])});
-            input_types.push_back(Nullable {static_cast<TypeIndex>(array_array_typeIndex[i][2])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(array_array_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(array_array_typeIndex[i][2])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, array_descs[i + array_typeIndex.size()]));
         }
 
         for (int i = 0; i < array_map_typeIndex.size(); i++) {
-            array_descs.push_back(ut_type::UTDataTypeDescs());
+            array_descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_map_typeIndex[i][0]); // array
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_map_typeIndex[i][1])}); // map
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_map_typeIndex[i][2])}); // key
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_map_typeIndex[i][3])}); // val
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_map_typeIndex[i][1])}); // map
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_map_typeIndex[i][2])}); // key
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_map_typeIndex[i][3])}); // val
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(
@@ -219,25 +210,25 @@ protected:
         }
 
         for (int i = 0; i < array_struct_typeIndex.size(); i++) {
-            array_descs.push_back(ut_type::UTDataTypeDescs());
+            array_descs.emplace_back();
             InputTypeSet input_types {};
             input_types.push_back(array_struct_typeIndex[i][0]); // arr
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][1])}); // struct
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][2])}); // f1
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][3])}); // f2
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][4])}); // f3
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][5])}); // f4
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][6])}); // f5
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][7])}); // f6
-            input_types.push_back(
-                    Nullable {static_cast<TypeIndex>(array_struct_typeIndex[i][8])}); // f7
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][1])}); // struct
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][2])}); // f1
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][3])}); // f2
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][4])}); // f3
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][5])}); // f4
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][6])}); // f5
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][7])}); // f6
+            input_types.emplace_back(
+                    Nullable {any_cast<TypeIndex>(array_struct_typeIndex[i][8])}); // f7
 
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(

--- a/be/test/vec/data_types/data_type_map_test.cpp
+++ b/be/test/vec/data_types/data_type_map_test.cpp
@@ -52,142 +52,138 @@ protected:
         // we need to load data from csv file into column_map list
         // step1. create data type for map nested type (const and nullable)
         // map<tinyint, tinyint>
-        BaseInputTypeSet map_tinyint = {TypeIndex::Map, TypeIndex::Int8, TypeIndex::Int8};
+        InputTypeSet map_tinyint = {TypeIndex::Map, TypeIndex::Int8, TypeIndex::Int8};
         // map<smallint, smallint>
-        BaseInputTypeSet map_smallint = {TypeIndex::Map, TypeIndex::Int16, TypeIndex::Int16};
+        InputTypeSet map_smallint = {TypeIndex::Map, TypeIndex::Int16, TypeIndex::Int16};
         // map<int, int>
-        BaseInputTypeSet map_int = {TypeIndex::Map, TypeIndex::Int32, TypeIndex::Int32};
+        InputTypeSet map_int = {TypeIndex::Map, TypeIndex::Int32, TypeIndex::Int32};
         // map<bigintm, bigint>
-        BaseInputTypeSet map_bigint = {TypeIndex::Map, TypeIndex::Int64, TypeIndex::Int64};
+        InputTypeSet map_bigint = {TypeIndex::Map, TypeIndex::Int64, TypeIndex::Int64};
         // map<largeint, largeint>
-        BaseInputTypeSet map_largeint = {TypeIndex::Map, TypeIndex::Int128, TypeIndex::Int128};
+        InputTypeSet map_largeint = {TypeIndex::Map, TypeIndex::Int128, TypeIndex::Int128};
         // map<float, float>
-        BaseInputTypeSet map_float = {TypeIndex::Map, TypeIndex::Float32, TypeIndex::Float32};
+        InputTypeSet map_float = {TypeIndex::Map, TypeIndex::Float32, TypeIndex::Float32};
         // map<double, double>
-        BaseInputTypeSet map_double = {TypeIndex::Map, TypeIndex::Float64, TypeIndex::Float64};
+        InputTypeSet map_double = {TypeIndex::Map, TypeIndex::Float64, TypeIndex::Float64};
         // map<ipv4, ipv4>
-        BaseInputTypeSet map_ipv4 = {TypeIndex::Map, TypeIndex::IPv4, TypeIndex::IPv4};
+        InputTypeSet map_ipv4 = {TypeIndex::Map, TypeIndex::IPv4, TypeIndex::IPv4};
         // map<ipv6, ipv6>
-        BaseInputTypeSet map_ipv6 = {TypeIndex::Map, TypeIndex::IPv6, TypeIndex::IPv6};
+        InputTypeSet map_ipv6 = {TypeIndex::Map, TypeIndex::IPv6, TypeIndex::IPv6};
         // map<date, date>
-        BaseInputTypeSet map_date = {TypeIndex::Map, TypeIndex::Date, TypeIndex::Date};
+        InputTypeSet map_date = {TypeIndex::Map, TypeIndex::Date, TypeIndex::Date};
         // map<datetime, datetime>
-        BaseInputTypeSet map_datetime = {TypeIndex::Map, TypeIndex::DateTime, TypeIndex::DateTime};
+        InputTypeSet map_datetime = {TypeIndex::Map, TypeIndex::DateTime, TypeIndex::DateTime};
         // map<datev2, datev2>
-        BaseInputTypeSet map_datev2 = {TypeIndex::Map, TypeIndex::DateV2, TypeIndex::DateV2};
+        InputTypeSet map_datev2 = {TypeIndex::Map, TypeIndex::DateV2, TypeIndex::DateV2};
         // map<datetimev2, datetimev2>
-        BaseInputTypeSet map_datetimev2 = {TypeIndex::Map, TypeIndex::DateTimeV2,
-                                           TypeIndex::DateTimeV2};
+        InputTypeSet map_datetimev2 = {TypeIndex::Map, TypeIndex::DateTimeV2,
+                                       TypeIndex::DateTimeV2};
         // map<varchar, varchar>
-        BaseInputTypeSet map_varchar = {TypeIndex::Map, TypeIndex::String, TypeIndex::String};
+        InputTypeSet map_varchar = {TypeIndex::Map, TypeIndex::String, TypeIndex::String};
         // map<decimal32(9, 5), decimal32(9, 5)> UT
-        BaseInputTypeSet map_decimal = {TypeIndex::Map, TypeIndex::Decimal32, TypeIndex::Decimal32};
+        InputTypeSet map_decimal = {TypeIndex::Map, TypeIndex::Decimal32, TypeIndex::Decimal32};
         // map<decimal64(18, 9), decimal64(18, 9)> UT
-        BaseInputTypeSet map_decimal64 = {TypeIndex::Map, TypeIndex::Decimal64,
-                                          TypeIndex::Decimal64};
+        InputTypeSet map_decimal64 = {TypeIndex::Map, TypeIndex::Decimal64, TypeIndex::Decimal64};
         // map<decimal128(38, 20), decimal128(38, 20)> UT
-        BaseInputTypeSet map_decimal128 = {TypeIndex::Map, TypeIndex::Decimal128V3,
-                                           TypeIndex::Decimal128V3};
+        InputTypeSet map_decimal128 = {TypeIndex::Map, TypeIndex::Decimal128V3,
+                                       TypeIndex::Decimal128V3};
         // map<decimal256(76, 40), decimal256(76, 40)> UT
-        BaseInputTypeSet map_decimal256 = {TypeIndex::Map, TypeIndex::Decimal256,
-                                           TypeIndex::Decimal256};
-        std::vector<BaseInputTypeSet> map_typeIndex = {
+        InputTypeSet map_decimal256 = {TypeIndex::Map, TypeIndex::Decimal256,
+                                       TypeIndex::Decimal256};
+        std::vector<InputTypeSet> map_typeIndex = {
                 map_tinyint,   map_smallint,   map_int,        map_bigint,  map_largeint,
                 map_float,     map_double,     map_ipv4,       map_ipv6,    map_date,
                 map_datetime,  map_datev2,     map_datetimev2, map_varchar, map_decimal,
                 map_decimal64, map_decimal128, map_decimal256};
         // map<array<tinyint>, array<tinyint>>
-        BaseInputTypeSet map_array_tinyint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int8,
-                                              TypeIndex::Array, TypeIndex::Int8};
+        InputTypeSet map_array_tinyint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int8,
+                                          TypeIndex::Array, TypeIndex::Int8};
         // map<array<smallint>, array<smallint>>
-        BaseInputTypeSet map_array_smallint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int16,
-                                               TypeIndex::Array, TypeIndex::Int16};
+        InputTypeSet map_array_smallint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int16,
+                                           TypeIndex::Array, TypeIndex::Int16};
         // map<array<int, int>, array<int, int>>
-        BaseInputTypeSet map_array_int = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int32,
-                                          TypeIndex::Array, TypeIndex::Int32};
+        InputTypeSet map_array_int = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int32,
+                                      TypeIndex::Array, TypeIndex::Int32};
         // map<array<bigint>, array<bigint>>
-        BaseInputTypeSet map_array_bigint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int64,
-                                             TypeIndex::Array, TypeIndex::Int64};
+        InputTypeSet map_array_bigint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int64,
+                                         TypeIndex::Array, TypeIndex::Int64};
         // map<array<largeint>, array<largeint>>
-        BaseInputTypeSet map_array_largeint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int128,
-                                               TypeIndex::Array, TypeIndex::Int128};
+        InputTypeSet map_array_largeint = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Int128,
+                                           TypeIndex::Array, TypeIndex::Int128};
         // map<array<float>, array<float>>
-        BaseInputTypeSet map_array_float = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Float32,
-                                            TypeIndex::Array, TypeIndex::Float32};
+        InputTypeSet map_array_float = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Float32,
+                                        TypeIndex::Array, TypeIndex::Float32};
         // map<array<double>, array<double>>
-        BaseInputTypeSet map_array_double = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Float64,
-                                             TypeIndex::Array, TypeIndex::Float64};
+        InputTypeSet map_array_double = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Float64,
+                                         TypeIndex::Array, TypeIndex::Float64};
         // map<array<ipv4>, array<ipv4>>
-        BaseInputTypeSet map_array_ipv4 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::IPv4,
-                                           TypeIndex::Array, TypeIndex::IPv4};
+        InputTypeSet map_array_ipv4 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::IPv4,
+                                       TypeIndex::Array, TypeIndex::IPv4};
         // map<array<ipv6>, array<ipv6>>
-        BaseInputTypeSet map_array_ipv6 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::IPv6,
-                                           TypeIndex::Array, TypeIndex::IPv6};
+        InputTypeSet map_array_ipv6 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::IPv6,
+                                       TypeIndex::Array, TypeIndex::IPv6};
         // map<array<date>, array<date>>
-        BaseInputTypeSet map_array_date = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Date,
-                                           TypeIndex::Array, TypeIndex::Date};
+        InputTypeSet map_array_date = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Date,
+                                       TypeIndex::Array, TypeIndex::Date};
         // map<array<datetime>, array<datetime>>
-        BaseInputTypeSet map_array_datetime = {TypeIndex::Map, TypeIndex::Array,
-                                               TypeIndex::DateTime, TypeIndex::Array,
-                                               TypeIndex::DateTime};
+        InputTypeSet map_array_datetime = {TypeIndex::Map, TypeIndex::Array, TypeIndex::DateTime,
+                                           TypeIndex::Array, TypeIndex::DateTime};
         // map<array<datev2>, array<datev2>>
-        BaseInputTypeSet map_array_datev2 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::DateV2,
-                                             TypeIndex::Array, TypeIndex::DateV2};
+        InputTypeSet map_array_datev2 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::DateV2,
+                                         TypeIndex::Array, TypeIndex::DateV2};
         // map<array<datetimev2>, array<datetimev2>>
-        BaseInputTypeSet map_array_datetimev2 = {TypeIndex::Map, TypeIndex::Array,
-                                                 TypeIndex::DateTimeV2, TypeIndex::Array,
-                                                 TypeIndex::DateTimeV2};
+        InputTypeSet map_array_datetimev2 = {TypeIndex::Map, TypeIndex::Array,
+                                             TypeIndex::DateTimeV2, TypeIndex::Array,
+                                             TypeIndex::DateTimeV2};
         // map<array<varchar>, array<varchar>>
-        BaseInputTypeSet map_array_varchar = {TypeIndex::Map, TypeIndex::Array, TypeIndex::String,
-                                              TypeIndex::Array, TypeIndex::String};
+        InputTypeSet map_array_varchar = {TypeIndex::Map, TypeIndex::Array, TypeIndex::String,
+                                          TypeIndex::Array, TypeIndex::String};
         // map<array<decimal32(9, 5)>, array<decimal32(9, 5)>>
-        BaseInputTypeSet map_array_decimal = {TypeIndex::Map, TypeIndex::Array,
-                                              TypeIndex::Decimal32, TypeIndex::Array,
-                                              TypeIndex::Decimal32};
+        InputTypeSet map_array_decimal = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Decimal32,
+                                          TypeIndex::Array, TypeIndex::Decimal32};
         // map<array<decimal64(18, 9)>, array<decimal64(18, 9)>>
-        BaseInputTypeSet map_array_decimal64 = {TypeIndex::Map, TypeIndex::Array,
-                                                TypeIndex::Decimal64, TypeIndex::Array,
-                                                TypeIndex::Decimal64};
+        InputTypeSet map_array_decimal64 = {TypeIndex::Map, TypeIndex::Array, TypeIndex::Decimal64,
+                                            TypeIndex::Array, TypeIndex::Decimal64};
         // map<array<decimal128(38, 20)>, array<decimal128(38, 20)>>
-        BaseInputTypeSet map_array_decimal128 = {TypeIndex::Map, TypeIndex::Array,
-                                                 TypeIndex::Decimal128V3, TypeIndex::Array,
-                                                 TypeIndex::Decimal128V3};
+        InputTypeSet map_array_decimal128 = {TypeIndex::Map, TypeIndex::Array,
+                                             TypeIndex::Decimal128V3, TypeIndex::Array,
+                                             TypeIndex::Decimal128V3};
         // map<array<decimal256(76, 40)>, array<decimal256(76, 40)>>
-        BaseInputTypeSet map_array_decimal256 = {TypeIndex::Map, TypeIndex::Array,
-                                                 TypeIndex::Decimal256, TypeIndex::Array,
-                                                 TypeIndex::Decimal256};
+        InputTypeSet map_array_decimal256 = {TypeIndex::Map, TypeIndex::Array,
+                                             TypeIndex::Decimal256, TypeIndex::Array,
+                                             TypeIndex::Decimal256};
         // map<map<char, double>, map<char, double>>
-        BaseInputTypeSet map_map_char_double = {
-                TypeIndex::Map, TypeIndex::Map,    TypeIndex::String, TypeIndex::Float64,
-                TypeIndex::Map, TypeIndex::String, TypeIndex::Float64};
+        InputTypeSet map_map_char_double = {TypeIndex::Map,     TypeIndex::Map, TypeIndex::String,
+                                            TypeIndex::Float64, TypeIndex::Map, TypeIndex::String,
+                                            TypeIndex::Float64};
         // map<map<datetime, decimal<76,56>>, map<datetime, decimal<76,56>>>
-        BaseInputTypeSet map_map_datetime_decimal = {
+        InputTypeSet map_map_datetime_decimal = {
                 TypeIndex::Map, TypeIndex::Map,        TypeIndex::DateTimeV2, TypeIndex::Decimal256,
                 TypeIndex::Map, TypeIndex::DateTimeV2, TypeIndex::Decimal256};
         // map<map<ipv4, ipv6>, map<ipv4, ipv6>>
-        BaseInputTypeSet map_map_ipv4_ipv6 = {TypeIndex::Map,  TypeIndex::Map, TypeIndex::IPv4,
-                                              TypeIndex::IPv6, TypeIndex::Map, TypeIndex::IPv4,
-                                              TypeIndex::IPv6};
+        InputTypeSet map_map_ipv4_ipv6 = {TypeIndex::Map,  TypeIndex::Map, TypeIndex::IPv4,
+                                          TypeIndex::IPv6, TypeIndex::Map, TypeIndex::IPv4,
+                                          TypeIndex::IPv6};
         // map<map<largeInt, string>, map<largeInt, string>>
-        BaseInputTypeSet map_map_largeint_string = {
+        InputTypeSet map_map_largeint_string = {
                 TypeIndex::Map, TypeIndex::Map,    TypeIndex::Int128, TypeIndex::String,
                 TypeIndex::Map, TypeIndex::Int128, TypeIndex::String};
         // map<struct<f1:int,f2:date,f3:decimal>, struct<f4:string,f5:double,f6:ipv4,f7:ipv6>>
-        BaseInputTypeSet map_struct = {TypeIndex::Map,    TypeIndex::Struct,    TypeIndex::Int32,
-                                       TypeIndex::Date,   TypeIndex::Decimal32, TypeIndex::Struct,
-                                       TypeIndex::String, TypeIndex::Float64,   TypeIndex::IPv4,
-                                       TypeIndex::IPv6};
+        InputTypeSet map_struct = {TypeIndex::Map,    TypeIndex::Struct,    TypeIndex::Int32,
+                                   TypeIndex::Date,   TypeIndex::Decimal32, TypeIndex::Struct,
+                                   TypeIndex::String, TypeIndex::Float64,   TypeIndex::IPv4,
+                                   TypeIndex::IPv6};
 
-        std::vector<BaseInputTypeSet> map_array_typeIndex = {
+        std::vector<InputTypeSet> map_array_typeIndex = {
                 map_array_tinyint,    map_array_smallint,  map_array_int,      map_array_bigint,
                 map_array_largeint,   map_array_float,     map_array_double,   map_array_ipv4,
                 map_array_ipv6,       map_array_date,      map_array_datetime, map_array_datev2,
                 map_array_datetimev2, map_array_varchar,   map_array_decimal,  map_array_decimal64,
                 map_array_decimal128, map_array_decimal256};
-        std::vector<BaseInputTypeSet> map_map_typeIndex = {
-                map_map_char_double, map_map_datetime_decimal, map_map_ipv4_ipv6,
-                map_map_largeint_string};
-        std::vector<BaseInputTypeSet> map_struct_typeIndex = {map_struct};
+        std::vector<InputTypeSet> map_map_typeIndex = {map_map_char_double,
+                                                       map_map_datetime_decimal, map_map_ipv4_ipv6,
+                                                       map_map_largeint_string};
+        std::vector<InputTypeSet> map_struct_typeIndex = {map_struct};
 
         descs_.reserve(map_typeIndex.size() + map_array_typeIndex.size() +
                        map_map_typeIndex.size() + map_struct_typeIndex.size());
@@ -195,8 +191,8 @@ protected:
             descs_.emplace_back();
             InputTypeSet input_types {};
             input_types.emplace_back(map_typeIndex[i][0]);
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_typeIndex[i][1])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_typeIndex[i][2])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_typeIndex[i][2])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, descs_[i]));
@@ -206,11 +202,11 @@ protected:
             InputTypeSet input_types {};
             input_types.emplace_back(map_array_typeIndex[i][0]);
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(map_array_typeIndex[i][1])}); // array1
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_array_typeIndex[i][2])});
+                    Nullable {any_cast<TypeIndex>(map_array_typeIndex[i][1])}); // array1
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_array_typeIndex[i][2])});
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(map_array_typeIndex[i][3])}); // array2
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_array_typeIndex[i][4])});
+                    Nullable {any_cast<TypeIndex>(map_array_typeIndex[i][3])}); // array2
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_array_typeIndex[i][4])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[3].type(), &typeid(Nullable)) << "nested type is not nullable";
@@ -223,13 +219,13 @@ protected:
             InputTypeSet input_types {};
             input_types.emplace_back(map_map_typeIndex[i][0]); // map
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(map_map_typeIndex[i][1])}); // map1
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_map_typeIndex[i][2])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_map_typeIndex[i][3])});
+                    Nullable {any_cast<TypeIndex>(map_map_typeIndex[i][1])}); // map1
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_map_typeIndex[i][2])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_map_typeIndex[i][3])});
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(map_map_typeIndex[i][4])}); // map2
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_map_typeIndex[i][5])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_map_typeIndex[i][6])});
+                    Nullable {any_cast<TypeIndex>(map_map_typeIndex[i][4])}); // map2
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_map_typeIndex[i][5])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_map_typeIndex[i][6])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[3].type(), &typeid(Nullable)) << "nested type is not nullable";
@@ -245,15 +241,15 @@ protected:
             InputTypeSet input_types {};
             input_types.emplace_back(map_struct_typeIndex[i][0]); // map
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][1])}); // struct
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][2])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][3])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][4])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][5])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][6])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][7])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][8])});
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(map_struct_typeIndex[i][9])});
+                    Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][1])}); // struct
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][2])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][3])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][4])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][5])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][6])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][7])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][8])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(map_struct_typeIndex[i][9])});
 
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(

--- a/be/test/vec/data_types/data_type_struct_test.cpp
+++ b/be/test/vec/data_types/data_type_struct_test.cpp
@@ -50,126 +50,122 @@ protected:
         // we need to load data from csv file into column_struct list
         // step1. create data type for struct nested type (const and nullable)
         // struct<tinyint>
-        BaseInputTypeSet struct_tinyint = {TypeIndex::Struct, TypeIndex::Int8};
+        InputTypeSet struct_tinyint = {TypeIndex::Struct, TypeIndex::Int8};
         // struct<smallint>
-        BaseInputTypeSet struct_smallint = {TypeIndex::Struct, TypeIndex::Int16};
+        InputTypeSet struct_smallint = {TypeIndex::Struct, TypeIndex::Int16};
         // struct<int>
-        BaseInputTypeSet struct_int = {TypeIndex::Struct, TypeIndex::Int32};
+        InputTypeSet struct_int = {TypeIndex::Struct, TypeIndex::Int32};
         // struct<bigint>
-        BaseInputTypeSet struct_bigint = {TypeIndex::Struct, TypeIndex::Int64};
+        InputTypeSet struct_bigint = {TypeIndex::Struct, TypeIndex::Int64};
         // struct<largeint>
-        BaseInputTypeSet struct_largeint = {TypeIndex::Struct, TypeIndex::Int128};
+        InputTypeSet struct_largeint = {TypeIndex::Struct, TypeIndex::Int128};
         // struct<float>
-        BaseInputTypeSet struct_float = {TypeIndex::Struct, TypeIndex::Float32};
+        InputTypeSet struct_float = {TypeIndex::Struct, TypeIndex::Float32};
         // struct<double>
-        BaseInputTypeSet struct_double = {TypeIndex::Struct, TypeIndex::Float64};
+        InputTypeSet struct_double = {TypeIndex::Struct, TypeIndex::Float64};
         // struct<ipv4>
-        BaseInputTypeSet struct_ipv4 = {TypeIndex::Struct, TypeIndex::IPv4};
+        InputTypeSet struct_ipv4 = {TypeIndex::Struct, TypeIndex::IPv4};
         // struct<ipv6>
-        BaseInputTypeSet struct_ipv6 = {TypeIndex::Struct, TypeIndex::IPv6};
+        InputTypeSet struct_ipv6 = {TypeIndex::Struct, TypeIndex::IPv6};
         // struct<date>
-        BaseInputTypeSet struct_date = {TypeIndex::Struct, TypeIndex::Date};
+        InputTypeSet struct_date = {TypeIndex::Struct, TypeIndex::Date};
         // struct<datetime>
-        BaseInputTypeSet struct_datetime = {TypeIndex::Struct, TypeIndex::DateTime};
+        InputTypeSet struct_datetime = {TypeIndex::Struct, TypeIndex::DateTime};
         // struct<datev2>
-        BaseInputTypeSet struct_datev2 = {TypeIndex::Struct, TypeIndex::DateV2};
+        InputTypeSet struct_datev2 = {TypeIndex::Struct, TypeIndex::DateV2};
         // struct<datetimev2>
-        BaseInputTypeSet struct_datetimev2 = {TypeIndex::Struct, TypeIndex::DateTimeV2};
+        InputTypeSet struct_datetimev2 = {TypeIndex::Struct, TypeIndex::DateTimeV2};
         // struct<varchar>
-        BaseInputTypeSet struct_varchar = {TypeIndex::Struct, TypeIndex::String};
+        InputTypeSet struct_varchar = {TypeIndex::Struct, TypeIndex::String};
         // struct<decimal32(9, 5)>
-        BaseInputTypeSet struct_decimal = {TypeIndex::Struct, TypeIndex::Decimal32};
+        InputTypeSet struct_decimal = {TypeIndex::Struct, TypeIndex::Decimal32};
         // struct<decimal64(18, 9)>
-        BaseInputTypeSet struct_decimal64 = {TypeIndex::Struct, TypeIndex::Decimal64};
+        InputTypeSet struct_decimal64 = {TypeIndex::Struct, TypeIndex::Decimal64};
         // struct<decimal128(38, 20)>
-        BaseInputTypeSet struct_decimal128 = {TypeIndex::Struct, TypeIndex::Decimal128V3};
+        InputTypeSet struct_decimal128 = {TypeIndex::Struct, TypeIndex::Decimal128V3};
         // struct<decimal256(76, 40)>
-        BaseInputTypeSet struct_decimal256 = {TypeIndex::Struct, TypeIndex::Decimal256};
-        std::vector<BaseInputTypeSet> struct_typeIndex = {
+        InputTypeSet struct_decimal256 = {TypeIndex::Struct, TypeIndex::Decimal256};
+        std::vector<InputTypeSet> struct_typeIndex = {
                 struct_tinyint,    struct_smallint,  struct_int,      struct_bigint,
                 struct_largeint,   struct_float,     struct_double,   struct_ipv4,
                 struct_ipv6,       struct_date,      struct_datetime, struct_datev2,
                 struct_datetimev2, struct_varchar,   struct_decimal,  struct_decimal64,
                 struct_decimal128, struct_decimal256};
         // struct<array<tinyint>>
-        BaseInputTypeSet struct_array_tinyint = {TypeIndex::Struct, TypeIndex::Array,
-                                                 TypeIndex::Int8};
+        InputTypeSet struct_array_tinyint = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Int8};
         // struct<array<smallint>>
-        BaseInputTypeSet struct_array_smallint = {TypeIndex::Struct, TypeIndex::Array,
-                                                  TypeIndex::Int16};
+        InputTypeSet struct_array_smallint = {TypeIndex::Struct, TypeIndex::Array,
+                                              TypeIndex::Int16};
         // struct<array<int>>
-        BaseInputTypeSet struct_array_int = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Int32};
+        InputTypeSet struct_array_int = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Int32};
         // struct<array<bigint>>
-        BaseInputTypeSet struct_array_bigint = {TypeIndex::Struct, TypeIndex::Array,
-                                                TypeIndex::Int64};
+        InputTypeSet struct_array_bigint = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Int64};
         // struct<array<largeint>>
-        BaseInputTypeSet struct_array_largeint = {TypeIndex::Struct, TypeIndex::Array,
-                                                  TypeIndex::Int128};
+        InputTypeSet struct_array_largeint = {TypeIndex::Struct, TypeIndex::Array,
+                                              TypeIndex::Int128};
         // struct<array<float>>
-        BaseInputTypeSet struct_array_float = {TypeIndex::Struct, TypeIndex::Array,
-                                               TypeIndex::Float32};
+        InputTypeSet struct_array_float = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Float32};
         // struct<array<double>>
-        BaseInputTypeSet struct_array_double = {TypeIndex::Struct, TypeIndex::Array,
-                                                TypeIndex::Float64};
+        InputTypeSet struct_array_double = {TypeIndex::Struct, TypeIndex::Array,
+                                            TypeIndex::Float64};
         // struct<array<ipv4>>
-        BaseInputTypeSet struct_array_ipv4 = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::IPv4};
+        InputTypeSet struct_array_ipv4 = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::IPv4};
         // struct<array<ipv6>>
-        BaseInputTypeSet struct_array_ipv6 = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::IPv6};
+        InputTypeSet struct_array_ipv6 = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::IPv6};
         // struct<array<date>>
-        BaseInputTypeSet struct_array_date = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Date};
+        InputTypeSet struct_array_date = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::Date};
         // struct<array<datetime>>
-        BaseInputTypeSet struct_array_datetime = {TypeIndex::Struct, TypeIndex::Array,
-                                                  TypeIndex::DateTime};
+        InputTypeSet struct_array_datetime = {TypeIndex::Struct, TypeIndex::Array,
+                                              TypeIndex::DateTime};
         // struct<array<datev2>>
-        BaseInputTypeSet struct_array_datev2 = {TypeIndex::Struct, TypeIndex::Array,
-                                                TypeIndex::DateV2};
+        InputTypeSet struct_array_datev2 = {TypeIndex::Struct, TypeIndex::Array, TypeIndex::DateV2};
         // struct<array<datetimev2>>
-        BaseInputTypeSet struct_array_datetimev2 = {TypeIndex::Struct, TypeIndex::Array,
-                                                    TypeIndex::DateTimeV2};
+        InputTypeSet struct_array_datetimev2 = {TypeIndex::Struct, TypeIndex::Array,
+                                                TypeIndex::DateTimeV2};
         // struct<array<varchar>>
-        BaseInputTypeSet struct_array_varchar = {TypeIndex::Struct, TypeIndex::Array,
-                                                 TypeIndex::String};
+        InputTypeSet struct_array_varchar = {TypeIndex::Struct, TypeIndex::Array,
+                                             TypeIndex::String};
         // struct<array<decimal32(9, 5)>>
-        BaseInputTypeSet struct_array_decimal = {TypeIndex::Struct, TypeIndex::Array,
-                                                 TypeIndex::Decimal32};
+        InputTypeSet struct_array_decimal = {TypeIndex::Struct, TypeIndex::Array,
+                                             TypeIndex::Decimal32};
         // struct<array<decimal64(18, 9)>>
-        BaseInputTypeSet struct_array_decimal64 = {TypeIndex::Struct, TypeIndex::Array,
-                                                   TypeIndex::Decimal64};
+        InputTypeSet struct_array_decimal64 = {TypeIndex::Struct, TypeIndex::Array,
+                                               TypeIndex::Decimal64};
         // struct<array<decimal128(38, 20)>>
-        BaseInputTypeSet struct_array_decimal128 = {TypeIndex::Struct, TypeIndex::Array,
-                                                    TypeIndex::Decimal128V3};
+        InputTypeSet struct_array_decimal128 = {TypeIndex::Struct, TypeIndex::Array,
+                                                TypeIndex::Decimal128V3};
         // struct<array<decimal256(76, 40)>>
-        BaseInputTypeSet struct_array_decimal256 = {TypeIndex::Struct, TypeIndex::Array,
-                                                    TypeIndex::Decimal256};
+        InputTypeSet struct_array_decimal256 = {TypeIndex::Struct, TypeIndex::Array,
+                                                TypeIndex::Decimal256};
         // struct<map<char,double>>
-        BaseInputTypeSet struct_map_char_double = {TypeIndex::Struct, TypeIndex::Map,
-                                                   TypeIndex::String, TypeIndex::Float64};
+        InputTypeSet struct_map_char_double = {TypeIndex::Struct, TypeIndex::Map, TypeIndex::String,
+                                               TypeIndex::Float64};
         // struct_map<datetime,decimal<76,56>>
-        BaseInputTypeSet struct_map_datetime_decimal = {
-                TypeIndex::Struct, TypeIndex::Map, TypeIndex::DateTimeV2, TypeIndex::Decimal256};
+        InputTypeSet struct_map_datetime_decimal = {TypeIndex::Struct, TypeIndex::Map,
+                                                    TypeIndex::DateTimeV2, TypeIndex::Decimal256};
         // struct_map<ipv4,ipv6>
-        BaseInputTypeSet struct_map_ipv4_ipv6 = {TypeIndex::Struct, TypeIndex::Map, TypeIndex::IPv4,
-                                                 TypeIndex::IPv6};
+        InputTypeSet struct_map_ipv4_ipv6 = {TypeIndex::Struct, TypeIndex::Map, TypeIndex::IPv4,
+                                             TypeIndex::IPv6};
         // struct_map<largeInt,string>
-        BaseInputTypeSet struct_map_largeint_string = {TypeIndex::Struct, TypeIndex::Map,
-                                                       TypeIndex::Int128, TypeIndex::String};
+        InputTypeSet struct_map_largeint_string = {TypeIndex::Struct, TypeIndex::Map,
+                                                   TypeIndex::Int128, TypeIndex::String};
         // struct<struct<f1:int,f2:date,f3:decimal>, struct<f4:string,f5:double,f6:ipv4,f7:ipv6>>
-        BaseInputTypeSet struct_struct = {
-                TypeIndex::Struct,    TypeIndex::Struct, TypeIndex::Int32,  TypeIndex::Date,
-                TypeIndex::Decimal32, TypeIndex::Struct, TypeIndex::String, TypeIndex::Float64,
-                TypeIndex::IPv4,      TypeIndex::IPv6};
+        InputTypeSet struct_struct = {TypeIndex::Struct, TypeIndex::Struct,    TypeIndex::Int32,
+                                      TypeIndex::Date,   TypeIndex::Decimal32, TypeIndex::Struct,
+                                      TypeIndex::String, TypeIndex::Float64,   TypeIndex::IPv4,
+                                      TypeIndex::IPv6};
 
-        std::vector<BaseInputTypeSet> struct_array_typeIndex = {
+        std::vector<InputTypeSet> struct_array_typeIndex = {
                 struct_array_tinyint,    struct_array_smallint,   struct_array_int,
                 struct_array_bigint,     struct_array_largeint,   struct_array_float,
                 struct_array_double,     struct_array_ipv4,       struct_array_ipv6,
                 struct_array_date,       struct_array_datetime,   struct_array_datev2,
                 struct_array_datetimev2, struct_array_varchar,    struct_array_decimal,
                 struct_array_decimal64,  struct_array_decimal128, struct_array_decimal256};
-        std::vector<BaseInputTypeSet> struct_map_typeIndex = {
+        std::vector<InputTypeSet> struct_map_typeIndex = {
                 struct_map_char_double, struct_map_datetime_decimal, struct_map_ipv4_ipv6,
                 struct_map_largeint_string};
-        std::vector<BaseInputTypeSet> struct_struct_typeIndex = {struct_struct};
+        std::vector<InputTypeSet> struct_struct_typeIndex = {struct_struct};
 
         descs_.reserve(struct_typeIndex.size() + struct_array_typeIndex.size() +
                        struct_map_typeIndex.size() + struct_struct_typeIndex.size());
@@ -177,7 +173,7 @@ protected:
             descs_.emplace_back();
             InputTypeSet input_types {};
             input_types.emplace_back(struct_typeIndex[i][0]);
-            input_types.emplace_back(Nullable {static_cast<TypeIndex>(struct_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(struct_typeIndex[i][1])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, descs_[i]));
         }
@@ -185,10 +181,8 @@ protected:
             descs_.emplace_back();
             InputTypeSet input_types {};
             input_types.emplace_back(struct_array_typeIndex[i][0]);
-            input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_array_typeIndex[i][1])});
-            input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_array_typeIndex[i][2])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(struct_array_typeIndex[i][1])});
+            input_types.emplace_back(Nullable {any_cast<TypeIndex>(struct_array_typeIndex[i][2])});
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(input_types, descs_[i + struct_typeIndex.size()]));
@@ -199,11 +193,11 @@ protected:
             InputTypeSet input_types {};
             input_types.emplace_back(struct_map_typeIndex[i][0]); // struct
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_map_typeIndex[i][1])}); // map
+                    Nullable {any_cast<TypeIndex>(struct_map_typeIndex[i][1])}); // map
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_map_typeIndex[i][2])}); // key
+                    Nullable {any_cast<TypeIndex>(struct_map_typeIndex[i][2])}); // key
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_map_typeIndex[i][3])}); // val
+                    Nullable {any_cast<TypeIndex>(struct_map_typeIndex[i][3])}); // val
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_EQ(input_types[2].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(
@@ -216,21 +210,21 @@ protected:
             InputTypeSet input_types {};
             input_types.emplace_back(struct_struct_typeIndex[i][0]); // struct
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][1])}); // struct
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][1])}); // struct
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][2])}); // f1
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][2])}); // f1
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][3])}); // f2
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][3])}); // f2
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][4])}); // f3
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][4])}); // f3
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][5])}); // f4
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][5])}); // f4
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][6])}); // f5
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][6])}); // f5
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][7])}); // f6
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][7])}); // f6
             input_types.emplace_back(
-                    Nullable {static_cast<TypeIndex>(struct_struct_typeIndex[i][8])}); // f7
+                    Nullable {any_cast<TypeIndex>(struct_struct_typeIndex[i][8])}); // f7
 
             EXPECT_EQ(input_types[1].type(), &typeid(Nullable)) << "nested type is not nullable";
             EXPECT_TRUE(parse_ut_data_type(

--- a/be/test/vec/function/function_array_aggregation_test.cpp
+++ b/be/test/vec/function/function_array_aggregation_test.cpp
@@ -65,10 +65,10 @@ void check_function(const std::string& func_name, const IntDataSet data_set,
             }
         }
         if (!row.second.is_null) {
-            converted_data_set.emplace_back(std::make_pair<CellSet, Expect>(
+            converted_data_set.emplace_back(std::make_pair<InputCell, Expect>(
                     {array}, convert_to<ReturnType>(row.second.value)));
         } else {
-            converted_data_set.emplace_back(std::make_pair<CellSet, Expect>({array}, Null()));
+            converted_data_set.emplace_back(std::make_pair<InputCell, Expect>({array}, Null()));
         }
     }
     static_cast<void>(check_function<ReturnType, true>(func_name, input_types, converted_data_set));

--- a/be/test/vec/function/function_array_aggregation_test.cpp
+++ b/be/test/vec/function/function_array_aggregation_test.cpp
@@ -22,7 +22,6 @@
 
 #include "function_test_util.h"
 #include "testutil/any_type.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
 
@@ -39,36 +38,34 @@ struct AnyValue {
 };
 
 using IntDataSet = std::vector<std::pair<std::vector<AnyValue<int>>, AnyValue<int>>>;
-
-template <typename To, typename From>
-constexpr decltype(auto) convert_to(From value) {
-    return static_cast<To::FieldType>(value);
-}
-
-template <typename T, typename ReturnType = T>
-void check_function(const std::string& func_name, const IntDataSet data_set,
-                    bool nullable = false) {
+//TODO: this interlayer could be removed totally
+template <typename DataType, typename ReturnType = DataType>
+void check_function_array_wrapper(const std::string& func_name, const IntDataSet data_set,
+                                  bool nullable = false) {
     InputTypeSet input_types;
     if (!nullable) {
-        input_types = {TypeIndex::Array, T{}.get_type_id()};
+        input_types = {TypeIndex::Array, DataType {}.get_type_id()};
     } else {
-        input_types = {TypeIndex::Array, TypeIndex::Nullable, T{}.get_type_id()};
+        input_types = {TypeIndex::Array, TypeIndex::Nullable, DataType {}.get_type_id()};
     }
     DataSet converted_data_set;
     for (const auto& row : data_set) {
-        Array array;
+        TestArray array;
         for (auto any_value : row.first) {
             if (any_value.is_null) {
-                array.push_back(Field());
+                array.emplace_back(Null());
             } else {
-                array.push_back(convert_to<T>(any_value.value));
+                //ATTN: these static cast is necessary, because AnyType contains certain type! store int8 and get
+                // int32 will cause error
+                array.emplace_back(static_cast<DataType::FieldType>(any_value.value));
             }
         }
         if (!row.second.is_null) {
             converted_data_set.emplace_back(std::make_pair<InputCell, Expect>(
-                    {array}, convert_to<ReturnType>(row.second.value)));
+                    {AnyType {array}}, static_cast<ReturnType::FieldType>(row.second.value)));
         } else {
-            converted_data_set.emplace_back(std::make_pair<InputCell, Expect>({array}, Null()));
+            converted_data_set.emplace_back(
+                    std::make_pair<InputCell, Expect>({AnyType {array}}, Null()));
         }
     }
     static_cast<void>(check_function<ReturnType, true>(func_name, input_types, converted_data_set));
@@ -80,13 +77,13 @@ TEST(VFunctionArrayAggregationTest, TestArrayMin) {
             {{}, nullptr},
             {{1, 2, 3}, 1},
     };
-    static_cast<void>(check_function<DataTypeInt8>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt16>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt32>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt128>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat32>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt8>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt16>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt32>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt64>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64>(func_name, data_set));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayMinNullable) {
@@ -96,13 +93,13 @@ TEST(VFunctionArrayAggregationTest, TestArrayMinNullable) {
             {{nullptr}, nullptr},
             {{1, nullptr, 3}, 1},
     };
-    static_cast<void>(check_function<DataTypeInt8>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt16>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt32>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt128>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat32>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt8>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt16>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt32>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64>(func_name, data_set, true));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayMax) {
@@ -111,13 +108,13 @@ TEST(VFunctionArrayAggregationTest, TestArrayMax) {
             {{}, nullptr},
             {{1, 2, 3}, 3},
     };
-    static_cast<void>(check_function<DataTypeInt8>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt16>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt32>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt128>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat32>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt8>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt16>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt32>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt64>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32>(func_name, data_set));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64>(func_name, data_set));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayMaxNullable) {
@@ -127,13 +124,13 @@ TEST(VFunctionArrayAggregationTest, TestArrayMaxNullable) {
             {{nullptr}, nullptr},
             {{1, nullptr, 3}, 3},
     };
-    static_cast<void>(check_function<DataTypeInt8>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt16>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt32>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt128>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat32>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt8>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt16>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt32>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64>(func_name, data_set, true));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArraySum) {
@@ -142,13 +139,20 @@ TEST(VFunctionArrayAggregationTest, TestArraySum) {
             {{}, nullptr},
             {{1, 2, 3}, 6},
     };
-    static_cast<void>(check_function<DataTypeInt8, DataTypeInt64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt16, DataTypeInt64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt32, DataTypeInt64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt64, DataTypeInt64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt128, DataTypeInt128>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat32, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat64, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt8, DataTypeInt64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt16, DataTypeInt64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt32, DataTypeInt64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt64, DataTypeInt64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt128, DataTypeInt128>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeFloat32, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeFloat64, DataTypeFloat64>(func_name, data_set));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArraySumNullable) {
@@ -158,13 +162,20 @@ TEST(VFunctionArrayAggregationTest, TestArraySumNullable) {
             {{nullptr}, nullptr},
             {{1, nullptr, 3}, 4},
     };
-    static_cast<void>(check_function<DataTypeInt8, DataTypeInt64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt16, DataTypeInt64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt32, DataTypeInt64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt64, DataTypeInt64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt128, DataTypeInt128>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat32, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat64, DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt8, DataTypeInt64>(func_name, data_set, true));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt16, DataTypeInt64>(func_name, data_set, true));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt32, DataTypeInt64>(func_name, data_set, true));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt64, DataTypeInt64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128, DataTypeInt128>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32, DataTypeFloat64>(
+            func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64, DataTypeFloat64>(
+            func_name, data_set, true));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayAverage) {
@@ -173,13 +184,20 @@ TEST(VFunctionArrayAggregationTest, TestArrayAverage) {
             {{}, nullptr},
             {{1, 2, 3}, 2},
     };
-    static_cast<void>(check_function<DataTypeInt8, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt16, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt32, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt64, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt128, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat32, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat64, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt8, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt16, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt32, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt64, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt128, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeFloat32, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeFloat64, DataTypeFloat64>(func_name, data_set));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayAverageNullable) {
@@ -189,13 +207,20 @@ TEST(VFunctionArrayAggregationTest, TestArrayAverageNullable) {
             {{nullptr}, nullptr},
             {{1, nullptr, 3}, 2},
     };
-    static_cast<void>(check_function<DataTypeInt8, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt16, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt32, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt64, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt128, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat32, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat64, DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt8, DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt16, DataTypeFloat64>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt32, DataTypeFloat64>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt64, DataTypeFloat64>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128, DataTypeFloat64>(
+            func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32, DataTypeFloat64>(
+            func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64, DataTypeFloat64>(
+            func_name, data_set, true));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayProduct) {
@@ -204,13 +229,20 @@ TEST(VFunctionArrayAggregationTest, TestArrayProduct) {
             {{}, nullptr},
             {{1, 2, 3}, 6},
     };
-    static_cast<void>(check_function<DataTypeInt8, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt16, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt32, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt64, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeInt128, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat32, DataTypeFloat64>(func_name, data_set));
-    static_cast<void>(check_function<DataTypeFloat64, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt8, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt16, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt32, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt64, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt128, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeFloat32, DataTypeFloat64>(func_name, data_set));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeFloat64, DataTypeFloat64>(func_name, data_set));
 }
 
 TEST(VFunctionArrayAggregationTest, TestArrayProductNullable) {
@@ -220,14 +252,20 @@ TEST(VFunctionArrayAggregationTest, TestArrayProductNullable) {
             {{nullptr}, nullptr},
             {{1, nullptr, 3}, 3},
     };
-    static_cast<void>(check_function<DataTypeInt8, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt16, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt32, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt64, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeInt128, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat32, DataTypeFloat64>(func_name, data_set, true));
-    static_cast<void>(check_function<DataTypeFloat64, DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(
+            check_function_array_wrapper<DataTypeInt8, DataTypeFloat64>(func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt16, DataTypeFloat64>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt32, DataTypeFloat64>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt64, DataTypeFloat64>(func_name,
+                                                                                   data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeInt128, DataTypeFloat64>(
+            func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat32, DataTypeFloat64>(
+            func_name, data_set, true));
+    static_cast<void>(check_function_array_wrapper<DataTypeFloat64, DataTypeFloat64>(
+            func_name, data_set, true));
 }
 
 } // namespace doris::vectorized
-

--- a/be/test/vec/function/function_array_element_test.cpp
+++ b/be/test/vec/function/function_array_element_test.cpp
@@ -90,7 +90,7 @@ TEST(function_array_element_test, element_at) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::Int64};
 
         TestArray vec = {std::string("2022-01-02 01:00:00"), std::string(""),
-                     std::string("2022-07-08 03:00:00")};
+                         std::string("2022-07-08 03:00:00")};
         DataSet data_set = {{{vec, Int64(0)}, Null()},
                             {{vec, Int64(1)}, std::string("2022-01-02 01:00:00")},
                             {{vec, Int64(4)}, Null()},
@@ -108,17 +108,13 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Int64};
 
-        TestArray vec = {std::string("2022-01-02"), std::string(""),
-                     std::string("2022-07-08")};
-        DataSet data_set = {{{vec, Int64(0)}, Null()},
-                            {{vec, Int64(1)}, std::string("2022-01-02")},
-                            {{vec, Int64(4)}, Null()},
-                            {{vec, Int64(-1)}, std::string("2022-07-08")},
-                            {{vec, Int64(-2)}, std::string("")},
-                            {{vec, Int64(-4)}, Null()},
-                            {{Null(), Int64(1)}, Null()},
-                            {{empty_arr, Int64(0)}, Null()},
-                            {{empty_arr, Int64(1)}, Null()}};
+        TestArray vec = {std::string("2022-01-02"), std::string(""), std::string("2022-07-08")};
+        DataSet data_set = {
+                {{vec, Int64(0)}, Null()},           {{vec, Int64(1)}, std::string("2022-01-02")},
+                {{vec, Int64(4)}, Null()},           {{vec, Int64(-1)}, std::string("2022-07-08")},
+                {{vec, Int64(-2)}, std::string("")}, {{vec, Int64(-4)}, Null()},
+                {{Null(), Int64(1)}, Null()},        {{empty_arr, Int64(0)}, Null()},
+                {{empty_arr, Int64(1)}, Null()}};
 
         static_cast<void>(check_function<DataTypeDate, true>(func_name, input_types, data_set));
     }
@@ -128,7 +124,7 @@ TEST(function_array_element_test, element_at) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2, TypeIndex::Int64};
 
         TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
-                     ut_type::DECIMALV2(0.0)};
+                         ut_type::DECIMALV2(0.0)};
         DataSet data_set = {{{vec, Int64(0)}, Null()},
                             {{vec, Int64(1)}, ut_type::DECIMALV2(17014116.67)},
                             {{vec, Int64(4)}, Null()},

--- a/be/test/vec/function/function_array_element_test.cpp
+++ b/be/test/vec/function/function_array_element_test.cpp
@@ -18,7 +18,6 @@
 #include <string>
 
 #include "function_test_util.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_date_time.h"

--- a/be/test/vec/function/function_array_element_test.cpp
+++ b/be/test/vec/function/function_array_element_test.cpp
@@ -30,13 +30,13 @@ namespace doris::vectorized {
 
 TEST(function_array_element_test, element_at) {
     std::string func_name = "element_at";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // element_at(Array<Int32>, Int32)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {
                 {{vec, 0}, Null()},    {{vec, 1}, Int32(1)},     {{vec, 4}, Null()},
                 {{vec, -1}, Int32(3)}, {{vec, -3}, Int32(1)},    {{vec, -4}, Null()},
@@ -49,7 +49,7 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int8, TypeIndex::Int32};
 
-        Array vec = {Int8(1), Int8(2), Int8(3)};
+        TestArray vec = {Int8(1), Int8(2), Int8(3)};
         DataSet data_set = {
                 {{vec, 0}, Null()},    {{vec, 1}, Int8(1)},      {{vec, 4}, Null()},
                 {{vec, -1}, Int8(3)},  {{vec, -3}, Int8(1)},     {{vec, -4}, Null()},
@@ -62,7 +62,7 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int128, TypeIndex::Int64};
 
-        Array vec = {Int128(1), Int128(2), Int128(3)};
+        TestArray vec = {Int128(1), Int128(2), Int128(3)};
         DataSet data_set = {{{vec, Int64(0)}, Null()},      {{vec, Int64(1)}, Int128(1)},
                             {{vec, Int64(4)}, Null()},      {{vec, Int64(-1)}, Int128(3)},
                             {{vec, Int64(-3)}, Int128(1)},  {{vec, Int64(-4)}, Null()},
@@ -76,7 +76,7 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Float64, TypeIndex::Int64};
 
-        Array vec = {double(1.11), double(2.22), double(3.33)};
+        TestArray vec = {double(1.11), double(2.22), double(3.33)};
         DataSet data_set = {{{vec, Int64(0)}, Null()},        {{vec, Int64(1)}, double(1.11)},
                             {{vec, Int64(4)}, Null()},        {{vec, Int64(-1)}, double(3.33)},
                             {{vec, Int64(-3)}, double(1.11)}, {{vec, Int64(-4)}, Null()},
@@ -90,13 +90,13 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::Int64};
 
-        Array vec = {str_to_date_time("2022-01-02 01:00:00"), str_to_date_time(""),
-                     str_to_date_time("2022-07-08 03:00:00")};
+        TestArray vec = {std::string("2022-01-02 01:00:00"), std::string(""),
+                     std::string("2022-07-08 03:00:00")};
         DataSet data_set = {{{vec, Int64(0)}, Null()},
-                            {{vec, Int64(1)}, str_to_date_time("2022-01-02 01:00:00")},
+                            {{vec, Int64(1)}, std::string("2022-01-02 01:00:00")},
                             {{vec, Int64(4)}, Null()},
-                            {{vec, Int64(-1)}, str_to_date_time("2022-07-08 03:00:00")},
-                            {{vec, Int64(-2)}, str_to_date_time("")},
+                            {{vec, Int64(-1)}, std::string("2022-07-08 03:00:00")},
+                            {{vec, Int64(-2)}, std::string("")},
                             {{vec, Int64(-4)}, Null()},
                             {{Null(), Int64(1)}, Null()},
                             {{empty_arr, Int64(0)}, Null()},
@@ -109,13 +109,13 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Int64};
 
-        Array vec = {str_to_date_time("2022-01-02"), str_to_date_time(""),
-                     str_to_date_time("2022-07-08")};
+        TestArray vec = {std::string("2022-01-02"), std::string(""),
+                     std::string("2022-07-08")};
         DataSet data_set = {{{vec, Int64(0)}, Null()},
-                            {{vec, Int64(1)}, str_to_date_time("2022-01-02")},
+                            {{vec, Int64(1)}, std::string("2022-01-02")},
                             {{vec, Int64(4)}, Null()},
-                            {{vec, Int64(-1)}, str_to_date_time("2022-07-08")},
-                            {{vec, Int64(-2)}, str_to_date_time("")},
+                            {{vec, Int64(-1)}, std::string("2022-07-08")},
+                            {{vec, Int64(-2)}, std::string("")},
                             {{vec, Int64(-4)}, Null()},
                             {{Null(), Int64(1)}, Null()},
                             {{empty_arr, Int64(0)}, Null()},
@@ -128,8 +128,8 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2, TypeIndex::Int64};
 
-        Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
-                     ut_type::DECIMALFIELD(0.0)};
+        TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
+                     ut_type::DECIMALV2(0.0)};
         DataSet data_set = {{{vec, Int64(0)}, Null()},
                             {{vec, Int64(1)}, ut_type::DECIMALV2(17014116.67)},
                             {{vec, Int64(4)}, Null()},
@@ -148,7 +148,7 @@ TEST(function_array_element_test, element_at) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::Int32};
 
-        Array vec = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         DataSet data_set = {{{vec, 1}, std::string("abc")},
                             {{vec, 2}, std::string("")},
                             {{vec, 10}, Null()},

--- a/be/test/vec/function/function_array_index_test.cpp
+++ b/be/test/vec/function/function_array_index_test.cpp
@@ -26,13 +26,13 @@ namespace doris::vectorized {
 
 TEST(function_array_index_test, array_contains) {
     std::string func_name = "array_contains";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // array_contains(Array<Int32>, Int32)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {{{vec, 2}, UInt8(1)},
                             {{vec, 4}, UInt8(0)},
                             {{Null(), 1}, Null()},
@@ -45,7 +45,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int8, TypeIndex::Int8};
 
-        Array vec = {Int8(1), Int8(2), Int8(3)};
+        TestArray vec = {Int8(1), Int8(2), Int8(3)};
         DataSet data_set = {{{vec, Int8(2)}, UInt8(1)},
                             {{vec, Int8(4)}, UInt8(0)},
                             {{Null(), Int8(1)}, Null()},
@@ -58,7 +58,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int64, TypeIndex::Int64};
 
-        Array vec = {Int64(1), Int64(2), Int64(3)};
+        TestArray vec = {Int64(1), Int64(2), Int64(3)};
         DataSet data_set = {{{vec, Int64(2)}, UInt8(1)},
                             {{vec, Int64(4)}, UInt8(0)},
                             {{Null(), Int64(1)}, Null()},
@@ -71,7 +71,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int128, TypeIndex::Int128};
 
-        Array vec = {Int128(11111111111LL), Int128(22222LL), Int128(333LL)};
+        TestArray vec = {Int128(11111111111LL), Int128(22222LL), Int128(333LL)};
         DataSet data_set = {{{vec, Int128(11111111111LL)}, UInt8(1)},
                             {{vec, Int128(4)}, UInt8(0)},
                             {{Null(), Int128(1)}, Null()},
@@ -84,7 +84,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Float32, TypeIndex::Float32};
 
-        Array vec = {float(1.2345), float(2.222), float(3.0)};
+        TestArray vec = {float(1.2345), float(2.222), float(3.0)};
         DataSet data_set = {{{vec, float(2.222)}, UInt8(1)},
                             {{vec, float(4)}, UInt8(0)},
                             {{Null(), float(1)}, Null()},
@@ -97,7 +97,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Float64, TypeIndex::Float64};
 
-        Array vec = {double(1.2345), double(2.222), double(3.0)};
+        TestArray vec = {double(1.2345), double(2.222), double(3.0)};
         DataSet data_set = {{{vec, double(2.222)}, UInt8(1)},
                             {{vec, double(4)}, UInt8(0)},
                             {{Null(), double(1)}, Null()},
@@ -110,7 +110,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Date};
 
-        Array vec = {str_to_date_time("2022-01-02", false), str_to_date_time("2022-07-08", false)};
+        TestArray vec = {std::string("2022-01-02"), std::string("2022-07-08")};
         DataSet data_set = {{{vec, std::string("2022-01-02")}, UInt8(1)},
                             {{vec, std::string("2022-01-03")}, UInt8(0)},
                             {{Null(), std::string("2022-01-04")}, Null()},
@@ -123,8 +123,8 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::DateTime};
 
-        Array vec = {str_to_date_time("2022-01-02 00:00:00"),
-                     str_to_date_time("2022-07-08 00:00:00")};
+        TestArray vec = {std::string("2022-01-02 00:00:00"),
+                     std::string("2022-07-08 00:00:00")};
         DataSet data_set = {{{vec, std::string("2022-01-02 00:00:00")}, UInt8(1)},
                             {{vec, std::string("2022-01-03 00:00:00")}, UInt8(0)},
                             {{Null(), std::string("2022-01-04 00:00:00")}, Null()},
@@ -138,8 +138,8 @@ TEST(function_array_index_test, array_contains) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2,
                                     TypeIndex::Decimal128V2};
 
-        Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
-                     ut_type::DECIMALFIELD(0.0)};
+        TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
+                     ut_type::DECIMALV2(0.0)};
         DataSet data_set = {{{vec, ut_type::DECIMALV2(-17014116.67)}, UInt8(1)},
                             {{vec, ut_type::DECIMALV2(0)}, UInt8(1)},
                             {{Null(), ut_type::DECIMALV2(0)}, Null()},
@@ -152,7 +152,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::String};
 
-        Array vec = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         DataSet data_set = {{{vec, std::string("abc")}, UInt8(1)},
                             {{vec, std::string("aaa")}, UInt8(0)},
                             {{vec, std::string("")}, UInt8(1)},
@@ -165,13 +165,13 @@ TEST(function_array_index_test, array_contains) {
 
 TEST(function_array_index_test, array_position) {
     std::string func_name = "array_position";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // array_position(Array<Int32>, Int32)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {{{vec, 2}, Int64(2)},
                             {{vec, 4}, Int64(0)},
                             {{Null(), 1}, Null()},
@@ -184,7 +184,7 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {{{vec, Int32(2)}, Int64(2)},
                             {{vec, Int32(4)}, Int64(0)},
                             {{Null(), Int32(1)}, Null()},
@@ -197,7 +197,7 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int8, TypeIndex::Int8};
 
-        Array vec = {Int8(1), Int8(2), Int8(3)};
+        TestArray vec = {Int8(1), Int8(2), Int8(3)};
         DataSet data_set = {{{vec, Int8(2)}, Int64(2)},
                             {{vec, Int8(4)}, Int64(0)},
                             {{Null(), Int8(1)}, Null()},
@@ -210,7 +210,7 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Date};
 
-        Array vec = {str_to_date_time("2022-01-02", false), str_to_date_time("2022-07-08", false)};
+        TestArray vec = {std::string("2022-01-02"), std::string("2022-07-08")};
         DataSet data_set = {{{vec, std::string("2022-01-02")}, Int64(1)},
                             {{vec, std::string("2022-01-03")}, Int64(0)},
                             {{Null(), std::string("2022-01-04")}, Null()},
@@ -223,8 +223,8 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::DateTime};
 
-        Array vec = {str_to_date_time("2022-01-02 00:00:00"),
-                     str_to_date_time("2022-07-08 00:00:00")};
+        TestArray vec = {std::string("2022-01-02 00:00:00"),
+                     std::string("2022-07-08 00:00:00")};
         DataSet data_set = {{{vec, std::string("2022-01-02 00:00:00")}, Int64(1)},
                             {{vec, std::string("2022-01-03 00:00:00")}, Int64(0)},
                             {{Null(), std::string("2022-01-04 00:00:00")}, Null()},
@@ -238,8 +238,8 @@ TEST(function_array_index_test, array_position) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2,
                                     TypeIndex::Decimal128V2};
 
-        Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
-                     ut_type::DECIMALFIELD(0)};
+        TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
+                     ut_type::DECIMALV2(0)};
         DataSet data_set = {{{vec, ut_type::DECIMALV2(-17014116.67)}, Int64(2)},
                             {{vec, ut_type::DECIMALV2(0)}, Int64(3)},
                             {{Null(), ut_type::DECIMALV2(0)}, Null()},
@@ -252,7 +252,7 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::String};
 
-        Array vec = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         DataSet data_set = {{{vec, std::string("abc")}, Int64(1)},
                             {{vec, std::string("aaa")}, Int64(0)},
                             {{vec, std::string("")}, Int64(2)},

--- a/be/test/vec/function/function_array_index_test.cpp
+++ b/be/test/vec/function/function_array_index_test.cpp
@@ -123,8 +123,7 @@ TEST(function_array_index_test, array_contains) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::DateTime};
 
-        TestArray vec = {std::string("2022-01-02 00:00:00"),
-                     std::string("2022-07-08 00:00:00")};
+        TestArray vec = {std::string("2022-01-02 00:00:00"), std::string("2022-07-08 00:00:00")};
         DataSet data_set = {{{vec, std::string("2022-01-02 00:00:00")}, UInt8(1)},
                             {{vec, std::string("2022-01-03 00:00:00")}, UInt8(0)},
                             {{Null(), std::string("2022-01-04 00:00:00")}, Null()},
@@ -139,7 +138,7 @@ TEST(function_array_index_test, array_contains) {
                                     TypeIndex::Decimal128V2};
 
         TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
-                     ut_type::DECIMALV2(0.0)};
+                         ut_type::DECIMALV2(0.0)};
         DataSet data_set = {{{vec, ut_type::DECIMALV2(-17014116.67)}, UInt8(1)},
                             {{vec, ut_type::DECIMALV2(0)}, UInt8(1)},
                             {{Null(), ut_type::DECIMALV2(0)}, Null()},
@@ -223,8 +222,7 @@ TEST(function_array_index_test, array_position) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::DateTime};
 
-        TestArray vec = {std::string("2022-01-02 00:00:00"),
-                     std::string("2022-07-08 00:00:00")};
+        TestArray vec = {std::string("2022-01-02 00:00:00"), std::string("2022-07-08 00:00:00")};
         DataSet data_set = {{{vec, std::string("2022-01-02 00:00:00")}, Int64(1)},
                             {{vec, std::string("2022-01-03 00:00:00")}, Int64(0)},
                             {{Null(), std::string("2022-01-04 00:00:00")}, Null()},
@@ -239,7 +237,7 @@ TEST(function_array_index_test, array_position) {
                                     TypeIndex::Decimal128V2};
 
         TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
-                     ut_type::DECIMALV2(0)};
+                         ut_type::DECIMALV2(0)};
         DataSet data_set = {{{vec, ut_type::DECIMALV2(-17014116.67)}, Int64(2)},
                             {{vec, ut_type::DECIMALV2(0)}, Int64(3)},
                             {{Null(), ut_type::DECIMALV2(0)}, Null()},

--- a/be/test/vec/function/function_array_size_test.cpp
+++ b/be/test/vec/function/function_array_size_test.cpp
@@ -32,7 +32,8 @@ TEST(function_array_size_test, size) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
         TestArray vec = {Int32(1), Int32(2), Int32(3)};
-        DataSet data_set = {{{vec}, Int64(3)}, {{Null()}, Null()}, {{empty_arr}, Int64(0)}};
+        DataSet data_set = {
+                {{AnyType(vec)}, Int64(3)}, {{Null()}, Null()}, {{AnyType(empty_arr)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
@@ -43,10 +44,10 @@ TEST(function_array_size_test, size) {
 
         TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
         TestArray vec2 = {std::string("abc"), std::string("123"), std::string("def")};
-        DataSet data_set = {{{vec1}, Int64(3)},
-                            {{vec2}, Int64(3)},
+        DataSet data_set = {{{AnyType(vec1)}, Int64(3)},
+                            {{AnyType(vec2)}, Int64(3)},
                             {{Null()}, Null()},
-                            {{empty_arr}, Int64(0)}};
+                            {{AnyType(empty_arr)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
@@ -61,7 +62,8 @@ TEST(function_array_size_test, cardinality) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
         TestArray vec = {Int32(1), Int32(2), Int32(3)};
-        DataSet data_set = {{{vec}, Int64(3)}, {{Null()}, Null()}, {{empty_arr}, Int64(0)}};
+        DataSet data_set = {
+                {{AnyType(vec)}, Int64(3)}, {{Null()}, Null()}, {{AnyType(empty_arr)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
@@ -72,10 +74,10 @@ TEST(function_array_size_test, cardinality) {
 
         TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
         TestArray vec2 = {std::string("abc"), std::string("123"), std::string("def")};
-        DataSet data_set = {{{vec1}, Int64(3)},
-                            {{vec2}, Int64(3)},
+        DataSet data_set = {{{AnyType(vec1)}, Int64(3)},
+                            {{AnyType(vec2)}, Int64(3)},
                             {{Null()}, Null()},
-                            {{empty_arr}, Int64(0)}};
+                            {{AnyType(empty_arr)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
@@ -90,7 +92,8 @@ TEST(function_array_size_test, array_size) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
         TestArray vec = {Int32(1), Int32(2), Int32(3)};
-        DataSet data_set = {{{vec}, Int64(3)}, {{Null()}, Null()}, {{empty_arr}, Int64(0)}};
+        DataSet data_set = {
+                {{AnyType(vec)}, Int64(3)}, {{Null()}, Null()}, {{AnyType(empty_arr)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }
@@ -101,10 +104,10 @@ TEST(function_array_size_test, array_size) {
 
         TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
         TestArray vec2 = {std::string("abc"), std::string("123"), std::string("def")};
-        DataSet data_set = {{{vec1}, Int64(3)},
-                            {{vec2}, Int64(3)},
+        DataSet data_set = {{{AnyType(vec1)}, Int64(3)},
+                            {{AnyType(vec2)}, Int64(3)},
                             {{Null()}, Null()},
-                            {{empty_arr}, Int64(0)}};
+                            {{AnyType(empty_arr)}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
     }

--- a/be/test/vec/function/function_array_size_test.cpp
+++ b/be/test/vec/function/function_array_size_test.cpp
@@ -16,28 +16,22 @@
 // under the License.
 
 #include <string>
-#include <vector>
 
-#include "common/status.h"
 #include "function_test_util.h"
-#include "gtest/gtest_pred_impl.h"
-#include "testutil/any_type.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 
 TEST(function_array_size_test, size) {
     std::string func_name = "size";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // size(Array<Int32>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {{{vec}, Int64(3)}, {{Null()}, Null()}, {{empty_arr}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
@@ -47,8 +41,8 @@ TEST(function_array_size_test, size) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
-        Array vec2 = {Field(String("abc", 3)), Field(String("123", 0)), Field(String("def", 3))};
+        TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
+        TestArray vec2 = {std::string("abc"), std::string("123"), std::string("def")};
         DataSet data_set = {{{vec1}, Int64(3)},
                             {{vec2}, Int64(3)},
                             {{Null()}, Null()},
@@ -60,13 +54,13 @@ TEST(function_array_size_test, size) {
 
 TEST(function_array_size_test, cardinality) {
     std::string func_name = "cardinality";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // cardinality(Array<Int32>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {{{vec}, Int64(3)}, {{Null()}, Null()}, {{empty_arr}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
@@ -76,8 +70,8 @@ TEST(function_array_size_test, cardinality) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
-        Array vec2 = {Field(String("abc", 3)), Field(String("123", 0)), Field(String("def", 3))};
+        TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
+        TestArray vec2 = {std::string("abc"), std::string("123"), std::string("def")};
         DataSet data_set = {{{vec1}, Int64(3)},
                             {{vec2}, Int64(3)},
                             {{Null()}, Null()},
@@ -89,13 +83,13 @@ TEST(function_array_size_test, cardinality) {
 
 TEST(function_array_size_test, array_size) {
     std::string func_name = "array_size";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // array_size(Array<Int32>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Int32(2), Int32(3)};
         DataSet data_set = {{{vec}, Int64(3)}, {{Null()}, Null()}, {{empty_arr}, Int64(0)}};
 
         static_cast<void>(check_function<DataTypeInt64, true>(func_name, input_types, data_set));
@@ -105,8 +99,8 @@ TEST(function_array_size_test, array_size) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
-        Array vec2 = {Field(String("abc", 3)), Field(String("123", 0)), Field(String("def", 3))};
+        TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
+        TestArray vec2 = {std::string("abc"), std::string("123"), std::string("def")};
         DataSet data_set = {{{vec1}, Int64(3)},
                             {{vec2}, Int64(3)},
                             {{Null()}, Null()},

--- a/be/test/vec/function/function_arrays_overlap_test.cpp
+++ b/be/test/vec/function/function_arrays_overlap_test.cpp
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "function_test_util.h"
-#include "testutil/any_type.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
@@ -29,16 +28,16 @@ namespace doris::vectorized {
 
 TEST(function_arrays_overlap_test, arrays_overlap) {
     std::string func_name = "arrays_overlap";
-    Array empty_arr;
+    TestArray empty_arr;
 
     // arrays_overlap(Array<Int32>, Array<Int32>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32, TypeIndex::Array,
                                     TypeIndex::Int32};
 
-        Array vec1 = {Int32(1), Int32(2), Int32(3)};
-        Array vec2 = {Int32(3)};
-        Array vec3 = {Int32(4), Int32(5)};
+        TestArray vec1 = {Int32(1), Int32(2), Int32(3)};
+        TestArray vec2 = {Int32(3)};
+        TestArray vec3 = {Int32(4), Int32(5)};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)},
                             {{vec1, vec3}, UInt8(0)},
                             {{Null(), vec1}, Null()},
@@ -52,8 +51,8 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int128, TypeIndex::Array,
                                     TypeIndex::Int128};
 
-        Array vec1 = {Int128(11111111111LL), Int128(22222LL), Int128(333LL)};
-        Array vec2 = {Int128(11111111111LL)};
+        TestArray vec1 = {Int128(11111111111LL), Int128(22222LL), Int128(333LL)};
+        TestArray vec2 = {Int128(11111111111LL)};
         DataSet data_set = {
                 {{vec1, vec2}, UInt8(1)}, {{Null(), vec1}, Null()}, {{empty_arr, vec1}, UInt8(0)}};
 
@@ -65,8 +64,8 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Float64, TypeIndex::Array,
                                     TypeIndex::Float64};
 
-        Array vec1 = {double(1.2345), double(2.222), double(3.0)};
-        Array vec2 = {double(1.2345)};
+        TestArray vec1 = {double(1.2345), double(2.222), double(3.0)};
+        TestArray vec2 = {double(1.2345)};
         DataSet data_set = {
                 {{vec1, vec2}, UInt8(1)}, {{Null(), vec1}, Null()}, {{empty_arr, vec1}, UInt8(0)}};
 
@@ -78,9 +77,8 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Array,
                                     TypeIndex::Date};
 
-        Array vec1 = {str_to_date_time("2022-01-02", false), str_to_date_time("", false),
-                      str_to_date_time("2022-07-08", false)};
-        Array vec2 = {str_to_date_time("2022-01-02", false)};
+        TestArray vec1 = {std::string("2022-01-02"), std::string(""), std::string("2022-07-08")};
+        TestArray vec2 = {std::string("2022-01-02")};
         DataSet data_set = {
                 {{vec1, vec2}, UInt8(1)}, {{Null(), vec1}, Null()}, {{empty_arr, vec1}, UInt8(0)}};
 
@@ -92,10 +90,10 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::Array,
                                     TypeIndex::DateTime};
 
-        Array vec1 = {str_to_date_time("2022-01-02 00:00:00"), str_to_date_time(""),
-                      str_to_date_time("2022-07-08 00:00:00")};
-        Array vec2 = {str_to_date_time("2022-01-02 00:00:00")};
-        Array vec3 = {str_to_date_time("")};
+        TestArray vec1 = {std::string("2022-01-02 00:00:00"), std::string(""),
+                          std::string("2022-07-08 00:00:00")};
+        TestArray vec2 = {std::string("2022-01-02 00:00:00")};
+        TestArray vec3 = {std::string("")};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)},
                             {{vec1, vec3}, UInt8(1)},
                             {{Null(), vec1}, Null()},
@@ -109,14 +107,14 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2, TypeIndex::Array,
                                     TypeIndex::Decimal128V2};
 
-        Array vec1 = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
-                      ut_type::DECIMALFIELD(0.0)};
-        Array vec2 = {ut_type::DECIMALFIELD(17014116.67)};
+        TestArray vec1 = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
+                          ut_type::DECIMALV2(0.0)};
+        TestArray vec2 = {ut_type::DECIMALV2(17014116.67)};
 
-        Array vec3 = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
-                      Null()};
-        Array vec4 = {ut_type::DECIMALFIELD(-17014116.67)};
-        Array vec5 = {ut_type::DECIMALFIELD(-17014116.68)};
+        TestArray vec3 = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
+                          Null()};
+        TestArray vec4 = {ut_type::DECIMALV2(-17014116.67)};
+        TestArray vec5 = {ut_type::DECIMALV2(-17014116.68)};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)}, {{Null(), vec1}, Null()},
                             {{vec1, Null()}, Null()}, {{empty_arr, vec1}, UInt8(0)},
                             {{vec3, vec4}, UInt8(1)}, {{vec3, vec5}, Null()},
@@ -130,11 +128,11 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::Array,
                                     TypeIndex::String};
 
-        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
-        Array vec2 = {Field(String("abc", 3))};
-        Array vec3 = {Field(String("", 0))};
-        Array vec4 = {Field(String("abc", 3)), Null()};
-        Array vec5 = {Field(String("abcd", 4)), Null()};
+        TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
+        TestArray vec2 = {std::string("abc")};
+        TestArray vec3 = {std::string("")};
+        TestArray vec4 = {std::string("abc"), Null()};
+        TestArray vec5 = {std::string("abcd"), Null()};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)}, {{vec1, vec3}, UInt8(1)},
                             {{Null(), vec1}, Null()}, {{empty_arr, vec1}, UInt8(0)},
                             {{vec4, vec1}, UInt8(1)}, {{vec1, vec5}, Null()},
@@ -148,13 +146,13 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2, TypeIndex::Array,
                                     TypeIndex::Decimal128V2};
 
-        Array vec1 = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67),
-                      ut_type::DECIMALFIELD(0.0)};
-        Array vec2 = {ut_type::DECIMALFIELD(17014116.67)};
+        TestArray vec1 = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67),
+                          ut_type::DECIMALV2(0.0)};
+        TestArray vec2 = {ut_type::DECIMALV2(17014116.67)};
 
-        Array vec3 = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67)};
-        Array vec4 = {ut_type::DECIMALFIELD(-17014116.67)};
-        Array vec5 = {ut_type::DECIMALFIELD(-17014116.68)};
+        TestArray vec3 = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67)};
+        TestArray vec4 = {ut_type::DECIMALV2(-17014116.67)};
+        TestArray vec5 = {ut_type::DECIMALV2(-17014116.68)};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)}, {{empty_arr, vec1}, UInt8(0)},
                             {{vec3, vec4}, UInt8(1)}, {{vec3, vec5}, UInt8(0)},
                             {{vec4, vec3}, UInt8(1)}, {{vec5, vec3}, UInt8(0)}};
@@ -167,11 +165,11 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String, TypeIndex::Array,
                                     TypeIndex::String};
 
-        Array vec1 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
-        Array vec2 = {Field(String("abc", 3))};
-        Array vec3 = {Field(String("", 0))};
-        Array vec4 = {Field(String("abc", 3))};
-        Array vec5 = {Field(String("abcd", 4))};
+        TestArray vec1 = {std::string("abc"), std::string(""), std::string("def")};
+        TestArray vec2 = {std::string("abc")};
+        TestArray vec3 = {std::string("")};
+        TestArray vec4 = {std::string("abc")};
+        TestArray vec5 = {std::string("abcd")};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)},      {{vec1, vec3}, UInt8(1)},
                             {{empty_arr, vec1}, UInt8(0)}, {{vec4, vec1}, UInt8(1)},
                             {{vec1, vec5}, UInt8(0)},      {{vec1, vec4}, UInt8(1)},

--- a/be/test/vec/function/function_arrays_overlap_test.cpp
+++ b/be/test/vec/function/function_arrays_overlap_test.cpp
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "function_test_util.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
 
@@ -77,7 +76,7 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Array,
                                     TypeIndex::Date};
 
-        TestArray vec1 = {std::string("2022-01-02"), std::string(""), std::string("2022-07-08")};
+        TestArray vec1 = {std::string("2022-01-02"), std::string("2022-01-02"), std::string("2022-07-08")};
         TestArray vec2 = {std::string("2022-01-02")};
         DataSet data_set = {
                 {{vec1, vec2}, UInt8(1)}, {{Null(), vec1}, Null()}, {{empty_arr, vec1}, UInt8(0)}};
@@ -90,12 +89,12 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::DateTime, TypeIndex::Array,
                                     TypeIndex::DateTime};
 
-        TestArray vec1 = {std::string("2022-01-02 00:00:00"), std::string(""),
+        TestArray vec1 = {std::string("2022-01-02 00:00:00"), std::string("2022-01-02 00:00:00"),
                           std::string("2022-07-08 00:00:00")};
         TestArray vec2 = {std::string("2022-01-02 00:00:00")};
         TestArray vec3 = {std::string("")};
         DataSet data_set = {{{vec1, vec2}, UInt8(1)},
-                            {{vec1, vec3}, UInt8(1)},
+                            {{vec1, vec3}, Null()},
                             {{Null(), vec1}, Null()},
                             {{empty_arr, vec1}, UInt8(0)}};
 

--- a/be/test/vec/function/function_arrays_overlap_test.cpp
+++ b/be/test/vec/function/function_arrays_overlap_test.cpp
@@ -76,7 +76,8 @@ TEST(function_arrays_overlap_test, arrays_overlap) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date, TypeIndex::Array,
                                     TypeIndex::Date};
 
-        TestArray vec1 = {std::string("2022-01-02"), std::string("2022-01-02"), std::string("2022-07-08")};
+        TestArray vec1 = {std::string("2022-01-02"), std::string("2022-01-02"),
+                          std::string("2022-07-08")};
         TestArray vec2 = {std::string("2022-01-02")};
         DataSet data_set = {
                 {{vec1, vec2}, UInt8(1)}, {{Null(), vec1}, Null()}, {{empty_arr, vec1}, UInt8(0)}};

--- a/be/test/vec/function/function_bitmap_test.cpp
+++ b/be/test/vec/function/function_bitmap_test.cpp
@@ -15,23 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 #include <gtest/gtest.h>
-#include <stdint.h>
 
 #include <cstdint>
 #include <limits>
-#include <numeric>
 #include <string>
 #include <vector>
 
 #include "common/config.h"
 #include "common/status.h"
 #include "function_test_util.h"
-#include "gtest/gtest_pred_impl.h"
-#include "testutil/any_type.h"
 #include "util/bitmap_value.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_bitmap.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
@@ -91,18 +86,18 @@ TEST(function_bitmap_test, function_bitmap_remove) {
     BitmapValue bitmap1_res(1);
     BitmapValue bitmap2_res({1, 3, 5});
     {
-        DataSet data_set = {{{&bitmap1, (int64_t)3}, bitmap1_res},
-                            {{&bitmap2, (int64_t)6}, bitmap2_res},
+        DataSet data_set = {{{&bitmap1, (int64_t)3}, &bitmap1_res},
+                            {{&bitmap2, (int64_t)6}, &bitmap2_res},
                             {{&bitmap1, Null()}, Null()}};
 
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
 }
-namespace doris {
-namespace config {
+
+namespace doris::config {
 DECLARE_Bool(enable_set_in_bitmap_value);
 }
-} // namespace doris
+
 TEST(function_bitmap_test, function_bitmap_to_base64) {
     config::Register::Field field("bool", "enable_set_in_bitmap_value",
                                   &config::enable_set_in_bitmap_value, "false", false);
@@ -262,10 +257,10 @@ TEST(function_bitmap_test, function_bitmap_from_base64) {
 
     BitmapValue empty_bitmap;
     {
-        DataSet data_set = {{{bitmap32_base64_1}, bitmap32_1}, {{bitmap32_base64_2}, bitmap32_2},
-                            {{bitmap32_base64_3}, bitmap32_3}, {{bitmap64_base64_1}, bitmap64_1},
-                            {{bitmap64_base64_2}, bitmap64_2}, {{bitmap64_base64_3}, bitmap64_3},
-                            {{base64_empty}, empty_bitmap},    {{Null()}, Null()}};
+        DataSet data_set = {{{bitmap32_base64_1}, &bitmap32_1}, {{bitmap32_base64_2}, &bitmap32_2},
+                            {{bitmap32_base64_3}, &bitmap32_3}, {{bitmap64_base64_1}, &bitmap64_1},
+                            {{bitmap64_base64_2}, &bitmap64_2}, {{bitmap64_base64_3}, &bitmap64_3},
+                            {{base64_empty}, &empty_bitmap},    {{Null()}, Null()}};
 
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
@@ -280,10 +275,10 @@ TEST(function_bitmap_test, function_bitmap_from_base64) {
     bitmap64_base64_3 = ("BAIAAAAAOzAAAAEAAB8AAQAAAB8AAQAAADowAAABAAAAAAAAABAAAAAAAA==");
 
     {
-        DataSet data_set = {{{bitmap32_base64_1}, bitmap32_1}, {{bitmap32_base64_2}, bitmap32_2},
-                            {{bitmap32_base64_3}, bitmap32_3}, {{bitmap64_base64_1}, bitmap64_1},
-                            {{bitmap64_base64_2}, bitmap64_2}, {{bitmap64_base64_3}, bitmap64_3},
-                            {{base64_empty}, empty_bitmap},    {{Null()}, Null()}};
+        DataSet data_set = {{{bitmap32_base64_1}, &bitmap32_1}, {{bitmap32_base64_2}, &bitmap32_2},
+                            {{bitmap32_base64_3}, &bitmap32_3}, {{bitmap64_base64_1}, &bitmap64_1},
+                            {{bitmap64_base64_2}, &bitmap64_2}, {{bitmap64_base64_3}, &bitmap64_3},
+                            {{base64_empty}, &empty_bitmap},    {{Null()}, Null()}};
 
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
@@ -293,7 +288,7 @@ TEST(function_bitmap_test, function_bitmap_from_base64) {
         BitmapValue bitmap;
         bitmap.add(0);
         bitmap.add(1);
-        DataSet data_set = {{{base64}, bitmap}};
+        DataSet data_set = {{{base64}, &bitmap}};
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
     {
@@ -305,7 +300,7 @@ TEST(function_bitmap_test, function_bitmap_from_base64) {
         std::string base64_64_v1(
                 "BAIAAAAAOjAAAAEAAAAAAB8AEAAAAAAAAQACAAMABAAFAAYABwAIAAkACgALAAwADQAOAA8AEAARABIAEw"
                 "AUABUAFgAXABgAGQAaABsAHAAdAB4AHwABAAAAOjAAAAEAAAAAAAAAEAAAAAAA");
-        DataSet data_set = {{{base64_32_v1}, bitmap32_3}, {{base64_64_v1}, bitmap64_3}};
+        DataSet data_set = {{{base64_32_v1}, &bitmap32_3}, {{base64_64_v1}, &bitmap64_3}};
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
     {
@@ -317,7 +312,7 @@ TEST(function_bitmap_test, function_bitmap_from_base64) {
         std::string base64_64_v2(
                 "DQIAAAAAAjowAAABAAAAAAAfABAAAAAAAAEAAgADAAQABQAGAAcACAAJAAoACwAMAA0ADgAPABAAEQASAB"
                 "MAFAAVABYAFwAYABkAGgAbABwAHQAeAB8AAQAAAAEBAAAAAAAAAA==");
-        DataSet data_set = {{{base64_32_v2}, bitmap32_3}, {{base64_64_v2}, bitmap64_3}};
+        DataSet data_set = {{{base64_32_v2}, &bitmap32_3}, {{base64_64_v2}, &bitmap64_3}};
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
 }

--- a/be/test/vec/function/function_hll_test.cpp
+++ b/be/test/vec/function/function_hll_test.cpp
@@ -125,11 +125,11 @@ TEST(function_hll_test, function_hll_from_base64_test) {
     const std::string input5 = "AA==";
     HyperLogLog empty_hll;
 
-    DataSet data_set = {{{input1}, hll1},
-                        {{input2}, hll2},
-                        {{input3}, hll3},
-                        {{input4}, hll4},
-                        {{input5}, empty_hll}};
+    DataSet data_set = {{{input1}, &hll1},
+                        {{input2}, &hll2},
+                        {{input3}, &hll3},
+                        {{input4}, &hll4},
+                        {{input5}, &empty_hll}};
 
     static_cast<void>(check_function<DataTypeHLL, true>(func_name, input_types, data_set));
 }

--- a/be/test/vec/function/function_ifnull_test.cpp
+++ b/be/test/vec/function/function_ifnull_test.cpp
@@ -68,10 +68,10 @@ TEST(IfNullTest, String_Test) {
 TEST(IfNullTest, String_Int_Test) {
     std::string func_name = "ifnull";
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::DateTime};
-    DataSet data_set = {{{std::string("2021-10-24 12:32:31"), std::string("2021-10-24 13:00:01")},
-                         std::string("2021-10-24 12:32:31")},
-                        {{Null(), std::string("2021-10-24 13:00:01")},
-                         std::string("2021-10-24 13:00:01")}};
+    DataSet data_set = {
+            {{std::string("2021-10-24 12:32:31"), std::string("2021-10-24 13:00:01")},
+             std::string("2021-10-24 12:32:31")},
+            {{Null(), std::string("2021-10-24 13:00:01")}, std::string("2021-10-24 13:00:01")}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
 }

--- a/be/test/vec/function/function_ifnull_test.cpp
+++ b/be/test/vec/function/function_ifnull_test.cpp
@@ -69,9 +69,9 @@ TEST(IfNullTest, String_Int_Test) {
     std::string func_name = "ifnull";
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::DateTime};
     DataSet data_set = {{{std::string("2021-10-24 12:32:31"), std::string("2021-10-24 13:00:01")},
-                         str_to_date_time("2021-10-24 12:32:31")},
+                         std::string("2021-10-24 12:32:31")},
                         {{Null(), std::string("2021-10-24 13:00:01")},
-                         str_to_date_time("2021-10-24 13:00:01")}};
+                         std::string("2021-10-24 13:00:01")}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
 }

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -1232,7 +1232,7 @@ TEST(FunctionJsonbTEST, JsonbExtractDoubleTest) {
 
 TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
     std::string func_name = "CAST";
-    InputTypeSet input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::UInt8}};
+    InputTypeSet input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::UInt8}};
 
     // cast to boolean
     DataSet data_set = {
@@ -1265,7 +1265,7 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
         static_cast<void>(
                 check_function<DataTypeUInt8, true>(func_name, input_types, const_dataset));
     }
-    input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::Int8}};
+    input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::Int8}};
     // cast to TINYINT
     data_set = {
             {{STRING("null"), static_cast<int8_t>(TypeIndex::Int8)}, Null()},
@@ -1298,7 +1298,7 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
                 check_function<DataTypeInt8, true>(func_name, input_types, const_dataset));
     }
 
-    input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::Int16}};
+    input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::Int16}};
     // cast to SMALLINT
     data_set = {
             {{STRING("null"), static_cast<int16_t>(TypeIndex::Int16)}, Null()},
@@ -1332,7 +1332,7 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
                 check_function<DataTypeInt16, true>(func_name, input_types, const_dataset));
     }
 
-    input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::Int32}};
+    input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::Int32}};
     // cast to INT
     data_set = {
             {{STRING("null"), static_cast<int32_t>(TypeIndex::Int32)}, Null()},
@@ -1366,7 +1366,7 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
                 check_function<DataTypeInt32, true>(func_name, input_types, const_dataset));
     }
 
-    input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::Int64}};
+    input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::Int64}};
     // cast to BIGINT
     data_set = {
             {{STRING("null"), BIGINT(1)}, Null()},
@@ -1394,7 +1394,7 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
                 check_function<DataTypeInt64, true>(func_name, input_types, const_dataset));
     }
 
-    input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::Float64}};
+    input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::Float64}};
     // cast to DOUBLE
     data_set = {
             {{STRING("null"), DOUBLE(1)}, Null()},
@@ -1422,7 +1422,7 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
                 check_function<DataTypeFloat64, true>(func_name, input_types, const_dataset));
     }
 
-    input_types = {Nullable {TypeIndex::JSONB}, ConstedNotnull {TypeIndex::String}};
+    input_types = {Nullable {TypeIndex::JSONB}, Consted {TypeIndex::String}};
     // cast to STRING
     data_set = {
             {{STRING("null"), STRING("1")}, STRING("null")},
@@ -1456,61 +1456,61 @@ TEST(FunctionJsonbTEST, JsonbCastToOtherTest) {
 TEST(FunctionJsonbTEST, JsonbCastFromOtherTest) {
     // CAST Nullable(X) to Nullable(JSONB)
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::UInt8}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::UInt8}, Consted {TypeIndex::JSONB}},
             {{{BOOLEAN(1), Null()}, STRING("true")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::UInt8}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::UInt8}, Consted {TypeIndex::JSONB}},
             {{{BOOLEAN(0), Null()}, STRING("false")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::Int8}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::Int8}, Consted {TypeIndex::JSONB}},
             {{{TINYINT(100), Null()}, STRING("100")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::Int16}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::Int16}, Consted {TypeIndex::JSONB}},
             {{{SMALLINT(10000), Null()}, STRING("10000")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::Int32}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::Int32}, Consted {TypeIndex::JSONB}},
             {{{INT(1000000000), Null()}, STRING("1000000000")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::Int64}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::Int64}, Consted {TypeIndex::JSONB}},
             {{{BIGINT(1152921504606846976), Null()}, STRING("1152921504606846976")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::Float64}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::Float64}, Consted {TypeIndex::JSONB}},
             {{{DOUBLE(6.18), Null()}, STRING("6.18")}}));
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::String}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::String}, Consted {TypeIndex::JSONB}},
             {{{STRING(R"(abcd)"), Null()}, Null()}})); // should fail
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Nullable {TypeIndex::String}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Nullable {TypeIndex::String}, Consted {TypeIndex::JSONB}},
             {{{STRING(R"("abcd")"), Null()}, STRING(R"("abcd")")}}));
 
     // CAST X to JSONB
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::UInt8}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::UInt8}, Consted {TypeIndex::JSONB}},
             {{{BOOLEAN(1), Null()}, STRING("true")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::UInt8}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::UInt8}, Consted {TypeIndex::JSONB}},
             {{{BOOLEAN(0), Null()}, STRING("false")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int8}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::Int8}, Consted {TypeIndex::JSONB}},
             {{{TINYINT(100), Null()}, STRING("100")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int16}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::Int16}, Consted {TypeIndex::JSONB}},
             {{{SMALLINT(10000), Null()}, STRING("10000")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int32}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::Int32}, Consted {TypeIndex::JSONB}},
             {{{INT(1000000000), Null()}, STRING("1000000000")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int64}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::Int64}, Consted {TypeIndex::JSONB}},
             {{{BIGINT(1152921504606846976), Null()}, STRING("1152921504606846976")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Float64}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::Float64}, Consted {TypeIndex::JSONB}},
             {{{DOUBLE(6.18), Null()}, STRING("6.18")}}));
     // String to JSONB should always be Nullable
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Notnull {TypeIndex::String}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::String}, Consted {TypeIndex::JSONB}},
             {{{STRING(R"(abcd)"), Null()}, Null()}})); // should fail
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Notnull {TypeIndex::String}, ConstedNotnull {TypeIndex::JSONB}},
+            "CAST", {Notnull {TypeIndex::String}, Consted {TypeIndex::JSONB}},
             {{{STRING(R"("abcd")"), Null()}, STRING(R"("abcd")")}}));
 }
 

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -1496,7 +1496,7 @@ TEST(FunctionJsonbTEST, JsonbCastFromOtherTest) {
             {{{TINYINT(100), STRING()}, STRING("100")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
             "CAST", {Notnull {TypeIndex::Int16}, ConstedNotnull {TypeIndex::JSONB}},
-            {{{SMALLINT(10000), STRING()}, STRING( "10000")}}));
+            {{{SMALLINT(10000), STRING()}, STRING("10000")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
             "CAST", {Notnull {TypeIndex::Int32}, ConstedNotnull {TypeIndex::JSONB}},
             {{{INT(1000000000), STRING()}, STRING("1000000000")}}));

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -1483,35 +1483,36 @@ TEST(FunctionJsonbTEST, JsonbCastFromOtherTest) {
             "CAST", {Nullable {TypeIndex::String}, Consted {TypeIndex::JSONB}},
             {{{STRING(R"("abcd")"), Null()}, STRING(R"("abcd")")}}));
 
-    // CAST X to JSONB
+    // CAST X to JSONB. the second argument is just a dummy because result type is not nullable so we need it
+    // rather than a Null.
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::UInt8}, Consted {TypeIndex::JSONB}},
-            {{{BOOLEAN(1), Null()}, STRING("true")}}));
+            "CAST", {Notnull {TypeIndex::UInt8}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{BOOLEAN(1), STRING()}, STRING("true")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::UInt8}, Consted {TypeIndex::JSONB}},
-            {{{BOOLEAN(0), Null()}, STRING("false")}}));
+            "CAST", {Notnull {TypeIndex::UInt8}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{BOOLEAN(0), STRING()}, STRING("false")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int8}, Consted {TypeIndex::JSONB}},
-            {{{TINYINT(100), Null()}, STRING("100")}}));
+            "CAST", {Notnull {TypeIndex::Int8}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{TINYINT(100), STRING()}, STRING("100")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int16}, Consted {TypeIndex::JSONB}},
-            {{{SMALLINT(10000), Null()}, STRING("10000")}}));
+            "CAST", {Notnull {TypeIndex::Int16}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{SMALLINT(10000), STRING()}, STRING( "10000")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int32}, Consted {TypeIndex::JSONB}},
-            {{{INT(1000000000), Null()}, STRING("1000000000")}}));
+            "CAST", {Notnull {TypeIndex::Int32}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{INT(1000000000), STRING()}, STRING("1000000000")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Int64}, Consted {TypeIndex::JSONB}},
-            {{{BIGINT(1152921504606846976), Null()}, STRING("1152921504606846976")}}));
+            "CAST", {Notnull {TypeIndex::Int64}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{BIGINT(1152921504606846976), STRING()}, STRING("1152921504606846976")}}));
     static_cast<void>(check_function<DataTypeJsonb, false>(
-            "CAST", {Notnull {TypeIndex::Float64}, Consted {TypeIndex::JSONB}},
-            {{{DOUBLE(6.18), Null()}, STRING("6.18")}}));
+            "CAST", {Notnull {TypeIndex::Float64}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{DOUBLE(6.18), STRING()}, STRING("6.18")}}));
     // String to JSONB should always be Nullable
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Notnull {TypeIndex::String}, Consted {TypeIndex::JSONB}},
-            {{{STRING(R"(abcd)"), Null()}, Null()}})); // should fail
+            "CAST", {Notnull {TypeIndex::String}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{STRING(R"(abcd)"), STRING()}, Null()}})); // should fail
     static_cast<void>(check_function<DataTypeJsonb, true>(
-            "CAST", {Notnull {TypeIndex::String}, Consted {TypeIndex::JSONB}},
-            {{{STRING(R"("abcd")"), Null()}, STRING(R"("abcd")")}}));
+            "CAST", {Notnull {TypeIndex::String}, ConstedNotnull {TypeIndex::JSONB}},
+            {{{STRING(R"("abcd")"), STRING()}, STRING(R"("abcd")")}}));
 }
 
 TEST(FunctionJsonbTEST, GetJSONSTRINGTest) {

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -578,8 +578,8 @@ TEST(MathFunctionTest, money_format_test) {
     {
         BaseInputTypeSet input_types = {TypeIndex::Decimal64};
         DataSet data_set = {{{Null()}, Null()},
-                            {{DECIMAL64(17014116, 670000000)}, VARCHAR("17,014,116.67")},
-                            {{DECIMAL64(-17014116, -670000000)}, VARCHAR("-17,014,116.67")}};
+                            {{DECIMAL64(17014116, 670000000, 9)}, VARCHAR("17,014,116.67")},
+                            {{DECIMAL64(-17014116, -670000000, 9)}, VARCHAR("-17,014,116.67")}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -49,10 +49,10 @@ TEST(MathFunctionTest, acosh_test) {
     std::vector input_types = {TypeIndex::Float64};
 
     DataSet data_set = {{{1.0}, 0.0},
-                        {{2.0}, 1.3169578969248168},
+                        {{2.0}, 1.3169578969248166},
                         {{3.0}, 1.7627471740390861},
                         {{10.0}, 2.9932228461263808},
-                        {{100.0}, 5.2982923656104850}};
+                        {{100.0}, 5.298292365610484}};
 
     static_cast<void>(
             check_function_all_arg_comb<DataTypeFloat64, true>(func_name, input_types, data_set));
@@ -103,8 +103,8 @@ TEST(MathFunctionTest, atanh_test) {
     std::vector input_types = {TypeIndex::Float64};
 
     DataSet data_set = {{{0.0}, 0.0},
-                        {{0.5}, 0.5493061443340549},
-                        {{-0.5}, -0.5493061443340549},
+                        {{0.5}, 0.5493061443340548},
+                        {{-0.5}, -0.5493061443340548},
                         {{0.9}, 1.4722194895832204},
                         {{-0.9}, -1.4722194895832204}};
 
@@ -148,8 +148,8 @@ TEST(MathFunctionTest, sinh_test) {
     DataSet data_set = {{{0.0}, 0.0},
                         {{1.0}, 1.1752011936438014},
                         {{-1.0}, -1.1752011936438014},
-                        {{2.0}, 3.6268604078470186},
-                        {{-2.0}, -3.6268604078470186}};
+                        {{2.0}, 3.626860407847019},
+                        {{-2.0}, -3.626860407847019}};
 
     static_cast<void>(
             check_function_all_arg_comb<DataTypeFloat64, true>(func_name, input_types, data_set));

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -682,8 +682,8 @@ TEST(MathFunctionTest, format_round_test) {
     {
         InputTypeSet input_types = {{TypeIndex::Decimal64, 5, 18}, TypeIndex::Int32};
         DataSet data_set = {
-                // oob
-                {{DECIMAL64(12345678901234, 67000, 5), INT(2)}, VARCHAR("12,345,678,901,234.67")},
+                // oob of 9e19(int64)
+                {{DECIMAL64(123456789012345, 67000, 5), INT(2)}, VARCHAR("12,345,678,901,234.67")},
                 // different scale
                 {{DECIMAL64(-17014116, -671, 3), INT(2)}, VARCHAR("-17,014,116.67")},
         };

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -637,8 +637,8 @@ TEST(MathFunctionTest, format_round_test) {
         BaseInputTypeSet input_types = {TypeIndex::Decimal64, TypeIndex::Int32};
         DataSet data_set = {
                 {{Null(), INT(2)}, Null()},
-                {{DECIMAL64(17014116, 670000000), INT(2)}, VARCHAR("17,014,116.67")},
-                {{DECIMAL64(-17014116, -670000000), INT(2)}, VARCHAR("-17,014,116.67")}};
+                {{DECIMAL64(17014116, 670000000,9), INT(2)}, VARCHAR("17,014,116.67")},
+                {{DECIMAL64(-17014116, -670000000,9), INT(2)}, VARCHAR("-17,014,116.67")}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -46,7 +46,7 @@ TEST(MathFunctionTest, acos_test) {
 TEST(MathFunctionTest, acosh_test) {
     std::string func_name = "acosh"; // acosh(x) = ln(x + sqrt(x^2 - 1)), x ∈ [1, +∞)
 
-    std::vector input_types = {TypeIndex::Float64};
+    InputTypeSet input_types = {TypeIndex::Float64};
 
     DataSet data_set = {{{1.0}, 0.0},
                         {{2.0}, 1.3169578969248166},
@@ -72,7 +72,7 @@ TEST(MathFunctionTest, asin_test) {
 TEST(MathFunctionTest, asinh_test) {
     std::string func_name = "asinh"; // asinh(x) = ln(x + sqrt(x^2 + 1)), x ∈ (-∞, +∞)
 
-    std::vector input_types = {TypeIndex::Float64};
+    InputTypeSet input_types = {TypeIndex::Float64};
 
     DataSet data_set = {{{0.0}, 0.0},
                         {{1.0}, 0.8813735870195430},
@@ -100,7 +100,7 @@ TEST(MathFunctionTest, atan_test) {
 TEST(MathFunctionTest, atanh_test) {
     std::string func_name = "atanh"; // atanh(x) = 0.5 * ln((1 + x) / (1 - x)), x ∈ (-1, 1)
 
-    std::vector input_types = {TypeIndex::Float64};
+    InputTypeSet input_types = {TypeIndex::Float64};
 
     DataSet data_set = {{{0.0}, 0.0},
                         {{0.5}, 0.5493061443340548},
@@ -143,7 +143,7 @@ TEST(MathFunctionTest, sin_test) {
 TEST(MathFunctionTest, sinh_test) {
     std::string func_name = "sinh"; // sinh(x) = (e^x - e^(-x)) / 2, x ∈ (-∞, +∞)
 
-    std::vector input_types = {TypeIndex::Float64};
+    InputTypeSet input_types = {TypeIndex::Float64};
 
     DataSet data_set = {{{0.0}, 0.0},
                         {{1.0}, 1.1752011936438014},
@@ -576,7 +576,7 @@ TEST(MathFunctionTest, money_format_test) {
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
     }
     {
-        BaseInputTypeSet input_types = {TypeIndex::Decimal64};
+        InputTypeSet input_types = {TypeIndex::Decimal64};
         DataSet data_set = {{{Null()}, Null()},
                             {{DECIMAL64(17014116, 670000000, 9)}, VARCHAR("17,014,116.67")},
                             {{DECIMAL64(-17014116, -670000000, 9)}, VARCHAR("-17,014,116.67")}};
@@ -634,11 +634,12 @@ TEST(MathFunctionTest, format_round_test) {
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
     }
     {
-        BaseInputTypeSet input_types = {TypeIndex::Decimal64, TypeIndex::Int32};
+        InputTypeSet input_types = {{TypeIndex::Decimal64, 5, 18}, TypeIndex::Int32};
         DataSet data_set = {
                 {{Null(), INT(2)}, Null()},
-                {{DECIMAL64(17014116, 670000000,9), INT(2)}, VARCHAR("17,014,116.67")},
-                {{DECIMAL64(-17014116, -670000000,9), INT(2)}, VARCHAR("-17,014,116.67")}};
+                {{DECIMAL64(17014116, 670000000, 9), INT(2)}, VARCHAR("17,014,116.67")},
+                {{DECIMAL64(-17014116, -670000000, 9), INT(2)}, VARCHAR("-17,014,116.67")},
+                {{DECIMAL64(-17014116, -67000, 5), INT(2)}, VARCHAR("-17,014,116.67")}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }

--- a/be/test/vec/function/function_nullif_test.cpp
+++ b/be/test/vec/function/function_nullif_test.cpp
@@ -51,10 +51,10 @@ TEST(NullIfTest, String_Int_Test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::DateTime};
     DataSet data_set = {
             {{std::string("2021-10-24 12:32:31"), std::string("2021-10-24 13:00:01")},
-             str_to_date_time("2021-10-24 12:32:31")},
+             std::string("2021-10-24 12:32:31")},
             {{std::string("2021-10-24 13:00:01"), std::string("2021-10-24 13:00:01")}, Null()},
             {{std::string("2021-10-24 13:00:01"), Null()},
-             str_to_date_time("2021-10-24 13:00:01")}};
+             std::string("2021-10-24 13:00:01")}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
 }

--- a/be/test/vec/function/function_nullif_test.cpp
+++ b/be/test/vec/function/function_nullif_test.cpp
@@ -53,8 +53,7 @@ TEST(NullIfTest, String_Int_Test) {
             {{std::string("2021-10-24 12:32:31"), std::string("2021-10-24 13:00:01")},
              std::string("2021-10-24 12:32:31")},
             {{std::string("2021-10-24 13:00:01"), std::string("2021-10-24 13:00:01")}, Null()},
-            {{std::string("2021-10-24 13:00:01"), Null()},
-             std::string("2021-10-24 13:00:01")}};
+            {{std::string("2021-10-24 13:00:01"), Null()}, std::string("2021-10-24 13:00:01")}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
 }

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -1429,11 +1429,11 @@ TEST(function_string_test, function_concat_ws_test) {
     {
         BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Array, TypeIndex::String};
 
-        Array vec1 = {Field(String("", 0)), Field(String("", 0)), Field(String("", 0))};
-        Array vec2 = {Field(String("123", 3)), Field(String("456", 3)), Field(String("789", 3))};
-        Array vec3 = {Field(String("", 0)), Field(String("?", 1)), Field(String("", 0))};
-        Array vec4 = {Field(String("abc", 3)), Field(String("", 0)), Field(String("def", 3))};
-        Array vec5 = {Field(String("abc", 3)), Field(String("def", 3)), Field(String("ghi", 3))};
+        TestArray vec1 = {std::string(""), std::string(""), std::string("")};
+        TestArray vec2 = {std::string("123"), std::string("456"), std::string("789")};
+        TestArray vec3 = {std::string(""), std::string("?"), std::string("")};
+        TestArray vec4 = {std::string("abc"), std::string(""), std::string("def")};
+        TestArray vec5 = {std::string("abc"), std::string("def"), std::string("ghi")};
         DataSet data_set = {{{std::string("-"), vec1}, std::string("--")},
                             {{std::string(""), vec2}, std::string("123456789")},
                             {{std::string("-"), vec3}, std::string("-?-")},

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -1410,7 +1410,7 @@ TEST(function_string_test, function_concat_ws_test) {
 
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("-"), std::string(""), std::string(""), std::string("")},
@@ -1973,7 +1973,7 @@ TEST(function_string_test, function_aes_encrypt_test) {
     }
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
         const char* iv = "0123456789abcdef";
         const char* mode = "AES_256_ECB";
         const char* key = "vectorized";
@@ -2040,7 +2040,7 @@ TEST(function_string_test, function_aes_decrypt_test) {
     }
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";
         const char* mode = "AES_128_OFB";
@@ -2077,7 +2077,7 @@ TEST(function_string_test, function_sm4_encrypt_test) {
     std::string func_name = "sm4_encrypt";
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
 
         const char* key = "doris";
         const char* iv = "0123456789abcdef";
@@ -2115,7 +2115,7 @@ TEST(function_string_test, function_sm4_encrypt_test) {
 
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
 
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";
@@ -2156,7 +2156,7 @@ TEST(function_string_test, function_sm4_decrypt_test) {
     std::string func_name = "sm4_decrypt";
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
 
         const char* key = "doris";
         const char* iv = "0123456789abcdef";
@@ -2192,7 +2192,7 @@ TEST(function_string_test, function_sm4_decrypt_test) {
 
     {
         InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                        TypeIndex::String};
+                                    TypeIndex::String};
 
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -35,7 +35,7 @@ TEST(function_string_test, function_string_substr_test) {
     std::string func_name = "substr";
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("AbCdEfg"), std::int32_t(1), std::int32_t(1)}, std::string("A")},
@@ -343,7 +343,7 @@ TEST(function_string_test, function_string_substr_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("ABC"), std::int32_t(123)}, std::string("")},
@@ -385,7 +385,7 @@ TEST(function_string_test, function_string_strright_test) {
     std::string func_name = "strright";
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("asd"), 1}, std::string("d")},
@@ -421,7 +421,7 @@ TEST(function_string_test, function_string_strright_test) {
 TEST(function_string_test, function_string_strleft_test) {
     std::string func_name = "strleft";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("asd"), 1}, std::string("a")},
@@ -487,7 +487,7 @@ TEST(function_string_test, function_string_strleft_test) {
 TEST(function_string_test, function_string_lower_test) {
     std::string func_name = "lower";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("AbCdEfg")}, std::string("abcdefg")},
                 {{std::string("HELLO123")}, std::string("hello123")},
@@ -514,7 +514,7 @@ TEST(function_string_test, function_string_lower_test) {
 TEST(function_string_test, function_string_upper_test) {
     std::string func_name = "upper";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("AbCdEfg")}, std::string("ABCDEFG")},
                 {{std::string("HELLO123")}, std::string("HELLO123")},
@@ -563,7 +563,7 @@ TEST(function_string_test, function_string_upper_test) {
 TEST(function_string_test, function_string_trim_test) {
     std::string func_name = "trim";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("    paddedStringNoEscape   ")}, std::string("paddedStringNoEscape")},
                 {{std::string("singleWord")}, std::string("singleWord")},
@@ -611,7 +611,7 @@ TEST(function_string_test, function_string_trim_test) {
 
 TEST(function_string_test, function_string_ltrim_test) {
     std::string func_name = "ltrim";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("AbCdEfg")}, std::string("AbCdEfg")},
             {{std::string("你好HELLO")}, std::string("你好HELLO")},
@@ -630,7 +630,7 @@ TEST(function_string_test, function_string_ltrim_test) {
 
 TEST(function_string_test, function_string_rtrim_test) {
     std::string func_name = "rtrim";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {{
             {{std::string("AbCdEfg")}, std::string("AbCdEfg")},
             {{std::string("你好HELLO")}, std::string("你好HELLO")},
@@ -651,7 +651,7 @@ TEST(function_string_test, function_string_rtrim_test) {
 TEST(function_string_test, function_string_repeat_test) {
     std::string func_name = "repeat";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("AbCdEfg"), std::int32_t(1)}, std::string("AbCdEfg")},
@@ -753,7 +753,7 @@ TEST(function_string_test, function_string_repeat_test) {
 TEST(function_string_test, function_string_reverse_test) {
     std::string func_name = "reverse";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("AbCdEfg")}, std::string("gfEdCbA")},
                 {{std::string("HELLO123")}, std::string("321OLLEH")},
@@ -814,7 +814,7 @@ TEST(function_string_test, function_string_reverse_test) {
 
 TEST(function_string_test, function_string_length_test) {
     std::string func_name = "length";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9")}, std::int32_t(12)},
             {{std::string("aGVsbG8gd29ybGQ")}, std::int32_t(15)},
@@ -858,7 +858,7 @@ TEST(function_string_test, function_string_length_test) {
 
 TEST(function_string_test, function_string_quote_test) {
     std::string func_name = "quote";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("hello")}, std::string(R"('hello')")},
             {{std::string("hello\t\n\nworld")}, std::string("'hello\t\n\nworld'")},
@@ -879,7 +879,7 @@ TEST(function_string_test, function_string_quote_test) {
 TEST(function_string_test, function_append_trailing_char_if_absent_test) {
     std::string func_name = "append_trailing_char_if_absent";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("ASD"), std::string("D")}, std::string("ASD")},
                         {{std::string("AS"), std::string("D")}, std::string("ASD")},
@@ -898,7 +898,7 @@ TEST(function_string_test, function_append_trailing_char_if_absent_test) {
 TEST(function_string_test, function_starts_with_test) {
     std::string func_name = "starts_with";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("hello world"), std::string("hello")}, uint8_t(1)},
                         {{std::string("hello world"), std::string("world")}, uint8_t(0)},
@@ -913,7 +913,7 @@ TEST(function_string_test, function_starts_with_test) {
 TEST(function_string_test, function_ends_with_test) {
     std::string func_name = "ends_with";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string("hello world"), std::string("hello")}, uint8_t(0)},
                         {{std::string("hello world"), std::string("world")}, uint8_t(1)},
@@ -950,7 +950,7 @@ TEST(function_string_test, function_ends_with_test) {
 TEST(function_string_test, function_ascii_test) {
     std::string func_name = "ascii";
 
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9")}, std::int32_t(89)},
@@ -972,7 +972,7 @@ TEST(function_string_test, function_ascii_test) {
 TEST(function_string_test, function_char_length_test) {
     std::string func_name = "char_length";
 
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9")}, std::int32_t(12)},
@@ -994,7 +994,7 @@ TEST(function_string_test, function_char_length_test) {
 TEST(function_string_test, function_concat_test) {
     std::string func_name = "concat";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
 
         DataSet data_set = {{{std::string("")}, std::string("")},
                             {{std::string("123")}, std::string("123")},
@@ -1004,7 +1004,7 @@ TEST(function_string_test, function_concat_test) {
     };
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("AbCdEfg"), std::string("AbCdEfg")}, std::string("AbCdEfgAbCdEfg")},
@@ -1171,7 +1171,7 @@ TEST(function_string_test, function_concat_test) {
     };
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string(""), std::string("1"), std::string("")}, std::string("1")},
@@ -1187,7 +1187,7 @@ TEST(function_string_test, function_elt_test) {
     std::string func_name = "elt";
 
     {
-        BaseInputTypeSet input_types = {
+        InputTypeSet input_types = {
                 TypeIndex::Int32,
                 TypeIndex::String,
                 TypeIndex::String,
@@ -1261,7 +1261,7 @@ TEST(function_string_test, function_elt_test) {
 TEST(function_string_test, function_concat_ws_test) {
     std::string func_name = "concat_ws";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("AbCdEfg"), std::string("AbCdEfg")}, std::string("AbCdEfg")},
@@ -1396,7 +1396,7 @@ TEST(function_string_test, function_concat_ws_test) {
     };
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("-"), std::string(""), std::string("")}, std::string("-")},
@@ -1409,7 +1409,7 @@ TEST(function_string_test, function_concat_ws_test) {
     };
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
 
         DataSet data_set = {
@@ -1427,7 +1427,7 @@ TEST(function_string_test, function_concat_ws_test) {
     };
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Array, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::Array, TypeIndex::String};
 
         TestArray vec1 = {std::string(""), std::string(""), std::string("")};
         TestArray vec2 = {std::string("123"), std::string("456"), std::string("789")};
@@ -1447,7 +1447,7 @@ TEST(function_string_test, function_concat_ws_test) {
 TEST(function_string_test, function_null_or_empty_test) {
     std::string func_name = "null_or_empty";
 
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("")}, uint8(true)},
                         {{std::string("aa")}, uint8(false)},
@@ -1459,7 +1459,7 @@ TEST(function_string_test, function_null_or_empty_test) {
 
 TEST(function_string_test, function_to_base64_test) {
     std::string func_name = "to_base64";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("ABC")}, std::string("QUJD")},
@@ -1484,7 +1484,7 @@ TEST(function_string_test, function_to_base64_test) {
 
 TEST(function_string_test, function_from_base64_test) {
     std::string func_name = "from_base64";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9")}, std::string("asd你好")},
@@ -1504,7 +1504,7 @@ TEST(function_string_test, function_from_base64_test) {
 
 TEST(function_string_test, function_reverse_test) {
     std::string func_name = "reverse";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("AbCdEfg")}, std::string("gfEdCbA")},
             {{std::string("HELLO123")}, std::string("321OLLEH")},
@@ -1524,7 +1524,7 @@ TEST(function_string_test, function_reverse_test) {
 TEST(function_string_test, function_instr_test) {
     std::string func_name = "instr";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("ABC"), std::string("ABC")}, std::int32_t(1)},
@@ -1607,7 +1607,7 @@ TEST(function_string_test, function_locate_test) {
     std::string func_name = "locate";
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
         DataSet data_set = {
                 {{std::string("ABC"), std::string("ABC")}, std::int32_t(1)},
@@ -1674,7 +1674,7 @@ TEST(function_string_test, function_locate_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
 
         DataSet data_set = {
                 {{std::string("ABC"), std::string("ABC"), std::int32_t(100)}, std::int32_t(0)},
@@ -1807,7 +1807,7 @@ TEST(function_string_test, function_locate_test) {
 TEST(function_string_test, function_find_in_set_test) {
     std::string func_name = "find_in_set";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("ABC"), std::string("A,B,C")}, std::int32_t(0)},
@@ -1845,7 +1845,7 @@ TEST(function_string_test, function_md5sum_test) {
     std::string func_name = "md5sum";
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("asd你好")}, {std::string("a38c15675555017e6b8ea042f2eb24f5")}},
                 {{std::string("hello world")}, {std::string("5eb63bbbe01eeed093cb22bb8f5acdc3")}},
@@ -1860,7 +1860,7 @@ TEST(function_string_test, function_md5sum_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
         DataSet data_set = {{{std::string("asd"), std::string("你好")},
                              {std::string("a38c15675555017e6b8ea042f2eb24f5")}},
                             {{std::string("hello "), std::string("world")},
@@ -1873,7 +1873,7 @@ TEST(function_string_test, function_md5sum_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {{{std::string("a"), std::string("sd"), std::string("你好")},
                              {std::string("a38c15675555017e6b8ea042f2eb24f5")}},
                             {{std::string(""), std::string(""), std::string("")},
@@ -1890,7 +1890,7 @@ TEST(function_string_test, function_sm3sum_test) {
     std::string func_name = "sm3sum";
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         DataSet data_set = {
                 {{std::string("asd你好")},
                  {std::string("0d6b9dfa8fe5708eb0dccfbaff4f2964abaaa976cc4445a7ecace49c0ceb31d3")}},
@@ -1913,7 +1913,7 @@ TEST(function_string_test, function_sm3sum_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("asd"), std::string("你好")},
                  {std::string("0d6b9dfa8fe5708eb0dccfbaff4f2964abaaa976cc4445a7ecace49c0ceb31d3")}},
@@ -1927,7 +1927,7 @@ TEST(function_string_test, function_sm3sum_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("a"), std::string("sd"), std::string("你好")},
                  {std::string("0d6b9dfa8fe5708eb0dccfbaff4f2964abaaa976cc4445a7ecace49c0ceb31d3")}},
@@ -1944,7 +1944,7 @@ TEST(function_string_test, function_sm3sum_test) {
 TEST(function_string_test, function_aes_encrypt_test) {
     std::string func_name = "aes_encrypt";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         const char* mode = "AES_128_ECB";
         const char* key = "doris";
@@ -1972,7 +1972,7 @@ TEST(function_string_test, function_aes_encrypt_test) {
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
         const char* iv = "0123456789abcdef";
         const char* mode = "AES_256_ECB";
@@ -2012,7 +2012,7 @@ TEST(function_string_test, function_aes_encrypt_test) {
 TEST(function_string_test, function_aes_decrypt_test) {
     std::string func_name = "aes_decrypt";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
         const char* mode = "AES_128_ECB";
         const char* key = "doris";
@@ -2039,7 +2039,7 @@ TEST(function_string_test, function_aes_decrypt_test) {
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
     }
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
         const char* key = "vectorized";
         const char* iv = "0123456789abcdef";
@@ -2076,7 +2076,7 @@ TEST(function_string_test, function_aes_decrypt_test) {
 TEST(function_string_test, function_sm4_encrypt_test) {
     std::string func_name = "sm4_encrypt";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
 
         const char* key = "doris";
@@ -2114,7 +2114,7 @@ TEST(function_string_test, function_sm4_encrypt_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
 
         const char* key = "vectorized";
@@ -2155,7 +2155,7 @@ TEST(function_string_test, function_sm4_encrypt_test) {
 TEST(function_string_test, function_sm4_decrypt_test) {
     std::string func_name = "sm4_decrypt";
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
 
         const char* key = "doris";
@@ -2191,7 +2191,7 @@ TEST(function_string_test, function_sm4_decrypt_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
                                         TypeIndex::String};
 
         const char* key = "vectorized";
@@ -2229,7 +2229,7 @@ TEST(function_string_test, function_sm4_decrypt_test) {
 
 TEST(function_string_test, function_extract_url_parameter_test) {
     std::string func_name = "extract_url_parameter";
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
     DataSet data_set = {
             {{VARCHAR(""), VARCHAR("k1")}, {VARCHAR("")}},
             {{VARCHAR("http://doris.apache.org?k1=aa"), VARCHAR("")}, {VARCHAR("")}},
@@ -2256,7 +2256,7 @@ TEST(function_string_test, function_parse_url_test) {
     std::string func_name = "parse_url";
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("zhangsan"), std::string("HOST")}, {Null()}},
                 {{std::string("facebook.com/path/p1"), std::string("HOST")}, {Null()}},
@@ -2303,7 +2303,7 @@ TEST(function_string_test, function_parse_url_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{std::string("http://fb.com/path/p1.p?q=1#f"), std::string("QUERY"),
                   std::string("q")},
@@ -2323,7 +2323,7 @@ TEST(function_string_test, function_parse_url_test) {
 
 TEST(function_string_test, function_hex_test) {
     std::string func_name = "hex";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("AbCdEfg")}, std::string("41624364456667")},
             {{std::string("你好HELLO")}, std::string("E4BDA0E5A5BD48454C4C4F")},
@@ -2343,7 +2343,7 @@ TEST(function_string_test, function_hex_test) {
 
 TEST(function_string_test, function_unhex_test) {
     std::string unhex_func_name = "unhex";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("41624364456667")}, std::string("AbCdEfg")},
             {{std::string("E4BDA0E5A5BD48454C4C4F")}, std::string("你好HELLO")},
@@ -2382,7 +2382,7 @@ TEST(function_string_test, function_unhex_test) {
 TEST(function_string_test, function_coalesce_test) {
     std::string func_name = "coalesce";
     {
-        BaseInputTypeSet input_types = {TypeIndex::Int32, TypeIndex::Int32, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::Int32, TypeIndex::Int32};
         DataSet data_set = {{{Null(), Null(), (int32_t)1}, {(int32_t)1}},
                             {{Null(), Null(), (int32_t)2}, {(int32_t)2}},
                             {{Null(), Null(), (int32_t)3}, {(int32_t)3}},
@@ -2392,7 +2392,7 @@ TEST(function_string_test, function_coalesce_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::Int32};
         DataSet data_set = {
                 {{std::string("qwer"), Null(), (int32_t)1}, {std::string("qwer")}},
                 {{std::string("asdf"), Null(), (int32_t)2}, {std::string("asdf")}},
@@ -2403,7 +2403,7 @@ TEST(function_string_test, function_coalesce_test) {
     }
 
     {
-        BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
         DataSet data_set = {
                 {{Null(), std::string("abc"), std::string("hij")}, {std::string("abc")}},
                 {{Null(), std::string("def"), std::string("klm")}, {std::string("def")}},
@@ -2415,7 +2415,7 @@ TEST(function_string_test, function_coalesce_test) {
 
 TEST(function_string_test, function_replace) {
     std::string func_name = "replace";
-    BaseInputTypeSet input_types = {
+    InputTypeSet input_types = {
             TypeIndex::String,
             TypeIndex::String,
             TypeIndex::String,
@@ -2689,7 +2689,7 @@ TEST(function_string_test, function_replace) {
 
 TEST(function_string_test, function_replace_empty) {
     std::string func_name = "replace_empty";
-    BaseInputTypeSet input_types = {
+    InputTypeSet input_types = {
             TypeIndex::String,
             TypeIndex::String,
             TypeIndex::String,
@@ -2971,7 +2971,7 @@ TEST(function_string_test, function_replace_empty) {
 
 TEST(function_string_test, function_bit_length_test) {
     std::string func_name = "bit_length";
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9")}, std::int32_t(96)},
             {{std::string("aGVsbG8gd29ybGQ")}, std::int32_t(120)},
@@ -2992,7 +2992,7 @@ TEST(function_string_test, function_bit_length_test) {
 TEST(function_string_test, function_uuid_test) {
     {
         std::string func_name = "uuid_to_int";
-        BaseInputTypeSet input_types = {TypeIndex::String};
+        InputTypeSet input_types = {TypeIndex::String};
         uint64_t high = 9572195551486940809ULL;
         uint64_t low = 1759290071393952876ULL;
         __int128 result = (__int128)high * (__int128)10000000000000000000ULL + (__int128)low;
@@ -3006,7 +3006,7 @@ TEST(function_string_test, function_uuid_test) {
     }
     {
         std::string func_name = "int_to_uuid";
-        BaseInputTypeSet input_types = {TypeIndex::Int128};
+        InputTypeSet input_types = {TypeIndex::Int128};
         uint64_t high = 9572195551486940809ULL;
         uint64_t low = 1759290071393952876ULL;
         __int128 value = (__int128)high * (__int128)10000000000000000000ULL + (__int128)low;
@@ -3137,7 +3137,7 @@ TEST(function_string_test, function_overlay_test) {
 TEST(function_string_test, function_initcap) {
     std::string func_name {"initcap"};
 
-    BaseInputTypeSet input_types = {TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String};
 
     DataSet data_set = {{{std::string("SKJ_ASD_SAD _1A")}, std::string("Skj_Asd_Sad _1a")},
                         {{std::string("BC'S aaaaA'' 'S")}, std::string("Bc'S Aaaaa'' 'S")},
@@ -3155,7 +3155,7 @@ TEST(function_string_test, function_initcap) {
 TEST(function_string_test, function_lpad_test) {
     std::string func_name = "lpad";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9"), std::int32_t(1), std::string("__123hehe1")},
@@ -3276,7 +3276,7 @@ TEST(function_string_test, function_lpad_test) {
 TEST(function_string_test, function_rpad_test) {
     std::string func_name = "rpad";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::Int32, TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("YXNk5L2g5aW9"), std::int32_t(1), std::string("__123hehe1")},
@@ -3396,7 +3396,7 @@ TEST(function_string_test, function_rpad_test) {
 
 TEST(function_string_test, function_xpath_string_test) {
     std::string func_name = "xpath_string";
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {
             {{std::string("<a>123</a>"), std::string("/a")}, std::string("123")},

--- a/be/test/vec/function/function_test_template.cpp
+++ b/be/test/vec/function/function_test_template.cpp
@@ -27,7 +27,7 @@ namespace doris::vectorized {
 TEST(FunctionTestTemplate, two_args_template) {
     std::string func_name = "atan2";
 
-    BaseInputTypeSet input_types = {TypeIndex::Float64, TypeIndex::Float64};
+    InputTypeSet input_types = {TypeIndex::Float64, TypeIndex::Float64};
 
     DataSet data_set = {
             {{-1.0, -2.0}, -2.677945044588987},    {{0.0, 0.0}, 0.0},
@@ -41,7 +41,7 @@ TEST(FunctionTestTemplate, two_args_template) {
 TEST(FunctionTestTemplate, three_args_template) {
     std::string func_name = "concat";
 
-    BaseInputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String};
 
     DataSet data_set = {{{std::string(""), std::string(""), std::string("")}, std::string("")},
                         {{std::string("123"), std::string("456"), std::string("789")},

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -63,6 +63,7 @@ static size_t type_index_to_data_type(const std::vector<AnyType>& input_types, s
     // default is nullable
     if (input_types[index].type() == &typeid(Consted)) {
         tp = any_cast<Consted>(input_types[index]).tp;
+        ut_desc.is_nullable = true;
     } else if (input_types[index].type() == &typeid(ConstedNotnull)) {
         tp = any_cast<ConstedNotnull>(input_types[index]).tp;
         ut_desc.is_nullable = false;
@@ -90,7 +91,7 @@ static size_t type_index_to_data_type(const std::vector<AnyType>& input_types, s
         type = std::make_shared<DataTypeBitMap>();
         return 1;
     case TypeIndex::HLL:
-        desc.type = doris::PrimitiveType::TYPE_OBJECT;
+        desc.type = doris::PrimitiveType::TYPE_HLL;
         type = std::make_shared<DataTypeHLL>();
         return 1;
     case TypeIndex::IPv4:
@@ -349,10 +350,10 @@ bool insert_cell(MutableColumnPtr& column, DataTypePtr type_ptr, const AnyType& 
         auto str = any_cast<ut_type::STRING>(cell);
         JsonBinaryValue jsonb_val(str.c_str(), str.size());
         column->insert_data(jsonb_val.value(), jsonb_val.size());
-    } else if (type.idx == TypeIndex::BitMap) {
+    } else if (type.is_bitmap()) {
         auto* bitmap = any_cast<BitmapValue*>(cell);
         column->insert_data((char*)bitmap, sizeof(BitmapValue));
-    } else if (type.idx == TypeIndex::HLL) {
+    } else if (type.is_hll()) {
         auto* hll = any_cast<HyperLogLog*>(cell);
         column->insert_data((char*)hll, sizeof(HyperLogLog));
     } else if (type.is_ipv4()) {

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -241,7 +241,7 @@ static size_t type_index_to_data_type(const std::vector<AnyType>& input_types, s
         type = std::make_shared<DataTypeStruct>(sub_types);
         return ret + 1;
     }
-    case TypeIndex::Nullable: {
+    case TypeIndex::Nullable: { //TODO: use Nullable(T) to replace (Nullable, T)
         ++index;
         size_t ret = type_index_to_data_type(input_types, index, ut_desc, type);
         if (ret <= 0) {

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
 #include <mysql/mysql.h>
 
 #include <cstdint>
@@ -35,7 +36,6 @@
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
 #include "vec/core/block.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/core/wide_integer.h"
 #include "vec/data_types/data_type.h"
@@ -53,6 +53,8 @@ class TableFunction;
 template <typename T>
 class DataTypeDecimal;
 
+// for an input row with only one column, should use {AnyType(xxx)} to represent it because TestArray is same with
+// InputCell. just {} will be treated as copy-constructor rather than initializer list.
 using TestArray = std::vector<AnyType>;
 //TODO: replace Map, Struct with AnyType combinations too
 
@@ -71,7 +73,7 @@ struct Nullable {
 struct Notnull {
     TypeIndex tp;
 };
-
+// Consted already defined in types.h
 struct ConstedNotnull {
     TypeIndex tp;
 };
@@ -243,7 +245,7 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
     }();
     auto func = SimpleFunctionFactory::instance().get_function(
             func_name, block.get_columns_with_type_and_name(), return_type);
-    EXPECT_TRUE(func != nullptr);
+    ASSERT_TRUE(func != nullptr);
 
     TypeDescriptor fn_ctx_return = get_return_type_descriptor<ResultType>();
 

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -243,9 +243,9 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
                                   : std::make_shared<ResultType>();
         }
     }();
-    auto func = SimpleFunctionFactory::instance().get_function(
+    FunctionBasePtr func = SimpleFunctionFactory::instance().get_function(
             func_name, block.get_columns_with_type_and_name(), return_type);
-    ASSERT_TRUE(func != nullptr);
+    assert(func.get() != nullptr);
 
     TypeDescriptor fn_ctx_return = get_return_type_descriptor<ResultType>();
 
@@ -302,11 +302,13 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
 
         if (expect_result_ne) {
             EXPECT_NE(0, column->compare_at(i, i, *expected_col_ptr, 1))
-                    << ", function result: " << block.get_data_types()[result]->to_string(*column, i)
+                    << ", function result: "
+                    << block.get_data_types()[result]->to_string(*column, i)
                     << ", expected result: " << result_type_ptr->to_string(*expected_col_ptr, i);
         } else {
             EXPECT_EQ(0, column->compare_at(i, i, *expected_col_ptr, 1))
-                    << ", function result: " << block.get_data_types()[result]->to_string(*column, i)
+                    << ", function result: "
+                    << block.get_data_types()[result]->to_string(*column, i)
                     << ", expected result: " << result_type_ptr->to_string(*expected_col_ptr, i);
         }
     }

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -259,7 +259,6 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
 
     auto result = block.columns() - 1;
     auto st = func->execute(fn_ctx, block, arguments, result, row_size);
-    std::cout << block.dump_data() << std::endl;
     if (expect_execute_fail) {
         EXPECT_NE(Status::OK(), st);
         return st;

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -16,16 +16,10 @@
 // under the License.
 
 #include <gtest/gtest.h>
-#include <stdint.h>
 
-#include <iomanip>
 #include <string>
-#include <vector>
 
-#include "common/status.h"
 #include "function_test_util.h"
-#include "runtime/runtime_state.h"
-#include "testutil/any_type.h"
 #include "util/timezone_utils.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_date.h"
@@ -104,7 +98,7 @@ TEST(VTimestampFunctionsTest, quarter_test) {
     InputTypeSet input_types = {TypeIndex::DateTime};
 
     DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, int8_t {1}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2021-01-32 00:00:00")}, Null()},
                         {{std::string("2025-10-23 00:00:00")}, int8_t {4}}};
 
@@ -117,7 +111,7 @@ TEST(VTimestampFunctionsTest, month_test) {
     InputTypeSet input_types = {TypeIndex::DateTime};
 
     DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, int8_t {1}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2021-01-32 00:00:00")}, Null()},
                         {{std::string("2025-05-23 00:00:00")}, int8_t {5}}};
 
@@ -130,7 +124,7 @@ TEST(VTimestampFunctionsTest, day_test) {
     InputTypeSet input_types = {TypeIndex::DateTime};
 
     DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, int8_t {1}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2021-01-32 00:00:00")}, Null()},
                         {{std::string("2025-05-23 00:00:00")}, int8_t {23}}};
 
@@ -144,7 +138,7 @@ TEST(VTimestampFunctionsTest, hour_test) {
 
     DataSet data_set = {{{std::string("2021-01-01 23:59:59")}, int8_t {23}},
                         {{std::string("2021-01-13 16:56:00")}, int8_t {16}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2025-05-23 24:00:00")}, Null()}};
 
     static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
@@ -157,7 +151,7 @@ TEST(VTimestampFunctionsTest, minute_test) {
 
     DataSet data_set = {{{std::string("2021-01-01 23:59:50")}, int8_t {59}},
                         {{std::string("2021-01-13 16:20:00")}, int8_t {20}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2025-05-23 24:00:00")}, Null()}};
 
     static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
@@ -170,7 +164,7 @@ TEST(VTimestampFunctionsTest, second_test) {
 
     DataSet data_set = {{{std::string("2021-01-01 23:50:59")}, int8_t {59}},
                         {{std::string("2021-01-13 16:20:00")}, int8_t {0}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2025-05-23 24:00:00")}, Null()}};
 
     static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
@@ -304,7 +298,7 @@ TEST(VTimestampFunctionsTest, years_add_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2025-05-23 00:00:00")},
                 {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2015-05-23 00:00:00")},
-                {{std::string(""), 5}, Null()},
+                {{Null(), 5}, Null()},
                 {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -327,7 +321,7 @@ TEST(VTimestampFunctionsTest, years_sub_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2015-05-23 00:00:00")},
                 {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2025-05-23 00:00:00")},
-                {{std::string(""), 5}, Null()},
+                {{Null(), 5}, Null()},
                 {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -349,7 +343,6 @@ TEST(VTimestampFunctionsTest, months_add_test) {
     DataSet data_set = {
             {{std::string("2020-10-23 00:00:00"), -4}, str_to_date_time("2020-06-23 00:00:00")},
             {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-09-23 00:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 00:00:00"), 10}, str_to_date_time("2021-03-23 00:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -364,7 +357,6 @@ TEST(VTimestampFunctionsTest, months_sub_test) {
     DataSet data_set = {
             {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-01-23 00:00:00")},
             {{std::string("2020-05-23 00:00:00"), -4}, str_to_date_time("2020-09-23 00:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 00:00:00"), 10}, str_to_date_time("2019-07-23 00:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -379,7 +371,6 @@ TEST(VTimestampFunctionsTest, days_add_test) {
     DataSet data_set = {
             {{std::string("2020-10-23 00:00:00"), -4}, str_to_date_time("2020-10-19 00:00:00")},
             {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-05-27 00:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 00:00:00"), 10}, str_to_date_time("2020-06-2 00:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -394,7 +385,6 @@ TEST(VTimestampFunctionsTest, days_sub_test) {
     DataSet data_set = {
             {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-05-19 00:00:00")},
             {{std::string("2020-05-23 00:00:00"), -4}, str_to_date_time("2020-05-27 00:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 00:00:00"), 31}, str_to_date_time("2020-04-22 00:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -409,7 +399,6 @@ TEST(VTimestampFunctionsTest, hours_add_test) {
     DataSet data_set = {
             {{std::string("2020-10-23 10:00:00"), -4}, str_to_date_time("2020-10-23 06:00:00")},
             {{std::string("2020-05-23 10:00:00"), 4}, str_to_date_time("2020-05-23 14:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-27 14:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -424,7 +413,6 @@ TEST(VTimestampFunctionsTest, hours_sub_test) {
     DataSet data_set = {
             {{std::string("2020-05-23 10:00:00"), 4}, str_to_date_time("2020-05-23 06:00:00")},
             {{std::string("2020-05-23 10:00:00"), -4}, str_to_date_time("2020-05-23 14:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 31}, str_to_date_time("2020-05-22 03:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -439,7 +427,6 @@ TEST(VTimestampFunctionsTest, minutes_add_test) {
     DataSet data_set = {
             {{std::string("2020-10-23 10:00:00"), 40}, str_to_date_time("2020-10-23 10:40:00")},
             {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 09:20:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 11:40:00")},
             {{Null(), 4}, Null()}};
 
@@ -454,7 +441,6 @@ TEST(VTimestampFunctionsTest, minutes_sub_test) {
     DataSet data_set = {
             {{std::string("2020-05-23 10:00:00"), 40}, str_to_date_time("2020-05-23 09:20:00")},
             {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 10:40:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 08:20:00")},
             {{Null(), 4}, Null()}};
 
@@ -469,7 +455,6 @@ TEST(VTimestampFunctionsTest, seconds_add_test) {
     DataSet data_set = {
             {{std::string("2020-10-23 10:00:00"), 40}, str_to_date_time("2020-10-23 10:00:40")},
             {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 09:59:20")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 10:01:40")},
             {{Null(), 4}, Null()}};
 
@@ -484,7 +469,6 @@ TEST(VTimestampFunctionsTest, seconds_sub_test) {
     DataSet data_set = {
             {{std::string("2020-05-23 10:00:00"), 40}, str_to_date_time("2020-05-23 09:59:20")},
             {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 10:00:40")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 09:58:20")},
             {{Null(), 4}, Null()}};
 
@@ -499,7 +483,6 @@ TEST(VTimestampFunctionsTest, weeks_add_test) {
     DataSet data_set = {
             {{std::string("2020-10-23 10:00:00"), 5}, str_to_date_time("2020-11-27 10:00:00")},
             {{std::string("2020-05-23 10:00:00"), -5}, str_to_date_time("2020-04-18 10:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2022-04-23 10:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -514,7 +497,6 @@ TEST(VTimestampFunctionsTest, weeks_sub_test) {
     DataSet data_set = {
             {{std::string("2020-05-23 10:00:00"), 5}, str_to_date_time("2020-04-18 10:00:00")},
             {{std::string("2020-05-23 10:00:00"), -5}, str_to_date_time("2020-6-27 10:00:00")},
-            {{std::string(""), 4}, Null()},
             {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2018-06-23 10:00:00")},
             {{Null(), 4}, Null()}};
 
@@ -527,7 +509,7 @@ TEST(VTimestampFunctionsTest, to_days_test) {
     InputTypeSet input_types = {TypeIndex::DateTime};
 
     DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, 738156},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("2021-01-32 00:00:00")}, Null()}};
 
     static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
@@ -540,7 +522,7 @@ TEST(VTimestampFunctionsTest, date_test) {
 
     DataSet data_set = {
             {{std::string("2021-01-01 06:00:00")}, str_to_date_time("2021-01-01", false)},
-            {{std::string("")}, Null()},
+            {{Null()}, Null()},
             {{Null()}, Null()}};
 
     static_cast<void>(check_function<DataTypeDate, true>(func_name, input_types, data_set));
@@ -552,14 +534,14 @@ TEST(VTimestampFunctionsTest, week_test) {
     InputTypeSet input_types = {TypeIndex::DateTime};
 
     DataSet data_set = {{{std::string("1989-03-21 06:00:00")}, int8_t {12}},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("9999-12-12 00:00:00")}, int8_t {50}}};
 
     static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
 
     InputTypeSet new_input_types = {TypeIndex::Date};
     DataSet new_data_set = {{{std::string("1989-03-21")}, int8_t {12}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("9999-12-12")}, int8_t {50}}};
 
     static_cast<void>(check_function<DataTypeInt8, true>(func_name, new_input_types, new_data_set));
@@ -571,14 +553,14 @@ TEST(VTimestampFunctionsTest, yearweek_test) {
     InputTypeSet input_types = {TypeIndex::DateTime};
 
     DataSet data_set = {{{std::string("1989-03-21 06:00:00")}, 198912},
-                        {{std::string("")}, Null()},
+                        {{Null()}, Null()},
                         {{std::string("9999-12-12 00:00:00")}, 999950}};
 
     static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
 
     InputTypeSet new_input_types = {TypeIndex::Date};
     DataSet new_data_set = {{{std::string("1989-03-21")}, 198912},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("9999-12-12")}, 999950}};
 
     static_cast<void>(
@@ -753,7 +735,7 @@ TEST(VTimestampFunctionsTest, quarter_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateV2};
 
         DataSet data_set = {{{std::string("2021-01-01")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32")}, Null()},
                             {{std::string("2025-10-23")}, int8_t {4}}};
 
@@ -763,7 +745,7 @@ TEST(VTimestampFunctionsTest, quarter_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2};
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32 00:00:00")}, Null()},
                             {{std::string("2025-10-23 00:00:00")}, int8_t {4}}};
 
@@ -778,7 +760,7 @@ TEST(VTimestampFunctionsTest, month_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateV2};
 
         DataSet data_set = {{{std::string("2021-01-01")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32")}, Null()},
                             {{std::string("2025-05-23")}, int8_t {5}}};
 
@@ -788,7 +770,7 @@ TEST(VTimestampFunctionsTest, month_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2};
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32 00:00:00")}, Null()},
                             {{std::string("2025-05-23 00:00:00")}, int8_t {5}}};
 
@@ -803,7 +785,7 @@ TEST(VTimestampFunctionsTest, day_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateV2};
 
         DataSet data_set = {{{std::string("2021-01-01")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32")}, Null()},
                             {{std::string("2025-05-23")}, int8_t {23}}};
 
@@ -813,7 +795,7 @@ TEST(VTimestampFunctionsTest, day_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2};
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:00")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32 00:00:00")}, Null()},
                             {{std::string("2025-05-23 00:00:00")}, int8_t {23}}};
 
@@ -829,7 +811,7 @@ TEST(VTimestampFunctionsTest, hour_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01")}, int8_t {0}},
                             {{std::string("2021-01-13")}, int8_t {0}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2025-05-23")}, int8_t {0}}};
         static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
     }
@@ -838,7 +820,7 @@ TEST(VTimestampFunctionsTest, hour_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:00.123")}, int8_t {0}},
                             {{std::string("2021-01-13 01:00:00.123")}, int8_t {1}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2025-05-23 23:00:00.123")}, int8_t {23}},
                             {{std::string("2025-05-23 25:00:00.123")}, Null()}};
         static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
@@ -853,7 +835,7 @@ TEST(VTimestampFunctionsTest, minute_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01")}, int8_t {0}},
                             {{std::string("2021-01-13")}, int8_t {0}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2025-05-23")}, int8_t {0}}};
 
         static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
@@ -863,7 +845,7 @@ TEST(VTimestampFunctionsTest, minute_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:00.123")}, int8_t {0}},
                             {{std::string("2021-01-13 00:11:00.123")}, int8_t {11}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2025-05-23 00:22:22.123")}, int8_t {22}},
                             {{std::string("2025-05-23 00:60:22.123")}, Null()}};
 
@@ -879,7 +861,7 @@ TEST(VTimestampFunctionsTest, second_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01")}, int8_t {0}},
                             {{std::string("2021-01-13")}, int8_t {0}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2025-05-23")}, int8_t {0}}};
 
         static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
@@ -889,7 +871,7 @@ TEST(VTimestampFunctionsTest, second_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:01.123")}, int8_t {1}},
                             {{std::string("2021-01-13 00:00:02.123")}, int8_t {2}},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2025-05-23 00:00:63.123")}, Null()},
                             {{std::string("2025-05-23 00:00:00.123")}, int8_t {0}}};
 
@@ -1059,7 +1041,7 @@ TEST(VTimestampFunctionsTest, years_add_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23"), 5}, str_to_date_v2("2025-05-23", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -5}, str_to_date_v2("2015-05-23", "%Y-%m-%d")},
-                {{std::string(""), 5}, Null()},
+                {{Null(), 5}, Null()},
                 {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
@@ -1080,7 +1062,7 @@ TEST(VTimestampFunctionsTest, years_add_v2_test) {
                              str_to_datetime_v2("2025-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
                              str_to_datetime_v2("2015-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 5}, Null()},
+                            {{Null(), 5}, Null()},
                             {{Null(), 5}, Null()}};
 
         static_cast<void>(
@@ -1105,7 +1087,7 @@ TEST(VTimestampFunctionsTest, years_sub_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23"), 5}, str_to_date_v2("2015-05-23", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -5}, str_to_date_v2("2025-05-23", "%Y-%m-%d")},
-                {{std::string(""), 5}, Null()},
+                {{Null(), 5}, Null()},
                 {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
@@ -1126,7 +1108,7 @@ TEST(VTimestampFunctionsTest, years_sub_v2_test) {
                              str_to_datetime_v2("2015-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
                              str_to_datetime_v2("2025-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 5}, Null()},
+                            {{Null(), 5}, Null()},
                             {{Null(), 5}, Null()}};
 
         static_cast<void>(
@@ -1148,29 +1130,51 @@ TEST(VTimestampFunctionsTest, months_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-10-23"), -4}, str_to_date_v2("2020-06-23", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-09-23", "%Y-%m-%d")},
-                {{std::string(""), 4}, Null()},
-                {{std::string("2020-05-23"), 10}, str_to_date_v2("2021-03-23", "%Y-%m-%d")},
-                {{Null(), 4}, Null()}};
+        DataSet data_set = {{{std::string("2020-10-23"), -4}, std::string("2020-06-23")},
+                            {{std::string("2020-05-23"), 4}, std::string("2020-09-23")},
+                            {{std::string("2020-05-23"), 10}, std::string("2021-03-23")},
+                            {{Null(), 4}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
     {
-        InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
+        InputTypeSet input_types = {{TypeIndex::DateTimeV2, 3}, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-10-23 00:00:11.123"), -4},
-                             str_to_datetime_v2("2020-06-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-10-23 00:00:11.1234"), -4},
+                             std::string("2020-06-23 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 4},
-                             str_to_datetime_v2("2020-09-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
+                             std::string("2020-09-23 00:00:11.1234")},
                             {{std::string("2020-05-23 00:00:11.123"), 10},
-                             str_to_datetime_v2("2021-03-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2021-03-23 00:00:11.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
-                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+                check_function<DataTypeDateTimeV2, true, 3>(func_name, input_types, data_set));
+    }
+
+    // eq
+    {
+        InputTypeSet input_types = {{TypeIndex::DateTimeV2, 2}, TypeIndex::Int32};
+
+        DataSet data_set = {{{std::string("2020-10-23 00:00:11.1234"), -4},
+                             std::string("2020-06-23 00:00:11.1200")},
+                            {{std::string("2020-05-23 00:00:11.1234"), 4},
+                             std::string("2020-09-23 00:00:11.12")}};
+
+        static_cast<void>(
+                check_function<DataTypeDateTimeV2, true, 4>(func_name, input_types, data_set));
+    }
+    // ne
+    {
+        InputTypeSet input_types = {{TypeIndex::DateTimeV2, 2}, TypeIndex::Int32};
+
+        DataSet data_set = {{{std::string("2020-10-23 00:00:11.1234"), -4},
+                             std::string("2020-06-23 00:00:11.1234")},
+                            {{std::string("2020-05-23 00:00:11.12"), 4},
+                             std::string("2020-09-23 00:00:11.1234")}};
+
+        static_cast<void>(check_function<DataTypeDateTimeV2, true, 4>(func_name, input_types,
+                                                                      data_set, false, true));
     }
 }
 
@@ -1183,7 +1187,6 @@ TEST(VTimestampFunctionsTest, months_sub_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-01-23", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -4}, str_to_date_v2("2020-09-23", "%Y-%m-%d")},
-                {{std::string(""), 4}, Null()},
                 {{std::string("2020-05-23"), 10}, str_to_date_v2("2019-07-23", "%Y-%m-%d")},
                 {{Null(), 4}, Null()}};
 
@@ -1196,7 +1199,6 @@ TEST(VTimestampFunctionsTest, months_sub_v2_test) {
                              str_to_datetime_v2("2020-01-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), -4},
                              str_to_datetime_v2("2020-09-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 00:00:11.123"), 10},
                              str_to_datetime_v2("2019-07-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1215,7 +1217,6 @@ TEST(VTimestampFunctionsTest, days_add_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-10-23"), -4}, str_to_date_v2("2020-10-19", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-05-27", "%Y-%m-%d")},
-                {{std::string(""), 4}, Null()},
                 {{std::string("2020-05-23"), 10}, str_to_date_v2("2020-06-02", "%Y-%m-%d")},
                 {{Null(), 4}, Null()}};
 
@@ -1228,7 +1229,6 @@ TEST(VTimestampFunctionsTest, days_add_v2_test) {
                              str_to_datetime_v2("2020-10-19 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), 4},
                              str_to_datetime_v2("2020-05-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 00:00:11.123"), 10},
                              str_to_datetime_v2("2020-06-02 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1247,7 +1247,6 @@ TEST(VTimestampFunctionsTest, days_sub_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-05-19", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -4}, str_to_date_v2("2020-05-27", "%Y-%m-%d")},
-                {{std::string(""), 4}, Null()},
                 {{std::string("2020-05-23"), 31}, str_to_date_v2("2020-04-22", "%Y-%m-%d")},
                 {{Null(), 4}, Null()}};
 
@@ -1260,7 +1259,6 @@ TEST(VTimestampFunctionsTest, days_sub_v2_test) {
                              str_to_datetime_v2("2020-05-19 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), -4},
                              str_to_datetime_v2("2020-05-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 00:00:11.123"), 31},
                              str_to_datetime_v2("2020-04-22 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1279,7 +1277,6 @@ TEST(VTimestampFunctionsTest, weeks_add_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-10-23"), 5}, str_to_date_v2("2020-11-27", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -5}, str_to_date_v2("2020-04-18", "%Y-%m-%d")},
-                {{std::string(""), 4}, Null()},
                 {{std::string("2020-05-23"), 100}, str_to_date_v2("2022-04-23", "%Y-%m-%d")},
                 {{Null(), 4}, Null()}};
 
@@ -1292,7 +1289,6 @@ TEST(VTimestampFunctionsTest, weeks_add_v2_test) {
                              str_to_datetime_v2("2020-11-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
                              str_to_datetime_v2("2020-04-18 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 00:00:11.123"), 100},
                              str_to_datetime_v2("2022-04-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1311,7 +1307,6 @@ TEST(VTimestampFunctionsTest, weeks_sub_v2_test) {
         DataSet data_set = {
                 {{std::string("2020-05-23"), 5}, str_to_date_v2("2020-04-18", "%Y-%m-%d")},
                 {{std::string("2020-05-23"), -5}, str_to_date_v2("2020-06-27", "%Y-%m-%d")},
-                {{std::string(""), 4}, Null()},
                 {{std::string("2020-05-23"), 100}, str_to_date_v2("2018-06-23", "%Y-%m-%d")},
                 {{Null(), 4}, Null()}};
 
@@ -1324,7 +1319,6 @@ TEST(VTimestampFunctionsTest, weeks_sub_v2_test) {
                              str_to_datetime_v2("2020-04-18 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
                              str_to_datetime_v2("2020-06-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 00:00:11.123"), 100},
                              str_to_datetime_v2("2018-06-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1341,7 +1335,7 @@ TEST(VTimestampFunctionsTest, to_days_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateV2};
 
         DataSet data_set = {{{std::string("2021-01-01")}, 738156},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32")}, Null()},
                             {{std::string("0000-01-01")}, 1}};
 
@@ -1351,7 +1345,7 @@ TEST(VTimestampFunctionsTest, to_days_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2};
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:11.123")}, 738156},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{std::string("2021-01-32 00:00:11.123")}, Null()},
                             {{std::string("0000-01-01 00:00:11.123")}, 1}};
 
@@ -1367,7 +1361,7 @@ TEST(VTimestampFunctionsTest, date_v2_test) {
 
         DataSet data_set = {
                 {{std::string("2021-01-01")}, str_to_date_v2("2021-01-01", "%Y-%m-%d")},
-                {{std::string("")}, Null()},
+                {{Null()}, Null()},
                 {{Null()}, Null()},
                 {{std::string("0000-01-01")}, str_to_date_v2("0000-01-01", "%Y-%m-%d")}};
 
@@ -1378,7 +1372,7 @@ TEST(VTimestampFunctionsTest, date_v2_test) {
 
         DataSet data_set = {{{std::string("2021-01-01 00:00:11.123")},
                              str_to_date_v2("2021-01-01", "%Y-%m-%d")},
-                            {{std::string("")}, Null()},
+                            {{Null()}, Null()},
                             {{Null()}, Null()},
                             {{std::string("0000-01-01 00:00:11.123")},
                              str_to_date_v2("0000-01-01", "%Y-%m-%d")}};
@@ -1393,7 +1387,7 @@ TEST(VTimestampFunctionsTest, week_v2_test) {
     {
         InputTypeSet new_input_types = {TypeIndex::DateV2};
         DataSet new_data_set = {{{std::string("1989-03-21")}, int8_t {12}},
-                                {{std::string("")}, Null()},
+                                {{Null()}, Null()},
                                 {{std::string("9999-12-12")}, int8_t {50}}};
 
         static_cast<void>(
@@ -1402,7 +1396,7 @@ TEST(VTimestampFunctionsTest, week_v2_test) {
     {
         InputTypeSet new_input_types = {TypeIndex::DateTimeV2};
         DataSet new_data_set = {{{std::string("1989-03-21 00:00:11.123")}, int8_t {12}},
-                                {{std::string("")}, Null()},
+                                {{Null()}, Null()},
                                 {{std::string("9999-12-12 00:00:11.123")}, int8_t {50}}};
 
         static_cast<void>(
@@ -1416,7 +1410,7 @@ TEST(VTimestampFunctionsTest, yearweek_v2_test) {
     {
         InputTypeSet new_input_types = {TypeIndex::DateV2};
         DataSet new_data_set = {{{std::string("1989-03-21")}, 198912},
-                                {{std::string("")}, Null()},
+                                {{Null()}, Null()},
                                 {{std::string("9999-12-12")}, 999950}};
 
         static_cast<void>(
@@ -1425,7 +1419,7 @@ TEST(VTimestampFunctionsTest, yearweek_v2_test) {
     {
         InputTypeSet new_input_types = {TypeIndex::DateTimeV2};
         DataSet new_data_set = {{{std::string("1989-03-21 00:00:11.123")}, 198912},
-                                {{std::string("")}, Null()},
+                                {{Null()}, Null()},
                                 {{std::string("9999-12-12 00:00:11.123")}, 999950}};
 
         static_cast<void>(
@@ -1618,7 +1612,6 @@ TEST(VTimestampFunctionsTest, hours_add_v2_test) {
                              str_to_datetime_v2("2020-10-23 06:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 10:00:00.123"), 4},
                              str_to_datetime_v2("2020-05-23 14:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
                              str_to_datetime_v2("2020-05-27 14:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1633,7 +1626,6 @@ TEST(VTimestampFunctionsTest, hours_add_v2_test) {
                              str_to_datetime_v2("2020-10-22 20:00:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23"), 4},
                              str_to_datetime_v2("2020-05-23 04:00:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23"), 100},
                              str_to_datetime_v2("2020-05-27 04:00:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1653,7 +1645,6 @@ TEST(VTimestampFunctionsTest, hours_sub_v2_test) {
                              str_to_datetime_v2("2020-05-23 06:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 10:00:00.123"), -4},
                              str_to_datetime_v2("2020-05-23 14:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 10:00:00.123"), 31},
                              str_to_datetime_v2("2020-05-22 03:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1669,7 +1660,6 @@ TEST(VTimestampFunctionsTest, hours_sub_v2_test) {
                              str_to_datetime_v2("2020-05-22 20:00:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23"), -4},
                              str_to_datetime_v2("2020-05-23 04:00:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23"), 31},
                              str_to_datetime_v2("2020-05-21 17:00:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1689,7 +1679,6 @@ TEST(VTimestampFunctionsTest, minutes_add_v2_test) {
                              str_to_datetime_v2("2020-10-23 10:40:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
                              str_to_datetime_v2("2020-05-23 09:20:00.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
                              str_to_datetime_v2("2020-05-23 11:40:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1704,7 +1693,6 @@ TEST(VTimestampFunctionsTest, minutes_add_v2_test) {
                              str_to_datetime_v2("2020-10-23 00:40:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23"), -40},
                              str_to_datetime_v2("2020-05-22 23:20:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23"), 100},
                              str_to_datetime_v2("2020-05-23 01:40:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1724,7 +1712,6 @@ TEST(VTimestampFunctionsTest, minutes_sub_v2_test) {
                              str_to_datetime_v2("2020-05-23 09:20:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
                              str_to_datetime_v2("2020-05-23 10:40:00.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
                              str_to_datetime_v2("2020-05-23 08:20:00.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1739,7 +1726,6 @@ TEST(VTimestampFunctionsTest, minutes_sub_v2_test) {
                              str_to_datetime_v2("2020-05-22 23:20:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23"), -40},
                              str_to_datetime_v2("2020-05-23 00:40:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23"), 100},
                              str_to_datetime_v2("2020-05-22 22:20:00", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1759,7 +1745,6 @@ TEST(VTimestampFunctionsTest, seconds_add_v2_test) {
                              str_to_datetime_v2("2020-10-23 10:00:40.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
                              str_to_datetime_v2("2020-05-23 09:59:20.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
                              str_to_datetime_v2("2020-05-23 10:01:40.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1774,7 +1759,6 @@ TEST(VTimestampFunctionsTest, seconds_add_v2_test) {
                              str_to_datetime_v2("2020-10-23 00:00:40", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23"), -40},
                              str_to_datetime_v2("2020-05-22 23:59:20", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23"), 100},
                              str_to_datetime_v2("2020-05-23 00:01:40", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1794,7 +1778,6 @@ TEST(VTimestampFunctionsTest, seconds_sub_v2_test) {
                              str_to_datetime_v2("2020-05-23 09:59:20.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
                              str_to_datetime_v2("2020-05-23 10:00:40.123", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
                              str_to_datetime_v2("2020-05-23 09:58:20.123", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1809,7 +1792,6 @@ TEST(VTimestampFunctionsTest, seconds_sub_v2_test) {
                              str_to_datetime_v2("2020-05-22 23:59:20", "%Y-%m-%d %H:%i:%s.%f")},
                             {{std::string("2020-05-23"), -40},
                              str_to_datetime_v2("2020-05-23 00:00:40", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string(""), 4}, Null()},
                             {{std::string("2020-05-23"), 100},
                              str_to_datetime_v2("2020-05-22 23:58:20", "%Y-%m-%d %H:%i:%s.%f")},
                             {{Null(), 4}, Null()}};
@@ -1845,8 +1827,6 @@ TEST(VTimestampFunctionsTest, months_between_test) {
             {{std::string("2020-12-01"), std::string("2020-01-01"), uint8_t(1)}, double(11.0)},
             {{std::string("2021-01-01"), std::string("2020-01-01"), uint8_t(0)}, double(12.0)},
             {{std::string("2022-01-01"), std::string("2020-01-01"), uint8_t(1)}, double(24.0)},
-            {{std::string(""), std::string("2020-01-01"), uint8_t(1)}, Null()},
-            {{std::string("2020-01-01"), std::string(""), uint8_t(1)}, Null()},
             {{Null(), std::string("2020-01-01"), uint8_t(1)}, Null()},
             {{std::string("2020-01-01"), Null(), uint8_t(1)}, Null()}};
     static_cast<void>(
@@ -1899,7 +1879,6 @@ TEST(VTimestampFunctionsTest, next_day_test) {
                              str_to_date_v2("2020-01-05", "%Y-%m-%d")},
                             {{std::string("2020-01-01"), std::string("SUNDAY")},
                              str_to_date_v2("2020-01-05", "%Y-%m-%d")},
-                            {{std::string(""), std::string("MON")}, Null()},
                             {{Null(), std::string("MON")}, Null()}};
         static_cast<void>(check_function_all_arg_comb<DataTypeDateV2, true>(func_name, input_types,
                                                                             data_set));

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -219,7 +219,7 @@ TEST(VTimestampFunctionsTest, convert_tz_test) {
                               std::string {"+08:00"}},
                              std::string("0000-01-01 00:00:00")}};
         static_cast<void>(
-                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
 
     {
@@ -236,7 +236,7 @@ TEST(VTimestampFunctionsTest, convert_tz_test) {
                               std::string {"america/Los_angeles"}},
                              std::string("2019-07-31 11:18:27")}};
         static_cast<void>(
-                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
 }
 
@@ -1162,14 +1162,18 @@ TEST(VTimestampFunctionsTest, months_add_v2_test) {
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true, 4>(func_name, input_types, data_set));
     }
-    // ne
+    // negative case
     {
         InputTypeSet input_types = {{TypeIndex::DateTimeV2, 2}, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-10-23 00:00:11.1234"), -4},
-                             std::string("2020-06-23 00:00:11.1234")},
-                            {{std::string("2020-05-23 00:00:11.12"), 4},
-                             std::string("2020-09-23 00:00:11.1234")}};
+        DataSet data_set = {
+                // input truncated to 2 decimal so output should be .12
+                {{std::string("2020-10-23 00:00:11.1234"), -4},
+                 std::string("2020-06-23 00:00:11.1234")},
+                // output should be .12
+                {{std::string("2020-05-23 00:00:11.12"), 4},
+                 std::string("2020-09-23 00:00:11.1234")},
+        };
 
         static_cast<void>(check_function<DataTypeDateTimeV2, true, 4>(func_name, input_types,
                                                                       data_set, false, true));

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -208,16 +208,16 @@ TEST(VTimestampFunctionsTest, convert_tz_test) {
     {
         DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
                               std::string {"UTC"}},
-                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2019-07-31 18:18:27")},
                             {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
                               std::string {"UTC"}},
-                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2019-07-31 18:18:27")},
                             {{std::string {"0000-01-01 00:00:00"}, std::string {"+08:00"},
                               std::string {"-02:00"}},
                              Null()},
                             {{std::string {"0000-01-01 00:00:00"}, std::string {"+08:00"},
                               std::string {"+08:00"}},
-                             str_to_datetime_v2("0000-01-01 00:00:00", "%Y-%m-%d %H:%i:%s.%f")}};
+                             std::string("0000-01-01 00:00:00")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
     }
@@ -225,16 +225,16 @@ TEST(VTimestampFunctionsTest, convert_tz_test) {
     {
         DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
                               std::string {"UTC"}},
-                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2019-07-31 18:18:27")},
                             {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
                               std::string {"Utc"}},
-                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2019-07-31 18:18:27")},
                             {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
                               std::string {"UTC"}},
-                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2019-07-31 18:18:27")},
                             {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
                               std::string {"america/Los_angeles"}},
-                             str_to_datetime_v2("2019-07-31 11:18:27", "%Y-%m-%d %H:%i:%s.%f")}};
+                             std::string("2019-07-31 11:18:27")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false));
     }
@@ -289,6 +289,7 @@ TEST(VTimestampFunctionsTest, date_format_test) {
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
     }
 }
+
 TEST(VTimestampFunctionsTest, years_add_test) {
     std::string func_name = "years_add";
 
@@ -296,8 +297,8 @@ TEST(VTimestampFunctionsTest, years_add_test) {
 
     {
         DataSet data_set = {
-                {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2025-05-23 00:00:00")},
-                {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2015-05-23 00:00:00")},
+                {{std::string("2020-05-23 00:00:00"), 5}, std::string("2025-05-23 00:00:00")},
+                {{std::string("2020-05-23 00:00:00"), -5}, std::string("2015-05-23 00:00:00")},
                 {{Null(), 5}, Null()},
                 {{Null(), 5}, Null()}};
 
@@ -319,8 +320,8 @@ TEST(VTimestampFunctionsTest, years_sub_test) {
 
     {
         DataSet data_set = {
-                {{std::string("2020-05-23 00:00:00"), 5}, str_to_date_time("2015-05-23 00:00:00")},
-                {{std::string("2020-05-23 00:00:00"), -5}, str_to_date_time("2025-05-23 00:00:00")},
+                {{std::string("2020-05-23 00:00:00"), 5}, std::string("2015-05-23 00:00:00")},
+                {{std::string("2020-05-23 00:00:00"), -5}, std::string("2025-05-23 00:00:00")},
                 {{Null(), 5}, Null()},
                 {{Null(), 5}, Null()}};
 
@@ -341,9 +342,9 @@ TEST(VTimestampFunctionsTest, months_add_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-10-23 00:00:00"), -4}, str_to_date_time("2020-06-23 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-09-23 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), 10}, str_to_date_time("2021-03-23 00:00:00")},
+            {{std::string("2020-10-23 00:00:00"), -4}, std::string("2020-06-23 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 4}, std::string("2020-09-23 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 10}, std::string("2021-03-23 00:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -355,9 +356,9 @@ TEST(VTimestampFunctionsTest, months_sub_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-01-23 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), -4}, str_to_date_time("2020-09-23 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), 10}, str_to_date_time("2019-07-23 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 4}, std::string("2020-01-23 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), -4}, std::string("2020-09-23 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 10}, std::string("2019-07-23 00:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -369,9 +370,9 @@ TEST(VTimestampFunctionsTest, days_add_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-10-23 00:00:00"), -4}, str_to_date_time("2020-10-19 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-05-27 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), 10}, str_to_date_time("2020-06-2 00:00:00")},
+            {{std::string("2020-10-23 00:00:00"), -4}, std::string("2020-10-19 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 4}, std::string("2020-05-27 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 10}, std::string("2020-06-2 00:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -383,9 +384,9 @@ TEST(VTimestampFunctionsTest, days_sub_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-05-23 00:00:00"), 4}, str_to_date_time("2020-05-19 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), -4}, str_to_date_time("2020-05-27 00:00:00")},
-            {{std::string("2020-05-23 00:00:00"), 31}, str_to_date_time("2020-04-22 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 4}, std::string("2020-05-19 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), -4}, std::string("2020-05-27 00:00:00")},
+            {{std::string("2020-05-23 00:00:00"), 31}, std::string("2020-04-22 00:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -397,9 +398,9 @@ TEST(VTimestampFunctionsTest, hours_add_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-10-23 10:00:00"), -4}, str_to_date_time("2020-10-23 06:00:00")},
-            {{std::string("2020-05-23 10:00:00"), 4}, str_to_date_time("2020-05-23 14:00:00")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-27 14:00:00")},
+            {{std::string("2020-10-23 10:00:00"), -4}, std::string("2020-10-23 06:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 4}, std::string("2020-05-23 14:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2020-05-27 14:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -411,9 +412,9 @@ TEST(VTimestampFunctionsTest, hours_sub_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-05-23 10:00:00"), 4}, str_to_date_time("2020-05-23 06:00:00")},
-            {{std::string("2020-05-23 10:00:00"), -4}, str_to_date_time("2020-05-23 14:00:00")},
-            {{std::string("2020-05-23 10:00:00"), 31}, str_to_date_time("2020-05-22 03:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 4}, std::string("2020-05-23 06:00:00")},
+            {{std::string("2020-05-23 10:00:00"), -4}, std::string("2020-05-23 14:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 31}, std::string("2020-05-22 03:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -425,9 +426,9 @@ TEST(VTimestampFunctionsTest, minutes_add_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-10-23 10:00:00"), 40}, str_to_date_time("2020-10-23 10:40:00")},
-            {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 09:20:00")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 11:40:00")},
+            {{std::string("2020-10-23 10:00:00"), 40}, std::string("2020-10-23 10:40:00")},
+            {{std::string("2020-05-23 10:00:00"), -40}, std::string("2020-05-23 09:20:00")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2020-05-23 11:40:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -439,9 +440,9 @@ TEST(VTimestampFunctionsTest, minutes_sub_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-05-23 10:00:00"), 40}, str_to_date_time("2020-05-23 09:20:00")},
-            {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 10:40:00")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 08:20:00")},
+            {{std::string("2020-05-23 10:00:00"), 40}, std::string("2020-05-23 09:20:00")},
+            {{std::string("2020-05-23 10:00:00"), -40}, std::string("2020-05-23 10:40:00")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2020-05-23 08:20:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -453,9 +454,9 @@ TEST(VTimestampFunctionsTest, seconds_add_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-10-23 10:00:00"), 40}, str_to_date_time("2020-10-23 10:00:40")},
-            {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 09:59:20")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 10:01:40")},
+            {{std::string("2020-10-23 10:00:00"), 40}, std::string("2020-10-23 10:00:40")},
+            {{std::string("2020-05-23 10:00:00"), -40}, std::string("2020-05-23 09:59:20")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2020-05-23 10:01:40")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -467,9 +468,9 @@ TEST(VTimestampFunctionsTest, seconds_sub_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-05-23 10:00:00"), 40}, str_to_date_time("2020-05-23 09:59:20")},
-            {{std::string("2020-05-23 10:00:00"), -40}, str_to_date_time("2020-05-23 10:00:40")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2020-05-23 09:58:20")},
+            {{std::string("2020-05-23 10:00:00"), 40}, std::string("2020-05-23 09:59:20")},
+            {{std::string("2020-05-23 10:00:00"), -40}, std::string("2020-05-23 10:00:40")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2020-05-23 09:58:20")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -481,9 +482,9 @@ TEST(VTimestampFunctionsTest, weeks_add_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-10-23 10:00:00"), 5}, str_to_date_time("2020-11-27 10:00:00")},
-            {{std::string("2020-05-23 10:00:00"), -5}, str_to_date_time("2020-04-18 10:00:00")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2022-04-23 10:00:00")},
+            {{std::string("2020-10-23 10:00:00"), 5}, std::string("2020-11-27 10:00:00")},
+            {{std::string("2020-05-23 10:00:00"), -5}, std::string("2020-04-18 10:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2022-04-23 10:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -495,9 +496,9 @@ TEST(VTimestampFunctionsTest, weeks_sub_test) {
     InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::Int32};
 
     DataSet data_set = {
-            {{std::string("2020-05-23 10:00:00"), 5}, str_to_date_time("2020-04-18 10:00:00")},
-            {{std::string("2020-05-23 10:00:00"), -5}, str_to_date_time("2020-6-27 10:00:00")},
-            {{std::string("2020-05-23 10:00:00"), 100}, str_to_date_time("2018-06-23 10:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 5}, std::string("2020-04-18 10:00:00")},
+            {{std::string("2020-05-23 10:00:00"), -5}, std::string("2020-6-27 10:00:00")},
+            {{std::string("2020-05-23 10:00:00"), 100}, std::string("2018-06-23 10:00:00")},
             {{Null(), 4}, Null()}};
 
     static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
@@ -520,10 +521,9 @@ TEST(VTimestampFunctionsTest, date_test) {
 
     InputTypeSet input_types = {TypeIndex::DateTime};
 
-    DataSet data_set = {
-            {{std::string("2021-01-01 06:00:00")}, str_to_date_time("2021-01-01", false)},
-            {{Null()}, Null()},
-            {{Null()}, Null()}};
+    DataSet data_set = {{{std::string("2021-01-01 06:00:00")}, std::string("2021-01-01")},
+                        {{Null()}, Null()},
+                        {{Null()}, Null()}};
 
     static_cast<void>(check_function<DataTypeDate, true>(func_name, input_types, data_set));
 }
@@ -572,9 +572,9 @@ TEST(VTimestampFunctionsTest, makedate_test) {
 
     InputTypeSet input_types = {TypeIndex::Int32, TypeIndex::Int32};
 
-    DataSet data_set = {{{2021, 3}, str_to_date_time("2021-01-03", false)},
-                        {{2021, 95}, str_to_date_time("2021-04-05", false)},
-                        {{2021, 400}, str_to_date_time("2022-02-04", false)},
+    DataSet data_set = {{{2021, 3}, std::string("2021-01-03")},
+                        {{2021, 95}, std::string("2021-04-05")},
+                        {{2021, 400}, std::string("2022-02-04")},
                         {{2021, 0}, Null()},
                         {{2021, -10}, Null()},
                         {{-1, 3}, Null()},
@@ -1038,11 +1038,10 @@ TEST(VTimestampFunctionsTest, years_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-05-23"), 5}, str_to_date_v2("2025-05-23", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), -5}, str_to_date_v2("2015-05-23", "%Y-%m-%d")},
-                {{Null(), 5}, Null()},
-                {{Null(), 5}, Null()}};
+        DataSet data_set = {{{std::string("2020-05-23"), 5}, std::string("2025-05-23")},
+                            {{std::string("2020-05-23"), -5}, std::string("2015-05-23")},
+                            {{Null(), 5}, Null()},
+                            {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1059,9 +1058,9 @@ TEST(VTimestampFunctionsTest, years_add_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 5},
-                             str_to_datetime_v2("2025-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2025-05-23 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
-                             str_to_datetime_v2("2015-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2015-05-23 00:00:11.123")},
                             {{Null(), 5}, Null()},
                             {{Null(), 5}, Null()}};
 
@@ -1084,11 +1083,10 @@ TEST(VTimestampFunctionsTest, years_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-05-23"), 5}, str_to_date_v2("2015-05-23", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), -5}, str_to_date_v2("2025-05-23", "%Y-%m-%d")},
-                {{Null(), 5}, Null()},
-                {{Null(), 5}, Null()}};
+        DataSet data_set = {{{std::string("2020-05-23"), 5}, std::string("2015-05-23")},
+                            {{std::string("2020-05-23"), -5}, std::string("2025-05-23")},
+                            {{Null(), 5}, Null()},
+                            {{Null(), 5}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1105,9 +1103,9 @@ TEST(VTimestampFunctionsTest, years_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 5},
-                             str_to_datetime_v2("2015-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2015-05-23 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
-                             str_to_datetime_v2("2025-05-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2025-05-23 00:00:11.123")},
                             {{Null(), 5}, Null()},
                             {{Null(), 5}, Null()}};
 
@@ -1184,11 +1182,10 @@ TEST(VTimestampFunctionsTest, months_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-01-23", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), -4}, str_to_date_v2("2020-09-23", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 10}, str_to_date_v2("2019-07-23", "%Y-%m-%d")},
-                {{Null(), 4}, Null()}};
+        DataSet data_set = {{{std::string("2020-05-23"), 4}, std::string("2020-01-23")},
+                            {{std::string("2020-05-23"), -4}, std::string("2020-09-23")},
+                            {{std::string("2020-05-23"), 10}, std::string("2019-07-23")},
+                            {{Null(), 4}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1196,11 +1193,11 @@ TEST(VTimestampFunctionsTest, months_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 4},
-                             str_to_datetime_v2("2020-01-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-01-23 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), -4},
-                             str_to_datetime_v2("2020-09-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-09-23 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 10},
-                             str_to_datetime_v2("2019-07-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2019-07-23 00:00:11.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1214,11 +1211,10 @@ TEST(VTimestampFunctionsTest, days_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-10-23"), -4}, str_to_date_v2("2020-10-19", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-05-27", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 10}, str_to_date_v2("2020-06-02", "%Y-%m-%d")},
-                {{Null(), 4}, Null()}};
+        DataSet data_set = {{{std::string("2020-10-23"), -4}, std::string("2020-10-19")},
+                            {{std::string("2020-05-23"), 4}, std::string("2020-05-27")},
+                            {{std::string("2020-05-23"), 10}, std::string("2020-06-02")},
+                            {{Null(), 4}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1226,11 +1222,11 @@ TEST(VTimestampFunctionsTest, days_add_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-10-23 00:00:11.123"), -4},
-                             str_to_datetime_v2("2020-10-19 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-10-19 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 4},
-                             str_to_datetime_v2("2020-05-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-27 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 10},
-                             str_to_datetime_v2("2020-06-02 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-06-02 00:00:11.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1244,11 +1240,10 @@ TEST(VTimestampFunctionsTest, days_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-05-23"), 4}, str_to_date_v2("2020-05-19", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), -4}, str_to_date_v2("2020-05-27", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 31}, str_to_date_v2("2020-04-22", "%Y-%m-%d")},
-                {{Null(), 4}, Null()}};
+        DataSet data_set = {{{std::string("2020-05-23"), 4}, std::string("2020-05-19")},
+                            {{std::string("2020-05-23"), -4}, std::string("2020-05-27")},
+                            {{std::string("2020-05-23"), 31}, std::string("2020-04-22")},
+                            {{Null(), 4}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1256,11 +1251,11 @@ TEST(VTimestampFunctionsTest, days_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 4},
-                             str_to_datetime_v2("2020-05-19 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-19 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), -4},
-                             str_to_datetime_v2("2020-05-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-27 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 31},
-                             str_to_datetime_v2("2020-04-22 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-04-22 00:00:11.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1274,11 +1269,10 @@ TEST(VTimestampFunctionsTest, weeks_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-10-23"), 5}, str_to_date_v2("2020-11-27", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), -5}, str_to_date_v2("2020-04-18", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 100}, str_to_date_v2("2022-04-23", "%Y-%m-%d")},
-                {{Null(), 4}, Null()}};
+        DataSet data_set = {{{std::string("2020-10-23"), 5}, std::string("2020-11-27")},
+                            {{std::string("2020-05-23"), -5}, std::string("2020-04-18")},
+                            {{std::string("2020-05-23"), 100}, std::string("2022-04-23")},
+                            {{Null(), 4}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1286,11 +1280,11 @@ TEST(VTimestampFunctionsTest, weeks_add_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-10-23 00:00:11.123"), 5},
-                             str_to_datetime_v2("2020-11-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-11-27 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
-                             str_to_datetime_v2("2020-04-18 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-04-18 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 100},
-                             str_to_datetime_v2("2022-04-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2022-04-23 00:00:11.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1304,11 +1298,10 @@ TEST(VTimestampFunctionsTest, weeks_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {
-                {{std::string("2020-05-23"), 5}, str_to_date_v2("2020-04-18", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), -5}, str_to_date_v2("2020-06-27", "%Y-%m-%d")},
-                {{std::string("2020-05-23"), 100}, str_to_date_v2("2018-06-23", "%Y-%m-%d")},
-                {{Null(), 4}, Null()}};
+        DataSet data_set = {{{std::string("2020-05-23"), 5}, std::string("2020-04-18")},
+                            {{std::string("2020-05-23"), -5}, std::string("2020-06-27")},
+                            {{std::string("2020-05-23"), 100}, std::string("2018-06-23")},
+                            {{Null(), 4}, Null()}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1316,11 +1309,11 @@ TEST(VTimestampFunctionsTest, weeks_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 00:00:11.123"), 5},
-                             str_to_datetime_v2("2020-04-18 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-04-18 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), -5},
-                             str_to_datetime_v2("2020-06-27 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-06-27 00:00:11.123")},
                             {{std::string("2020-05-23 00:00:11.123"), 100},
-                             str_to_datetime_v2("2018-06-23 00:00:11.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2018-06-23 00:00:11.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1359,23 +1352,20 @@ TEST(VTimestampFunctionsTest, date_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2};
 
-        DataSet data_set = {
-                {{std::string("2021-01-01")}, str_to_date_v2("2021-01-01", "%Y-%m-%d")},
-                {{Null()}, Null()},
-                {{Null()}, Null()},
-                {{std::string("0000-01-01")}, str_to_date_v2("0000-01-01", "%Y-%m-%d")}};
+        DataSet data_set = {{{std::string("2021-01-01")}, std::string("2021-01-01")},
+                            {{Null()}, Null()},
+                            {{Null()}, Null()},
+                            {{std::string("0000-01-01")}, std::string("0000-01-01")}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2};
 
-        DataSet data_set = {{{std::string("2021-01-01 00:00:11.123")},
-                             str_to_date_v2("2021-01-01", "%Y-%m-%d")},
+        DataSet data_set = {{{std::string("2021-01-01 00:00:11.123")}, std::string("2021-01-01")},
                             {{Null()}, Null()},
                             {{Null()}, Null()},
-                            {{std::string("0000-01-01 00:00:11.123")},
-                             str_to_date_v2("0000-01-01", "%Y-%m-%d")}};
+                            {{std::string("0000-01-01 00:00:11.123")}, std::string("0000-01-01")}};
 
         static_cast<void>(check_function<DataTypeDateV2, true>(func_name, input_types, data_set));
     }
@@ -1433,21 +1423,21 @@ TEST(VTimestampFunctionsTest, from_days_test) {
     InputTypeSet input_types = {TypeIndex::Int32};
 
     {
-        DataSet data_set = {{{730669}, str_to_date_time("2000-07-03", false)}, {{0}, Null()}};
+        DataSet data_set = {{{730669}, std::string("2000-07-03")}, {{0}, Null()}};
 
         static_cast<void>(check_function<DataTypeDate, true>(func_name, input_types, data_set));
     }
 
     {
         std::cout << "test date 0000-02-28" << std::endl;
-        DataSet data_set = {{{59}, str_to_date_time("0000-02-28", false)}, {{0}, Null()}};
+        DataSet data_set = {{{59}, std::string("0000-02-28")}, {{0}, Null()}};
 
         static_cast<void>(check_function<DataTypeDate, true>(func_name, input_types, data_set));
     }
 
     {
         std::cout << "test date 0000-03-01" << std::endl;
-        DataSet data_set = {{{60}, str_to_date_time("0000-03-01", false)}, {{0}, Null()}};
+        DataSet data_set = {{{60}, std::string("0000-03-01")}, {{0}, Null()}};
 
         static_cast<void>(check_function<DataTypeDate, true>(func_name, input_types, data_set));
     }
@@ -1523,80 +1513,79 @@ TEST(VTimestampFunctionsTest, datetrunc_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("second")},
-                             str_to_date_time("2022-10-08 11:44:23")}};
+                             std::string("2022-10-08 11:44:23")}};
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("minute")},
-                             str_to_date_time("2022-10-08 11:44:00")}};
+                             std::string("2022-10-08 11:44:00")}};
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("hour")},
-                             str_to_date_time("2022-10-08 11:00:00")}};
+                             std::string("2022-10-08 11:00:00")}};
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("day")},
-                             str_to_date_time("2022-10-08 00:00:00")}};
+                             std::string("2022-10-08 00:00:00")}};
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("month")},
-                             str_to_date_time("2022-10-01 00:00:00")}};
+                             std::string("2022-10-01 00:00:00")}};
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("year")},
-                             str_to_date_time("2022-01-01 00:00:00")}};
+                             std::string("2022-01-01 00:00:00")}};
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
 
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
-        DataSet data_set = {
-                {{std::string("2022-10-08 11:44:23.123"), std::string("second")},
-                 str_to_datetime_v2("2022-10-08 11:44:23.000", "%Y-%m-%d %H:%i:%s.%f")}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23.123"), std::string("second")},
+                             std::string("2022-10-08 11:44:23.000")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("minute")},
-                             str_to_datetime_v2("2022-10-08 11:44:00", "%Y-%m-%d %H:%i:%s")}};
+                             std::string("2022-10-08 11:44:00")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("hour")},
-                             str_to_datetime_v2("2022-10-08 11:00:00", "%Y-%m-%d %H:%i:%s")}};
+                             std::string("2022-10-08 11:00:00")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("day")},
-                             str_to_datetime_v2("2022-10-08 00:00:00", "%Y-%m-%d %H:%i:%s")}};
+                             std::string("2022-10-08 00:00:00")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("month")},
-                             str_to_datetime_v2("2022-10-01 00:00:00", "%Y-%m-%d %H:%i:%s")}};
+                             std::string("2022-10-01 00:00:00")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
     {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("year")},
-                             str_to_datetime_v2("2022-01-01 00:00:00", "%Y-%m-%d %H:%i:%s")}};
+                             std::string("2022-01-01 00:00:00")}};
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }
@@ -1609,11 +1598,11 @@ TEST(VTimestampFunctionsTest, hours_add_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-10-23 10:00:00.123"), -4},
-                             str_to_datetime_v2("2020-10-23 06:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-10-23 06:00:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 4},
-                             str_to_datetime_v2("2020-05-23 14:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 14:00:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
-                             str_to_datetime_v2("2020-05-27 14:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-27 14:00:00.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1622,12 +1611,9 @@ TEST(VTimestampFunctionsTest, hours_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-10-23"), -4},
-                             str_to_datetime_v2("2020-10-22 20:00:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 4},
-                             str_to_datetime_v2("2020-05-23 04:00:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 100},
-                             str_to_datetime_v2("2020-05-27 04:00:00", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-10-23"), -4}, std::string("2020-10-22 20:00:00")},
+                            {{std::string("2020-05-23"), 4}, std::string("2020-05-23 04:00:00")},
+                            {{std::string("2020-05-23"), 100}, std::string("2020-05-27 04:00:00")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1642,11 +1628,11 @@ TEST(VTimestampFunctionsTest, hours_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 10:00:00.123"), 4},
-                             str_to_datetime_v2("2020-05-23 06:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 06:00:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), -4},
-                             str_to_datetime_v2("2020-05-23 14:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 14:00:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 31},
-                             str_to_datetime_v2("2020-05-22 03:00:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-22 03:00:00.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1656,12 +1642,9 @@ TEST(VTimestampFunctionsTest, hours_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-05-23"), 4},
-                             str_to_datetime_v2("2020-05-22 20:00:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), -4},
-                             str_to_datetime_v2("2020-05-23 04:00:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 31},
-                             str_to_datetime_v2("2020-05-21 17:00:00", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-05-23"), 4}, std::string("2020-05-22 20:00:00")},
+                            {{std::string("2020-05-23"), -4}, std::string("2020-05-23 04:00:00")},
+                            {{std::string("2020-05-23"), 31}, std::string("2020-05-21 17:00:00")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1676,11 +1659,11 @@ TEST(VTimestampFunctionsTest, minutes_add_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-10-23 10:00:00.123"), 40},
-                             str_to_datetime_v2("2020-10-23 10:40:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-10-23 10:40:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
-                             str_to_datetime_v2("2020-05-23 09:20:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 09:20:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
-                             str_to_datetime_v2("2020-05-23 11:40:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 11:40:00.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1689,12 +1672,9 @@ TEST(VTimestampFunctionsTest, minutes_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-10-23"), 40},
-                             str_to_datetime_v2("2020-10-23 00:40:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), -40},
-                             str_to_datetime_v2("2020-05-22 23:20:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 100},
-                             str_to_datetime_v2("2020-05-23 01:40:00", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-10-23"), 40}, std::string("2020-10-23 00:40:00")},
+                            {{std::string("2020-05-23"), -40}, std::string("2020-05-22 23:20:00")},
+                            {{std::string("2020-05-23"), 100}, std::string("2020-05-23 01:40:00")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1709,11 +1689,11 @@ TEST(VTimestampFunctionsTest, minutes_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 10:00:00.123"), 40},
-                             str_to_datetime_v2("2020-05-23 09:20:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 09:20:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
-                             str_to_datetime_v2("2020-05-23 10:40:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 10:40:00.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
-                             str_to_datetime_v2("2020-05-23 08:20:00.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 08:20:00.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1722,12 +1702,9 @@ TEST(VTimestampFunctionsTest, minutes_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-05-23"), 40},
-                             str_to_datetime_v2("2020-05-22 23:20:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), -40},
-                             str_to_datetime_v2("2020-05-23 00:40:00", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 100},
-                             str_to_datetime_v2("2020-05-22 22:20:00", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-05-23"), 40}, std::string("2020-05-22 23:20:00")},
+                            {{std::string("2020-05-23"), -40}, std::string("2020-05-23 00:40:00")},
+                            {{std::string("2020-05-23"), 100}, std::string("2020-05-22 22:20:00")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1742,11 +1719,11 @@ TEST(VTimestampFunctionsTest, seconds_add_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-10-23 10:00:00.123"), 40},
-                             str_to_datetime_v2("2020-10-23 10:00:40.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-10-23 10:00:40.123")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
-                             str_to_datetime_v2("2020-05-23 09:59:20.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 09:59:20.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
-                             str_to_datetime_v2("2020-05-23 10:01:40.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 10:01:40.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1755,12 +1732,9 @@ TEST(VTimestampFunctionsTest, seconds_add_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-10-23"), 40},
-                             str_to_datetime_v2("2020-10-23 00:00:40", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), -40},
-                             str_to_datetime_v2("2020-05-22 23:59:20", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 100},
-                             str_to_datetime_v2("2020-05-23 00:01:40", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-10-23"), 40}, std::string("2020-10-23 00:00:40")},
+                            {{std::string("2020-05-23"), -40}, std::string("2020-05-22 23:59:20")},
+                            {{std::string("2020-05-23"), 100}, std::string("2020-05-23 00:01:40")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1775,11 +1749,11 @@ TEST(VTimestampFunctionsTest, seconds_sub_v2_test) {
         InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::Int32};
 
         DataSet data_set = {{{std::string("2020-05-23 10:00:00.123"), 40},
-                             str_to_datetime_v2("2020-05-23 09:59:20.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 09:59:20.123")},
                             {{std::string("2020-05-23 10:00:00.123"), -40},
-                             str_to_datetime_v2("2020-05-23 10:00:40.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 10:00:40.123")},
                             {{std::string("2020-05-23 10:00:00.123"), 100},
-                             str_to_datetime_v2("2020-05-23 09:58:20.123", "%Y-%m-%d %H:%i:%s.%f")},
+                             std::string("2020-05-23 09:58:20.123")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1788,12 +1762,9 @@ TEST(VTimestampFunctionsTest, seconds_sub_v2_test) {
     {
         InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::Int32};
 
-        DataSet data_set = {{{std::string("2020-05-23"), 40},
-                             str_to_datetime_v2("2020-05-22 23:59:20", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), -40},
-                             str_to_datetime_v2("2020-05-23 00:00:40", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2020-05-23"), 100},
-                             str_to_datetime_v2("2020-05-22 23:58:20", "%Y-%m-%d %H:%i:%s.%f")},
+        DataSet data_set = {{{std::string("2020-05-23"), 40}, std::string("2020-05-22 23:59:20")},
+                            {{std::string("2020-05-23"), -40}, std::string("2020-05-23 00:00:40")},
+                            {{std::string("2020-05-23"), 100}, std::string("2020-05-22 23:58:20")},
                             {{Null(), 4}, Null()}};
 
         static_cast<void>(
@@ -1837,82 +1808,53 @@ TEST(VTimestampFunctionsTest, next_day_test) {
     std::string func_name = "next_day";
     BaseInputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::String};
     {
-        DataSet data_set = {{{std::string("2020-01-01"), std::string("MO")},
-                             str_to_date_v2("2020-01-06", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("MON")},
-                             str_to_date_v2("2020-01-06", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("MONDAY")},
-                             str_to_date_v2("2020-01-06", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("TU")},
-                             str_to_date_v2("2020-01-07", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("TUE")},
-                             str_to_date_v2("2020-01-07", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("TUESDAY")},
-                             str_to_date_v2("2020-01-07", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("WE")},
-                             str_to_date_v2("2020-01-08", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("WED")},
-                             str_to_date_v2("2020-01-08", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("WEDNESDAY")},
-                             str_to_date_v2("2020-01-08", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("TH")},
-                             str_to_date_v2("2020-01-02", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("THU")},
-                             str_to_date_v2("2020-01-02", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("THURSDAY")},
-                             str_to_date_v2("2020-01-02", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("FR")},
-                             str_to_date_v2("2020-01-03", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("FRI")},
-                             str_to_date_v2("2020-01-03", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("FRIDAY")},
-                             str_to_date_v2("2020-01-03", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("SA")},
-                             str_to_date_v2("2020-01-04", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("SAT")},
-                             str_to_date_v2("2020-01-04", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("SATURDAY")},
-                             str_to_date_v2("2020-01-04", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("SU")},
-                             str_to_date_v2("2020-01-05", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("SUN")},
-                             str_to_date_v2("2020-01-05", "%Y-%m-%d")},
-                            {{std::string("2020-01-01"), std::string("SUNDAY")},
-                             str_to_date_v2("2020-01-05", "%Y-%m-%d")},
-                            {{Null(), std::string("MON")}, Null()}};
+        DataSet data_set = {
+                {{std::string("2020-01-01"), std::string("MO")}, std::string("2020-01-06")},
+                {{std::string("2020-01-01"), std::string("MON")}, std::string("2020-01-06")},
+                {{std::string("2020-01-01"), std::string("MONDAY")}, std::string("2020-01-06")},
+                {{std::string("2020-01-01"), std::string("TU")}, std::string("2020-01-07")},
+                {{std::string("2020-01-01"), std::string("TUE")}, std::string("2020-01-07")},
+                {{std::string("2020-01-01"), std::string("TUESDAY")}, std::string("2020-01-07")},
+                {{std::string("2020-01-01"), std::string("WE")}, std::string("2020-01-08")},
+                {{std::string("2020-01-01"), std::string("WED")}, std::string("2020-01-08")},
+                {{std::string("2020-01-01"), std::string("WEDNESDAY")}, std::string("2020-01-08")},
+                {{std::string("2020-01-01"), std::string("TH")}, std::string("2020-01-02")},
+                {{std::string("2020-01-01"), std::string("THU")}, std::string("2020-01-02")},
+                {{std::string("2020-01-01"), std::string("THURSDAY")}, std::string("2020-01-02")},
+                {{std::string("2020-01-01"), std::string("FR")}, std::string("2020-01-03")},
+                {{std::string("2020-01-01"), std::string("FRI")}, std::string("2020-01-03")},
+                {{std::string("2020-01-01"), std::string("FRIDAY")}, std::string("2020-01-03")},
+                {{std::string("2020-01-01"), std::string("SA")}, std::string("2020-01-04")},
+                {{std::string("2020-01-01"), std::string("SAT")}, std::string("2020-01-04")},
+                {{std::string("2020-01-01"), std::string("SATURDAY")}, std::string("2020-01-04")},
+                {{std::string("2020-01-01"), std::string("SU")}, std::string("2020-01-05")},
+                {{std::string("2020-01-01"), std::string("SUN")}, std::string("2020-01-05")},
+                {{std::string("2020-01-01"), std::string("SUNDAY")}, std::string("2020-01-05")},
+                {{Null(), std::string("MON")}, Null()}};
         static_cast<void>(check_function_all_arg_comb<DataTypeDateV2, true>(func_name, input_types,
                                                                             data_set));
     }
     {
-        DataSet data_set = {// date over month
-                            {{std::string("2020-01-28"), std::string("MON")},
-                             str_to_date_v2("2020-02-03", "%Y-%m-%d")},
-                            {{std::string("2020-01-31"), std::string("SAT")},
-                             str_to_date_v2("2020-02-01", "%Y-%m-%d")},
+        DataSet data_set = {
+                // date over month
+                {{std::string("2020-01-28"), std::string("MON")}, std::string("2020-02-03")},
+                {{std::string("2020-01-31"), std::string("SAT")}, std::string("2020-02-01")},
 
-                            // date over year
-                            {{std::string("2020-12-28"), std::string("FRI")},
-                             str_to_date_v2("2021-01-01", "%Y-%m-%d")},
-                            {{std::string("2020-12-31"), std::string("THU")},
-                             str_to_date_v2("2021-01-07", "%Y-%m-%d")},
+                // date over year
+                {{std::string("2020-12-28"), std::string("FRI")}, std::string("2021-01-01")},
+                {{std::string("2020-12-31"), std::string("THU")}, std::string("2021-01-07")},
 
-                            // leap year(29 Feb)
-                            {{std::string("2020-02-27"), std::string("SAT")},
-                             str_to_date_v2("2020-02-29", "%Y-%m-%d")},
-                            {{std::string("2020-02-29"), std::string("MON")},
-                             str_to_date_v2("2020-03-02", "%Y-%m-%d")},
+                // leap year(29 Feb)
+                {{std::string("2020-02-27"), std::string("SAT")}, std::string("2020-02-29")},
+                {{std::string("2020-02-29"), std::string("MON")}, std::string("2020-03-02")},
 
-                            // non leap year(28 Feb)
-                            {{std::string("2019-02-26"), std::string("THU")},
-                             str_to_date_v2("2019-02-28", "%Y-%m-%d")},
-                            {{std::string("2019-02-28"), std::string("SUN")},
-                             str_to_date_v2("2019-03-03", "%Y-%m-%d")},
+                // non leap year(28 Feb)
+                {{std::string("2019-02-26"), std::string("THU")}, std::string("2019-02-28")},
+                {{std::string("2019-02-28"), std::string("SUN")}, std::string("2019-03-03")},
 
-                            // date over month
-                            {{std::string("2020-04-29"), std::string("FRI")},
-                             str_to_date_v2("2020-05-01", "%Y-%m-%d")},
-                            {{std::string("2020-05-31"), std::string("MON")},
-                             str_to_date_v2("2020-06-01", "%Y-%m-%d")}};
+                // date over month
+                {{std::string("2020-04-29"), std::string("FRI")}, std::string("2020-05-01")},
+                {{std::string("2020-05-31"), std::string("MON")}, std::string("2020-06-01")}};
         static_cast<void>(check_function_all_arg_comb<DataTypeDateV2, true>(func_name, input_types,
                                                                             data_set));
     }

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -1786,7 +1786,7 @@ TEST(VTimestampFunctionsTest, year_of_week_test) {
 
 TEST(VTimestampFunctionsTest, months_between_test) {
     std::string func_name = "months_between";
-    BaseInputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::DateV2, TypeIndex::UInt8};
+    InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::DateV2, TypeIndex::UInt8};
     DataSet data_set = {
             {{std::string("2020-01-01"), std::string("2020-02-01"), uint8_t(0)}, double(-1.0)},
             {{std::string("2020-01-01"), std::string("2020-03-01"), uint8_t(1)}, double(-2.0)},
@@ -1806,7 +1806,7 @@ TEST(VTimestampFunctionsTest, months_between_test) {
 
 TEST(VTimestampFunctionsTest, next_day_test) {
     std::string func_name = "next_day";
-    BaseInputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::String};
+    InputTypeSet input_types = {TypeIndex::DateV2, TypeIndex::String};
     {
         DataSet data_set = {
                 {{std::string("2020-01-01"), std::string("MO")}, std::string("2020-01-06")},

--- a/be/test/vec/function/table_function_test.cpp
+++ b/be/test/vec/function/table_function_test.cpp
@@ -27,7 +27,6 @@
 #include "common/status.h"
 #include "exprs/mock_vexpr.h"
 #include "testutil/any_type.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/exprs/table_function/vexplode.h"
 #include "vec/exprs/table_function/vexplode_numbers.h"
@@ -86,7 +85,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
         TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
-        InputDataSet input_set = {{vec}, {Null()}, {Array()}};
+        InputDataSet input_set = {{AnyType {vec}}, {Null()}, {AnyType {TestArray {}}}};
 
         InputTypeSet output_types = {TypeIndex::Int32};
         InputDataSet output_set = {{Int32(1)}, {Null()}, {Int32(2)},
@@ -99,7 +98,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
         TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::String};
         InputDataSet output_set = {
@@ -112,7 +111,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2};
         TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67)};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::Decimal128V2};
         InputDataSet output_set = {{Null()},
@@ -134,13 +133,13 @@ TEST_F(TableFunctionTest, vexplode_outer_v2) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
         TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
-        InputDataSet input_set = {{vec}, {Null()}, {Array()}};
+        InputDataSet input_set = {{AnyType {vec}}, {Null()}, {AnyType {TestArray {}}}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Int32};
 
-        InputDataSet output_set = {{{InputCell {Int32(1)}}}, {{InputCell {Null()}}},
-                                   {{InputCell {Int32(2)}}}, {{InputCell {Int32(3)}}},
-                                   {{InputCell {Null()}}},   {{InputCell {Null()}}}};
+        InputDataSet output_set = {{{TestArray {Int32(1)}}}, {{TestArray {Null()}}},
+                                   {{TestArray {Int32(2)}}}, {{TestArray {Int32(3)}}},
+                                   {{TestArray {Null()}}},   {{TestArray {Null()}}}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }
@@ -149,15 +148,15 @@ TEST_F(TableFunctionTest, vexplode_outer_v2) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
         TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String};
 
-        InputDataSet output_set = {{{InputCell {Null()}}},
-                                   {{InputCell {Null()}}},
-                                   {{InputCell {std::string("abc")}}},
-                                   {{InputCell {std::string("")}}},
-                                   {{InputCell {std::string("def")}}}};
+        InputDataSet output_set = {{{TestArray {Null()}}},
+                                   {{TestArray {Null()}}},
+                                   {{TestArray {std::string("abc")}}},
+                                   {{TestArray {std::string("")}}},
+                                   {{TestArray {std::string("def")}}}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }
@@ -166,14 +165,14 @@ TEST_F(TableFunctionTest, vexplode_outer_v2) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2};
         TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67)};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Decimal128V2};
 
-        InputDataSet output_set = {{{InputCell {Null()}}},
-                                   {{InputCell {Null()}}},
-                                   {{InputCell {ut_type::DECIMALV2(17014116.67)}}},
-                                   {{InputCell {ut_type::DECIMALV2(-17014116.67)}}}};
+        InputDataSet output_set = {{{TestArray {Null()}}},
+                                   {{TestArray {Null()}}},
+                                   {{TestArray {ut_type::DECIMALV2(17014116.67)}}},
+                                   {{TestArray {ut_type::DECIMALV2(-17014116.67)}}}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }
@@ -189,7 +188,7 @@ TEST_F(TableFunctionTest, vexplode) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
         TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
-        InputDataSet input_set = {{vec}, {Null()}, {Array()}};
+        InputDataSet input_set = {{AnyType {vec}}, {Null()}, {AnyType {TestArray {}}}};
 
         InputTypeSet output_types = {TypeIndex::Int32};
         InputDataSet output_set = {{Int32(1)}, {Null()}, {Int32(2)}, {Int32(3)}};
@@ -201,7 +200,7 @@ TEST_F(TableFunctionTest, vexplode) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
         TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::String};
         InputDataSet output_set = {{std::string("abc")}, {std::string("")}, {std::string("def")}};
@@ -213,7 +212,7 @@ TEST_F(TableFunctionTest, vexplode) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date};
         TestArray vec = {Null(), std::string("2022-01-02")};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::Date};
         InputDataSet output_set = {{Null()}, {std::string("2022-01-02")}};
@@ -232,13 +231,13 @@ TEST_F(TableFunctionTest, vexplode_v2) {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
         TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
-        InputDataSet input_set = {{vec}, {Null()}, {Array()}};
+        InputDataSet input_set = {{AnyType {vec}}, {Null()}, {AnyType {TestArray {}}}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Int32};
-        InputDataSet output_set = {{{InputCell {Int32(1)}}},
-                                   {{InputCell {Null()}}},
-                                   {{InputCell {Int32(2)}}},
-                                   {{InputCell {Int32(3)}}}};
+        InputDataSet output_set = {{{TestArray {Int32(1)}}},
+                                   {{TestArray {Null()}}},
+                                   {{TestArray {Int32(2)}}},
+                                   {{TestArray {Int32(3)}}}};
 
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set);
     }
@@ -247,13 +246,13 @@ TEST_F(TableFunctionTest, vexplode_v2) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
         TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String};
 
-        InputDataSet output_set = {{{InputCell {std::string("abc")}}},
-                                   {{InputCell {std::string("")}}},
-                                   {{InputCell {std::string("def")}}}};
+        InputDataSet output_set = {{{TestArray {std::string("abc")}}},
+                                   {{TestArray {std::string("")}}},
+                                   {{TestArray {std::string("def")}}}};
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set);
     }
 
@@ -261,12 +260,12 @@ TEST_F(TableFunctionTest, vexplode_v2) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date};
         TestArray vec = {Null(), std::string("2022-01-02")};
-        InputDataSet input_set = {{Null()}, {Array()}, {vec}};
+        InputDataSet input_set = {{Null()}, {AnyType {TestArray {}}}, {AnyType {vec}}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Date};
 
-        InputDataSet output_set = {{{InputCell {Null()}}},
-                                   {{InputCell {std::string("2022-01-02")}}}};
+        InputDataSet output_set = {{{TestArray {Null()}}},
+                                   {{TestArray {std::string("2022-01-02")}}}};
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set);
     }
 }
@@ -284,9 +283,9 @@ TEST_F(TableFunctionTest, vexplode_v2_two_param) {
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String, TypeIndex::String};
 
-        InputDataSet output_set = {{{InputCell {std::string("one"), std::string("1")}}},
-                                   {{InputCell {std::string("two"), std::string("2")}}},
-                                   {{InputCell {std::string("three"), std::string("3")}}}};
+        InputDataSet output_set = {{{TestArray {std::string("one"), std::string("1")}}},
+                                   {{TestArray {std::string("two"), std::string("2")}}},
+                                   {{TestArray {std::string("three"), std::string("3")}}}};
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, false);
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, true);
     }
@@ -299,9 +298,9 @@ TEST_F(TableFunctionTest, vexplode_v2_two_param) {
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String, TypeIndex::String};
 
-        InputDataSet output_set = {{{InputCell {Null(), std::string("one")}}},
-                                   {{InputCell {Null(), std::string("two")}}},
-                                   {{InputCell {Null(), std::string("three")}}}};
+        InputDataSet output_set = {{{TestArray {Null(), std::string("one")}}},
+                                   {{TestArray {Null(), std::string("two")}}},
+                                   {{TestArray {Null(), std::string("three")}}}};
 
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, false);
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, true);
@@ -311,14 +310,14 @@ TEST_F(TableFunctionTest, vexplode_v2_two_param) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
         TestArray vec = {std::string("one"), std::string("two"), std::string("three")};
-        TestArray vec1 = {std::string("1"), Field(Null()), std::string("3")};
+        TestArray vec1 = {std::string("1"), Null(), std::string("3")};
         InputDataSet input_set = {{vec, vec1}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String, TypeIndex::String};
 
-        InputDataSet output_set = {{{InputCell {std::string("one"), std::string("1")}}},
-                                   {{InputCell {std::string("two"), Null()}}},
-                                   {{InputCell {std::string("three"), std::string("3")}}}};
+        InputDataSet output_set = {{{TestArray {std::string("one"), std::string("1")}}},
+                                   {{TestArray {std::string("two"), Null()}}},
+                                   {{TestArray {std::string("three"), std::string("3")}}}};
 
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, false);
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, true);
@@ -371,5 +370,4 @@ TEST_F(TableFunctionTest, vexplode_split) {
         }
     }
 }
-
 } // namespace doris::vectorized

--- a/be/test/vec/function/table_function_test.cpp
+++ b/be/test/vec/function/table_function_test.cpp
@@ -85,7 +85,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     // explode_outer(Array<Int32>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
-        Array vec = {Int32(1), Null(), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
         InputDataSet input_set = {{vec}, {Null()}, {Array()}};
 
         InputTypeSet output_types = {TypeIndex::Int32};
@@ -98,7 +98,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     // explode_outer(Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("abc")), Field(std::string("")), Field(std::string("def"))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::String};
@@ -111,7 +111,7 @@ TEST_F(TableFunctionTest, vexplode_outer) {
     // explode_outer(Array<Decimal>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2};
-        Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67)};
+        TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67)};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::Decimal128V2};
@@ -133,14 +133,14 @@ TEST_F(TableFunctionTest, vexplode_outer_v2) {
     // explode_outer(Array<Int32>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
-        Array vec = {Int32(1), Null(), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
         InputDataSet input_set = {{vec}, {Null()}, {Array()}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Int32};
 
-        InputDataSet output_set = {{{CellSet {Int32(1)}}}, {{CellSet {Null()}}},
-                                   {{CellSet {Int32(2)}}}, {{CellSet {Int32(3)}}},
-                                   {{CellSet {Null()}}},   {{CellSet {Null()}}}};
+        InputDataSet output_set = {{{InputCell {Int32(1)}}}, {{InputCell {Null()}}},
+                                   {{InputCell {Int32(2)}}}, {{InputCell {Int32(3)}}},
+                                   {{InputCell {Null()}}},   {{InputCell {Null()}}}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }
@@ -148,16 +148,16 @@ TEST_F(TableFunctionTest, vexplode_outer_v2) {
     // explode_outer(Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("abc")), Field(std::string("")), Field(std::string("def"))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String};
 
-        InputDataSet output_set = {{{CellSet {Null()}}},
-                                   {{CellSet {Null()}}},
-                                   {{CellSet {std::string("abc")}}},
-                                   {{CellSet {std::string("")}}},
-                                   {{CellSet {std::string("def")}}}};
+        InputDataSet output_set = {{{InputCell {Null()}}},
+                                   {{InputCell {Null()}}},
+                                   {{InputCell {std::string("abc")}}},
+                                   {{InputCell {std::string("")}}},
+                                   {{InputCell {std::string("def")}}}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }
@@ -165,15 +165,15 @@ TEST_F(TableFunctionTest, vexplode_outer_v2) {
     // explode_outer(Array<Decimal>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Decimal128V2};
-        Array vec = {ut_type::DECIMALFIELD(17014116.67), ut_type::DECIMALFIELD(-17014116.67)};
+        TestArray vec = {ut_type::DECIMALV2(17014116.67), ut_type::DECIMALV2(-17014116.67)};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Decimal128V2};
 
-        InputDataSet output_set = {{{CellSet {Null()}}},
-                                   {{CellSet {Null()}}},
-                                   {{CellSet {ut_type::DECIMALV2(17014116.67)}}},
-                                   {{CellSet {ut_type::DECIMALV2(-17014116.67)}}}};
+        InputDataSet output_set = {{{InputCell {Null()}}},
+                                   {{InputCell {Null()}}},
+                                   {{InputCell {ut_type::DECIMALV2(17014116.67)}}},
+                                   {{InputCell {ut_type::DECIMALV2(-17014116.67)}}}};
 
         check_vec_table_function(&explode_outer, input_types, input_set, output_types, output_set);
     }
@@ -188,7 +188,7 @@ TEST_F(TableFunctionTest, vexplode) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Null(), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
         InputDataSet input_set = {{vec}, {Null()}, {Array()}};
 
         InputTypeSet output_types = {TypeIndex::Int32};
@@ -200,7 +200,7 @@ TEST_F(TableFunctionTest, vexplode) {
     // explode(Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("abc")), Field(std::string("")), Field(std::string("def"))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::String};
@@ -212,7 +212,7 @@ TEST_F(TableFunctionTest, vexplode) {
     // explode(Array<Date>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date};
-        Array vec = {Null(), str_to_date_time("2022-01-02", false)};
+        TestArray vec = {Null(), std::string("2022-01-02")};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::Date};
@@ -231,14 +231,14 @@ TEST_F(TableFunctionTest, vexplode_v2) {
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Int32};
 
-        Array vec = {Int32(1), Null(), Int32(2), Int32(3)};
+        TestArray vec = {Int32(1), Null(), Int32(2), Int32(3)};
         InputDataSet input_set = {{vec}, {Null()}, {Array()}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Int32};
-        InputDataSet output_set = {{{CellSet {Int32(1)}}},
-                                   {{CellSet {Null()}}},
-                                   {{CellSet {Int32(2)}}},
-                                   {{CellSet {Int32(3)}}}};
+        InputDataSet output_set = {{{InputCell {Int32(1)}}},
+                                   {{InputCell {Null()}}},
+                                   {{InputCell {Int32(2)}}},
+                                   {{InputCell {Int32(3)}}}};
 
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set);
     }
@@ -246,26 +246,27 @@ TEST_F(TableFunctionTest, vexplode_v2) {
     // explode(Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("abc")), Field(std::string("")), Field(std::string("def"))};
+        TestArray vec = {std::string("abc"), std::string(""), std::string("def")};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String};
 
-        InputDataSet output_set = {{{CellSet {std::string("abc")}}},
-                                   {{CellSet {std::string("")}}},
-                                   {{CellSet {std::string("def")}}}};
+        InputDataSet output_set = {{{InputCell {std::string("abc")}}},
+                                   {{InputCell {std::string("")}}},
+                                   {{InputCell {std::string("def")}}}};
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set);
     }
 
     // explode(Array<Date>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::Date};
-        Array vec = {Null(), str_to_date_time("2022-01-02", false)};
+        TestArray vec = {Null(), std::string("2022-01-02")};
         InputDataSet input_set = {{Null()}, {Array()}, {vec}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::Date};
 
-        InputDataSet output_set = {{{CellSet {Null()}}}, {{CellSet {std::string("2022-01-02")}}}};
+        InputDataSet output_set = {{{InputCell {Null()}}},
+                                   {{InputCell {std::string("2022-01-02")}}}};
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set);
     }
 }
@@ -277,16 +278,15 @@ TEST_F(TableFunctionTest, vexplode_v2_two_param) {
     // explode(Array<String>, Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("one")), Field(std::string("two")),
-                     Field(std::string("three"))};
-        Array vec1 = {Field(std::string("1")), Field(std::string("2")), Field(std::string("3"))};
+        TestArray vec = {std::string("one"), std::string("two"), std::string("three")};
+        TestArray vec1 = {std::string("1"), std::string("2"), std::string("3")};
         InputDataSet input_set = {{vec, vec1}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String, TypeIndex::String};
 
-        InputDataSet output_set = {{{CellSet {std::string("one"), std::string("1")}}},
-                                   {{CellSet {std::string("two"), std::string("2")}}},
-                                   {{CellSet {std::string("three"), std::string("3")}}}};
+        InputDataSet output_set = {{{InputCell {std::string("one"), std::string("1")}}},
+                                   {{InputCell {std::string("two"), std::string("2")}}},
+                                   {{InputCell {std::string("three"), std::string("3")}}}};
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, false);
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, true);
     }
@@ -294,15 +294,14 @@ TEST_F(TableFunctionTest, vexplode_v2_two_param) {
     // explode(null, Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("one")), Field(std::string("two")),
-                     Field(std::string("three"))};
+        TestArray vec = {std::string("one"), std::string("two"), std::string("three")};
         InputDataSet input_set = {{Null(), vec}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String, TypeIndex::String};
 
-        InputDataSet output_set = {{{CellSet {Null(), std::string("one")}}},
-                                   {{CellSet {Null(), std::string("two")}}},
-                                   {{CellSet {Null(), std::string("three")}}}};
+        InputDataSet output_set = {{{InputCell {Null(), std::string("one")}}},
+                                   {{InputCell {Null(), std::string("two")}}},
+                                   {{InputCell {Null(), std::string("three")}}}};
 
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, false);
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, true);
@@ -311,16 +310,15 @@ TEST_F(TableFunctionTest, vexplode_v2_two_param) {
     // explode(Array<Null>, Array<String>)
     {
         InputTypeSet input_types = {TypeIndex::Array, TypeIndex::String};
-        Array vec = {Field(std::string("one")), Field(std::string("two")),
-                     Field(std::string("three"))};
-        Array vec1 = {Field(std::string("1")), Field(Null()), Field(std::string("3"))};
+        TestArray vec = {std::string("one"), std::string("two"), std::string("three")};
+        TestArray vec1 = {std::string("1"), Field(Null()), std::string("3")};
         InputDataSet input_set = {{vec, vec1}};
 
         InputTypeSet output_types = {TypeIndex::Struct, TypeIndex::String, TypeIndex::String};
 
-        InputDataSet output_set = {{{CellSet {std::string("one"), std::string("1")}}},
-                                   {{CellSet {std::string("two"), Null()}}},
-                                   {{CellSet {std::string("three"), std::string("3")}}}};
+        InputDataSet output_set = {{{InputCell {std::string("one"), std::string("1")}}},
+                                   {{InputCell {std::string("two"), Null()}}},
+                                   {{InputCell {std::string("three"), std::string("3")}}}};
 
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, false);
         check_vec_table_function(&explode, input_types, input_set, output_types, output_set, true);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

fixed problems in BEUT listed here:
1. cannot compare decimal of datetimev2
2. parsing from string to datetime which should lead to null result leads to illegal value.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

