### PR TITLE
[fix](config) Turn on default value of `enable_cloud_tablet_report`

### DIFF
--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -76,7 +76,7 @@ DEFINE_mInt32(tablet_txn_info_min_expired_seconds, "1800");
 
 DEFINE_mBool(enable_use_cloud_unique_id_from_fe, "true");
 
-DEFINE_mBool(enable_cloud_tablet_report, "false");
+DEFINE_mBool(enable_cloud_tablet_report, "true");
 
 DEFINE_mInt32(delete_bitmap_rpc_retry_times, "25");
 


### PR DESCRIPTION
On the cloud, clearing redundant tablets through reporting has become more stable, and now this feature is enabled by default in branch-3.0

Previously closed PR:
https://github.com/apache/doris/pull/44176

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

