### PR TITLE
[fix](resource) Fix `S3FileWriter` thread attach task

### DIFF
--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -45,6 +45,7 @@
 #include "io/fs/s3_file_writer.h"
 #include "io/fs/s3_obj_storage_client.h"
 #include "runtime/exec_env.h"
+#include "runtime/thread_context.h"
 #include "util/s3_uri.h"
 #include "util/s3_util.h"
 
@@ -357,6 +358,7 @@ Status S3FileSystem::batch_upload_impl(const std::vector<Path>& local_files,
     std::vector<FileWriterPtr> obj_writers(local_files.size());
 
     auto upload_task = [&, this](size_t idx) {
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->s3_file_buffer_tracker());
         const auto& local_file = local_files[idx];
         const auto& remote_file = remote_files[idx];
         auto& obj_writer = obj_writers[idx];


### PR DESCRIPTION
### What problem does this PR solve?

Fix 1 
```
read.F20250412 04:16:47.972313 198085 thread_context.h:204] Check failed: is_attach_task() 
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# Allocator<false, false, false, DefaultMemoryAllocator>::sys_memory_check(unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.cpp:191
11# Allocator<false, false, false, DefaultMemoryAllocator>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.h:254
12# doris::io::Memory<Allocator<false, false, false, DefaultMemoryAllocator> >::Memory(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:48
13# doris::io::FileBuffer::FileBuffer(doris::io::BufferType, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>, unsigned long, doris::io::OperationState) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:86
14# doris::io::UploadFileBuffer::UploadFileBuffer(std::function<void (doris::io::UploadFileBuffer&)>, doris::io::OperationState, unsigned long, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.h:157
15# decltype (::new ((void*)(0)) doris::io::UploadFileBuffer(std::declval<std::function<void (doris::io::UploadFileBuffer&)> >(), std::declval<doris::io::OperationState>(), std::declval<unsigned long&>(), std::declval<std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()> >())) std::construct_at<doris::io::UploadFileBuffer, std::function<void (doris::io::UploadFileBuffer&)>, doris::io::OperationState, unsigned long&, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()> >(doris::io::UploadFileBuffer*, std::function<void (doris::io::UploadFileBuffer&)>&&, doris::io::OperationState&&, unsigned long&, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97
16# doris::io::FileBufferBuilder::build(std::shared_ptr<doris::io::FileBuffer>*) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:247
17# doris::io::S3FileWriter::_build_upload_buffer() at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:199
18# doris::io::S3FileWriter::_close_impl() at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:215
19# doris::io::S3FileWriter::close(bool) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:156
20# doris::vectorized::ParquetOutputStream::Close() at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vparquet_transformer.cpp:85
21# doris::vectorized::ParquetOutputStream::~ParquetOutputStream() at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vparquet_transformer.cpp:58
22# doris::vectorized::ParquetOutputStream::~ParquetOutputStream() at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vparquet_transformer.cpp:56
23# doris::vectorized::VParquetTransformer::~VParquetTransformer() at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vparquet_transformer.h:110
24# doris::vectorized::VParquetTransformer::~VParquetTransformer() at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vparquet_transformer.h:110
25# doris::vectorized::VFileResultWriter::~VFileResultWriter() at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/writer/vfile_result_writer.h:56
26# doris::pipeline::AsyncWriterSink<doris::vectorized::VFileResultWriter, doris::pipeline::ResultFileSinkOperatorX>::~AsyncWriterSink() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:1059
27# doris::pipeline::ResultFileSinkLocalState::~ResultFileSinkLocalState() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/result_file_sink_operator.cpp:57
28# doris::RuntimeState::~RuntimeState() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/runtime_state.cpp:211
29# doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_fragment_context.cpp:149
30# std::_Function_handler<void (), doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
```

Fix 2:
```
F20250411 00:00:31.856455 173889 thread_context.h:204] Check failed: is_attach_task()
9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# Allocator<false, false, false, DefaultMemoryAllocator>::sys_memory_check(unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.cpp:191
11# Allocator<false, false, false, DefaultMemoryAllocator>::alloc_impl(unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/allocator.h:254
12# doris::io::Memory<Allocator<false, false, false, DefaultMemoryAllocator> >::Memory(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:48
13# doris::io::FileBuffer::FileBuffer(doris::io::BufferType, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>, unsigned long, doris::io::OperationState) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:86
14# doris::io::UploadFileBuffer::UploadFileBuffer(std::function<void (doris::io::UploadFileBuffer&)>, doris::io::OperationState, unsigned long, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.h:157
15# decltype (::new ((void*)(0)) doris::io::UploadFileBuffer(std::declval<std::function<void (doris::io::UploadFileBuffer&)> >(), std::declval<doris::io::OperationState>(), std::declval<unsigned long&>(), std::declval<std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()> >())) std::construct_at<doris::io::UploadFileBuffer, std::function<void (doris::io::UploadFileBuffer&)>, doris::io::OperationState, unsigned long&, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()> >(doris::io::UploadFileBuffer*, std::function<void (doris::io::UploadFileBuffer&)>&&, doris::io::OperationState&&, unsigned long&, std::function<std::unique_ptr<doris::io::FileBlocksHolder, std::default_delete<doris::io::FileBlocksHolder> > ()>&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97
16# doris::io::FileBufferBuilder::build(std::shared_ptr<doris::io::FileBuffer>*) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_bufferpool.cpp:247
17# doris::io::S3FileWriter::_build_upload_buffer() at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:199
18# doris::io::S3FileWriter::appendv(doris::Slice const*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_writer.cpp:251
19# std::enable_if<is_invocable_r_v<doris::Status, doris::io::S3FileSystem::batch_upload_impl(std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&, std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&)::$_0&, unsigned long>, doris::Status>::type std::__invoke_r<doris::Status, doris::io::S3FileSystem::batch_upload_impl(std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&, std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&)::$_0&, unsigned long>(doris::io::S3FileSystem::batch_upload_impl(std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&, std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&)::$_0&, unsigned long&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
20# std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<doris::Status>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_state<doris::io::S3FileSystem::batch_upload_impl(std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&, std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&)::$_0, std::allocator<int>, doris::Status (unsigned long)>::_M_run(unsigned long&&)::{lambda()#1}, doris::Status> >::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
21# std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/future:575
22# __pthread_once_slow at ./nptl/pthread_once.c:118
23# std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>, bool) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/future:411
24# std::__future_base::_Task_state<doris::io::S3FileSystem::batch_upload_impl(std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&, std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&)::$_0, std::allocator<int>, doris::Status (unsigned long)>::_M_run(unsigned long&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/future:1447
25# std::_Function_handler<void (), doris::io::S3FileSystem::batch_upload_impl(std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&, std::vector<std::filesystem::__cxx11::path, std::allocator<std::filesystem::__cxx11::path> > const&)::$_1>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

