### PR TITLE
[Fix](inverted index) fix rename column build index bug

### DIFF
--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -748,9 +748,8 @@ void TabletIndex::init_from_thrift(const TOlapTableIndex& index,
             col_unique_ids[i] = tablet_schema.column(column_idx).unique_id();
         } else {
             // if column unique id not found by column name, find by column unique id
-            // column unique id can not bigger than tablet schema column size, if bigger than column size means
-            // this column is a new column added by light schema change
-            if (index.__isset.column_unique_ids &&
+            // column unique id can not found means this column is a new column added by light schema change
+            if (index.__isset.column_unique_ids && !index.column_unique_ids.empty() &&
                 tablet_schema.has_column_unique_id(index.column_unique_ids[i])) {
                 col_unique_ids[i] = index.column_unique_ids[i];
             } else {

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -751,7 +751,7 @@ void TabletIndex::init_from_thrift(const TOlapTableIndex& index,
             // column unique id can not bigger than tablet schema column size, if bigger than column size means
             // this column is a new column added by light schema change
             if (index.__isset.column_unique_ids &&
-                index.column_unique_ids[i] < tablet_schema.num_columns()) {
+                tablet_schema.has_column_unique_id(index.column_unique_ids[i])) {
                 col_unique_ids[i] = index.column_unique_ids[i];
             } else {
                 col_unique_ids[i] = -1;

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -400,7 +400,8 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 auto column_name = inverted_index.columns[0];
                 auto column_idx = output_rowset_schema->field_index(column_name);
                 if (column_idx < 0) {
-                    if (!inverted_index.column_unique_ids.empty()) {
+                    if (inverted_index.__isset.column_unique_ids &&
+                        !inverted_index.column_unique_ids.empty()) {
                         column_idx = output_rowset_schema->field_index(
                                 inverted_index.column_unique_ids[0]);
                     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
fix DCHECK error after multiple add/drop rename column when building inverted index

```
F20250408 11:43:45.886974 1066024 index_builder.cpp:423] Check failed: output_rowset_schema->has_inverted_index_with_index_id(index_id) 
*** Check failure stack trace: ***
F20250408 11:43:45.886988 1066022 index_builder.cpp:423] Check failed: output_rowset_schema->has_inverted_index_with_index_id(index_id) 
*** Check failure stack trace: ***
    @     0x590b0f234d26  google::LogMessage::SendToLog()
    @     0x590b0f234d26  google::LogMessage::SendToLog()
    @     0x590b0f231770  google::LogMessage::Flush()
    @     0x590b0f231770  google::LogMessage::Flush()
    @     0x590b0f235569  google::LogMessageFatal::~LogMessageFatal()
    @     0x590b0f235569  google::LogMessageFatal::~LogMessageFatal()
    @     0x590ad85d3459  doris::IndexBuilder::handle_single_rowset()
    @     0x590ad85daf25  doris::IndexBuilder::handle_inverted_index_data()
    @     0x590ad85d3459  doris::IndexBuilder::handle_single_rowset()
    @     0x590ad85ddc31  doris::IndexBuilder::do_build_inverted_index()
    @     0x590ad85daf25  doris::IndexBuilder::handle_inverted_index_data()
    @     0x590ad711ad86  doris::StorageEngine::_handle_index_change()
    @     0x590ad85ddc31  doris::IndexBuilder::do_build_inverted_index()
    @     0x590ad711a1da  doris::StorageEngine::process_index_change_task()
    @     0x590ad711ad86  doris::StorageEngine::_handle_index_change()
    @     0x590ad857b89d  doris::EngineIndexChangeTask::execute()
    @     0x590ad711a1da  doris::StorageEngine::process_index_change_task()
    @     0x590ad49deea2  doris::alter_inverted_index_callback()
    @     0x590ad4a1de9d  _ZNSt17_Function_handlerIFvvEZZN5doris14TaskWorkerPool11submit_taskERKNS1_17TAgentTaskRequestEENK3$_0clIS5_EEDaOT_EUlvE_E9_M_invokeERKSt9_Any_data
    @     0x590ad857b89d  doris::EngineIndexChangeTask::execute()
    @     0x590ad936128b  doris::ThreadPool::dispatch_thread()
    @     0x590ad49deea2  doris::alter_inverted_index_callback()
    @     0x590ad4a1de9d  _ZNSt17_Function_handlerIFvvEZZN5doris14TaskWorkerPool11submit_taskERKNS1_17TAgentTaskRequestEENK3$_0clIS5_EEDaOT_EUlvE_E9_M_invokeERKSt9_Any_data
    @     0x590ad9337828  doris::Thread::supervise_thread()
    @     0x740bd7c9caa4  (unknown)
    @     0x740bd7d29c3c  (unknown)
    @              (nil)  (unknown)
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1744083830 (unix time) try "date -d @1744083830" if you are using GNU date ***
*** Current BE git commitID: 3640f6c240 ***
*** SIGABRT unknown detail explain (@0x10417b) received by PID 1065339 (TID 1066024 OR 0x7408c42006c0) from PID 1065339; stack trace: ***
    @     0x590ad936128b  doris::ThreadPool::dispatch_thread()
    @     0x590ad9337828  doris::Thread::supervise_thread()
    @     0x740bd7c9caa4  (unknown)
    @     0x740bd7d29c3c  (unknown)
    @              (nil)  (unknown)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x0000740BD7C45330 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill in /lib/x86_64-linux-gnu/libc.so.6
 3# gsignal in /lib/x86_64-linux-gnu/libc.so.6
 4# abort in /lib/x86_64-linux-gnu/libc.so.6
 5# 0x0000590B0F23F5FD in /root/wyx/doris/be/lib/doris_be
 6# 0x0000590B0F231C3A in /root/wyx/doris/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /root/wyx/doris/be/lib/doris_be
 8# google::LogMessage::Flush() in /root/wyx/doris/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /root/wyx/doris/be/lib/doris_be
10# doris::IndexBuilder::handle_single_rowset(std::shared_ptr<doris::RowsetMeta>, std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > >&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/task/index_builder.cpp:423
11# doris::IndexBuilder::handle_inverted_index_data() at /home/zcp/repo_center/doris_master/doris/be/src/olap/task/index_builder.cpp:711
12# doris::IndexBuilder::do_build_inverted_index() in /root/wyx/doris/be/lib/doris_be
13# doris::StorageEngine::_handle_index_change(std::shared_ptr<doris::IndexBuilder>) at /home/zcp/repo_center/doris_master/doris/be/src/olap/olap_server.cpp:1213
14# doris::StorageEngine::process_index_change_task(doris::TAlterInvertedIndexReq const&) at /home/zcp/repo_center/doris_master/doris/be/src/olap/olap_server.cpp:1207
15# doris::EngineIndexChangeTask::execute() in /root/wyx/doris/be/lib/doris_be
16# doris::alter_inverted_index_callback(doris::StorageEngine&, doris::TAgentTaskRequest const&) in /root/wyx/doris/be/lib/doris_be
17# std::_Function_handler<void (), doris::TaskWorkerPool::submit_task(doris::TAgentTaskRequest const&)::$_0::operator()<doris::TAgentTaskRequest const&>(doris::TAgentTaskRequest const&) const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
18# doris::ThreadPool::dispatch_thread() in /root/wyx/doris/be/lib/doris_be
19# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:497
20# 0x0000740BD7C9CAA4 in /lib/x86_64-linux-gnu/libc.so.6
21# 0x0000740BD7D29C3C in /lib/x86_64-linux-gnu/libc.so.6
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

