### PR TITLE
[Fix](filecache) Fix file cache sync clear API failing to delete correctly due to relative paths

### DIFF
--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -714,7 +714,7 @@ Status FSFileCacheStorage::clear(std::string& msg) {
     for (; key_it != std::filesystem::directory_iterator(); ++key_it) {
         if (!key_it->is_directory()) continue; // all file cache data is in sub-directories
         ++total;
-        std::string cache_key = key_it->path().filename().native();
+        std::string cache_key = key_it->path().string();
         auto st = global_local_filesystem()->delete_directory(cache_key);
         if (st.ok()) continue;
         failed++;


### PR DESCRIPTION
log and tested manually, robust/auto tests will be added in the future.
![image](https://github.com/user-attachments/assets/b0b781a1-3353-422b-9f2e-9f3cca3160e5)


