### PR TITLE
[fix](runtime filter) Terminate runtime filter in partitioned hash join

### DIFF
--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -321,7 +321,6 @@ Status PartitionedHashJoinSinkLocalState::_revoke_unpartitioned_block(
 }
 
 Status PartitionedHashJoinSinkLocalState::terminate(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     if (_terminated) {
         return Status::OK();
     }

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -331,6 +331,7 @@ Status PartitionedHashJoinSinkLocalState::terminate(RuntimeState* state) {
     if (_parent->cast<PartitionedHashJoinSinkOperatorX>()._inner_sink_operator) {
         RETURN_IF_ERROR(inner_sink_state->_runtime_filter_producer_helper->terminate(state));
     }
+    inner_sink_state->_terminated = true;
     return PipelineXSpillSinkLocalState<PartitionedHashJoinSharedState>::terminate(state);
 }
 

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -324,10 +324,12 @@ Status PartitionedHashJoinSinkLocalState::terminate(RuntimeState* state) {
     if (_terminated) {
         return Status::OK();
     }
+    HashJoinBuildSinkLocalState* inner_sink_state {nullptr};
+    if (auto* tmp_sink_state = _shared_state->inner_runtime_state->get_sink_local_state()) {
+        inner_sink_state = assert_cast<HashJoinBuildSinkLocalState*>(tmp_sink_state);
+    }
     if (_parent->cast<PartitionedHashJoinSinkOperatorX>()._inner_sink_operator) {
-        RETURN_IF_ERROR(
-                _parent->cast<PartitionedHashJoinSinkOperatorX>()._inner_sink_operator->terminate(
-                        state));
+        RETURN_IF_ERROR(inner_sink_state->_runtime_filter_producer_helper->terminate(state));
     }
     return PipelineXSpillSinkLocalState<PartitionedHashJoinSharedState>::terminate(state);
 }

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
@@ -51,6 +51,7 @@ public:
     Status close(RuntimeState* state, Status exec_status) override;
     Status revoke_memory(RuntimeState* state, const std::shared_ptr<SpillContext>& spill_context);
     size_t revocable_mem_size(RuntimeState* state) const;
+    Status terminate(RuntimeState* state) override;
     [[nodiscard]] size_t get_reserve_mem_size(RuntimeState* state, bool eos);
     void update_memory_usage();
     MOCK_FUNCTION void update_profile_from_inner();

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -1876,8 +1876,7 @@ size_t PipelineFragmentContext::get_revocable_size(bool* has_running_task) const
                 LOG_EVERY_N(INFO, 50) << "Query: " << print_id(_query_id)
                                       << " is running, task: " << (void*)task.get()
                                       << ", is_revoking: " << task->is_revoking()
-                                      << ", is_running: " << task->is_running()
-                                      << ", task info: " << task->debug_string();
+                                      << ", is_running: " << task->is_running();
                 *has_running_task = true;
                 return 0;
             }

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -594,12 +594,15 @@ Status PipelineTask::execute(bool* done) {
 
             DBUG_EXECUTE_IF("PipelineTask::execute.terminate", {
                 if (_eos) {
-                    auto required_pipeline_id = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
-                            "PipelineTask::execute.terminate", "pipeline_id", -1);
-                    auto required_task_id = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
-                            "PipelineTask::execute.terminate", "task_id", -1);
-                    auto required_fragment_id = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
-                            "PipelineTask::execute.terminate", "fragment_id", -1);
+                    auto required_pipeline_id =
+                            DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                                    "PipelineTask::execute.terminate", "pipeline_id", -1);
+                    auto required_task_id =
+                            DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                                    "PipelineTask::execute.terminate", "task_id", -1);
+                    auto required_fragment_id =
+                            DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                                    "PipelineTask::execute.terminate", "fragment_id", -1);
                     if (required_pipeline_id == pipeline_id() && required_task_id == task_id() &&
                         fragment_context->get_fragment_id() == required_fragment_id) {
                         _wake_up_early = true;

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -645,9 +645,6 @@ Status PipelineTask::finalize() {
     _op_shared_states.clear();
     _shared_state_map.clear();
     _block.reset();
-    _operators.clear();
-    _sink.reset();
-    _pipeline.reset();
     return Status::OK();
 }
 

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -592,6 +592,25 @@ Status PipelineTask::execute(bool* done) {
                 }
             });
 
+            DBUG_EXECUTE_IF("PipelineTask::execute.terminate", {
+                if (_eos) {
+                    auto required_pipeline_id = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                            "PipelineTask::execute.terminate", "pipeline_id", -1);
+                    auto required_task_id = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                            "PipelineTask::execute.terminate", "task_id", -1);
+                    auto required_fragment_id = DebugPoints::instance()->get_debug_param_or_default<int32_t>(
+                            "PipelineTask::execute.terminate", "fragment_id", -1);
+                    if (required_pipeline_id == pipeline_id() && required_task_id == task_id() &&
+                        fragment_context->get_fragment_id() == required_fragment_id) {
+                        _wake_up_early = true;
+                        terminate();
+                    } else if (required_pipeline_id == pipeline_id() &&
+                               fragment_context->get_fragment_id() == required_fragment_id) {
+                        LOG(WARNING) << "PipelineTask::execute.terminate sleep 5s";
+                        sleep(5);
+                    }
+                }
+            });
             status = _sink->sink(_state, block, _eos);
 
             if (status.is<ErrorCode::END_OF_FILE>()) {

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -645,6 +645,9 @@ Status PipelineTask::finalize() {
     _op_shared_states.clear();
     _shared_state_map.clear();
     _block.reset();
+    _operators.clear();
+    _sink.reset();
+    _pipeline.reset();
     return Status::OK();
 }
 

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -190,6 +190,7 @@ public:
 
     // TODO: Maybe we do not need this safe code anymore
     void stop_if_finished() {
+        std::unique_lock<std::mutex> lc(_dependency_lock);
         if (!is_finalized()) {
             if (_sink->is_finished(_state)) {
                 set_wake_up_early();

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -190,7 +190,6 @@ public:
 
     // TODO: Maybe we do not need this safe code anymore
     void stop_if_finished() {
-        std::unique_lock<std::mutex> lc(_dependency_lock);
         if (!is_finalized()) {
             if (_sink->is_finished(_state)) {
                 set_wake_up_early();

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -189,15 +189,7 @@ public:
     std::string task_name() const { return fmt::format("task{}({})", _index, _pipeline->_name); }
 
     // TODO: Maybe we do not need this safe code anymore
-    void stop_if_finished() {
-        std::unique_lock<std::mutex> lc(_dependency_lock);
-        if (!is_finalized()) {
-            if (_sink->is_finished(_state)) {
-                set_wake_up_early();
-                terminate();
-            }
-        }
-    }
+    void stop_if_finished();
 
     PipelineId pipeline_id() const { return _pipeline->id(); }
     [[nodiscard]] size_t get_revocable_size() const;

--- a/be/src/runtime_filter/runtime_filter.cpp
+++ b/be/src/runtime_filter/runtime_filter.cpp
@@ -133,16 +133,15 @@ void RuntimeFilter::_check_wrapper_state(std::vector<RuntimeFilterWrapper::State
     try {
         _wrapper->check_state(assumed_states);
     } catch (const Exception& e) {
-        throw Exception(
-                ErrorCode::INTERNAL_ERROR,
-                "rf wrapper meet invalid state, {}, {}. Instance ID: {}, Query Info: [{}]",
-                e.what(), debug_string(),
-                print_id(_state && _state->get_runtime_state()
-                                 ? _state->get_runtime_state()->fragment_instance_id()
-                                 : TUniqueId()),
-                _state && _state->get_query_ctx()
-                        ? _state->get_query_ctx()->print_all_pipeline_context()
-                        : "");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "rf wrapper meet invalid state, {}, {}. Instance ID: {}, Query Info: [{}]",
+                        e.what(), debug_string(),
+                        print_id(_state && _state->get_runtime_state()
+                                         ? _state->get_runtime_state()->fragment_instance_id()
+                                         : TUniqueId()),
+                        _state && _state->get_query_ctx()
+                                ? _state->get_query_ctx()->print_all_pipeline_context()
+                                : "");
     }
 }
 

--- a/be/src/runtime_filter/runtime_filter.cpp
+++ b/be/src/runtime_filter/runtime_filter.cpp
@@ -129,4 +129,21 @@ std::string RuntimeFilter::_debug_string() const {
                        _has_remote_target ? "GLOBAL" : "LOCAL");
 }
 
+void RuntimeFilter::_check_wrapper_state(std::vector<RuntimeFilterWrapper::State> assumed_states) {
+    try {
+        _wrapper->check_state(assumed_states);
+    } catch (const Exception& e) {
+        throw Exception(
+                ErrorCode::INTERNAL_ERROR,
+                "rf wrapper meet invalid state, {}, {}. Instance ID: {}, Query Info: [{}]",
+                e.what(), debug_string(),
+                print_id(_state && _state->get_runtime_state()
+                                 ? _state->get_runtime_state()->fragment_instance_id()
+                                 : TUniqueId()),
+                _state && _state->get_query_ctx()
+                        ? _state->get_query_ctx()->print_all_pipeline_context()
+                        : "");
+    }
+}
+
 } // namespace doris

--- a/be/src/runtime_filter/runtime_filter.h
+++ b/be/src/runtime_filter/runtime_filter.h
@@ -108,14 +108,7 @@ protected:
 
     std::string _debug_string() const;
 
-    void _check_wrapper_state(std::vector<RuntimeFilterWrapper::State> assumed_states) {
-        try {
-            _wrapper->check_state(assumed_states);
-        } catch (const Exception& e) {
-            throw Exception(ErrorCode::INTERNAL_ERROR, "rf wrapper meet invalid state, {}, {}",
-                            e.what(), debug_string());
-        }
-    }
+    void _check_wrapper_state(std::vector<RuntimeFilterWrapper::State> assumed_states);
 
     RuntimeFilterParamsContext* _state = nullptr;
     // _wrapper is a runtime filter function wrapper

--- a/regression-test/suites/query_p0/join/test_terminate.groovy
+++ b/regression-test/suites/query_p0/join/test_terminate.groovy
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_terminate", "nonConcurrent") {
+    sql "set enable_spill = true"
+    sql "set enable_force_spill = true"
+    sql "set disable_join_reorder=true;"
+    sql "set runtime_filter_type='bloom_filter';"
+    sql "set parallel_pipeline_task_num=2"
+    sql "set enable_runtime_filter_prune=false;"
+
+    sql """ drop table if exists t1; """
+    sql """ drop table if exists t2; """
+
+    sql """
+        create table t1 (
+            k1 int null,
+            k2 int null
+        )
+        duplicate key (k1)
+        distributed BY hash(k1) buckets 16
+        properties("replication_num" = "1");
+        """
+
+    sql """
+        create table t2 (
+            k1 int null,
+            k2 int null
+        )
+        duplicate key (k1)
+        distributed BY hash(k1) buckets 16
+        properties("replication_num" = "1");
+
+    """
+
+    sql """
+    insert into t1 values(1,1),(2,2),(3,3);
+    """
+    
+    sql """
+    insert into t2 values(1,1),(2,2),(3,3);
+    """
+
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("PipelineTask::execute.terminate",[pipeline_id: 1, task_id: 1, fragment_id: 3])
+        sql """ select * from t1 join [shuffle] t2 on t1.k2 = t2.k2  """
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("PipelineTask::execute.terminate")
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

If pipeline task is terminated, related operators should call `terminate`. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

