### PR TITLE
[opt](recycler) Speed up recycling txn info by introducing parallelism

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2674,6 +2674,7 @@ int InstanceRecycler::recycle_expired_txn_label() {
                     .tag("instance_id", instance_id_);
             return ret;
         }
+        recycle_txn_info_keys.clear();
         return ret;
     };
 

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2583,6 +2583,7 @@ int InstanceRecycler::recycle_expired_txn_label() {
         // Remove txn index kv
         auto index_key = txn_index_key({instance_id_, txn_id});
         txn->remove(index_key);
+        // Remove txn info kv
         std::string info_key, info_val;
         txn_info_key({instance_id_, db_id, txn_id}, &info_key);
         err = txn->get(info_key, &info_val);
@@ -2595,6 +2596,7 @@ int InstanceRecycler::recycle_expired_txn_label() {
             LOG_WARNING("failed to parse txn info").tag("key", hex(info_key));
             return -1;
         }
+        txn->remove(info_key);
         // Remove sub txn index kvs
         std::vector<std::string> sub_txn_index_keys;
         for (auto sub_txn_id : txn_info.sub_txn_ids()) {
@@ -2631,8 +2633,6 @@ int InstanceRecycler::recycle_expired_txn_label() {
             }
             txn->atomic_set_ver_value(label_key, label_val);
         }
-        // Remove txn info kv
-        txn->remove(info_key);
         // Remove recycle txn kv
         txn->remove(k);
         err = txn->commit();

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2500,6 +2500,7 @@ int InstanceRecycler::recycle_expired_txn_label() {
     int64_t num_scanned = 0;
     int64_t num_expired = 0;
     int64_t num_recycled = 0;
+    int ret = 0;
 
     RecycleTxnKeyInfo recycle_txn_key_info0 {instance_id_, 0, 0};
     RecycleTxnKeyInfo recycle_txn_key_info1 {instance_id_, INT64_MAX, INT64_MAX};
@@ -2507,6 +2508,7 @@ int InstanceRecycler::recycle_expired_txn_label() {
     std::string end_recycle_txn_key;
     recycle_txn_key(recycle_txn_key_info0, &begin_recycle_txn_key);
     recycle_txn_key(recycle_txn_key_info1, &end_recycle_txn_key);
+    std::vector<std::string> recycle_txn_info_keys;
 
     LOG_INFO("begin to recycle expired txn").tag("instance_id", instance_id_);
 
@@ -2534,12 +2536,15 @@ int InstanceRecycler::recycle_expired_txn_label() {
         return final_expiration;
     };
 
+    SyncExecutor<int> concurrent_delete_executor(
+            _thread_pool_group.s3_producer_pool,
+            fmt::format("recycle expired txn label, instance id {}", instance_id_),
+            [](const int& ret) { return ret != 0; });
+
     int64_t current_time_ms =
             duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 
-    auto handle_recycle_txn_kv = [&num_scanned, &num_expired, &num_recycled, &current_time_ms,
-                                  &calc_expiration,
-                                  this](std::string_view k, std::string_view v) -> int {
+    auto handle_recycle_txn_kv = [&](std::string_view k, std::string_view v) -> int {
         ++num_scanned;
         RecycleTxnPB recycle_txn_pb;
         if (!recycle_txn_pb.ParseFromArray(v.data(), v.size())) {
@@ -2551,10 +2556,12 @@ int InstanceRecycler::recycle_expired_txn_label() {
             (calc_expiration(recycle_txn_pb) <= current_time_ms)) {
             VLOG_DEBUG << "found recycle txn, key=" << hex(k);
             num_expired++;
-        } else {
-            return 0;
+            recycle_txn_info_keys.emplace_back(k);
         }
+        return 0;
+    };
 
+    auto delete_recycle_txn_kv = [&](const std::string& k) -> int {
         std::string_view k1 = k;
         //RecycleTxnKeyInfo 0:instance_id  1:db_id  2:txn_id
         k1.remove_prefix(1); // Remove key space
@@ -2638,8 +2645,40 @@ int InstanceRecycler::recycle_expired_txn_label() {
         return 0;
     };
 
+    auto loop_done = [&]() -> int {
+        for (const auto& k : recycle_txn_info_keys) {
+            concurrent_delete_executor.add([&]() {
+                if (delete_recycle_txn_kv(k) != 0) {
+                    LOG_WARNING("failed to delete recycle txn kv")
+                            .tag("instance id", instance_id_)
+                            .tag("key", hex(k));
+                    return -1;
+                }
+                return 0;
+            });
+        }
+        bool finished = true;
+        std::vector<int> rets = concurrent_delete_executor.when_all(&finished);
+        for (int r : rets) {
+            if (r != 0) {
+                ret = -1;
+            }
+        }
+
+        ret = finished ? ret : -1;
+
+        if (ret != 0) {
+            LOG_WARNING("recycle txn kv ret!=0")
+                    .tag("finished", finished)
+                    .tag("ret", ret)
+                    .tag("instance_id", instance_id_);
+            return ret;
+        }
+        return ret;
+    };
+
     return scan_and_recycle(begin_recycle_txn_key, end_recycle_txn_key,
-                            std::move(handle_recycle_txn_kv));
+                            std::move(handle_recycle_txn_kv), std::move(loop_done));
 }
 
 struct CopyJobIdTuple {

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -2583,7 +2583,6 @@ int InstanceRecycler::recycle_expired_txn_label() {
         // Remove txn index kv
         auto index_key = txn_index_key({instance_id_, txn_id});
         txn->remove(index_key);
-        // Remove txn info kv
         std::string info_key, info_val;
         txn_info_key({instance_id_, db_id, txn_id}, &info_key);
         err = txn->get(info_key, &info_val);
@@ -2596,7 +2595,6 @@ int InstanceRecycler::recycle_expired_txn_label() {
             LOG_WARNING("failed to parse txn info").tag("key", hex(info_key));
             return -1;
         }
-        txn->remove(info_key);
         // Remove sub txn index kvs
         std::vector<std::string> sub_txn_index_keys;
         for (auto sub_txn_id : txn_info.sub_txn_ids()) {
@@ -2633,6 +2631,8 @@ int InstanceRecycler::recycle_expired_txn_label() {
             }
             txn->atomic_set_ver_value(label_key, label_val);
         }
+        // Remove txn info kv
+        txn->remove(info_key);
         // Remove recycle txn kv
         txn->remove(k);
         err = txn->commit();

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
     config::recycler_sleep_before_scheduling_seconds = 0; // we dont have to wait in UT
 
     ::testing::InitGoogleTest(&argc, argv);
+    config::recycle_pool_parallelism=1;
     auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
     s3_producer_pool->start();
     auto recycle_tablet_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -4288,21 +4288,24 @@ void check_multiple_txn_info_kvs(std::shared_ptr<cloud::TxnKv> txn_kv, int64_t s
 }
 
 TEST(RecyclerTest, concurrent_recycle_txn_label_test) {
+    config::label_keep_max_second = 259200;
     doris::cloud::RecyclerThreadPoolGroup recycle_txn_label_thread_group;
     config::recycle_pool_parallelism = 10;
-    auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
-    s3_producer_pool->start();
-    auto recycle_tablet_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
-    recycle_tablet_pool->start();
-    auto group_recycle_function_pool =
+    auto recycle_txn_label_s3_producer_pool =
             std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
-    group_recycle_function_pool->start();
+    recycle_txn_label_s3_producer_pool->start();
+    auto recycle_txn_label_recycle_tablet_pool =
+            std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
+    recycle_txn_label_recycle_tablet_pool->start();
+    auto recycle_txn_label_group_recycle_function_pool =
+            std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
+    recycle_txn_label_group_recycle_function_pool->start();
     recycle_txn_label_thread_group =
-            RecyclerThreadPoolGroup(std::move(s3_producer_pool), std::move(recycle_tablet_pool),
-                                    std::move(group_recycle_function_pool));
-    cloud::config::init(nullptr, true);
+            RecyclerThreadPoolGroup(std::move(recycle_txn_label_s3_producer_pool),
+                                    std::move(recycle_txn_label_recycle_tablet_pool),
+                                    std::move(recycle_txn_label_group_recycle_function_pool));
 
-    auto mem_txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    auto mem_txn_kv = std::make_shared<MemTxnKv>();
 
     // cloud::config::fdb_cluster_file_path = "fdb.cluster";
     // auto fdb_txn_kv = std::dynamic_pointer_cast<cloud::TxnKv>(std::make_shared<cloud::FdbTxnKv>());

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -72,7 +72,6 @@ int main(int argc, char** argv) {
     config::recycler_sleep_before_scheduling_seconds = 0; // we dont have to wait in UT
 
     ::testing::InitGoogleTest(&argc, argv);
-    config::recycle_pool_parallelism=1;
     auto s3_producer_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
     s3_producer_pool->start();
     auto recycle_tablet_pool = std::make_shared<SimpleThreadPool>(config::recycle_pool_parallelism);
@@ -4075,8 +4074,8 @@ int put_single_kv(const std::unique_ptr<Transaction>& txn, int64_t i) {
     std::string key;
     std::string val;
     int64_t db_id = i;
-    int64_t txn_id = 10000 + i;
-    int64_t sub_txn_id = 20000 + i;
+    int64_t txn_id = 100000 + i;
+    int64_t sub_txn_id = 200000 + i;
     int64_t current_time = duration_cast<std::chrono::milliseconds>(
                                    std::chrono::system_clock::now().time_since_epoch())
                                    .count();
@@ -4266,8 +4265,9 @@ void check_kv(std::shared_ptr<cloud::TxnKv> txn_kv, int64_t size) {
 }
 
 TEST(RecyclerTest, concurrent_recycle_txn_label_test) {
+    config::recycle_pool_parallelism = 32;
     cloud::config::init(nullptr, true);
-    cloud::config::fdb_cluster_file_path = "/mnt/disk2/lianyukang/doris/fdb_cluster";
+    cloud::config::fdb_cluster_file_path = "fdb.cluster";
     auto fdb_txn_kv = std::dynamic_pointer_cast<cloud::TxnKv>(std::make_shared<cloud::FdbTxnKv>());
     ASSERT_TRUE(fdb_txn_kv.get()) << "exit get FdbTxnKv error" << std::endl;
     ASSERT_EQ(fdb_txn_kv->init(), 0) << "exit inti FdbTxnKv error" << std::endl;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This PR changes the recycle txn label function to a concurrent recycle implementation.

Performance Comparison: Using release mode, connecting to FDB, and recycling 10,000 transaction-related key-value pairs.

|      | cost(ms) |
| ----------- | ----------- |
| Before this PR      | 15229       |
| After this PR (1 concurrent)   | 18764        |
| After this PR (2 concurrent)   | 8844        |
| After this PR (5 concurrent)   | 3890        |
| After this PR (10 concurrent)   | 2165        |
| After this PR (20 concurrent)   | 1248        |

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

