### PR TITLE
[enhance](auth)Remove restrictions on user creation and other operations when enabling ranger/LDAP

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
@@ -18,8 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -62,10 +60,6 @@ public class CreateRoleStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
-
-        if (Config.access_controller_type.equalsIgnoreCase("ranger-doris")) {
-            throw new AnalysisException("Create role is prohibited when Ranger is enabled.");
-        }
 
         FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not create role");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
@@ -18,13 +18,10 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
-import org.apache.doris.mysql.authenticate.AuthenticateType;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.mysql.privilege.Role;
 import org.apache.doris.qe.ConnectContext;
@@ -118,11 +115,6 @@ public class CreateUserStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
-
-        if (Config.access_controller_type.equalsIgnoreCase("ranger-doris")
-                && AuthenticateType.getAuthTypeConfig() == AuthenticateType.LDAP) {
-            throw new AnalysisException("Create user is prohibited when Ranger and LDAP are enabled at same time.");
-        }
 
         userIdent.analyze();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropRoleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropRoleStmt.java
@@ -18,8 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -52,10 +50,6 @@ public class DropRoleStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
-
-        if (Config.access_controller_type.equalsIgnoreCase("ranger-doris")) {
-            throw new AnalysisException("Drop role is prohibited when Ranger is enabled.");
-        }
 
         FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not drop role");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropUserStmt.java
@@ -19,11 +19,9 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
-import org.apache.doris.mysql.authenticate.AuthenticateType;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
@@ -55,11 +53,6 @@ public class DropUserStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
         super.analyze(analyzer);
-
-        if (Config.access_controller_type.equalsIgnoreCase("ranger-doris")
-                && AuthenticateType.getAuthTypeConfig() == AuthenticateType.LDAP) {
-            throw new AnalysisException("Drop user is prohibited when Ranger and LDAP are enabled at same time.");
-        }
 
         userIdent.analyze();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.CompoundPredicate.Operator;
 import org.apache.doris.catalog.AccessPrivilegeWithCols;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -138,10 +137,6 @@ public class GrantStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
-
-        if (Config.access_controller_type.equalsIgnoreCase("ranger-doris")) {
-            throw new AnalysisException("Grant is prohibited when Ranger is enabled.");
-        }
 
         if (userIdent != null) {
             userIdent.analyze();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AccessPrivilegeWithCols;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.mysql.privilege.ColPrivilegeKey;
@@ -119,10 +118,6 @@ public class RevokeStmt extends DdlStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
-        if (Config.access_controller_type.equalsIgnoreCase("ranger-doris")) {
-            throw new AnalysisException("Revoke is prohibited when Ranger is enabled.");
-        }
-
         if (userIdent != null) {
             userIdent.analyze();
         } else {


### PR DESCRIPTION
### What problem does this PR solve?
- In version 2.1, the global permission check still calls the internal permission interface. If grant is not allowed, it will be impossible to assign admin and other permissions to users
- According to the current design of LDAP, if there is no user in LDAP, Doris will check again to see if the user exists internally. If there is, login will also be allowed. Therefore, creating users should not be prohibited


Issue Number: close #xxx

Related PR: #32538 

Problem Summary:
Remove restrictions on user creation and other operations when enabling ranger/LDAP
### Release note

Remove restrictions on user creation and other operations when enabling ranger/LDAP

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->
        The PR that restricts operations has not added a case, and the current PR is only the logic before revert

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

