### PR TITLE
[fix](cloud-mow) Make new MS can erase initiator when upgrading MS

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2447,12 +2447,6 @@ void MetaServiceImpl::get_delete_bitmap_update_lock(google::protobuf::RpcControl
                     return;
                 }
             } else {
-                // initiator may remain in initiators when upgrade ms, need to clear it
-                if (lock_info.initiators_size() > 0) {
-                    lock_info.clear_initiators();
-                    LOG(INFO) << "clear initiators for key=" << hex(lock_key)
-                              << " table_id=" << table_id;
-                }
                 if (request->lock_id() == COMPACTION_DELETE_BITMAP_LOCK_ID) {
                     std::string current_lock_msg = "locked by lock_id=-1";
                     if (!put_mow_tablet_compaction_key(code, msg, txn, instance_id, table_id,

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2685,7 +2685,7 @@ void MetaServiceImpl::remove_delete_bitmap_update_lock(
     DeleteBitmapUpdateLockPB lock_info;
     if (!check_delete_bitmap_lock(code, msg, ss, txn, instance_id, request->table_id(),
                                   request->lock_id(), request->initiator(), lock_key, lock_info,
-                                  true, ", remove lock")) {
+                                  ", remove lock")) {
         LOG(WARNING) << "failed to check delete bitmap tablet lock"
                      << " table_id=" << request->table_id() << " tablet_id=" << request->tablet_id()
                      << " request lock_id=" << request->lock_id()

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2673,19 +2673,6 @@ void MetaServiceImpl::remove_delete_bitmap_update_lock(
         msg = "failed to init txn";
         return;
     }
-    std::string lock_key =
-            meta_delete_bitmap_update_lock_key({instance_id, request->table_id(), -1});
-    std::string lock_val;
-    DeleteBitmapUpdateLockPB lock_info;
-    if (!check_delete_bitmap_lock(code, msg, ss, txn, instance_id, request->table_id(),
-                                  request->lock_id(), request->initiator(), lock_key, lock_info,
-                                  ", remove lock")) {
-        LOG(WARNING) << "failed to check delete bitmap tablet lock"
-                     << " table_id=" << request->table_id() << " tablet_id=" << request->tablet_id()
-                     << " request lock_id=" << request->lock_id()
-                     << " request initiator=" << request->initiator() << " msg " << msg;
-        return;
-    }
     if (request->lock_id() == COMPACTION_DELETE_BITMAP_LOCK_ID) {
         std::string tablet_compaction_key =
                 mow_tablet_compaction_key({instance_id, request->table_id(), request->initiator()});
@@ -2694,6 +2681,19 @@ void MetaServiceImpl::remove_delete_bitmap_update_lock(
                   << " lock_id=" << request->lock_id() << " initiator=" << request->initiator()
                   << " key=" << hex(tablet_compaction_key);
     } else {
+        std::string lock_key =
+                meta_delete_bitmap_update_lock_key({instance_id, request->table_id(), -1});
+        std::string lock_val;
+        DeleteBitmapUpdateLockPB lock_info;
+        if (!check_delete_bitmap_lock(code, msg, ss, txn, instance_id, request->table_id(),
+                                      request->lock_id(), request->initiator(), lock_key, lock_info,
+                                      ", remove lock")) {
+            LOG(WARNING) << "failed to check delete bitmap tablet lock"
+                         << " table_id=" << request->table_id() << " tablet_id=" << request->tablet_id()
+                         << " request lock_id=" << request->lock_id()
+                         << " request initiator=" << request->initiator() << " msg " << msg;
+            return;
+        }
         bool modify_initiators = false;
         auto initiators = lock_info.mutable_initiators();
         for (auto iter = initiators->begin(); iter != initiators->end(); iter++) {

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -2689,7 +2689,8 @@ void MetaServiceImpl::remove_delete_bitmap_update_lock(
                                       request->lock_id(), request->initiator(), lock_key, lock_info,
                                       ", remove lock")) {
             LOG(WARNING) << "failed to check delete bitmap tablet lock"
-                         << " table_id=" << request->table_id() << " tablet_id=" << request->tablet_id()
+                         << " table_id=" << request->table_id()
+                         << " tablet_id=" << request->tablet_id()
                          << " request lock_id=" << request->lock_id()
                          << " request initiator=" << request->initiator() << " msg " << msg;
             return;

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -587,7 +587,32 @@ static void remove_delete_bitmap_update_lock(std::unique_ptr<Transaction>& txn,
                 mow_tablet_compaction_key({instance_id, table_id, lock_initiator});
         std::string tablet_compaction_val;
         TxnErrorCode err = txn->get(tablet_compaction_key, &tablet_compaction_val);
-        if (err != TxnErrorCode::TXN_OK) {
+        if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            // initiator may remain in initiators when upgrade ms, need to clear it
+            std::string lock_key = meta_delete_bitmap_update_lock_key({instance_id, table_id, -1});
+            std::string lock_val;
+            err = txn->get(lock_key, &lock_val);
+            LOG(INFO) << "get remove delete bitmap update lock info, table_id=" << table_id
+                      << " key=" << hex(lock_key) << " err=" << err;
+            if (err != TxnErrorCode::TXN_OK) {
+                LOG(WARNING) << "failed to get delete bitmap update lock key, instance_id="
+                             << instance_id << " table_id=" << table_id << " key=" << hex(lock_key)
+                             << " err=" << err;
+                return;
+            }
+            DeleteBitmapUpdateLockPB lock_info;
+            if (!lock_info.ParseFromString(lock_val)) [[unlikely]] {
+                LOG(WARNING) << "failed to parse DeleteBitmapUpdateLockPB, instance_id="
+                             << instance_id << " table_id=" << table_id << " key=" << hex(lock_key);
+                return;
+            }
+            if (lock_info.initiators_size() > 0) {
+                lock_info.clear_initiators();
+                LOG(INFO) << "clear initiators for key=" << hex(lock_key)
+                          << " table_id=" << table_id;
+            }
+//            txn->remove(lock_key);
+        } else if (err != TxnErrorCode::TXN_OK) {
             LOG(WARNING) << "failed to get tablet compaction key, instance_id=" << instance_id
                          << " table_id=" << table_id << " initiator=" << lock_initiator
                          << " key=" << hex(tablet_compaction_key) << " err=" << err;
@@ -627,7 +652,7 @@ static void remove_delete_bitmap_update_lock(std::unique_ptr<Transaction>& txn,
                 break;
             }
         }
-        if (!found) {
+        if (!found && !initiators->empty()) {
             return;
         }
         if (initiators->empty()) {

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -611,7 +611,7 @@ static void remove_delete_bitmap_update_lock(std::unique_ptr<Transaction>& txn,
                 LOG(INFO) << "clear initiators for key=" << hex(lock_key)
                           << " table_id=" << table_id;
             }
-//            txn->remove(lock_key);
+            //            txn->remove(lock_key);
         } else if (err != TxnErrorCode::TXN_OK) {
             LOG(WARNING) << "failed to get tablet compaction key, instance_id=" << instance_id
                          << " table_id=" << table_id << " initiator=" << lock_initiator

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -650,11 +650,12 @@ static void remove_delete_bitmap_update_lock(std::unique_ptr<Transaction>& txn,
                          << " table_id=" << table_id << " initiator=" << lock_initiator
                          << " key=" << hex(tablet_compaction_key) << " err=" << err;
             return;
+        } else {
+            txn->remove(tablet_compaction_key);
+            INSTANCE_LOG(INFO) << "remove tablet compaction key, table_id=" << table_id
+                               << ", key=" << hex(tablet_compaction_key)
+                               << " initiator=" << lock_initiator;
         }
-        txn->remove(tablet_compaction_key);
-        INSTANCE_LOG(INFO) << "remove tablet compaction key, table_id=" << table_id
-                           << ", key=" << hex(tablet_compaction_key)
-                           << " initiator=" << lock_initiator;
     } else {
         remove_delete_bitmap_update_lock_v1(txn, instance_id, table_id, tablet_id, lock_id,
                                             lock_initiator);


### PR DESCRIPTION
Here is a scene
1. Upgrading MS, now we have a new MS and an old MS
2. Compaction applied for delete bitmap lock in the old MS
3. Compaction failed to update delete bitmap in new ms because of tablet compaction key not found
4. Compaction abort
5. Compaction failed to perform an abort in the new MS because of tablet compaction key not found, witch will lead to fail to release delete bitmap lock
Now this pr can make step 5 success, so delete bitmap lock can release successfully during upgrade ms
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

