### PR TITLE
[fix](stream loader) do not redirect to https for stream load

### DIFF
--- a/fe/.idea/vcs.xml
+++ b/fe/.idea/vcs.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-  -->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
@@ -27,6 +11,8 @@
     </option>
   </component>
   <component name="VcsDirectoryMappings">
-      <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../be/src/apache-orc" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../be/src/clucene" vcs="Git" />
   </component>
 </project>

--- a/fe/.idea/vcs.xml
+++ b/fe/.idea/vcs.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
@@ -11,8 +27,6 @@
     </option>
   </component>
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../be/src/apache-orc" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../be/src/clucene" vcs="Git" />
+      <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>
 </project>

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -145,9 +145,6 @@ public class LoadAction extends RestBaseController {
                 }
             }
         }
-        if (needRedirect(request.getScheme())) {
-            return redirectToHttps(request);
-        }
 
         String authToken = request.getHeader("token");
         // if auth token is not null, check it first

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -104,10 +104,6 @@ public class LoadAction extends RestBaseController {
     @RequestMapping(path = "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_load", method = RequestMethod.PUT)
     public Object load(HttpServletRequest request, HttpServletResponse response,
             @PathVariable(value = DB_KEY) String db, @PathVariable(value = TABLE_KEY) String table) {
-        if (needRedirect(request.getScheme())) {
-            return redirectToHttps(request);
-        }
-
         if (Config.disable_mini_load) {
             ResponseEntity entity = ResponseEntityBuilder.notFound("The mini load operation has been"
                     + " disabled by default, if you need to add disable_mini_load=false in fe.conf.");
@@ -260,10 +256,6 @@ public class LoadAction extends RestBaseController {
             HttpServletResponse response,
             @PathVariable(value = DB_KEY) String db) {
         LOG.info("streamload action 2PC, db: {}, headers: {}", db, getAllHeaders(request));
-        if (needRedirect(request.getScheme())) {
-            return redirectToHttps(request);
-        }
-
         executeCheckPassword(request, response);
         return executeStreamLoad2PC(request, db);
     }
@@ -274,10 +266,6 @@ public class LoadAction extends RestBaseController {
             @PathVariable(value = DB_KEY) String db,
             @PathVariable(value = TABLE_KEY) String table) {
         LOG.info("streamload action 2PC, db: {}, tbl: {}, headers: {}", db, table, getAllHeaders(request));
-        if (needRedirect(request.getScheme())) {
-            return redirectToHttps(request);
-        }
-
         executeCheckPassword(request, response);
         return executeStreamLoad2PC(request, db);
     }
@@ -724,10 +712,6 @@ public class LoadAction extends RestBaseController {
     public Object createIngestionLoad(HttpServletRequest request, HttpServletResponse response,
                                   @PathVariable(value = CATALOG_KEY) String catalog,
                                   @PathVariable(value = DB_KEY) String db) {
-        if (needRedirect(request.getScheme())) {
-            return redirectToHttps(request);
-        }
-
         executeCheckPassword(request, response);
 
         if (!InternalCatalog.INTERNAL_CATALOG_NAME.equals(catalog)) {
@@ -845,10 +829,6 @@ public class LoadAction extends RestBaseController {
     public Object updateIngestionLoad(HttpServletRequest request, HttpServletResponse response,
                                       @PathVariable(value = CATALOG_KEY) String catalog,
                                       @PathVariable(value = DB_KEY) String db) {
-        if (needRedirect(request.getScheme())) {
-            return redirectToHttps(request);
-        }
-
         executeCheckPassword(request, response);
 
         if (!InternalCatalog.INTERNAL_CATALOG_NAME.equals(catalog)) {


### PR DESCRIPTION
### What problem does this PR solve?
auditlog stream load plugin does not work when https is enabled.
The reason is when https is enabled, LoadAction will add an extra redirection(from http to https), which breaks the process of audit plugin.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

