### PR TITLE
[feature](k8s) add ddc workload group support for doris-operator

### DIFF
--- a/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
+++ b/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
@@ -51,7 +51,7 @@ log_stderr()
     echo "[`date`] $@" >&2
 }
 
-function add_default_conf()
+function add_workloadgroup_config()
 {
     if [[ "x$ENABLE_WORKLOAD_GROUP" == "xtrue" ]]; then
           echo "doris_cgroup_cpu_path=$WORKLOAD_GROUP_PATH" >> ${DORIS_HOME}/conf/be.conf
@@ -251,7 +251,7 @@ function check_and_register()
 }
 
 
-function work_load_group_for_cgroup_path() {
+function make_dir_for_workloadgroup() {
     output=$(cat /proc/filesystems | grep cgroup)
     if [ -z "$output" ]; then
         log_stderr "[error] The host machine does not have cgroup installed, so the workload group function will be limited."
@@ -279,7 +279,7 @@ fi
 
 if [[ "x$ENABLE_WORKLOAD_GROUP" == "xtrue" ]]; then
       log_stderr '[info] Enable workload group !'
-      work_load_group_for_cgroup_path
+      make_dir_for_workloadgroup
 fi
 
 
@@ -291,7 +291,7 @@ else
 fi
 
 update_conf_from_configmap
-add_default_conf
+add_workloadgroup_config
 # resolve password for root to manage nodes in doris.
 resolve_password_from_secret
 collect_env_info

--- a/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
+++ b/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
@@ -43,9 +43,19 @@ DB_ADMIN_PASSWD=$PASSWD
 
 COMPUTE_GROUP_NAME=${COMPUTE_GROUP_NAME}
 
+ENABLE_WORKLOAD_GROUP=${ENABLE_WORKLOAD_GROUP:-false}
+WORKLOAD_GROUP_PATH="/sys/fs/cgroup/cpu/doris"
+
 log_stderr()
 {
     echo "[`date`] $@" >&2
+}
+
+function add_default_conf()
+{
+    if [[ "x$ENABLE_WORKLOAD_GROUP" == "xtrue" ]]; then
+          echo "doris_cgroup_cpu_path=$WORKLOAD_GROUP_PATH" >> ${DORIS_HOME}/conf/be.conf
+    fi
 }
 
 update_conf_from_configmap()
@@ -240,12 +250,38 @@ function check_and_register()
     fi
 }
 
+
+function work_load_group_for_cgroup_path() {
+    output=$(cat /proc/filesystems | grep cgroup)
+    if [ -z "$output" ]; then
+        log_stderr "[error] The host machine does not have cgroup installed, so the workload group function will be limited."
+        exit 1
+    fi
+
+    mkdir -p /sys/fs/cgroup/cpu/doris
+    chmod 770 /sys/fs/cgroup/cpu/doris
+    chown -R root:root /sys/fs/cgroup/cpu/doris
+
+    if [[ -f "/sys/fs/cgroup/cgroup.controllers" ]]; then
+        log_stderr "[info] The host machine cgroup version: v2."
+        chmod a+w /sys/fs/cgroup/cgroup.procs
+    else
+        log_stderr "[info] The host machine cgroup version: v1."
+    fi
+}
+
 fe_addrs=$1
 if [[ "x$fe_addrs" == "x" ]]; then
     echo "need fe address as paramter!"
     echo "  Example $0 <fe_addr>"
     exit 1
 fi
+
+if [[ "x$ENABLE_WORKLOAD_GROUP" == "xtrue" ]]; then
+      log_stderr '[info] Enable workload group !'
+      work_load_group_for_cgroup_path
+fi
+
 
 # pre check for starting
 if cat /proc/cpuinfo | grep -q "avx2" &>/dev/null; then
@@ -255,6 +291,7 @@ else
 fi
 
 update_conf_from_configmap
+add_default_conf
 # resolve password for root to manage nodes in doris.
 resolve_password_from_secret
 collect_env_info

--- a/docker/runtime/be/resource/be_entrypoint.sh
+++ b/docker/runtime/be/resource/be_entrypoint.sh
@@ -49,7 +49,7 @@ log_stderr()
     echo "[`date`] $@" >&2
 }
 
-function add_default_conf()
+function add_workloadgroup_config()
 {
     if [[ "x$ENABLE_WORKLOAD_GROUP" == "xtrue" ]]; then
           echo "doris_cgroup_cpu_path=$WORKLOAD_GROUP_PATH" >> ${DORIS_HOME}/conf/be.conf
@@ -282,7 +282,7 @@ function check_and_register()
     fi
 }
 
-function work_load_group_for_cgroup_path() {
+function make_dir_for_workloadgroup() {
     output=$(cat /proc/filesystems | grep cgroup)
     if [ -z "$output" ]; then
         log_stderr "[error] The host machine does not have cgroup installed, so the workload group function will be limited."
@@ -310,7 +310,7 @@ fi
 
 if [[ "x$ENABLE_WORKLOAD_GROUP" == "xtrue" ]]; then
       log_stderr '[info] Enable workload group !'
-      work_load_group_for_cgroup_path
+      make_dir_for_workloadgroup
 fi
 
 
@@ -322,7 +322,7 @@ else
 fi
 
 update_conf_from_configmap
-add_default_conf
+add_workloadgroup_config
 mount_kerberos_config
 # resolve password for root to manage nodes in doris.
 resolve_password_from_secret


### PR DESCRIPTION
### What problem does this PR solve?

add DDC workload group support for doris-operator , doris be image, the built-in script has important logic in this PR.

Related PR: doris-operator: [378](https://github.com/apache/doris-operator/pull/378)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

