### PR TITLE
[bugfix](becore) be core when exist elegantly

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -741,7 +741,6 @@ void ExecEnv::destroy() {
 
     SAFE_DELETE(_load_channel_mgr);
 
-    SAFE_DELETE(_spill_stream_mgr);
     SAFE_DELETE(_inverted_index_query_cache);
     SAFE_DELETE(_inverted_index_searcher_cache);
     SAFE_DELETE(_lookup_connection_cache);
@@ -774,6 +773,9 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_bfd_parser);
     SAFE_DELETE(_result_cache);
     SAFE_DELETE(_vstream_mgr);
+    // When _vstream_mgr is deconstructed, it will try call query context's dctor and will
+    // access spill stream mgr, so spill stream mgr should be deconstructed after data stream manager
+    SAFE_DELETE(_spill_stream_mgr);
     SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_workload_sched_mgr);
     SAFE_DELETE(_workload_group_manager);

--- a/be/src/vec/spill/spill_stream_manager.h
+++ b/be/src/vec/spill/spill_stream_manager.h
@@ -125,6 +125,7 @@ public:
         if (_spill_gc_thread) {
             _spill_gc_thread->join();
         }
+        _spill_io_thread_pool->shutdown();
     }
 
     // 创建SpillStream并登记


### PR DESCRIPTION
### What problem does this PR solve?

When _vstream_mgr is deconstructed, it will try call query context's dctor and will access spill stream mgr, so spill stream mgr should be deconstructed after data stream manager

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

