### PR TITLE
[opt](Decimal)Optimize Decimal multiplication when type promotion occurs.

### DIFF
--- a/be/test/vec/function/function_multiply_test.cpp
+++ b/be/test/vec/function/function_multiply_test.cpp
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "vec/core/types.h"
+
+namespace doris::vectorized {
+
+TEST(MultiplyTest, test_64_64_128) {
+    Int64 a = 1234567890123456789;
+    Int64 b = 1234567890123456789;
+
+    Int128 c_1 = a * b;
+
+    Int128 a_2 = a;
+    Int128 b_2 = b;
+    Int128 c_2 = a_2 * b_2;
+
+    Int128 c_3 = static_cast<Int128>(a) * static_cast<Int128>(b);
+
+    EXPECT_NE(c_2, c_1);
+    EXPECT_EQ(c_2, c_3);
+}
+
+}; // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

For example, in the case of Decimal64 * Decimal64 resulting in Decimal128.
Previously, we converted the two 64-bit integers into 128-bit integers first, and then performed the calculation of 128 * 128. (This requires three multiplication instructions.)
However, we can directly compute 64 multiplied by 64 to obtain a 128-bit result. (This only requires one multiplication instruction.)
https://godbolt.org/z/eTY5Gz4WP

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

