### PR TITLE
[Bug](Compaction): fix compact version miss when too many invisible version

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1262,8 +1262,8 @@ std::vector<RowsetSharedPtr> Tablet::_pick_visible_rowsets_to_compaction(
             // 1. had been visible;
             // 2. exceeds the limit of keep invisible versions.
             int64_t version_end = version.second;
-            if (version_end <= visible_version ||
-                version_end > visible_version + keep_invisible_version_limit) {
+            if (version_end <= visible_version || ((candidate_rowsets.empty() || candidate_rowsets.front()->version().second > visible_version) 
+                    && version_end > visible_version + keep_invisible_version_limit) {
                 candidate_rowsets.push_back(rs);
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

when too many invisible version, compact may choose some versions before `visible version`, and choose some versions after `visible_version + keep_invisible_version_limit`, it will lead that check version miss fail

![image](https://github.com/user-attachments/assets/c4083c0b-6f2d-43ef-9e80-6a5641b0f40c)

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [  ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

