### PR TITLE
[enhance](load) delete temporary files and disk detection

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -153,11 +153,10 @@ void StreamLoadAction::handle(HttpRequest* req) {
     // update statistics
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
-    if (_exec_env->load_path_mgr() != nullptr) {
+    if(!ctx->data_saved_path.empty()){
         _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
-    } else {
-        LOG(WARNING) << "LoadPathMgr instance is null, cannot call clean_tmp_files.";
     }
+    _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
 }
 
 Status StreamLoadAction::_handle(std::shared_ptr<StreamLoadContext> ctx) {

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -156,7 +156,6 @@ void StreamLoadAction::handle(HttpRequest* req) {
     if(!ctx->data_saved_path.empty()){
         _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
     }
-    _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
 }
 
 Status StreamLoadAction::_handle(std::shared_ptr<StreamLoadContext> ctx) {

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -154,10 +154,10 @@ void StreamLoadAction::handle(HttpRequest* req) {
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
     if (!ctx->data_saved_path.empty()) {
-         load_path_mgr->clean_tmp_files(ctx->data_saved_path);
+        _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
       }
-    if (load_path_mgr != nullptr) {
-        load_path_mgr->clean_tmp_files(ctx->data_saved_path);
+    if (_exec_env->load_path_mgr() != nullptr) {
+        _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
     } else {
         LOG(WARNING) << "LoadPathMgr instance is null, cannot call clean_tmp_files.";
     }

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -153,7 +153,9 @@ void StreamLoadAction::handle(HttpRequest* req) {
     // update statistics
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
-    LoadPathMgr* load_path_mgr = _exec_env->load_path_mgr();
+    if (!ctx->data_saved_path.empty()) {
+         load_path_mgr->clean_tmp_files(ctx->data_saved_path);
+      }
     if (load_path_mgr != nullptr) {
         load_path_mgr->clean_tmp_files(ctx->data_saved_path);
     } else {

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -153,6 +153,12 @@ void StreamLoadAction::handle(HttpRequest* req) {
     // update statistics
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
+    LoadPathMgr* load_path_mgr = _exec_env->load_path_mgr();
+    if (load_path_mgr != nullptr) {
+        load_path_mgr->clean_tmp_files(ctx->data_saved_path);
+    } else {
+        LOG(WARNING) << "LoadPathMgr instance is null, cannot call clean_tmp_files.";
+    }
 }
 
 Status StreamLoadAction::_handle(std::shared_ptr<StreamLoadContext> ctx) {
@@ -429,13 +435,16 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         ctx->pipe = pipe;
         RETURN_IF_ERROR(_exec_env->new_load_stream_mgr()->put(ctx->id, ctx));
     } else {
-        RETURN_IF_ERROR(_data_saved_path(http_req, &request.path));
+
+
+        RETURN_IF_ERROR(_data_saved_path(http_req, &request.path, ctx->body_bytes));
         auto file_sink = std::make_shared<MessageBodyFileSink>(request.path);
         RETURN_IF_ERROR(file_sink->open());
         request.__isset.path = true;
         request.fileType = TFileType::FILE_LOCAL;
         request.__set_file_size(ctx->body_bytes);
         ctx->body_sink = file_sink;
+        ctx->data_saved_path = request.path;
     }
     if (!http_req->header(HTTP_COLUMNS).empty()) {
         request.__set_columns(http_req->header(HTTP_COLUMNS));
@@ -794,9 +803,9 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
     return _exec_env->stream_load_executor()->execute_plan_fragment(ctx, mocked);
 }
 
-Status StreamLoadAction::_data_saved_path(HttpRequest* req, std::string* file_path) {
+Status StreamLoadAction::_data_saved_path(HttpRequest* req, std::string* file_path, int64_t file_bytes) {
     std::string prefix;
-    RETURN_IF_ERROR(_exec_env->load_path_mgr()->allocate_dir(req->param(HTTP_DB_KEY), "", &prefix));
+    RETURN_IF_ERROR(_exec_env->load_path_mgr()->allocate_dir(req->param(HTTP_DB_KEY), "", &prefix, file_bytes));
     timeval tv;
     gettimeofday(&tv, nullptr);
     struct tm tm;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -153,7 +153,7 @@ void StreamLoadAction::handle(HttpRequest* req) {
     // update statistics
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
-    if(!ctx->data_saved_path.empty()){
+    if (!ctx->data_saved_path.empty()) {
         _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
     }
 }
@@ -798,9 +798,11 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
     return _exec_env->stream_load_executor()->execute_plan_fragment(ctx, mocked);
 }
 
-Status StreamLoadAction::_data_saved_path(HttpRequest* req, std::string* file_path, int64_t file_bytes) {
+Status StreamLoadAction::_data_saved_path(HttpRequest* req, std::string* file_path,
+                                          int64_t file_bytes) {
     std::string prefix;
-    RETURN_IF_ERROR(_exec_env->load_path_mgr()->allocate_dir(req->param(HTTP_DB_KEY), "", &prefix, file_bytes));
+    RETURN_IF_ERROR(_exec_env->load_path_mgr()->allocate_dir(req->param(HTTP_DB_KEY), "", &prefix,
+                                                             file_bytes));
     timeval tv;
     gettimeofday(&tv, nullptr);
     struct tm tm;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -153,9 +153,6 @@ void StreamLoadAction::handle(HttpRequest* req) {
     // update statistics
     streaming_load_requests_total->increment(1);
     streaming_load_duration_ms->increment(ctx->load_cost_millis);
-    if (!ctx->data_saved_path.empty()) {
-        _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
-      }
     if (_exec_env->load_path_mgr() != nullptr) {
         _exec_env->load_path_mgr()->clean_tmp_files(ctx->data_saved_path);
     } else {
@@ -437,8 +434,6 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         ctx->pipe = pipe;
         RETURN_IF_ERROR(_exec_env->new_load_stream_mgr()->put(ctx->id, ctx));
     } else {
-
-
         RETURN_IF_ERROR(_data_saved_path(http_req, &request.path, ctx->body_bytes));
         auto file_sink = std::make_shared<MessageBodyFileSink>(request.path);
         RETURN_IF_ERROR(file_sink->open());

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -51,6 +51,7 @@ private:
     Status _process_put(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
     void _save_stream_load_record(std::shared_ptr<StreamLoadContext> ctx, const std::string& str);
     Status _handle_group_commit(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
+
 private:
     ExecEnv* _exec_env;
 

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -47,11 +47,10 @@ public:
 private:
     Status _on_header(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
     Status _handle(std::shared_ptr<StreamLoadContext> ctx);
-    Status _data_saved_path(HttpRequest* req, std::string* file_path);
+    Status _data_saved_path(HttpRequest* req, std::string* file_path, int64_t file_bytes);
     Status _process_put(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
     void _save_stream_load_record(std::shared_ptr<StreamLoadContext> ctx, const std::string& str);
     Status _handle_group_commit(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
-
 private:
     ExecEnv* _exec_env;
 

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -107,7 +107,7 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
             int64_t remaining_bytes = _available_bytes - file_bytes;
             double used_ratio = 1.0 - static_cast<double>(remaining_bytes) / _disk_capacity_bytes;
             if (used_ratio >= config::storage_flood_stage_usage_percent / 100.0 &&
-                remaining_bytes <= config::storage_flood_stage_left_capacity_bytes) {  // 剩余空间少于10%
+                remaining_bytes <= config::storage_flood_stage_left_capacity_bytes) {
                 LOG(WARNING) << "Store path " << _path_vec[_idx]
                              << " has less than 10% free space, skip it";
                 ++path_vec_num;

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -127,7 +127,7 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
         }
     }
     if (path_vec_num == size) {
-        return Status::BufferAllocFailed("Store path has less than 10% free space");
+       return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>("exceed capacity limit.");
     }
     return status;
 }

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -104,6 +104,7 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
         RETURN_IF_ERROR(io::global_local_filesystem()->get_space_info(_path_vec[_idx], &disk_capacity_bytes, &available_bytes));
         check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
         if (!is_available) {
+            ++path_vec_num;
             continue;
         }
         // add SHARD_PREFIX for compatible purpose
@@ -116,7 +117,6 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
             *prefix = path;
             return Status::OK();
         }
-        ++path_vec_num;
     }
     if (path_vec_num == size) {
        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>("exceed capacity limit.");

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -101,7 +101,8 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
     size_t disk_capacity_bytes = 0;
     size_t available_bytes = 0;
     while (retry--) {
-        RETURN_IF_ERROR(io::global_local_filesystem()->get_space_info(_path_vec[_idx], &disk_capacity_bytes, &available_bytes));
+        RETURN_IF_ERROR(io::global_local_filesystem()->get_space_info(
+                _path_vec[_idx], &disk_capacity_bytes, &available_bytes));
         check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
         if (!is_available) {
             ++path_vec_num;
@@ -119,22 +120,23 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
         }
     }
     if (path_vec_num == size) {
-       return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>("exceed capacity limit.");
+        return Status::Error<DISK_REACH_CAPACITY_LIMIT, false>("exceed capacity limit.");
     }
     return status;
 }
 
-bool LoadPathMgr::check_disk_space( size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available) {
-        int64_t remaining_bytes = available_bytes - file_bytes;
-        double used_ratio = 1.0 - static_cast<double>(remaining_bytes) / disk_capacity_bytes;
-        *is_available = !(used_ratio >= config::storage_flood_stage_usage_percent / 100.0 &&
-                          remaining_bytes <= config::storage_flood_stage_left_capacity_bytes);
-        if (!*is_available) {
-            LOG(WARNING) << "Exceed capacity limit. disk_capacity: " << disk_capacity_bytes
-                         << ", available: " << available_bytes << ", file_bytes: " << file_bytes;
-        }
-        return is_available;
+bool LoadPathMgr::check_disk_space(size_t disk_capacity_bytes, size_t available_bytes,
+                                   int64_t file_bytes, bool* is_available) {
+    int64_t remaining_bytes = available_bytes - file_bytes;
+    double used_ratio = 1.0 - static_cast<double>(remaining_bytes) / disk_capacity_bytes;
+    *is_available = !(used_ratio >= config::storage_flood_stage_usage_percent / 100.0 &&
+                      remaining_bytes <= config::storage_flood_stage_left_capacity_bytes);
+    if (!*is_available) {
+        LOG(WARNING) << "Exceed capacity limit. disk_capacity: " << disk_capacity_bytes
+                     << ", available: " << available_bytes << ", file_bytes: " << file_bytes;
     }
+    return is_available;
+}
 
 bool LoadPathMgr::is_too_old(time_t cur_time, const std::string& label_dir, int64_t reserve_hours) {
     struct stat dir_stat;
@@ -200,7 +202,7 @@ void LoadPathMgr::process_path(time_t now, const std::string& path, int64_t rese
     }
 }
 
-void LoadPathMgr::clean_files_in_path_vec(const std::string& path){
+void LoadPathMgr::clean_files_in_path_vec(const std::string& path) {
     bool exists = false;
     // Check if the path exists
     Status status = io::global_local_filesystem()->exists(path, &exists);

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -102,7 +102,7 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
     size_t available_bytes = 0;
     while (retry--) {
         RETURN_IF_ERROR(io::global_local_filesystem()->get_space_info(_path_vec[_idx], &disk_capacity_bytes, &available_bytes));
-        RETURN_IF_ERROR(check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available));
+        check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
         if (!is_available) {
             continue;
         }
@@ -124,7 +124,7 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
     return status;
 }
 
-Status LoadPathMgr::check_disk_space( size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available) {
+bool LoadPathMgr::check_disk_space( size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available) {
         int64_t remaining_bytes = available_bytes - file_bytes;
         double used_ratio = 1.0 - static_cast<double>(remaining_bytes) / disk_capacity_bytes;
         *is_available = !(used_ratio >= config::storage_flood_stage_usage_percent / 100.0 &&
@@ -133,7 +133,7 @@ Status LoadPathMgr::check_disk_space( size_t disk_capacity_bytes, size_t availab
             LOG(WARNING) << "Exceed capacity limit. disk_capacity: " << disk_capacity_bytes
                          << ", available: " << available_bytes << ", file_bytes: " << file_bytes;
         }
-        return Status::OK();
+        return is_available;
     }
 
 bool LoadPathMgr::is_too_old(time_t cur_time, const std::string& label_dir, int64_t reserve_hours) {

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -198,14 +198,14 @@ void LoadPathMgr::process_path(time_t now, const std::string& path, int64_t rese
 
 void LoadPathMgr::clean_files_in_path_vec(const std::string& path){
     bool exists = false;
-    // 检查路径是否存在
+    // Check if the path exists
     Status status = io::global_local_filesystem()->exists(path, &exists);
     if (!status.ok()) {
         LOG(WARNING) << "Failed to check if path exists: " << path << ", error: " << status;
         return;
     }
     if (exists) {
-        // 若路径存在，则删除该路径对应的文件或目录
+        // If the path exists, delete the file or directory corresponding to that path
         status = io::global_local_filesystem()->delete_directory_or_file(path);
         if (status.ok()) {
             LOG(INFO) << "Delete path success: " << path;

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -100,7 +100,8 @@ Status LoadPathMgr::allocate_dir(const std::string& db, const std::string& label
     while (retry--) {
         {
             size_t _disk_capacity_bytes = 0;
-            size_t _available_bytes = 0;
+            size_t disk_capacity_bytes = 0;
+            size_t available_bytes = 0;
 
             RETURN_IF_ERROR(io::global_local_filesystem()->get_space_info(_path_vec[_idx], &_disk_capacity_bytes,
                                                                           &_available_bytes));

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -47,7 +47,7 @@ public:
 
     Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix, int64_t file_bytes);
 
-    Status check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available);
+    bool check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available);
 
     void get_load_data_path(std::vector<std::string>* data_paths);
 

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -47,6 +47,8 @@ public:
 
     Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix, int64_t file_bytes);
 
+    Status check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available);
+
     void get_load_data_path(std::vector<std::string>* data_paths);
 
     Status get_load_error_file_name(const std::string& db, const std::string& label,

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -45,7 +45,7 @@ public:
     Status init();
     void stop();
 
-    Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix);
+    Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix, int64_t file_bytes);
 
     void get_load_data_path(std::vector<std::string>* data_paths);
 
@@ -54,12 +54,18 @@ public:
     std::string get_load_error_absolute_path(const std::string& file_path);
     const std::string& get_load_error_file_dir() const { return _error_log_dir; }
 
+    void clean_tmp_files(const std::string& file_path) {
+        clean_files_in_path_vec(file_path);
+    }
+
 private:
     bool is_too_old(time_t cur_time, const std::string& label_dir, int64_t reserve_hours);
     void clean_one_path(const std::string& path);
     void clean_error_log();
     void clean();
     void process_path(time_t now, const std::string& path, int64_t reserve_hours);
+
+    void clean_files_in_path_vec(const std::string& path);
 
     ExecEnv* _exec_env = nullptr;
     std::mutex _lock;

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -45,9 +45,11 @@ public:
     Status init();
     void stop();
 
-    Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix, int64_t file_bytes);
+    Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix,
+                        int64_t file_bytes);
 
-    bool check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes, bool* is_available);
+    bool check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes,
+                          bool* is_available);
 
     void get_load_data_path(std::vector<std::string>* data_paths);
 
@@ -56,9 +58,7 @@ public:
     std::string get_load_error_absolute_path(const std::string& file_path);
     const std::string& get_load_error_file_dir() const { return _error_log_dir; }
 
-    void clean_tmp_files(const std::string& file_path) {
-        clean_files_in_path_vec(file_path);
-    }
+    void clean_tmp_files(const std::string& file_path) { clean_files_in_path_vec(file_path); }
 
 private:
     bool is_too_old(time_t cur_time, const std::string& label_dir, int64_t reserve_hours);

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -48,8 +48,7 @@ public:
     Status allocate_dir(const std::string& db, const std::string& label, std::string* prefix,
                         int64_t file_bytes);
 
-    bool check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes,
-                          bool* is_available);
+    bool check_disk_space(size_t disk_capacity_bytes, size_t available_bytes, int64_t file_bytes);
 
     void get_load_data_path(std::vector<std::string>* data_paths);
 

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -105,6 +105,8 @@ public:
         }
     }
 
+    std::string data_saved_path;
+
     std::string to_json() const;
 
     std::string prepare_stream_load_record(const std::string& stream_load_record);

--- a/be/test/runtime/stream_load_parquet_test.cpp
+++ b/be/test/runtime/stream_load_parquet_test.cpp
@@ -30,7 +30,7 @@ protected:
         // create tmp file
         _test_dir = "/tmp/test_clean_file";
         _test_dir1 = "/tmp/test_clean_file/mini_download";
-        _test_dir2 = "/tmp/test_clean_file/test.parquet";
+        _test_dir2 = "/tmp/test_clean_file1/mini_download/test.parquet";
 
         auto result = io::global_local_filesystem()->delete_directory_or_file(_test_dir1);
         result = io::global_local_filesystem()->create_directory(_test_dir1);
@@ -62,8 +62,8 @@ TEST_F(LoadPathMgrTest, CheckDiskSpaceTest) {
     size_t disk_capacity_bytes = 10;
     size_t available_bytes = 9;
     int64_t file_bytes = 1;
-    _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes,
-                                     &is_available);
+    is_available =
+            _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes);
     ASSERT_TRUE(is_available);
 
     // Check disk space
@@ -71,8 +71,8 @@ TEST_F(LoadPathMgrTest, CheckDiskSpaceTest) {
     disk_capacity_bytes = 10;
     available_bytes = 2;
     file_bytes = 1;
-    _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes,
-                                     &is_available);
+    is_available =
+            _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes);
     ASSERT_FALSE(is_available);
 
     std::string prefix;

--- a/be/test/runtime/stream_load_parquet_test.cpp
+++ b/be/test/runtime/stream_load_parquet_test.cpp
@@ -15,88 +15,85 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "runtime/load_path_mgr.h"
-#include "runtime/exec_env.h"
 #include "gtest/gtest.h"
 #include "olap/storage_engine.h"
+#include "runtime/exec_env.h"
+#include "runtime/load_path_mgr.h"
 namespace doris {
 
-    class LoadPathMgrTest : public testing::Test {
-    protected:
-        void SetUp() override {
-            _exec_env = ExecEnv::GetInstance();
+class LoadPathMgrTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
 
-            _load_path_mgr = std::make_unique<LoadPathMgr>(_exec_env);
+        _load_path_mgr = std::make_unique<LoadPathMgr>(_exec_env);
+        // create tmp file
+        _test_dir = "/tmp/test_clean_file";
+        _test_dir1 = "/tmp/test_clean_file/mini_download";
+        _test_dir2 = "/tmp/test_clean_file/test.parquet";
 
-            // 创建临时测试目录
-            _test_dir = "/tmp/test_clean_file";
-            _test_dir1 = "/tmp/test_clean_file/mini_download";
-            _test_dir2 = "/tmp/test_clean_file/test.parquet";
+        auto result = io::global_local_filesystem()->delete_directory_or_file(_test_dir1);
+        result = io::global_local_filesystem()->create_directory(_test_dir1);
+        EXPECT_TRUE(result.ok());
 
-            auto result =  io::global_local_filesystem()->delete_directory_or_file(_test_dir1);
-            result = io::global_local_filesystem()->create_directory(_test_dir1);
-            EXPECT_TRUE(result.ok());
+        result = io::global_local_filesystem()->delete_directory_or_file(_test_dir2);
+        result = io::global_local_filesystem()->create_directory(_test_dir2);
+        EXPECT_TRUE(result.ok());
 
-            result =  io::global_local_filesystem()->delete_directory_or_file(_test_dir2);
-            result = io::global_local_filesystem()->create_directory(_test_dir2);
-            EXPECT_TRUE(result.ok());
-
-            const_cast<std::vector<StorePath>&>(_exec_env->store_paths()).emplace_back(_test_dir, 1024);
-
-        }
-
-        void TearDown() override {
-            const_cast<std::vector<StorePath>&>(_exec_env->store_paths()).clear();
-            _load_path_mgr->stop();
-            _exec_env->destroy();
-
-        }
-
-        ExecEnv* _exec_env;
-        std::unique_ptr<LoadPathMgr> _load_path_mgr;
-        std::string _test_dir;
-        std::string _test_dir1;
-        std::string _test_dir2;
-    };
-
-    TEST_F(LoadPathMgrTest, CheckDiskSpaceTest) {
-
-        // Check disk space
-        bool is_available = false;
-        size_t disk_capacity_bytes = 10;
-        size_t available_bytes = 9;
-        int64_t file_bytes = 1;
-        _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
-        ASSERT_TRUE(is_available);
-
-        // Check disk space
-        is_available = false;
-        disk_capacity_bytes = 10;
-        available_bytes = 2;
-        file_bytes = 1;
-        _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
-        ASSERT_FALSE(is_available);
-
-        std::string prefix;
-        Status status = _load_path_mgr->allocate_dir("tmp", "test_label1", &prefix, 1);
-        EXPECT_TRUE(status.ok());
-        std::cout << "NormalAllocation: " << prefix.size() << std::endl;
-        EXPECT_FALSE(prefix.empty());
-
-        prefix.clear();
-        status = _load_path_mgr->allocate_dir("tmp", "test_label2", &prefix, 999999999999999999);
-        EXPECT_TRUE(!status.ok());
-        std::cout << "UnNormalAllocation: " << prefix.size() << std::endl;
-        EXPECT_TRUE(prefix.empty());
-
-        std::cout << "clean_tmp_files" << std::endl;
-        bool exists = false;
-        status = io::global_local_filesystem()->exists(_test_dir2, &exists);
-        EXPECT_TRUE(exists);
-        _load_path_mgr->clean_tmp_files(_test_dir2);
-        status = io::global_local_filesystem()->exists(_test_dir2, &exists);
-        EXPECT_FALSE(exists);
-
+        const_cast<std::vector<StorePath>&>(_exec_env->store_paths()).emplace_back(_test_dir, 1024);
     }
+
+    void TearDown() override {
+        const_cast<std::vector<StorePath>&>(_exec_env->store_paths()).clear();
+        _load_path_mgr->stop();
+        _exec_env->destroy();
+    }
+
+    ExecEnv* _exec_env;
+    std::unique_ptr<LoadPathMgr> _load_path_mgr;
+    std::string _test_dir;
+    std::string _test_dir1;
+    std::string _test_dir2;
+};
+
+TEST_F(LoadPathMgrTest, CheckDiskSpaceTest) {
+    // Check disk space
+    bool is_available = false;
+    size_t disk_capacity_bytes = 10;
+    size_t available_bytes = 9;
+    int64_t file_bytes = 1;
+    _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes,
+                                     &is_available);
+    ASSERT_TRUE(is_available);
+
+    // Check disk space
+    is_available = false;
+    disk_capacity_bytes = 10;
+    available_bytes = 2;
+    file_bytes = 1;
+    _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes,
+                                     &is_available);
+    ASSERT_FALSE(is_available);
+
+    std::string prefix;
+    Status status = _load_path_mgr->allocate_dir("tmp", "test_label1", &prefix, 1);
+    EXPECT_TRUE(status.ok());
+    std::cout << "NormalAllocation: " << prefix.size() << std::endl;
+    EXPECT_FALSE(prefix.empty());
+
+    prefix.clear();
+    status = _load_path_mgr->allocate_dir("tmp", "test_label2", &prefix, 999999999999999999);
+    EXPECT_TRUE(!status.ok());
+    std::cout << "UnNormalAllocation: " << prefix.size() << std::endl;
+    EXPECT_TRUE(prefix.empty());
+
+    std::cout << "clean_tmp_files" << std::endl;
+    bool exists = false;
+    status = io::global_local_filesystem()->exists(_test_dir2, &exists);
+    EXPECT_TRUE(exists);
+    _load_path_mgr->clean_tmp_files(_test_dir2);
+    status = io::global_local_filesystem()->exists(_test_dir2, &exists);
+    EXPECT_FALSE(exists);
+}
 
 } // namespace doris

--- a/be/test/runtime/stream_load_parquet_test.cpp
+++ b/be/test/runtime/stream_load_parquet_test.cpp
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/load_path_mgr.h"
+#include "runtime/exec_env.h"
+#include "gtest/gtest.h"
+#include "olap/storage_engine.h"
+namespace doris {
+
+    class LoadPathMgrTest : public testing::Test {
+    protected:
+        void SetUp() override {
+            _exec_env = ExecEnv::GetInstance();
+            _load_path_mgr = std::make_unique<LoadPathMgr>(_exec_env);
+
+            // 创建临时测试目录
+            _test_dir = "/tmp/test_clean_file";
+            io::global_local_filesystem()->delete_directory_or_file(_test_dir);
+            io::global_local_filesystem()->create_directory(_test_dir);
+        }
+
+        void TearDown() override {
+            _load_path_mgr->stop();
+            _exec_env->destroy();
+        }
+
+        ExecEnv* _exec_env;
+        std::unique_ptr<LoadPathMgr> _load_path_mgr;
+        std::string _test_dir;
+    };
+
+    TEST_F(LoadPathMgrTest, CheckDiskSpaceTest) {
+
+        // Check disk space
+        bool is_available = false;
+        size_t disk_capacity_bytes = 10;
+        size_t available_bytes = 9;
+        int64_t file_bytes = 1;
+        _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
+        ASSERT_TRUE(is_available);
+
+        // Check disk space
+        is_available = false;
+        disk_capacity_bytes = 10;
+        available_bytes = 2;
+        file_bytes = 1;
+        _load_path_mgr->check_disk_space(disk_capacity_bytes, available_bytes, file_bytes, &is_available);
+        ASSERT_FALSE(is_available);
+
+        SUCCEED();
+    }
+
+} // namespace doris

--- a/be/test/runtime/stream_load_parquet_test.cpp
+++ b/be/test/runtime/stream_load_parquet_test.cpp
@@ -31,9 +31,14 @@ namespace doris {
             // 创建临时测试目录
             _test_dir = "/tmp/test_clean_file";
             _test_dir1 = "/tmp/test_clean_file/mini_download";
+            _test_dir2 = "/tmp/test_clean_file/test.parquet";
 
             auto result =  io::global_local_filesystem()->delete_directory_or_file(_test_dir1);
             result = io::global_local_filesystem()->create_directory(_test_dir1);
+            EXPECT_TRUE(result.ok());
+
+            result =  io::global_local_filesystem()->delete_directory_or_file(_test_dir2);
+            result = io::global_local_filesystem()->create_directory(_test_dir2);
             EXPECT_TRUE(result.ok());
 
             const_cast<std::vector<StorePath>&>(_exec_env->store_paths()).emplace_back(_test_dir, 1024);
@@ -51,6 +56,7 @@ namespace doris {
         std::unique_ptr<LoadPathMgr> _load_path_mgr;
         std::string _test_dir;
         std::string _test_dir1;
+        std::string _test_dir2;
     };
 
     TEST_F(LoadPathMgrTest, CheckDiskSpaceTest) {
@@ -82,6 +88,14 @@ namespace doris {
         EXPECT_TRUE(!status.ok());
         std::cout << "UnNormalAllocation: " << prefix.size() << std::endl;
         EXPECT_TRUE(prefix.empty());
+
+        std::cout << "clean_tmp_files" << std::endl;
+        bool exists = false;
+        status = io::global_local_filesystem()->exists(_test_dir2, &exists);
+        EXPECT_TRUE(exists);
+        _load_path_mgr->clean_tmp_files(_test_dir2);
+        status = io::global_local_filesystem()->exists(_test_dir2, &exists);
+        EXPECT_FALSE(exists);
 
     }
 

--- a/be/test/runtime/stream_load_parquet_test.cpp
+++ b/be/test/runtime/stream_load_parquet_test.cpp
@@ -64,4 +64,10 @@ namespace doris {
         SUCCEED();
     }
 
+    TEST_F(LoadPathMgrTest, NormalAllocation) {
+        std::string prefix;
+        Status status = _load_path_mgr->allocate_dir("tmp", "test_label", &prefix, 1024);
+        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(prefix.empty());
+    }
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: At present, when using stream-load to import a Parquet file, the file is not deleted after successful import, which can easily lead to insufficient storage file disk space. This problem also occurs when the imported Parquet file is large. This PR is designed to solve the above problems

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

