### PR TITLE
[fix](cloud-mow)Schema change fail should release delete bitmap lock

### DIFF
--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -542,9 +542,11 @@ Status CloudSchemaChangeJob::_process_delete_bitmap(int64_t alter_version,
 }
 
 void CloudSchemaChangeJob::clean_up_on_failed() {
-    _cloud_storage_engine.meta_mgr().remove_delete_bitmap_update_lock(
-            _new_tablet->table_id(), SCHEMA_CHANGE_DELETE_BITMAP_LOCK_ID, _initiator,
-            _new_tablet->tablet_id());
+    if (_new_tablet->enable_unique_key_merge_on_write()) {
+        _cloud_storage_engine.meta_mgr().remove_delete_bitmap_update_lock(
+                _new_tablet->table_id(), SCHEMA_CHANGE_DELETE_BITMAP_LOCK_ID, _initiator,
+                _new_tablet->tablet_id());
+    }
     for (const auto& output_rs : _output_rowsets) {
         if (output_rs.use_count() > 2) {
             LOG(WARNING) << "Rowset " << output_rs->rowset_id().to_string() << " has "

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -542,7 +542,8 @@ Status CloudSchemaChangeJob::_process_delete_bitmap(int64_t alter_version,
 }
 
 void CloudSchemaChangeJob::clean_up_on_failed() {
-    if (_new_tablet->enable_unique_key_merge_on_write()) {
+    if (_new_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+        _new_tablet->enable_unique_key_merge_on_write()) {
         _cloud_storage_engine.meta_mgr().remove_delete_bitmap_update_lock(
                 _new_tablet->table_id(), SCHEMA_CHANGE_DELETE_BITMAP_LOCK_ID, _initiator,
                 _new_tablet->tablet_id());

--- a/be/src/cloud/cloud_schema_change_job.h
+++ b/be/src/cloud/cloud_schema_change_job.h
@@ -56,6 +56,7 @@ private:
     int64_t _output_cumulative_point = 0;
     // absolute expiration time in second
     int64_t _expiration;
+    int64_t _initiator;
 };
 
 } // namespace doris

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -1477,7 +1477,8 @@ Status CloudCompactionMixin::execute_compact() {
     HANDLE_EXCEPTION_IF_CATCH_EXCEPTION(
             execute_compact_impl(permits), [&](const doris::Exception& ex) {
                 auto st = garbage_collection();
-                if (!st.ok() && initiator() != INVALID_COMPACTION_INITIATOR_ID) {
+                if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+                    _tablet->enable_unique_key_merge_on_write() && !st.ok()) {
                     // if compaction fail, be will try to abort compaction, and delete bitmap lock
                     // will release if abort job successfully, but if abort failed, delete bitmap
                     // lock will not release, in this situation, be need to send this rpc to ms

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -587,7 +587,7 @@ static void remove_delete_bitmap_update_lock_v1(std::unique_ptr<Transaction>& tx
     std::string lock_val;
     TxnErrorCode err = txn->get(lock_key, &lock_val);
     LOG(INFO) << "get remove delete bitmap update lock info, table_id=" << table_id
-              << " key=" << hex(lock_key) << " err=" << err;
+              << " key=" << hex(lock_key) << " err=" << err << " initiator=" << lock_initiator;
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to get delete bitmap update lock key, instance_id=" << instance_id
                      << " table_id=" << table_id << " key=" << hex(lock_key) << " err=" << err;

--- a/regression-test/suites/fault_injection_p0/cloud/test_sc_fail_release_delete_bitmap_lock.groovy
+++ b/regression-test/suites/fault_injection_p0/cloud/test_sc_fail_release_delete_bitmap_lock.groovy
@@ -1,0 +1,136 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
+
+suite("test_sc_fail_release_delete_bitmap_lock", "nonConcurrent") {
+    if (!isCloudMode()) {
+        return
+    }
+    GetDebugPoint().clearDebugPointsForAllFEs()
+
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    def backendId_to_params = [string: [:]]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+
+    def set_be_param = { paramName, paramValue ->
+        // for eache be node, set paramName=paramValue
+        for (String id in backendId_to_backendIP.keySet()) {
+            def beIp = backendId_to_backendIP.get(id)
+            def bePort = backendId_to_backendHttpPort.get(id)
+            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s", beIp, bePort, paramName, paramValue))
+            assertTrue(out.contains("OK"))
+        }
+    }
+
+    def reset_be_param = { paramName ->
+        // for eache be node, reset paramName to default
+        for (String id in backendId_to_backendIP.keySet()) {
+            def beIp = backendId_to_backendIP.get(id)
+            def bePort = backendId_to_backendHttpPort.get(id)
+            def original_value = backendId_to_params.get(id).get(paramName)
+            def (code, out, err) = curl("POST", String.format("http://%s:%s/api/update_config?%s=%s", beIp, bePort, paramName, original_value))
+            assertTrue(out.contains("OK"))
+        }
+    }
+
+    def get_be_param = { paramName ->
+        // for eache be node, get param value by default
+        def paramValue = ""
+        for (String id in backendId_to_backendIP.keySet()) {
+            def beIp = backendId_to_backendIP.get(id)
+            def bePort = backendId_to_backendHttpPort.get(id)
+            // get the config value from be
+            def (code, out, err) = curl("GET", String.format("http://%s:%s/api/show_config?conf_item=%s", beIp, bePort, paramName))
+            assertTrue(code == 0)
+            assertTrue(out.contains(paramName))
+            // parsing
+            def resultList = parseJson(out)[0]
+            assertTrue(resultList.size() == 4)
+            // get original value
+            paramValue = resultList[2]
+            backendId_to_params.get(id, [:]).put(paramName, paramValue)
+        }
+    }
+    def customFeConfig = [schema_change_max_retry_time: 0]
+    def tableName = "tbl_basic"
+
+    def do_insert_into = {
+        sql """ INSERT INTO ${tableName} (id, name, score) VALUES (1, "Emily", 25),(2, "Benjamin", 35);"""
+    }
+
+    def waitForSC = {
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).pollDelay(100, TimeUnit.MILLISECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
+            def res = sql_return_maparray "SHOW ALTER TABLE COLUMN WHERE TableName='${tableName}' ORDER BY createtime DESC LIMIT 1"
+            assert res.size() == 1
+            log.info("res[0].State:" + res[0].State)
+            if (res[0].State == "FINISHED" || res[0].State == "CANCELLED") {
+                return true;
+            }
+            return false;
+        });
+    }
+
+    try {
+        // create table
+        sql """ drop table if exists ${tableName}; """
+
+        sql """
+        CREATE TABLE `${tableName}` (
+            `id` int(11) NOT NULL,
+            `name` varchar(10) NULL,
+            `score` int(11) NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "disable_auto_compaction" = "true",
+            "enable_unique_key_merge_on_write" = "true",
+            "replication_num" = "1"
+        );
+        """
+        setFeConfigTemporary(customFeConfig) {
+            get_be_param("delete_bitmap_lock_expiration_seconds")
+            set_be_param("delete_bitmap_lock_expiration_seconds", "60")
+            sql """ INSERT INTO ${tableName} (id, name, score) VALUES (1, "AAA", 15);"""
+            sql """ INSERT INTO ${tableName} (id, name, score) VALUES (2, "BBB", 25);"""
+            sql """ INSERT INTO ${tableName} (id, name, score) VALUES (3, "CCC", 35);"""
+            sql """ INSERT INTO ${tableName} (id, name, score) VALUES (4, "DDD", 45);"""
+            sql """ INSERT INTO ${tableName} (id, name, score) VALUES (5, "EEE", 55);"""
+            def tablets = sql_return_maparray """ show tablets from ${tableName}; """
+            logger.info("tablets: " + tablets)
+            GetDebugPoint().enableDebugPointForAllBEs("CloudMetaMgr::test_update_delete_bitmap_fail")
+            sql "alter table ${tableName} modify column score varchar(100);"
+            waitForSC()
+            def res = sql_return_maparray "SHOW ALTER TABLE COLUMN WHERE TableName='${tableName}' ORDER BY createtime DESC LIMIT 1"
+            assert res[0].State == "CANCELLED"
+            assert res[0].Msg.contains("[DELETE_BITMAP_LOCK_ERROR]test update delete bitmap failed")
+            GetDebugPoint().disableDebugPointForAllBEs("CloudMetaMgr::test_update_delete_bitmap_fail")
+            now = System.currentTimeMillis()
+            do_insert_into()
+            time_cost = System.currentTimeMillis() - now
+            log.info("time_cost(ms): ${time_cost}")
+            assertTrue(time_cost < 10000, "wait time should less than 10s")
+        }
+    } finally {
+        reset_be_param("delete_bitmap_lock_expiration_seconds")
+        GetDebugPoint().clearDebugPointsForAllBEs()
+    }
+
+}


### PR DESCRIPTION
When sc fail, it will abort sc job by fe, however it forget to release  delete bitmap lock, which will block  data input.
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

