### PR TITLE
[fix](restapi) Unify Permission Requirements for Executing SHOW FRONTENDS/BACKENDS And NODE RestAPI

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackendsStmt.java
@@ -19,11 +19,13 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.proc.BackendsProcDir;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSetMetaData;
@@ -37,10 +39,10 @@ public class ShowBackendsStmt extends ShowStmt implements NotFallbackInParser {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
 
-        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)
-                && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(),
-                                                                          PrivPredicate.OPERATOR)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN/OPERATOR");
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackendsStmt.java
@@ -42,7 +42,7 @@ public class ShowBackendsStmt extends ShowStmt implements NotFallbackInParser {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackendsStmt.java
@@ -41,8 +41,8 @@ public class ShowBackendsStmt extends ShowStmt implements NotFallbackInParser {
 
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString());
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
@@ -51,7 +51,7 @@ public class ShowFrontendsStmt extends ShowStmt implements NotFallbackInParser {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
 
         if (detail != null && !detail.equalsIgnoreCase("disks")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
@@ -19,11 +19,13 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.proc.FrontendsProcNode;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSetMetaData;
@@ -46,10 +48,10 @@ public class ShowFrontendsStmt extends ShowStmt implements NotFallbackInParser {
 
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
-        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)
-                && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(),
-                                                                          PrivPredicate.OPERATOR)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN/OPERATOR");
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString());
         }
 
         if (detail != null && !detail.equalsIgnoreCase("disks")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowFrontendsStmt.java
@@ -50,8 +50,8 @@ public class ShowFrontendsStmt extends ShowStmt implements NotFallbackInParser {
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString());
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
 
         if (detail != null && !detail.equalsIgnoreCase("disks")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/BackendsAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/BackendsAction.java
@@ -18,7 +18,10 @@
 package org.apache.doris.httpv2.rest;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Backend;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -66,12 +69,8 @@ public class BackendsAction extends RestBaseController {
 
     @RequestMapping(path = "/api/backends", method = {RequestMethod.GET})
     public Object getBackends(HttpServletRequest request, HttpServletResponse response) {
-        /**
-         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
-         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
-         * To ensure that the connector works properly, we do not verify the permission of the interface.
-         */
         executeCheckPassword(request, response);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         boolean needAlive = false;
         String isAlive = request.getParameter(IS_ALIVE);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -107,12 +107,8 @@ public class NodeAction extends RestBaseController {
     // Returns all fe information, similar to 'show frontends'.
     @RequestMapping(path = "/frontends", method = RequestMethod.GET)
     public Object frontends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
-        /**
-         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
-         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
-         * To ensure that the connector works properly, we do not verify the permission of the interface.
-         */
         executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
 
         return fetchNodeInfo(request, response, "/frontends");
     }
@@ -120,12 +116,8 @@ public class NodeAction extends RestBaseController {
     // Returns all be information, similar to 'show backends'.
     @RequestMapping(path = "/backends", method = RequestMethod.GET)
     public Object backends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
-        /**
-         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
-         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
-         * To ensure that the connector works properly, we do not verify the permission of the interface.
-         */
         executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
 
         return fetchNodeInfo(request, response, "/backends");
     }
@@ -133,12 +125,8 @@ public class NodeAction extends RestBaseController {
     // Returns all broker information, similar to 'show broker'.
     @RequestMapping(path = "/brokers", method = RequestMethod.GET)
     public Object brokers_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
-        /**
-         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
-         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
-         * To ensure that the connector works properly, we do not verify the permission of the interface.
-         */
         executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
 
         return fetchNodeInfo(request, response, "/brokers");
     }
@@ -235,12 +223,8 @@ public class NodeAction extends RestBaseController {
     // }
     @RequestMapping(path = "/node_list", method = RequestMethod.GET)
     public Object nodeList(HttpServletRequest request, HttpServletResponse response) {
-        /**
-         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
-         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
-         * To ensure that the connector works properly, we do not verify the permission of the interface.
-         */
         executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
 
         Map<String, List<String>> result = Maps.newHashMap();
         result.put("frontend", getFeList());
@@ -266,12 +250,8 @@ public class NodeAction extends RestBaseController {
      */
     @RequestMapping(path = "/config", method = RequestMethod.GET)
     public Object config(HttpServletRequest request, HttpServletResponse response) {
-        /**
-         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
-         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
-         * To ensure that the connector works properly, we do not verify the permission of the interface.
-         */
         executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
 
         List<List<String>> configs = ConfigBase.getConfigInfo(null);
         // Sort all configs by config key.
@@ -332,7 +312,7 @@ public class NodeAction extends RestBaseController {
             @RequestParam(value = "type") String type,
             @RequestBody(required = false) ConfigInfoRequestBody requestBody) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
 
         initHttpExecutor();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -107,8 +107,12 @@ public class NodeAction extends RestBaseController {
     // Returns all fe information, similar to 'show frontends'.
     @RequestMapping(path = "/frontends", method = RequestMethod.GET)
     public Object frontends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        /**
+         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
+         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
+         * To ensure that the connector works properly, we do not verify the permission of the interface.
+         */
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         return fetchNodeInfo(request, response, "/frontends");
     }
@@ -116,8 +120,12 @@ public class NodeAction extends RestBaseController {
     // Returns all be information, similar to 'show backends'.
     @RequestMapping(path = "/backends", method = RequestMethod.GET)
     public Object backends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        /**
+         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
+         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
+         * To ensure that the connector works properly, we do not verify the permission of the interface.
+         */
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         return fetchNodeInfo(request, response, "/backends");
     }
@@ -125,8 +133,12 @@ public class NodeAction extends RestBaseController {
     // Returns all broker information, similar to 'show broker'.
     @RequestMapping(path = "/brokers", method = RequestMethod.GET)
     public Object brokers_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        /**
+         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
+         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
+         * To ensure that the connector works properly, we do not verify the permission of the interface.
+         */
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         return fetchNodeInfo(request, response, "/brokers");
     }
@@ -223,8 +235,12 @@ public class NodeAction extends RestBaseController {
     // }
     @RequestMapping(path = "/node_list", method = RequestMethod.GET)
     public Object nodeList(HttpServletRequest request, HttpServletResponse response) {
+        /**
+         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
+         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
+         * To ensure that the connector works properly, we do not verify the permission of the interface.
+         */
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         Map<String, List<String>> result = Maps.newHashMap();
         result.put("frontend", getFeList());
@@ -250,8 +266,12 @@ public class NodeAction extends RestBaseController {
      */
     @RequestMapping(path = "/config", method = RequestMethod.GET)
     public Object config(HttpServletRequest request, HttpServletResponse response) {
+        /**
+         * As required, the interface should require user have GlobalAuth-PrivPredicate.ADMIN permission.
+         * However, a user who uses spark-doris-connector/flink-doris-connector does not have corresponding permission.
+         * To ensure that the connector works properly, we do not verify the permission of the interface.
+         */
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         List<List<String>> configs = ConfigBase.getConfigInfo(null);
         // Sort all configs by config key.

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -18,6 +18,7 @@
 package org.apache.doris.httpv2.rest.manager;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ConfigBase;
 import org.apache.doris.common.MarkedCountDownLatch;
@@ -108,7 +109,7 @@ public class NodeAction extends RestBaseController {
     @RequestMapping(path = "/frontends", method = RequestMethod.GET)
     public Object frontends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         return fetchNodeInfo(request, response, "/frontends");
     }
@@ -117,7 +118,7 @@ public class NodeAction extends RestBaseController {
     @RequestMapping(path = "/backends", method = RequestMethod.GET)
     public Object backends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         return fetchNodeInfo(request, response, "/backends");
     }
@@ -126,7 +127,7 @@ public class NodeAction extends RestBaseController {
     @RequestMapping(path = "/brokers", method = RequestMethod.GET)
     public Object brokers_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         return fetchNodeInfo(request, response, "/brokers");
     }
@@ -185,7 +186,7 @@ public class NodeAction extends RestBaseController {
     @RequestMapping(path = "/configuration_name", method = RequestMethod.GET)
     public Object configurationName(HttpServletRequest request, HttpServletResponse response) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         Map<String, List<String>> result = Maps.newHashMap();
         try {
@@ -224,7 +225,7 @@ public class NodeAction extends RestBaseController {
     @RequestMapping(path = "/node_list", method = RequestMethod.GET)
     public Object nodeList(HttpServletRequest request, HttpServletResponse response) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         Map<String, List<String>> result = Maps.newHashMap();
         result.put("frontend", getFeList());
@@ -251,7 +252,7 @@ public class NodeAction extends RestBaseController {
     @RequestMapping(path = "/config", method = RequestMethod.GET)
     public Object config(HttpServletRequest request, HttpServletResponse response) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
+        checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT);
 
         List<List<String>> configs = ConfigBase.getConfigInfo(null);
         // Sort all configs by config key.

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -313,7 +313,7 @@ public class NodeAction extends RestBaseController {
             @RequestParam(value = "type") String type,
             @RequestBody(required = false) ConfigInfoRequestBody requestBody) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.OPERATOR);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN_OR_NODE);
 
         initHttpExecutor();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
@@ -62,7 +62,7 @@ public class ShowBackendsCommand extends ShowCommand {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
 
         List<List<String>> backendInfos = BackendsProcDir.getBackendInfos();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
@@ -61,8 +61,8 @@ public class ShowBackendsCommand extends ShowCommand {
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString());
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
 
         List<List<String>> backendInfos = BackendsProcDir.getBackendInfos();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
@@ -20,10 +20,12 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.proc.BackendsProcDir;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -57,10 +59,10 @@ public class ShowBackendsCommand extends ShowCommand {
 
     @Override
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
-        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)
-                && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(),
-                                                                          PrivPredicate.OPERATOR)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN/OPERATOR");
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString());
         }
 
         List<List<String>> backendInfos = BackendsProcDir.getBackendInfos();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommand.java
@@ -20,11 +20,13 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.proc.FrontendsProcNode;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -70,10 +72,10 @@ public class ShowFrontendsCommand extends ShowCommand {
 
     @Override
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
-        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)
-                && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(),
-                                                                          PrivPredicate.OPERATOR)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN/OPERATOR");
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString());
         }
 
         if (detail != null && !detail.equalsIgnoreCase("disks")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommand.java
@@ -74,8 +74,8 @@ public class ShowFrontendsCommand extends ShowCommand {
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString());
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
+                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
 
         if (detail != null && !detail.equalsIgnoreCase("disks")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommand.java
@@ -75,7 +75,7 @@ public class ShowFrontendsCommand extends ShowCommand {
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
                 InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DB_ACCESS_DENIED_ERROR,
-                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
         }
 
         if (detail != null && !detail.equalsIgnoreCase("disks")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2322,8 +2322,13 @@ public class ShowExecutor {
         resultSet = new ShowResultSet(showExportStmt.getMetaData(), infos);
     }
 
-    private void handleShowBackends() {
+    private void handleShowBackends() throws AnalysisException {
         final ShowBackendsStmt showStmt = (ShowBackendsStmt) stmt;
+        try {
+            showStmt.analyze(null);
+        } catch (Exception e) {
+            throw (AnalysisException) e;
+        }
         List<List<String>> backendInfos = BackendsProcDir.getBackendInfos();
 
         backendInfos.sort(new Comparator<List<String>>() {
@@ -2336,8 +2341,13 @@ public class ShowExecutor {
         resultSet = new ShowResultSet(showStmt.getMetaData(), backendInfos);
     }
 
-    private void handleShowFrontends() {
+    private void handleShowFrontends() throws AnalysisException {
         final ShowFrontendsStmt showStmt = (ShowFrontendsStmt) stmt;
+        try {
+            showStmt.analyze(null);
+        } catch (Exception e) {
+            throw (AnalysisException) e;
+        }
 
         List<List<String>> infos = Lists.newArrayList();
         FrontendsProcNode.getFrontendsInfo(Env.getCurrentEnv(), showStmt.getDetailType(), infos);

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/BackendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/BackendsTableValuedFunction.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.tablefunction;
 
-import org.apache.doris.catalog.*;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
-import org.apache.doris.common.ErrorReport;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -87,7 +90,7 @@ public class BackendsTableValuedFunction extends MetadataTableValuedFunction {
             throw new AnalysisException("backends table-valued-function does not support any params");
         }
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
-            InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             String message = ErrorCode.ERR_DB_ACCESS_DENIED_ERROR.formatErrorMsg(
                     PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
             throw new AnalysisException(message);

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/BackendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/BackendsTableValuedFunction.java
@@ -17,11 +17,10 @@
 
 package org.apache.doris.tablefunction;
 
-import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.*;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
@@ -87,10 +86,10 @@ public class BackendsTableValuedFunction extends MetadataTableValuedFunction {
         if (params.size() != 0) {
             throw new AnalysisException("backends table-valued-function does not support any params");
         }
-        if (!Env.getCurrentEnv().getAccessManager()
-                .checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN_OR_NODE)) {
-            String message = ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR.formatErrorMsg(
-                    PrivPredicate.ADMIN_OR_NODE.getPrivs().toString());
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+            InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            String message = ErrorCode.ERR_DB_ACCESS_DENIED_ERROR.formatErrorMsg(
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
             throw new AnalysisException(message);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsDisksTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsDisksTableValuedFunction.java
@@ -74,9 +74,9 @@ public class FrontendsDisksTableValuedFunction extends MetadataTableValuedFuncti
             throw new AnalysisException("frontends_disks table-valued-function does not support any params");
         }
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
-            InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             String message = ErrorCode.ERR_DB_ACCESS_DENIED_ERROR.formatErrorMsg(
-                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
             throw new AnalysisException(message);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsDisksTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsDisksTableValuedFunction.java
@@ -19,8 +19,10 @@ package org.apache.doris.tablefunction;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
@@ -71,10 +73,10 @@ public class FrontendsDisksTableValuedFunction extends MetadataTableValuedFuncti
         if (params.size() != 0) {
             throw new AnalysisException("frontends_disks table-valued-function does not support any params");
         }
-        if (!Env.getCurrentEnv().getAccessManager()
-                .checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN_OR_NODE)) {
-            String message = ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR.formatErrorMsg(
-                    PrivPredicate.ADMIN_OR_NODE.getPrivs().toString());
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+            InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            String message = ErrorCode.ERR_DB_ACCESS_DENIED_ERROR.formatErrorMsg(
+                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
             throw new AnalysisException(message);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
@@ -83,9 +83,9 @@ public class FrontendsTableValuedFunction extends MetadataTableValuedFunction {
             throw new AnalysisException("frontends table-valued-function does not support any params");
         }
         if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
-            InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+                InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
             String message = ErrorCode.ERR_DB_ACCESS_DENIED_ERROR.formatErrorMsg(
-                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
+                    PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
             throw new AnalysisException(message);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
@@ -19,8 +19,10 @@ package org.apache.doris.tablefunction;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
@@ -80,10 +82,10 @@ public class FrontendsTableValuedFunction extends MetadataTableValuedFunction {
         if (params.size() != 0) {
             throw new AnalysisException("frontends table-valued-function does not support any params");
         }
-        if (!Env.getCurrentEnv().getAccessManager()
-                .checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN_OR_NODE)) {
-            String message = ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR.formatErrorMsg(
-                    PrivPredicate.ADMIN_OR_NODE.getPrivs().toString());
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+            InternalCatalog.INTERNAL_CATALOG_NAME, InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)) {
+            String message = ErrorCode.ERR_DB_ACCESS_DENIED_ERROR.formatErrorMsg(
+                PrivPredicate.SELECT.getPrivs().toString(), InfoSchemaDb.DATABASE_NAME);
             throw new AnalysisException(message);
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFrontendsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFrontendsStmtTest.java
@@ -19,13 +19,11 @@ package org.apache.doris.analysis;
 
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
-import org.apache.doris.qe.ShowResultSetMetaData;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFrontendsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFrontendsStmtTest.java
@@ -17,13 +17,14 @@
 
 package org.apache.doris.analysis;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
+
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFrontendsStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowFrontendsStmtTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.analysis;
 
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -24,9 +26,6 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.ShowResultSetMetaData;
-
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +33,7 @@ import org.junit.jupiter.api.Assertions;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ShowBackendsStmtTest {
+public class ShowFrontendsStmtTest {
     private Analyzer analyzer;
     private ConnectContext ctx = new ConnectContext();
 
@@ -60,27 +59,11 @@ public class ShowBackendsStmtTest {
             }
         };
 
-        ShowBackendsStmt stmt = new ShowBackendsStmt();
+        ShowFrontendsStmt stmt = new ShowFrontendsStmt();
         Assertions.assertThrows(AnalysisException.class, () -> stmt.analyze(analyzer));
 
         privilege.set(true);
         stmt.analyze(analyzer);
     }
 
-    @Test
-    public void getMetaData() {
-        ShowBackendsStmt stmt = new ShowBackendsStmt();
-        ShowResultSetMetaData result = stmt.getMetaData();
-        Assertions.assertEquals(result.getColumnCount(), 27);
-        result.getColumns().forEach(col -> Assertions.assertEquals(col.getType(), ScalarType.createVarchar(30)));
-    }
-
-    @Test
-    public void getRedirectStatus() {
-        ShowBackendsStmt stmt = new ShowBackendsStmt();
-        Assertions.assertEquals(RedirectStatus.FORWARD_NO_SYNC, stmt.getRedirectStatus());
-
-        ctx.getSessionVariable().forwardToMaster = false;
-        Assertions.assertEquals(RedirectStatus.NO_FORWARD, stmt.getRedirectStatus());
-    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.AnalysisException;
@@ -27,15 +25,12 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
-import org.junit.Test;
+
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-
-/**
- * @Author zhaorongsheng
- * @Date 2025/4/23 19:43
- * @Version 1.0
- */
 public class ShowBackendsCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.nereids.trees.plans.commands;
 
 import mockit.Expectations;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions;
  * @Date 2025/4/23 19:43
  * @Version 1.0
  */
-public class ShowFrontendsCommandTest  extends TestWithFeService {
+public class ShowBackendsCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
 
@@ -55,7 +55,7 @@ public class ShowFrontendsCommandTest  extends TestWithFeService {
     @Test
     public void testNormal() throws Exception {
         runBefore();
-        ShowFrontendsCommand command = new ShowFrontendsCommand(null);
+        ShowBackendsCommand command = new ShowBackendsCommand();
         Assertions.assertDoesNotThrow(() -> command.run(connectContext, null));
     }
 
@@ -81,7 +81,7 @@ public class ShowFrontendsCommandTest  extends TestWithFeService {
                 result = false;
             }
         };
-        ShowFrontendsCommand command = new ShowFrontendsCommand(null);
+        ShowBackendsCommand command = new ShowBackendsCommand();
         Assertions.assertThrows(AnalysisException.class, () -> command.run(connectContext, null));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -39,9 +39,9 @@ public class ShowBackendsCommandTest extends TestWithFeService {
     @Mocked
     private Env env;
     @Mocked
-    private ConnectContext ctx;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    @Mocked
+    private ConnectContext ctx;
     @Mocked
     private InternalCatalog catalog;
     @Mocked
@@ -57,6 +57,14 @@ public class ShowBackendsCommandTest extends TestWithFeService {
                 env.getAccessManager();
                 minTimes = 0;
                 result = accessControllerManager;
+
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog(anyString);
+                minTimes = 0;
+                result = catalog;
 
                 ConnectContext.get();
                 minTimes = 0;
@@ -87,6 +95,14 @@ public class ShowBackendsCommandTest extends TestWithFeService {
                 env.getAccessManager();
                 minTimes = 0;
                 result = accessControllerManager;
+
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog(anyString);
+                minTimes = 0;
+                result = catalog;
 
                 ConnectContext.get();
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -25,7 +25,6 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.utframe.TestWithFeService;
 
 import mockit.Expectations;
 import mockit.Mocked;
@@ -108,7 +107,6 @@ public class ShowBackendsCommandTest {
                 minTimes = 0;
                 result = ctx;
 
-                accessControllerManager.checkGlobalPriv(ctx, PrivPredicate.SHOW);
                 accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
                 minTimes = 0;
                 result = false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -80,7 +80,7 @@ public class ShowBackendsCommandTest {
     public void testNormal() throws Exception {
         runBefore();
         ShowBackendsCommand command = new ShowBackendsCommand();
-        Assertions.assertDoesNotThrow(() -> command.run(ctx, null));
+        Assertions.assertDoesNotThrow(() -> command.doRun(ctx, null));
     }
 
     @Test
@@ -113,6 +113,6 @@ public class ShowBackendsCommandTest {
             }
         };
         ShowBackendsCommand command = new ShowBackendsCommand();
-        Assertions.assertThrows(AnalysisException.class, () -> command.run(ctx, null));
+        Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -32,7 +32,7 @@ import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ShowBackendsCommandTest extends TestWithFeService {
+public class ShowBackendsCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
 
@@ -68,9 +68,9 @@ public class ShowBackendsCommandTest extends TestWithFeService {
 
                 ConnectContext.get();
                 minTimes = 0;
-                result = connectContext;
+                result = ctx;
 
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, infoDB, PrivPredicate.SELECT);
+                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
                 minTimes = 0;
                 result = true;
             }
@@ -81,7 +81,7 @@ public class ShowBackendsCommandTest extends TestWithFeService {
     public void testNormal() throws Exception {
         runBefore();
         ShowBackendsCommand command = new ShowBackendsCommand();
-        Assertions.assertDoesNotThrow(() -> command.run(connectContext, null));
+        Assertions.assertDoesNotThrow(() -> command.run(ctx, null));
     }
 
     @Test
@@ -106,15 +106,15 @@ public class ShowBackendsCommandTest extends TestWithFeService {
 
                 ConnectContext.get();
                 minTimes = 0;
-                result = connectContext;
+                result = ctx;
 
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, infoDB, PrivPredicate.SELECT);
+                accessControllerManager.checkGlobalPriv(ctx, PrivPredicate.SHOW);
+                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
                 minTimes = 0;
                 result = false;
             }
         };
         ShowBackendsCommand command = new ShowBackendsCommand();
-        Assertions.assertThrows(AnalysisException.class, () -> command.run(connectContext, null));
+        Assertions.assertThrows(AnalysisException.class, () -> command.run(ctx, null));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -41,6 +42,10 @@ public class ShowBackendsCommandTest extends TestWithFeService {
     private ConnectContext ctx;
     @Mocked
     private AccessControllerManager accessControllerManager;
+    @Mocked
+    private InternalCatalog catalog;
+    @Mocked
+    private CatalogMgr catalogMgr;
 
     private void runBefore() throws Exception {
         new Expectations() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.AnalysisException;
@@ -27,16 +25,13 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
-import org.junit.Test;
+
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-
-/**
- * @Author zhaorongsheng
- * @Date 2025/4/23 19:43
- * @Version 1.0
- */
-public class ShowFrontendsCommandTest  extends TestWithFeService {
+public class ShowFrontendsCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.nereids.trees.plans.commands;
 
 import mockit.Expectations;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -1,0 +1,93 @@
+package org.apache.doris.nereids.trees.plans.commands;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.backup.CatalogMocker;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @Author zhaorongsheng
+ * @Date 2025/4/23 19:43
+ * @Version 1.0
+ */
+public class ShowFrontendsCommandTest  extends TestWithFeService {
+    private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
+    private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
+
+    @Mocked
+    private Env env;
+    @Mocked
+    private ConnectContext ctx;
+    @Mocked
+    private AccessControllerManager accessControllerManager;
+
+    private void runBefore() throws Exception {
+        new Expectations() {
+            {
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getAccessManager();
+                minTimes = 0;
+                result = accessControllerManager;
+
+                ConnectContext.get();
+                minTimes = 0;
+                result = connectContext;
+
+                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
+                accessControllerManager.checkDbPriv(connectContext, internalCtl, infoDB, PrivPredicate.SELECT);
+                minTimes = 0;
+                result = true;
+            }
+        };
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        runBefore();
+        ShowFrontendsCommand command = new ShowFrontendsCommand(null);
+        Assertions.assertDoesNotThrow(() -> command.run(connectContext, null));
+    }
+
+    @Test
+    public void testNoPrivilege() throws Exception {
+        new Expectations() {
+            {
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getAccessManager();
+                minTimes = 0;
+                result = accessControllerManager;
+
+                ConnectContext.get();
+                minTimes = 0;
+                result = connectContext;
+
+                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
+                accessControllerManager.checkDbPriv(connectContext, internalCtl, infoDB, PrivPredicate.SELECT);
+                minTimes = 0;
+                result = false;
+            }
+        };
+        ShowFrontendsCommand command = new ShowFrontendsCommand(null);
+        Assertions.assertThrows(AnalysisException.class, () -> command.run(connectContext, null));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -80,7 +80,7 @@ public class ShowFrontendsCommandTest {
     public void testNormal() throws Exception {
         runBefore();
         ShowFrontendsCommand command = new ShowFrontendsCommand(null);
-        Assertions.assertDoesNotThrow(() -> command.run(ctx, null));
+        Assertions.assertDoesNotThrow(() -> command.doRun(ctx, null));
     }
 
     @Test
@@ -113,6 +113,6 @@ public class ShowFrontendsCommandTest {
             }
         };
         ShowFrontendsCommand command = new ShowFrontendsCommand(null);
-        Assertions.assertThrows(AnalysisException.class, () -> command.run(ctx, null));
+        Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -32,7 +32,7 @@ import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ShowFrontendsCommandTest extends TestWithFeService {
+public class ShowFrontendsCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
 
@@ -68,9 +68,9 @@ public class ShowFrontendsCommandTest extends TestWithFeService {
 
                 ConnectContext.get();
                 minTimes = 0;
-                result = connectContext;
+                result = ctx;
 
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, infoDB, PrivPredicate.SELECT);
+                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
                 minTimes = 0;
                 result = true;
             }
@@ -81,7 +81,7 @@ public class ShowFrontendsCommandTest extends TestWithFeService {
     public void testNormal() throws Exception {
         runBefore();
         ShowFrontendsCommand command = new ShowFrontendsCommand(null);
-        Assertions.assertDoesNotThrow(() -> command.run(connectContext, null));
+        Assertions.assertDoesNotThrow(() -> command.run(ctx, null));
     }
 
     @Test
@@ -106,15 +106,15 @@ public class ShowFrontendsCommandTest extends TestWithFeService {
 
                 ConnectContext.get();
                 minTimes = 0;
-                result = connectContext;
+                result = ctx;
 
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, infoDB, PrivPredicate.SELECT);
+                accessControllerManager.checkGlobalPriv(ctx, PrivPredicate.SHOW);
+                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
                 minTimes = 0;
                 result = false;
             }
         };
         ShowFrontendsCommand command = new ShowFrontendsCommand(null);
-        Assertions.assertThrows(AnalysisException.class, () -> command.run(connectContext, null));
+        Assertions.assertThrows(AnalysisException.class, () -> command.run(ctx, null));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -25,7 +25,6 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.utframe.TestWithFeService;
 
 import mockit.Expectations;
 import mockit.Mocked;
@@ -108,7 +107,6 @@ public class ShowFrontendsCommandTest {
                 minTimes = 0;
                 result = ctx;
 
-                accessControllerManager.checkGlobalPriv(ctx, PrivPredicate.SHOW);
                 accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
                 minTimes = 0;
                 result = false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -41,6 +42,10 @@ public class ShowFrontendsCommandTest extends TestWithFeService {
     private ConnectContext ctx;
     @Mocked
     private AccessControllerManager accessControllerManager;
+    @Mocked
+    private InternalCatalog catalog;
+    @Mocked
+    private CatalogMgr catalogMgr;
 
     private void runBefore() throws Exception {
         new Expectations() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -58,6 +58,14 @@ public class ShowFrontendsCommandTest extends TestWithFeService {
                 minTimes = 0;
                 result = accessControllerManager;
 
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog(anyString);
+                minTimes = 0;
+                result = catalog;
+
                 ConnectContext.get();
                 minTimes = 0;
                 result = connectContext;
@@ -87,6 +95,14 @@ public class ShowFrontendsCommandTest extends TestWithFeService {
                 env.getAccessManager();
                 minTimes = 0;
                 result = accessControllerManager;
+
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog(anyString);
+                minTimes = 0;
+                result = catalog;
 
                 ConnectContext.get();
                 minTimes = 0;

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -32,6 +32,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    sql """revoke select_priv on information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {
@@ -39,7 +40,7 @@ suite("test_show_backend_auth","p0,auth_call") {
             exception "denied"
         }
     }
-    sql """grant node_priv on *.*.* to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
     connect(user, "${pwd}", context.config.jdbcUrl) {
         def res = sql """SHOW BACKENDS"""
         assertTrue(res.size() > 0)

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -34,8 +34,14 @@ suite("test_show_backend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
-        def show_result = sql """SHOW BACKENDS"""
-        logger.info("show_result: " + show_result)
+        
+        try {
+            def show_result = sql """SHOW BACKENDS"""
+            logger.info("show_result: " + show_result)
+        } catch (Exception e) {
+            logger.info("show_result: " + e)
+            e.printStackTrace()
+        }
         test {
             sql """SHOW BACKENDS"""
             exception "denied"

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -32,7 +32,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
-    sql """revoke select_priv on information_schema.* from ${user}"""
+    sql """revoke select_priv on information_schema from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -34,6 +34,8 @@ suite("test_show_backend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
+        def show_result = sql """SHOW BACKENDS"""
+        logger.info("show_result: " + show_result)
         test {
             sql """SHOW BACKENDS"""
             exception "denied"

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -34,7 +34,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
     logger.info("show grants result: " + show_grants_result)
-    sql """revoke select_priv on internal.information_schema.* from ${user}"""
+    // sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -32,6 +32,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -34,7 +34,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
     logger.info("show grants result: " + show_grants_result)
-    // sql """revoke select_priv on internal.information_schema.* from ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -33,7 +33,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
-    logger.info("show grants result: " + show_result)
+    logger.info("show grants result: " + show_grants_result)
     sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -32,6 +32,7 @@ suite("test_show_backend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
     logger.info("show grants result: " + show_grants_result)
     sql """revoke select_priv on internal.information_schema.* from ${user}"""

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -32,7 +32,6 @@ suite("test_show_backend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
-    sql """revoke select_priv on information_schema from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {

--- a/regression-test/suites/auth_call/test_show_backend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_backend_auth.groovy
@@ -32,6 +32,8 @@ suite("test_show_backend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    def show_grants_result = sql """show grants for ${user}"""
+    logger.info("show grants result: " + show_result)
     sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -32,6 +32,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    sql """revoke select_priv on information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {
@@ -43,7 +44,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
             exception "denied"
         }
     }
-    sql """grant node_priv on *.*.* to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
     connect(user, "${pwd}", context.config.jdbcUrl) {
         def res = sql """SHOW frontends"""
         assertTrue(res.size() > 0)

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -32,6 +32,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         try {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -34,8 +34,13 @@ suite("test_show_frontend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
-        def show_result = sql """SHOW frontends"""
-        logger.info("show_result: " + show_result)
+        try {
+            def show_result = sql """SHOW frontends"""
+            logger.info("show_result: " + show_result)
+        } catch (Exception e) {
+            logger.info("show_result: " + e)
+            e.printStackTrace()
+        }
         test {
             sql """SHOW frontends"""
             exception "denied"

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -34,7 +34,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
     logger.info("show grants result: " + show_grants_result)
-    sql """revoke select_priv on internal.information_schema.* from ${user}"""
+    // sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         try {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -32,7 +32,6 @@ suite("test_show_frontend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
-    sql """revoke select_priv on information_schema from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -32,6 +32,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
     logger.info("show grants result: " + show_grants_result)
     sql """revoke select_priv on internal.information_schema.* from ${user}"""

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -34,7 +34,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
     logger.info("show grants result: " + show_grants_result)
-    // sql """revoke select_priv on internal.information_schema.* from ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         try {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -32,7 +32,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
-    sql """revoke select_priv on information_schema.* from ${user}"""
+    sql """revoke select_priv on information_schema from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -33,7 +33,7 @@ suite("test_show_frontend_auth","p0,auth_call") {
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
     def show_grants_result = sql """show grants for ${user}"""
-    logger.info("show grants result: " + show_result)
+    logger.info("show grants result: " + show_grants_result)
     sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -32,6 +32,8 @@ suite("test_show_frontend_auth","p0,auth_call") {
     try_sql("DROP USER ${user}")
     sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
     sql """grant select_priv on regression_test to ${user}"""
+    def show_grants_result = sql """show grants for ${user}"""
+    logger.info("show grants result: " + show_result)
     sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {

--- a/regression-test/suites/auth_call/test_show_frontend_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_frontend_auth.groovy
@@ -34,6 +34,8 @@ suite("test_show_frontend_auth","p0,auth_call") {
     sql """grant select_priv on regression_test to ${user}"""
 
     connect(user, "${pwd}", context.config.jdbcUrl) {
+        def show_result = sql """SHOW frontends"""
+        logger.info("show_result: " + show_result)
         test {
             sql """SHOW frontends"""
             exception "denied"

--- a/regression-test/suites/auth_p0/test_backends_auth.groovy
+++ b/regression-test/suites/auth_p0/test_backends_auth.groovy
@@ -33,6 +33,8 @@ suite("test_backends_auth","p0,auth") {
     }
 
     sql """grant select_priv on regression_test to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
         test {
@@ -49,7 +51,7 @@ suite("test_backends_auth","p0,auth") {
         }
     }
 
-    sql """grant admin_priv on *.*.* to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
 
     connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
          sql """

--- a/regression-test/suites/auth_p0/test_frontends_auth.groovy
+++ b/regression-test/suites/auth_p0/test_frontends_auth.groovy
@@ -33,6 +33,8 @@ suite("test_frontends_auth","p0,auth") {
     }
 
     sql """grant select_priv on regression_test to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
         test {
@@ -49,7 +51,7 @@ suite("test_frontends_auth","p0,auth") {
         }
     }
 
-    sql """grant admin_priv on *.*.* to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
 
     connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
          sql """

--- a/regression-test/suites/auth_p0/test_frontends_disks_auth.groovy
+++ b/regression-test/suites/auth_p0/test_frontends_disks_auth.groovy
@@ -33,6 +33,8 @@ suite("test_frontends_disks_auth","p0,auth") {
     }
 
     sql """grant select_priv on regression_test to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
+    sql """revoke select_priv on internal.information_schema.* from ${user}"""
 
     connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
         test {
@@ -43,7 +45,7 @@ suite("test_frontends_disks_auth","p0,auth") {
         }
     }
 
-    sql """grant admin_priv on *.*.* to ${user}"""
+    sql """grant select_priv on internal.information_schema.* to ${user}"""
 
     connect(user=user, password="${pwd}", url=context.config.jdbcUrl) {
          sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #50138 

Problem Summary:

Unify Permission Requirements for Executing SHOW FRONTENDS/BACKENDS And NODE RestAPI. Make it as same as the privileges of system default database `information_schema`.


### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason 

- Behavior changed:
    - [x] No.
    - [ ] Yes. 

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

