### PR TITLE
[fix](txn) Restart fe after commit txn causes `loadedTblIndexes` lossing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -277,6 +277,7 @@ public class TransactionState implements Writable {
     // this map should be set when load execution begin, so that when the txn commit, it will know
     // which tables and rollups it loaded.
     // tbl id -> (index ids)
+    @SerializedName(value = "loadedTblIndexes")
     private Map<Long, Set<Long>> loadedTblIndexes = Maps.newHashMap();
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

it will loss in upsert binlog
```
commit txn -> restart fe -> replay commit -> publish
```
loadedTblIndexes will be updated after publish, but binlog record has been generated at this time
```
public void finishTransaction(long transactionId, Map<Long, Long> partitionVisibleVersions,
            Map<Long, Set<Long>> backendPartitions) throws UserException {
            ...
            writeLock();
            try {
                ...
                unprotectUpsertTransactionState(transactionState, false); // add binlog
                ...
            } finally {
                ...
                writeUnlock();
            }
            updateCatalogAfterVisible(transactionState, db, partitionVisibleVersions, backendPartitions); -> will update `loadedTblIndexes`
        } finally {
            MetaLockUtils.writeUnlockTables(tableList);
        }

        LOG.info("finish transaction {} successfully, publish times {}, publish result {}",
                transactionState, transactionState.getPublishCount(), publishResult.name());
    }
```


```
public UpsertRecord(long commitSeq, TransactionState state) {
        this.commitSeq = commitSeq;
        txnId = state.getTransactionId();
        ...

        Map<Long, Set<Long>> loadedTableIndexIds = state.getLoadedTblIndexes();
        Map<Long, Map<Long, Long>> tabletDeltaRows = state.getTableIdToTabletDeltaRows();
        ...
}
```


