### PR TITLE
[fix] last failed version should not greater than commit version when report missed version

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -1262,7 +1262,8 @@ public class ReportHandler extends Daemon {
                                 // Because last failed version should always larger than replica's version.
                                 long newLastFailedVersion = replica.getLastFailedVersion();
                                 if (newLastFailedVersion < 0) {
-                                    newLastFailedVersion = replica.getVersion() + 1;
+                                    newLastFailedVersion = Math.min(partition.getCommittedVersion(),
+                                            replica.getVersion() + 1);
                                     replica.updateLastFailedVersion(newLastFailedVersion);
                                     LOG.warn("set missing version for replica {} of tablet {} on backend {}, "
                                             + "version in fe {}, version in be {}, be missing {}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

fe处理be上报的relica版本缺失时，直接将lastFailedVersion设置为version+1，可能大于partition的commit version，导致故障副本不能通过clone恢复。当只有两个副本时，这将导致写入一直失败。


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

