### PR TITLE
[fix](thirdparty)Fix uuid_string_t compilation issue with newer XCode SDKs on macOS

### DIFF
--- a/thirdparty/patches/brpc-uuid-string.patch
+++ b/thirdparty/patches/brpc-uuid-string.patch
@@ -1,0 +1,123 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -110,6 +110,34 @@ set(DEFINE_CLOCK_GETTIME "-DNO_CLOCK_GETTIME_IN_MAC")
+     endif()
+     set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -Wno-deprecated-declarations -Wno-inconsistent-missing-override")
++
++    # Check if xcrun exists and get SDK version if it does
++    execute_process(
++        COMMAND which xcrun
++        RESULT_VARIABLE XCRUN_RESULT
++        OUTPUT_QUIET
++        ERROR_QUIET
++    )
++
++    if(XCRUN_RESULT EQUAL 0)
++        # xcrun exists, detect SDK version
++        execute_process(
++            COMMAND xcrun --sdk macosx --show-sdk-version
++            OUTPUT_VARIABLE MACOSX_SDK_VERSION
++            OUTPUT_STRIP_TRAILING_WHITESPACE
++        )
++        message(STATUS "Detected macOS SDK version: ${MACOSX_SDK_VERSION}")
++
++        if(MACOSX_SDK_VERSION VERSION_LESS 10.14)
++            message(STATUS "macOS SDK version < 10.14; not applying _DARWIN_C_SOURCE or uuid fix.")
++        else()
++            message(STATUS "macOS SDK version >= 10.14; applying Darwin-specific uuid fix.")
++            add_definitions(-D_DARWIN_C_SOURCE)
++            add_definitions(-DUSE_DARWIN_UUID_FIX)
++        endif()
++    else()
++        message(STATUS "xcrun not found; skipping Darwin-specific SDK checks.")
++    endif()
+ endif()
+
+ set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DBRPC_WITH_RDMA=${WITH_RDMA_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+
+diff --git a/src/brpc/macos_uuid_fix.h b/src/brpc/macos_uuid_fix.h
+new file mode 100644
+index 00000000..623a6454
+--- /dev/null
++++ b/src/brpc/macos_uuid_fix.h
+@@ -0,0 +1,9 @@
++#ifdef __APPLE__
++#ifdef USE_DARWIN_UUID_FIX
++#include <uuid/uuid.h>
++#ifndef _UUID_STRING_T
++#define _UUID_STRING_T
++typedef char uuid_string_t[37];
++#endif
++#endif
++#endif
+
+diff --git a/src/butil/mac/bundle_locations.mm b/src/butil/mac/bundle_locations.mm
+--- a/src/butil/mac/bundle_locations.mm
++++ b/src/butil/mac/bundle_locations.mm
+@@ -1,7 +1,8 @@
+ // Copyright (c) 2012 The Chromium Authors. All rights reserved.
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
++#include "brpc/macos_uuid_fix.h"
+ #include "butil/mac/bundle_locations.h"
+
+ #include "butil/logging.h"
+
+diff --git a/src/butil/mac/foundation_util.h b/src/butil/mac/foundation_util.h
+--- a/src/butil/mac/foundation_util.h
++++ b/src/butil/mac/foundation_util.h
+@@ -2,6 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
++#include "brpc/macos_uuid_fix.h"
+ #ifndef BUTIL_MAC_FOUNDATION_UTIL_H_
+ #define BUTIL_MAC_FOUNDATION_UTIL_H_
+
+
+diff --git a/src/butil/mac/foundation_util.mm b/src/butil/mac/foundation_util.mm
+--- a/src/butil/mac/foundation_util.mm
++++ b/src/butil/mac/foundation_util.mm
+@@ -2,6 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
++#include "brpc/macos_uuid_fix.h"
+ #include "butil/mac/foundation_util.h"
+
+ #include <stdlib.h>
+
+diff --git a/src/butil/threading/platform_thread_mac.mm b/src/butil/threading/platform_thread_mac.mm
+--- a/src/butil/threading/platform_thread_mac.mm
++++ b/src/butil/threading/platform_thread_mac.mm
+@@ -3,3 +3,4 @@
+ // found in the LICENSE file.
+
++#include "brpc/macos_uuid_fix.h"
+ #include "butil/threading/platform_thread.h"
+
+diff --git a/src/butil/file_util_mac.mm b/src/butil/file_util_mac.mm
+--- a/src/butil/file_util_mac.mm
++++ b/src/butil/file_util_mac.mm
+@@ -2,6 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
++#include "brpc/macos_uuid_fix.h"
+ #include "butil/file_util.h"
+
+ #import <Foundation/Foundation.h>
+
+diff --git a/src/butil/strings/sys_string_conversions_mac.mm b/src/butil/strings/sys_string_conversions_mac.mm
+--- a/src/butil/strings/sys_string_conversions_mac.mm
++++ b/src/butil/strings/sys_string_conversions_mac.mm
+@@ -2,5 +2,6 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+
++#include "brpc/macos_uuid_fix.h"
+ #include "butil/mac/foundation_util.h"
+ #include "butil/mac/scoped_cftyperef.h"
+


### PR DESCRIPTION
- Explicitly define _DARWIN_C_SOURCE to expose system definitions.
- Introduce compatibility header (macos_uuid_fix.h) for conditional definition of uuid_string_t.
- Refactor affected macOS source files to include the compatibility header.

This addresses build failures caused by Apple's removal of implicit uuid_string_t definitions in recent macOS SDK versions.

### What problem does this PR solve?

**Problem**
On macOS 10.14 and later SDKs, building thirdpary can fail with an exception :

```
error: unknown type name 'uuid_string_t'
```
**The exception message:**
```
[61/310] Building CXX object src/CMakeFiles/BUTIL_LIB.dir/butil/file_util_posix.cc.o
FAILED: src/CMakeFiles/BUTIL_LIB.dir/butil/file_util_posix.cc.o 
/opt/homebrew/opt/llvm@16/bin/clang++  -I/Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src -I/Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/doris_build -I/Users/msakarya/Repository/doris/doris-project/doris/thirdparty/installed/include -I/Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/doris_build/src -Wno-deprecated-declarations -Wno-inconsistent-missing-override  -DBRPC_WITH_GLOG=1 -DBRPC_WITH_RDMA=0 -DGFLAGS_NS=google -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\"1.4.0\|master\|7e3c475d51\|2025-03-04T21:06:46+08:00\" -D__STRICT_ANSI__ -g  -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -DNDEBUG -std=gnu++11 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -MD -MT src/CMakeFiles/BUTIL_LIB.dir/butil/file_util_posix.cc.o -MF src/CMakeFiles/BUTIL_LIB.dir/butil/file_util_posix.cc.o.d -o src/CMakeFiles/BUTIL_LIB.dir/butil/file_util_posix.cc.o -c /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/file_util_posix.cc
In file included from /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/file_util_posix.cc:26:
In file included from /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/mac/foundation_util.h:32:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h:23:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:23:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/hfs/hfs_format.h:807:2: error: unknown type name 'uuid_string_t'; did you mean 'io_string_t'?
        uuid_string_t   ext_jnl_uuid;
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/device/device_types.h:89:33: note: 'io_string_t' declared here
typedef char                    io_string_t[512];
                                ^
In file included from /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/file_util_posix.cc:26:
In file included from /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/mac/foundation_util.h:32:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h:23:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:23:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/hfs/hfs_format.h:809:20: error: unknown type name 'uuid_string_t'; did you mean 'io_string_t'?
        char            reserved[JIB_RESERVED_SIZE];
                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/hfs/hfs_format.h:800:61: note: expanded from macro 'JIB_RESERVED_SIZE'
#define JIB_RESERVED_SIZE  ((32*sizeof(u_int32_t)) - sizeof(uuid_string_t) - 48)
                                                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/device/device_types.h:89:33: note: 'io_string_t' declared here
typedef char                    io_string_t[512];
                                ^
In file included from /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/file_util_posix.cc:26:
In file included from /Users/msakarya/Repository/doris/doris-project/doris/thirdparty/src/brpc-1.4.0/src/butil/mac/foundation_util.h:32:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h:23:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:23:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/hfs/hfs_format.h:809:20: error: array is too large (18446744073709551184 elements)
        char            reserved[JIB_RESERVED_SIZE];
                                 ^~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/hfs/hfs_format.h:800:28: note: expanded from macro 'JIB_RESERVED_SIZE'
#define JIB_RESERVED_SIZE  ((32*sizeof(u_int32_t)) - sizeof(uuid_string_t) - 48)
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.
[63/310] Building CXX object src/CMakeFiles/BUTIL_LIB.dir/butil/location.cc.o
ninja: build stopped: subcommand failed.
```

### Original Situation (Older SDK Versions)
In earlier macOS SDK versions (prior to approximately macOS 10.14), the uuid_string_t type was consistently defined by Apple within the SDK header files (specifically <uuid/uuid.h>). Therefore, simply including standard headers from Apple's frameworks automatically provided this type.

### Change in macOS SDK (Newer Versions)
 In more recent macOS SDKs (e.g., 11.x, 12.x, and onward), Apple modified or tightened internal header dependencies. The file /usr/include/hfs/hfs_format.h now references the type uuid_string_t directly, but no longer guarantees inclusion of <uuid/uuid.h>. As a result, when compiling projects that include these headers indirectly through frameworks (like CoreServices), the compiler encounters uuid_string_t without a valid definition.

### Underlying Reason
The core issue is Apple's restructuring and cleanup of internal header files. Apple expects projects to explicitly include <uuid/uuid.h> themselves if uuid_string_t is used directly or indirectly. Thus, relying on indirect inclusion through other headers or frameworks no longer works reliably.

### Previous Behavior

On macOS SDK 10.14+, third-party builds would fail due to the missing uuid_string_t definition, causing compilation to stop with the “unknown type name 'uuid_string_t'” error.

### New Behavior

The build now completes successfully on macOS 10.14+ because _DARWIN_C_SOURCE is properly defined and uuid_string_t is explicitly made available.

### Why Modified

To fix the repeated build failures on modern macOS systems and ensure Doris can compile third-party cleanly across different macOS SDK versions.

### Potential Impacts

No impact on earlier macOS versions or on non-macOS systems. The fix only applies if the detected SDK version is 10.14 or higher.

### **Solution**

### Which code was refactored and why was this part of the code refactored?
Several existing macOS-specific source files (bundle_locations.mm, foundation_util.h/mm, platform_thread_mac.mm, file_util_mac.mm, and sys_string_conversions_mac.mm) were refactored slightly by adding an explicit inclusion of the new compatibility header (macos_uuid_fix.h). The purpose of this minimal refactoring was to consolidate the fix in a single place, simplifying future maintenance and clearly communicating the intention of addressing the SDK compatibility issue across multiple files, rather than repeatedly patching individual locations.

Detect the macOS SDK version at CMake configure time (xcrun --sdk macosx --show-sdk-version).

If the SDK version is 10.14 or newer, define _DARWIN_C_SOURCE and USE_DARWIN_UUID_FIX.

Introduce a new header, macos_uuid_fix.h, which conditionally redefines uuid_string_t when _DARWIN_C_SOURCE is needed.

With this approach, the uuid_string_t type is properly declared, and the compilation error is resolved.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->



