### PR TITLE
[opt](nereids) Optimize type conversion strategy for ComparisonPredicate with literals

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -986,7 +986,7 @@ public class TypeCoercionUtils {
             }
             return comparisonPredicate.withChildren(left, right);
         }
-            
+
         // try to convert the right literal to left type.
         if (isRightLiteralConvertible(left, right)) {
             if (!supportCompare(left.getDataType())) {
@@ -1143,6 +1143,7 @@ public class TypeCoercionUtils {
 
     /**
      * check should downgrade from commonTypeClazz to targetTypeClazz.
+     *
      * @param commonTypeClazz before downgrade type
      * @param targetTypeClazz try to downgrade to type
      * @param commonType original common type
@@ -1150,7 +1151,6 @@ public class TypeCoercionUtils {
      * @param commonTypePredicate constraint for original type
      * @param otherPredicate constraint for other expressions aka literals
      * @param others literals
-     *
      * @return true for should downgrade
      */
     private static boolean shouldDowngrade(
@@ -1330,10 +1330,10 @@ public class TypeCoercionUtils {
     /**
      * get common type for comparison.
      * in legacy planner, comparison predicate convert int vs string to double.
-     *   however, in predicate and between predicate convert int vs string to string
-     *   but after between rewritten to comparison predicate,
-     *   int vs string been convert to double again
-     *   so, in Nereids, only in predicate set this flag to true.
+     * however, in predicate and between predicate convert int vs string to string
+     * but after between rewritten to comparison predicate,
+     * int vs string been convert to double again
+     * so, in Nereids, only in predicate set this flag to true.
      */
     private static Optional<DataType> findCommonPrimitiveTypeForComparison(
             DataType leftType, DataType rightType, boolean intStringToString) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -960,6 +960,15 @@ public class TypeCoercionUtils {
     }
 
     /**
+     * check if the right literal can be converted to the type of the left expression.
+     */
+    private static boolean isRightLiteralConvertible(Expression left, Expression right) {
+        return !(left instanceof Literal)
+                && (right instanceof Literal)
+                && canCastTo(right.getDataType(), left.getDataType());
+    }
+
+    /**
      * process comparison predicate type coercion.
      */
     public static Expression processComparisonPredicate(ComparisonPredicate comparisonPredicate) {
@@ -975,6 +984,16 @@ public class TypeCoercionUtils {
                 throw new AnalysisException("data type " + left.getDataType()
                         + " could not used in ComparisonPredicate " + comparisonPredicate.toSql());
             }
+            return comparisonPredicate.withChildren(left, right);
+        }
+            
+        // try to convert the right literal to left type.
+        if (isRightLiteralConvertible(left, right)) {
+            if (!supportCompare(left.getDataType())) {
+                throw new AnalysisException("data type " + left.getDataType()
+                        + " could not used in ComparisonPredicate " + comparisonPredicate.toSql());
+            }
+            right = castIfNotSameType(right, left.getDataType());
             return comparisonPredicate.withChildren(left, right);
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #50159 

Problem Summary:
In a comparison operation (ComparisonPredicate), the literal on the right side is preferentially cast to the type of the expression on the left side.  

This optimization allows the query conditions to be pushed down to the external storage layer , thereby reducing the amount of data scanned and improving query efficiency.

### Release note

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

