### PR TITLE
[fix](nereids)Use utf-8 when convert string like literal to double.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.types.DataType;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -49,7 +50,7 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
      * get double value
      */
     public static double getDouble(String str) {
-        byte[] bytes = str.getBytes();
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
         long v = 0;
         int pos = 0;
         int len = Math.min(bytes.length, 7);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
@@ -31,4 +31,11 @@ public class StringLikeLiteralTest {
         double d2 = StringLikeLiteral.getDouble(maxStr);
         Assertions.assertTrue(d1 < d2);
     }
+
+    @Test
+    public void testUtf8() {
+        System.setProperty("file.encoding", "ANSI_X3.4-1968");
+        double d1 = StringLikeLiteral.getDouble("一般风险准备");
+        Assertions.assertEquals(d1, 6.4379158486625512E16);
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Use utf-8 when convert string like literal to double.
StringLike columns in Doris are all stored with utf-8 encoding. So we need to use utf-8 encoding to read the column statistics min/max value. Otherwise, Java will use the system default encoding. In this case, doris may read wrong statistics min/max value.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

