### PR TITLE
[fix](doris compose) fix chose arrow_flight_sql_port

### DIFF
--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -42,11 +42,13 @@ FE_RPC_PORT = 9020
 FE_QUERY_PORT = 9030
 FE_EDITLOG_PORT = 9010
 FE_JAVA_DBG_PORT = 5005
+FE_ARROW_FLIGHT_SQL_PORT = 8070
 
 BE_PORT = 9060
 BE_WEBSVR_PORT = 8040
 BE_HEARTBEAT_PORT = 9050
 BE_BRPC_PORT = 8060
+BE_ARROW_FLIGHT_SQL_PORT = 8050
 
 FDB_PORT = 4500
 
@@ -551,6 +553,7 @@ class FE(Node):
             "rpc_port": FE_RPC_PORT,
             "query_port": FE_QUERY_PORT,
             "edit_log_port": FE_EDITLOG_PORT,
+            "arrow_flight_sql_port": FE_ARROW_FLIGHT_SQL_PORT,
             "java_debug_port": FE_JAVA_DBG_PORT,
         }
 
@@ -663,6 +666,7 @@ class BE(Node):
             "webserver_port": BE_WEBSVR_PORT,
             "heartbeat_service_port": BE_HEARTBEAT_PORT,
             "brpc_port": BE_BRPC_PORT,
+            "arrow_flight_sql_port": BE_ARROW_FLIGHT_SQL_PORT,
         }
 
     def cloud_unique_id(self):

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -902,7 +902,7 @@ class DownCommand(Command):
                     shutil.rmtree(node.get_path())
                     register_file = "{}/{}-{}-register".format(
                         CLUSTER.get_status_path(cluster.name),
-                        node.node_type(), node.get_ip())
+                        node.node_type(), node.id)
                     if os.path.exists(register_file):
                         os.remove(register_file)
                     LOG.info(

--- a/docker/runtime/doris-compose/resource/init_be.sh
+++ b/docker/runtime/doris-compose/resource/init_be.sh
@@ -22,7 +22,7 @@ DIR=$(
 
 source $DIR/common.sh
 
-REGISTER_FILE=$DORIS_HOME/status/be-$MY_IP-register
+REGISTER_FILE="${DORIS_HOME}/status/be-${MY_ID}-register"
 
 add_local_be() {
     wait_master_fe_ready

--- a/docker/runtime/doris-compose/resource/init_fe.sh
+++ b/docker/runtime/doris-compose/resource/init_fe.sh
@@ -22,7 +22,7 @@ DIR=$(
 
 source $DIR/common.sh
 
-REGISTER_FILE=$DORIS_HOME/status/fe-$MY_IP-register
+REGISTER_FILE="${DORIS_HOME}/status/fe-${MY_ID}-register"
 MASTER_EDITLOG_PORT=""
 
 add_local_fe() {


### PR DESCRIPTION
### What problem does this PR solve?

PR #49236 change default arrow_flight_sql_port from -1(no use) to 8050/8070,  then doris-compose need to chose arrow_flight_sql_port in host mode.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

