### PR TITLE
[fix](paimon)Set the target size of the split.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonSource.java
@@ -26,6 +26,7 @@ import org.apache.doris.datasource.paimon.PaimonExternalTable;
 import org.apache.doris.datasource.property.constants.PaimonProperties;
 import org.apache.doris.thrift.TFileAttributes;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.paimon.table.Table;
 
 
@@ -33,6 +34,13 @@ public class PaimonSource {
     private final PaimonExternalTable paimonExtTable;
     private final Table originTable;
     private final TupleDescriptor desc;
+
+    @VisibleForTesting
+    public PaimonSource() {
+        this.desc = null;
+        this.paimonExtTable = null;
+        this.originTable = null;
+    }
 
     public PaimonSource(TupleDescriptor desc) {
         this.desc = desc;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -17,13 +17,34 @@
 
 package org.apache.doris.datasource.paimon.source;
 
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.analysis.TupleId;
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.doris.datasource.paimon.PaimonFileExternalCatalog;
+import org.apache.doris.planner.PlanNodeId;
+import org.apache.doris.qe.SessionVariable;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
+import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.Split;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class PaimonScanNodeTest {
@@ -151,5 +172,115 @@ public class PaimonScanNodeTest {
 
         Optional<Long> result = PaimonScanNode.calcuteTableLevelCount(splits);
         Assert.assertFalse(result.isPresent());
+    }
+
+    @Mocked
+    private SessionVariable sv;
+
+    @Mocked
+    private PaimonFileExternalCatalog paimonFileExternalCatalog;
+
+    @Test
+    public void testSplitWeight() throws UserException {
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(3));
+        PaimonScanNode paimonScanNode = new PaimonScanNode(new PlanNodeId(1), desc, false, sv);
+
+        paimonScanNode.setSource(new PaimonSource());
+
+        DataFileMeta dfm1 = DataFileMeta.forAppend("f1.parquet", 64 * 1024 * 1024, 1, SimpleStats.EMPTY_STATS, 1, 1, 1,
+                Collections.emptyList(), null, null, null, null);
+        BinaryRow binaryRow1 = BinaryRow.singleColumn(1);
+        DataSplit ds1 = DataSplit.builder()
+                .rawConvertible(true)
+                .withPartition(binaryRow1)
+                .withBucket(1)
+                .withBucketPath("b1")
+                .withDataFiles(Collections.singletonList(dfm1))
+                .build();
+
+        DataFileMeta dfm2 = DataFileMeta.forAppend("f2.parquet", 32 * 1024 * 1024, 2, SimpleStats.EMPTY_STATS, 1, 1, 1,
+                Collections.emptyList(), null, null, null, null);
+        BinaryRow binaryRow2 = BinaryRow.singleColumn(1);
+        DataSplit ds2 = DataSplit.builder()
+                .rawConvertible(true)
+                .withPartition(binaryRow2)
+                .withBucket(1)
+                .withBucketPath("b1")
+                .withDataFiles(Collections.singletonList(dfm2))
+                .build();
+
+
+        new MockUp<PaimonScanNode>() {
+            @Mock
+            public List<org.apache.paimon.table.source.Split> getPaimonSplitFromAPI() {
+                return new ArrayList<org.apache.paimon.table.source.Split>() {{
+                        add(ds1);
+                        add(ds2);
+                    }};
+            }
+        };
+
+        new MockUp<PaimonSource>() {
+            @Mock
+            public ExternalCatalog getCatalog() {
+                return paimonFileExternalCatalog;
+            }
+        };
+
+        new MockUp<ExternalCatalog>() {
+            @Mock
+            public Map<String, String> getProperties() {
+                return Collections.emptyMap();
+            }
+        };
+
+        new Expectations() {{
+                sv.isForceJniScanner();
+                result = false;
+
+                sv.getIgnoreSplitType();
+                result = "NONE";
+            }};
+
+        // native
+        mockNativeReader();
+        List<org.apache.doris.spi.Split> s1 = paimonScanNode.getSplits(1);
+        PaimonSplit s11 = (PaimonSplit) s1.get(0);
+        PaimonSplit s12 = (PaimonSplit) s1.get(1);
+        Assert.assertEquals(2, s1.size());
+        Assert.assertEquals(100, s11.getSplitWeight().getRawValue());
+        Assert.assertNull(s11.getSplit());
+        Assert.assertEquals(50, s12.getSplitWeight().getRawValue());
+        Assert.assertNull(s12.getSplit());
+
+        // jni
+        mockJniReader();
+        List<org.apache.doris.spi.Split> s2 = paimonScanNode.getSplits(1);
+        PaimonSplit s21 = (PaimonSplit) s2.get(0);
+        PaimonSplit s22 = (PaimonSplit) s2.get(1);
+        Assert.assertEquals(2, s2.size());
+        Assert.assertNotNull(s21.getSplit());
+        Assert.assertNotNull(s22.getSplit());
+        Assert.assertEquals(100, s21.getSplitWeight().getRawValue());
+        Assert.assertEquals(50, s22.getSplitWeight().getRawValue());
+    }
+
+    private void mockJniReader() {
+        new MockUp<PaimonScanNode>() {
+            @Mock
+            public boolean supportNativeReader(Optional<List<RawFile>> optRawFiles) {
+                return false;
+            }
+        };
+    }
+
+    private void mockNativeReader() {
+        new MockUp<PaimonScanNode>() {
+            @Mock
+            public boolean supportNativeReader(Optional<List<RawFile>> optRawFiles) {
+                return true;
+            }
+        };
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -29,8 +29,6 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.stats.SimpleStats;


### PR DESCRIPTION
### What problem does this PR solve?

FollowUp #44038

Problem Summary:

We need to set the target size for all splits so that we can calculate the proportion of each split later.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

