### PR TITLE
enable faiss hnsw

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -395,6 +395,10 @@ if (USE_DWARF)
     add_compile_options(-gdwarf-5)
 endif()
 
+if (BUILD_FAISS)
+    add_definitions(-DBUILD_FAISS)
+endif()
+
 # For CMAKE_BUILD_TYPE=Debug
 if (OS_MACOSX AND ARCH_ARM)
     # Using -O0 may meet ARM64 branch out of range errors when linking with tcmalloc.

--- a/be/src/olap/rowset/segment_v2/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index_writer.h
@@ -49,9 +49,9 @@ class AnnIndexColumnWriter : public IndexColumnWriter {
 public:
     static constexpr const char* INDEX_TYPE = "index_type";
     static constexpr const char* METRIC_TYPE = "metric_type";
+    static constexpr const char* QUANTILIZER = "quantilizer";
     static constexpr const char* DIM = "dim";
-    static constexpr const char* DISKANN_MAX_DEGREE = "max_degree";
-    static constexpr const char* DISKANN_SEARCH_LIST = "search_list";
+    static constexpr const char* MAX_DEGREE = "max_degree";
 
     explicit AnnIndexColumnWriter(const std::string& field_name,
                                   XIndexFileWriter* index_file_writer,

--- a/be/src/vector/CMakeLists.txt
+++ b/be/src/vector/CMakeLists.txt
@@ -18,16 +18,24 @@
 # where to put generated libraries
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/vector")
 
-set(HEADER_FILES
+set(VECTOR_LIB_SRC
         vector_index.h
         stream_wrapper.h
 )
 
-# Use INTERFACE library type for header-only libraries
-add_library(vector INTERFACE)
+set(VECTOR_LIB_DEPENDENCIES)
+
 if (BUILD_FAISS)
-    target_link_libraries(vector INTERFACE faiss)
+    # append faiss src to VECTOR_LIB_SRC
+    list(APPEND VECTOR_LIB_SRC
+        faiss_vector_index.h
+        faiss_vector_index.cpp
+    )
+    list(APPEND VECTOR_LIB_DEPENDENCIES faiss)
 endif()
+
+add_library(vector OBJECT ${VECTOR_LIB_SRC})
+target_link_libraries(vector PRIVATE ${VECTOR_LIB_DEPENDENCIES})
 
 # Make the headers available to targets that link against the vector library
 target_include_directories(vector INTERFACE

--- a/be/src/vector/faiss_vector_index.cpp
+++ b/be/src/vector/faiss_vector_index.cpp
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "faiss_vector_index.h"
+
+#include <faiss/index_io.h>
+
+#include <memory>
+
+#include "CLucene/store/IndexOutput.h"
+#include "common/exception.h"
+#include "common/logging.h"
+#include "common/status.h"
+#include "faiss/IndexHNSW.h"
+#include "faiss/impl/io.h"
+
+struct FaissIndexWriter : faiss::IOWriter {
+public:
+    FaissIndexWriter() = default;
+    FaissIndexWriter(lucene::store::IndexOutput* output) : _output(output) {}
+    ~FaissIndexWriter() override {
+        if (_output != nullptr) {
+            _output->close();
+            delete _output;
+        }
+    }
+
+    size_t operator()(const void* ptr, size_t size, size_t nitems) override {
+        size_t bytes = size * nitems;
+        if (bytes > 0) {
+            try {
+                _output->writeBytes(reinterpret_cast<const uint8_t*>(ptr), bytes);
+            } catch (const std::exception& e) {
+                throw doris::Exception(doris::ErrorCode::IO_ERROR,
+                                       "Failed to write vector index {}", e.what());
+            }
+        }
+        return nitems;
+    };
+
+    lucene::store::IndexOutput* _output = nullptr;
+};
+
+doris::Status FaissVectorIndex::add(int n, const float* vec) {
+    DCHECK(vec != nullptr);
+
+    _index->add(n, vec);
+
+    return doris::Status::OK();
+}
+
+void FaissVectorIndex::set_build_params(const FaissBuildParameter& params) {
+    if (params.index_type == FaissBuildParameter::IndexType::BruteForce) {
+        _index = std::make_shared<faiss::IndexFlatL2>(params.d);
+    } else if (params.index_type == FaissBuildParameter::IndexType::HNSW) {
+        _index = std::make_shared<faiss::IndexHNSWFlat>(params.d, params.m);
+    } else {
+        throw doris::Exception(doris::ErrorCode::INVALID_ARGUMENT, "Unsupported index type: {}",
+                               static_cast<int>(params.index_type));
+    }
+}
+
+doris::Status FaissVectorIndex::search(const float* query_vec, int k, SearchResult* result,
+                                       const SearchParameters* params) {
+    return doris::Status::OK();
+}
+
+doris::Status FaissVectorIndex::save() {
+    lucene::store::IndexOutput* idx_output = _dir->createOutput("faiss.idx");
+    auto writer = std::make_unique<FaissIndexWriter>(idx_output);
+    faiss::write_index(_index.get(), writer.get());
+    VLOG_DEBUG << "Faiss index saved to faiss.idx";
+    return doris::Status::OK();
+}
+doris::Status FaissVectorIndex::load(Metric type) {
+    // Load the index from the directory
+    // This is a placeholder for actual implementation
+    return doris::Status::OK();
+}

--- a/be/src/vector/faiss_vector_index.cpp
+++ b/be/src/vector/faiss_vector_index.cpp
@@ -83,7 +83,7 @@ doris::Status FaissVectorIndex::save() {
     lucene::store::IndexOutput* idx_output = _dir->createOutput("faiss.idx");
     auto writer = std::make_unique<FaissIndexWriter>(idx_output);
     faiss::write_index(_index.get(), writer.get());
-    VLOG_DEBUG << "Faiss index saved to faiss.idx";
+    VLOG_DEBUG << fmt::format("Faiss index saved to faiss.idx, rows {}", _index->ntotal);
     return doris::Status::OK();
 }
 doris::Status FaissVectorIndex::load(Metric type) {

--- a/be/src/vector/faiss_vector_index.h
+++ b/be/src/vector/faiss_vector_index.h
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <CLucene.h>
+#include <CLucene/store/IndexInput.h>
+#include <CLucene/store/IndexOutput.h>
+#include <faiss/Index.h>
+
+#include <memory>
+#include <string>
+
+#include "common/status.h"
+#include "vector_index.h"
+
+struct FaissBuildParameter {
+    enum class IndexType { BruteForce, IVF, HNSW };
+
+    enum class Quantilizer { FLAT, SQ, PQ };
+
+    static IndexType string_to_index_type(const std::string& type) {
+        if (type == "brute_force") {
+            return IndexType::BruteForce;
+        } else if (type == "ivf") {
+            return IndexType::IVF;
+        } else if (type == "hnsw") {
+            return IndexType::HNSW;
+        }
+        return IndexType::HNSW; // default
+    }
+
+    static Quantilizer string_to_quantilizer(const std::string& type) {
+        if (type == "flat") {
+            return Quantilizer::FLAT;
+        } else if (type == "sq") {
+            return Quantilizer::SQ;
+        } else if (type == "pq") {
+            return Quantilizer::PQ;
+        }
+        return Quantilizer::FLAT; // default
+    }
+
+    // HNSW
+    int d = 0;
+    int m = 0;
+    IndexType index_type;
+    Quantilizer quantilizer;
+};
+
+class FaissVectorIndex : public VectorIndex {
+public:
+    FaissVectorIndex(std::shared_ptr<lucene::store::Directory> dir) : _index(nullptr), _dir(dir) {}
+
+    doris::Status add(int n, const float* vec) override;
+
+    void set_build_params(const FaissBuildParameter& params);
+
+    doris::Status search(const float* query_vec, int k, SearchResult* result,
+                         const SearchParameters* params = nullptr) override;
+
+    doris::Status save() override;
+
+    doris::Status load(Metric type) override;
+
+private:
+    std::shared_ptr<faiss::Index> _index;
+
+    std::shared_ptr<lucene::store::Directory> _dir;
+};

--- a/be/src/vector/vector_index.h
+++ b/be/src/vector/vector_index.h
@@ -54,14 +54,12 @@ struct SearchParameters {
     virtual ~SearchParameters() {}
 };
 
-struct BuilderParameter {};
-
 class VectorIndex {
 public:
     enum class Metric { L2, COSINE, INNER_PRODUCT, UNKNOWN };
 
     virtual doris::Status add(int n, const float* vec) = 0;
-    virtual void set_build_params(std::shared_ptr<BuilderParameter> params) = 0;
+
     virtual doris::Status search(const float* query_vec, int k, SearchResult* result,
                                  const SearchParameters* params = nullptr) = 0;
     //virtual Status save(FileWriter* writer);

--- a/build.sh
+++ b/build.sh
@@ -646,7 +646,6 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
         -DENABLE_CLANG_COVERAGE="${DENABLE_CLANG_COVERAGE}" \
         -DDORIS_JAVA_HOME="${JAVA_HOME}" \
         -DBUILD_AZURE="${BUILD_AZURE}" \
-        -DBUILD_FAISS="${BUILD_FAISS}" \
         "${DORIS_HOME}/be"
 
     if [[ "${OUTPUT_BE_BINARY}" -eq 1 ]]; then


### PR DESCRIPTION
```
CREATE TABLE `vector_table` (
  `siteid` int(11) NULL DEFAULT "10" COMMENT "",
  `embedding` array<float>  NOT NULL  COMMENT "",
  `comment` text NULL,
  INDEX idx_test_ann (`embedding`) USING ANN PROPERTIES(
    "index_type"="hnsw",
    "metric_type"="l2",
    "dim"="8",
    "max_degree"="100") COMMENT 'test diskann index',
  INDEX idx_comment (`comment`) USING INVERTED PROPERTIES("support_phrase" = "true", "parser" = "english", "lower_case" = "true") COMMENT 'inverted index for comment' )
  ENGINE=OLAP duplicate KEY(`siteid`) COMMENT "OLAP" DISTRIBUTED BY HASH(`siteid`) BUCKETS 1 PROPERTIES ( "replication_num" = "1" );

INSERT INTO `vector_table` (`siteid`, `embedding`,`comment`) VALUES
(10, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,20],"emb1"),
(20, [7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0,30],"emb2")
--------------

Query OK, 2 rows affected (0.07 sec)
{'label':'label_858347013b14baf_b9db5d59b5e30322', 'status':'VISIBLE', 'txnId':'18029'}
```

```
I20250401 19:18:17.977408 3765348 faiss_vector_index.cpp:86] Faiss index saved to faiss.idx, rows 2
```

