### PR TITLE
[feature](profile) Provide a new profile display for the refactored RF

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -201,7 +201,9 @@ public:
             }
 
             if (null_pred.condition_values.size() != 0) {
-                filters.emplace_back(_column_name, null_pred, _runtime_filter_id);
+                filters.emplace_back(_column_name, null_pred, _runtime_filter_id,
+                                     _predicate_filtered_rows_counter,
+                                     _predicate_input_rows_counter);
                 return;
             }
 
@@ -214,7 +216,9 @@ public:
             }
 
             if (low.condition_values.size() != 0) {
-                filters.emplace_back(_column_name, low, _runtime_filter_id);
+                filters.emplace_back(_column_name, low, _runtime_filter_id,
+                                     _predicate_filtered_rows_counter,
+                                     _predicate_input_rows_counter);
             }
 
             TCondition high;
@@ -226,7 +230,9 @@ public:
             }
 
             if (high.condition_values.size() != 0) {
-                filters.emplace_back(_column_name, high, _runtime_filter_id);
+                filters.emplace_back(_column_name, high, _runtime_filter_id,
+                                     _predicate_filtered_rows_counter,
+                                     _predicate_input_rows_counter);
             }
         } else {
             // 3. convert to is null and is not null filter condition
@@ -239,7 +245,9 @@ public:
             }
 
             if (null_pred.condition_values.size() != 0) {
-                filters.emplace_back(_column_name, null_pred, _runtime_filter_id);
+                filters.emplace_back(_column_name, null_pred, _runtime_filter_id,
+                                     _predicate_filtered_rows_counter,
+                                     _predicate_input_rows_counter);
             }
         }
     }
@@ -255,7 +263,8 @@ public:
         }
 
         if (condition.condition_values.size() != 0) {
-            filters.emplace_back(_column_name, condition, _runtime_filter_id);
+            filters.emplace_back(_column_name, condition, _runtime_filter_id,
+                                 _predicate_filtered_rows_counter, _predicate_input_rows_counter);
         }
     }
 
@@ -292,7 +301,13 @@ public:
         _contain_null = _is_nullable_col && contain_null;
     }
 
-    void set_runtime_filter_id(int runtime_filter_id) { _runtime_filter_id = runtime_filter_id; }
+    void set_runtime_filter_info(int runtime_filter_id,
+                                 RuntimeProfile::Counter* predicate_filtered_rows_counter,
+                                 RuntimeProfile::Counter* predicate_input_rows_counter) {
+        _runtime_filter_id = runtime_filter_id;
+        _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
+        _predicate_input_rows_counter = predicate_input_rows_counter;
+    }
 
     int precision() const { return _precision; }
 
@@ -355,6 +370,8 @@ private:
                                                   primitive_type == PrimitiveType::TYPE_DATETIMEV2;
 
     int _runtime_filter_id = -1;
+    RuntimeProfile::Counter* _predicate_filtered_rows_counter = nullptr;
+    RuntimeProfile::Counter* _predicate_input_rows_counter = nullptr;
 };
 
 class OlapScanKeys {

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -115,6 +115,7 @@ uint16_t BitmapFilterColumnPredicate<T>::_evaluate_inner(const vectorized::IColu
     }
     _evaluated_rows += size;
     _passed_rows += new_size;
+    update_filter_info(size - new_size, size);
     return new_size;
 }
 } //namespace doris

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -270,6 +270,11 @@ public:
             _evaluated_rows += current_evaluated_rows;
         }
 
+        Defer defer([&]() {
+            update_filter_info(current_evaluated_rows - current_passed_rows,
+                               current_evaluated_rows);
+        });
+
         if (column.is_nullable()) {
             const auto* nullable_column_ptr =
                     vectorized::check_and_get_column<vectorized::ColumnNullable>(column);

--- a/be/src/olap/filter_olap_param.h
+++ b/be/src/olap/filter_olap_param.h
@@ -19,16 +19,23 @@
 
 #include <string>
 
+#include "util/runtime_profile.h"
 namespace doris {
 template <typename T>
 struct FilterOlapParam {
-    FilterOlapParam(std::string column_name, T filter, int runtime_filter_id)
+    FilterOlapParam(std::string column_name, T filter, int runtime_filter_id,
+                    RuntimeProfile::Counter* filtered_counter,
+                    RuntimeProfile::Counter* input_counter)
             : column_name(std::move(column_name)),
               filter(std::move(filter)),
-              runtime_filter_id(runtime_filter_id) {}
+              runtime_filter_id(runtime_filter_id),
+              filtered_rows_counter(filtered_counter),
+              input_rows_counter(input_counter) {}
     std::string column_name;
     T filter;
     int runtime_filter_id;
+    RuntimeProfile::Counter* filtered_rows_counter = nullptr;
+    RuntimeProfile::Counter* input_rows_counter = nullptr;
 };
 
 } // namespace doris

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -521,7 +521,8 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     SCOPED_RAW_TIMER(&_stats.tablet_reader_init_conditions_param_timer_ns);
     std::vector<ColumnPredicate*> predicates;
     auto emplace_predicate = [&predicates](auto& param, ColumnPredicate* predicate) {
-        predicate->set_runtime_filter_id(param.runtime_filter_id);
+        predicate->set_runtime_filter_info(param.runtime_filter_id, param.filtered_rows_counter,
+                                           param.input_rows_counter);
         predicates.emplace_back(predicate);
     };
 

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -100,6 +100,10 @@ private:
         _profile->add_child(_execution_profile.get(), true, nullptr);
         _wait_timer = ADD_TIMER(_profile, "WaitTime");
 
+        _rf_filter = ADD_COUNTER_WITH_LEVEL(
+                parent_profile, fmt::format("RF{} FilterRows", desc->filter_id), TUnit::UNIT, 1);
+        _rf_input = ADD_COUNTER_WITH_LEVEL(
+                parent_profile, fmt::format("RF{} InputRows", desc->filter_id), TUnit::UNIT, 1);
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 
@@ -129,6 +133,10 @@ private:
     std::unique_ptr<RuntimeProfile> _storage_profile;   // for storage layer stats
     std::unique_ptr<RuntimeProfile> _execution_profile; // for execution layer stats
     RuntimeProfile::Counter* _wait_timer = nullptr;
+    //_rf_filter is used to record the number of rows filtered by the runtime filter.
+    //It aggregates the filtering statistics from both the Storage and Execution.
+    RuntimeProfile::Counter* _rf_filter = nullptr;
+    RuntimeProfile::Counter* _rf_input = nullptr;
 
     int32_t _rf_wait_time_ms;
     const int64_t _registration_time;

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -435,6 +435,26 @@ RuntimeProfile::NonZeroCounter* RuntimeProfile::add_nonzero_counter(
     return counter;
 }
 
+RuntimeProfile::CollaborationCounter* RuntimeProfile::add_collaboration_counter(
+        const std::string& name, TUnit::type type, Counter* other_counter,
+        const std::string& parent_counter_name, int64_t level) {
+    std::lock_guard<std::mutex> l(_counter_map_lock);
+    if (_counter_map.find(name) != _counter_map.end()) {
+        DCHECK(dynamic_cast<CollaborationCounter*>(_counter_map[name]));
+        return static_cast<CollaborationCounter*>(_counter_map[name]);
+    }
+
+    DCHECK(parent_counter_name == ROOT_COUNTER ||
+           _counter_map.find(parent_counter_name) != _counter_map.end());
+    CollaborationCounter* counter =
+            _pool->add(new CollaborationCounter(type, level, other_counter));
+    _counter_map[name] = counter;
+    std::set<std::string>* child_counters =
+            find_or_insert(&_child_counter_map, parent_counter_name, std::set<std::string>());
+    child_counters->insert(name);
+    return counter;
+}
+
 RuntimeProfile::DerivedCounter* RuntimeProfile::add_derived_counter(
         const std::string& name, TUnit::type type, const DerivedCounterFunction& counter_fn,
         const std::string& parent_counter_name) {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -295,6 +295,43 @@ public:
         const std::string _parent_name;
     };
 
+    // When the collaboration Counter modifies itself, it also modifies the other counter.
+
+    class CollaborationCounter : public Counter {
+    public:
+        CollaborationCounter(TUnit::type type, int64_t level, Counter* other_counter,
+                             int64_t value = 0)
+                : Counter(type, value, level), _other_counter(other_counter) {}
+
+        virtual Counter* clone() const override {
+            return new CollaborationCounter(type(), level(), _other_counter, value());
+        }
+
+        void update(int64_t delta) override {
+            if (_other_counter != nullptr) {
+                _other_counter->update(delta);
+            }
+            Counter::update(delta);
+        }
+
+        void set(int64_t value) override {
+            if (_other_counter != nullptr) {
+                _other_counter->set(value);
+            }
+            Counter::set(value);
+        }
+
+        void set(double value) override {
+            if (_other_counter != nullptr) {
+                _other_counter->set(value);
+            }
+            Counter::set(value);
+        }
+
+    private:
+        Counter* _other_counter = nullptr; // Pointer to the other counter to be modified
+    };
+
     // Create a runtime profile object with 'name'.
     RuntimeProfile(const std::string& name, bool is_averaged_profile = false);
 
@@ -345,6 +382,11 @@ public:
 
     NonZeroCounter* add_nonzero_counter(
             const std::string& name, TUnit::type type,
+            const std::string& parent_counter_name = RuntimeProfile::ROOT_COUNTER,
+            int64_t level = 2);
+
+    CollaborationCounter* add_collaboration_counter(
+            const std::string& name, TUnit::type type, Counter* other_counter,
             const std::string& parent_counter_name = RuntimeProfile::ROOT_COUNTER,
             int64_t level = 2);
 

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -63,10 +63,14 @@ public:
 
     void attach_profile_counter(RuntimeProfile::Counter* expr_filtered_rows_counter,
                                 RuntimeProfile::Counter* expr_input_rows_counter,
-                                RuntimeProfile::Counter* always_true_counter) {
+                                RuntimeProfile::Counter* always_true_counter,
+                                RuntimeProfile::Counter* predicate_filtered_rows_counter,
+                                RuntimeProfile::Counter* predicate_input_rows_counter) {
         _expr_filtered_rows_counter = expr_filtered_rows_counter;
         _expr_input_rows_counter = expr_input_rows_counter;
         _always_true_counter = always_true_counter;
+        _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
+        _predicate_input_rows_counter = predicate_input_rows_counter;
     }
 
     void update_counters(int64_t filter_rows, int64_t input_rows) {
@@ -96,6 +100,9 @@ public:
         }
     }
 
+    auto* predicate_filtered_rows_counter() const { return _predicate_filtered_rows_counter; }
+    auto* predicate_input_rows_counter() const { return _predicate_input_rows_counter; }
+
 private:
     void reset_judge_selectivity() {
         _always_true = false;
@@ -121,6 +128,12 @@ private:
     RuntimeProfile::Counter* _expr_filtered_rows_counter = nullptr;
     RuntimeProfile::Counter* _expr_input_rows_counter = nullptr;
     RuntimeProfile::Counter* _always_true_counter = nullptr;
+
+    // Used to record filtering information on predicates.
+    // The transfer relationship of these counters is:
+    // RuntimeFilterConsumer(create) ==> VRuntimeFilterWrapper(pass) ==> FilterOlapParam(pass) ==> ColumnPredicate(record)
+    RuntimeProfile::Counter* _predicate_filtered_rows_counter = nullptr;
+    RuntimeProfile::Counter* _predicate_input_rows_counter = nullptr;
 
     std::string _expr_name;
     double _ignore_thredhold;

--- a/be/test/util/runtime_profile_counter_tree_node_test.cpp
+++ b/be/test/util/runtime_profile_counter_tree_node_test.cpp
@@ -279,4 +279,34 @@ TEST_F(RuntimeProfileCounterTreeNodeTest, NonZeroCounterToThrfit) {
     ASSERT_EQ(child_counter_map[RuntimeProfile::ROOT_COUNTER].size(), 0);
 }
 
+TEST_F(RuntimeProfileCounterTreeNodeTest, CollaborationCounterTest) {
+    auto root_counter = std::make_unique<RuntimeProfile::Counter>(TUnit::UNIT);
+    auto child_counter1 = std::make_unique<RuntimeProfile::CollaborationCounter>(
+            TUnit::UNIT, 2, root_counter.get());
+    auto child_counter2 = std::make_unique<RuntimeProfile::CollaborationCounter>(
+            TUnit::UNIT, 2, root_counter.get());
+
+    auto c1 = std::make_unique<RuntimeProfile::CollaborationCounter>(TUnit::UNIT, 2,
+                                                                     child_counter1.get());
+    auto c2 = std::make_unique<RuntimeProfile::CollaborationCounter>(TUnit::UNIT, 2,
+                                                                     child_counter1.get());
+    auto c3 = std::make_unique<RuntimeProfile::CollaborationCounter>(TUnit::UNIT, 2,
+                                                                     child_counter2.get());
+    auto c4 = std::make_unique<RuntimeProfile::CollaborationCounter>(TUnit::UNIT, 2,
+                                                                     child_counter2.get());
+
+    c1->update(1);
+    c2->update(10);
+    c3->update(100);
+    c4->update(1000);
+
+    ASSERT_EQ(root_counter->value(), 1111);
+    ASSERT_EQ(child_counter1->value(), 11);
+    ASSERT_EQ(child_counter2->value(), 1100);
+    ASSERT_EQ(c1->value(), 1);
+    ASSERT_EQ(c2->value(), 10);
+    ASSERT_EQ(c3->value(), 100);
+    ASSERT_EQ(c4->value(), 1000);
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?
merge
```
                          RuntimeFilterConsumerHelper:
                                -  RF0  FilterRows:  sum  1.390255M  (1390255),  avg  695.127K  (695127),  max  696.953K  (696953),  min  693.302K  (693302)
                                -  RF0  InputRows:  sum  1.445035M  (1445035),  avg  722.517K  (722517),  max  724.399K  (724399),  min  720.636K  (720636)
                                -  RF1  FilterRows:  sum  0,  avg  0,  max  0,  min  0
                                -  RF1  InputRows:  sum  0,  avg  0,  max  0,  min  0
                                -  RF2  FilterRows:  sum  11,  avg  5,  max  6,  min  5
                                -  RF2  InputRows:  sum  80.74K  (80740),  avg  40.37K  (40370),  max  54.666K  (54666),  min  26.074K  (26074)
                                -  RF3  FilterRows:  sum  52.586K  (52586),  avg  26.293K  (26293),  max  26.343K  (26343),  min  26.243K  (26243)
                                -  RF3  InputRows:  sum  54.78K  (54780),  avg  27.39K  (27390),  max  27.446K  (27446),  min  27.334K  (27334)
                                -  RF4  FilterRows:  sum  0,  avg  0,  max  0,  min  0
                                -  RF4  InputRows:  sum  0,  avg  0,  max  0,  min  0
                                -  RF5  FilterRows:  sum  0,  avg  0,  max  0,  min  0
                                -  RF5  InputRows:  sum  585,  avg  292,  max  320,  min  265
```

```
RuntimeFilterConsumerHelper:
                              -  AcquireRuntimeFilterTime:  5.532ms
                              -  RF0  FilterRows:  696.953K  (696953)
                              -  RF0  InputRows:  724.399K  (724399)
                              -  RF1  FilterRows:  0
                              -  RF1  InputRows:  0
                              -  RF2  FilterRows:  6
                              -  RF2  InputRows:  26.074K  (26074)
                              -  RF3  FilterRows:  26.343K  (26343)
                              -  RF3  InputRows:  27.446K  (27446)
                              -  RF4  FilterRows:  0
                              -  RF4  InputRows:  0
                              -  RF5  FilterRows:  0
                              -  RF5  InputRows:  265
                            RF0:
                                  -  TimeoutLimit:  900000ms
                                  -  Info:  Consumer:  ([id:  0,  state:  [READY],  type:  MINMAX_FILTER,  column_type:  INT],  mode:  LOCAL,  state:  APPLIED)
                                  -  WaitTime:  112.0ms
                                Storage:
                                      -  PredicateFilteredRows:  696.953K  (696953)
                                      -  PredicateInputRows:  724.399K  (724399)
                                Execution:
                                      -  AlwaysTruePassRows:  0
                                      -  ExprFilteredRows:  0
                                      -  ExprInputRows:  0
                            RF1:
                                  -  TimeoutLimit:  900000ms
                                  -  Info:  Consumer:  ([id:  1,  state:  [READY],  type:  IN_OR_BLOOM_FILTER(IN_FILTER),  column_type:  INT,  size:  76,  max_in_num:  1024],  mode:  LOCAL,  state:  APPLIED)
                                  -  WaitTime:  111.0ms
                                Storage:
                                      -  PredicateFilteredRows:  0
                                      -  PredicateInputRows:  0
                                Execution:
                                      -  AlwaysTruePassRows:  0
                                      -  ExprFilteredRows:  0
                                      -  ExprInputRows:  0
                            RF2:
                                  -  TimeoutLimit:  900000ms
                                  -  Info:  Consumer:  ([id:  2,  state:  [READY],  type:  MINMAX_FILTER,  column_type:  INT],  mode:  LOCAL,  state:  APPLIED)
                                  -  WaitTime:  163.0ms
                                Storage:
                                      -  PredicateFilteredRows:  6
                                      -  PredicateInputRows:  26.074K  (26074)
                                Execution:
                                      -  AlwaysTruePassRows:  0
                                      -  ExprFilteredRows:  0
                                      -  ExprInputRows:  0
                            RF3:
                                  -  TimeoutLimit:  900000ms
                                  -  Info:  Consumer:  ([id:  3,  state:  [READY],  type:  IN_OR_BLOOM_FILTER(BLOOM_FILTER),  column_type:  INT,  bf_size:  1048576,  build_bf_by_runtime_size:  true],  mode:  LOCAL,  state:  APPLIED)
                                  -  WaitTime:  163.0ms
                                Storage:
                                      -  PredicateFilteredRows:  26.343K  (26343)
                                      -  PredicateInputRows:  27.446K  (27446)
                                Execution:
                                      -  AlwaysTruePassRows:  0
                                      -  ExprFilteredRows:  0
                                      -  ExprInputRows:  0
                            RF4:
                                  -  TimeoutLimit:  900000ms
                                  -  Info:  Consumer:  ([id:  4,  state:  [READY],  type:  MINMAX_FILTER,  column_type:  INT],  mode:  LOCAL,  state:  APPLIED)
                                  -  WaitTime:  112.0ms
                                Storage:
                                      -  PredicateFilteredRows:  0
                                      -  PredicateInputRows:  0
                                Execution:
                                      -  AlwaysTruePassRows:  0
                                      -  ExprFilteredRows:  0
                                      -  ExprInputRows:  0
                            RF5:
                                  -  TimeoutLimit:  900000ms
                                  -  Info:  Consumer:  ([id:  5,  state:  [READY],  type:  IN_OR_BLOOM_FILTER(BLOOM_FILTER),  column_type:  INT,  bf_size:  1048576,  build_bf_by_runtime_size:  true],  mode:  LOCAL,  state:  APPLIED)
                                  -  WaitTime:  112.0ms
                                Storage:
                                      -  PredicateFilteredRows:  0
                                      -  PredicateInputRows:  265
                                Execution:
                                      -  AlwaysTruePassRows:  0
                                      -  ExprFilteredRows:  0
                                      -  ExprInputRows:  0
```
Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

