### PR TITLE
[Improvement](function) change from_unixtime's intermedia type from vdatetime to datetimev2

### DIFF
--- a/be/src/vec/functions/date_time_transforms.h
+++ b/be/src/vec/functions/date_time_transforms.h
@@ -275,7 +275,7 @@ struct FromUnixTimeImpl {
             return false;
 
         } else {
-            DateV2Value<DateV2ValueType> dt;
+            DateV2Value<DateTimeV2ValueType> dt;
             if (val < 0 || val > TIMESTAMP_VALID_MAX) {
                 return true;
             }

--- a/be/src/vec/functions/date_time_transforms.h
+++ b/be/src/vec/functions/date_time_transforms.h
@@ -257,7 +257,7 @@ struct FromUnixTimeImpl {
     static bool execute(const FromType& val, StringRef format, ColumnString::Chars& res_data,
                         size_t& offset, const cctz::time_zone& time_zone) {
         if constexpr (std::is_same_v<Impl, time_format_type::NoneImpl>) {
-            DateV2Value<DateV2ValueType> dt;
+            DateV2Value<DateTimeV2ValueType> dt;
             if (val < 0 || val > TIMESTAMP_VALID_MAX) {
                 return true;
             }

--- a/be/src/vec/functions/function_datetime_string_to_string.cpp
+++ b/be/src/vec/functions/function_datetime_string_to_string.cpp
@@ -18,6 +18,7 @@
 #include "vec/functions/function_datetime_string_to_string.h"
 
 #include "vec/data_types/data_type_time_v2.h" // IWYU pragma: keep
+#include "vec/functions/date_time_transforms.h"
 #include "vec/functions/simple_function_factory.h"
 #include "vec/runtime/vdatetime_value.h"
 
@@ -28,7 +29,7 @@ using FunctionDateFormatV2 =
         FunctionDateTimeStringToString<DateFormatImpl<DateV2Value<DateV2ValueType>, UInt32>>;
 using FunctionDateTimeV2DateFormat =
         FunctionDateTimeStringToString<DateFormatImpl<DateV2Value<DateTimeV2ValueType>, UInt64>>;
-using FunctionFromUnixTime = FunctionDateTimeStringToString<FromUnixTimeImpl<VecDateTimeValue>>;
+using FunctionFromUnixTime = FunctionDateTimeStringToString<FromUnixTimeImpl>;
 
 void register_function_date_time_string_to_string(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionDateFormat>();

--- a/be/src/vec/functions/function_datetime_string_to_string.h
+++ b/be/src/vec/functions/function_datetime_string_to_string.h
@@ -25,6 +25,7 @@
 
 #include "common/cast_set.h"
 #include "common/status.h"
+#include "runtime/runtime_state.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
@@ -42,9 +43,7 @@
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/functions/date_format_type.h"
-#include "vec/functions/date_time_transforms.h"
 #include "vec/functions/function.h"
-#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
@@ -67,7 +66,9 @@ public:
     bool is_variadic() const override { return true; }
     size_t get_number_of_arguments() const override { return 0; }
     DataTypes get_variadic_argument_types_impl() const override {
-        if constexpr (has_variadic_argument) return Transform::get_variadic_argument_types();
+        if constexpr (has_variadic_argument) {
+            return Transform::get_variadic_argument_types();
+        }
         return {};
     }
 


### PR DESCRIPTION
### What problem does this PR solve?
change from_unixtime's intermedia type from vdatetime to datetimev2

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

