### PR TITLE
[refactor](terminate) add terminate interface

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -84,9 +84,6 @@ void Dependency::set_ready() {
 }
 
 Dependency* Dependency::is_blocked_by(PipelineTask* task) {
-    if (task && task->wake_up_early()) {
-        return nullptr;
-    }
     std::unique_lock<std::mutex> lc(_task_lock);
     auto ready = _ready.load();
     if (!ready && task) {

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -106,7 +106,6 @@ Status HashJoinBuildSinkLocalState::terminate(RuntimeState* state) {
     if (_terminated) {
         return Status::OK();
     }
-    _shared_state->build_block.reset();
     RETURN_IF_ERROR(_runtime_filter_producer_helper->terminate(state));
     return JoinBuildSinkLocalState::terminate(state);
 }

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -233,12 +233,10 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
 
     try {
         if (!_terminated && _runtime_filter_producer_helper && !state->is_cancelled()) {
-            if (_should_build_hash_table) {
-                RETURN_IF_ERROR(_runtime_filter_producer_helper->build(
-                        state, _shared_state->build_block.get()));
-            }
-            RETURN_IF_ERROR(_runtime_filter_producer_helper->publish(
-                    state, p._use_shared_hash_table, p._runtime_filters));
+            RETURN_IF_ERROR(_runtime_filter_producer_helper->build(
+                    state, _shared_state->build_block.get(), p._use_shared_hash_table,
+                    p._runtime_filters));
+            RETURN_IF_ERROR(_runtime_filter_producer_helper->publish(state));
         }
     } catch (Exception& e) {
         bool blocked_by_shared_hash_table_signal =

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -232,12 +232,8 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
         }
     }};
 
-    if (!_runtime_filter_producer_helper || state->is_cancelled() || !_eos) {
-        return Base::close(state, exec_status);
-    }
-
     try {
-        if (!_terminated) {
+        if (!_terminated && _runtime_filter_producer_helper && !state->is_cancelled()) {
             if (_should_build_hash_table) {
                 RETURN_IF_ERROR(_runtime_filter_producer_helper->build(
                         state, _shared_state->build_block.get()));

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -36,6 +36,7 @@ public:
 
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
     Status open(RuntimeState* state) override;
+    Status terminate(RuntimeState* state) override;
     Status process_build_block(RuntimeState* state, vectorized::Block& block);
 
     void init_short_circuit_for_probe();

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -120,6 +120,15 @@ std::string PipelineXSinkLocalState<SharedStateArg>::name_suffix() {
     }() + ")";
 }
 
+template <typename SharedStateArg>
+Status PipelineXSinkLocalState<SharedStateArg>::terminate(RuntimeState* state) {
+    if (_terminated) {
+        return Status::OK();
+    }
+    _terminated = true;
+    return Status::OK();
+}
+
 DataDistribution OperatorBase::required_data_distribution() const {
     return _child && _child->is_serial_operator() && !is_source()
                    ? DataDistribution(ExchangeType::PASSTHROUGH)
@@ -235,6 +244,17 @@ Status OperatorXBase::prepare(RuntimeState* state) {
         RETURN_IF_ERROR(_child->prepare(state));
     }
     return Status::OK();
+}
+
+Status OperatorXBase::terminate(RuntimeState* state) {
+    if (_child && !is_source()) {
+        RETURN_IF_ERROR(_child->terminate(state));
+    }
+    auto result = state->get_local_state_result(operator_id());
+    if (!result) {
+        return result.error();
+    }
+    return result.value()->terminate(state);
 }
 
 Status OperatorXBase::close(RuntimeState* state) {
@@ -388,6 +408,14 @@ void PipelineXLocalStateBase::reached_limit(vectorized::Block* block, bool* eos)
     }
 }
 
+Status DataSinkOperatorXBase::terminate(RuntimeState* state) {
+    auto result = state->get_sink_local_state_result();
+    if (!result) {
+        return result.error();
+    }
+    return result.value()->terminate(state);
+}
+
 std::string DataSinkOperatorXBase::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
 
@@ -528,6 +556,15 @@ Status PipelineXLocalState<SharedStateArg>::open(RuntimeState* state) {
                     state, _intermediate_projections[i][j]));
         }
     }
+    return Status::OK();
+}
+
+template <typename SharedStateArg>
+Status PipelineXLocalState<SharedStateArg>::terminate(RuntimeState* state) {
+    if (_terminated) {
+        return Status::OK();
+    }
+    _terminated = true;
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -247,7 +247,7 @@ protected:
     std::vector<vectorized::VExprContextSPtrs> _intermediate_projections;
 
     bool _closed = false;
-    bool _terminated = false;
+    std::atomic<bool> _terminated = false;
     vectorized::Block _origin_block;
 };
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -102,6 +102,7 @@ public:
 
     [[nodiscard]] virtual std::string get_name() const = 0;
     [[nodiscard]] virtual Status prepare(RuntimeState* state) = 0;
+    [[nodiscard]] virtual Status terminate(RuntimeState* state) = 0;
     [[nodiscard]] virtual Status close(RuntimeState* state);
 
     [[nodiscard]] virtual Status set_child(OperatorPtr child) {
@@ -173,6 +174,7 @@ public:
     // idempotent (e.g. wait for runtime filters).
     virtual Status open(RuntimeState* state) = 0;
     virtual Status close(RuntimeState* state) = 0;
+    virtual Status terminate(RuntimeState* state) = 0;
 
     // If use projection, we should clear `_origin_block`.
     void clear_origin_block();
@@ -245,6 +247,7 @@ protected:
     std::vector<vectorized::VExprContextSPtrs> _intermediate_projections;
 
     bool _closed = false;
+    bool _terminated = false;
     vectorized::Block _origin_block;
 };
 
@@ -262,6 +265,7 @@ public:
     virtual std::string name_suffix() const;
 
     Status close(RuntimeState* state) override;
+    Status terminate(RuntimeState* state) override;
 
     [[nodiscard]] std::string debug_string(int indentation_level = 0) const override;
 
@@ -434,6 +438,7 @@ public:
     // Do initialization. This step can be executed multiple times, so we should make sure it is
     // idempotent (e.g. wait for runtime filters).
     virtual Status open(RuntimeState* state) = 0;
+    virtual Status terminate(RuntimeState* state) = 0;
     virtual Status close(RuntimeState* state, Status exec_status) = 0;
     [[nodiscard]] virtual bool is_finished() const { return false; }
 
@@ -480,6 +485,7 @@ protected:
     // Set to true after close() has been called. subclasses should check and set this in
     // close().
     bool _closed = false;
+    bool _terminated = false;
     std::atomic<bool> _eos = false;
     //NOTICE: now add a faker profile, because sometimes the profile record is useless
     //so we want remove some counters and timers, eg: in join node, if it's broadcast_join
@@ -510,6 +516,7 @@ public:
 
     Status open(RuntimeState* state) override { return Status::OK(); }
 
+    Status terminate(RuntimeState* state) override;
     Status close(RuntimeState* state, Status exec_status) override;
 
     [[nodiscard]] std::string debug_string(int indentation_level) const override;
@@ -557,6 +564,7 @@ public:
     }
 
     Status prepare(RuntimeState* state) override { return Status::OK(); }
+    Status terminate(RuntimeState* state) override;
     [[nodiscard]] bool is_finished(RuntimeState* state) const {
         auto result = state->get_sink_local_state_result();
         if (!result) {
@@ -818,6 +826,7 @@ public:
     [[nodiscard]] virtual Status hold_tablets(RuntimeState* state) { return Status::OK(); }
     Status prepare(RuntimeState* state) override;
 
+    Status terminate(RuntimeState* state) override;
     [[nodiscard]] virtual Status get_block(RuntimeState* state, vectorized::Block* block,
                                            bool* eos) = 0;
 

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -69,7 +69,6 @@ Status PartitionedHashJoinSinkLocalState::open(RuntimeState* state) {
     _shared_state->setup_shared_profile(_profile);
     RETURN_IF_ERROR(PipelineXSpillSinkLocalState::open(state));
     auto& p = _parent->cast<PartitionedHashJoinSinkOperatorX>();
-    _shared_state->inner_runtime_state->set_task(state->get_task());
     for (uint32_t i = 0; i != p._partition_count; ++i) {
         auto& spilling_stream = _shared_state->spilled_streams[i];
         RETURN_IF_ERROR(ExecEnv::GetInstance()->spill_stream_mgr()->register_spill_stream(
@@ -521,7 +520,6 @@ Status PartitionedHashJoinSinkLocalState::_setup_internal_operator(RuntimeState*
     auto inner_runtime_state = RuntimeState::create_unique(
             state->fragment_instance_id(), state->query_id(), state->fragment_id(),
             state->query_options(), TQueryGlobals {}, state->exec_env(), state->get_query_ctx());
-    inner_runtime_state->set_task(state->get_task());
     inner_runtime_state->set_task_execution_context(state->get_task_execution_context().lock());
     inner_runtime_state->set_be_number(state->be_number());
 

--- a/be/src/pipeline/exec/set_probe_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_probe_sink_operator.cpp
@@ -95,11 +95,7 @@ Status SetProbeSinkOperatorX<is_intersect>::sink(RuntimeState* state, vectorized
                 local_state._shared_state->hash_table_variants->method_variant));
     }
 
-    if (eos
-#ifndef BE_TEST
-        && !state->get_task()->wake_up_early()
-#endif
-    ) {
+    if (eos && !local_state._terminated) {
         _finalize_probe(local_state);
     }
     return Status::OK();

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -461,7 +461,6 @@ Status PipelineFragmentContext::_build_pipeline_tasks(const doris::TPipelineFrag
                         pipeline, cur_task_id, task_runtime_state.get(), this,
                         pipeline_id_to_profile[pip_idx].get(), get_shared_state(pipeline), i);
                 pipeline->incr_created_tasks(i, task.get());
-                task_runtime_state->set_task(task.get());
                 pipeline_id_to_task.insert({pipeline->id(), task.get()});
                 _tasks[i].emplace_back(std::move(task));
             }

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -511,7 +511,7 @@ Status PipelineTask::execute(bool* done) {
             _eos = eos;
         }
 
-        if ((!_block->empty() || _eos) && !_wake_up_early) {
+        if (!_block->empty() || _eos) {
             SCOPED_TIMER(_sink_timer);
             Status status = Status::OK();
             DEFER_RELEASE_RESERVED();

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -203,8 +203,6 @@ public:
     [[nodiscard]] size_t get_revocable_size() const;
     [[nodiscard]] Status revoke_memory(const std::shared_ptr<SpillContext>& spill_context);
 
-    bool wake_up_early() const { return _wake_up_early; }
-
     Status blocked(Dependency* dependency) {
         DCHECK_EQ(_blocked_dep, nullptr) << "task: " << debug_string();
         _blocked_dep = dependency;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -635,10 +635,6 @@ public:
 
     void set_task_id(int id) { _task_id = id; }
 
-    void set_task(pipeline::PipelineTask* task) { _task = task; }
-
-    pipeline::PipelineTask* get_task() const { return _task; }
-
     int task_id() const { return _task_id; }
 
     void set_task_num(int task_num) { _task_num = task_num; }

--- a/be/src/runtime_filter/runtime_filter_producer_helper.h
+++ b/be/src/runtime_filter/runtime_filter_producer_helper.h
@@ -30,11 +30,7 @@ namespace doris {
 #include "common/compile_check_begin.h"
 // this class used in hash join node
 /**
-<<<<<<< HEAD
- * init -> (skip_process ->) send_filter_size -> (share_filters ->) process
-=======
  * init -> (skip_runtime_filters ->) send_filter_size -> build filter -> publish filter
->>>>>>> cd8c422b04 ([refactor](terminate) add terminate interface)
  */
 class RuntimeFilterProducerHelper {
 public:

--- a/be/src/runtime_filter/runtime_filter_producer_helper.h
+++ b/be/src/runtime_filter/runtime_filter_producer_helper.h
@@ -63,12 +63,12 @@ public:
     MOCK_FUNCTION Status skip_process(RuntimeState* state);
 
     // build rf
-    Status build(RuntimeState* state, const vectorized::Block* block);
+    Status build(RuntimeState* state, const vectorized::Block* block, bool use_shared_table,
+                 std::map<int, std::shared_ptr<RuntimeFilterWrapper>>& runtime_filters);
     // if task is terminated, rf also need to publish
     Status terminate(RuntimeState* state);
     // publish rf
-    Status publish(RuntimeState* state, bool use_shared_table,
-                   std::map<int, std::shared_ptr<RuntimeFilterWrapper>>& runtime_filters);
+    Status publish(RuntimeState* state);
 
 protected:
     virtual void _init_expr(const vectorized::VExprContextSPtrs& build_expr_ctxs,

--- a/be/src/runtime_filter/runtime_filter_producer_helper.h
+++ b/be/src/runtime_filter/runtime_filter_producer_helper.h
@@ -30,7 +30,11 @@ namespace doris {
 #include "common/compile_check_begin.h"
 // this class used in hash join node
 /**
+<<<<<<< HEAD
  * init -> (skip_process ->) send_filter_size -> (share_filters ->) process
+=======
+ * init -> (skip_runtime_filters ->) send_filter_size -> build filter -> publish filter
+>>>>>>> cd8c422b04 ([refactor](terminate) add terminate interface)
  */
 class RuntimeFilterProducerHelper {
 public:
@@ -62,8 +66,12 @@ public:
     // skip all runtime filter process, send size and rf to remote imeediately, mainly used to make join spill instance do not block other instance
     MOCK_FUNCTION Status skip_process(RuntimeState* state);
 
-    // build rf's predicate and publish rf
-    Status process(RuntimeState* state, const vectorized::Block* block, bool use_shared_table,
+    // build rf
+    Status build(RuntimeState* state, const vectorized::Block* block);
+    // if task is terminated, rf also need to publish
+    Status terminate(RuntimeState* state);
+    // publish rf
+    Status publish(RuntimeState* state, bool use_shared_table,
                    std::map<int, std::shared_ptr<RuntimeFilterWrapper>>& runtime_filters);
 
 protected:

--- a/be/src/runtime_filter/runtime_filter_producer_helper_cross.h
+++ b/be/src/runtime_filter/runtime_filter_producer_helper_cross.h
@@ -44,7 +44,7 @@ public:
         for (auto filter : _producers) {
             filter->set_wrapper_state_and_ready_to_publish(RuntimeFilterWrapper::State::READY);
         }
-        return _publish(state);
+        return publish(state);
     }
 
 private:

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -579,12 +579,6 @@ Status VExpr::init_function_context(RuntimeState* state, VExprContext* context,
             constant_cols.push_back(const_col);
         }
         fn_ctx->set_constant_cols(constant_cols);
-    } else {
-        if (function->is_udf_function()) {
-            auto* timer = ADD_TIMER(state->get_task()->get_task_profile(),
-                                    "UDF[" + function->get_name() + "]");
-            fn_ctx->set_udf_execute_timer(timer);
-        }
     }
 
     if (scope == FunctionContext::FRAGMENT_LOCAL) {

--- a/be/test/pipeline/operator/partitioned_aggregation_test_helper.cpp
+++ b/be/test/pipeline/operator/partitioned_aggregation_test_helper.cpp
@@ -186,7 +186,6 @@ PartitionedAggregationTestHelper::create_operators() {
             shared_state_map;
     pipeline_task = std::make_shared<PipelineTask>(source_pipeline, 0, runtime_state.get(), nullptr,
                                                    nullptr, shared_state_map, 0);
-    runtime_state->set_task(pipeline_task.get());
     return {std::move(source_operator), std::move(sink_operator)};
 }
 

--- a/be/test/pipeline/operator/partitioned_hash_join_test_helper.cpp
+++ b/be/test/pipeline/operator/partitioned_hash_join_test_helper.cpp
@@ -159,7 +159,6 @@ PartitionedHashJoinTestHelper::create_operators() {
             shared_state_map;
     pipeline_task = std::make_shared<PipelineTask>(probe_pipeline, 0, runtime_state.get(), nullptr,
                                                    nullptr, shared_state_map, 0);
-    runtime_state->set_task(pipeline_task.get());
     return {probe_operator, sink_operator};
 }
 

--- a/be/test/pipeline/operator/spill_sort_test_helper.cpp
+++ b/be/test/pipeline/operator/spill_sort_test_helper.cpp
@@ -164,7 +164,6 @@ SpillSortTestHelper::create_operators() {
             shared_state_map;
     pipeline_task = std::make_shared<PipelineTask>(source_pipeline, 0, runtime_state.get(), nullptr,
                                                    nullptr, shared_state_map, 0);
-    runtime_state->set_task(pipeline_task.get());
     return {std::move(source_operator), std::move(sink_operator)};
 }
 

--- a/be/test/pipeline/pipeline_test.cpp
+++ b/be/test/pipeline/pipeline_test.cpp
@@ -279,7 +279,6 @@ TEST_F(PipelineTest, HAPPY_PATH) {
                 cur_pipe, task_id, local_runtime_state.get(), _context.back().get(),
                 _pipeline_profiles[cur_pipe->id()].get(), shared_state_map, task_id);
         cur_pipe->incr_created_tasks(task_id, task.get());
-        local_runtime_state->set_task(task.get());
         task->set_task_queue(_task_queue.get());
         _pipeline_tasks[cur_pipe->id()].push_back(std::move(task));
         _runtime_states[cur_pipe->id()].push_back(std::move(local_runtime_state));
@@ -943,7 +942,6 @@ TEST_F(PipelineTest, PLAN_HASH_JOIN) {
                         _pipelines[i], task_id, local_runtime_state.get(), _context.back().get(),
                         _pipeline_profiles[_pipelines[i]->id()].get(), shared_state_map, j);
                 _pipelines[i]->incr_created_tasks(j, task.get());
-                local_runtime_state->set_task(task.get());
                 task->set_task_queue(_task_queue.get());
                 _pipeline_tasks[_pipelines[i]->id()].push_back(std::move(task));
                 _runtime_states[_pipelines[i]->id()].push_back(std::move(local_runtime_state));

--- a/be/test/runtime_filter/runtime_filter_consumer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_consumer_helper_test.cpp
@@ -47,7 +47,6 @@ class RuntimeFilterConsumerHelperTest : public RuntimeFilterTest {
 
         _task.reset(new pipeline::PipelineTask(_pipeline, 0, _runtime_states[0].get(), nullptr,
                                                &_profile, {}, 0));
-        _runtime_states[0]->set_task(_task.get());
 
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(ExecEnv::GetInstance()->init_pipeline_task_scheduler());
     }

--- a/be/test/runtime_filter/runtime_filter_producer_helper_cross_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_helper_cross_test.cpp
@@ -46,7 +46,6 @@ class RuntimeFilterProducerHelperCrossTest : public RuntimeFilterTest {
 
         _task.reset(new pipeline::PipelineTask(_pipeline, 0, _runtime_states[0].get(), nullptr,
                                                &_profile, {}, 0));
-        _runtime_states[0]->set_task(_task.get());
     }
 
     pipeline::OperatorPtr _op;

--- a/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
@@ -77,7 +77,6 @@ TEST_F(RuntimeFilterProducerHelperTest, basic) {
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
-    vectorized::SharedHashTableContextPtr shared_hash_table_ctx;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
             helper.publish(_runtime_states[0].get(), false, runtime_filters));
 }

--- a/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
@@ -46,7 +46,6 @@ class RuntimeFilterProducerHelperTest : public RuntimeFilterTest {
         for (int i = 0; i < INSTANCE_NUM; i++) {
             _tasks.emplace_back(new pipeline::PipelineTask(_pipeline, 0, _runtime_states[i].get(),
                                                            nullptr, &_profile, {}, 0));
-            _runtime_states[i]->set_task(_tasks.back().get());
         }
     }
 

--- a/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
@@ -77,8 +77,10 @@ TEST_F(RuntimeFilterProducerHelperTest, basic) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
+    vectorized::SharedHashTableContextPtr shared_hash_table_ctx;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.process(_runtime_states[0].get(), &block, false, runtime_filters));
+            helper.publish(_runtime_states[0].get(), false, runtime_filters));
 }
 
 TEST_F(RuntimeFilterProducerHelperTest, wake_up_eraly) {
@@ -102,9 +104,7 @@ TEST_F(RuntimeFilterProducerHelperTest, wake_up_eraly) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     _tasks[0]->set_wake_up_early();
-    std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.process(_runtime_states[0].get(), &block, false, runtime_filters));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.terminate(_runtime_states[0].get()));
 }
 
 TEST_F(RuntimeFilterProducerHelperTest, skip_process) {
@@ -133,8 +133,9 @@ TEST_F(RuntimeFilterProducerHelperTest, skip_process) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.process(_runtime_states[0].get(), &block, false, runtime_filters));
+            helper.publish(_runtime_states[0].get(), false, runtime_filters));
 }
 
 TEST_F(RuntimeFilterProducerHelperTest, broadcast) {
@@ -157,14 +158,15 @@ TEST_F(RuntimeFilterProducerHelperTest, broadcast) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.process(_runtime_states[0].get(), &block, true, runtime_filters));
+            helper.publish(_runtime_states[0].get(), true, runtime_filters));
 
     auto helper2 = RuntimeFilterProducerHelper(&_profile, false, true);
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
             helper2.init(_runtime_states[1].get(), build_expr_ctxs, runtime_filter_descs));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper2.process(_runtime_states[1].get(), &block, true, runtime_filters));
+            helper2.publish(_runtime_states[1].get(), true, runtime_filters));
 }
 
 } // namespace doris

--- a/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_helper_test.cpp
@@ -76,9 +76,9 @@ TEST_F(RuntimeFilterProducerHelperTest, basic) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.publish(_runtime_states[0].get(), false, runtime_filters));
+            helper.build(_runtime_states[0].get(), &block, false, runtime_filters));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.publish(_runtime_states[0].get()));
 }
 
 TEST_F(RuntimeFilterProducerHelperTest, wake_up_eraly) {
@@ -131,9 +131,9 @@ TEST_F(RuntimeFilterProducerHelperTest, skip_process) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.publish(_runtime_states[0].get(), false, runtime_filters));
+            helper.build(_runtime_states[0].get(), &block, false, runtime_filters));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.publish(_runtime_states[0].get()));
 }
 
 TEST_F(RuntimeFilterProducerHelperTest, broadcast) {
@@ -156,15 +156,16 @@ TEST_F(RuntimeFilterProducerHelperTest, broadcast) {
     block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
 
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.build(_runtime_states[0].get(), &block));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper.publish(_runtime_states[0].get(), true, runtime_filters));
+            helper.build(_runtime_states[0].get(), &block, true, runtime_filters));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.publish(_runtime_states[0].get()));
 
     auto helper2 = RuntimeFilterProducerHelper(&_profile, false, true);
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
             helper2.init(_runtime_states[1].get(), build_expr_ctxs, runtime_filter_descs));
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            helper2.publish(_runtime_states[1].get(), true, runtime_filters));
+            helper2.build(_runtime_states[1].get(), &block, true, runtime_filters));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper2.publish(_runtime_states[1].get()));
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Add terminate interface. `terminate` will be called when a task is waken up before EOS. This happened once all downstream tasks finished.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

