### PR TITLE
[fix](shutdown) Fix coredump due to shutdown in the wrong order

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -772,6 +772,7 @@ void ExecEnv::destroy() {
 
     SAFE_DELETE(_bfd_parser);
     SAFE_DELETE(_result_cache);
+    SAFE_DELETE(_vstream_mgr);
     SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_workload_sched_mgr);
     SAFE_DELETE(_workload_group_manager);
@@ -793,7 +794,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_backend_client_cache);
     SAFE_DELETE(_result_queue_mgr);
 
-    SAFE_DELETE(_vstream_mgr);
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_user_function_cache);
 


### PR DESCRIPTION
### What problem does this PR solve?

When a BE is down, global object should shut down following a specific order to ensure BE will not crash. Because all running queries will finish once fragment mgr finished, stream mgr must be released before it because it may wake up some blocked tasks.

#0  __GI___pthread_sigmask (how=2, newmask=<optimized out>, oldmask=0x0) at ./nptl/pthread_sigmask.c:43
#1  0x00007f842b2bb71e in PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] () from /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
#2  0x00007f842b2bc206 in JVM_handle_linux_signal () from /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
#3  <signal handler called>
#4  ___pthread_mutex_lock (mutex=0x1b8) at ./nptl/pthread_mutex_lock.c:80
#5  0x000055c5f03edcca in __gthread_mutex_lock (__mutex=0x1b8) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749
#6  std::mutex::lock (this=0x1b8) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:100
#7  std::lock_guard<std::mutex>::lock_guard (__m=..., this=<optimized out>) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:229
#8  doris::RuntimeProfile::add_info_string (this=0x0, key=..., value=...) at /home/zcp/repo_center/doris_master/doris/be/src/util/runtime_profile.cpp:354
#9  0x000055c5f9cccaa7 in doris::pipeline::PipelineTask::_state_transition (this=0x7f84015b4000, new_state=doris::pipeline::PipelineTask::State::RUNNABLE) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.h:339
#10 0x000055c5fa53aec5 in doris::pipeline::PipelineTask::wake_up (this=0x7fffbd28a8e8, dep=<optimized out>) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:748
#11 0x000055c5f9cba3f5 in doris::pipeline::Dependency::set_ready (this=0x7f832f848310) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/dependency.cpp:72
#12 0x000055c5f9c53bcd in doris::vectorized::VDataStreamRecvr::SenderQueue::set_source_ready (this=0x7f839d485880) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:142
#13 doris::vectorized::VDataStreamRecvr::SenderQueue::close (this=0x7f839d485880) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:301
#14 0x000055c5f9c55b39 in doris::vectorized::VDataStreamRecvr::close (this=0x7f83fbe78940) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:488
#15 0x000055c5f9c4dc68 in doris::vectorized::VDataStreamMgr::~VDataStreamMgr (this=0x7f83f6d99da0) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_mgr.cpp:58
#16 0x000055c5f00cb651 in doris::ExecEnv::destroy (this=0x55c5fdf7a198 <doris::ExecEnv::GetInstance()::s_exec_env>) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/exec_env_init.cpp:796
#17 0x000055c5ef387909 in main (argc=<optimized out>, argv=<optimized out>) at /home/zcp/repo_center/doris_master/doris/be/src/service/doris_main.cpp:635

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

