### PR TITLE
[opt](nereids) if stats for any side of join children is null, do not prune runtime filter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
@@ -274,6 +274,9 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
     private boolean isEffectiveRuntimeFilter(EqualTo equalTo, PhysicalHashJoin join) {
         Statistics leftStats = ((AbstractPlan) join.child(0)).getStats();
         Statistics rightStats = ((AbstractPlan) join.child(1)).getStats();
+        if (leftStats == null || rightStats == null) {
+            return true;
+        }
         Set<Slot> leftSlots = equalTo.child(0).getInputSlots();
         if (leftSlots.size() > 1) {
             return false;


### PR DESCRIPTION

### What problem does this PR solve?
runtime filter pruning depends on stats of join children.
But some times, stats may be removed by some post processors.
if the stats is removed, NPE occurs.
In this pr, if prunner meets null stats, just keep the related runtime filter to avoid NPE

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

