### PR TITLE
print error info when parse_conf_cache_paths failed, so that user know how to correct it

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -344,9 +344,7 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
                 doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths);
         if (!olap_res) {
             LOG(FATAL) << "parse config file cache path failed, path="
-                       << doris::config::file_cache_path
-                       << " err: "
-                       << olap_res;
+                       << doris::config::file_cache_path << " err: " << olap_res;
             exit(-1);
         }
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -344,7 +344,8 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
                 doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths);
         if (!olap_res) {
             LOG(FATAL) << "parse config file cache path failed, path="
-                       << doris::config::file_cache_path;
+                       << doris::config::file_cache_path
+                       << " err: " << olap_res;
             exit(-1);
         }
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -345,7 +345,8 @@ void ExecEnv::init_file_cache_factory(std::vector<doris::CachePath>& cache_paths
         if (!olap_res) {
             LOG(FATAL) << "parse config file cache path failed, path="
                        << doris::config::file_cache_path
-                       << " err: " << olap_res;
+                       << " err: "
+                       << olap_res;
             exit(-1);
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
when [parse_conf_cache_paths](doris::parse_conf_cache_paths) return error,  ExecEnv::init_file_cache_factory just print fatal log without tell user what is wrong, how to fix it

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

