### PR TITLE
[Chore](runtime-filter) add lock for all runtime filter producer/consumer's public method

### DIFF
--- a/be/src/runtime_filter/runtime_filter.h
+++ b/be/src/runtime_filter/runtime_filter.h
@@ -46,11 +46,13 @@ public:
 
     template <class T>
     Status assign(const T& request, butil::IOBufAsZeroCopyInputStream* data) {
+        std::unique_lock<std::recursive_mutex> l(_rmtx);
         return _wrapper->assign(request, data);
     }
 
     template <class T>
     Status serialize(T* request, void** data, int* len) {
+        std::unique_lock<std::recursive_mutex> l(_rmtx);
         auto real_runtime_filter_type = _wrapper->get_real_type();
 
         request->set_filter_type(get_type(real_runtime_filter_type));
@@ -81,7 +83,7 @@ public:
         return Status::OK();
     }
 
-    virtual std::string debug_string() const = 0;
+    virtual std::string debug_string() = 0;
 
 protected:
     RuntimeFilter(const TRuntimeFilterDesc* desc)
@@ -118,6 +120,8 @@ protected:
     friend class RuntimeFilterProducer;
     friend class RuntimeFilterConsumer;
     friend class RuntimeFilterMerger;
+
+    std::recursive_mutex _rmtx; // lock all member function of runtime filter producer/consumer
 };
 #include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -68,7 +68,7 @@ void RuntimeFilterConsumer::signal(RuntimeFilter* other) {
 
 std::shared_ptr<pipeline::RuntimeFilterTimer> RuntimeFilterConsumer::create_filter_timer(
         std::shared_ptr<pipeline::Dependency> dependencies) {
-            std::unique_lock<std::recursive_mutex> l(_rmtx);
+    std::unique_lock<std::recursive_mutex> l(_rmtx);
     auto timer = std::make_shared<pipeline::RuntimeFilterTimer>(_registration_time,
                                                                 _rf_wait_time_ms, dependencies);
     _filter_timer.push_back(timer);

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -45,6 +45,7 @@ Status RuntimeFilterConsumer::_apply_ready_expr(
 }
 
 Status RuntimeFilterConsumer::acquire_expr(std::vector<vectorized::VRuntimeFilterPtr>& push_exprs) {
+    std::unique_lock<std::recursive_mutex> l(_rmtx);
     if (_rf_state == State::READY) {
         RETURN_IF_ERROR(_apply_ready_expr(push_exprs));
     }
@@ -55,6 +56,7 @@ Status RuntimeFilterConsumer::acquire_expr(std::vector<vectorized::VRuntimeFilte
 }
 
 void RuntimeFilterConsumer::signal(RuntimeFilter* other) {
+    std::unique_lock<std::recursive_mutex> l(_rmtx);
     COUNTER_SET(_wait_timer, int64_t((MonotonicMillis() - _registration_time) * NANOS_PER_MILLIS));
     _set_state(State::READY, other->_wrapper);
     if (!_filter_timer.empty()) {
@@ -66,6 +68,7 @@ void RuntimeFilterConsumer::signal(RuntimeFilter* other) {
 
 std::shared_ptr<pipeline::RuntimeFilterTimer> RuntimeFilterConsumer::create_filter_timer(
         std::shared_ptr<pipeline::Dependency> dependencies) {
+            std::unique_lock<std::recursive_mutex> l(_rmtx);
     auto timer = std::make_shared<pipeline::RuntimeFilterTimer>(_registration_time,
                                                                 _rf_wait_time_ms, dependencies);
     _filter_timer.push_back(timer);
@@ -211,13 +214,13 @@ Status RuntimeFilterConsumer::_get_push_exprs(std::vector<vectorized::VRuntimeFi
 }
 
 void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_operator_profile) {
+    std::unique_lock<std::recursive_mutex> l(_rmtx);
     DCHECK(parent_operator_profile != nullptr);
     int filter_id = -1;
     {
         // since debug_string will read from  RuntimeFilter::_wrapper
         // and it is a shared_ptr, instead of a atomic_shared_ptr
         // so it is not thread safe
-        std::unique_lock<std::mutex> l(_mtx);
         filter_id = _wrapper->filter_id();
         parent_operator_profile->add_description(fmt::format("RF{} Info", filter_id),
                                                  debug_string(), "RuntimeFilterInfo");

--- a/be/src/runtime_filter/runtime_filter_merger.h
+++ b/be/src/runtime_filter/runtime_filter_merger.h
@@ -46,7 +46,7 @@ public:
         return Status::OK();
     }
 
-    std::string debug_string() const override {
+    std::string debug_string() override {
         return fmt::format(
                 "Merger: ({}, expected_producer_num: {}, received_producer_num: {}, "
                 "received_rf_size_num: {}, received_sum_size: {})",

--- a/be/src/runtime_filter/runtime_filter_producer.cpp
+++ b/be/src/runtime_filter/runtime_filter_producer.cpp
@@ -142,7 +142,7 @@ public:
 
 void RuntimeFilterProducer::latch_dependency(
         const std::shared_ptr<pipeline::CountedFinishDependency>& dependency) {
-            std::unique_lock<std::recursive_mutex> l(_rmtx);
+    std::unique_lock<std::recursive_mutex> l(_rmtx);
     if (_rf_state != State::WAITING_FOR_SEND_SIZE) {
         _check_state({State::WAITING_FOR_DATA});
         return;

--- a/be/test/runtime_filter/runtime_filter_producer_helper_set_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_producer_helper_set_test.cpp
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime_filter/runtime_filter_producer_helper_set.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "pipeline/exec/hashjoin_build_sink.h"
+#include "pipeline/exec/mock_operator.h"
+#include "pipeline/exec/operator.h"
+#include "pipeline/pipeline_task.h"
+#include "runtime_filter/runtime_filter_test_utils.h"
+#include "vec/columns/columns_number.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/exprs/vslot_ref.h"
+
+namespace doris {
+
+class RuntimeFilterProducerHelperSetTest : public RuntimeFilterTest {
+    void SetUp() override {
+        RuntimeFilterTest::SetUp();
+        _pipeline = std::make_shared<pipeline::Pipeline>(0, INSTANCE_NUM, INSTANCE_NUM);
+        _op.reset(new pipeline::MockOperatorX());
+        FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_pipeline->add_operator(_op, 2));
+
+        _sink.reset(new pipeline::HashJoinBuildSinkOperatorX(
+                &_pool, 0, _op->operator_id(),
+                TPlanNodeBuilder(0, TPlanNodeType::HASH_JOIN_NODE).build(), _tbl));
+        FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_pipeline->set_sink(_sink));
+
+        _task.reset(new pipeline::PipelineTask(_pipeline, 0, _runtime_states[0].get(), nullptr,
+                                               &_profile, {}, 0));
+    }
+
+    pipeline::OperatorPtr _op;
+    pipeline::DataSinkOperatorPtr _sink;
+    pipeline::PipelinePtr _pipeline;
+    std::shared_ptr<pipeline::PipelineTask> _task;
+    ObjectPool _pool;
+};
+
+TEST_F(RuntimeFilterProducerHelperSetTest, basic) {
+    auto helper = RuntimeFilterProducerHelperSet();
+
+    vectorized::VExprContextSPtr ctx;
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(vectorized::VExpr::create_expr_tree(
+            TRuntimeFilterDescBuilder::get_default_expr(), ctx));
+    ctx->_last_result_column_id = 0;
+
+    vectorized::VExprContextSPtrs build_expr_ctxs = {ctx};
+    std::vector<TRuntimeFilterDesc> runtime_filter_descs = {TRuntimeFilterDescBuilder().build()};
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
+            helper.init(_runtime_states[0].get(), build_expr_ctxs, runtime_filter_descs));
+
+    vectorized::Block block;
+    auto column = vectorized::ColumnInt32::create();
+    column->insert(1);
+    column->insert(2);
+    block.insert({std::move(column), std::make_shared<vectorized::DataTypeInt32>(), "col1"});
+
+    std::map<int, std::shared_ptr<RuntimeFilterWrapper>> runtime_filters;
+    FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.process(_runtime_states[0].get(), &block, 2));
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?
1. add lock for all runtime filter producer/consumer's public method
2. add ut for set runtime filter
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

