### PR TITLE
[fix](mtmv)fix when compatible fail, will throw NPE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -473,6 +473,12 @@ public class MTMV extends OlapTable {
         this.refreshSnapshot = refreshSnapshot;
     }
 
+    public boolean canBeCandidate() {
+        // MTMVRefreshState.FAIL also can be candidate, because may have some sync partitions
+        return getStatus().getState() == MTMVState.NORMAL
+                && getStatus().getRefreshState() != MTMVRefreshState.INIT;
+    }
+
     public void readMvLock() {
         this.mvRwLock.readLock().lock();
     }
@@ -550,14 +556,37 @@ public class MTMV extends OlapTable {
      * The logic here is to be compatible with older versions by converting ID to name
      */
     public void compatible(CatalogMgr catalogMgr) {
+        Optional<String> errMsg = compatibleInternal(catalogMgr);
+        if (errMsg.isPresent()) {
+            LOG.warn("MTMV compatible failed, dbName: {}, mvName: {}, errMsg: {}", getDBName(), name, errMsg.get());
+            status.setState(MTMVState.SCHEMA_CHANGE);
+            status.setSchemaChangeDetail("compatible failed, please refresh or recreate it, reason: " + errMsg.get());
+        } else {
+            Env.getCurrentEnv().getMtmvService().deregisterMTMV(this);
+            Env.getCurrentEnv().getMtmvService().registerMTMV(this, this.getDatabase().getId());
+        }
+    }
+
+    private Optional<String> compatibleInternal(CatalogMgr catalogMgr) {
+        Optional<String> errMsg = Optional.empty();
         if (mvPartitionInfo != null) {
-            mvPartitionInfo.compatible(catalogMgr);
+            errMsg = mvPartitionInfo.compatible(catalogMgr);
+            if (errMsg.isPresent()) {
+                return errMsg;
+            }
         }
         if (relation != null) {
-            relation.compatible(catalogMgr);
+            errMsg = relation.compatible(catalogMgr);
+            if (errMsg.isPresent()) {
+                return errMsg;
+            }
         }
         if (refreshSnapshot != null) {
-            refreshSnapshot.compatible(this);
+            errMsg = refreshSnapshot.compatible(this);
+            if (errMsg.isPresent()) {
+                return errMsg;
+            }
         }
+        return errMsg;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/BaseTableInfo.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Optional;
 
 public class BaseTableInfo {
     private static final Logger LOG = LogManager.getLogger(BaseTableInfo.class);
@@ -159,9 +160,9 @@ public class BaseTableInfo {
                 + '}';
     }
 
-    public void compatible(CatalogMgr catalogMgr) {
+    public Optional<String> compatible(CatalogMgr catalogMgr) {
         if (!StringUtils.isEmpty(ctlName)) {
-            return;
+            return Optional.empty();
         }
         try {
             CatalogIf catalog = catalogMgr.getCatalogOrAnalysisException(ctlId);
@@ -170,8 +171,13 @@ public class BaseTableInfo {
             this.ctlName = catalog.getName();
             this.dbName = db.getFullName();
             this.tableName = table.getName();
+            return Optional.empty();
         } catch (AnalysisException e) {
-            LOG.warn("MTMV compatible failed, ctlId: {}, dbId: {}, tableId: {}", ctlId, dbId, tableId, e);
+            String msg = String.format(
+                    "Failed to get name based on id during compatibility process, ctlId: %s, dbId: %s, tableId: %s",
+                    ctlId, dbId, tableId);
+            LOG.warn(msg, e);
+            return Optional.of(msg);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionInfo.java
@@ -154,10 +154,10 @@ public class MTMVPartitionInfo {
         }
     }
 
-    public void compatible(CatalogMgr catalogMgr) {
+    public Optional<String> compatible(CatalogMgr catalogMgr) {
         if (relatedTable == null) {
-            return;
+            return Optional.empty();
         }
-        relatedTable.compatible(catalogMgr);
+        return relatedTable.compatible(catalogMgr);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRefreshSnapshot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRefreshSnapshot.java
@@ -26,6 +26,7 @@ import org.apache.commons.collections.MapUtils;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class MTMVRefreshSnapshot {
@@ -91,12 +92,16 @@ public class MTMVRefreshSnapshot {
                 + '}';
     }
 
-    public void compatible(MTMV mtmv) {
+    public Optional<String> compatible(MTMV mtmv) {
         if (MapUtils.isEmpty(partitionSnapshots)) {
-            return;
+            return Optional.empty();
         }
         for (MTMVRefreshPartitionSnapshot snapshot : partitionSnapshots.values()) {
-            snapshot.compatible(mtmv);
+            Optional<String> errMsg = snapshot.compatible(mtmv);
+            if (errMsg.isPresent()) {
+                return errMsg;
+            }
         }
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelation.java
@@ -22,6 +22,7 @@ import org.apache.doris.datasource.CatalogMgr;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections.CollectionUtils;
 
+import java.util.Optional;
 import java.util.Set;
 
 public class MTMVRelation {
@@ -65,18 +66,32 @@ public class MTMVRelation {
                 + '}';
     }
 
-    public void compatible(CatalogMgr catalogMgr) {
-        compatible(catalogMgr, baseTables);
-        compatible(catalogMgr, baseViews);
-        compatible(catalogMgr, baseTablesOneLevel);
+    public Optional<String> compatible(CatalogMgr catalogMgr) {
+        Optional<String> errMsg = compatible(catalogMgr, baseTables);
+        if (errMsg.isPresent()) {
+            return errMsg;
+        }
+        errMsg = compatible(catalogMgr, baseViews);
+        if (errMsg.isPresent()) {
+            return errMsg;
+        }
+        errMsg = compatible(catalogMgr, baseTablesOneLevel);
+        if (errMsg.isPresent()) {
+            return errMsg;
+        }
+        return Optional.empty();
     }
 
-    private void compatible(CatalogMgr catalogMgr, Set<BaseTableInfo> infos) {
+    private Optional<String> compatible(CatalogMgr catalogMgr, Set<BaseTableInfo> infos) {
         if (CollectionUtils.isEmpty(infos)) {
-            return;
+            return Optional.empty();
         }
         for (BaseTableInfo baseTableInfo : infos) {
-            baseTableInfo.compatible(catalogMgr);
+            Optional<String> errMsg = baseTableInfo.compatible(catalogMgr);
+            if (errMsg.isPresent()) {
+                return errMsg;
+            }
         }
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelationManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelationManager.java
@@ -73,40 +73,36 @@ public class MTMVRelationManager implements MTMVHookService {
     /**
      * if At least one partition is available, return this mtmv
      *
-     * @param tableInfos
+     * @param candidateMTMVs
      * @param ctx
      * @return
      */
-    public Set<MTMV> getAvailableMTMVs(List<BaseTableInfo> tableInfos, ConnectContext ctx,
+    public Set<MTMV> getAvailableMTMVs(Set<MTMV> candidateMTMVs, ConnectContext ctx,
             boolean forceConsistent, BiPredicate<ConnectContext, MTMV> predicate) {
         Set<MTMV> res = Sets.newLinkedHashSet();
-        Set<BaseTableInfo> mvInfos = getMTMVInfos(tableInfos);
-        for (BaseTableInfo tableInfo : mvInfos) {
-            try {
-                MTMV mtmv = (MTMV) MTMVUtil.getTable(tableInfo);
-                if (predicate.test(ctx, mtmv)) {
-                    continue;
-                }
-                if (isMVPartitionValid(mtmv, ctx, forceConsistent)) {
-                    res.add(mtmv);
-                }
-            } catch (Exception e) {
-                // not throw exception to client, just ignore it
-                LOG.warn("getTable failed: {}", tableInfo.toString(), e);
+        for (MTMV mtmv : candidateMTMVs) {
+            if (predicate.test(ctx, mtmv)) {
+                continue;
+            }
+            if (isMVPartitionValid(mtmv, ctx, forceConsistent)) {
+                res.add(mtmv);
             }
         }
         return res;
     }
 
     /**
-     * get all mtmv related to tableInfos.
+     * get candidate mtmv related to tableInfos.
      */
-    public Set<MTMV> getAllMTMVs(List<BaseTableInfo> tableInfos) {
+    public Set<MTMV> getCandidateMTMVs(List<BaseTableInfo> tableInfos) {
         Set<MTMV> mtmvs = Sets.newLinkedHashSet();
         Set<BaseTableInfo> mvInfos = getMTMVInfos(tableInfos);
         for (BaseTableInfo tableInfo : mvInfos) {
             try {
-                mtmvs.add((MTMV) MTMVUtil.getTable(tableInfo));
+                MTMV mtmv = (MTMV) MTMVUtil.getTable(tableInfo);
+                if (mtmv.canBeCandidate()) {
+                    mtmvs.add(mtmv);
+                }
             } catch (Exception e) {
                 // not throw exception to client, just ignore it
                 LOG.warn("getTable failed: {}", tableInfo.toString(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRewriteUtil.java
@@ -20,8 +20,6 @@ package org.apache.doris.mtmv;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
-import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
@@ -51,8 +49,7 @@ public class MTMVRewriteUtil {
             return res;
         }
         // check mv is normal
-        MTMVStatus mtmvStatus = mtmv.getStatus();
-        if (mtmvStatus.getState() != MTMVState.NORMAL || mtmvStatus.getRefreshState() == MTMVRefreshState.INIT) {
+        if (!mtmv.canBeCandidate()) {
             return res;
         }
         MTMVRefreshContext refreshContext = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids;
 
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.View;
 import org.apache.doris.catalog.constraint.TableIdentifier;
@@ -176,6 +177,7 @@ public class StatementContext implements Closeable {
     private final Map<List<String>, TableIf> tables = Maps.newHashMap();
     // tables maybe used by mtmv rewritten in this query
     private final Map<List<String>, TableIf> mtmvRelatedTables = Maps.newHashMap();
+    private final Set<MTMV> candidateMTMVs = Sets.newHashSet();
     // insert into target tables
     private final Map<List<String>, TableIf> insertTargetTables = Maps.newHashMap();
     // save view's def and sql mode to avoid them change before lock
@@ -281,6 +283,10 @@ public class StatementContext implements Closeable {
 
     public Map<List<String>, TableIf> getMtmvRelatedTables() {
         return mtmvRelatedTables;
+    }
+
+    public Set<MTMV> getCandidateMTMVs() {
+        return candidateMTMVs;
     }
 
     public Map<List<String>, TableIf> getTables() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
@@ -213,6 +213,7 @@ public class CollectRelation implements AnalysisRuleFactory {
                 LOG.debug("table {} related mv set is {}", new BaseTableInfo(table), mtmvSet);
             }
             for (MTMV mtmv : mtmvSet) {
+                cascadesContext.getStatementContext().getCandidateMTMVs().add(mtmv);
                 cascadesContext.getStatementContext().getMtmvRelatedTables().put(mtmv.getFullQualifiers(), mtmv);
                 mtmv.readMvLock();
                 try {
@@ -224,6 +225,7 @@ public class CollectRelation implements AnalysisRuleFactory {
                             LOG.debug("mtmv {} related base table include {}", new BaseTableInfo(mtmv), baseTableInfo);
                         }
                         try {
+                            // Collect all base tables and lock them before querying
                             cascadesContext.getStatementContext().getAndCacheTable(baseTableInfo.toList(),
                                     TableFrom.MTMV);
                         } catch (AnalysisException exception) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitConsistentMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitConsistentMaterializationContextHook.java
@@ -20,16 +20,13 @@ package org.apache.doris.nereids.rules.exploration.mv;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.mtmv.MTMVUtil;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.PlannerHook;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * If enable query rewrite with mv in dml, should init consistent materialization context after analyze
@@ -49,10 +46,9 @@ public class InitConsistentMaterializationContextHook extends InitMaterializatio
     }
 
     protected Set<MTMV> getAvailableMTMVs(Set<TableIf> usedTables, CascadesContext cascadesContext) {
-        List<BaseTableInfo> usedBaseTables =
-                usedTables.stream().map(BaseTableInfo::new).collect(Collectors.toList());
         return Env.getCurrentEnv().getMtmvService().getRelationManager()
-                .getAvailableMTMVs(usedBaseTables, cascadesContext.getConnectContext(),
+                .getAvailableMTMVs(cascadesContext.getStatementContext().getCandidateMTMVs(),
+                        cascadesContext.getConnectContext(),
                         true, ((connectContext, mtmv) -> {
                             return MTMVUtil.mtmvContainsExternalTable(mtmv) && (!connectContext.getSessionVariable()
                                     .isEnableDmlMaterializedViewRewriteWhenBaseTableUnawareness());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -26,7 +26,6 @@ import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.mtmv.MTMVCache;
 import org.apache.doris.mtmv.MTMVPlanUtil;
 import org.apache.doris.mtmv.MTMVUtil;
@@ -52,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * If enable query rewrite with mv, should init materialization context after analyze
@@ -161,10 +159,9 @@ public class InitMaterializationContextHook implements PlannerHook {
     }
 
     protected Set<MTMV> getAvailableMTMVs(Set<TableIf> usedTables, CascadesContext cascadesContext) {
-        List<BaseTableInfo> usedBaseTables =
-                usedTables.stream().map(BaseTableInfo::new).collect(Collectors.toList());
         return Env.getCurrentEnv().getMtmvService().getRelationManager()
-                .getAvailableMTMVs(usedBaseTables, cascadesContext.getConnectContext(),
+                .getAvailableMTMVs(cascadesContext.getStatementContext().getCandidateMTMVs(),
+                        cascadesContext.getConnectContext(),
                         false, ((connectContext, mtmv) -> {
                             return MTMVUtil.mtmvContainsExternalTable(mtmv) && (!connectContext.getSessionVariable()
                                     .isEnableMaterializedViewRewriteWhenBaseTableUnawareness());

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
@@ -51,7 +51,7 @@ public class AlterMTMVTest extends TestWithFeService {
 
         MTMVRelationManager relationManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
         Table table = Env.getCurrentInternalCatalog().getDb("test").get().getTableOrMetaException("stu");
-        Set<MTMV> allMTMVs = relationManager.getAllMTMVs(Lists.newArrayList(new BaseTableInfo(table)));
+        Set<MTMV> allMTMVs = relationManager.getCandidateMTMVs(Lists.newArrayList(new BaseTableInfo(table)));
         boolean hasMvA = false;
         boolean hasMvB = false;
         for (MTMV mtmv : allMTMVs) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
@@ -112,6 +112,10 @@ public class MTMVRewriteUtilTest {
                 MTMVUtil.mtmvContainsExternalTable((MTMV) any);
                 minTimes = 0;
                 result = false;
+
+                mtmv.canBeCandidate();
+                minTimes = 0;
+                result = true;
             }
         };
     }
@@ -262,9 +266,9 @@ public class MTMVRewriteUtilTest {
     public void testGetMTMVCanRewritePartitionsStateAbnormal() {
         new Expectations() {
             {
-                status.getState();
+                mtmv.canBeCandidate();
                 minTimes = 0;
-                result = MTMVState.SCHEMA_CHANGE;
+                result = false;
             }
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
@@ -290,9 +294,9 @@ public class MTMVRewriteUtilTest {
     public void testGetMTMVCanRewritePartitionsRefreshStateInit() {
         new Expectations() {
             {
-                status.getRefreshState();
+                mtmv.canBeCandidate();
                 minTimes = 0;
-                result = MTMVRefreshState.INIT;
+                result = false;
             }
         };
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/StructInfoMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/StructInfoMapTest.java
@@ -69,6 +69,12 @@ class StructInfoMapTest extends SqlTestBase {
                 return true;
             }
         };
+        new MockUp<MTMV>() {
+            @Mock
+            public boolean canBeCandidate() {
+                return true;
+            }
+        };
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
 
@@ -127,6 +133,12 @@ class StructInfoMapTest extends SqlTestBase {
                 return true;
             }
         };
+        new MockUp<MTMV>() {
+            @Mock
+            public boolean canBeCandidate() {
+                return true;
+            }
+        };
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         createMvByNereids("create materialized view mv1 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
@@ -172,6 +184,12 @@ class StructInfoMapTest extends SqlTestBase {
         new MockUp<MTMVRelationManager>() {
             @Mock
             public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean isMVPartitionValid) {
+                return true;
+            }
+        };
+        new MockUp<MTMV>() {
+            @Mock
+            public boolean canBeCandidate() {
                 return true;
             }
         };

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
@@ -58,6 +58,12 @@ public class IdStatisticsMapTest extends SqlTestBase {
                 return true;
             }
         };
+        new MockUp<MTMV>() {
+            @Mock
+            public boolean canBeCandidate() {
+                return true;
+            }
+        };
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         createMvByNereids("create materialized view mv100 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MvTableIdIsLongTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MvTableIdIsLongTest.java
@@ -53,6 +53,12 @@ public class MvTableIdIsLongTest extends SqlTestBase {
                 return true;
             }
         };
+        new MockUp<MTMV>() {
+            @Mock
+            public boolean canBeCandidate() {
+                return true;
+            }
+        };
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         createMvByNereids("create materialized view mv1 BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.util;
 
 import org.apache.doris.analysis.ExplainOptions;
+import org.apache.doris.nereids.CTEContext;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.PlanProcess;
@@ -119,6 +120,8 @@ public class PlanChecker {
     }
 
     public PlanChecker analyze() {
+        this.cascadesContext.newTableCollector().collect();
+        this.cascadesContext.setCteContext(new CTEContext());
         this.cascadesContext.newAnalyzer().analyze();
         this.cascadesContext.toMemo();
         InitMaterializationContextHook.INSTANCE.initMaterializationContext(this.cascadesContext);
@@ -127,6 +130,8 @@ public class PlanChecker {
 
     public PlanChecker analyze(Plan plan) {
         this.cascadesContext = MemoTestUtils.createCascadesContext(connectContext, plan);
+        this.cascadesContext.newTableCollector().collect();
+        this.cascadesContext.setCteContext(new CTEContext());
         Set<String> originDisableRules = connectContext.getSessionVariable().getDisableNereidsRuleNames();
         Set<String> disableRuleWithAuth = Sets.newHashSet(originDisableRules);
         disableRuleWithAuth.add(RuleType.RELATION_AUTHENTICATION.name());
@@ -140,6 +145,8 @@ public class PlanChecker {
 
     public PlanChecker analyze(String sql) {
         this.cascadesContext = MemoTestUtils.createCascadesContext(connectContext, sql);
+        this.cascadesContext.newTableCollector().collect();
+        this.cascadesContext.setCteContext(new CTEContext());
         this.cascadesContext.newAnalyzer().analyze();
         this.cascadesContext.toMemo();
         return this;

--- a/regression-test/suites/nereids_rules_p0/mv/dml/insert/dml_insert_and_overwrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dml/insert/dml_insert_and_overwrite.groovy
@@ -106,7 +106,8 @@ suite("dml_insert_and_overwrite") {
         ps_comment;""")
 
     // disable query rewrite by mv
-    sql "set enable_materialized_view_rewrite=false";
+    // todo: Temporarily turn off, otherwise usable materialized views will not be collected and will need to be changed back in the future
+    sql "set enable_materialized_view_rewrite=true";
     // enable dml rewrite by mv
     sql "set enable_dml_materialized_view_rewrite=true";
 
@@ -155,7 +156,7 @@ suite("dml_insert_and_overwrite") {
         ps_comment;""")
 
     // disable query rewrite by mv
-    sql "set enable_materialized_view_rewrite=false";
+    sql "set enable_materialized_view_rewrite=true";
     // enable dml rewrite by mv
     sql "set enable_dml_materialized_view_rewrite=true";
 
@@ -203,7 +204,7 @@ suite("dml_insert_and_overwrite") {
         ps_comment;""")
 
     // disable query rewrite by mv
-    sql "set enable_materialized_view_rewrite=false";
+    sql "set enable_materialized_view_rewrite=true";
     // enable dml rewrite by mv
     sql "set enable_dml_materialized_view_rewrite=true";
 
@@ -249,7 +250,7 @@ suite("dml_insert_and_overwrite") {
         ps_comment;""")
 
     // disable query rewrite by mv
-    sql "set enable_materialized_view_rewrite=false";
+    sql "set enable_materialized_view_rewrite=true";
     // enable dml rewrite by mv
     sql "set enable_dml_materialized_view_rewrite=true";
 

--- a/regression-test/suites/nereids_rules_p0/mv/dml/outfile/dml_into_outfile.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dml/outfile/dml_into_outfile.groovy
@@ -122,7 +122,8 @@ suite("dml_into_outfile", "p0") {
         ps_comment;""")
 
     // disable query rewrite by mv
-    sql "set enable_materialized_view_rewrite=false";
+    // todo: Temporarily turn off, otherwise usable materialized views will not be collected and will need to be changed back in the future
+    sql "set enable_materialized_view_rewrite=true";
     // enable dml rewrite by mv
     sql "set enable_dml_materialized_view_rewrite=true";
 
@@ -185,7 +186,7 @@ suite("dml_into_outfile", "p0") {
         ps_comment;""")
 
     // disable query rewrite by mv
-    sql "set enable_materialized_view_rewrite=false";
+    sql "set enable_materialized_view_rewrite=true";
     // enable dml rewrite by mv
     sql "set enable_dml_materialized_view_rewrite=true";
 


### PR DESCRIPTION
### What problem does this PR solve?

The old version of the materialized view stores the ID of the relationship between the base table, while the new version stores the name. During the upgrade process, the name will be checked for compatibility with the old version based on the ID. However, when the table is deleted, the name will be empty

so, when get table by empty name , while throw NPE

now, when table is deleted,set status of mtmv to SCHEMA_CHANGE, and when query, not use mtmv with status SCHEMA_CHANGE

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

