### PR TITLE
[Enhance] Support the json_search function like MySQL, extra the escape and start_path arguments

### DIFF
--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -391,9 +391,13 @@ public:
         return true;
     }
 
-    size_t get_leg_vector_size() { return leg_vector.size(); }
+    bool operator==(const JsonbPath& other) const { return leg_vector == other.leg_vector; }
 
-    leg_info* get_leg_from_leg_vector(size_t i) { return leg_vector[i].get(); }
+    bool operator!=(const JsonbPath& other) const { return !operator==(other); }
+
+    size_t get_leg_vector_size() const { return leg_vector.size(); }
+
+    leg_info* get_leg_from_leg_vector(size_t i) const { return leg_vector[i].get(); }
 
     void clean() { leg_vector.clear(); }
 

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -401,9 +401,15 @@ public:
 
     bool starts_with(const JsonbPath& other) const {
         for (size_t i = 0; i < other.get_leg_vector_size(); i++) {
-            if (other.leg_vector[i]->leg_len != leg_vector[i]->leg_len ||
-                strcmp(other.leg_vector[i]->leg_ptr, leg_vector[i]->leg_ptr) != 0) {
-                return false;
+            if (other.leg_vector[i]->type == MEMBER_CODE) {
+                if (strncmp(leg_vector[i]->leg_ptr, other.leg_vector[i]->leg_ptr,
+                            other.leg_vector[i]->leg_len) != 0) {
+                    return false;
+                }
+            } else if (other.leg_vector[i]->type == ARRAY_CODE) {
+                if (leg_vector[i]->array_index != other.leg_vector[i]->array_index) {
+                    return false;
+                }
             }
         }
         return true;
@@ -420,9 +426,15 @@ public:
             return false;
         }
         for (size_t i = 0; i < get_leg_vector_size(); i++) {
-            if (leg_vector[i]->leg_len != other.leg_vector[i]->leg_len ||
-                strcmp(leg_vector[i]->leg_ptr, other.leg_vector[i]->leg_ptr) != 0) {
-                return false;
+            if (other.leg_vector[i]->type == MEMBER_CODE) {
+                if (strncmp(leg_vector[i]->leg_ptr, other.leg_vector[i]->leg_ptr,
+                            other.leg_vector[i]->leg_len) != 0) {
+                    return false;
+                }
+            } else if (other.leg_vector[i]->type == ARRAY_CODE) {
+                if (leg_vector[i]->array_index != other.leg_vector[i]->array_index) {
+                    return false;
+                }
             }
         }
         return true;

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -1866,14 +1866,8 @@ struct JsonSearchUtil {
                 bool find_start_element = false;
                 find_start_root_element(root_element, start_element, &find_start_element,
                                         start_path);
-                if (!find_start_element) {
-                    null_map->get_data()[i] = 1;
-                    result_col->insert_data("", 0);
-                    continue;
-                }
 
                 auto cur_path = std::make_unique<JsonbPath>();
-                // cur_path->add_leg_to_leg_vector("$", MEMBER_CODE);
                 auto find = find_matches(start_element, is_one, state, start_path, &matches);
                 if (is_one && find) {
                     break;

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -2109,35 +2109,35 @@ struct JsonSearchNormal {
         get_##arg_name##_string = get_fn;                                                   \
     }
 
-#define JSON_SEARCH_EXTRA_PREPARE_ESCAPE()                                                        \
-    JsonSearchUtil::CheckNullFun escape_null_check = JsonSearchUtil::always_null;                 \
-    JsonSearchUtil::GetJsonEscapeFun get_escape_string;                                           \
-                                                                                                  \
-    ColumnPtr col_escape;                                                                         \
-    bool escape_is_const = false;                                                                 \
-    const ColumnString* col_escape_string;                                                        \
-                                                                                                  \
-    RETURN_IF_ERROR(JsonSearchUtil::parse_column_args(                                            \
-            context, block, arguments, 3, &escape_is_const, col_escape, col_escape_string));      \
-                                                                                                  \
-    if (!escape_is_const) {                                                                       \
-        /* return Status::RuntimeError("JsonSearch escape_char CANNOT be non-constant column");*/ \
-    }                                                                                             \
-    do {                                                                                          \
-        escape_null_check = [col_escape](size_t) { return col_escape->is_null_at(0); };           \
-        get_escape_string = [col_escape_string](std::shared_ptr<LikeState>& state) {              \
-            auto escape_string = col_escape_string->get_data_at(0).to_string();                   \
-            if (escape_string.length() == 0) {                                                    \
-                return Status::OK();                                                              \
-            }                                                                                     \
-                                                                                                  \
-            if (escape_string.length() > 1) {                                                     \
-                return Status::RuntimeError("Illegal arg pattern {} should be char",              \
-                                            col_escape_string->get_name());                       \
-            }                                                                                     \
-            state->search_state.escape_char = escape_string.at(0);                                \
-            return Status::OK();                                                                  \
-        };                                                                                        \
+#define JSON_SEARCH_EXTRA_PREPARE_ESCAPE()                                                   \
+    JsonSearchUtil::CheckNullFun escape_null_check = JsonSearchUtil::always_null;            \
+    JsonSearchUtil::GetJsonEscapeFun get_escape_string;                                      \
+                                                                                             \
+    ColumnPtr col_escape;                                                                    \
+    bool escape_is_const = false;                                                            \
+    const ColumnString* col_escape_string;                                                   \
+                                                                                             \
+    RETURN_IF_ERROR(JsonSearchUtil::parse_column_args(                                       \
+            context, block, arguments, 3, &escape_is_const, col_escape, col_escape_string)); \
+                                                                                             \
+    if (!escape_is_const) {                                                                  \
+        return Status::RuntimeError("JsonSearch escape_char CANNOT be non-constant column"); \
+    }                                                                                        \
+    do {                                                                                     \
+        escape_null_check = [col_escape](size_t) { return col_escape->is_null_at(0); };      \
+        get_escape_string = [col_escape_string](std::shared_ptr<LikeState>& state) {         \
+            auto escape_string = col_escape_string->get_data_at(0).to_string();              \
+            if (escape_string.length() == 0) {                                               \
+                return Status::OK();                                                         \
+            }                                                                                \
+                                                                                             \
+            if (escape_string.length() > 1) {                                                \
+                return Status::RuntimeError("Illegal arg pattern {} should be char",         \
+                                            col_escape_string->get_name());                  \
+            }                                                                                \
+            state->search_state.escape_char = escape_string.at(0);                           \
+            return Status::OK();                                                             \
+        };                                                                                   \
     } while (false)
 
 struct JsonSearchEscape {

--- a/be/test/util/jsonb_parser_simd_test.cpp
+++ b/be/test/util/jsonb_parser_simd_test.cpp
@@ -15,10 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "util/jsonb_parser_simd.h"
+
 #include "common/status.h"
 #include "gtest/gtest.h"
 #include "util/jsonb_error.h"
-#include "util/jsonb_parser_simd.h"
 #include "util/jsonb_utils.h"
 #include "util/jsonb_writer.h"
 

--- a/be/test/util/jsonb_parser_simd_test.cpp
+++ b/be/test/util/jsonb_parser_simd_test.cpp
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "util/jsonb_parser_simd.h"
-
 #include "common/status.h"
 #include "gtest/gtest.h"
 #include "util/jsonb_error.h"
+#include "util/jsonb_parser_simd.h"
 #include "util/jsonb_utils.h"
 #include "util/jsonb_writer.h"
 

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -2128,6 +2128,15 @@ TEST(FunctionJsonSearchTest, EscapeJsonSearchTest) {
               STRING("\\")},
              STRING("\"$.k1\"")},
 
+            // specical default escape_char '\\'
+            {{STRING(R"({"k1":"v1\\", "k2": "100\\"})"), STRING("one"), STRING("v1\\\\"),
+              STRING("")},
+             STRING("\"$.k1\"")},
+
+            // specical Null escape_char '\\'
+            {{STRING(R"({"k1":"v1\\", "k2": "100\\"})"), STRING("one"), STRING("v1\\\\"), Null()},
+             STRING("\"$.k1\"")},
+
             // Array test cases with escape characters
             {{STRING(R"(["v1%", "v2%"])"), STRING("one"), STRING("v1%"), STRING("\\")},
              STRING("\"$[0]\"")},

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -2112,25 +2112,28 @@ TEST(FunctionJsonSearchTest, EscapeJsonSearchTest) {
     // json_search(json_doc, one/all, search_str, escape_char)
     std::string func_name = "json_search";
     InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                TypeIndex::String};
+                                Consted {TypeIndex::String}};
 
     DataSet data_set = {
-            {{STRING(R"({"k1":"v1%", "k2": "100%"})"), STRING("one"), STRING("v1%"), STRING("\\")},
+            {{STRING(R"({"k1":"v1%", "k2": "100%"})"), STRING("one"), STRING("v1%"),
+              std::string("\\")},
              STRING("\"$.k1\"")},
 
-            {{STRING(R"({"k1":"v1|%", "k2": "100%"})"), STRING("one"), STRING("v1%"), STRING("|")},
+            {{STRING(R"({"k1":"v1|%", "k2": "100%"})"), STRING("one"), STRING("v1%"),
+              std::string("|")},
              STRING("\"$.k1\"")},
 
-            {{STRING(R"({"k1":"v1%", "k2": "100%"})"), STRING("one"), STRING("v1"), STRING("\\")},
+            {{STRING(R"({"k1":"v1%", "k2": "100%"})"), STRING("one"), STRING("v1"),
+              std::string("\\")},
              Null()},
 
             {{STRING(R"({"k1":"v1\\", "k2": "100\\"})"), STRING("one"), STRING("v1\\\\"),
-              STRING("\\")},
+              std::string("\\")},
              STRING("\"$.k1\"")},
 
             // specical default escape_char '\\'
             {{STRING(R"({"k1":"v1\\", "k2": "100\\"})"), STRING("one"), STRING("v1\\\\"),
-              STRING("")},
+              std::string("")},
              STRING("\"$.k1\"")},
 
             // specical Null escape_char '\\'
@@ -2138,17 +2141,21 @@ TEST(FunctionJsonSearchTest, EscapeJsonSearchTest) {
              STRING("\"$.k1\"")},
 
             // Array test cases with escape characters
-            {{STRING(R"(["v1%", "v2%"])"), STRING("one"), STRING("v1%"), STRING("\\")},
+            {{STRING(R"(["v1%", "v2%"])"), STRING("one"), STRING("v1%"), std::string("\\")},
              STRING("\"$[0]\"")},
 
-            {{STRING(R"(["v1|%", "v2%"])"), STRING("one"), STRING("v1%"), STRING("|")},
+            {{STRING(R"(["v1|%", "v2%"])"), STRING("one"), STRING("v1%"), std::string("|")},
              STRING("\"$[0]\"")},
 
-            {{STRING(R"(["v1\\", "v2\\"])"), STRING("one"), STRING("v1\\\\"), STRING("\\")},
+            {{STRING(R"(["v1\\", "v2\\"])"), STRING("one"), STRING("v1\\\\"), std::string("\\")},
              STRING("\"$[0]\"")},
     };
 
-    static_cast<void>(check_function<DataTypeJsonb, true>(func_name, input_types, data_set));
+    for (const auto& line : data_set) {
+        DataSet const_dataset = {line};
+        static_cast<void>(
+                check_function<DataTypeJsonb, true>(func_name, input_types, const_dataset));
+    }
 }
 
 TEST(FunctionJsonSearchTest, StartJsonSearchTest) {
@@ -2156,48 +2163,52 @@ TEST(FunctionJsonSearchTest, StartJsonSearchTest) {
     // json_search(json_doc, one/all, search_str, escape_char, start_path)
     std::string func_name = "json_search";
     InputTypeSet input_types = {TypeIndex::String, TypeIndex::String, TypeIndex::String,
-                                TypeIndex::String, TypeIndex::String};
+                                Consted {TypeIndex::String}, TypeIndex::String};
 
     DataSet data_set = {
-            {{STRING(R"({"k1":{"k2":"v1"}, "k3": "v1"})"), STRING("one"), STRING("v1"),
-              STRING("\\"), STRING("$.k1")},
+            {{STRING(R"({"k1":{"k2":"v1"}, "k3": "v1"})"), STRING("one"), VARCHAR("v1"),
+              VARCHAR("\\"), STRING("$.k1")},
              STRING("\"$.k1.k2\"")},
 
             {{STRING(R"({"k1":{"k2":"v1"}, "k3": "v1"})"), STRING("one"), STRING("v1"),
-              STRING("\\"), STRING("$.k3")},
+              VARCHAR("\\"), STRING("$.k3")},
              STRING("\"$.k3\"")},
 
             {{STRING(R"({"k1":["a","b","c"], "k2": ["a","d"]})"), STRING("one"), STRING("a"),
-              STRING("\\"), STRING("$.k1")},
+              std::string("\\"), STRING("$.k1")},
              STRING("\"$.k1[0]\"")},
 
-            {{STRING(R"({"a":{"b":{"c":"value"}}})"), STRING("one"), STRING("value"), STRING("\\"),
-              STRING("$.a.b")},
+            {{STRING(R"({"a":{"b":{"c":"value"}}})"), STRING("one"), STRING("value"),
+              std::string("\\"), STRING("$.a.b")},
              STRING("\"$.a.b.c\"")},
 
             // Array test cases with start path
             {{STRING(R"({"arr1": [1, 2, 3], "arr2": [4, 5, 6]})"), STRING("one"), STRING("5"),
-              STRING("\\"), STRING("$.arr2")},
+              std::string("\\"), STRING("$.arr2")},
              Null()},
 
             {{STRING(R"({"arr1": ["1", "2", "3"], "arr2": ["4", "5", "6"]})"), STRING("one"),
-              STRING("5"), STRING("\\"), STRING("$.arr2")},
+              STRING("5"), std::string("\\"), STRING("$.arr2")},
              STRING("\"$.arr2[1]\"")},
 
-            {{STRING(R"({"nested": {"arr": [7, 8, 9]}})"), STRING("one"), STRING("8"), STRING("\\"),
-              STRING("$.nested.arr")},
+            {{STRING(R"({"nested": {"arr": [7, 8, 9]}})"), STRING("one"), STRING("8"),
+              std::string("\\"), STRING("$.nested.arr")},
              Null()},
 
             {{STRING(R"({"nested": {"arr": ["7", "8", "9"]}})"), STRING("one"), STRING("8"),
-              STRING("\\"), STRING("$.nested.arr")},
+              std::string("\\"), STRING("$.nested.arr")},
              STRING("\"$.nested.arr[1]\"")},
 
-            {{STRING(R"([["a", "b"], ["c", "d"]])"), STRING("one"), STRING("d"), STRING("\\"),
+            {{STRING(R"([["a", "b"], ["c", "d"]])"), STRING("one"), STRING("d"), std::string("\\"),
               STRING("$[1]")},
              STRING("\"$[1][1]\"")},
     };
 
-    static_cast<void>(check_function<DataTypeJsonb, true>(func_name, input_types, data_set));
+    for (const auto& line : data_set) {
+        DataSet const_dataset = {line};
+        static_cast<void>(
+                check_function<DataTypeJsonb, true>(func_name, input_types, const_dataset));
+    }
 }
 
 } // namespace doris::vectorized

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -2182,6 +2182,10 @@ TEST(FunctionJsonSearchTest, StartJsonSearchTest) {
               std::string("\\"), STRING("$.a.b")},
              STRING("\"$.a.b.c\"")},
 
+            {{STRING(R"({"a":{"b":{"c":"value"}}})"), STRING("one"), STRING("value"),
+              std::string("\\"), STRING("$.not")},
+             Null()},
+
             // Array test cases with start path
             {{STRING(R"({"arr1": [1, 2, 3], "arr2": [4, 5, 6]})"), STRING("one"), STRING("5"),
               std::string("\\"), STRING("$.arr2")},
@@ -2202,6 +2206,10 @@ TEST(FunctionJsonSearchTest, StartJsonSearchTest) {
             {{STRING(R"([["a", "b"], ["c", "d"]])"), STRING("one"), STRING("d"), std::string("\\"),
               STRING("$[1]")},
              STRING("\"$[1][1]\"")},
+
+            {{STRING(R"([["a", "b"], ["c", "d"]])"), STRING("one"), STRING("d"), std::string("\\"),
+              STRING("$[4]")},
+             Null()},
     };
 
     for (const auto& line : data_set) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonSearch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonSearch.java
@@ -37,11 +37,25 @@ public class JsonSearch extends ScalarFunction implements ExplicitlyCastableSign
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(JsonType.INSTANCE)
-                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT)
+                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(JsonType.INSTANCE)
+                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT,
+                            VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(JsonType.INSTANCE)
+                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT,
+                            VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT)
     );
 
     public JsonSearch(Expression arg0, Expression arg1, Expression arg2) {
         super("json_search", arg0, arg1, arg2);
+    }
+
+    public JsonSearch(Expression arg0, Expression arg1, Expression arg2, Expression arg3) {
+        super("json_search", arg0, arg1, arg2, arg3);
+    }
+
+    public JsonSearch(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4) {
+        super("json_search", arg0, arg1, arg2, arg3, arg4);
     }
 
     @Override
@@ -51,8 +65,14 @@ public class JsonSearch extends ScalarFunction implements ExplicitlyCastableSign
 
     @Override
     public JsonSearch withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.size() == 3);
-        return new JsonSearch(children.get(0), children.get(1), children.get(2));
+        Preconditions.checkArgument(children.size() == 3 || children.size() == 4 || children.size() == 5);
+        if (children.size() == 3) {
+            return new JsonSearch(children.get(0), children.get(1), children.get(2));
+        } else if (children.size() == 4) {
+            return new JsonSearch(children.get(0), children.get(1), children.get(2), children.get(3));
+        } else {
+            return new JsonSearch(children.get(0), children.get(1), children.get(2), children.get(3), children.get(4));
+        }
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: https://github.com/apache/doris/issues/48203

Problem Summary: Support the `json_search` function like MySQL support, extra the two arguments, escape and start_path.

REMAINING PROBLEMS: 

**Because this question https://github.com/apache/doris/issues/50150, I did not test if `start_path` did not exist.**

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. can use escape and start_path arguments

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

