### PR TITLE
[fix](thrift) Pick THRIFT-5492: Add readEnd to TBufferedTransport

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -574,4 +574,21 @@ else
     fi
 fi
 
+# patch thrift
+if [[ " ${TP_ARCHIVES[*]} " =~ " THRIFT " ]]; then
+    if [[ "${THRIFT_SOURCE}" == 'thrift-0.16.0' ]]; then
+        cd "${TP_SOURCE_DIR}/${THRIFT_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            for patch_file in "${TP_PATCH_DIR}"/thrift-0.16*; do
+                echo "patch ${patch_file}"
+                patch -p1 --ignore-whitespace <"${patch_file}"
+            done
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${THRIFT_SOURCE}"
+fi
+
+
 # vim: ts=4 sw=4 ts=4 tw=100:

--- a/thirdparty/patches/thrift-0.16-reset-consumed-message-size.patch
+++ b/thirdparty/patches/thrift-0.16-reset-consumed-message-size.patch
@@ -1,0 +1,29 @@
+From 89e0bc5fa4949b68503f7b6892128cc8fc5bc1d4 Mon Sep 17 00:00:00 2001
+From: Steve Licking <steve.licking@intel.com>
+Date: Fri, 31 Dec 2021 10:54:05 -0800
+Subject: [PATCH] THRIFT-5492: Add readEnd to TBufferedTransport client: cpp
+ Patch: Steve Licking
+
+---
+ lib/cpp/src/thrift/transport/TBufferTransports.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lib/cpp/src/thrift/transport/TBufferTransports.h b/lib/cpp/src/thrift/transport/TBufferTransports.h
+index 179934ba0..6feb540af 100644
+--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
++++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
+@@ -270,6 +270,11 @@ public:
+    */
+   uint32_t readAll(uint8_t* buf, uint32_t len) { return TBufferBase::readAll(buf, len); }
+ 
++  uint32_t readEnd() override {
++    resetConsumedMessageSize();
++    return 0;
++  }
++
+ protected:
+   void initPointers() {
+     setReadBuffer(rBuf_.get(), 0);
+-- 
+2.39.3
+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

From https://issues.apache.org/jira/browse/THRIFT-5492:

The remainingMessageSize_ is decremented as messages are parsed, for example when parsing a field in the message that is of type binary I see the code calling readStringBody in TBinaryProtocol.tcc:455 which then calls this->trans_->consume(size) which goes to TBufferTransports.h:124 and calls countConsumedMessageBytes which finally decrements remainingMessageSize_.

However, nothing ever resets remainingMessageSize_, so after it is decremented from 100*1024*1024 down to zero it fails with an END_OF_FILE exception.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

