### PR TITLE
[fix](serDe) global function could not deserialization from image

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/GlobalFunctionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/GlobalFunctionMgr.java
@@ -61,7 +61,7 @@ public class GlobalFunctionMgr extends MetaObject implements GsonPostProcessable
     @Override
     public void write(DataOutput out) throws IOException {
         // write functions
-        Text.writeString(out, GsonUtils.GSON.toJson(name2Function));
+        Text.writeString(out, GsonUtils.GSON.toJson(this, GlobalFunctionMgr.class));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/UdfTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/UdfTest.java
@@ -18,6 +18,8 @@
 package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Function;
+import org.apache.doris.catalog.GlobalFunctionMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateFormat;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateTrunc;
@@ -49,6 +51,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.util.List;
 
 public class UdfTest extends TestWithFeService implements PlanPatternMatchSupported {
     @Override
@@ -192,8 +195,13 @@ public class UdfTest extends TestWithFeService implements PlanPatternMatchSuppor
         Env.getCurrentEnv().getGlobalFunctionMgr().write(new DataOutputStream(outputStream));
         byte[] buffer = outputStream.toByteArray();
         ByteArrayInputStream inputStream = new ByteArrayInputStream(buffer);
-        Env.getCurrentEnv().getGlobalFunctionMgr().readFields(new DataInputStream(inputStream));
+        GlobalFunctionMgr newMgr = GlobalFunctionMgr.read(new DataInputStream(inputStream));
 
+        List<Function> functions = newMgr.getFunctions();
+        Assertions.assertEquals(1, functions.stream()
+                .map(f -> f.getFunctionName().getFunction())
+                .filter(name -> name.equals("f8"))
+                .count());
         Assertions.assertEquals(1, Env.getCurrentEnv().getFunctionRegistry()
                 .findUdfBuilder(connectContext.getDatabase(), "f8").size());
     }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #36552

Problem Summary:

when write GlobalFunctionMgr to image, we only write its attribute name2Function.
but when read from image, we try to read a GlobalFunctionMgr.class.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->


Co-authored-by: Gavin Chou <gavin@selectdb.com>
