### PR TITLE
[refactor](profile) Refactor of RuntimeFilter profile

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -307,9 +307,17 @@ public:
             int runtime_filter_id,
             std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter,
             std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter) {
+        DCHECK(predicate_filtered_rows_counter != nullptr);
+        DCHECK(predicate_input_rows_counter != nullptr);
+
         _runtime_filter_id = runtime_filter_id;
-        _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
-        _predicate_input_rows_counter = predicate_input_rows_counter;
+
+        if (predicate_filtered_rows_counter != nullptr) {
+            _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
+        }
+        if (predicate_input_rows_counter != nullptr) {
+            _predicate_input_rows_counter = predicate_input_rows_counter;
+        }
     }
 
     int precision() const { return _precision; }

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gen_cpp/Metrics_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <glog/logging.h>
 #include <stddef.h>
@@ -41,6 +42,7 @@
 #include "runtime/define_primitive_type.h"
 #include "runtime/primitive_type.h"
 #include "runtime/type_limit.h"
+#include "util/runtime_profile.h"
 #include "vec/core/types.h"
 #include "vec/io/io_helper.h"
 #include "vec/runtime/ipv4_value.h"
@@ -301,9 +303,10 @@ public:
         _contain_null = _is_nullable_col && contain_null;
     }
 
-    void set_runtime_filter_info(int runtime_filter_id,
-                                 RuntimeProfile::Counter* predicate_filtered_rows_counter,
-                                 RuntimeProfile::Counter* predicate_input_rows_counter) {
+    void attach_profile_counter(
+            int runtime_filter_id,
+            std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter,
+            std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter) {
         _runtime_filter_id = runtime_filter_id;
         _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
         _predicate_input_rows_counter = predicate_input_rows_counter;
@@ -370,8 +373,11 @@ private:
                                                   primitive_type == PrimitiveType::TYPE_DATETIMEV2;
 
     int _runtime_filter_id = -1;
-    RuntimeProfile::Counter* _predicate_filtered_rows_counter = nullptr;
-    RuntimeProfile::Counter* _predicate_input_rows_counter = nullptr;
+
+    std::shared_ptr<RuntimeProfile::Counter> _predicate_filtered_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+    std::shared_ptr<RuntimeProfile::Counter> _predicate_input_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
 };
 
 class OlapScanKeys {

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -113,8 +113,6 @@ uint16_t BitmapFilterColumnPredicate<T>::_evaluate_inner(const vectorized::IColu
     } else {
         new_size = evaluate<false>(column, nullptr, sel, size);
     }
-    _evaluated_rows += size;
-    _passed_rows += new_size;
     update_filter_info(size - new_size, size);
     return new_size;
 }

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -259,8 +259,15 @@ public:
             int filter_id, std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter,
             std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter) {
         _runtime_filter_id = filter_id;
-        _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
-        _predicate_input_rows_counter = predicate_input_rows_counter;
+        DCHECK(predicate_filtered_rows_counter != nullptr);
+        DCHECK(predicate_input_rows_counter != nullptr);
+
+        if (predicate_filtered_rows_counter != nullptr) {
+            _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
+        }
+        if (predicate_input_rows_counter != nullptr) {
+            _predicate_input_rows_counter = predicate_input_rows_counter;
+        }
     }
 
     /// TODO: Currently we only record statistics for runtime filters, in the future we should record for all predicates

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <memory>
 #include <roaring/roaring.hh>
 
 #include "common/exception.h"
@@ -24,6 +25,7 @@
 #include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
 #include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/columns/column.h"
 #include "vec/exprs/vruntimefilter_wrapper.h"
 
@@ -184,8 +186,6 @@ public:
         }
 
         uint16_t new_size = _evaluate_inner(column, sel, size);
-        _evaluated_rows += size;
-        _passed_rows += new_size;
         if (_can_ignore()) {
             do_judge_selectivity(size - new_size, size);
         }
@@ -255,13 +255,9 @@ public:
 
     int get_runtime_filter_id() const { return _runtime_filter_id; }
 
-    void set_runtime_filter_info(int filter_id,
-                                 RuntimeProfile::Counter* predicate_filtered_rows_counter,
-                                 RuntimeProfile::Counter* predicate_input_rows_counter) {
-        if (filter_id >= 0) {
-            DCHECK(predicate_filtered_rows_counter != nullptr);
-            DCHECK(predicate_input_rows_counter != nullptr);
-        }
+    void attach_profile_counter(
+            int filter_id, std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter,
+            std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter) {
         _runtime_filter_id = filter_id;
         _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
         _predicate_input_rows_counter = predicate_input_rows_counter;
@@ -269,17 +265,8 @@ public:
 
     /// TODO: Currently we only record statistics for runtime filters, in the future we should record for all predicates
     void update_filter_info(int64_t filter_rows, int64_t input_rows) const {
-        if (_predicate_input_rows_counter) {
-            COUNTER_UPDATE(_predicate_input_rows_counter, input_rows);
-        }
-        if (_predicate_filtered_rows_counter) {
-            COUNTER_UPDATE(_predicate_filtered_rows_counter, filter_rows);
-        }
-    }
-
-    PredicateFilterInfo get_filtered_info() const {
-        return PredicateFilterInfo {static_cast<int>(type()), _evaluated_rows - 1,
-                                    _evaluated_rows - 1 - _passed_rows};
+        COUNTER_UPDATE(_predicate_input_rows_counter, input_rows);
+        COUNTER_UPDATE(_predicate_filtered_rows_counter, filter_rows);
     }
 
     static std::string pred_type_string(PredicateType type) {
@@ -353,8 +340,6 @@ protected:
     // TODO: the value is only in delete condition, better be template value
     bool _opposite;
     int _runtime_filter_id = -1;
-    mutable uint64_t _evaluated_rows = 1;
-    mutable uint64_t _passed_rows = 0;
     // VRuntimeFilterWrapper and ColumnPredicate share the same logic,
     // but it's challenging to unify them, so the code is duplicated.
     // _judge_counter, _judge_input_rows, _judge_filter_rows, and _always_true
@@ -368,8 +353,11 @@ protected:
     mutable uint64_t _judge_filter_rows = 0;
     mutable bool _always_true = false;
 
-    RuntimeProfile::Counter* _predicate_filtered_rows_counter = nullptr;
-    RuntimeProfile::Counter* _predicate_input_rows_counter = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> _predicate_filtered_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+
+    std::shared_ptr<RuntimeProfile::Counter> _predicate_input_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
 };
 
 } //namespace doris

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -267,9 +267,12 @@ public:
             } else {
                 current_evaluated_rows += size;
             }
-            _evaluated_rows += current_evaluated_rows;
         }
 
+        // defer is created after its reference args are created.
+        // so defer will be destroyed BEFORE the reference args.
+        // so reference here is safe.
+        // https://stackoverflow.com/questions/14688285/c-local-variable-destruction-order
         Defer defer([&]() {
             update_filter_info(current_evaluated_rows - current_passed_rows,
                                current_evaluated_rows);
@@ -359,7 +362,6 @@ public:
             for (uint16_t i = 0; i < size; i++) {
                 current_passed_rows += flags[i];
             }
-            _passed_rows += current_passed_rows;
             do_judge_selectivity(current_evaluated_rows - current_passed_rows,
                                  current_evaluated_rows);
         }

--- a/be/src/olap/filter_olap_param.h
+++ b/be/src/olap/filter_olap_param.h
@@ -24,18 +24,22 @@ namespace doris {
 template <typename T>
 struct FilterOlapParam {
     FilterOlapParam(std::string column_name, T filter, int runtime_filter_id,
-                    RuntimeProfile::Counter* filtered_counter,
-                    RuntimeProfile::Counter* input_counter)
+                    std::shared_ptr<RuntimeProfile::Counter> filtered_counter,
+                    std::shared_ptr<RuntimeProfile::Counter> input_counter)
             : column_name(std::move(column_name)),
               filter(std::move(filter)),
               runtime_filter_id(runtime_filter_id),
               filtered_rows_counter(filtered_counter),
-              input_rows_counter(input_counter) {}
+              input_rows_counter(input_counter) {
+        DCHECK(filtered_rows_counter != nullptr);
+        DCHECK(input_rows_counter != nullptr);
+    }
+
     std::string column_name;
     T filter;
     int runtime_filter_id;
-    RuntimeProfile::Counter* filtered_rows_counter = nullptr;
-    RuntimeProfile::Counter* input_rows_counter = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> filtered_rows_counter = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> input_rows_counter = nullptr;
 };
 
 } // namespace doris

--- a/be/src/olap/filter_olap_param.h
+++ b/be/src/olap/filter_olap_param.h
@@ -28,18 +28,24 @@ struct FilterOlapParam {
                     std::shared_ptr<RuntimeProfile::Counter> input_counter)
             : column_name(std::move(column_name)),
               filter(std::move(filter)),
-              runtime_filter_id(runtime_filter_id),
-              filtered_rows_counter(filtered_counter),
-              input_rows_counter(input_counter) {
+              runtime_filter_id(runtime_filter_id) {
         DCHECK(filtered_rows_counter != nullptr);
         DCHECK(input_rows_counter != nullptr);
+        if (filtered_counter != nullptr) {
+            filtered_rows_counter = filtered_counter;
+        }
+        if (input_counter != nullptr) {
+            input_rows_counter = input_counter;
+        }
     }
 
     std::string column_name;
     T filter;
     int runtime_filter_id;
-    std::shared_ptr<RuntimeProfile::Counter> filtered_rows_counter = nullptr;
-    std::shared_ptr<RuntimeProfile::Counter> input_rows_counter = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> filtered_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+    std::shared_ptr<RuntimeProfile::Counter> input_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
 };
 
 } // namespace doris

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -77,11 +77,7 @@ struct DataDirInfo {
     DataDirType data_dir_type = DataDirType::OLAP_DATA_DIR;
     std::string metric_name;
 };
-struct PredicateFilterInfo {
-    int type = 0;
-    uint64_t input_row = 0;
-    uint64_t filtered_row = 0;
-};
+
 // Sort DataDirInfo by available space.
 struct DataDirInfoLessAvailability {
     bool operator()(const DataDirInfo& left, const DataDirInfo& right) const {
@@ -337,9 +333,6 @@ struct OlapReaderStatistics {
     int64_t short_cond_ns = 0;
     int64_t expr_filter_ns = 0;
     int64_t output_col_ns = 0;
-
-    std::map<int, PredicateFilterInfo> filter_info;
-
     int64_t rows_key_range_filtered = 0;
     int64_t rows_stats_filtered = 0;
     int64_t rows_stats_rp_filtered = 0;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1877,17 +1877,6 @@ uint16_t SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_ro
     return selected_size;
 }
 
-void SegmentIterator::_collect_runtime_filter_predicate() {
-    // collect profile
-    for (auto* p : _filter_info_id) {
-        // There is a situation, such as with in or minmax filters,
-        // where intermediate conversion to a key range or other types
-        // prevents obtaining the filter id.
-        if (p->is_runtime_filter()) {
-            _opts.stats->filter_info[p->get_runtime_filter_id()] = p->get_filtered_info();
-        }
-    }
-}
 Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_column_ids,
                                                 std::vector<rowid_t>& rowid_vector,
                                                 uint16_t* sel_rowid_idx, size_t select_size,
@@ -2147,7 +2136,6 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
             //          In SSB test, it make no difference; So need more scenarios to test
             selected_size = _evaluate_short_circuit_predicate(_sel_rowid_idx.data(), selected_size);
 
-            _collect_runtime_filter_predicate();
             if (selected_size > 0) {
                 // step 3.1: output short circuit and predicate column
                 // when lazy materialization enables, _predicate_column_ids = distinct(_short_cir_pred_column_ids + _vec_pred_column_ids)

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -520,16 +520,13 @@ Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
 Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     SCOPED_RAW_TIMER(&_stats.tablet_reader_init_conditions_param_timer_ns);
     std::vector<ColumnPredicate*> predicates;
-    auto emplace_predicate = [&predicates](auto& param, ColumnPredicate* predicate) {
-        predicate->set_runtime_filter_info(param.runtime_filter_id, param.filtered_rows_counter,
-                                           param.input_rows_counter);
-        predicates.emplace_back(predicate);
-    };
 
-    auto parse_and_emplace_predicates = [this, &emplace_predicate](auto& params) {
+    auto parse_and_emplace_predicates = [this, &predicates](auto& params) {
         for (const auto& param : params) {
             ColumnPredicate* predicate = _parse_to_predicate({param.column_name, param.filter});
-            emplace_predicate(param, predicate);
+            predicate->attach_profile_counter(param.runtime_filter_id, param.filtered_rows_counter,
+                                              param.input_rows_counter);
+            predicates.emplace_back(predicate);
         }
     };
 
@@ -545,7 +542,9 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
                 parse_to_predicate(mcolumn, index, tmp_cond, _predicate_arena.get());
         // record condition value into predicate_params in order to pushdown segment_iterator,
         // _gen_predicate_result_sign will build predicate result unique sign with condition value
-        emplace_predicate(param, predicate);
+        predicate->attach_profile_counter(param.runtime_filter_id, param.filtered_rows_counter,
+                                          param.input_rows_counter);
+        predicates.emplace_back(predicate);
     }
     parse_and_emplace_predicates(read_params.bloom_filters);
     parse_and_emplace_predicates(read_params.bitmap_filters);

--- a/be/src/pipeline/exec/datagen_operator.cpp
+++ b/be/src/pipeline/exec/datagen_operator.cpp
@@ -96,8 +96,8 @@ Status DataGenLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     // TODO: use runtime filter to filte result block, maybe this node need derive from vscan_node.
     for (const auto& filter_desc : p._runtime_filter_descs) {
         std::shared_ptr<RuntimeFilterConsumer> filter;
-        RETURN_IF_ERROR(state->register_consumer_runtime_filter(
-                filter_desc, p.is_serial_operator(), p.node_id(), &filter, _runtime_profile.get()));
+        RETURN_IF_ERROR(state->register_consumer_runtime_filter(filter_desc, p.is_serial_operator(),
+                                                                p.node_id(), &filter));
     }
     return Status::OK();
 }

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -43,8 +43,8 @@ Status MultiCastDataStreamSourceLocalState::init(RuntimeState* state, LocalState
     _filter_timer = ADD_TIMER(_runtime_profile, "FilterTime");
     _get_data_timer = ADD_TIMER(_runtime_profile, "GetDataTime");
     _materialize_data_timer = ADD_TIMER(_runtime_profile, "MaterializeDataTime");
-    RETURN_IF_ERROR(_helper.init(state, profile(), false, _filter_dependencies, p.operator_id(),
-                                 p.node_id(), p.get_name() + "_FILTER_DEPENDENCY"));
+    RETURN_IF_ERROR(_helper.init(state, false, _filter_dependencies, p.operator_id(), p.node_id(),
+                                 p.get_name() + "_FILTER_DEPENDENCY"));
     return Status::OK();
 }
 
@@ -81,7 +81,7 @@ Status MultiCastDataStreamSourceLocalState::close(RuntimeState* state) {
         rf_time += dep->watcher_elapse_time();
     }
     COUNTER_SET(_wait_for_rf_timer, rf_time);
-
+    _helper.collect_realtime_profile(profile());
     return Base::close(state);
 }
 

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -87,8 +87,6 @@ private:
 
     Status _init_scanners(std::list<vectorized::ScannerSPtr>* scanners) override;
 
-    void add_filter_info(int id, const PredicateFilterInfo& info);
-
     Status _build_key_ranges_and_filters();
 
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
@@ -122,7 +120,6 @@ private:
     RuntimeProfile::Counter* _short_cond_timer = nullptr;
     RuntimeProfile::Counter* _expr_filter_timer = nullptr;
     RuntimeProfile::Counter* _output_col_timer = nullptr;
-    std::map<int, PredicateFilterInfo> _filter_info;
 
     RuntimeProfile::Counter* _stats_filtered_counter = nullptr;
     RuntimeProfile::Counter* _stats_rp_filtered_counter = nullptr;
@@ -188,8 +185,6 @@ private:
     // total number of segment related to this scan node
     RuntimeProfile::Counter* _total_segment_counter = nullptr;
 
-    RuntimeProfile::Counter* _runtime_filter_info = nullptr;
-
     // timer about tablet reader
     RuntimeProfile::Counter* _tablet_reader_init_timer = nullptr;
     RuntimeProfile::Counter* _tablet_reader_capture_rs_readers_timer = nullptr;
@@ -217,7 +212,6 @@ private:
     RuntimeProfile::Counter* _segment_create_column_readers_timer = nullptr;
     RuntimeProfile::Counter* _segment_load_index_timer = nullptr;
 
-    std::mutex _profile_mtx;
     std::vector<TabletWithVersion> _tablets;
     std::vector<TabletReader::ReadSource> _read_sources;
 };

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -508,10 +508,10 @@ Status RuntimeState::register_producer_runtime_filter(
 
 Status RuntimeState::register_consumer_runtime_filter(
         const doris::TRuntimeFilterDesc& desc, bool need_local_merge, int node_id,
-        std::shared_ptr<RuntimeFilterConsumer>* consumer_filter, RuntimeProfile* parent_profile) {
+        std::shared_ptr<RuntimeFilterConsumer>* consumer_filter) {
     bool need_merge = desc.has_remote_targets || need_local_merge;
     RuntimeFilterMgr* mgr = need_merge ? global_runtime_filter_mgr() : local_runtime_filter_mgr();
-    return mgr->register_consumer_filter(desc, node_id, consumer_filter, parent_profile);
+    return mgr->register_consumer_filter(desc, node_id, consumer_filter);
 }
 
 bool RuntimeState::is_nereids() const {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -549,10 +549,9 @@ public:
                                             std::shared_ptr<RuntimeFilterProducer>* producer_filter,
                                             RuntimeProfile* parent_profile);
 
-    Status register_consumer_runtime_filter(const doris::TRuntimeFilterDesc& desc,
-                                            bool need_local_merge, int node_id,
-                                            std::shared_ptr<RuntimeFilterConsumer>* consumer_filter,
-                                            RuntimeProfile* parent_profile);
+    Status register_consumer_runtime_filter(
+            const doris::TRuntimeFilterDesc& desc, bool need_local_merge, int node_id,
+            std::shared_ptr<RuntimeFilterConsumer>* consumer_filter);
 
     bool is_nereids() const;
 

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -231,13 +231,12 @@ void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_oper
     c->update(_always_true_counter->value());
 
     {
-        // return debug_string_cache instead of calling debug_string()
         // since debug_string will read from  RuntimeFilter::_wrapper
-        // it is a shared_ptr, instead of a atomic_shared_ptr
+        // and it is a shared_ptr, instead of a atomic_shared_ptr
         // so it is not thread safe
         std::unique_lock<std::mutex> l(_mtx);
         parent_operator_profile->add_description(fmt::format("RF{} Info", _filter_id),
-                                                 _debug_string_cache, "RuntimeFilterInfo");
+                                                 debug_string(), "RuntimeFilterInfo");
     }
 }
 

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -231,9 +231,13 @@ void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_oper
     c->update(_always_true_counter->value());
 
     {
+        // return debug_string_cache instead of calling debug_string()
+        // since debug_string will read from  RuntimeFilter::_wrapper
+        // it is a shared_ptr, instead of a atomic_shared_ptr
+        // so it is not thread safe
         std::unique_lock<std::mutex> l(_mtx);
         parent_operator_profile->add_description(fmt::format("RF{} Info", _filter_id),
-                                                 _wrapper_debug_string, "RuntimeFilterInfo");
+                                                 _debug_string_cache, "RuntimeFilterInfo");
     }
 }
 

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -230,8 +230,11 @@ void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_oper
                                              TUnit::UNIT, "RuntimeFilterInfo", 2);
     c->update(_always_true_counter->value());
 
-    parent_operator_profile->add_description(fmt::format("RF{} Info", _filter_id), debug_string(),
-                                             "RuntimeFilterInfo");
+    {
+        std::unique_lock<std::mutex> l(_mtx);
+        parent_operator_profile->add_description(fmt::format("RF{} Info", _filter_id),
+                                                 _wrapper_debug_string, "RuntimeFilterInfo");
+    }
 }
 
 } // namespace doris

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -227,7 +227,7 @@ void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_oper
     c->update(_wait_timer->value());
 
     c = parent_operator_profile->add_counter(fmt::format("RF{} AlwaysTrueFilterRows", _filter_id),
-                                             TUnit::UNIT, "RuntimeFilterInfo", 1);
+                                             TUnit::UNIT, "RuntimeFilterInfo", 2);
     c->update(_always_true_counter->value());
 
     parent_operator_profile->add_description(fmt::format("RF{} Info", _filter_id), debug_string(),

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -103,7 +103,7 @@ private:
         _rf_filter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
         _rf_input = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
         _always_true_counter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
-        _wrapper_debug_string = debug_string();
+        _debug_string_cache = debug_string();
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 
@@ -139,7 +139,7 @@ private:
                                   RuntimeFilterWrapper::State::READY});
             _check_state({State::NOT_READY, State::TIMEOUT});
         }
-        _wrapper_debug_string = debug_string();
+        _debug_string_cache = debug_string();
         _rf_state = rf_state;
     }
 
@@ -159,7 +159,7 @@ private:
     std::shared_ptr<RuntimeProfile::Counter> _rf_input = nullptr;
     std::shared_ptr<RuntimeProfile::Counter> _always_true_counter = nullptr;
     // protected by _mtx
-    std::string _wrapper_debug_string;
+    std::string _debug_string_cache;
 
     int32_t _rf_wait_time_ms;
     const int64_t _registration_time;

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -103,6 +103,7 @@ private:
         _rf_filter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
         _rf_input = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
         _always_true_counter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
+        _wrapper_debug_string = debug_string();
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 
@@ -138,6 +139,7 @@ private:
                                   RuntimeFilterWrapper::State::READY});
             _check_state({State::NOT_READY, State::TIMEOUT});
         }
+        _wrapper_debug_string = debug_string();
         _rf_state = rf_state;
     }
 
@@ -156,6 +158,8 @@ private:
     std::shared_ptr<RuntimeProfile::Counter> _rf_filter = nullptr;
     std::shared_ptr<RuntimeProfile::Counter> _rf_input = nullptr;
     std::shared_ptr<RuntimeProfile::Counter> _always_true_counter = nullptr;
+    // protected by _mtx
+    std::string _wrapper_debug_string;
 
     int32_t _rf_wait_time_ms;
     const int64_t _registration_time;

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -141,7 +141,8 @@ private:
 
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 
-    std::shared_ptr<RuntimeProfile::Counter> _wait_timer = std::make_shared<RuntimeProfile::Counter>(TUnit::TIME_NS, 0);
+    std::shared_ptr<RuntimeProfile::Counter> _wait_timer =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::TIME_NS, 0);
     //_rf_filter is used to record the number of rows filtered by the runtime filter.
     //It aggregates the filtering statistics from both the Storage and Execution.
     // Counter will be shared by RuntimeFilterConsumer & VRuntimeFilterWrapper

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -100,10 +100,6 @@ private:
         _rf_wait_time_ms = wait_infinitely ? _state->get_query_ctx()->execution_timeout() * 1000
                                            : _state->get_query_ctx()->runtime_filter_wait_time_ms();
         _wait_timer = std::make_shared<RuntimeProfile::Counter>(TUnit::TIME_NS, 0);
-        _rf_filter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
-        _rf_input = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
-        _always_true_counter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
-        _debug_string_cache = debug_string();
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 
@@ -139,7 +135,6 @@ private:
                                   RuntimeFilterWrapper::State::READY});
             _check_state({State::NOT_READY, State::TIMEOUT});
         }
-        _debug_string_cache = debug_string();
         _rf_state = rf_state;
     }
 
@@ -155,11 +150,12 @@ private:
     // Counter will be shared by RuntimeFilterConsumer & VRuntimeFilterWrapper
     // OperatorLocalState's close method will collect the statistics from RuntimeFilterConsumer
     // VRuntimeFilterWrapper will update the statistics.
-    std::shared_ptr<RuntimeProfile::Counter> _rf_filter = nullptr;
-    std::shared_ptr<RuntimeProfile::Counter> _rf_input = nullptr;
-    std::shared_ptr<RuntimeProfile::Counter> _always_true_counter = nullptr;
-    // protected by _mtx
-    std::string _debug_string_cache;
+    std::shared_ptr<RuntimeProfile::Counter> _rf_filter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
+    std::shared_ptr<RuntimeProfile::Counter> _rf_input =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
+    std::shared_ptr<RuntimeProfile::Counter> _always_true_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
 
     int32_t _rf_wait_time_ms;
     const int64_t _registration_time;

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -99,7 +99,6 @@ private:
                                _runtime_filter_type == RuntimeFilterType::BITMAP_FILTER;
         _rf_wait_time_ms = wait_infinitely ? _state->get_query_ctx()->execution_timeout() * 1000
                                            : _state->get_query_ctx()->runtime_filter_wait_time_ms();
-        _wait_timer = std::make_shared<RuntimeProfile::Counter>(TUnit::TIME_NS, 0);
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 
@@ -142,9 +141,7 @@ private:
 
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 
-    std::unique_ptr<RuntimeProfile> _storage_profile;   // for storage layer stats
-    std::unique_ptr<RuntimeProfile> _execution_profile; // for execution layer stats
-    std::shared_ptr<RuntimeProfile::Counter> _wait_timer = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> _wait_timer = std::make_shared<RuntimeProfile::Counter>(TUnit::TIME_NS, 0);
     //_rf_filter is used to record the number of rows filtered by the runtime filter.
     //It aggregates the filtering statistics from both the Storage and Execution.
     // Counter will be shared by RuntimeFilterConsumer & VRuntimeFilterWrapper

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <gen_cpp/Metrics_types.h>
+
+#include <memory>
 #include <string>
 
 #include "pipeline/dependency.h"
@@ -39,12 +42,10 @@ public:
     };
 
     static Status create(RuntimeFilterParamsContext* state, const TRuntimeFilterDesc* desc,
-                         int node_id, std::shared_ptr<RuntimeFilterConsumer>* res,
-                         RuntimeProfile* parent_profile) {
+                         int node_id, std::shared_ptr<RuntimeFilterConsumer>* res) {
         *res = std::shared_ptr<RuntimeFilterConsumer>(
-                new RuntimeFilterConsumer(state, desc, node_id, parent_profile));
+                new RuntimeFilterConsumer(state, desc, node_id));
         RETURN_IF_ERROR((*res)->_init_with_desc(desc, &state->get_query_ctx()->query_options()));
-        (*res)->_profile->add_info_string("Info", ((*res)->debug_string()));
         return Status::OK();
     }
 
@@ -65,6 +66,9 @@ public:
 
     bool is_applied() { return _rf_state == State::APPLIED; }
 
+    // Called by RuntimeFilterConsumerHelper
+    void collect_realtime_profile(RuntimeProfile* parent_operator_profile);
+
     static std::string to_string(const State& state) {
         switch (state) {
         case State::NOT_READY:
@@ -81,31 +85,24 @@ public:
     }
 
 private:
+    friend class RuntimeFilterProducer;
+
     RuntimeFilterConsumer(RuntimeFilterParamsContext* state, const TRuntimeFilterDesc* desc,
-                          int node_id, RuntimeProfile* parent_profile)
+                          int node_id)
             : RuntimeFilter(state, desc),
               _probe_expr(desc->planId_to_target_expr.find(node_id)->second),
-              _profile(new RuntimeProfile(fmt::format("RF{}", desc->filter_id))),
-              _storage_profile(new RuntimeProfile(fmt::format("Storage", desc->filter_id))),
-              _execution_profile(new RuntimeProfile(fmt::format("Execution", desc->filter_id))),
               _registration_time(MonotonicMillis()),
-              _rf_state(State::NOT_READY) {
+              _rf_state(State::NOT_READY),
+              _filter_id(desc->filter_id) {
         // If bitmap filter is not applied, it will cause the query result to be incorrect
         bool wait_infinitely = _state->get_query_ctx()->runtime_filter_wait_infinitely() ||
                                _runtime_filter_type == RuntimeFilterType::BITMAP_FILTER;
         _rf_wait_time_ms = wait_infinitely ? _state->get_query_ctx()->execution_timeout() * 1000
                                            : _state->get_query_ctx()->runtime_filter_wait_time_ms();
-        _profile->add_info_string("TimeoutLimit", std::to_string(_rf_wait_time_ms) + "ms");
-
-        parent_profile->add_child(_profile.get(), true, nullptr);
-        _profile->add_child(_storage_profile.get(), true, nullptr);
-        _profile->add_child(_execution_profile.get(), true, nullptr);
-        _wait_timer = ADD_TIMER(_profile, "WaitTime");
-
-        _rf_filter = ADD_COUNTER_WITH_LEVEL(
-                parent_profile, fmt::format("RF{} FilterRows", desc->filter_id), TUnit::UNIT, 1);
-        _rf_input = ADD_COUNTER_WITH_LEVEL(
-                parent_profile, fmt::format("RF{} InputRows", desc->filter_id), TUnit::UNIT, 1);
+        _wait_timer = std::make_shared<RuntimeProfile::Counter>(TUnit::TIME_NS, 0);
+        _rf_filter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
+        _rf_input = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
+        _always_true_counter = std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0, 1);
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 
@@ -142,21 +139,23 @@ private:
             _check_state({State::NOT_READY, State::TIMEOUT});
         }
         _rf_state = rf_state;
-        _profile->add_info_string("Info", debug_string());
     }
 
     TExpr _probe_expr;
 
     std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 
-    std::unique_ptr<RuntimeProfile> _profile;
     std::unique_ptr<RuntimeProfile> _storage_profile;   // for storage layer stats
     std::unique_ptr<RuntimeProfile> _execution_profile; // for execution layer stats
-    RuntimeProfile::Counter* _wait_timer = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> _wait_timer = nullptr;
     //_rf_filter is used to record the number of rows filtered by the runtime filter.
     //It aggregates the filtering statistics from both the Storage and Execution.
-    RuntimeProfile::Counter* _rf_filter = nullptr;
-    RuntimeProfile::Counter* _rf_input = nullptr;
+    // Counter will be shared by RuntimeFilterConsumer & VRuntimeFilterWrapper
+    // OperatorLocalState's close method will collect the statistics from RuntimeFilterConsumer
+    // VRuntimeFilterWrapper will update the statistics.
+    std::shared_ptr<RuntimeProfile::Counter> _rf_filter = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> _rf_input = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> _always_true_counter = nullptr;
 
     int32_t _rf_wait_time_ms;
     const int64_t _registration_time;
@@ -169,6 +168,7 @@ private:
     bool _reached_timeout = false;
 
     friend class RuntimeFilterProducer;
+    int _filter_id = -1;
 };
 #include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/runtime_filter/runtime_filter_consumer_helper.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer_helper.cpp
@@ -17,8 +17,6 @@
 
 #include "runtime_filter/runtime_filter_consumer_helper.h"
 
-#include <mutex>
-
 #include "pipeline/pipeline_task.h"
 #include "runtime_filter/runtime_filter_consumer.h"
 #include "util/runtime_profile.h"

--- a/be/src/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/runtime_filter/runtime_filter_mgr.cpp
@@ -70,15 +70,14 @@ std::vector<std::shared_ptr<RuntimeFilterConsumer>> RuntimeFilterMgr::get_consum
     return iter->second;
 }
 
-Status RuntimeFilterMgr::register_consumer_filter(const TRuntimeFilterDesc& desc, int node_id,
-                                                  std::shared_ptr<RuntimeFilterConsumer>* consumer,
-                                                  RuntimeProfile* parent_profile) {
+Status RuntimeFilterMgr::register_consumer_filter(
+        const TRuntimeFilterDesc& desc, int node_id,
+        std::shared_ptr<RuntimeFilterConsumer>* consumer) {
     SCOPED_CONSUME_MEM_TRACKER(_tracker.get());
     int32_t key = desc.filter_id;
 
     std::lock_guard<std::mutex> l(_lock);
-    RETURN_IF_ERROR(
-            RuntimeFilterConsumer::create(_state, &desc, node_id, consumer, parent_profile));
+    RETURN_IF_ERROR(RuntimeFilterConsumer::create(_state, &desc, node_id, consumer));
     _consumer_map[key].push_back(*consumer);
     return Status::OK();
 }

--- a/be/src/runtime_filter/runtime_filter_mgr.h
+++ b/be/src/runtime_filter/runtime_filter_mgr.h
@@ -89,8 +89,7 @@ public:
     // get/set consumer
     std::vector<std::shared_ptr<RuntimeFilterConsumer>> get_consume_filters(int filter_id);
     Status register_consumer_filter(const TRuntimeFilterDesc& desc, int node_id,
-                                    std::shared_ptr<RuntimeFilterConsumer>* consumer_filter,
-                                    RuntimeProfile* parent_profile);
+                                    std::shared_ptr<RuntimeFilterConsumer>* consumer_filter);
 
     Status register_local_merger_producer_filter(
             const TRuntimeFilterDesc& desc, std::shared_ptr<RuntimeFilterProducer> producer_filter,

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -455,13 +455,12 @@ void RuntimeProfile::add_description(const std::string& name, const std::string&
     if (_counter_map.find(name) != _counter_map.end()) {
         Counter* counter = _counter_map[name];
         if (DescriptionEntry* derived_counter = dynamic_cast<DescriptionEntry*>(counter)) {
-            derived_counter->update(description);
-
+            // Do replace instead of update to avoid data race.
+            _counter_map.erase(name);
         } else {
             DCHECK(false) << "Counter type mismatch, name: " << name
                           << ", type: " << counter->type() << ", description: " << description;
         }
-        return;
     }
 
     // Parent counter must already exist.

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -454,7 +454,7 @@ void RuntimeProfile::add_description(const std::string& name, const std::string&
 
     if (_counter_map.find(name) != _counter_map.end()) {
         Counter* counter = _counter_map[name];
-        if (DesctiptionEntry* derived_counter = dynamic_cast<DesctiptionEntry*>(counter)) {
+        if (DescriptionEntry* derived_counter = dynamic_cast<DescriptionEntry*>(counter)) {
             derived_counter->update(description);
 
         } else {
@@ -467,7 +467,7 @@ void RuntimeProfile::add_description(const std::string& name, const std::string&
     // Parent counter must already exist.
     DCHECK(parent_counter_name == ROOT_COUNTER ||
            _counter_map.find(parent_counter_name) != _counter_map.end());
-    DesctiptionEntry* counter = _pool->add(new DesctiptionEntry(name, description));
+    DescriptionEntry* counter = _pool->add(new DescriptionEntry(name, description));
     _counter_map[name] = counter;
     std::set<std::string>* child_counters =
             find_or_insert(&_child_counter_map, parent_counter_name, std::set<std::string>());

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -454,7 +454,7 @@ void RuntimeProfile::add_description(const std::string& name, const std::string&
 
     if (_counter_map.find(name) != _counter_map.end()) {
         Counter* counter = _counter_map[name];
-        if (DescriptionEntry* derived_counter = dynamic_cast<DescriptionEntry*>(counter)) {
+        if (dynamic_cast<DescriptionEntry*>(counter) != nullptr) {
             // Do replace instead of update to avoid data race.
             _counter_map.erase(name);
         } else {

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -397,9 +397,6 @@ RuntimeProfile::Counter* RuntimeProfile::add_counter(const std::string& name, TU
     std::lock_guard<std::mutex> l(_counter_map_lock);
 
     if (_counter_map.find(name) != _counter_map.end()) {
-        // TODO: FIX DUPLICATE COUNTERS
-        // In production, we will return the existing counter.
-        // This will not make be crash, but the result may be wrong.
         return _counter_map[name];
     }
 
@@ -434,26 +431,6 @@ RuntimeProfile::NonZeroCounter* RuntimeProfile::add_nonzero_counter(
     return counter;
 }
 
-RuntimeProfile::CollaborationCounter* RuntimeProfile::add_collaboration_counter(
-        const std::string& name, TUnit::type type, Counter* other_counter,
-        const std::string& parent_counter_name, int64_t level) {
-    std::lock_guard<std::mutex> l(_counter_map_lock);
-    if (_counter_map.find(name) != _counter_map.end()) {
-        DCHECK(dynamic_cast<CollaborationCounter*>(_counter_map[name]));
-        return static_cast<CollaborationCounter*>(_counter_map[name]);
-    }
-
-    DCHECK(parent_counter_name == ROOT_COUNTER ||
-           _counter_map.find(parent_counter_name) != _counter_map.end());
-    CollaborationCounter* counter =
-            _pool->add(new CollaborationCounter(type, level, other_counter));
-    _counter_map[name] = counter;
-    std::set<std::string>* child_counters =
-            find_or_insert(&_child_counter_map, parent_counter_name, std::set<std::string>());
-    child_counters->insert(name);
-    return counter;
-}
-
 RuntimeProfile::DerivedCounter* RuntimeProfile::add_derived_counter(
         const std::string& name, TUnit::type type, const DerivedCounterFunction& counter_fn,
         const std::string& parent_counter_name) {
@@ -469,6 +446,32 @@ RuntimeProfile::DerivedCounter* RuntimeProfile::add_derived_counter(
             find_or_insert(&_child_counter_map, parent_counter_name, std::set<std::string>());
     child_counters->insert(name);
     return counter;
+}
+
+void RuntimeProfile::add_description(const std::string& name, const std::string& description,
+                                     std::string parent_counter_name) {
+    std::lock_guard<std::mutex> l(_counter_map_lock);
+
+    if (_counter_map.find(name) != _counter_map.end()) {
+        Counter* counter = _counter_map[name];
+        if (DesctiptionEntry* derived_counter = dynamic_cast<DesctiptionEntry*>(counter)) {
+            derived_counter->update(description);
+
+        } else {
+            DCHECK(false) << "Counter type mismatch, name: " << name
+                          << ", type: " << counter->type() << ", description: " << description;
+        }
+        return;
+    }
+
+    // Parent counter must already exist.
+    DCHECK(parent_counter_name == ROOT_COUNTER ||
+           _counter_map.find(parent_counter_name) != _counter_map.end());
+    DesctiptionEntry* counter = _pool->add(new DesctiptionEntry(name, description));
+    _counter_map[name] = counter;
+    std::set<std::string>* child_counters =
+            find_or_insert(&_child_counter_map, parent_counter_name, std::set<std::string>());
+    child_counters->insert(name);
 }
 
 RuntimeProfile::Counter* RuntimeProfile::get_counter(const std::string& name) {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -295,13 +295,13 @@ public:
         const std::string _parent_name;
     };
 
-    class DesctiptionEntry : public Counter {
+    class DescriptionEntry : public Counter {
     public:
-        DesctiptionEntry(const std::string& name, const std::string& description)
+        DescriptionEntry(const std::string& name, const std::string& description)
                 : Counter(TUnit::NONE, 0, 2), _description(description), _name(name) {}
 
         virtual Counter* clone() const override {
-            return new DesctiptionEntry(_name, _description);
+            return new DescriptionEntry(_name, _description);
         }
 
         void set(int64_t value) override {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -295,41 +295,38 @@ public:
         const std::string _parent_name;
     };
 
-    // When the collaboration Counter modifies itself, it also modifies the other counter.
-
-    class CollaborationCounter : public Counter {
+    class DesctiptionEntry : public Counter {
     public:
-        CollaborationCounter(TUnit::type type, int64_t level, Counter* other_counter,
-                             int64_t value = 0)
-                : Counter(type, value, level), _other_counter(other_counter) {}
+        DesctiptionEntry(const std::string& name, const std::string& description)
+                : Counter(TUnit::NONE, 0, 2), _description(description), _name(name) {}
 
         virtual Counter* clone() const override {
-            return new CollaborationCounter(type(), level(), _other_counter, value());
-        }
-
-        void update(int64_t delta) override {
-            if (_other_counter != nullptr) {
-                _other_counter->update(delta);
-            }
-            Counter::update(delta);
+            return new DesctiptionEntry(_name, _description);
         }
 
         void set(int64_t value) override {
-            if (_other_counter != nullptr) {
-                _other_counter->set(value);
-            }
-            Counter::set(value);
+            // Do nothing
+        }
+        void set(double value) override {
+            // Do nothing
+        }
+        void update(int64_t delta) override {
+            // Do nothing
         }
 
-        void set(double value) override {
-            if (_other_counter != nullptr) {
-                _other_counter->set(value);
-            }
-            Counter::set(value);
+        void update(std::string description) { this->_description = description; }
+
+        TCounter to_thrift(const std::string& name) const override {
+            TCounter counter;
+            counter.name = name;
+            counter.__set_level(2);
+            counter.__set_description(_description);
+            return counter;
         }
 
     private:
-        Counter* _other_counter = nullptr; // Pointer to the other counter to be modified
+        std::string _description;
+        std::string _name;
     };
 
     // Create a runtime profile object with 'name'.
@@ -385,11 +382,9 @@ public:
             const std::string& parent_counter_name = RuntimeProfile::ROOT_COUNTER,
             int64_t level = 2);
 
-    CollaborationCounter* add_collaboration_counter(
-            const std::string& name, TUnit::type type, Counter* other_counter,
-            const std::string& parent_counter_name = RuntimeProfile::ROOT_COUNTER,
-            int64_t level = 2);
-
+    // Add a description entry under target counter.
+    void add_description(const std::string& name, const std::string& description,
+                         std::string parent_counter_name);
     // Add a derived counter with 'name'/'type'. The counter is owned by the
     // RuntimeProfile object.
     // If parent_counter_name is a non-empty string, the counter is added as a child of

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -323,8 +323,8 @@ public:
         }
 
     private:
-        std::string _description;
-        std::string _name;
+        const std::string _description;
+        const std::string _name;
     };
 
     // Create a runtime profile object with 'name'.

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -314,8 +314,6 @@ public:
             // Do nothing
         }
 
-        void update(std::string description) { this->_description = description; }
-
         TCounter to_thrift(const std::string& name) const override {
             TCounter counter;
             counter.name = name;

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -592,9 +592,6 @@ void OlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_rows_short_circuit_cond_input_counter,
                    stats.short_circuit_cond_input_rows);
     COUNTER_UPDATE(local_state->_rows_expr_cond_input_counter, stats.expr_cond_input_rows);
-    for (const auto& [id, info] : stats.filter_info) {
-        local_state->add_filter_info(id, info);
-    }
     COUNTER_UPDATE(local_state->_stats_filtered_counter, stats.rows_stats_filtered);
     COUNTER_UPDATE(local_state->_stats_rp_filtered_counter, stats.rows_stats_rp_filtered);
     COUNTER_UPDATE(local_state->_dict_filtered_counter, stats.rows_dict_filtered);

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -89,8 +89,6 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
 
 Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* result_column_id) {
     DCHECK(_open_finished || _getting_const_col);
-    DCHECK(_expr_filtered_rows_counter && _expr_input_rows_counter && _always_true_counter)
-            << "rf counter must be initialized";
     if (_judge_counter.fetch_sub(1) == 0) {
         reset_judge_selectivity();
     }
@@ -99,9 +97,7 @@ Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* 
         block->insert({create_always_true_column(size, _data_type->is_nullable()), _data_type,
                        expr_name()});
         *result_column_id = block->columns() - 1;
-        if (_always_true_counter) {
-            COUNTER_UPDATE(_always_true_counter, size);
-        }
+        COUNTER_UPDATE(_always_true_filter_rows, size);
         return Status::OK();
     } else {
         if (_getting_const_col) {

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -17,8 +17,11 @@
 
 #pragma once
 
+#include <gen_cpp/Metrics_types.h>
+
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "common/config.h"
@@ -61,21 +64,17 @@ public:
 
     VExprSPtr get_impl() const override { return _impl; }
 
-    void attach_profile_counter(RuntimeProfile::Counter* expr_filtered_rows_counter,
-                                RuntimeProfile::Counter* expr_input_rows_counter,
-                                RuntimeProfile::Counter* always_true_counter,
-                                RuntimeProfile::Counter* predicate_filtered_rows_counter,
-                                RuntimeProfile::Counter* predicate_input_rows_counter) {
-        _expr_filtered_rows_counter = expr_filtered_rows_counter;
-        _expr_input_rows_counter = expr_input_rows_counter;
-        _always_true_counter = always_true_counter;
-        _predicate_filtered_rows_counter = predicate_filtered_rows_counter;
-        _predicate_input_rows_counter = predicate_input_rows_counter;
+    void attach_profile_counter(std::shared_ptr<RuntimeProfile::Counter> rf_input_rows,
+                                std::shared_ptr<RuntimeProfile::Counter> rf_filter_rows,
+                                std::shared_ptr<RuntimeProfile::Counter> always_true_filter_rows) {
+        _rf_input_rows = rf_input_rows;
+        _rf_filter_rows = rf_filter_rows;
+        _always_true_filter_rows = always_true_filter_rows;
     }
 
     void update_counters(int64_t filter_rows, int64_t input_rows) {
-        COUNTER_UPDATE(_expr_filtered_rows_counter, filter_rows);
-        COUNTER_UPDATE(_expr_input_rows_counter, input_rows);
+        COUNTER_UPDATE(_rf_filter_rows, filter_rows);
+        COUNTER_UPDATE(_rf_input_rows, input_rows);
     }
 
     template <typename T>
@@ -100,8 +99,12 @@ public:
         }
     }
 
-    auto* predicate_filtered_rows_counter() const { return _predicate_filtered_rows_counter; }
-    auto* predicate_input_rows_counter() const { return _predicate_input_rows_counter; }
+    std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter() const {
+        return _rf_filter_rows;
+    }
+    std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter() const {
+        return _rf_input_rows;
+    }
 
 private:
     void reset_judge_selectivity() {
@@ -125,15 +128,12 @@ private:
     std::atomic_uint64_t _judge_filter_rows = 0;
     std::atomic_int _always_true = false;
 
-    RuntimeProfile::Counter* _expr_filtered_rows_counter = nullptr;
-    RuntimeProfile::Counter* _expr_input_rows_counter = nullptr;
-    RuntimeProfile::Counter* _always_true_counter = nullptr;
-
-    // Used to record filtering information on predicates.
-    // The transfer relationship of these counters is:
-    // RuntimeFilterConsumer(create) ==> VRuntimeFilterWrapper(pass) ==> FilterOlapParam(pass) ==> ColumnPredicate(record)
-    RuntimeProfile::Counter* _predicate_filtered_rows_counter = nullptr;
-    RuntimeProfile::Counter* _predicate_input_rows_counter = nullptr;
+    std::shared_ptr<RuntimeProfile::Counter> _rf_input_rows =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+    std::shared_ptr<RuntimeProfile::Counter> _rf_filter_rows =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+    std::shared_ptr<RuntimeProfile::Counter> _always_true_filter_rows =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
 
     std::string _expr_name;
     double _ignore_thredhold;

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -67,9 +67,19 @@ public:
     void attach_profile_counter(std::shared_ptr<RuntimeProfile::Counter> rf_input_rows,
                                 std::shared_ptr<RuntimeProfile::Counter> rf_filter_rows,
                                 std::shared_ptr<RuntimeProfile::Counter> always_true_filter_rows) {
-        _rf_input_rows = rf_input_rows;
-        _rf_filter_rows = rf_filter_rows;
-        _always_true_filter_rows = always_true_filter_rows;
+        DCHECK(rf_input_rows != nullptr);
+        DCHECK(rf_filter_rows != nullptr);
+        DCHECK(always_true_filter_rows != nullptr);
+
+        if (rf_input_rows != nullptr) {
+            _rf_input_rows = rf_input_rows;
+        }
+        if (rf_filter_rows != nullptr) {
+            _rf_filter_rows = rf_filter_rows;
+        }
+        if (always_true_filter_rows != nullptr) {
+            _always_true_filter_rows = always_true_filter_rows;
+        }
     }
 
     void update_counters(int64_t filter_rows, int64_t input_rows) {

--- a/be/test/runtime_filter/runtime_filter_consumer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_consumer_helper_test.cpp
@@ -78,8 +78,8 @@ TEST_F(RuntimeFilterConsumerHelperTest, basic) {
     const_cast<std::vector<TupleDescriptor*>&>(row_desc._tuple_desc_map).push_back(&tuple_desc);
     auto helper = RuntimeFilterConsumerHelper(0, runtime_filter_descs, row_desc);
 
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.init(_runtime_states[0].get(), &_profile, true,
-                                                 runtime_filter_dependencies, 0, 0, ""));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
+            helper.init(_runtime_states[0].get(), true, runtime_filter_dependencies, 0, 0, ""));
 
     vectorized::VExprContextSPtrs conjuncts;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.acquire_runtime_filter(conjuncts));

--- a/be/test/runtime_filter/runtime_filter_consumer_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_consumer_test.cpp
@@ -30,9 +30,8 @@ class RuntimeFilterConsumerTest : public RuntimeFilterTest {
 public:
     void test_signal_aquire(TRuntimeFilterDesc desc) {
         std::shared_ptr<RuntimeFilterConsumer> consumer;
-        FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-                RuntimeFilterConsumer::create(RuntimeFilterParamsContext::create(_query_ctx.get()),
-                                              &desc, 0, &consumer, &_profile));
+        FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
+                RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
         std::shared_ptr<RuntimeFilterProducer> producer;
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterProducer::create(
@@ -60,11 +59,11 @@ TEST_F(RuntimeFilterConsumerTest, basic) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
-            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer, &_profile));
+            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterConsumer> registed_consumer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
-            desc, true, 0, &registed_consumer, &_profile));
+            desc, true, 0, &registed_consumer));
 }
 
 TEST_F(RuntimeFilterConsumerTest, signal_aquire_in_or_bloom) {
@@ -117,7 +116,7 @@ TEST_F(RuntimeFilterConsumerTest, timeout_aquire) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
-            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer, &_profile));
+            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterProducer> producer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterProducer::create(
@@ -142,18 +141,18 @@ TEST_F(RuntimeFilterConsumerTest, wait_infinity) {
     const_cast<TQueryOptions&>(_query_ctx->_query_options)
             .__set_runtime_filter_wait_infinitely(true);
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
-            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer, &_profile));
+            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterConsumer> registed_consumer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
-            desc, true, 0, &registed_consumer, &_profile));
+            desc, true, 0, &registed_consumer));
 }
 
 TEST_F(RuntimeFilterConsumerTest, aquire_disabled) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
-            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer, &_profile));
+            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterProducer> producer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterProducer::create(
@@ -171,7 +170,7 @@ TEST_F(RuntimeFilterConsumerTest, aquire_ignored) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
-            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer, &_profile));
+            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterProducer> producer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterProducer::create(
@@ -193,9 +192,8 @@ TEST_F(RuntimeFilterConsumerTest, bitmap_filter) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
 
     {
-        auto st =
-                RuntimeFilterConsumer::create(RuntimeFilterParamsContext::create(_query_ctx.get()),
-                                              &desc, 0, &consumer, &_profile);
+        auto st = RuntimeFilterConsumer::create(
+                RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer);
         ASSERT_FALSE(st.ok());
     }
     desc.__set_src_expr(
@@ -216,17 +214,15 @@ TEST_F(RuntimeFilterConsumerTest, bitmap_filter) {
                     .build());
 
     {
-        auto st =
-                RuntimeFilterConsumer::create(RuntimeFilterParamsContext::create(_query_ctx.get()),
-                                              &desc, 0, &consumer, &_profile);
+        auto st = RuntimeFilterConsumer::create(
+                RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer);
         ASSERT_FALSE(st.ok());
     }
     {
         desc.__set_has_local_targets(false);
         desc.__set_has_remote_targets(true);
-        auto st =
-                RuntimeFilterConsumer::create(RuntimeFilterParamsContext::create(_query_ctx.get()),
-                                              &desc, 0, &consumer, &_profile);
+        auto st = RuntimeFilterConsumer::create(
+                RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer);
         ASSERT_FALSE(st.ok());
         desc.__set_has_local_targets(true);
         desc.__set_has_remote_targets(false);
@@ -234,7 +230,7 @@ TEST_F(RuntimeFilterConsumerTest, bitmap_filter) {
 
     desc.__set_bitmap_target_expr(TRuntimeFilterDescBuilder::get_default_expr());
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
-            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer, &_profile));
+            RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 }
 
 TEST_F(RuntimeFilterConsumerTest, aquire_signal_at_same_time) {

--- a/be/test/runtime_filter/runtime_filter_consumer_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_consumer_test.cpp
@@ -237,9 +237,8 @@ TEST_F(RuntimeFilterConsumerTest, aquire_signal_at_same_time) {
     for (int i = 0; i < 100; i++) {
         std::shared_ptr<RuntimeFilterConsumer> consumer;
         auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
-        FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-                RuntimeFilterConsumer::create(RuntimeFilterParamsContext::create(_query_ctx.get()),
-                                              &desc, 0, &consumer, &_profile));
+        FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterConsumer::create(
+                RuntimeFilterParamsContext::create(_query_ctx.get()), &desc, 0, &consumer));
 
         std::shared_ptr<RuntimeFilterProducer> producer;
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(RuntimeFilterProducer::create(

--- a/be/test/runtime_filter/runtime_filter_mgr_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_mgr_test.cpp
@@ -65,8 +65,7 @@ TEST_F(RuntimeFilterMgrTest, TestRuntimeFilterMgr) {
         // Get / Register consumer
         EXPECT_TRUE(global_runtime_filter_mgr->get_consume_filters(filter_id).empty());
         std::shared_ptr<RuntimeFilterConsumer> consumer_filter;
-        EXPECT_TRUE(global_runtime_filter_mgr
-                            ->register_consumer_filter(desc, 0, &consumer_filter, profile.get())
+        EXPECT_TRUE(global_runtime_filter_mgr->register_consumer_filter(desc, 0, &consumer_filter)
                             .ok());
         EXPECT_FALSE(global_runtime_filter_mgr->get_consume_filters(filter_id).empty());
     }

--- a/be/test/runtime_filter/runtime_filter_producer_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_test.cpp
@@ -106,8 +106,8 @@ TEST_F(RuntimeFilterProducerTest, sync_filter_size_local_merge) {
             _runtime_states[1]->register_producer_runtime_filter(desc, &producer2, &_profile));
 
     std::shared_ptr<RuntimeFilterConsumer> consumer;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
-            desc, true, 0, &consumer, &_profile));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
+            _runtime_states[1]->register_consumer_runtime_filter(desc, true, 0, &consumer));
 
     ASSERT_EQ(producer->_need_sync_filter_size, true);
     ASSERT_EQ(producer->_rf_state, RuntimeFilterProducer::State::WAITING_FOR_SEND_SIZE);
@@ -141,8 +141,8 @@ TEST_F(RuntimeFilterProducerTest, set_ignore_or_disable) {
             _runtime_states[1]->register_producer_runtime_filter(desc, &producer2, &_profile));
 
     std::shared_ptr<RuntimeFilterConsumer> consumer;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
-            desc, true, 0, &consumer, &_profile));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
+            _runtime_states[1]->register_consumer_runtime_filter(desc, true, 0, &consumer));
 
     ASSERT_EQ(producer->_need_sync_filter_size, true);
     ASSERT_EQ(producer->_rf_state, RuntimeFilterProducer::State::WAITING_FOR_SEND_SIZE);
@@ -183,8 +183,8 @@ TEST_F(RuntimeFilterProducerTest, sync_filter_size_local_merge_with_ignored) {
             _runtime_states[1]->register_producer_runtime_filter(desc, &producer2, &_profile));
 
     std::shared_ptr<RuntimeFilterConsumer> consumer;
-    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
-            desc, true, 0, &consumer, &_profile));
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
+            _runtime_states[1]->register_consumer_runtime_filter(desc, true, 0, &consumer));
 
     ASSERT_EQ(producer->_need_sync_filter_size, true);
     ASSERT_EQ(producer->_rf_state, RuntimeFilterProducer::State::WAITING_FOR_SEND_SIZE);

--- a/be/test/util/runtime_profile_counter_tree_node_test.cpp
+++ b/be/test/util/runtime_profile_counter_tree_node_test.cpp
@@ -289,7 +289,7 @@ TEST_F(RuntimeProfileCounterTreeNodeTest, DescriptionCounter) {
     */
 
     auto rootCounter = std::make_unique<RuntimeProfile::Counter>(TUnit::UNIT);
-    auto descriptionEntry = std::make_unique<RuntimeProfile::DesctiptionEntry>(
+    auto descriptionEntry = std::make_unique<RuntimeProfile::DescriptionEntry>(
             "description_entry", "Updated description");
 
     counterMap["root"] = rootCounter.get();

--- a/be/test/util/runtime_profile_counter_tree_node_test.cpp
+++ b/be/test/util/runtime_profile_counter_tree_node_test.cpp
@@ -290,14 +290,13 @@ TEST_F(RuntimeProfileCounterTreeNodeTest, DescriptionCounter) {
 
     auto rootCounter = std::make_unique<RuntimeProfile::Counter>(TUnit::UNIT);
     auto descriptionEntry = std::make_unique<RuntimeProfile::DesctiptionEntry>(
-            "description_entry", "This is a test description");
+            "description_entry", "Updated description");
 
     counterMap["root"] = rootCounter.get();
     counterMap["description_entry"] = descriptionEntry.get();
 
     childCounterMap[RuntimeProfile::ROOT_COUNTER].insert("root");
     childCounterMap["root"].insert("description_entry");
-    descriptionEntry->update("Updated description");
 
     RuntimeProfileCounterTreeNode rootNode = RuntimeProfileCounterTreeNode::from_map(
             counterMap, childCounterMap, RuntimeProfile::ROOT_COUNTER);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Counter.java
@@ -20,8 +20,8 @@ package org.apache.doris.common.profile;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.thrift.TUnit;
-import com.google.common.base.Strings;
 
+import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Counter.java
@@ -20,6 +20,7 @@ package org.apache.doris.common.profile;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.thrift.TUnit;
+import com.google.common.base.Strings;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -35,6 +36,8 @@ public class Counter {
     private volatile int type;
     @SerializedName(value = "level")
     private volatile long level;
+    @SerializedName(value = "description")
+    private volatile String description;
 
     public static Counter read(DataInput input) throws IOException {
         return GsonUtils.GSON.fromJson(Text.readString(input), Counter.class);
@@ -77,6 +80,13 @@ public class Counter {
         this.level = level;
     }
 
+    public Counter(String description) {
+        this.description = description;
+        this.value = 0;
+        // Make sure not merge.
+        this.level = 2;
+    }
+
     public void addValue(Counter other) {
         if (other == null) {
             return;
@@ -115,7 +125,11 @@ public class Counter {
     }
 
     public String print() {
-        return RuntimeProfile.printCounter(value, getType());
+        if (Strings.isNullOrEmpty(description)) {
+            return RuntimeProfile.printCounter(value, getType());
+        } else {
+            return description;
+        }
     }
 
     public String toString() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/RuntimeProfile.java
@@ -267,12 +267,18 @@ public class RuntimeProfile {
                 // If different node has counter with the same name, it will lead to chaos.
                 Counter counter = this.counterMap.get(tcounter.name);
                 if (counter == null) {
-                    counterMap.put(tcounter.name, new Counter(tcounter.type, tcounter.value, tcounter.level));
+                    if (tcounter.isSetDescription()) {
+                        counterMap.put(tcounter.name, new Counter(tcounter.description));
+                    } else {
+                        counterMap.put(tcounter.name, new Counter(tcounter.type, tcounter.value, tcounter.level));
+                    }
                 } else {
                     counter.setLevel(tcounter.level);
                     if (counter.getType() != tcounter.type) {
                         LOG.error("Cannot update counters with the same name but different types"
                                 + " type=" + tcounter.type);
+                    } else if (tcounter.isSetDescription()) {
+                        continue;
                     } else {
                         counter.setValue(tcounter.type, tcounter.value);
                     }

--- a/gensrc/thrift/RuntimeProfile.thrift
+++ b/gensrc/thrift/RuntimeProfile.thrift
@@ -26,6 +26,7 @@ struct TCounter {
   2: required Metrics.TUnit type
   3: required i64 value 
   4: optional i64 level
+  5: optional string description
 }
 
 // A single runtime profile


### PR DESCRIPTION
### What problem does this PR solve?

Refactor of runtime filter profile.

1. Counter is shared by related objects.
2. Update RuntimeProfile only when pipeline task is closed.
3. A new Counter type, which is similar to info_string but could be added as a Counter.

```
use ssb;
SELECT  c_city,  s_city,  d_year,  SUM(lo_revenue)  AS  REVENUE  FROM  customer,  lineorder,  supplier,  dates  WHERE  lo_custkey  =  c_custkey  AND  lo_suppkey  =  s_suppkey  AND  lo_orderdate  =  d_datekey  AND  (  c_city  =  'UNITED  KI1'  OR  c_city  =  'UNITED  KI5'  )  AND  (  s_city  =  'UNITED  KI1'  OR  s_city  =  'UNITED  KI5'  )  AND  d_year  >=  1992  AND  d_year  <=  1997  GROUP  BY  c_city,  s_city,  d_year  ORDER  BY  d_year  ASC,  REVENUE  DESC
```
We will have a structured counter in executon profile like 
```text
-  RuntimeFilterInfo:  
      -  AcquireRuntimeFilter:  6.972ms
      -  RF0  AlwaysTrueFilterRows:  0
      -  RF0  FilterRows:  41
      -  RF0  Info:  Consumer:  ([id:  0,  state:  [READY],  type:  MINMAX_FILTER,  column_type:  INT],  mode:  LOCAL,  state:  APPLIED)
      -  RF0  InputRows:  48.757K  (48757)
      -  RF0  WaitTime:  161.0ms
      -  RF1  AlwaysTrueFilterRows:  0
      -  RF1  FilterRows:  11.288919M  (11288919)
      -  RF1  Info:  Consumer:  ([id:  1,  state:  [READY],  type:  IN_OR_BLOOM_FILTER(BLOOM_FILTER),  column_type:  INT,  bf_size:  1048576,  build_bf_by_runtime_size:  true],  mode:  LOCAL,  state:  APPLIED)
      -  RF1  InputRows:  11.381544M  (11381544)
      -  RF1  WaitTime:  160.0ms
      -  RF2  AlwaysTrueFilterRows:  0
      -  RF2  FilterRows:  0
      -  RF2  Info:  Consumer:  ([id:  2,  state:  [READY],  type:  MINMAX_FILTER,  column_type:  INT],  mode:  LOCAL,  state:  APPLIED)
      -  RF2  InputRows:  48.686K  (48686)
      -  RF2  WaitTime:  224.0ms
      -  RF3  AlwaysTrueFilterRows:  0
      -  RF3  FilterRows:  91.841K  (91841)
      -  RF3  Info:  Consumer:  ([id:  3,  state:  [READY],  type:  IN_OR_BLOOM_FILTER(BLOOM_FILTER),  column_type:  INT,  bf_size:  1048576,  build_bf_by_runtime_size:  true],  mode:  LOCAL,  state:  APPLIED)
      -  RF3  InputRows:  92.625K  (92625)
      -  RF3  WaitTime:  223.0ms
      -  RF4  AlwaysTrueFilterRows:  0
      -  RF4  FilterRows:  0
      -  RF4  Info:  Consumer:  ([id:  4,  state:  [READY],  type:  MINMAX_FILTER,  column_type:  INT],  mode:  LOCAL,  state:  APPLIED)
      -  RF4  InputRows:  0
      -  RF4  WaitTime:  149.0ms
      -  RF5  AlwaysTrueFilterRows:  0
      -  RF5  FilterRows:  0
      -  RF5  Info:  Consumer:  ([id:  5,  state:  [READY],  type:  IN_OR_BLOOM_FILTER(BLOOM_FILTER),  column_type:  INT,  bf_size:  1048576,  build_bf_by_runtime_size:  true],  mode:  LOCAL,  state:  APPLIED)
      -  RF5  InputRows:  7
      -  RF5  WaitTime:  149.0ms
```
Merged profile will be like 
```
-  RuntimeFilterInfo:  sum  ,  avg  ,  max  ,  min  
    -  RF0  FilterRows:  sum  2.139K  (2139),  avg  44,  max  59,  min  30
    -  RF0  InputRows:  sum  2.340004M  (2340004),  avg  48.75K  (48750),  max  48.76K  (48760),  min  48.741K  (48741)
    -  RF1  FilterRows:  sum  542.210415M  (542210415),  avg  11.29605M  (11296050),  max  11.307756M  (11307756),  min  11.281476M  (11281476)
    -  RF1  InputRows:  sum  546.667366M  (546667366),  avg  11.388903M  (11388903),  max  11.400674M  (11400674),  min  11.374343M  (11374343)
    -  RF2  FilterRows:  sum  109,  avg  2,  max  12,  min  0
    -  RF2  InputRows:  sum  2.336525M  (2336525),  avg  48.677K  (48677),  max  48.708K  (48708),  min  48.645K  (48645)
    -  RF3  FilterRows:  sum  4.421298M  (4421298),  avg  92.11K  (92110),  max  92.878K  (92878),  min  91.634K  (91634)
    -  RF3  InputRows:  sum  4.456951M  (4456951),  avg  92.853K  (92853),  max  93.618K  (93618),  min  92.338K  (92338)
    -  RF4  FilterRows:  sum  0,  avg  0,  max  0,  min  0
    -  RF4  InputRows:  sum  0,  avg  0,  max  0,  min  0
    -  RF5  FilterRows:  sum  0,  avg  0,  max  0,  min  0
    -  RF5  InputRows:  sum  340,  avg  7,  max  9,  min  6
```


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

