### PR TITLE
[fix](serde) fix serde write_to_orc bufferlist

### DIFF
--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -84,6 +84,7 @@ struct ColumnVectorBatch;
     bufferRef.data = ptr;                                                            \
     bufferRef.size = BUFFER_UNIT_SIZE;                                               \
     size_t offset = 0;                                                               \
+    buffer_list.clear();                                                             \
     buffer_list.emplace_back(bufferRef);
 
 #define REALLOC_MEMORY_FOR_ORC_WRITER()                                                  \
@@ -97,6 +98,7 @@ struct ColumnVectorBatch;
         free(const_cast<char*>(bufferRef.data));                                         \
         bufferRef.data = new_ptr;                                                        \
         bufferRef.size = bufferRef.size + BUFFER_UNIT_SIZE;                              \
+        buffer_list.back() = bufferRef;                                                  \
     }
 
 namespace doris {

--- a/be/test/vec/data_types/data_type_array_test.cpp
+++ b/be/test/vec/data_types/data_type_array_test.cpp
@@ -502,6 +502,10 @@ TEST_F(DataTypeArrayTest, SerdeArrowTest) {
     CommonDataTypeSerdeTest::assert_arrow_format(array_cols, types);
 }
 
+TEST_F(DataTypeArrayTest, SerdeOrcTest) {
+    CommonDataTypeSerdeTest::assert_orc_writer(array_columns[0], serdes[0]);
+}
+
 //================== datatype for array ut test ==================
 TEST_F(DataTypeArrayTest, GetNumberOfDimensionsTest) {
     // for array-scalar

--- a/be/test/vec/data_types/data_type_array_test.cpp
+++ b/be/test/vec/data_types/data_type_array_test.cpp
@@ -502,10 +502,6 @@ TEST_F(DataTypeArrayTest, SerdeArrowTest) {
     CommonDataTypeSerdeTest::assert_arrow_format(array_cols, types);
 }
 
-TEST_F(DataTypeArrayTest, SerdeOrcTest) {
-    CommonDataTypeSerdeTest::assert_orc_writer(array_columns[0], serdes[0]);
-}
-
 //================== datatype for array ut test ==================
 TEST_F(DataTypeArrayTest, GetNumberOfDimensionsTest) {
     // for array-scalar

--- a/be/test/vec/data_types/serde/data_type_serde_string_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_string_test.cpp
@@ -193,4 +193,10 @@ TEST_F(DataTypeStringSerDeTest, serdes) {
     test_func(*serde_str, column_str32);
 }
 
+TEST_F(DataTypeStringSerDeTest, SerdeOrcTest) {
+    MutableColumns columns;
+    columns.push_back(column_str32->assume_mutable());
+    CommonDataTypeSerdeTest::assert_orc_writer(columns[0], serde_str);
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?
All allocated memory references are stored in buffer_list
When more space is needed, inside the function:
allocate new memory
free old memory
Update bufferRef to point to new memory
But buffer_list still retains references to the released memory
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

