### PR TITLE
[fix](cloud) remove unnecessary DCHECK existence when delete file cache directory

### DIFF
--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -217,7 +217,6 @@ Status FSFileCacheStorage::remove(const FileCacheKey& key) {
     std::vector<FileInfo> files;
     bool exists {false};
     RETURN_IF_ERROR(fs->list(dir, true, &files, &exists));
-    DCHECK(exists);
     if (files.empty()) {
         RETURN_IF_ERROR(fs->delete_directory(dir));
     }


### PR DESCRIPTION
Remove has been make async in recent code base, so multiple threads could operate on filesystem. The DCHECK is not guranteed to be exist no more and such DCHECK becomes unnecessary

The deletion is meant to make the directory disappear and the removal logic will handle the non-existence case correctly.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

