### PR TITLE
[chore](memcmp)Remove the template parameter in memcmp_small_allow_overflow15

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -2330,9 +2330,9 @@ private:
     size_t split_str(size_t& pos, const StringRef str_ref, StringRef delimiter_ref) const {
         size_t old_size = pos;
         size_t str_size = str_ref.size;
-        while (pos < str_size &&
-               memcmp_small_allow_overflow15(str_ref.data + pos, delimiter_ref.data,
-                                             delimiter_ref.size)) {
+        while (pos < str_size && memcmp_small_allow_overflow15((const uint8_t*)str_ref.data + pos,
+                                                               (const uint8_t*)delimiter_ref.data,
+                                                               delimiter_ref.size)) {
             pos++;
         }
         return pos - old_size;
@@ -2471,8 +2471,9 @@ private:
     size_t find_pos(size_t pos, const StringRef str_ref, const StringRef pattern_ref) const {
         size_t old_size = pos;
         size_t str_size = str_ref.size;
-        while (pos < str_size && memcmp_small_allow_overflow15(str_ref.data + pos, pattern_ref.data,
-                                                               pattern_ref.size)) {
+        while (pos < str_size &&
+               memcmp_small_allow_overflow15((const uint8_t*)str_ref.data + pos,
+                                             (const uint8_t*)pattern_ref.data, pattern_ref.size)) {
             pos++;
         }
         return pos - old_size;


### PR DESCRIPTION
### What problem does this PR solve?

In the past, we manually implemented some memcmp code. 
However, we passed in template parameters during the implementation, which resulted in different outcomes for signed and unsigned numbers for the same memory segment. 
Here, we will directly remove the template.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

