### PR TITLE
[opt](deps) patch re2 to add ignore_replace_escape option

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -96,7 +96,7 @@ jobs:
             'autoconf'
             'libtool-bin'
             'pkg-config'
-            'cmake'
+            'cmake=3.22.1-1ubuntu1'
             'ninja-build'
             'ccache'
             'python-is-python3'
@@ -116,6 +116,7 @@ jobs:
           )
 
           sudo apt update
+          sudo apt-cache policy cmake
           sudo DEBIAN_FRONTEND=noninteractive apt install --yes "${packages[@]}"
 
           mkdir -p "${DEFAULT_DIR}"

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -96,7 +96,7 @@ jobs:
             'autoconf'
             'libtool-bin'
             'pkg-config'
-            'cmake=3.22.1-1ubuntu1'
+            'cmake=3.22.1-1ubuntu1.22.04.2'
             'ninja-build'
             'ccache'
             'python-is-python3'

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -239,7 +239,9 @@ jobs:
 
           # Install specific version of cmake
           brew unlink cmake || true
-          brew install --build-from-source https://raw.githubusercontent.com/Homebrew/homebrew-core/e38c9acd1a/Formula/cmake.rb
+          wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-macos-universal.tar.gz
+          tar -xzf cmake-3.22.1-macos-universal.tar.gz
+          sudo cp -r cmake-3.22.1-macos-universal/CMake.app/Contents/* /usr/local/
           cmake --version
 
       - name: Build

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -163,7 +163,7 @@ jobs:
             'coreutils'
             'gnu-getopt'
             'python@3'
-            'cmake'
+            'cmake@3.22'
             'ninja'
             'ccache'
             'bison'
@@ -177,7 +177,9 @@ jobs:
             'llvm@16'
           )
 
+          brew unlink cmake || true
           brew install "${packages[@]}" || true
+          brew link cmake@3.22
 
       - name: Build
         run: |
@@ -214,7 +216,7 @@ jobs:
             'coreutils'
             'gnu-getopt'
             'python@3'
-            'cmake'
+            'cmake@3.22'
             'ninja'
             'ccache'
             'bison'
@@ -228,7 +230,9 @@ jobs:
             'llvm@16'
           )
 
+          brew unlink cmake || true
           brew install "${packages[@]}" || true
+          brew link cmake@3.22
 
       - name: Build
         run: |

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -163,7 +163,6 @@ jobs:
             'coreutils'
             'gnu-getopt'
             'python@3'
-            'cmake@3.22'
             'ninja'
             'ccache'
             'bison'
@@ -177,9 +176,15 @@ jobs:
             'llvm@16'
           )
 
-          brew unlink cmake || true
+          # Install packages except cmake
           brew install "${packages[@]}" || true
-          brew link cmake@3.22
+
+          # Install specific version of cmake
+          brew unlink cmake || true
+          wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-macos-universal.tar.gz
+          tar -xzf cmake-3.22.1-macos-universal.tar.gz
+          sudo cp -r cmake-3.22.1-macos-universal/CMake.app/Contents/* /usr/local/
+          cmake --version
 
       - name: Build
         run: |
@@ -216,7 +221,6 @@ jobs:
             'coreutils'
             'gnu-getopt'
             'python@3'
-            'cmake@3.22'
             'ninja'
             'ccache'
             'bison'
@@ -230,9 +234,13 @@ jobs:
             'llvm@16'
           )
 
-          brew unlink cmake || true
+          # Install packages except cmake
           brew install "${packages[@]}" || true
-          brew link cmake@3.22
+
+          # Install specific version of cmake
+          brew unlink cmake || true
+          brew install --build-from-source https://raw.githubusercontent.com/Homebrew/homebrew-core/e38c9acd1a/Formula/cmake.rb
+          cmake --version
 
       - name: Build
         run: |

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## 20250416
+
+- Mofified: patch re2 to set `ignore_replace_escape` option
+
 ## 20250408
 
 - Modified: jindofs 6.3.4 -> 6.8.2

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -603,5 +603,20 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " FAISS " ]]; then
     echo "Finished patching ${FAISS_SOURCE}"
 fi
 
+# patch re2
+if [[ " ${TP_ARCHIVES[*]} " =~ " RE2 " ]]; then
+    if [[ "${RE2_SOURCE}" == 're2-2021-02-02' ]]; then
+        cd "${TP_SOURCE_DIR}/${RE2_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            for patch_file in "${TP_PATCH_DIR}"/re2-*; do
+                echo "patch ${patch_file}"
+                patch -p1 --ignore-whitespace <"${patch_file}"
+            done
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${RE2_SOURCE}"
+fi
 
 # vim: ts=4 sw=4 ts=4 tw=100:

--- a/thirdparty/patches/re2-2021-02-02-ignore-replace.patch
+++ b/thirdparty/patches/re2-2021-02-02-ignore-replace.patch
@@ -1,0 +1,63 @@
+diff --git a/re2/re2.cc b/re2/re2.cc
+index 85ba1f4..0f23c22 100644
+--- a/re2/re2.cc
++++ b/re2/re2.cc
+@@ -55,7 +55,8 @@ RE2::Options::Options(RE2::CannedOptions opt)
+     case_sensitive_(true),
+     perl_classes_(false),
+     word_boundary_(false),
+-    one_line_(false) {
++    one_line_(false),
++    ignore_replace_escape_(false) {
+ }
+ 
+ // static empty objects for use as const references.
+@@ -1030,9 +1031,13 @@ bool RE2::Rewrite(std::string* out,
+     } else if (c == '\\') {
+       out->push_back('\\');
+     } else {
+-      if (options_.log_errors())
+-        LOG(ERROR) << "invalid rewrite pattern: " << rewrite.data();
+-      return false;
++      if (options_.ignore_replace_escape()) {
++        out->push_back(*s);
++      } else {
++        if (options_.log_errors())
++          LOG(ERROR) << "invalid rewrite pattern: " << rewrite.data();
++        return false;
++      }
+     }
+   }
+   return true;
+diff --git a/re2/re2.h b/re2/re2.h
+index 09c1fbe..79fe995 100644
+--- a/re2/re2.h
++++ b/re2/re2.h
+@@ -665,7 +665,8 @@ class RE2 {
+       case_sensitive_(true),
+       perl_classes_(false),
+       word_boundary_(false),
+-      one_line_(false) {
++      one_line_(false),
++      ignore_replace_escape_(false) {
+     }
+ 
+     /*implicit*/ Options(CannedOptions);
+@@ -709,6 +710,9 @@ class RE2 {
+     bool one_line() const { return one_line_; }
+     void set_one_line(bool b) { one_line_ = b; }
+ 
++    bool ignore_replace_escape() const { return ignore_replace_escape_; }
++    void set_ignore_replace_escape(bool b) { ignore_replace_escape_ = b; }
++
+     void Copy(const Options& src) {
+       *this = src;
+     }
+@@ -729,6 +733,7 @@ class RE2 {
+     bool perl_classes_;
+     bool word_boundary_;
+     bool one_line_;
++    bool ignore_replace_escape_;
+   };
+ 
+   // Returns the options set in the constructor.


### PR DESCRIPTION
### What problem does this PR solve?

Currently, the [re2](https://github.com/google/re2) lib will ignore the invalid escape char
and ignore the whole replace string.

https://github.com/google/re2/blob/c84a140c93352cdabbfb547c531be34515b12228/re2/re2.cc?#L1052-L1054

For example, `select regexp_replace('abc', 'b', '\}');`

`\}` is an invalid escape char, so the result is `ac`.

You can see the `b` is matched but replaced with empty.

This PR add a patch to "re2" lib, to add `ignore_replace_escape` option.
Default is false, if set to true, the invalid escape char like `\{` will be treated as `{`.
So the result in example will be `a{c`.

Actually, it makes sense. Because when parsing the "pattern"(which is `b` in example),

https://github.com/google/re2/blob/c84a140c93352cdabbfb547c531be34515b12228/re2/parse.cc#L1507-L1514

It also ignore the invalid escape char.

But in order to not change the current behavior, I add an option. So that later
we can use this option to decide the logic of `regexp_replace`.

