### PR TITLE
[opt](nereids) set sessoin var to turn on/off string column min/max stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1659,6 +1659,10 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_ELIMINATE_SORT_NODE)
     public boolean enableEliminateSortNode = true;
 
+    public static final  String ENABLE_STRING_MIN_MAX_STATS = "enable_string_min_max_stats";
+    @VariableMgr.VarAttr(name = ENABLE_STRING_MIN_MAX_STATS, needForward = true, fuzzy = false)
+    public boolean enableStringMinMaxStats = true;
+
     @VariableMgr.VarAttr(name = INTERNAL_SESSION)
     public boolean internalSession = false;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsBuilder.java
@@ -73,6 +73,10 @@ public class StatisticsBuilder {
         return expressionToColumnStats.entrySet();
     }
 
+    public ColumnStatistic getColumnStatistic(Expression expression) {
+        return expressionToColumnStats.get(expression);
+    }
+
     public Statistics build() {
         return new Statistics(rowCount, widthInJoinCluster, expressionToColumnStats, deltaRowCount);
     }


### PR DESCRIPTION
### What problem does this PR solve?
string column min/max value is used to estimate filter selectivity. However, min/max-based selectivity estimation for string types exhibits relatively high error rates.​
This pr introduce a session var: enable_string_min_max_stats to enable or disable string column min/max.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

