### PR TITLE
[fix](transaction) remove visible rowset from memory during deletion transaction

### DIFF
--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -673,6 +673,7 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
     if (it == txn_tablet_map.end()) {
         return Status::Error<TRANSACTION_NOT_EXIST>("key not founded from txn_tablet_map");
     }
+    Status st = Status::OK();
     auto load_itr = it->second.find(tablet_info);
     if (load_itr != it->second.end()) {
         // found load for txn,tablet
@@ -681,7 +682,7 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
         auto& rowset = load_info->rowset;
         if (rowset != nullptr && meta != nullptr) {
             if (!rowset->is_pending()) {
-                return Status::Error<TRANSACTION_ALREADY_COMMITTED>(
+                st = Status::Error<TRANSACTION_ALREADY_COMMITTED>(
                         "could not delete transaction from engine, just remove it from memory not "
                         "delete from disk, because related rowset already published. partition_id: "
                         "{}, transaction_id: {}, tablet: {}, rowset id: {}, version: {}, state: {}",
@@ -705,7 +706,7 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
         txn_tablet_map.erase(it);
         _clear_txn_partition_map_unlocked(transaction_id, partition_id);
     }
-    return Status::OK();
+    return st;
 }
 
 void TxnManager::get_tablet_related_txns(TTabletId tablet_id, TabletUid tablet_uid,

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -421,4 +421,48 @@ TEST_F(TxnManagerTest, DeleteCommittedTxnForIngestingBinlog) {
     EXPECT_FALSE(k_engine->pending_local_rowsets().contains(_rowset_ingested->rowset_id()));
 }
 
+TEST_F(TxnManagerTest, DeleteCommittedTxnCleanupOnError) {
+    // first commit a transaction
+    auto guard = k_engine->pending_local_rowsets().add(_rowset->rowset_id());
+    auto st = k_engine->txn_manager()->commit_txn(_meta.get(), partition_id, transaction_id,
+                                                  tablet_id, _tablet_uid, load_id, _rowset,
+                                                  std::move(guard), false);
+    ASSERT_TRUE(st.ok()) << st;
+
+    // verify transaction exists before deletion
+    std::vector<TPartitionId> partition_ids;
+    k_engine->txn_manager()->get_partition_ids(transaction_id, &partition_ids);
+    ASSERT_EQ(1, partition_ids.size());
+    ASSERT_EQ(partition_id, partition_ids[0]);
+
+    // also verify using get_tablet_related_txns
+    int64_t found_partition_id;
+    std::set<int64_t> found_txn_ids;
+    k_engine->txn_manager()->get_tablet_related_txns(tablet_id, _tablet_uid, &found_partition_id,
+                                                     &found_txn_ids);
+    ASSERT_EQ(1, found_txn_ids.size());
+    ASSERT_EQ(transaction_id, *found_txn_ids.begin());
+
+    // make rowset visible
+    Version version(0, 1);
+    _rowset->make_visible(version);
+
+    // now try to delete the transaction
+    // this should return TRANSACTION_ALREADY_COMMITTED but still clean up the transaction state
+    st = k_engine->txn_manager()->delete_txn(_meta.get(), partition_id, transaction_id, tablet_id,
+                                             _tablet_uid);
+    ASSERT_TRUE(st.is<ErrorCode::TRANSACTION_ALREADY_COMMITTED>()) << st;
+
+    // verify transaction is removed from txn map
+    partition_ids.clear();
+    k_engine->txn_manager()->get_partition_ids(transaction_id, &partition_ids);
+    ASSERT_TRUE(partition_ids.empty()) << "Transaction should be removed from txn map";
+
+    // verify by checking if we can get tablet related txns
+    found_txn_ids.clear();
+    k_engine->txn_manager()->get_tablet_related_txns(tablet_id, _tablet_uid, &found_partition_id,
+                                                     &found_txn_ids);
+    ASSERT_TRUE(found_txn_ids.empty()) << "Transaction should not be found in tablet related txns";
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Repeatedly reporting errors in the log:
```
W20250415 17:54:01.151019 218169 storage_engine.cpp:785] failed to clear transaction. txn_id=1002, partition_id=1744709709398, tablet_id=1744709709485, status=[E-228]could not delete transaction from engine, just remove it from memory not delete from disk, because related rowset already published. partition_id: 1744709709398, transaction_id: 1002, tablet: 1744709709485.fb491f2a6f29dad0-28fe3fdfba3272b5, rowset id: 020000000000001fc6430de53121366b7d7bc36d82a1ae92, version: [2-2], state: VISIBLE
W20250415 17:54:01.152154 218169 storage_engine.cpp:785] failed to clear transaction. txn_id=1002, partition_id=1744709709398, tablet_id=1744709709493, status=[E-228]could not delete transaction from engine, just remove it from memory not delete from disk, because related rowset already published. partition_id: 1744709709398, transaction_id: 1002, tablet: 1744709709493.7a47a3bf7dcc70f0-353230158f6c2390, rowset id: 0200000000000019c6430de53121366b7d7bc36d82a1ae92, version: [2-2], state: VISIBLE
W20250415 17:54:01.152177 218169 storage_engine.cpp:785] failed to clear transaction. txn_id=1002, partition_id=1744709709398, tablet_id=1744709709509, status=[E-228]could not delete transaction from engine, just remove it from memory not delete from disk, because related rowset already published. partition_id: 1744709709398, transaction_id: 1002, tablet: 1744709709509.7f49efdb3b6c2c1d-ed627da9d22c9884, rowset id: 020000000000001bc6430de53121366b7d7bc36d82a1ae92, version: [2-2], state: VISIBLE
```
This bug can occur in the following scenarios:
1. After load the three replicas of the table, the publish task failed after making the rowset as visible in one of the replica.
2. The transactions became visible. Then FE clear visible transaction.
3. The BE node that fails to publish will not delete the memory transaction and report it to FE. FE cannot find the transaction and issues a clear command. However, the deletion fails due to the rowset already published.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

