### PR TITLE
[fix](ci) use a fix version of cmake in build-thirdparty ci pipeline

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -96,7 +96,7 @@ jobs:
             'autoconf'
             'libtool-bin'
             'pkg-config'
-            'cmake'
+            'cmake=3.22.1-1ubuntu1'
             'ninja-build'
             'ccache'
             'python-is-python3'
@@ -116,6 +116,7 @@ jobs:
           )
 
           sudo apt update
+          sudo apt-cache policy cmake
           sudo DEBIAN_FRONTEND=noninteractive apt install --yes "${packages[@]}"
 
           mkdir -p "${DEFAULT_DIR}"


### PR DESCRIPTION
### What problem does this PR solve?

The default installed cmake is 4.0, which does not allowed `cmake_minimum_required()` less then 3.5.
It will cause unable to compile libevent, which cmake_minimum_required is 3.1

Install a fix cmake version to resolve this problem

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

