### PR TITLE
[Fix](result) Fix the duplicated query result caused by query retry

### DIFF
--- a/be/src/common/utils.h
+++ b/be/src/common/utils.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <random>
 #include <string>
 
 namespace doris {
@@ -75,4 +76,11 @@ To convert_to(From from) {
     return _to;
 }
 
+inline bool random_bool_slow(double probability_of_true = 0.5) {
+    // Due to an unknown JNI bug, we cannot use thread_local variables here.
+    static std::random_device seed;
+    static std::mt19937 gen(seed());
+    std::bernoulli_distribution d(probability_of_true);
+    return d(gen);
+}
 } // namespace doris

--- a/be/src/pipeline/exec/result_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_sink_operator.cpp
@@ -60,6 +60,7 @@ Status ResultSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info)
             RETURN_IF_ERROR(get_arrow_schema_from_expr_ctxs(_output_vexpr_ctxs, &arrow_schema,
                                                             state->timezone()));
         }
+        VLOG_DEBUG << "create sender in INIT with instance id " << fragment_instance_id;
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
                 fragment_instance_id, p._result_sink_buffer_size_rows, &_sender, state,
                 p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL, arrow_schema));
@@ -135,6 +136,7 @@ Status ResultSinkOperatorX::prepare(RuntimeState* state) {
             RETURN_IF_ERROR(get_arrow_schema_from_expr_ctxs(_output_vexpr_ctxs, &arrow_schema,
                                                             state->timezone()));
         }
+        VLOG_DEBUG << "create sender in prepare with query id " << state->query_id();
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
                 state->query_id(), _result_sink_buffer_size_rows, &_sender, state,
                 _sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL, arrow_schema));

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -53,7 +53,8 @@ class GetResultBatchCtx;
 class Block;
 } // namespace vectorized
 
-// manage all result buffer control block in one backend
+// manage all result buffer control block in one backend. here we use uniform id `unique_id` to identify buffer slots.
+// for parallel result sink, it's `instance_id`, for non-parallel sink, it's `query_id`.
 class ResultBufferMgr {
 public:
     ResultBufferMgr();
@@ -63,27 +64,25 @@ public:
 
     void stop();
 
-    // create one result sender for this query_id
-    // the returned sender do not need release
-    // sender is not used when call cancel or unregister
-    Status create_sender(const TUniqueId& query_id, int buffer_size,
+    // for non-parallel sink, use query_id. but for parallel sink, use instance id.
+    Status create_sender(const TUniqueId& unique_id, int buffer_size,
                          std::shared_ptr<ResultBlockBufferBase>* sender, RuntimeState* state,
                          bool arrow_flight, std::shared_ptr<arrow::Schema> schema = nullptr);
 
     template <typename ResultBlockBufferType>
-    Status find_buffer(const TUniqueId& finst_id, std::shared_ptr<ResultBlockBufferType>& buffer);
+    Status find_buffer(const TUniqueId& unique_id, std::shared_ptr<ResultBlockBufferType>& buffer);
     // cancel
-    bool cancel(const TUniqueId& query_id, const Status& reason);
+    bool cancel(const TUniqueId& unique_id, const Status& reason);
 
     // cancel one query at a future time.
-    void cancel_at_time(time_t cancel_time, const TUniqueId& query_id);
+    void cancel_at_time(time_t cancel_time, const TUniqueId& unique_id);
 
 private:
     using BufferMap = std::unordered_map<TUniqueId, std::shared_ptr<ResultBlockBufferBase>>;
     using TimeoutMap = std::map<time_t, std::vector<TUniqueId>>;
 
     template <typename ResultBlockBufferType>
-    std::shared_ptr<ResultBlockBufferType> _find_control_block(const TUniqueId& query_id);
+    std::shared_ptr<ResultBlockBufferType> _find_control_block(const TUniqueId& unique_id);
 
     // used to erase the buffer that fe not clears
     // when fe crush, this thread clear the buffer avoid memory leak in this backend

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -49,8 +49,7 @@ TEST_F(ResultBufferMgrTest, create_normal) {
     EXPECT_NE(control_block1, nullptr);
     control_block1.reset();
 
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state, false).ok());
-    EXPECT_NE(control_block1, nullptr);
+    EXPECT_FALSE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state, false).ok());
 }
 
 TEST_F(ResultBufferMgrTest, create_arrow) {
@@ -75,9 +74,7 @@ TEST_F(ResultBufferMgrTest, create_same_buffer) {
     std::shared_ptr<ResultBlockBufferBase> control_block1;
     EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block1, &_state, false).ok());
     std::shared_ptr<ResultBlockBufferBase> control_block2;
-    EXPECT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block2, &_state, false).ok());
-
-    EXPECT_EQ(control_block1.get(), control_block1.get());
+    EXPECT_FALSE(buffer_mgr.create_sender(query_id, 1024, &control_block2, &_state, false).ok());
 }
 
 TEST_F(ResultBufferMgrTest, find_buffer) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/job/AssignedJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/job/AssignedJob.java
@@ -29,6 +29,8 @@ public interface AssignedJob {
 
     TUniqueId instanceId();
 
+    void resetInstanceId(TUniqueId instanceId);
+
     UnassignedJob unassignedJob();
 
     DistributedPlanWorker getAssignedWorker();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/job/StaticAssignedJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/job/StaticAssignedJob.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 public class StaticAssignedJob implements AssignedJob {
     private final int indexInUnassignedJob;
     private final UnassignedJob unassignedJob;
-    private final TUniqueId instanceId;
+    private TUniqueId instanceId; // when retry query, we'll need to reset instanceId
     private final DistributedPlanWorker worker;
     private final ScanSource scanSource;
 
@@ -53,6 +53,14 @@ public class StaticAssignedJob implements AssignedJob {
     @Override
     public TUniqueId instanceId() {
         return instanceId;
+    }
+
+    @Override
+    public void resetInstanceId(TUniqueId instanceId) {
+        if (instanceId == null) {
+            throw new IllegalArgumentException("instanceId can not be null");
+        }
+        this.instanceId = instanceId;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -133,6 +133,8 @@ public class ConnectContext {
     protected volatile LoadTaskInfo streamLoadInfo;
 
     protected volatile TUniqueId queryId = null;
+    // only be active one time. tell Coordinator to regenerate instance ids for certain query(when retry).
+    protected volatile TUniqueId needRegenerateInstanceId = null;
     protected volatile AtomicInteger instanceIdGenerator = new AtomicInteger();
     protected volatile String traceId;
     protected volatile TUniqueId lastQueryId = null;
@@ -941,6 +943,10 @@ public class ConnectContext {
         }
     }
 
+    public void setNeedRegenerateInstanceId(TUniqueId needRegenerateInstanceId) {
+        this.needRegenerateInstanceId = needRegenerateInstanceId;
+    }
+
     public void setTraceId(String traceId) {
         this.traceId = traceId;
     }
@@ -963,6 +969,14 @@ public class ConnectContext {
         } else {
             return new TUniqueId(queryId.hi, queryId.lo + instanceIdGenerator.incrementAndGet());
         }
+    }
+
+    public boolean consumeNeedRegenerateQueryId() {
+        if (needRegenerateInstanceId == queryId) {
+            needRegenerateInstanceId = null; // consume it
+            return true;
+        }
+        return false;
     }
 
     public String getSqlHash() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -909,6 +909,7 @@ public class StmtExecutor {
                     AuditLog.getQueryAudit().log("Query {} {} times with new query id: {}",
                             DebugUtil.printId(queryId), i, DebugUtil.printId(newQueryId));
                     context.setQueryId(newQueryId);
+                    context.setNeedRegenerateInstanceId(newQueryId);
                     if (Config.isCloudMode()) {
                         // sleep random millis [1000, 1500] ms
                         // in the begining of retryTime/2
@@ -940,11 +941,12 @@ public class StmtExecutor {
                 if (this.coord != null && (this.coord.isQueryCancelled() || this.coord.isTimeout())) {
                     throw e;
                 }
-                // cloud mode retry
-                LOG.debug("due to exception {} retry {} rpc {} user {}",
+                LOG.warn("due to exception {} retry {} rpc {} user {}",
                         e.getMessage(), i, e instanceof RpcException, e instanceof UserException);
+
                 boolean isNeedRetry = false;
                 if (Config.isCloudMode()) {
+                    // cloud mode retry
                     isNeedRetry = false;
                     // errCode = 2, detailMessage = No backend available as scan node,
                     // please check the status of your backends. [10003: not alive]

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
@@ -84,7 +84,11 @@ public class QueryProcessor extends AbstractJobProcessor {
             distinctWorkerJobs.putIfAbsent(topInstance.getAssignedWorker().id(), topInstance);
         }
 
+        boolean regenerateInstanceId = coordinatorContext.connectContext.consumeNeedRegenerateQueryId();
         for (AssignedJob topInstance : distinctWorkerJobs.values()) {
+            if (regenerateInstanceId) {
+                topInstance.resetInstanceId(coordinatorContext.connectContext.nextInstanceId());
+            }
             DistributedPlanWorker topWorker = topInstance.getAssignedWorker();
             TNetworkAddress execBeAddr = new TNetworkAddress(topWorker.host(), topWorker.brpcPort());
             receivers.add(

--- a/regression-test/suites/pipeline_p1/test_task_out_of_sync.groovy
+++ b/regression-test/suites/pipeline_p1/test_task_out_of_sync.groovy
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_task_out_of_sync", "nonConcurrent") {
+    sql "SET enable_profile = true" // need profile to know where the wrong is
+    sql "set debug_skip_fold_constant = true" // test BE
+
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs("VectorizedFnCall.wait_before_execute", [possibility: 0.2])
+        for (int i = 0; i < 30; i++) {
+            try {
+                def result = sql "select cast(timediff('2020-05-04 17:00:00', '2020-05-05 00:00:00') as int)"
+                assertEquals(result.size(), 1) // only one row
+            } catch (org.opentest4j.AssertionFailedError e) {
+                // wrong rows quantity!
+                logger.info("AssertionFailedError: ${e}")
+                assert false
+            } catch (Exception e) {
+                // sql failed is expected
+            }
+        }
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("VectorizedFnCall.wait_before_execute")
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

In BE we use instance id as BufferControlBlock's identity. but when query auto retry by BE because of RPC errors or something.  it will change query_id but not instance_id. so BE may send result of origin query and retry-query together as the origin query's result by mistake.

### Release note

Fix the duplicated query result caused by query retry

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

