### PR TITLE
branch-2.1: [fix](nereids)canInferNotNullForMarkSlot method get wrong result if fold constant rule is disabled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -569,7 +569,7 @@ public class ExpressionUtils {
              * markSlotSize = 3 -> loopCount = 8  ---- 000, 001, 010, 011, 100, 101, 110, 111
              * markSlotSize = 4 -> loopCount = 16 ---- 0000, 0001, ... 1111
              */
-            int loopCount = 2 << markSlotSize;
+            int loopCount = 1 << markSlotSize;
             for (int i = 0; i < loopCount; ++i) {
                 replaceMap.clear();
                 /*
@@ -597,10 +597,13 @@ public class ExpressionUtils {
                     } else {
                         meetNullOrFalse = true;
                     }
+                } else {
+                    return false;
                 }
             }
+            return true;
         }
-        return true;
+        return false;
     }
 
     private static boolean isNullOrFalse(Expression expression) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/CanInferNotNullForMarkSlotTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/CanInferNotNullForMarkSlotTest.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.nereids.rules.expression.ExpressionRewriteTestHelper;
+import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.IsNull;
+import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
+import org.apache.doris.nereids.trees.expressions.Or;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.types.BooleanType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CanInferNotNullForMarkSlotTest.
+ */
+public class CanInferNotNullForMarkSlotTest extends ExpressionRewriteTestHelper {
+
+    @Test
+    public void test() {
+        SlotReference slot = new SlotReference("slot", BooleanType.INSTANCE);
+        MarkJoinSlotReference markSlot1 = new MarkJoinSlotReference("markSlot1");
+        MarkJoinSlotReference markSlot2 = new MarkJoinSlotReference("markSlot2");
+
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new And(BooleanLiteral.TRUE, markSlot1), context));
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new And(BooleanLiteral.FALSE, markSlot1), context));
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new And(NullLiteral.INSTANCE, markSlot1), context));
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new Or(BooleanLiteral.TRUE, markSlot1), context));
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new Or(BooleanLiteral.FALSE, markSlot1), context));
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new Or(NullLiteral.INSTANCE, markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils
+                .canInferNotNullForMarkSlot(new And(new Or(BooleanLiteral.TRUE, markSlot2), markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils
+                .canInferNotNullForMarkSlot(new And(new Or(BooleanLiteral.FALSE, markSlot2), markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils
+                .canInferNotNullForMarkSlot(new And(new Or(NullLiteral.INSTANCE, markSlot2), markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils
+                .canInferNotNullForMarkSlot(new Or(new And(BooleanLiteral.TRUE, markSlot2), markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils
+                .canInferNotNullForMarkSlot(new Or(new And(BooleanLiteral.FALSE, markSlot2), markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils
+                .canInferNotNullForMarkSlot(new Or(new And(NullLiteral.INSTANCE, markSlot2), markSlot1), context));
+        Assertions.assertTrue(ExpressionUtils.canInferNotNullForMarkSlot(
+                new And(new Or(BooleanLiteral.FALSE, markSlot2), new IsNull(markSlot1)), context));
+        Assertions.assertTrue(ExpressionUtils.canInferNotNullForMarkSlot(
+                new And(new Or(NullLiteral.INSTANCE, markSlot2), new IsNull(markSlot1)), context));
+        Assertions.assertTrue(
+                ExpressionUtils.canInferNotNullForMarkSlot(new And(new IsNull(markSlot2), markSlot1), context));
+
+        Assertions.assertFalse(
+                ExpressionUtils.canInferNotNullForMarkSlot(new Or(new IsNull(markSlot2), markSlot1), context));
+        Assertions.assertFalse(ExpressionUtils.canInferNotNullForMarkSlot(
+                new And(new Or(BooleanLiteral.TRUE, markSlot2), new IsNull(markSlot1)), context));
+        Assertions.assertFalse(ExpressionUtils.canInferNotNullForMarkSlot(
+                new Or(new And(BooleanLiteral.TRUE, markSlot2), new IsNull(markSlot1)), context));
+        Assertions.assertFalse(ExpressionUtils.canInferNotNullForMarkSlot(
+                new Or(new And(BooleanLiteral.FALSE, markSlot2), new IsNull(markSlot1)), context));
+        Assertions.assertFalse(ExpressionUtils.canInferNotNullForMarkSlot(
+                new Or(new And(NullLiteral.INSTANCE, markSlot2), new IsNull(markSlot1)), context));
+        Assertions.assertFalse(ExpressionUtils.canInferNotNullForMarkSlot(new And(slot, markSlot1), context));
+    }
+}


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/49428

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

