### PR TITLE
[fix](cloud) Some resource APIs should not check if cluster_name is empty

### DIFF
--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2035,7 +2035,7 @@ void MetaServiceImpl::alter_cluster(google::protobuf::RpcController* controller,
                 });
     } break;
     case AlterClusterRequest::ADD_NODE: {
-        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false);
+        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false, false);
         if (msg != "") {
             LOG(WARNING) << msg;
             break;
@@ -2059,7 +2059,7 @@ void MetaServiceImpl::alter_cluster(google::protobuf::RpcController* controller,
         msg = resource_mgr_->modify_nodes(instance_id, to_add, to_del);
     } break;
     case AlterClusterRequest::DROP_NODE: {
-        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false);
+        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false, false);
         if (msg != "") {
             LOG(WARNING) << msg;
             break;
@@ -2082,7 +2082,7 @@ void MetaServiceImpl::alter_cluster(google::protobuf::RpcController* controller,
         msg = resource_mgr_->modify_nodes(instance_id, to_add, to_del);
     } break;
     case AlterClusterRequest::DECOMMISSION_NODE: {
-        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false);
+        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false, false);
         if (msg != "") {
             LOG(WARNING) << msg;
             break;
@@ -2144,7 +2144,7 @@ void MetaServiceImpl::alter_cluster(google::protobuf::RpcController* controller,
         }
     } break;
     case AlterClusterRequest::NOTIFY_DECOMMISSIONED: {
-        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false);
+        resource_mgr_->check_cluster_params_valid(request->cluster(), &msg, false, false);
         if (msg != "") {
             LOG(WARNING) << msg;
             break;

--- a/cloud/src/resource-manager/resource_manager.cpp
+++ b/cloud/src/resource-manager/resource_manager.cpp
@@ -140,7 +140,7 @@ std::string ResourceManager::get_node(const std::string& cloud_unique_id,
 }
 
 bool ResourceManager::check_cluster_params_valid(const ClusterPB& cluster, std::string* err,
-                                                 bool check_master_num) {
+                                                 bool check_master_num, bool check_cluster_name) {
     // check
     if (!cluster.has_type()) {
         *err = "cluster must have type arg";
@@ -155,7 +155,7 @@ bool ResourceManager::check_cluster_params_valid(const ClusterPB& cluster, std::
         return false;
     }
 
-    if (!cluster.has_cluster_name() || cluster.cluster_name() == "") {
+    if (check_cluster_name && (!cluster.has_cluster_name() || cluster.cluster_name() == "")) {
         *err = "not have cluster name";
         return false;
     }
@@ -315,7 +315,8 @@ std::pair<MetaServiceCode, std::string> ResourceManager::add_cluster(const std::
     std::unique_ptr<int, std::function<void(int*)>> defer(
             (int*)0x01, [&msg](int*) { LOG(INFO) << "add_cluster err=" << msg; });
 
-    if (!check_cluster_params_valid(cluster.cluster, &msg, true)) {
+    // just check cluster_name not empty in add_cluster
+    if (!check_cluster_params_valid(cluster.cluster, &msg, true, true)) {
         LOG(WARNING) << msg;
         return std::make_pair(MetaServiceCode::INVALID_ARGUMENT, msg);
     }

--- a/cloud/src/resource-manager/resource_manager.h
+++ b/cloud/src/resource-manager/resource_manager.h
@@ -108,13 +108,31 @@ public:
     virtual std::pair<TxnErrorCode, std::string> get_instance(std::shared_ptr<Transaction> txn,
                                                               const std::string& instance_id,
                                                               InstanceInfoPB* inst_pb);
-    // return err msg
+    /**
+     * Modifies the nodes associated with a given instance.
+     * This function allows adding and removing nodes from the instance.
+     *
+     * @param instance_id The ID of the instance to modify nodes for.
+     * @param to_add A vector of NodeInfo structures representing nodes to be added.
+     * @param to_del A vector of NodeInfo structures representing nodes to be removed.
+     * @return An error message if the operation fails, or an empty string for success.
+     */
     virtual std::string modify_nodes(const std::string& instance_id,
                                      const std::vector<NodeInfo>& to_add,
                                      const std::vector<NodeInfo>& to_del);
 
+    /**
+     * Checks the validity of the parameters for a cluster.
+     * This function verifies if the provided cluster parameters meet the required conditions.
+     *
+     * @param cluster The ClusterPB structure containing the cluster parameters to validate.
+     * @param err Output parameter to store any error message if validation fails.
+     * @param check_master_num Flag indicating whether to check the number of master nodes.
+     * @param check_cluster_name Flag indicating whether to check the cluster name is empty, just add_cluster need.
+     * @return True if the parameters are valid, false otherwise.
+     */
     bool check_cluster_params_valid(const ClusterPB& cluster, std::string* err,
-                                    bool check_master_num, bool check_cluster_name = false);
+                                    bool check_master_num, bool check_cluster_name);
 
     /**
      * Check cloud_unique_id is degraded format, and get instance_id from cloud_unique_id

--- a/cloud/src/resource-manager/resource_manager.h
+++ b/cloud/src/resource-manager/resource_manager.h
@@ -114,7 +114,7 @@ public:
                                      const std::vector<NodeInfo>& to_del);
 
     bool check_cluster_params_valid(const ClusterPB& cluster, std::string* err,
-                                    bool check_master_num);
+                                    bool check_master_num, bool check_cluster_name = false);
 
     /**
      * Check cloud_unique_id is degraded format, and get instance_id from cloud_unique_id


### PR DESCRIPTION
### What problem does this PR solve?

due to https://github.com/apache/doris/pull/49775

but some api cant check cluster name, 
1. Cloud Management The request may not have passed in the cluster_name in the inventory logic
2. sql node mode also not pass cluster_name to ms, so in cloud use sql `ALTER SYSTEM ADD BACKEND ip:host` will return err, not have cluster name 

```

```
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

