### PR TITLE
[chore](log) Standardize S3 failure log formats to enable critical operation monitoring

### DIFF
--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -107,7 +107,7 @@ Status ObjClientHolder::reset(const S3ClientConf& conf) {
         return Status::InvalidArgument("failed to init s3 client with conf {}", conf.to_string());
     }
 
-    LOG(INFO) << "reset s3 client with new conf: " << conf.to_string();
+    LOG(WARNING) << "reset s3 client with new conf: " << conf.to_string();
 
     {
         std::lock_guard lock(_mtx);


### PR DESCRIPTION


### What problem does this PR solve?


This change unifies S3 error logging patterns for four critical operations that require alerting:
* failed to complete multipart upload
* failed to upload part
* failed to put object
* failed to get object.*\.(dat|idx) (specific to data/index files)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

