### PR TITLE
branch-3.0: correct `DeleteBitmap::get_delete_bitmap_count`

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1314,7 +1314,13 @@ void DeleteBitmap::remove_stale_delete_bitmap_from_queue(const std::vector<std::
 
 uint64_t DeleteBitmap::get_delete_bitmap_count() {
     std::shared_lock l(lock);
-    return delete_bitmap.size();
+    uint64_t count = 0;
+    for (auto it = delete_bitmap.begin(); it != delete_bitmap.end(); it++) {
+        if (std::get<1>(it->first) != DeleteBitmap::INVALID_SEGMENT_ID) {
+            count++;
+        }
+    }
+    return count;
 }
 
 bool DeleteBitmap::has_calculated_for_multi_segments(const RowsetId& rowset_id) const {


### PR DESCRIPTION
fix `DeleteBitmap::get_delete_bitmap_count`, don't include `ROWSET_SENTINEL_MARK` for better problem hunting. 