### PR TITLE
[fix](catalog) do cache load when cache value is not present

### DIFF
--- a/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_use_meta_cache.out
@@ -27,6 +27,8 @@ test_use_meta_cache_db_hive
 -- !sql07 --
 test_use_meta_cache_tbl_hive
 
+-- !aother_test_sql --
+
 -- !sql08 --
 
 -- !sql09 --
@@ -117,6 +119,8 @@ test_use_meta_cache_db_hive
 
 -- !sql07 --
 test_use_meta_cache_tbl_hive
+
+-- !aother_test_sql --
 
 -- !sql08 --
 


### PR DESCRIPTION
### What problem does this PR solve?

The MetaCache is used to cache the external table instance, like hive table.
The type of cache value is `Optional<Table>`.

When first loading a key, if the key does not exist(table not exists), the cacheloader
will return `null`, and finally there will be a cache entry `<key, EmptyOptional>` in cache.

So when the second time to get this key from cache, the cache will return the `EmptyOptional`
instead of try loading this key again from remote datasource.
But what we expect is to try loading the key from remote datasource if it does not exist in cache.

So we need check the return result of the cache, if return result is `null` or `EmptyOptional`,
we should load the key again. Otherwise, the following case may be failed:

1. select a non-exist hive table in Doris.
2. create the table in Hive.
3. select the table in Doris, expect to get table succeed, but still return "table does not exist".

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

