### PR TITLE
[fix](nereids) fix fold constant return wrong scale of datetime type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -789,7 +789,10 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
                 .toRule(ExpressionRuleType.FOLD_CONSTANT_ON_FE);
     }
 
-    private Expression ensureResultType(Expression originExpr, Expression result, ExpressionRewriteContext context) {
+    /**
+     * ensure the result's data type equals to the originExpr's dataType
+     */
+    public static Expression ensureResultType(Expression originExpr, Expression result, ExpressionRewriteContext context) {
         if (originExpr.getDataType().equals(result.getDataType())) {
             return result;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -566,7 +566,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
             defaultResult = newDefault;
         }
         if (whenClauses.isEmpty()) {
-            return TypeCoercionUtils.ensureResultType(
+            return TypeCoercionUtils.ensureSameResultType(
                     originCaseWhen, defaultResult == null ? new NullLiteral(caseWhen.getDataType()) : defaultResult,
                     context
             );
@@ -577,10 +577,12 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
                 // it's safe to return null literal here
                 return new NullLiteral();
             } else {
-                return TypeCoercionUtils.ensureResultType(originCaseWhen, new CaseWhen(whenClauses), context);
+                return TypeCoercionUtils.ensureSameResultType(originCaseWhen, new CaseWhen(whenClauses), context);
             }
         }
-        return TypeCoercionUtils.ensureResultType(originCaseWhen, new CaseWhen(whenClauses, defaultResult), context);
+        return TypeCoercionUtils.ensureSameResultType(
+                originCaseWhen, new CaseWhen(whenClauses, defaultResult), context
+        );
     }
 
     @Override
@@ -588,11 +590,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         If originIf = ifExpr;
         ifExpr = rewriteChildren(ifExpr, context);
         if (ifExpr.child(0) instanceof NullLiteral || ifExpr.child(0).equals(BooleanLiteral.FALSE)) {
-            return TypeCoercionUtils.ensureResultType(originIf, ifExpr.child(2), context);
+            return TypeCoercionUtils.ensureSameResultType(originIf, ifExpr.child(2), context);
         } else if (ifExpr.child(0).equals(BooleanLiteral.TRUE)) {
-            return TypeCoercionUtils.ensureResultType(originIf, ifExpr.child(1), context);
+            return TypeCoercionUtils.ensureSameResultType(originIf, ifExpr.child(1), context);
         }
-        return TypeCoercionUtils.ensureResultType(originIf, ifExpr, context);
+        return TypeCoercionUtils.ensureSameResultType(originIf, ifExpr, context);
     }
 
     @Override
@@ -696,14 +698,14 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         for (Expression expr : nvl.children()) {
             if (expr.isLiteral()) {
                 if (!expr.isNullLiteral()) {
-                    return TypeCoercionUtils.ensureResultType(originNvl, expr, context);
+                    return TypeCoercionUtils.ensureSameResultType(originNvl, expr, context);
                 }
             } else {
-                return TypeCoercionUtils.ensureResultType(originNvl, nvl, context);
+                return TypeCoercionUtils.ensureSameResultType(originNvl, nvl, context);
             }
         }
         // all nulls
-        return TypeCoercionUtils.ensureResultType(originNvl, nvl.child(0), context);
+        return TypeCoercionUtils.ensureSameResultType(originNvl, nvl.child(0), context);
     }
 
     private <E extends Expression> E rewriteChildren(E expr, ExpressionRewriteContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
@@ -58,10 +58,10 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
     private static Expression rewriteCoalesce(ExpressionMatchingContext<Coalesce> ctx) {
         Coalesce coalesce = ctx.expr;
         if (1 == coalesce.arity()) {
-            return TypeCoercionUtils.ensureResultType(coalesce, coalesce.child(0), ctx.rewriteContext);
+            return TypeCoercionUtils.ensureSameResultType(coalesce, coalesce.child(0), ctx.rewriteContext);
         }
         if (!(coalesce.child(0) instanceof NullLiteral) && coalesce.child(0).nullable()) {
-            return TypeCoercionUtils.ensureResultType(coalesce, coalesce, ctx.rewriteContext);
+            return TypeCoercionUtils.ensureSameResultType(coalesce, coalesce, ctx.rewriteContext);
         }
         ImmutableList.Builder<Expression> childBuilder = ImmutableList.builder();
         for (int i = 0; i < coalesce.arity(); i++) {
@@ -70,7 +70,7 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
                 continue;
             }
             if (!child.nullable()) {
-                return TypeCoercionUtils.ensureResultType(coalesce, child, ctx.rewriteContext);
+                return TypeCoercionUtils.ensureSameResultType(coalesce, child, ctx.rewriteContext);
             } else {
                 for (int j = i; j < coalesce.arity(); j++) {
                     childBuilder.add(coalesce.children().get(j));
@@ -80,11 +80,11 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
         }
         List<Expression> newChildren = childBuilder.build();
         if (newChildren.isEmpty()) {
-            return TypeCoercionUtils.ensureResultType(
+            return TypeCoercionUtils.ensureSameResultType(
                     coalesce, new NullLiteral(coalesce.getDataType()), ctx.rewriteContext
             );
         } else {
-            return TypeCoercionUtils.ensureResultType(
+            return TypeCoercionUtils.ensureSameResultType(
                     coalesce, coalesce.withChildren(newChildren), ctx.rewriteContext
             );
         }
@@ -97,10 +97,10 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
     private static Expression rewriteNvl(ExpressionMatchingContext<Nvl> ctx) {
         Nvl nvl = ctx.expr;
         if (nvl.child(0) instanceof NullLiteral) {
-            return TypeCoercionUtils.ensureResultType(nvl, nvl.child(1), ctx.rewriteContext);
+            return TypeCoercionUtils.ensureSameResultType(nvl, nvl.child(1), ctx.rewriteContext);
         }
         if (!nvl.child(0).nullable()) {
-            return TypeCoercionUtils.ensureResultType(nvl, nvl.child(0), ctx.rewriteContext);
+            return TypeCoercionUtils.ensureSameResultType(nvl, nvl.child(0), ctx.rewriteContext);
         }
         return nvl;
     }
@@ -112,7 +112,7 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
     private static Expression rewriteNullIf(ExpressionMatchingContext<NullIf> ctx) {
         NullIf nullIf = ctx.expr;
         if (nullIf.child(0) instanceof NullLiteral || nullIf.child(1) instanceof NullLiteral) {
-            return TypeCoercionUtils.ensureResultType(
+            return TypeCoercionUtils.ensureSameResultType(
                     nullIf, new Nullable(nullIf.child(0)), ctx.rewriteContext
             );
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.NullIf;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -57,10 +58,10 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
     private static Expression rewriteCoalesce(ExpressionMatchingContext<Coalesce> ctx) {
         Coalesce coalesce = ctx.expr;
         if (1 == coalesce.arity()) {
-            return FoldConstantRuleOnFE.ensureResultType(coalesce, coalesce.child(0), ctx.rewriteContext);
+            return TypeCoercionUtils.ensureResultType(coalesce, coalesce.child(0), ctx.rewriteContext);
         }
         if (!(coalesce.child(0) instanceof NullLiteral) && coalesce.child(0).nullable()) {
-            return FoldConstantRuleOnFE.ensureResultType(coalesce, coalesce, ctx.rewriteContext);
+            return TypeCoercionUtils.ensureResultType(coalesce, coalesce, ctx.rewriteContext);
         }
         ImmutableList.Builder<Expression> childBuilder = ImmutableList.builder();
         for (int i = 0; i < coalesce.arity(); i++) {
@@ -69,7 +70,7 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
                 continue;
             }
             if (!child.nullable()) {
-                return FoldConstantRuleOnFE.ensureResultType(coalesce, child, ctx.rewriteContext);
+                return TypeCoercionUtils.ensureResultType(coalesce, child, ctx.rewriteContext);
             } else {
                 for (int j = i; j < coalesce.arity(); j++) {
                     childBuilder.add(coalesce.children().get(j));
@@ -79,11 +80,11 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
         }
         List<Expression> newChildren = childBuilder.build();
         if (newChildren.isEmpty()) {
-            return FoldConstantRuleOnFE.ensureResultType(
+            return TypeCoercionUtils.ensureResultType(
                     coalesce, new NullLiteral(coalesce.getDataType()), ctx.rewriteContext
             );
         } else {
-            return FoldConstantRuleOnFE.ensureResultType(
+            return TypeCoercionUtils.ensureResultType(
                     coalesce, coalesce.withChildren(newChildren), ctx.rewriteContext
             );
         }
@@ -96,10 +97,10 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
     private static Expression rewriteNvl(ExpressionMatchingContext<Nvl> ctx) {
         Nvl nvl = ctx.expr;
         if (nvl.child(0) instanceof NullLiteral) {
-            return FoldConstantRuleOnFE.ensureResultType(nvl, nvl.child(1), ctx.rewriteContext);
+            return TypeCoercionUtils.ensureResultType(nvl, nvl.child(1), ctx.rewriteContext);
         }
         if (!nvl.child(0).nullable()) {
-            return FoldConstantRuleOnFE.ensureResultType(nvl, nvl.child(0), ctx.rewriteContext);
+            return TypeCoercionUtils.ensureResultType(nvl, nvl.child(0), ctx.rewriteContext);
         }
         return nvl;
     }
@@ -111,7 +112,7 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
     private static Expression rewriteNullIf(ExpressionMatchingContext<NullIf> ctx) {
         NullIf nullIf = ctx.expr;
         if (nullIf.child(0) instanceof NullLiteral || nullIf.child(1) instanceof NullLiteral) {
-            return FoldConstantRuleOnFE.ensureResultType(
+            return TypeCoercionUtils.ensureResultType(
                     nullIf, new Nullable(nullIf.child(0)), ctx.rewriteContext
             );
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -156,7 +156,8 @@ public class TypeCoercionUtils {
     private static final Logger LOG = LogManager.getLogger(TypeCoercionUtils.class);
 
     /**
-     * ensure the result's data type equals to the originExpr's dataType
+     * ensure the result's data type equals to the originExpr's dataType,
+     * ATTN: this method usually used in fold constant rule
      */
     public static Expression ensureSameResultType(
             Expression originExpr, Expression result, ExpressionRewriteContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -158,7 +158,7 @@ public class TypeCoercionUtils {
     /**
      * ensure the result's data type equals to the originExpr's dataType
      */
-    public static Expression ensureResultType(
+    public static Expression ensureSameResultType(
             Expression originExpr, Expression result, ExpressionRewriteContext context) {
         if (originExpr.getDataType().equals(result.getDataType())) {
             return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -163,7 +163,7 @@ public class TypeCoercionUtils {
         if (originExpr.getDataType().equals(result.getDataType())) {
             return result;
         }
-        // backend can use direct use all string like type without cast
+        // backend can direct use all string like type without cast
         if (originExpr.getDataType().isStringLikeType() && result.getDataType().isStringLikeType()) {
             return result;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -160,15 +160,17 @@ public class TypeCoercionUtils {
      */
     public static Expression ensureSameResultType(
             Expression originExpr, Expression result, ExpressionRewriteContext context) {
-        if (originExpr.getDataType().equals(result.getDataType())) {
+        DataType originDataType = originExpr.getDataType();
+        DataType newDataType = result.getDataType();
+        if (originDataType.equals(newDataType)) {
             return result;
         }
         // backend can direct use all string like type without cast
-        if (originExpr.getDataType().isStringLikeType() && result.getDataType().isStringLikeType()) {
+        if (originDataType.isStringLikeType() && newDataType.isStringLikeType()) {
             return result;
         }
         return FoldConstantRuleOnFE.PATTERN_MATCH_INSTANCE.visitCast(
-                new Cast(result, originExpr.getDataType()), context
+                new Cast(result, originDataType), context
         );
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -1191,10 +1191,10 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 )
         ));
 
-        // assertRewriteExpression("nvl(NULL, 1)", "1");
-        // assertRewriteExpression("nvl(NULL, NULL)", "NULL");
-        // assertRewriteAfterTypeCoercion("nvl(IA, NULL)", "ifnull(IA, NULL)");
-        // assertRewriteAfterTypeCoercion("nvl(IA, 1)", "ifnull(IA, 1)");
+        assertRewriteExpression("nvl(NULL, 1)", "1");
+        assertRewriteExpression("nvl(NULL, NULL)", "NULL");
+        assertRewriteAfterTypeCoercion("nvl(IA, NULL)", "ifnull(IA, NULL)");
+        assertRewriteAfterTypeCoercion("nvl(IA, 1)", "ifnull(IA, 1)");
 
         Expression foldNvl = executor.rewrite(
                 PARSER.parseExpression("nvl(cast('2025-04-17' as datetime(0)), cast('2025-04-18 01:02:03.123456' as datetime(6)))"),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -1191,10 +1191,10 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 )
         ));
 
-        assertRewriteExpression("nvl(NULL, 1)", "1");
-        assertRewriteExpression("nvl(NULL, NULL)", "NULL");
-        assertRewriteAfterTypeCoercion("nvl(IA, NULL)", "ifnull(IA, NULL)");
-        assertRewriteAfterTypeCoercion("nvl(IA, 1)", "ifnull(IA, 1)");
+        // assertRewriteExpression("nvl(NULL, 1)", "1");
+        // assertRewriteExpression("nvl(NULL, NULL)", "NULL");
+        // assertRewriteAfterTypeCoercion("nvl(IA, NULL)", "ifnull(IA, NULL)");
+        // assertRewriteAfterTypeCoercion("nvl(IA, 1)", "ifnull(IA, 1)");
 
         Expression foldNvl = executor.rewrite(
                 PARSER.parseExpression("nvl(cast('2025-04-17' as datetime(0)), cast('2025-04-18 01:02:03.123456' as datetime(6)))"),


### PR DESCRIPTION
### What problem does this PR solve?

fix fold constant return wrong scale of datetime type

for example, this sql should return data type `datatime(6)`, but the fold constant rule will direct return the first argument, so return the wrong data type `datetime(0)`
```sql
select nvl(cast('2025-04-17 01:02:03' as datetime(0)), cast('2025-04-17 01:02:03.123456' as datetime(6)))
```


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

