### PR TITLE
[fix](query tvf): resolve column mismatch error in JDBC query function

### DIFF
--- a/be/src/pipeline/exec/jdbc_scan_operator.cpp
+++ b/be/src/pipeline/exec/jdbc_scan_operator.cpp
@@ -32,7 +32,7 @@ std::string JDBCScanLocalState::name_suffix() const {
 Status JDBCScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* scanners) {
     auto& p = _parent->cast<JDBCScanOperatorX>();
     std::unique_ptr<vectorized::JdbcScanner> scanner = vectorized::JdbcScanner::create_unique(
-            state(), this, p._limit, p._tuple_id, p._query_string, p._table_type,
+            state(), this, p._limit, p._tuple_id, p._query_string, p._table_type, p._is_tvf,
             _scanner_profile.get());
     RETURN_IF_ERROR(scanner->prepare(state(), _conjuncts));
     scanners->push_back(std::move(scanner));
@@ -47,6 +47,7 @@ JDBCScanOperatorX::JDBCScanOperatorX(ObjectPool* pool, const TPlanNode& tnode, i
           _query_string(tnode.jdbc_scan_node.query_string),
           _table_type(tnode.jdbc_scan_node.table_type) {
     _output_tuple_id = tnode.jdbc_scan_node.tuple_id;
+    _is_tvf = tnode.jdbc_scan_node.__isset.is_tvf ? tnode.jdbc_scan_node.is_tvf : false;
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/jdbc_scan_operator.h
+++ b/be/src/pipeline/exec/jdbc_scan_operator.h
@@ -61,6 +61,7 @@ private:
     TupleId _tuple_id;
     std::string _query_string;
     TOdbcTableType::type _table_type;
+    bool _is_tvf;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exec/scan/jdbc_scanner.cpp
+++ b/be/src/vec/exec/scan/jdbc_scanner.cpp
@@ -37,13 +37,14 @@ namespace doris::vectorized {
 
 JdbcScanner::JdbcScanner(RuntimeState* state, doris::pipeline::JDBCScanLocalState* local_state,
                          int64_t limit, const TupleId& tuple_id, const std::string& query_string,
-                         TOdbcTableType::type table_type, RuntimeProfile* profile)
+                         TOdbcTableType::type table_type, bool is_tvf, RuntimeProfile* profile)
         : Scanner(state, local_state, limit, profile),
           _jdbc_eos(false),
           _tuple_id(tuple_id),
           _query_string(query_string),
           _tuple_desc(nullptr),
-          _table_type(table_type) {
+          _table_type(table_type),
+          _is_tvf(is_tvf) {
     _init_profile(local_state->_scanner_profile);
 }
 
@@ -83,6 +84,7 @@ Status JdbcScanner::prepare(RuntimeState* state, const VExprContextSPtrs& conjun
     _jdbc_param.query_string = std::move(_query_string);
     _jdbc_param.use_transaction = false; // not useful for scanner but only sink.
     _jdbc_param.table_type = _table_type;
+    _jdbc_param.is_tvf = _is_tvf;
     _jdbc_param.connection_pool_min_size = jdbc_table->connection_pool_min_size();
     _jdbc_param.connection_pool_max_size = jdbc_table->connection_pool_max_size();
     _jdbc_param.connection_pool_max_life_time = jdbc_table->connection_pool_max_life_time();

--- a/be/src/vec/exec/scan/jdbc_scanner.h
+++ b/be/src/vec/exec/scan/jdbc_scanner.h
@@ -47,7 +47,7 @@ public:
 
     JdbcScanner(RuntimeState* state, doris::pipeline::JDBCScanLocalState* parent, int64_t limit,
                 const TupleId& tuple_id, const std::string& query_string,
-                TOdbcTableType::type table_type, RuntimeProfile* profile);
+                TOdbcTableType::type table_type, bool is_tvf, RuntimeProfile* profile);
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
 
@@ -83,6 +83,7 @@ private:
     const TupleDescriptor* _tuple_desc = nullptr;
     // the sql query database type: like mysql, PG...
     TOdbcTableType::type _table_type;
+    bool _is_tvf;
     // Scanner of JDBC.
     std::unique_ptr<JdbcConnector> _jdbc_connector;
     JdbcConnectorParam _jdbc_param;

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -216,9 +216,11 @@ Status JdbcConnector::query() {
             return Status::InternalError("GetJniExceptionMsg meet error, query={}, msg={}",
                                          _conn_param.query_string, status.to_string());
         }
-        if (colunm_count != materialize_num) {
-            return Status::InternalError("input and output column num not equal of jdbc query.");
-        }
+        if (colunm_count < materialize_num) {
+        	return Status::InternalError(
+                    "JDBC query returned fewer columns ({}) than required ({}).",
+                    colunm_count, materialize_num);
+	    }
     }
 
     LOG(INFO) << "JdbcConnector::query has exec success: " << _sql_str;

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -218,8 +218,8 @@ Status JdbcConnector::query() {
         }
         if (colunm_count < materialize_num) {
         	return Status::InternalError(
-                    "JDBC query returned fewer columns ({}) than required ({}).",
-                    colunm_count, materialize_num);
+                    "JDBC query returned fewer columns ({}) than required ({}).", colunm_count,
+                    materialize_num);
 	    }
     }
 

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -217,10 +217,10 @@ Status JdbcConnector::query() {
                                          _conn_param.query_string, status.to_string());
         }
         if (colunm_count < materialize_num) {
-        	return Status::InternalError(
+            return Status::InternalError(
                     "JDBC query returned fewer columns ({}) than required ({}).", colunm_count,
                     materialize_num);
-	    }
+        }
     }
 
     LOG(INFO) << "JdbcConnector::query has exec success: " << _sql_str;

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -151,6 +151,7 @@ Status JdbcConnector::open(RuntimeState* state, bool read) {
         ctor_params.__set_connection_pool_cache_clear_time(
                 config::jdbc_connection_pool_cache_clear_time_sec);
         ctor_params.__set_connection_pool_keep_alive(_conn_param.connection_pool_keep_alive);
+        ctor_params.__set_is_tvf(_conn_param.is_tvf);
 
         jbyteArray ctor_params_bytes;
         // Pushed frame will be popped when jni_frame goes out-of-scope.

--- a/be/src/vec/exec/vjdbc_connector.h
+++ b/be/src/vec/exec/vjdbc_connector.h
@@ -56,6 +56,7 @@ struct JdbcConnectorParam {
     std::string table_name;
     bool use_transaction = false;
     TOdbcTableType::type table_type;
+    bool is_tvf = false;
     int32_t connection_pool_min_size = -1;
     int32_t connection_pool_max_size = -1;
     int32_t connection_pool_max_wait_time = -1;

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -236,7 +236,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
             }
 
             do {
-                for (int j = 0; j < outputTable.getColumns().length; ++j) {
+                for (int j = 0; j < outputColumnCount; ++j) {
                     String outputColumnName = outputTable.getFields()[j];
                     Integer columnIndex = columnIndexMap.get(outputColumnName);
 
@@ -250,7 +250,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                 curBlockRows++;
             } while (curBlockRows < batchSize && resultSet.next());
 
-            for (int j = 0; j < outputTable.getColumns().length; ++j) {
+            for (int j = 0; j < outputColumnCount; ++j) {
                 String outputColumnName = outputTable.getFields()[j];
                 Integer columnIndex = columnIndexMap.get(outputColumnName);
 

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -238,13 +238,13 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
             do {
                 for (int j = 0; j < outputColumnCount; ++j) {
                     String outputColumnName = outputTable.getFields()[j];
-                    Integer columnIndex = columnIndexMap.get(outputColumnName);
+                    Integer columnIndex = columnIndexMap.get(outputColumnName.toLowerCase());
 
                     if (columnIndex != null) {
                         ColumnType type = convertTypeIfNecessary(j, outputTable.getColumnType(j), replaceStringList);
                         block.get(j)[curBlockRows] = getColumnValue(columnIndex, type, replaceStringList);
                     } else {
-                        throw new RuntimeException("Column not found in result set: " + outputColumnName);
+                        throw new RuntimeException("Column not found in columnIndexMap: " + outputColumnName);
                     }
                 }
                 curBlockRows++;
@@ -252,7 +252,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
 
             for (int j = 0; j < outputColumnCount; ++j) {
                 String outputColumnName = outputTable.getFields()[j];
-                Integer columnIndex = columnIndexMap.get(outputColumnName);
+                Integer columnIndex = columnIndexMap.get(outputColumnName.toLowerCase());
 
                 if (columnIndex != null) {
                     ColumnType type = outputTable.getColumnType(j);
@@ -268,7 +268,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                             isNullable
                     );
                 } else {
-                    throw new RuntimeException("Column not found in result set: " + outputColumnName);
+                    throw new RuntimeException("Column not found in columnIndexMap: " + outputColumnName);
                 }
             }
         } catch (Exception e) {
@@ -717,3 +717,4 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
         return hexString.toString();
     }
 }
+

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -496,6 +496,15 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
     protected abstract Object getColumnValue(int columnIndex, ColumnType type, String[] replaceStringList)
             throws SQLException;
 
+    /**
+     * Some special column types (like bitmap/hll in Doris) may need to be converted to string.
+     * Subclass can override this method to handle such conversions.
+     *
+     * @param outputIdx
+     * @param origType
+     * @param replaceStringList
+     * @return
+     */
     protected ColumnType convertTypeIfNecessary(int outputIdx, ColumnType origType, String[] replaceStringList) {
         return origType;
     }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -241,7 +241,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                     Integer columnIndex = columnIndexMap.get(outputColumnName);
 
                     if (columnIndex != null) {
-                        ColumnType type = outputTable.getColumnType(j);
+                        ColumnType type = convertTypeIfNecessary(j, outputTable.getColumnType(j), replaceStringList);
                         block.get(j)[curBlockRows] = getColumnValue(columnIndex, type, replaceStringList);
                     } else {
                         throw new RuntimeException("Column not found in result set: " + outputColumnName);
@@ -495,6 +495,10 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
 
     protected abstract Object getColumnValue(int columnIndex, ColumnType type, String[] replaceStringList)
             throws SQLException;
+
+    protected ColumnType convertTypeIfNecessary(int outputIdx, ColumnType origType, String[] replaceStringList) {
+        return origType;
+    }
 
     /*
     | Type                                        | Java Array Type            |

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -287,8 +287,8 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
 
     private int getRealColumnIndex(String outputColumnName, int indexInOutputTable) {
         // -1 because ResultSetMetaData column index starts from 1, but index in outputTable starts from 0.
-        int columnIndex = this.isTvf ?
-                resultSetColumnMap.getOrDefault(outputColumnName.toLowerCase(), 0) - 1 : indexInOutputTable;
+        int columnIndex = this.isTvf
+                ? resultSetColumnMap.getOrDefault(outputColumnName.toLowerCase(), 0) - 1 : indexInOutputTable;
         return columnIndex;
     }
 

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/ClickHouseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/ClickHouseJdbcExecutor.java
@@ -43,7 +43,7 @@ public class ClickHouseJdbcExecutor extends BaseJdbcExecutor {
     @Override
     protected void initializeBlock(int columnCount, String[] replaceStringList, int batchSizeNum,
             VectorTable outputTable) {
-        for (int i = 0; i < columnCount; ++i) {
+        for (int i = 0; i < outputTable.getColumns().length; ++i) {
             if (outputTable.getColumnType(i).getType() == Type.ARRAY) {
                 block.add(new Object[batchSizeNum]);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/source/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/source/JdbcScanNode.java
@@ -264,6 +264,7 @@ public class JdbcScanNode extends ExternalScanNode {
             msg.jdbc_scan_node.setQueryString(getJdbcQueryStr());
         }
         msg.jdbc_scan_node.setTableType(jdbcType);
+        msg.jdbc_scan_node.setIsTvf(isTableValuedFunction);
         super.toThrift(msg);
     }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -664,6 +664,7 @@ struct TJdbcScanNode {
   2: optional string table_name
   3: optional string query_string
   4: optional Types.TOdbcTableType table_type
+  5: optional bool is_tvf
 }
 
 struct TBrokerScanNode {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -459,6 +459,7 @@ struct TJdbcExecutorCtorParams {
   15: optional bool connection_pool_keep_alive
   16: optional i64 catalog_id
   17: optional string jdbc_driver_checksum
+  18: optional bool is_tvf
 }
 
 struct TJavaUdfExecutorCtorParams {

--- a/regression-test/data/external_table_p0/jdbc/test_doris_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_doris_jdbc_catalog.out
@@ -150,6 +150,14 @@ a	1
 1	a
 
 -- !sql --
+\N
+a
+
+-- !sql --
+\N
+1
+
+-- !sql --
 doris_jdbc_catalog
 
 -- !sql --

--- a/regression-test/data/external_table_p0/jdbc/test_doris_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_doris_jdbc_catalog.out
@@ -141,19 +141,31 @@ char_col	char(85)	Yes	true	\N	NONE
 varchar_col	char(85)	Yes	true	\N	NONE
 json_col	text	Yes	true	\N	NONE
 
--- !sql --
+-- !sql1 --
 \N	\N
 a	1
 
--- !sql --
+-- !sql2 --
 \N	\N
 1	a
 
--- !sql --
+-- !sql3 --
 \N
 a
 
--- !sql --
+-- !sql4 --
+\N
+1
+
+-- !sql5 --
+\N
+1
+
+-- !sql6 --
+\N	\N
+1	a
+
+-- !sql7 --
 \N
 1
 

--- a/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
@@ -235,6 +235,10 @@ suite("test_doris_jdbc_catalog", "p0,external,doris,external_docker,external_doc
 
     order_qt_sql """ select tinyint_col,varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
 
+    order_qt_sql """ select varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
+
+    order_qt_sql """ select tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
+
     //clean
     qt_sql """select current_catalog()"""
     sql "switch internal"

--- a/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
@@ -231,30 +231,30 @@ suite("test_doris_jdbc_catalog", "p0,external,doris,external_docker,external_doc
     // test query tvf
     qt_sql """desc function query("catalog" = "doris_jdbc_catalog", "query" = "select * from regression_test_jdbc_catalog_p0.base");"""
 
-    order_qt_sql """ select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
+    order_qt_sql1 """ select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
 
-    order_qt_sql """ select tinyint_col,varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
+    order_qt_sql2 """ select tinyint_col,varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
 
-    order_qt_sql """ select varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
+    order_qt_sql3 """ select varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
 
-    order_qt_sql """ select tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
+    order_qt_sql4 """ select tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
 
-    order_qt_sql """ with tmp as (select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col from tmp;"""
+    order_qt_sql5 """ with tmp as (select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col from tmp;"""
 
-    order_qt_sql """ with tmp as (select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col,varchar_col from tmp;"""
+    order_qt_sql6 """ with tmp as (select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col,varchar_col from tmp;"""
 
-    order_qt_sql """ with tmp as (select tinyint_col,varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col from tmp;"""
+    order_qt_sql7 """ with tmp as (select tinyint_col,varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col from tmp;"""
 
-    //clean
-    qt_sql """select current_catalog()"""
-    sql "switch internal"
-    qt_sql """select current_catalog()"""
-    sql "use regression_test_jdbc_catalog_p0"
-    sql """ drop table if exists test_doris_jdbc_doris_in_tb """
-    sql """ drop table if exists bowen_hll_test """
-    sql """ drop table if exists base """
-    sql """ drop table if exists all_null_tbl """
-    sql """ drop table if exists arr """
-    sql """ drop table if exists test_insert_order """
+    // //clean
+    // qt_sql """select current_catalog()"""
+    // sql "switch internal"
+    // qt_sql """select current_catalog()"""
+    // sql "use regression_test_jdbc_catalog_p0"
+    // sql """ drop table if exists test_doris_jdbc_doris_in_tb """
+    // sql """ drop table if exists bowen_hll_test """
+    // sql """ drop table if exists base """
+    // sql """ drop table if exists all_null_tbl """
+    // sql """ drop table if exists arr """
+    // sql """ drop table if exists test_insert_order """
 
 }

--- a/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
@@ -239,6 +239,12 @@ suite("test_doris_jdbc_catalog", "p0,external,doris,external_docker,external_doc
 
     order_qt_sql """ select tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base");"""
 
+    order_qt_sql """ with tmp as (select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col from tmp;"""
+
+    order_qt_sql """ with tmp as (select varchar_col,tinyint_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col,varchar_col from tmp;"""
+
+    order_qt_sql """ with tmp as (select tinyint_col,varchar_col from query("catalog" = "doris_jdbc_catalog", "query" = "select varchar_col,tinyint_col from regression_test_jdbc_catalog_p0.base")) select tinyint_col from tmp;"""
+
     //clean
     qt_sql """select current_catalog()"""
     sql "switch internal"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
  This PR addresses two issues with the WITH clause in SQL queries:
1. Column Count Mismatch: Previously, if the outer query selected fewer columns than the inner query, an error would occur. This PR allows the outer query to select a subset of the columns from the inner query, preventing such errors.
2. Column Order Mismatch: The order of columns in the outer query did not align with the results from the inner query, leading to incorrect data alignment. This PR ensures that the results are returned in the order specified by the outer query.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

