### PR TITLE
[Improvement](memory)  reduce some memtracker overhead

### DIFF
--- a/be/src/olap/rowset/segment_v2/stream_reader.h
+++ b/be/src/olap/rowset/segment_v2/stream_reader.h
@@ -41,13 +41,13 @@ struct SubstreamIterator {
 };
 
 // path -> StreamReader
-using SubstreamReaderTree = vectorized::SubcolumnsTree<SubstreamIterator>;
+using SubstreamReaderTree = vectorized::SubcolumnsTree<SubstreamIterator, false>;
 
 // Reader for the storage layer, the file_column_type indicates the read type of the column in segment file
 struct SubcolumnReader {
     std::unique_ptr<ColumnReader> reader;
     std::shared_ptr<const vectorized::IDataType> file_column_type;
 };
-using SubcolumnColumnReaders = vectorized::SubcolumnsTree<SubcolumnReader>;
+using SubcolumnColumnReaders = vectorized::SubcolumnsTree<SubcolumnReader, true>;
 
 } // namespace doris::segment_v2

--- a/be/src/vec/columns/column_object.h
+++ b/be/src/vec/columns/column_object.h
@@ -235,7 +235,7 @@ public:
         // the root Node should be JSONB type when finalize
         bool is_root = false;
     };
-    using Subcolumns = SubcolumnsTree<Subcolumn>;
+    using Subcolumns = SubcolumnsTree<Subcolumn, false>;
 
 private:
     /// If true then all subcolumns are nullable.

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -289,6 +289,9 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_add
         return;
     }
 #endif
+    if (!doris::config::crash_in_memory_tracker_inaccurate) {
+        return;
+    }
     doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->add_address_sanitizers(
             buf, size);
 }
@@ -301,6 +304,9 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_
         return;
     }
 #endif
+    if (!doris::config::crash_in_memory_tracker_inaccurate) {
+        return;
+    }
     doris::thread_context()
             ->thread_mem_tracker_mgr->limiter_mem_tracker()
             ->remove_address_sanitizers(buf, size);


### PR DESCRIPTION
### What problem does this PR solve?
1. some subcolumn will shared by multiple tasks, and do SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER at ctor/dtor, but some subcolumn from ColumnObject no need to do those things.
2. Allocator::realloc_impl has some overhead coz `doris::thread_context()
            ->thread_mem_tracker_mgr->limiter_mem_tracker()`, add a shorcut to avoid this.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

