### PR TITLE
[enhancement](image): load image supports reading in batches

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2883,6 +2883,19 @@ public class Config extends ConfigBase {
     })
     public static int sync_image_timeout_second = 300;
 
+    @ConfField(mutable = true, description = {
+        "FE启动时加载image文件某个模块的二进制内容到字节数组，并将字节数组反序列化为utf8编码字符串时单批次（单位：byte, 至少500MB）"
+            + "的大小。等于-1的值表示一次性读取完整的字节数组后反序列化反序列化为utf8编码字符串；"
+            + "不等于-1的值（至少16MB）表示分批每次读取多大的字节数组后反序列化为utf8编码字符串，最后合并成完成的字符串。默认值为-1",
+        "The size of a single batch (in bytes) when loading the binary content of a module of the "
+            + "image file into a byte array and deserializing the byte array into a utf8 encoded string when FE starts."
+            + " A value equal to -1 means reading the entire byte array at once and "
+            + "then deserializing it into a utf8 encoded string; a value not equal to -1 means reading "
+            + "a certain size (at least 16MB) of byte array in batches and then deserializing it into a "
+            + "utf8 encoded string, and finally merging it into a completed string. The default value is -1"
+    })
+    public static int metadata_text_read_max_batch_bytes = -1;
+
     @ConfField(mutable = true, masterOnly = true)
     public static int publish_topic_info_interval_ms = 30000; // 30s
 

--- a/fe/fe-common/src/test/java/org/apache/doris/common/io/TextTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/io/TextTest.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.io;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+public class TextTest {
+    static Stream<Arguments> provideTestData() {
+        return Stream.of(
+                Arguments.arguments("Hello".getBytes(StandardCharsets.UTF_8)),
+                Arguments.arguments("helloé".getBytes(StandardCharsets.UTF_8)),
+                Arguments.arguments(createBytes("中".getBytes(StandardCharsets.UTF_8), 1024 * 1024 * 16)),
+                Arguments.arguments(createBytes("中".getBytes(StandardCharsets.UTF_8), 1024 * 1024 * 16 + 1)),
+                Arguments.arguments(createBytes("中".getBytes(StandardCharsets.UTF_8), 1024 * 1024 * 32)),
+                Arguments.arguments(createBytes("中".getBytes(StandardCharsets.UTF_8), 43214321)),
+                Arguments.arguments("特殊\n\r\t字符".getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @MethodSource("provideTestData")
+    void testReadString(byte[] inputBytes) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutput dataOutput = new DataOutputStream(bos);
+        dataOutput.writeInt(inputBytes.length);
+        dataOutput.write(inputBytes);
+        String result = Text.readString(new DataInputStream(new ByteArrayInputStream(bos.toByteArray())));
+        Assertions.assertEquals(new String(inputBytes, StandardCharsets.UTF_8), result);
+    }
+
+    private static byte[] createBytes(byte[] metaBytes, int scala) {
+        byte[] bytes = new byte[metaBytes.length * scala];
+        for (int i = 0; i < scala; i++) {
+            System.arraycopy(metaBytes, 0, bytes, i * metaBytes.length, metaBytes.length);
+        }
+        return bytes;
+    }
+}


### PR DESCRIPTION
Text.readString supports reading in batches to avoid the situation where the size of delete info in image file becomes too large due to a long period without checkpointing, which could cause the method CharBuffer.allocate size to exceed the maximum value of Integer.MAX_VALUE and result in an overflow.

### What problem does this PR solve?

Issue Number: close #6447 

Related PR: #6448

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [  ] Confirm the release note
- [  ] Confirm test cases
- [  ] Confirm document
- [  ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

