### PR TITLE
[bugfix](cloud) Fix ms crash when set the custom config path

### DIFF
--- a/cloud/src/main.cpp
+++ b/cloud/src/main.cpp
@@ -198,12 +198,12 @@ int main(int argc, char** argv) {
     }
 
     auto conf_file = args.get<std::string>(ARG_CONF);
-    if (!config::init(conf_file.c_str(), true)) {
+    if (!config::init(conf_file.c_str(), true, true, true)) {
         std::cerr << "failed to init config file, conf=" << conf_file << std::endl;
         return -1;
     }
     if (!std::filesystem::equivalent(conf_file, config::custom_conf_path) &&
-        !config::init(config::custom_conf_path.c_str(), false)) {
+        !config::init(config::custom_conf_path.c_str(), true, false, false)) {
         std::cerr << "failed to init custom config file, conf=" << config::custom_conf_path
                   << std::endl;
         return -1;


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #45394

Problem Summary:

### Release note

How to reproduce:

set custom config path in doris_cloud.conf:

```
custom_conf_path = ./conf/doris_cloud_custom.conf
```

Then restart the ms, ms will fail to start.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

