### PR TITLE
[Feat](refactor-param)filesystem adaptation layer

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticator.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopAuthenticator.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.common.security.authentication;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
@@ -47,5 +48,10 @@ public interface HadoopAuthenticator {
         } else {
             return new HadoopSimpleAuthenticator((SimpleAuthenticationConfig) config);
         }
+    }
+
+    static HadoopAuthenticator getHadoopAuthenticator(Configuration configuration) {
+        AuthenticationConfig authConfig = AuthenticationConfig.getKerberosConfig(configuration);
+        return getHadoopAuthenticator(authConfig);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsCompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsCompatibleProperties.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.property.storage;
+
+import org.apache.doris.datasource.property.ConnectorProperty;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public abstract class HdfsCompatibleProperties extends StorageProperties {
+
+
+    @ConnectorProperty(names = {"fs.defaultFS"}, required = false, description = "")
+    protected String fsDefaultFS = "";
+
+    @ConnectorProperty(names = {"hadoop.config.resources"},
+            required = false,
+            description = "The xml files of Hadoop configuration.")
+    protected String hadoopConfigResources = "";
+
+    protected static final List<String> HDFS_COMPATIBLE_PROPERTIES_KEYS = Arrays.asList("fs.defaultFS",
+            "hadoop.config.resources");
+
+    protected Configuration configuration;
+
+
+    protected HdfsCompatibleProperties(Type type, Map<String, String> origProps) {
+        super(type, origProps);
+    }
+
+    public abstract Configuration getHadoopConfiguration();
+
+
+    @Override
+    protected String getResourceConfigPropName() {
+        return "hadoop.config.resources";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsProperties.java
@@ -25,10 +25,12 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-public class HdfsProperties extends StorageProperties {
+public class HdfsProperties extends HdfsCompatibleProperties {
 
     @ConnectorProperty(names = {"hdfs.authentication.type", "hadoop.security.authentication"},
             required = false,
@@ -50,21 +52,11 @@ public class HdfsProperties extends StorageProperties {
             description = "The username of Hadoop. Doris will user this user to access HDFS")
     private String hadoopUsername = "";
 
-    @ConnectorProperty(names = {"hadoop.config.resources"},
-            required = false,
-            description = "The xml files of Hadoop configuration.")
-    private String hadoopConfigResources = "";
-
     @ConnectorProperty(names = {"hdfs.impersonation.enabled"},
             required = false,
             supported = false,
             description = "Whether to enable the impersonation of HDFS.")
     private boolean hdfsImpersonationEnabled = false;
-
-    @ConnectorProperty(names = {"fs.defaultFS"}, required = false, description = "")
-    private String fsDefaultFS = "";
-
-    private Configuration configuration;
 
     private Map<String, String> backendConfigProperties;
 
@@ -77,6 +69,10 @@ public class HdfsProperties extends StorageProperties {
      */
     private Map<String, String> userOverriddenHdfsConfig;
 
+    private static final List<String> HDFS_PROPERTIES_KEYS = Arrays.asList("hdfs.authentication.type",
+            "hadoop.security.authentication", "hadoop.username",
+            "hdfs.authentication.kerberos.principal", "hadoop.kerberos.principal", "dfs.nameservices");
+
     public HdfsProperties(Map<String, String> origProps) {
         super(Type.HDFS, origProps);
     }
@@ -85,11 +81,20 @@ public class HdfsProperties extends StorageProperties {
         if (MapUtils.isEmpty(props)) {
             return false;
         }
-        if (props.containsKey("hadoop.config.resources") || props.containsKey("hadoop.security.authentication")
-                || props.containsKey("dfs.nameservices") || props.containsKey("fs.defaultFS")) {
+        if (HDFS_PROPERTIES_KEYS.stream().anyMatch(props::containsKey)) {
             return true;
         }
-        return false;
+        // This logic is somewhat hacky due to the shared usage of base parameters
+        // between native HDFS and HDFS-compatible implementations (such as OSS_HDFS).
+        // Since both may contain keys defined in HDFS_COMPATIBLE_PROPERTIES_KEYS,
+        // we cannot reliably determine whether the configuration belongs to native HDFS
+        // based on the presence of those keys alone.
+        // To work around this, we explicitly exclude OSS_HDFS by checking
+        // !OSSHdfsProperties.guessIsMe(props).
+        // This is currently the most practical way to differentiate native HDFS
+        // from HDFS-compatible systems using shared configuration.
+        return HDFS_COMPATIBLE_PROPERTIES_KEYS.stream().anyMatch(props::containsKey)
+                && (!OSSHdfsProperties.guessIsMe(props));
     }
 
     @Override
@@ -113,11 +118,6 @@ public class HdfsProperties extends StorageProperties {
 
     }
 
-    @Override
-    protected String getResourceConfigPropName() {
-        return "hadoop.config.resources";
-    }
-
     protected void checkRequiredProperties() {
         super.checkRequiredProperties();
         if ("kerberos".equalsIgnoreCase(hdfsAuthenticationType) && (Strings.isNullOrEmpty(hdfsKerberosPrincipal)
@@ -125,9 +125,18 @@ public class HdfsProperties extends StorageProperties {
             throw new IllegalArgumentException("HDFS authentication type is kerberos, "
                     + "but principal or keytab is not set.");
         }
-
+        // If fsDefaultFS is not explicitly provided, we attempt to infer it from the 'uri' field.
+        // However, the 'uri' is not a dedicated HDFS-specific property and may be present
+        // even when the user is configuring multiple storage backends.
+        // Additionally, since we are not using FileSystem.get(Configuration conf),
+        // fsDefaultFS is not strictly required here.
+        // This is a best-effort fallback to populate fsDefaultFS when possible.
         if (StringUtils.isBlank(fsDefaultFS)) {
-            this.fsDefaultFS = HdfsPropertiesUtils.constructDefaultFsFromUri(origProps);
+            try {
+                this.fsDefaultFS = HdfsPropertiesUtils.validateAndGetUri(origProps);
+            } catch (UserException e) {
+                //ignore
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.property.storage;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.property.ConnectorProperty;
+
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * todo
+ * Should consider using the same class as DLF Properties.
+ */
+public class OSSHdfsProperties extends HdfsCompatibleProperties {
+
+    @Setter
+    @ConnectorProperty(names = {"oss.endpoint"},
+            description = "The endpoint of OSS.")
+    protected String endpoint = "";
+
+    @ConnectorProperty(names = {"oss.access_key"}, description = "The access key of OSS.")
+    protected String accessKey = "";
+
+    @ConnectorProperty(names = {"oss.secret_key"}, description = "The secret key of OSS.")
+    protected String secretKey = "";
+
+    @ConnectorProperty(names = {"oss.region"},
+            description = "The region of OSS.")
+    protected String region;
+
+    /**
+     * TODO: Do not expose to users for now.
+     * Mutual exclusivity between parameters should be validated at the framework level
+     * to prevent messy, repetitive checks in application code.
+     */
+    @ConnectorProperty(names = {"oss.security_token"}, required = false,
+            description = "The security token of OSS.")
+    protected String securityToken = "";
+
+    private static final String OSS_ENDPOINT_KEY_NAME = "oss.endpoint";
+
+    private Map<String, String> backendConfigProperties;
+
+    protected OSSHdfsProperties(Map<String, String> origProps) {
+        super(Type.HDFS, origProps);
+    }
+
+    public static boolean guessIsMe(Map<String, String> props) {
+        String endpoint = props.get(OSS_ENDPOINT_KEY_NAME);
+        if (StringUtils.isBlank(endpoint)) {
+            return false;
+        }
+        return endpoint.endsWith(OSS_HDFS_ENDPOINT_SUFFIX);
+    }
+
+    @Override
+    protected void checkRequiredProperties() {
+        super.checkRequiredProperties();
+        if (!endpointIsValid(endpoint)) {
+            throw new IllegalArgumentException("Property oss.endpoint is required and must be a valid OSS endpoint.");
+        }
+    }
+
+    @Override
+    protected void initNormalizeAndCheckProps() throws UserException {
+        super.initNormalizeAndCheckProps();
+        initConfigurationParams();
+
+    }
+
+    private static final String OSS_HDFS_ENDPOINT_SUFFIX = ".oss-dls.aliyuncs.com";
+
+    private boolean endpointIsValid(String endpoint) {
+        // example: cn-shanghai.oss-dls.aliyuncs.com contains the "oss-dls.aliyuncs".
+        // https://www.alibabacloud.com/help/en/e-mapreduce/latest/oss-kusisurumen
+        return StringUtils.isNotBlank(endpoint) && endpoint.endsWith(OSS_HDFS_ENDPOINT_SUFFIX);
+    }
+
+    @Override
+    public Map<String, String> getBackendConfigProperties() {
+        return backendConfigProperties;
+    }
+
+    private void initConfigurationParams() {
+        Configuration conf = new Configuration(true);
+        // TODO: Currently we load all config parameters and pass them to the BE directly.
+        // In the future, we should pass the path to the configuration directory instead,
+        // and let the BE load the config file on its own.
+        Map<String, String> config = loadConfigFromFile(getResourceConfigPropName());
+        config.put("fs.oss.endpoint", endpoint);
+        config.put("fs.oss.accessKeyId", accessKey);
+        config.put("fs.oss.accessKeySecret", secretKey);
+        config.put("fs.oss.region", region);
+        config.put("fs.oss.impl", "com.aliyun.jindodata.oss.JindoOssFileSystem");
+        config.put("fs.AbstractFileSystem.oss.impl", "com.aliyun.jindodata.oss.JindoOSS");
+        config.forEach(conf::set);
+        this.backendConfigProperties = config;
+        this.configuration = conf;
+    }
+
+    @Override
+    public String validateAndNormalizeUri(String url) throws UserException {
+        return validateUri(url);
+    }
+
+    @Override
+    public String validateAndGetUri(Map<String, String> loadProps) throws UserException {
+        String uri = loadProps.get("uri");
+        return validateUri(uri);
+    }
+
+    private String validateUri(String uri) throws UserException {
+        if (StringUtils.isBlank(uri)) {
+            throw new UserException("The uri is empty.");
+        }
+        URI uriObj = URI.create(uri);
+        if (uriObj.getScheme() == null) {
+            throw new UserException("The uri scheme is empty.");
+        }
+        if (!uriObj.getScheme().equalsIgnoreCase("oss")) {
+            throw new UserException("The uri scheme is not oss.");
+        }
+        return uriObj.toString();
+    }
+
+    @Override
+    public Configuration getHadoopConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public String getStorageName() {
+        return "HDFS";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/StorageProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/StorageProperties.java
@@ -39,6 +39,8 @@ public abstract class StorageProperties extends ConnectionProperties {
     public static final String FS_OSS_SUPPORT = "fs.oss.support";
     public static final String FS_OBS_SUPPORT = "fs.obs.support";
     public static final String FS_COS_SUPPORT = "fs.cos.support";
+    public static final String FS_OSS_HDFS_SUPPORT = "fs.oss-hdfs.support";
+    public static final String DEPRECATED_OSS_HDFS_SUPPORT = "oss.hdfs.enabled";
 
     public static final String FS_PROVIDER_KEY = "provider";
 
@@ -111,6 +113,9 @@ public abstract class StorageProperties extends ConnectionProperties {
             Arrays.asList(
                     props -> (isFsSupport(props, FS_HDFS_SUPPORT)
                             || HdfsProperties.guessIsMe(props)) ? new HdfsProperties(props) : null,
+                    props -> ((isFsSupport(props, FS_OSS_HDFS_SUPPORT)
+                            || isFsSupport(props, DEPRECATED_OSS_HDFS_SUPPORT))
+                            || OSSHdfsProperties.guessIsMe(props)) ? new OSSHdfsProperties(props) : null,
                     props -> (isFsSupport(props, FS_S3_SUPPORT)
                             || S3Properties.guessIsMe(props)) ? new S3Properties(props) : null,
                     props -> (isFsSupport(props, FS_OSS_SUPPORT)

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/FileSystem.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.fsv2.remote.RemoteFile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * File system interface.
+ * All file operations should use DFSFileSystem.
+ * @see org.apache.doris.fsv2.remote.dfs.DFSFileSystem
+ * If the file system use the object storage's SDK, use ObjStorage
+ * @see org.apache.doris.fsv2.remote.ObjFileSystem
+ * Read and Write operation put in FileOperations
+ * @see org.apache.doris.fsv2.operations.FileOperations
+ */
+public interface FileSystem {
+    Map<String, String> getProperties();
+
+    Status exists(String remotePath);
+
+    default Status directoryExists(String dir) {
+        return exists(dir);
+    }
+
+    Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize);
+
+    Status upload(String localPath, String remotePath);
+
+    Status directUpload(String content, String remoteFile);
+
+    Status rename(String origFilePath, String destFilePath);
+
+    default Status renameDir(String origFilePath, String destFilePath) {
+        return renameDir(origFilePath, destFilePath, () -> {});
+    }
+
+    default Status renameDir(String origFilePath,
+                             String destFilePath,
+                             Runnable runWhenPathNotExist) {
+        throw new UnsupportedOperationException("Unsupported operation rename dir on current file system.");
+    }
+
+    Status delete(String remotePath);
+
+    default Status deleteDirectory(String dir) {
+        return delete(dir);
+    }
+
+    Status makeDir(String remotePath);
+
+    Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result);
+
+    /**
+     * List files in remotePath by wildcard <br/>
+     * The {@link RemoteFile}'name will only contain file name (Not full path)
+     * @param remotePath remote path
+     * @param result All eligible files under the path
+     * @return
+     */
+    default Status globList(String remotePath, List<RemoteFile> result) {
+        return globList(remotePath, result, true);
+    }
+
+    /**
+     * List files in remotePath by wildcard <br/>
+     * @param remotePath remote path
+     * @param result All eligible files under the path
+     * @param fileNameOnly for {@link RemoteFile}'name: whether the full path is included.<br/>
+     *                     true: only contains file name, false: contains full path<br/>
+     * @return
+     */
+    Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly);
+
+    default Status listDirectories(String remotePath, Set<String> result) {
+        throw new UnsupportedOperationException("Unsupported operation list directories on current file system.");
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/FileSystemFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/FileSystemFactory.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.fsv2.remote.RemoteFileSystem;
+
+import java.util.Map;
+
+public class FileSystemFactory {
+
+    public static RemoteFileSystem get(Map<String, String> properties) throws UserException {
+        StorageProperties storageProperties = StorageProperties.createPrimary(properties);
+        return get(storageProperties);
+    }
+
+    public static RemoteFileSystem get(StorageProperties storageProperties) {
+        return StorageTypeMapper.create(storageProperties);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/PersistentFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/PersistentFileSystem.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.persist.gson.GsonPreProcessable;
+
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Use for persistence, Repository will persist properties of file system.
+ */
+public abstract class PersistentFileSystem implements FileSystem, GsonPreProcessable {
+    public static final String STORAGE_TYPE = "_DORIS_STORAGE_TYPE_";
+    @SerializedName("prop")
+    public Map<String, String> properties = Maps.newHashMap();
+    @SerializedName("n")
+    public String name;
+    public StorageBackend.StorageType type;
+
+    @Getter
+    protected StorageProperties storageProperties;
+
+    public PersistentFileSystem(String name, StorageBackend.StorageType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public StorageBackend.StorageType getStorageType() {
+        return type;
+    }
+
+    /**
+     *
+     * @param in persisted data
+     * @return file systerm
+     */
+    @Deprecated
+    public static PersistentFileSystem read(DataInput in) throws IOException {
+        Text.readString(in);
+        Map<String, String> properties = Maps.newHashMap();
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            String key = Text.readString(in);
+            String value = Text.readString(in);
+            properties.put(key, value);
+        }
+        if (properties.containsKey(STORAGE_TYPE)) {
+            properties.remove(STORAGE_TYPE);
+        }
+        try {
+            return FileSystemFactory.get(properties);
+        } catch (UserException e) {
+            // do we ignore this exception?
+            throw new IOException("Failed to create file system from properties: " + properties, e);
+        }
+    }
+
+    @Override
+    public void gsonPreProcess() {
+        properties.put(STORAGE_TYPE, type.name());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/StorageTypeMapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/StorageTypeMapper.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2;
+
+import org.apache.doris.datasource.property.storage.AzureProperties;
+import org.apache.doris.datasource.property.storage.COSProperties;
+import org.apache.doris.datasource.property.storage.HdfsProperties;
+import org.apache.doris.datasource.property.storage.OBSProperties;
+import org.apache.doris.datasource.property.storage.OSSHdfsProperties;
+import org.apache.doris.datasource.property.storage.OSSProperties;
+import org.apache.doris.datasource.property.storage.S3Properties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.fsv2.remote.AzureFileSystem;
+import org.apache.doris.fsv2.remote.RemoteFileSystem;
+import org.apache.doris.fsv2.remote.S3FileSystem;
+import org.apache.doris.fsv2.remote.dfs.DFSFileSystem;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+public enum StorageTypeMapper {
+    OSS(OSSProperties.class, S3FileSystem::new),
+    OBS(OBSProperties.class, S3FileSystem::new),
+    COS(COSProperties.class, S3FileSystem::new),
+    AZURE(AzureProperties.class, AzureFileSystem::new),
+    S3(S3Properties.class, S3FileSystem::new),
+    HDFS(HdfsProperties.class, DFSFileSystem::new),
+    OSS_HDFS(OSSHdfsProperties.class, DFSFileSystem::new);
+
+    private final Class<? extends StorageProperties> propClass;
+    private final Function<StorageProperties, RemoteFileSystem> factory;
+
+    <T extends StorageProperties> StorageTypeMapper(Class<T> propClass, Function<T, RemoteFileSystem> factory) {
+        this.propClass = propClass;
+        this.factory = prop -> factory.apply(propClass.cast(prop));
+    }
+
+    public static RemoteFileSystem create(StorageProperties prop) {
+        return Arrays.stream(values())
+                .filter(type -> type.propClass.isInstance(prop))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Unknown storage type"))
+                .factory.apply(prop);
+    }
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/AzureObjStorage.java
@@ -1,0 +1,381 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.obj;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.S3URI;
+import org.apache.doris.datasource.property.storage.AzureProperties;
+import org.apache.doris.fsv2.remote.RemoteFile;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.PagedResponse;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.batch.BlobBatch;
+import com.azure.storage.blob.batch.BlobBatchClient;
+import com.azure.storage.blob.batch.BlobBatchClientBuilder;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
+    private static final Logger LOG = LogManager.getLogger(AzureObjStorage.class);
+    private static final String URI_TEMPLATE = "https://%s.blob.core.windows.net";
+
+    protected AzureProperties azureProperties;
+    private BlobServiceClient client;
+    private boolean isUsePathStyle;
+
+    private boolean forceParsingByStandardUri;
+
+    public AzureObjStorage(AzureProperties azureProperties) {
+        this.azureProperties = azureProperties;
+        this.isUsePathStyle = Boolean.parseBoolean(azureProperties.getUsePathStyle());
+        this.forceParsingByStandardUri = Boolean.parseBoolean(azureProperties.getForceParsingByStandardUrl());
+    }
+
+    // To ensure compatibility with S3 usage, the path passed by the user still starts with 'S3://${containerName}'.
+    // For Azure, we need to remove this part.
+    private static String removeUselessSchema(String remotePath) {
+        String prefix = "s3://";
+
+        if (remotePath.startsWith(prefix)) {
+            remotePath = remotePath.substring(prefix.length());
+        }
+        // Remove the useless container name
+        int firstSlashIndex = remotePath.indexOf('/');
+        return remotePath.substring(firstSlashIndex + 1);
+    }
+
+
+    @Override
+    public BlobServiceClient getClient() throws UserException {
+        if (client == null) {
+            String uri = String.format(URI_TEMPLATE, azureProperties.getAccessKey());
+            StorageSharedKeyCredential cred = new StorageSharedKeyCredential(azureProperties.getAccessKey(),
+                    azureProperties.getSecretKey());
+            BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
+            builder.credential(cred);
+            builder.endpoint(uri);
+            client = builder.buildClient();
+        }
+        return client;
+    }
+
+    @Override
+    public Triple<String, String, String> getStsToken() throws DdlException {
+        return null;
+    }
+
+    @Override
+    public Status headObject(String remotePath) {
+        try {
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            BlobClient blobClient = getClient().getBlobContainerClient(uri.getBucket()).getBlobClient(uri.getKey());
+            LOG.info("headObject remotePath:{} bucket:{} key:{} properties:{}",
+                    remotePath, uri.getBucket(), uri.getKey(), blobClient.getProperties());
+            return Status.OK;
+        } catch (BlobStorageException e) {
+            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                return new Status(Status.ErrCode.NOT_FOUND, "remote path does not exist: " + remotePath);
+            } else {
+                LOG.warn("headObject {} failed:", remotePath, e);
+                return new Status(Status.ErrCode.COMMON_ERROR, "headObject "
+                        + remotePath + " failed: " + e.getMessage());
+            }
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "headObject "
+                    + remotePath + " failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status getObject(String remoteFilePath, File localFile) {
+        try {
+            S3URI uri = S3URI.create(remoteFilePath, isUsePathStyle, forceParsingByStandardUri);
+            BlobClient blobClient = getClient().getBlobContainerClient(uri.getBucket()).getBlobClient(uri.getKey());
+            BlobProperties properties = blobClient.downloadToFile(localFile.getAbsolutePath());
+            LOG.info("get file " + remoteFilePath + " success: " + properties.toString());
+            return Status.OK;
+        } catch (BlobStorageException e) {
+            return new Status(
+                    Status.ErrCode.COMMON_ERROR,
+                    "get file from azure error: " + e.getServiceMessage());
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "getObject "
+                    + remoteFilePath + " failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status putObject(String remotePath, @Nullable InputStream content, long contentLength) {
+        try {
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            BlobClient blobClient = getClient().getBlobContainerClient(uri.getBucket()).getBlobClient(uri.getKey());
+            blobClient.upload(content, contentLength);
+            return Status.OK;
+        } catch (BlobStorageException e) {
+            return new Status(
+                    Status.ErrCode.COMMON_ERROR,
+                    "Error occurred while copying the blob:: " + e.getServiceMessage());
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "putObject "
+                    + remotePath + " failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status deleteObject(String remotePath) {
+        try {
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            BlobClient blobClient = getClient().getBlobContainerClient(uri.getBucket()).getBlobClient(uri.getKey());
+            blobClient.delete();
+            LOG.info("delete file " + remotePath + " success");
+            return Status.OK;
+        } catch (BlobStorageException e) {
+            if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+                return Status.OK;
+            }
+            return new Status(
+                    Status.ErrCode.COMMON_ERROR,
+                    "get file from azure error: " + e.getServiceMessage());
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "deleteObject "
+                    + remotePath + " failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status deleteObjects(String remotePath) {
+        try {
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            BlobContainerClient blobClient = getClient().getBlobContainerClient(uri.getBucket());
+            String containerUrl = blobClient.getBlobContainerUrl();
+            String continuationToken = "";
+            boolean isTruncated = false;
+            long totalObjects = 0;
+            do {
+                RemoteObjects objects = listObjects(remotePath, continuationToken);
+                List<RemoteObject> objectList = objects.getObjectList();
+                if (!objectList.isEmpty()) {
+                    BlobBatchClient blobBatchClient = new BlobBatchClientBuilder(
+                            getClient()).buildClient();
+                    BlobBatch blobBatch = blobBatchClient.getBlobBatch();
+
+                    for (RemoteObject blob : objectList) {
+                        blobBatch.deleteBlob(containerUrl, blob.getKey());
+                    }
+                    Response<Void> resp = blobBatchClient.submitBatchWithResponse(blobBatch, true, null, Context.NONE);
+                    LOG.info("{} objects deleted for dir {} return http code {}",
+                            objectList.size(), remotePath, resp.getStatusCode());
+                    totalObjects += objectList.size();
+                }
+
+                isTruncated = objects.isTruncated();
+                continuationToken = objects.getContinuationToken();
+            } while (isTruncated);
+            LOG.info("total delete {} objects for dir {}", totalObjects, remotePath);
+            return Status.OK;
+        } catch (BlobStorageException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "list objects for delete objects failed: " + e.getMessage());
+        } catch (Exception e) {
+            LOG.warn(String.format("delete objects %s failed", remotePath), e);
+            return new Status(Status.ErrCode.COMMON_ERROR, "delete objects failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status copyObject(String origFilePath, String destFilePath) {
+        try {
+            S3URI origUri = S3URI.create(origFilePath, isUsePathStyle, forceParsingByStandardUri);
+            S3URI destUri = S3URI.create(destFilePath, isUsePathStyle, forceParsingByStandardUri);
+            BlobClient sourceBlobClient = getClient().getBlobContainerClient(origUri.getBucket())
+                    .getBlobClient(origUri.getKey());
+            BlobClient destinationBlobClient = getClient().getBlobContainerClient(destUri.getBucket())
+                    .getBlobClient(destUri.getKey());
+            destinationBlobClient.beginCopy(sourceBlobClient.getBlobUrl(), null);
+            LOG.info("Blob copied from " + origFilePath + " to " + destFilePath);
+            return Status.OK;
+        } catch (BlobStorageException e) {
+            return new Status(
+                    Status.ErrCode.COMMON_ERROR,
+                    "Error occurred while copying the blob:: " + e.getServiceMessage());
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "copyObject from "
+                    + origFilePath + "to " + destFilePath + " failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public RemoteObjects listObjects(String remotePath, String continuationToken) throws DdlException {
+        try {
+            ListBlobsOptions options = new ListBlobsOptions().setPrefix(remotePath);
+            //S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            PagedIterable<BlobItem> pagedBlobs = getClient().getBlobContainerClient("selectdb-qa-datalake-test")
+                    .listBlobs(options, continuationToken, null);
+            PagedResponse<BlobItem> pagedResponse = pagedBlobs.iterableByPage().iterator().next();
+            List<RemoteObject> remoteObjects = new ArrayList<>();
+
+            for (BlobItem blobItem : pagedResponse.getElements()) {
+                remoteObjects.add(new RemoteObject(blobItem.getName(), "", blobItem.getProperties().getETag(),
+                        blobItem.getProperties().getContentLength()));
+            }
+            return new RemoteObjects(remoteObjects, pagedResponse.getContinuationToken() != null,
+                    pagedResponse.getContinuationToken());
+        } catch (BlobStorageException e) {
+            LOG.warn(String.format("Failed to list objects for S3: %s", remotePath), e);
+            throw new DdlException("Failed to list objects for S3, Error message: " + e.getMessage(), e);
+        } catch (UserException e) {
+            LOG.warn(String.format("Failed to list objects for S3: %s", remotePath), e);
+            throw new DdlException("Failed to list objects for S3, Error message: " + e.getMessage(), e);
+        }
+    }
+
+    // Due to historical reasons, when the BE parses the object storage path.
+    // It assumes the path starts with 'S3://${containerName}'
+    // So here the path needs to be constructed in a format that BE can parse.
+    private String constructS3Path(String fileName, String bucket) throws UserException {
+        LOG.debug("the path is {}", String.format("s3://%s/%s", bucket, fileName));
+        return String.format("s3://%s/%s", bucket, fileName);
+    }
+
+    public static String getLongestPrefix(String globPattern) {
+        int length = globPattern.length();
+        int earliestSpecialCharIndex = length;
+
+        char[] specialChars = {'*', '?', '[', '{', '\\'};
+
+        for (char specialChar : specialChars) {
+            int index = globPattern.indexOf(specialChar);
+            if (index != -1 && index < earliestSpecialCharIndex) {
+                earliestSpecialCharIndex = index;
+            }
+        }
+
+        return globPattern.substring(0, earliestSpecialCharIndex);
+    }
+
+    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+        long roundCnt = 0;
+        long elementCnt = 0;
+        long matchCnt = 0;
+        long startTime = System.nanoTime();
+        Status st = Status.OK;
+        try {
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            String globPath = uri.getKey();
+            String bucket = uri.getBucket();
+            LOG.info("try to glob list for azure, remote path {}, orig {}", globPath, remotePath);
+            BlobContainerClient client = getClient().getBlobContainerClient(bucket);
+            java.nio.file.Path pathPattern = Paths.get(globPath);
+            LOG.info("path pattern {}", pathPattern.toString());
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pathPattern);
+
+            HashSet<String> directorySet = new HashSet<>();
+            String listPrefix = getLongestPrefix(globPath);
+            LOG.info("azure glob list prefix is {}", listPrefix);
+            ListBlobsOptions options = new ListBlobsOptions().setPrefix(listPrefix);
+            String newContinuationToken = null;
+            do {
+                roundCnt++;
+                PagedResponse<BlobItem> pagedResponse = getPagedBlobItems(client, options, newContinuationToken);
+
+                for (BlobItem blobItem : pagedResponse.getElements()) {
+                    elementCnt++;
+                    java.nio.file.Path blobPath = Paths.get(blobItem.getName());
+
+                    boolean isPrefix = false;
+                    while (blobPath.normalize().toString().startsWith(listPrefix)) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("get blob {}", blobPath.normalize().toString());
+                        }
+                        if (!matcher.matches(blobPath)) {
+                            isPrefix = true;
+                            blobPath = blobPath.getParent();
+                            continue;
+                        }
+                        if (directorySet.contains(blobPath.normalize().toString())) {
+                            break;
+                        }
+                        if (isPrefix) {
+                            directorySet.add(blobPath.normalize().toString());
+                        }
+
+                        matchCnt++;
+                        RemoteFile remoteFile = new RemoteFile(
+                                fileNameOnly ? blobPath.getFileName().toString() : constructS3Path(blobPath.toString(),
+                                        uri.getBucket()),
+                                !isPrefix,
+                                isPrefix ? -1 : blobItem.getProperties().getContentLength(),
+                                isPrefix ? -1 : blobItem.getProperties().getContentLength(),
+                                isPrefix ? 0 : blobItem.getProperties().getLastModified().getSecond());
+                        result.add(remoteFile);
+
+                        blobPath = blobPath.getParent();
+                        isPrefix = true;
+                    }
+                }
+                newContinuationToken = pagedResponse.getContinuationToken();
+            } while (newContinuationToken != null);
+
+        } catch (BlobStorageException e) {
+            LOG.warn("glob file " + remotePath + " failed because azure error: " + e.getMessage());
+            st = new Status(Status.ErrCode.COMMON_ERROR, "glob file " + remotePath
+                    + " failed because azure error: " + e.getMessage());
+        } catch (Exception e) {
+            LOG.warn("errors while glob file " + remotePath, e);
+            st = new Status(Status.ErrCode.COMMON_ERROR, "errors while glob file " + remotePath + e.getMessage());
+        } finally {
+            long endTime = System.nanoTime();
+            long duration = endTime - startTime;
+            LOG.info("process {} elements under prefix {} for {} round, match {} elements, take {} micro second",
+                    remotePath, elementCnt, roundCnt, matchCnt,
+                    duration / 1000);
+        }
+        return st;
+    }
+
+    public PagedResponse<BlobItem> getPagedBlobItems(BlobContainerClient client, ListBlobsOptions options,
+                                                     String newContinuationToken) {
+        PagedIterable<BlobItem> pagedBlobs = client.listBlobs(options, newContinuationToken, null);
+        return pagedBlobs.iterableByPage().iterator().next();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/ObjStorage.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.obj;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
+
+import org.apache.commons.lang3.tuple.Triple;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * It is just used for reading remote object storage on cloud.
+ * @param <C> cloud SDK Client
+ */
+public interface ObjStorage<C> {
+    C getClient() throws UserException;
+
+    Triple<String, String, String> getStsToken() throws DdlException;
+
+    Status headObject(String remotePath);
+
+    Status getObject(String remoteFilePath, File localFile);
+
+    Status putObject(String remotePath, @Nullable InputStream content, long contentLenghth);
+
+    Status deleteObject(String remotePath);
+
+    Status deleteObjects(String remotePath);
+
+    Status copyObject(String origFilePath, String destFilePath);
+
+    RemoteObjects listObjects(String remotePath, String continuationToken) throws DdlException;
+
+    default String normalizePrefix(String prefix) {
+        return prefix.isEmpty() ? "" : (prefix.endsWith("/") ? prefix : String.format("%s/", prefix));
+    }
+
+    default String getRelativePath(String prefix, String key) throws DdlException {
+        String expectedPrefix = normalizePrefix(prefix);
+        if (!key.startsWith(expectedPrefix)) {
+            throw new DdlException(
+                    "List a object whose key: " + key + " does not start with object prefix: " + expectedPrefix);
+        }
+        return key.substring(expectedPrefix.length());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/RemoteObject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/RemoteObject.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.obj;
+
+public class RemoteObject {
+    private final String key;
+    private final String relativePath;
+    private final String etag;
+    private final long size;
+
+    public RemoteObject(String key, String relativePath, String etag, long size) {
+        this.key = key;
+        this.relativePath = relativePath;
+        this.etag = etag;
+        this.size = size;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getRelativePath() {
+        return relativePath;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteObject{" + "key='" + key + '\'' + ", relativePath='" + relativePath + '\'' + ", etag='" + etag
+                + '\'' + ", size=" + size + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/RemoteObjects.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/RemoteObjects.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.obj;
+
+import java.util.List;
+
+public class RemoteObjects {
+    private final List<RemoteObject> objectList;
+
+    private final boolean isTruncated;
+
+    private final String continuationToken;
+
+    public RemoteObjects(List<RemoteObject> objectList, boolean isTruncated, String continuationToken) {
+        this.objectList = objectList;
+        this.isTruncated = isTruncated;
+        this.continuationToken = continuationToken;
+    }
+
+    public List<RemoteObject> getObjectList() {
+        return objectList;
+    }
+
+    public boolean isTruncated() {
+        return isTruncated;
+    }
+
+    public String getContinuationToken() {
+        return continuationToken;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteObjects{" + "objectList=" + objectList + ", isTruncated=" + isTruncated
+                + ", continuationToken='" + continuationToken + '\'' + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/obj/S3ObjStorage.java
@@ -1,0 +1,347 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.obj;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.credentials.CloudCredential;
+import org.apache.doris.common.util.S3URI;
+import org.apache.doris.common.util.S3Util;
+import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
+import org.apache.doris.fsv2.remote.RemoteFile;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class S3ObjStorage implements ObjStorage<S3Client> {
+    private static final Logger LOG = LogManager.getLogger(S3ObjStorage.class);
+    private S3Client client;
+
+    protected Map<String, String> properties;
+
+    protected AbstractS3CompatibleProperties s3Properties;
+
+    private boolean isUsePathStyle = false;
+
+    private boolean forceParsingByStandardUri = false;
+
+    public S3ObjStorage(AbstractS3CompatibleProperties properties) {
+        this.properties = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        setProperties(properties);
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    protected void setProperties(AbstractS3CompatibleProperties properties) {
+        this.s3Properties = properties;
+        isUsePathStyle = Boolean.parseBoolean(properties.getUsePathStyle());
+        forceParsingByStandardUri = Boolean.parseBoolean(s3Properties.getForceParsingByStandardUrl());
+    }
+
+    @Override
+    public S3Client getClient() throws UserException {
+        if (client == null) {
+            String endpointStr = s3Properties.getEndpoint();
+            if (!endpointStr.contains("://")) {
+                endpointStr = "http://" + endpointStr;
+            }
+            URI endpoint = URI.create(endpointStr);
+            CloudCredential credential = new CloudCredential();
+            credential.setAccessKey(s3Properties.getAccessKey());
+            credential.setSecretKey(s3Properties.getSecretKey());
+
+            /* if (properties.containsKey(S3Properties.SESSION_TOKEN)) {
+                credential.setSessionToken(properties.get(S3Properties.SESSION_TOKEN));
+            }*/
+            client = S3Util.buildS3Client(endpoint, s3Properties.getRegion(), credential, isUsePathStyle);
+        }
+        return client;
+    }
+
+
+
+    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+        try {
+            remotePath = s3Properties.validateAndNormalizeUri(remotePath);
+            URI uri = new URI(remotePath);
+            String bucketName = uri.getHost();
+            String prefix = uri.getPath().substring(1);
+            int wildcardIndex = prefix.indexOf('*');
+            String searchPrefix = wildcardIndex > 0 ? prefix.substring(0, wildcardIndex) : prefix;
+            try (S3Client s3 = getClient()) {
+                ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                        .bucket(bucketName)
+                        .prefix(searchPrefix)
+                        .build();
+
+                ListObjectsV2Response listResponse = s3.listObjectsV2(listRequest);
+                String regex = prefix.replace(".", "\\.")
+                        .replace("*", ".*")
+                        .replace("?", ".");
+                Pattern pattern = Pattern.compile(regex);
+                List<RemoteFile> matchedFiles = listResponse.contents().stream()
+                        .filter(obj -> pattern.matcher(obj.key()).matches())
+                        .map(obj -> {
+                            String fullKey = obj.key();
+                            String fullPath = "s3://" + bucketName + "/" + fullKey;
+                            return new RemoteFile(
+                                    fileNameOnly ? fullPath.substring(fullPath.lastIndexOf('/') + 1) : fullPath,
+                                    true,
+                                    obj.size(),
+                                    -1,
+                                    obj.lastModified().toEpochMilli()
+                            );
+                        })
+                        .collect(Collectors.toList());
+
+                result.addAll(matchedFiles);
+            }
+            return Status.OK;
+        } catch (Exception e) {
+            LOG.warn("Errors while getting file status", e);
+            return new Status(Status.ErrCode.COMMON_ERROR, "Errors while getting file status " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Triple<String, String, String> getStsToken() throws DdlException {
+        return null;
+    }
+
+    @Override
+    public Status headObject(String remotePath) {
+        try {
+            remotePath = s3Properties.validateAndNormalizeUri(remotePath);
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            HeadObjectResponse response = getClient()
+                    .headObject(HeadObjectRequest.builder().bucket(uri.getBucket()).key(uri.getKey()).build());
+            LOG.info("head file " + remotePath + " success: " + response.toString());
+            return Status.OK;
+        } catch (S3Exception e) {
+            if (e.statusCode() == HttpStatus.SC_NOT_FOUND) {
+                return new Status(Status.ErrCode.NOT_FOUND, "remote path does not exist: " + remotePath);
+            } else {
+                LOG.warn("headObject failed:", e);
+                return new Status(Status.ErrCode.COMMON_ERROR, "headObject failed: " + e.getMessage());
+            }
+        } catch (UserException ue) {
+            LOG.warn("connect to s3 failed: ", ue);
+            return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
+        }
+    }
+
+    @Override
+    public Status getObject(String remoteFilePath, File localFile) {
+        try {
+            remoteFilePath = s3Properties.validateAndNormalizeUri(remoteFilePath);
+            S3URI uri = S3URI.create(remoteFilePath, isUsePathStyle, forceParsingByStandardUri);
+            GetObjectResponse response = getClient().getObject(
+                    GetObjectRequest.builder().bucket(uri.getBucket()).key(uri.getKey()).build(), localFile.toPath());
+            LOG.info("get file " + remoteFilePath + " success: " + response.toString());
+            return Status.OK;
+        } catch (S3Exception s3Exception) {
+            return new Status(
+                    Status.ErrCode.COMMON_ERROR,
+                    "get file from s3 error: " + s3Exception.awsErrorDetails().errorMessage());
+        } catch (UserException ue) {
+            LOG.warn("connect to s3 failed: ", ue);
+            return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
+        } catch (Exception e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.toString());
+        }
+    }
+
+    @Override
+    public Status putObject(String remotePath, @Nullable InputStream content, long contentLength) {
+        try {
+            remotePath = s3Properties.validateAndNormalizeUri(remotePath);
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            RequestBody body = RequestBody.fromInputStream(content, contentLength);
+            PutObjectResponse response =
+                    getClient()
+                            .putObject(
+                                    PutObjectRequest.builder().bucket(uri.getBucket()).key(uri.getKey()).build(),
+                                    body);
+            LOG.info("put object success: " + response.toString());
+            return Status.OK;
+        } catch (S3Exception e) {
+            LOG.error("put object failed:", e);
+            return new Status(Status.ErrCode.COMMON_ERROR, "put object failed: " + e.getMessage());
+        } catch (Exception ue) {
+            LOG.error("connect to s3 failed: ", ue);
+            return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
+        }
+    }
+
+    @Override
+    public Status deleteObject(String remotePath) {
+        try {
+            remotePath = s3Properties.validateAndNormalizeUri(remotePath);
+            S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            DeleteObjectResponse response =
+                    getClient()
+                            .deleteObject(
+                                    DeleteObjectRequest.builder().bucket(uri.getBucket()).key(uri.getKey()).build());
+            LOG.info("delete file " + remotePath + " success: " + response.toString());
+            return Status.OK;
+        } catch (S3Exception e) {
+            LOG.warn("delete file failed: ", e);
+            if (e.statusCode() == HttpStatus.SC_NOT_FOUND) {
+                return Status.OK;
+            }
+            return new Status(Status.ErrCode.COMMON_ERROR, "delete file failed: " + e.getMessage());
+        } catch (UserException ue) {
+            LOG.warn("connect to s3 failed: ", ue);
+            return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
+        }
+    }
+
+    @Override
+    public Status deleteObjects(String absolutePath) {
+        try {
+            absolutePath = s3Properties.validateAndNormalizeUri(absolutePath);
+            S3URI baseUri = S3URI.create(absolutePath, isUsePathStyle, forceParsingByStandardUri);
+            String continuationToken = "";
+            boolean isTruncated = false;
+            long totalObjects = 0;
+            do {
+                RemoteObjects objects = listObjects(absolutePath, continuationToken);
+                List<RemoteObject> objectList = objects.getObjectList();
+                if (!objectList.isEmpty()) {
+                    Delete delete = Delete.builder()
+                            .objects(objectList.stream()
+                                    .map(RemoteObject::getKey)
+                                    .map(k -> ObjectIdentifier.builder().key(k).build())
+                                    .collect(Collectors.toList()))
+                            .build();
+                    DeleteObjectsRequest req = DeleteObjectsRequest.builder()
+                            .bucket(baseUri.getBucket())
+                            .delete(delete)
+                            .build();
+
+                    DeleteObjectsResponse resp = getClient().deleteObjects(req);
+                    if (resp.errors().size() > 0) {
+                        LOG.warn("{} errors returned while deleting {} objects for dir {}",
+                                resp.errors().size(), objectList.size(), absolutePath);
+                    }
+                    LOG.info("{} of {} objects deleted for dir {}",
+                            resp.deleted().size(), objectList.size(), absolutePath);
+                    totalObjects += objectList.size();
+                }
+
+                isTruncated = objects.isTruncated();
+                continuationToken = objects.getContinuationToken();
+            } while (isTruncated);
+            LOG.info("total delete {} objects for dir {}", totalObjects, absolutePath);
+            return Status.OK;
+        } catch (DdlException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "list objects for delete objects failed: " + e.getMessage());
+        } catch (Exception e) {
+            LOG.warn(String.format("delete objects %s failed", absolutePath), e);
+            return new Status(Status.ErrCode.COMMON_ERROR, "delete objects failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status copyObject(String origFilePath, String destFilePath) {
+        try {
+            origFilePath = s3Properties.validateAndNormalizeUri(origFilePath);
+            destFilePath = s3Properties.validateAndNormalizeUri(destFilePath);
+            S3URI origUri = S3URI.create(origFilePath, isUsePathStyle, forceParsingByStandardUri);
+            S3URI descUri = S3URI.create(destFilePath, isUsePathStyle, forceParsingByStandardUri);
+            CopyObjectResponse response = getClient()
+                    .copyObject(
+                            CopyObjectRequest.builder()
+                                    .copySource(origUri.getBucket() + "/" + origUri.getKey())
+                                    .destinationBucket(descUri.getBucket())
+                                    .destinationKey(descUri.getKey())
+                                    .build());
+            LOG.info("copy file from " + origFilePath + " to " + destFilePath + " success: " + response.toString());
+            return Status.OK;
+        } catch (S3Exception e) {
+            LOG.error("copy file failed: ", e);
+            return new Status(Status.ErrCode.COMMON_ERROR, "copy file failed: " + e.getMessage());
+        } catch (UserException ue) {
+            LOG.error("copy to s3 failed: ", ue);
+            return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
+        }
+    }
+
+    @Override
+    public RemoteObjects listObjects(String absolutePath, String continuationToken) throws DdlException {
+        try {
+            absolutePath = s3Properties.validateAndNormalizeUri(absolutePath);
+            S3URI uri = S3URI.create(absolutePath, isUsePathStyle, forceParsingByStandardUri);
+            String bucket = uri.getBucket();
+            String prefix = uri.getKey();
+            ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .prefix(normalizePrefix(prefix));
+            if (!StringUtils.isEmpty(continuationToken)) {
+                requestBuilder.continuationToken(continuationToken);
+            }
+            ListObjectsV2Response response = getClient().listObjectsV2(requestBuilder.build());
+            List<RemoteObject> remoteObjects = new ArrayList<>();
+            for (S3Object c : response.contents()) {
+                String relativePath = getRelativePath(prefix, c.key());
+                remoteObjects.add(new RemoteObject(c.key(), relativePath, c.eTag(), c.size()));
+            }
+            return new RemoteObjects(remoteObjects, response.isTruncated(), response.nextContinuationToken());
+        } catch (Exception e) {
+            LOG.warn(String.format("Failed to list objects for S3: %s", absolutePath), e);
+            throw new DdlException("Failed to list objects for S3, Error message: " + e.getMessage(), e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/AzureFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/AzureFileSystem.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.doris.analysis.StorageBackend.StorageType;
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.property.storage.AzureProperties;
+import org.apache.doris.fsv2.obj.AzureObjStorage;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import java.util.List;
+
+public class AzureFileSystem extends ObjFileSystem {
+
+    public AzureFileSystem(AzureProperties azureProperties) {
+        super(StorageType.AZURE.name(), StorageType.S3, new AzureObjStorage(azureProperties));
+        this.storageProperties = azureProperties;
+        this.properties.putAll(storageProperties.getOrigProps());
+    }
+
+    @Override
+    protected FileSystem nativeFileSystem(String remotePath) throws UserException {
+        return null;
+    }
+
+    @Override
+    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+        AzureObjStorage azureObjStorage = (AzureObjStorage) getObjStorage();
+        return azureObjStorage.globList(remotePath, result, fileNameOnly);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/BrokerFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/BrokerFileSystem.java
@@ -1,0 +1,701 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.backup.Status;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.FsBroker;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.BrokerUtil;
+import org.apache.doris.datasource.property.PropertyConverter;
+import org.apache.doris.fs.operations.BrokerFileOperations;
+import org.apache.doris.fs.operations.OpParams;
+import org.apache.doris.service.FrontendOptions;
+import org.apache.doris.thrift.TBrokerCheckPathExistRequest;
+import org.apache.doris.thrift.TBrokerCheckPathExistResponse;
+import org.apache.doris.thrift.TBrokerDeletePathRequest;
+import org.apache.doris.thrift.TBrokerFD;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TBrokerIsSplittableRequest;
+import org.apache.doris.thrift.TBrokerIsSplittableResponse;
+import org.apache.doris.thrift.TBrokerListPathRequest;
+import org.apache.doris.thrift.TBrokerListResponse;
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerPReadRequest;
+import org.apache.doris.thrift.TBrokerPWriteRequest;
+import org.apache.doris.thrift.TBrokerReadResponse;
+import org.apache.doris.thrift.TBrokerRenamePathRequest;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+
+import com.google.common.base.Preconditions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class BrokerFileSystem extends RemoteFileSystem {
+    private static final Logger LOG = LogManager.getLogger(BrokerFileSystem.class);
+    private final BrokerFileOperations operations;
+
+    public BrokerFileSystem(String name, Map<String, String> properties) {
+        super(name, StorageBackend.StorageType.BROKER);
+        properties.putAll(PropertyConverter.convertToHadoopFSProperties(properties));
+        this.properties = properties;
+        this.operations = new BrokerFileOperations(name, properties);
+    }
+
+    public Pair<TPaloBrokerService.Client, TNetworkAddress> getBroker() {
+        Pair<TPaloBrokerService.Client, TNetworkAddress> result = Pair.of(null, null);
+        FsBroker broker;
+        try {
+            String localIP = FrontendOptions.getLocalHostAddress();
+            broker = Env.getCurrentEnv().getBrokerMgr().getBroker(name, localIP);
+        } catch (AnalysisException e) {
+            LOG.warn("failed to get a broker address: " + e.getMessage());
+            return null;
+        }
+        TNetworkAddress address = new TNetworkAddress(broker.host, broker.port);
+        TPaloBrokerService.Client client;
+        try {
+            client = ClientPool.brokerPool.borrowObject(address);
+        } catch (Exception e) {
+            LOG.warn("failed to get broker client: " + e.getMessage());
+            return null;
+        }
+
+        result.first = client;
+        result.second = address;
+        LOG.info("get broker: {}", BrokerUtil.printBroker(name, address));
+        return result;
+    }
+
+    @Override
+    public Status exists(String remotePath) {
+        // 1. get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // check path
+        boolean needReturn = true;
+        try {
+            TBrokerCheckPathExistRequest req = new TBrokerCheckPathExistRequest(TBrokerVersion.VERSION_ONE,
+                    remotePath, properties);
+            TBrokerCheckPathExistResponse rep = client.checkPathExist(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                return new Status(Status.ErrCode.COMMON_ERROR,
+                        "failed to check remote path exist: " + remotePath
+                                + ", broker: " + BrokerUtil.printBroker(name, address)
+                                + ". msg: " + opst.getMessage());
+            }
+
+            if (!rep.isIsPathExist()) {
+                return new Status(Status.ErrCode.NOT_FOUND, "remote path does not exist: " + remotePath);
+            }
+
+            return Status.OK;
+        } catch (TException e) {
+            needReturn = false;
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to check remote path exist: " + remotePath
+                            + ", broker: " + BrokerUtil.printBroker(name, address)
+                            + ". msg: " + e.getMessage());
+        } finally {
+            if (needReturn) {
+                ClientPool.brokerPool.returnObject(address, client);
+            } else {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            }
+        }
+    }
+
+    @Override
+    public Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("download from {} to {}, file size: {}.", remoteFilePath, localFilePath, fileSize);
+        }
+
+        long start = System.currentTimeMillis();
+
+        // 1. get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // 2. open file reader with broker
+        TBrokerFD fd = new TBrokerFD();
+        Status opStatus = operations.openReader(OpParams.of(client, address, remoteFilePath, fd));
+        if (!opStatus.ok()) {
+            return opStatus;
+        }
+        LOG.info("finished to open reader. fd: {}. download {} to {}.",
+                fd, remoteFilePath, localFilePath);
+        Preconditions.checkNotNull(fd);
+        // 3. delete local file if exist
+        File localFile = new File(localFilePath);
+        if (localFile.exists()) {
+            try {
+                Files.walk(Paths.get(localFilePath), FileVisitOption.FOLLOW_LINKS)
+                        .sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            } catch (IOException e) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "failed to delete exist local file: " + localFilePath);
+            }
+        }
+
+        // 4. create local file
+        Status status = Status.OK;
+        try {
+            if (!localFile.createNewFile()) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "failed to create local file: " + localFilePath);
+            }
+        } catch (IOException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to create local file: "
+                    + localFilePath + ", msg: " + e.getMessage());
+        }
+
+        // 5. read remote file with broker and write to local
+        String lastErrMsg = null;
+        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(localFile))) {
+            final long bufSize = 1024 * 1024; // 1MB
+            long leftSize = fileSize;
+            long readOffset = 0;
+            while (leftSize > 0) {
+                long readLen = Math.min(leftSize, bufSize);
+                TBrokerReadResponse rep = null;
+                // We only retry if we encounter a timeout thrift exception.
+                int tryTimes = 0;
+                while (tryTimes < 3) {
+                    try {
+                        TBrokerPReadRequest req = new TBrokerPReadRequest(TBrokerVersion.VERSION_ONE,
+                                fd, readOffset, readLen);
+                        rep = client.pread(req);
+                        if (rep.getOpStatus().getStatusCode() != TBrokerOperationStatusCode.OK) {
+                            // pread return failure.
+                            lastErrMsg = String.format("failed to read via broker %s. "
+                                            + "current read offset: %d, read length: %d,"
+                                            + " file size: %d, file: %s, err code: %d, msg: %s",
+                                    BrokerUtil.printBroker(name, address),
+                                    readOffset, readLen, fileSize,
+                                    remoteFilePath, rep.getOpStatus().getStatusCode().getValue(),
+                                    rep.getOpStatus().getMessage());
+                            LOG.warn(lastErrMsg);
+                            status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                        }
+                        if (rep.opStatus.statusCode != TBrokerOperationStatusCode.END_OF_FILE) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("download. readLen: {}, read data len: {}, left size:{}. total size: {}",
+                                        readLen, rep.getData().length, leftSize, fileSize);
+                            }
+                        } else {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("read eof: " + remoteFilePath);
+                            }
+                        }
+                        break;
+                    } catch (TTransportException e) {
+                        if (e.getType() == TTransportException.TIMED_OUT) {
+                            // we only retry when we encounter timeout exception.
+                            lastErrMsg = String.format("failed to read via broker %s. "
+                                            + "current read offset: %d, read length: %d,"
+                                            + " file size: %d, file: %s, timeout.",
+                                    BrokerUtil.printBroker(name, address),
+                                    readOffset, readLen, fileSize,
+                                    remoteFilePath);
+                            tryTimes++;
+                            continue;
+                        }
+
+                        lastErrMsg = String.format("failed to read via broker %s. "
+                                        + "current read offset: %d, read length: %d,"
+                                        + " file size: %d, file: %s. msg: %s",
+                                BrokerUtil.printBroker(name, address),
+                                readOffset, readLen, fileSize,
+                                remoteFilePath, e.getMessage());
+                        LOG.warn(lastErrMsg);
+                        status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                        break;
+                    } catch (TException e) {
+                        lastErrMsg = String.format("failed to read via broker %s. "
+                                        + "current read offset: %d, read length: %d,"
+                                        + " file size: %d, file: %s. msg: %s",
+                                BrokerUtil.printBroker(name, address),
+                                readOffset, readLen, fileSize,
+                                remoteFilePath, e.getMessage());
+                        LOG.warn(lastErrMsg);
+                        status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                        break;
+                    }
+                } // end of retry loop
+
+                if (status.ok() && tryTimes < 3) {
+                    // read succeed, write to local file
+                    Preconditions.checkNotNull(rep);
+                    // NOTICE(cmy): Sometimes the actual read length does not equal to the expected read length,
+                    // even if the broker's read buffer size is large enough.
+                    // I don't know why, but have to adapt to it.
+                    if (rep.getData().length != readLen) {
+                        LOG.warn("the actual read length does not equal to "
+                                        + "the expected read length: {} vs. {}, file: {}, broker: {}",
+                                rep.getData().length, readLen, remoteFilePath,
+                                BrokerUtil.printBroker(name, address));
+                    }
+
+                    out.write(rep.getData());
+                    readOffset += rep.getData().length;
+                    leftSize -= rep.getData().length;
+                } else {
+                    status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                    break;
+                }
+            } // end of reading remote file
+        } catch (IOException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "Got exception: " + e.getMessage() + ", broker: "
+                    + BrokerUtil.printBroker(name, address));
+        } finally {
+            // close broker reader
+            Status closeStatus = operations.closeReader(OpParams.of(client, address, fd));
+            if (!closeStatus.ok()) {
+                LOG.warn(closeStatus.getErrMsg());
+                if (status.ok()) {
+                    // we return close write error only if no other error has been encountered.
+                    status = closeStatus;
+                }
+                ClientPool.brokerPool.invalidateObject(address, client);
+            } else {
+                ClientPool.brokerPool.returnObject(address, client);
+            }
+        }
+
+        LOG.info("finished to download from {} to {} with size: {}. cost {} ms",
+                remoteFilePath, localFilePath, fileSize, (System.currentTimeMillis() - start));
+        return status;
+    }
+
+    // directly upload the content to remote file
+    @Override
+    public Status directUpload(String content, String remoteFile) {
+        // 1. get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        TBrokerFD fd = new TBrokerFD();
+        Status status = Status.OK;
+        try {
+            // 2. open file writer with broker
+            status = operations.openWriter(OpParams.of(client, address, remoteFile, fd));
+            if (!status.ok()) {
+                return status;
+            }
+
+            // 3. write content
+            try {
+                ByteBuffer bb = ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8));
+                TBrokerPWriteRequest req = new TBrokerPWriteRequest(TBrokerVersion.VERSION_ONE, fd, 0, bb);
+                TBrokerOperationStatus opst = client.pwrite(req);
+                if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                    // pwrite return failure.
+                    status = new Status(Status.ErrCode.COMMON_ERROR, "write failed: " + opst.getMessage()
+                            + ", broker: " + BrokerUtil.printBroker(name, address));
+                }
+            } catch (TException e) {
+                status = new Status(Status.ErrCode.BAD_CONNECTION, "write exception: " + e.getMessage()
+                        + ", broker: " + BrokerUtil.printBroker(name, address));
+            }
+        } finally {
+            Status closeStatus = operations.closeWriter(OpParams.of(client, address, fd));
+            if (closeStatus.getErrCode() == Status.ErrCode.BAD_CONNECTION
+                    || status.getErrCode() == Status.ErrCode.BAD_CONNECTION) {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            } else {
+                ClientPool.brokerPool.returnObject(address, client);
+            }
+        }
+
+        return status;
+    }
+
+    @Override
+    public Status upload(String localPath, String remotePath) {
+        long start = System.currentTimeMillis();
+        // 1. get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // 2. open file write with broker
+        TBrokerFD fd = new TBrokerFD();
+        Status status = operations.openWriter(OpParams.of(client, address, remotePath, fd));
+        if (!status.ok()) {
+            return status;
+        }
+
+        // 3. read local file and write to remote with broker
+        File localFile = new File(localPath);
+        long fileLength = localFile.length();
+        byte[] readBuf = new byte[1024];
+        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(localFile))) {
+            // save the last err msg
+            String lastErrMsg = null;
+            // save the current write offset of remote file
+            long writeOffset = 0;
+            // read local file, 1MB at a time
+            int bytesRead;
+            while ((bytesRead = in.read(readBuf)) != -1) {
+                ByteBuffer bb = ByteBuffer.wrap(readBuf, 0, bytesRead);
+
+                // We only retry if we encounter a timeout thrift exception.
+                int tryTimes = 0;
+                while (tryTimes < 3) {
+                    try {
+                        TBrokerPWriteRequest req
+                                = new TBrokerPWriteRequest(TBrokerVersion.VERSION_ONE, fd, writeOffset, bb);
+                        TBrokerOperationStatus opst = client.pwrite(req);
+                        if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                            // pwrite return failure.
+                            lastErrMsg = String.format("failed to write via broker %s. "
+                                            + "current write offset: %d, write length: %d,"
+                                            + " file length: %d, file: %s, err code: %d, msg: %s",
+                                    BrokerUtil.printBroker(name, address),
+                                    writeOffset, bytesRead, fileLength,
+                                    remotePath, opst.getStatusCode().getValue(), opst.getMessage());
+                            LOG.warn(lastErrMsg);
+                            status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                        }
+                        break;
+                    } catch (TTransportException e) {
+                        if (e.getType() == TTransportException.TIMED_OUT) {
+                            // we only retry when we encounter timeout exception.
+                            lastErrMsg = String.format("failed to write via broker %s. "
+                                            + "current write offset: %d, write length: %d,"
+                                            + " file length: %d, file: %s. timeout",
+                                    BrokerUtil.printBroker(name, address),
+                                    writeOffset, bytesRead, fileLength,
+                                    remotePath);
+                            tryTimes++;
+                            continue;
+                        }
+
+                        lastErrMsg = String.format("failed to write via broker %s. "
+                                        + "current write offset: %d, write length: %d,"
+                                        + " file length: %d, file: %s. encounter TTransportException: %s",
+                                BrokerUtil.printBroker(name, address),
+                                writeOffset, bytesRead, fileLength,
+                                remotePath, e.getMessage());
+                        LOG.warn(lastErrMsg, e);
+                        status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                        break;
+                    } catch (TException e) {
+                        lastErrMsg = String.format("failed to write via broker %s. "
+                                        + "current write offset: %d, write length: %d,"
+                                        + " file length: %d, file: %s. encounter TException: %s",
+                                BrokerUtil.printBroker(name, address),
+                                writeOffset, bytesRead, fileLength,
+                                remotePath, e.getMessage());
+                        LOG.warn(lastErrMsg, e);
+                        status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                        break;
+                    }
+                }
+
+                if (status.ok() && tryTimes < 3) {
+                    // write succeed, update current write offset
+                    writeOffset += bytesRead;
+                } else {
+                    status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                    break;
+                }
+            } // end of read local file loop
+        } catch (FileNotFoundException e1) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "encounter file not found exception: " + e1.getMessage()
+                    + ", broker: " + BrokerUtil.printBroker(name, address));
+        } catch (IOException e1) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "encounter io exception: " + e1.getMessage()
+                    + ", broker: " + BrokerUtil.printBroker(name, address));
+        } finally {
+            // close write
+            Status closeStatus = operations.closeWriter(OpParams.of(client, address, fd));
+            if (!closeStatus.ok()) {
+                LOG.warn(closeStatus.getErrMsg());
+                if (status.ok()) {
+                    // we return close write error only if no other error has been encountered.
+                    status = closeStatus;
+                }
+                ClientPool.brokerPool.invalidateObject(address, client);
+            } else {
+                ClientPool.brokerPool.returnObject(address, client);
+            }
+        }
+
+        if (status.ok()) {
+            LOG.info("finished to upload {} to remote path {}. cost: {} ms",
+                    localPath, remotePath, (System.currentTimeMillis() - start));
+        }
+        return status;
+    }
+
+    @Override
+    public Status rename(String origFilePath, String destFilePath) {
+        long start = System.currentTimeMillis();
+        // 1. get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // 2. rename
+        boolean needReturn = true;
+        try {
+            TBrokerRenamePathRequest req = new TBrokerRenamePathRequest(TBrokerVersion.VERSION_ONE,
+                    origFilePath, destFilePath, properties);
+            TBrokerOperationStatus ost = client.renamePath(req);
+            if (ost.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                return new Status(Status.ErrCode.COMMON_ERROR,
+                        "failed to rename " + origFilePath + " to " + destFilePath + ", msg: " + ost.getMessage()
+                                + ", broker: " + BrokerUtil.printBroker(name, address));
+            }
+        } catch (TException e) {
+            needReturn = false;
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to rename " + origFilePath + " to " + destFilePath + ", msg: " + e.getMessage()
+                            + ", broker: " + BrokerUtil.printBroker(name, address));
+        } finally {
+            if (needReturn) {
+                ClientPool.brokerPool.returnObject(address, client);
+            } else {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            }
+        }
+
+        LOG.info("finished to rename {} to  {}. cost: {} ms",
+                origFilePath, destFilePath, (System.currentTimeMillis() - start));
+        return Status.OK;
+    }
+
+    @Override
+    public Status delete(String remotePath) {
+        // get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // delete
+        boolean needReturn = true;
+        try {
+            TBrokerDeletePathRequest req = new TBrokerDeletePathRequest(TBrokerVersion.VERSION_ONE,
+                    remotePath, properties);
+            TBrokerOperationStatus opst = client.deletePath(req);
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                return new Status(Status.ErrCode.COMMON_ERROR,
+                        "failed to delete remote path: " + remotePath + ". msg: " + opst.getMessage()
+                                + ", broker: " + BrokerUtil.printBroker(name, address));
+            }
+
+            LOG.info("finished to delete remote path {}.", remotePath);
+        } catch (TException e) {
+            needReturn = false;
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to delete remote path: " + remotePath + ". msg: " + e.getMessage()
+                            + ", broker: " + BrokerUtil.printBroker(name, address));
+        } finally {
+            if (needReturn) {
+                ClientPool.brokerPool.returnObject(address, client);
+            } else {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            }
+        }
+
+        return Status.OK;
+    }
+
+    @Override
+    public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
+        // get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.BAD_CONNECTION, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // invoke broker 'listLocatedFiles' interface
+        boolean needReturn = true;
+        try {
+            TBrokerListPathRequest req = new TBrokerListPathRequest(TBrokerVersion.VERSION_ONE, remotePath,
+                    recursive, properties);
+            req.setOnlyFiles(true);
+            TBrokerListResponse response = client.listLocatedFiles(req);
+            TBrokerOperationStatus operationStatus = response.getOpStatus();
+            if (operationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                return new Status(Status.ErrCode.COMMON_ERROR,
+                        "failed to listLocatedFiles, remote path: " + remotePath + ". msg: "
+                                + operationStatus.getMessage() + ", broker: " + BrokerUtil.printBroker(name, address));
+            }
+            List<TBrokerFileStatus> fileStatus = response.getFiles();
+            for (TBrokerFileStatus tFile : fileStatus) {
+                org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(tFile.path);
+                RemoteFile file = new RemoteFile(path.getName(), path, !tFile.isDir, tFile.isDir, tFile.size,
+                        tFile.getBlockSize(), tFile.getModificationTime(), null /* blockLocations is null*/);
+                result.add(file);
+            }
+            LOG.info("finished to listLocatedFiles, remote path {}. get files: {}", remotePath, result);
+            return Status.OK;
+        } catch (TException e) {
+            needReturn = false;
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to listLocatedFiles, remote path: "
+                + remotePath + ". msg: " + e.getMessage() + ", broker: " + BrokerUtil.printBroker(name, address));
+        } finally {
+            if (needReturn) {
+                ClientPool.brokerPool.returnObject(address, client);
+            } else {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            }
+        }
+    }
+
+    public boolean isSplittable(String remotePath, String inputFormat) throws UserException {
+        // get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            throw new UserException("failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // invoke 'isSplittable' interface
+        boolean needReturn = true;
+        try {
+            TBrokerIsSplittableRequest req = new TBrokerIsSplittableRequest().setVersion(TBrokerVersion.VERSION_ONE)
+                    .setPath(remotePath).setInputFormat(inputFormat).setProperties(properties);
+            TBrokerIsSplittableResponse response = client.isSplittable(req);
+            TBrokerOperationStatus operationStatus = response.getOpStatus();
+            if (operationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new UserException("failed to get path isSplittable, remote path: " + remotePath + ". msg: "
+                    + operationStatus.getMessage() + ", broker: " + BrokerUtil.printBroker(name, address));
+            }
+            boolean result = response.isSplittable();
+            LOG.info("finished to get path isSplittable, remote path {} with format {}, isSplittable: {}",
+                    remotePath, inputFormat, result);
+            return result;
+        } catch (TException e) {
+            needReturn = false;
+            throw new UserException("failed to get path isSplittable, remote path: "
+                + remotePath + ". msg: " + e.getMessage() + ", broker: " + BrokerUtil.printBroker(name, address));
+        } finally {
+            if (needReturn) {
+                ClientPool.brokerPool.returnObject(address, client);
+            } else {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            }
+        }
+    }
+
+    // List files in remotePath
+    @Override
+    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+        // get a proper broker
+        Pair<TPaloBrokerService.Client, TNetworkAddress> pair = getBroker();
+        if (pair == null) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "failed to get broker client");
+        }
+        TPaloBrokerService.Client client = pair.first;
+        TNetworkAddress address = pair.second;
+
+        // list
+        boolean needReturn = true;
+        try {
+            TBrokerListPathRequest req = new TBrokerListPathRequest(TBrokerVersion.VERSION_ONE, remotePath,
+                    false /* not recursive */, properties);
+            req.setFileNameOnly(fileNameOnly);
+            TBrokerListResponse rep = client.listPath(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                return new Status(Status.ErrCode.COMMON_ERROR,
+                        "failed to list remote path: " + remotePath + ". msg: " + opst.getMessage()
+                                + ", broker: " + BrokerUtil.printBroker(name, address));
+            }
+
+            List<TBrokerFileStatus> fileStatus = rep.getFiles();
+            for (TBrokerFileStatus tFile : fileStatus) {
+                RemoteFile file = new RemoteFile(tFile.path, !tFile.isDir, tFile.size, 0, tFile.getModificationTime());
+                result.add(file);
+            }
+            LOG.info("finished to list remote path {}. get files: {}", remotePath, result);
+        } catch (TException e) {
+            needReturn = false;
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to list remote path: " + remotePath + ". msg: " + e.getMessage()
+                            + ", broker: " + BrokerUtil.printBroker(name, address));
+        } finally {
+            if (needReturn) {
+                ClientPool.brokerPool.returnObject(address, client);
+            } else {
+                ClientPool.brokerPool.invalidateObject(address, client);
+            }
+        }
+
+        return Status.OK;
+    }
+
+    @Override
+    public Status makeDir(String remotePath) {
+        return new Status(Status.ErrCode.COMMON_ERROR, "mkdir is not implemented.");
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/ObjFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/ObjFileSystem.java
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.backup.Status;
+import org.apache.doris.fsv2.obj.ObjStorage;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+public abstract class ObjFileSystem extends RemoteFileSystem {
+    private static final Logger LOG = LogManager.getLogger(ObjFileSystem.class);
+
+    protected final ObjStorage<?> objStorage;
+
+    public ObjFileSystem(String name, StorageBackend.StorageType type, ObjStorage<?> objStorage) {
+        super(name, type);
+        this.objStorage = objStorage;
+    }
+
+    public ObjStorage<?> getObjStorage() {
+        return objStorage;
+    }
+
+    @Override
+    public Status exists(String remotePath) {
+        return objStorage.headObject(remotePath);
+    }
+
+    @Override
+    public Status directoryExists(String dir) {
+        return listFiles(dir, false, new ArrayList<>());
+    }
+
+    /**
+     * download data from remote file and check data size with expected file size.
+     * @param remoteFilePath remote file path
+     * @param localFilePath local file path
+     * @param fileSize download data size
+     * @return
+     */
+    @Override
+    public Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize) {
+        long start = System.currentTimeMillis();
+        // Write the data to a local file
+        File localFile = new File(localFilePath);
+        if (localFile.exists()) {
+            try {
+                Files.walk(Paths.get(localFilePath), FileVisitOption.FOLLOW_LINKS)
+                        .sorted(Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(File::delete);
+            } catch (IOException e) {
+                return new Status(
+                        Status.ErrCode.COMMON_ERROR, "failed to delete exist local file: " + localFilePath);
+            }
+        }
+        Status st = objStorage.getObject(remoteFilePath, localFile);
+        if (st != Status.OK) {
+            return st;
+        }
+        if (localFile.length() == fileSize) {
+            LOG.info(
+                    "finished to get file from {} to {} with size: {}. cost {} ms",
+                    remoteFilePath,
+                    localFile.toPath(),
+                    fileSize,
+                    (System.currentTimeMillis() - start));
+            return Status.OK;
+        } else {
+            return new Status(Status.ErrCode.COMMON_ERROR, localFile.toString());
+        }
+    }
+
+    @Override
+    public Status directUpload(String content, String remoteFile) {
+        Status st = objStorage.putObject(remoteFile, new ByteArrayInputStream(content.getBytes()), content.length());
+        if (st != Status.OK) {
+            return st;
+        }
+        LOG.info("upload content success.");
+        return Status.OK;
+    }
+
+    @Override
+    public Status upload(String localPath, String remotePath) {
+        File localFile = new File(localPath);
+        Status st = null;
+        try {
+            st = objStorage.putObject(remotePath, new FileInputStream(localFile), localFile.length());
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        if (st != Status.OK) {
+            return st;
+        }
+        LOG.info("upload file " + localPath + " success.");
+        return Status.OK;
+    }
+
+    @Override
+    public Status makeDir(String remotePath) {
+        if (!remotePath.endsWith("/")) {
+            remotePath += "/";
+        }
+        Status st = objStorage.putObject(remotePath, new ByteArrayInputStream(new byte[0]), 0);
+        if (st != Status.OK) {
+            return st;
+        }
+        LOG.info("makeDir success.");
+        return Status.OK;
+    }
+
+    @Override
+    public Status rename(String origFilePath, String destFilePath) {
+        Status status = objStorage.copyObject(origFilePath, destFilePath);
+        if (status.ok()) {
+            return delete(origFilePath);
+        } else {
+            return status;
+        }
+    }
+
+    public Status copy(String origFilePath, String destFilePath) {
+        return objStorage.copyObject(origFilePath, destFilePath);
+    }
+
+    @Override
+    public Status delete(String remotePath) {
+        return objStorage.deleteObject(remotePath);
+    }
+
+    @Override
+    public Status deleteDirectory(String absolutePath) {
+        return objStorage.deleteObjects(absolutePath);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFSPhantomManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFSPhantomManager.java
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.doris.common.CustomThreadFactory;
+
+import com.google.common.collect.Sets;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The RemoteFSPhantomManager class is responsible for managing the phantom references
+ * of RemoteFileSystem objects. It ensures that the associated FileSystem resources are
+ * automatically cleaned up when the RemoteFileSystem objects are garbage collected.
+ * <p>
+ * By utilizing a ReferenceQueue and PhantomReference, this class can monitor the lifecycle
+ * of RemoteFileSystem objects. When a RemoteFileSystem object is no longer in use and is
+ * garbage collected, its corresponding FileSystem resource is properly closed to prevent
+ * resource leaks.
+ * <p>
+ * The class provides a thread-safe mechanism to ensure that the cleanup thread is started only once.
+ * <p>
+ * Main functionalities include:
+ * - Registering phantom references of RemoteFileSystem objects.
+ * - Starting a periodic cleanup thread that automatically closes unused FileSystem resources.
+ */
+public class RemoteFSPhantomManager {
+
+    private static final Logger LOG = LogManager.getLogger(RemoteFSPhantomManager.class);
+
+    // Scheduled executor for periodic resource cleanup
+    private static ScheduledExecutorService cleanupExecutor;
+
+    // Reference queue for monitoring RemoteFileSystem objects' phantom references
+    private static final ReferenceQueue<RemoteFileSystem> referenceQueue = new ReferenceQueue<>();
+
+    // Map storing the phantom references and their corresponding FileSystem objects
+    private static final ConcurrentHashMap<PhantomReference<RemoteFileSystem>, FileSystem> referenceMap
+            = new ConcurrentHashMap<>();
+
+    private static final Set<FileSystem> fsSet = Sets.newConcurrentHashSet();
+
+    // Flag indicating whether the cleanup thread has been started
+    private static final AtomicBoolean isStarted = new AtomicBoolean(false);
+
+    /**
+     * Registers a phantom reference for a RemoteFileSystem object in the manager.
+     * If the cleanup thread has not been started, it will be started.
+     *
+     * @param remoteFileSystem the RemoteFileSystem object to be registered
+     */
+    public static void registerPhantomReference(RemoteFileSystem remoteFileSystem) {
+        if (!isStarted.get()) {
+            start();
+            isStarted.set(true);
+        }
+        if (fsSet.contains(remoteFileSystem.dfsFileSystem)) {
+            throw new RuntimeException("FileSystem already exists: " + remoteFileSystem.dfsFileSystem.getUri());
+        }
+        RemoteFileSystemPhantomReference phantomReference = new RemoteFileSystemPhantomReference(remoteFileSystem,
+                referenceQueue);
+        referenceMap.put(phantomReference, remoteFileSystem.dfsFileSystem);
+        fsSet.add(remoteFileSystem.dfsFileSystem);
+    }
+
+    /**
+     * Starts the cleanup thread, which periodically checks and cleans up unused FileSystem resources.
+     * The method uses double-checked locking to ensure thread-safe startup of the cleanup thread.
+     */
+    public static void start() {
+        if (isStarted.compareAndSet(false, true)) {
+            synchronized (RemoteFSPhantomManager.class) {
+                LOG.info("Starting cleanup thread for RemoteFileSystem objects");
+                if (cleanupExecutor == null) {
+                    CustomThreadFactory threadFactory = new CustomThreadFactory("remote-fs-phantom-cleanup");
+                    cleanupExecutor = Executors.newScheduledThreadPool(1, threadFactory);
+                    cleanupExecutor.scheduleAtFixedRate(() -> {
+                        Reference<? extends RemoteFileSystem> ref;
+                        while ((ref = referenceQueue.poll()) != null) {
+                            RemoteFileSystemPhantomReference phantomRef = (RemoteFileSystemPhantomReference) ref;
+
+                            FileSystem fs = referenceMap.remove(phantomRef);
+                            if (fs != null) {
+                                try {
+                                    fs.close();
+                                    fsSet.remove(fs);
+                                    LOG.info("Closed file system: {}", fs.getUri());
+                                } catch (IOException e) {
+                                    LOG.warn("Failed to close file system", e);
+                                }
+                            }
+                        }
+                    }, 0, 1, TimeUnit.MINUTES);
+                }
+            }
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFile.java
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.Path;
+
+// represent a file or a dir in remote storage
+public class RemoteFile {
+    // Only file name, not full path
+    private final String name;
+    private final boolean isFile;
+    private final boolean isDirectory;
+    private final long size;
+    // Block size of underlying file system. e.g. HDFS and S3.
+    // A large file will split into multiple blocks. The blocks are transparent to the user.
+    // Default block size for HDFS 2.x is 128M.
+    private final long blockSize;
+    private long modificationTime;
+    private Path path;
+    BlockLocation[] blockLocations;
+
+    public RemoteFile(String name, boolean isFile, long size, long blockSize) {
+        this(name, null, isFile, !isFile, size, blockSize, 0, null);
+    }
+
+    public RemoteFile(String name, boolean isFile, long size, long blockSize, long modificationTime) {
+        this(name, null, isFile, !isFile, size, blockSize, modificationTime, null);
+    }
+
+    public RemoteFile(Path path, boolean isDirectory, long size, long blockSize, long modificationTime,
+            BlockLocation[] blockLocations) {
+        this(path.getName(), path, !isDirectory, isDirectory, size, blockSize, modificationTime, blockLocations);
+    }
+
+    public RemoteFile(String name, Path path, boolean isFile, boolean isDirectory,
+            long size, long blockSize, long modificationTime, BlockLocation[] blockLocations) {
+        Preconditions.checkState(!Strings.isNullOrEmpty(name));
+        this.name = name;
+        this.isFile = isFile;
+        this.isDirectory = isDirectory;
+        this.size = size;
+        this.blockSize = blockSize;
+        this.modificationTime = modificationTime;
+        this.path = path;
+        this.blockLocations = blockLocations;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
+    public boolean isFile() {
+        return isFile;
+    }
+
+    public boolean isDirectory() {
+        return isDirectory;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public long getBlockSize() {
+        return blockSize;
+    }
+
+    public long getModificationTime() {
+        return modificationTime;
+    }
+
+    public BlockLocation[] getBlockLocations() {
+        return blockLocations;
+    }
+
+    @Override
+    public String toString() {
+        return "[name: " + name + ", is file: " + isFile + "]";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFileSystem.java
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.UserException;
+import org.apache.doris.fsv2.PersistentFileSystem;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+import java.io.Closeable;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+public abstract class RemoteFileSystem extends PersistentFileSystem implements Closeable {
+    // this field will be visited by multi-threads, better use volatile qualifier
+    protected volatile org.apache.hadoop.fs.FileSystem dfsFileSystem = null;
+    private final ReentrantLock fsLock = new ReentrantLock();
+    protected static final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public RemoteFileSystem(String name, StorageBackend.StorageType type) {
+        super(name, type);
+    }
+
+    protected org.apache.hadoop.fs.FileSystem nativeFileSystem(String remotePath) throws UserException {
+        throw new UserException("Not support to getFileSystem.");
+    }
+
+    @Override
+    public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
+        try {
+            org.apache.hadoop.fs.FileSystem fileSystem = nativeFileSystem(remotePath);
+            Path locatedPath = new Path(remotePath);
+            RemoteIterator<LocatedFileStatus> locatedFiles = getLocatedFiles(recursive, fileSystem, locatedPath);
+            while (locatedFiles.hasNext()) {
+                LocatedFileStatus fileStatus = locatedFiles.next();
+                RemoteFile location = new RemoteFile(
+                        fileStatus.getPath(), fileStatus.isDirectory(), fileStatus.getLen(),
+                        fileStatus.getBlockSize(), fileStatus.getModificationTime(), fileStatus.getBlockLocations());
+                result.add(location);
+            }
+        } catch (FileNotFoundException e) {
+            return new Status(Status.ErrCode.NOT_FOUND, e.getMessage());
+        } catch (Exception e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        }
+        return Status.OK;
+    }
+
+    protected RemoteIterator<LocatedFileStatus> getLocatedFiles(boolean recursive,
+                FileSystem fileSystem, Path locatedPath) throws IOException {
+        return fileSystem.listFiles(locatedPath, recursive);
+    }
+
+    @Override
+    public Status listDirectories(String remotePath, Set<String> result) {
+        try {
+            FileSystem fileSystem = nativeFileSystem(remotePath);
+            FileStatus[] fileStatuses = getFileStatuses(remotePath, fileSystem);
+            result.addAll(
+                    Arrays.stream(fileStatuses)
+                            .filter(FileStatus::isDirectory)
+                            .map(file -> file.getPath().toString() + "/")
+                            .collect(ImmutableSet.toImmutableSet()));
+        } catch (Exception e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        }
+        return Status.OK;
+    }
+
+    protected FileStatus[] getFileStatuses(String remotePath, FileSystem fileSystem) throws IOException {
+        return fileSystem.listStatus(new Path(remotePath));
+    }
+
+    @Override
+    public Status renameDir(String origFilePath,
+                            String destFilePath,
+                            Runnable runWhenPathNotExist) {
+        Status status = exists(destFilePath);
+        if (status.ok()) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "Destination directory already exists: " + destFilePath);
+        }
+
+        String targetParent = new Path(destFilePath).getParent().toString();
+        status = exists(targetParent);
+        if (Status.ErrCode.NOT_FOUND.equals(status.getErrCode())) {
+            status = makeDir(targetParent);
+        }
+        if (!status.ok()) {
+            return new Status(Status.ErrCode.COMMON_ERROR, status.getErrMsg());
+        }
+
+        runWhenPathNotExist.run();
+
+        return rename(origFilePath, destFilePath);
+    }
+
+    @Override
+    public void close() throws IOException {
+        fsLock.lock();
+        try {
+            if (!closed.getAndSet(true)) {
+                if (dfsFileSystem != null) {
+                    dfsFileSystem.close();
+                }
+            }
+        } finally {
+            fsLock.unlock();
+        }
+    }
+
+    public  boolean connectivityTest() throws UserException {
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFileSystemPhantomReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/RemoteFileSystemPhantomReference.java
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+
+public class RemoteFileSystemPhantomReference extends PhantomReference<RemoteFileSystem> {
+
+    private FileSystem fs;
+
+    /**
+     * Creates a new phantom reference that refers to the given object and
+     * is registered with the given queue.
+     *
+     * <p> It is possible to create a phantom reference with a {@code null}
+     * queue.  Such a reference will never be enqueued.
+     *
+     * @param referent the object the new phantom reference will refer to
+     * @param q        the queue with which the reference is to be registered,
+     *                 or {@code null} if registration is not required
+     */
+    public RemoteFileSystemPhantomReference(RemoteFileSystem referent, ReferenceQueue<? super RemoteFileSystem> q) {
+        super(referent, q);
+        this.fs = referent.dfsFileSystem;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/S3FileSystem.java
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.security.authentication.HadoopAuthenticator;
+import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
+import org.apache.doris.fsv2.obj.S3ObjStorage;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class S3FileSystem extends ObjFileSystem {
+
+    private static final Logger LOG = LogManager.getLogger(S3FileSystem.class);
+    private HadoopAuthenticator authenticator = null;
+    private AbstractS3CompatibleProperties s3Properties;
+
+
+    public S3FileSystem(AbstractS3CompatibleProperties s3Properties) {
+
+        super(StorageBackend.StorageType.S3.name(), StorageBackend.StorageType.S3,
+                new S3ObjStorage(s3Properties));
+        this.s3Properties = s3Properties;
+        this.storageProperties = s3Properties;
+        initFsProperties();
+
+    }
+
+    @VisibleForTesting
+    public S3FileSystem(S3ObjStorage storage) {
+        super(StorageBackend.StorageType.S3.name(), StorageBackend.StorageType.S3, storage);
+        initFsProperties();
+    }
+
+    private void initFsProperties() {
+        this.properties.putAll(storageProperties.getOrigProps());
+    }
+
+
+    @Override
+    protected FileSystem nativeFileSystem(String remotePath) throws UserException {
+        throw new UserException("S3 does not support native file system");
+    }
+
+    // broker file pattern glob is too complex, so we use hadoop directly
+    @Override
+    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+        S3ObjStorage objStorage = (S3ObjStorage) this.objStorage;
+        return objStorage.globList(remotePath, result, fileNameOnly);
+    }
+
+    @Override
+    public boolean connectivityTest() throws UserException {
+        S3ObjStorage objStorage = (S3ObjStorage) this.objStorage;
+        try {
+            objStorage.getClient().listBuckets();
+            return true;
+        } catch (Exception e) {
+            LOG.error("S3 connectivityTest error", e);
+        }
+        return false;
+
+    }
+
+    @VisibleForTesting
+    public HadoopAuthenticator getAuthenticator() {
+        return authenticator;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/DFSFileSystem.java
@@ -1,0 +1,497 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote.dfs;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.backup.Status;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.security.authentication.HadoopAuthenticator;
+import org.apache.doris.common.util.URI;
+import org.apache.doris.datasource.property.storage.HdfsCompatibleProperties;
+import org.apache.doris.fs.operations.HDFSFileOperations;
+import org.apache.doris.fs.operations.HDFSOpParams;
+import org.apache.doris.fs.operations.OpParams;
+import org.apache.doris.fsv2.remote.RemoteFSPhantomManager;
+import org.apache.doris.fsv2.remote.RemoteFile;
+import org.apache.doris.fsv2.remote.RemoteFileSystem;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+
+public class DFSFileSystem extends RemoteFileSystem {
+
+    public static final String PROP_ALLOW_FALLBACK_TO_SIMPLE_AUTH = "ipc.client.fallback-to-simple-auth-allowed";
+    private static final Logger LOG = LogManager.getLogger(DFSFileSystem.class);
+    private HDFSFileOperations operations = null;
+    private HadoopAuthenticator authenticator = null;
+    private HdfsCompatibleProperties hdfsProperties;
+
+    public DFSFileSystem(HdfsCompatibleProperties hdfsProperties) {
+        super(StorageBackend.StorageType.HDFS.name(), StorageBackend.StorageType.HDFS);
+        this.properties.putAll(hdfsProperties.getOrigProps());
+        this.storageProperties = hdfsProperties;
+        this.hdfsProperties = hdfsProperties;
+    }
+
+    public DFSFileSystem(HdfsCompatibleProperties hdfsProperties, StorageBackend.StorageType storageType) {
+        super(storageType.name(), storageType);
+        this.properties.putAll(hdfsProperties.getOrigProps());
+        this.hdfsProperties = hdfsProperties;
+    }
+
+    @VisibleForTesting
+    @Override
+    public FileSystem nativeFileSystem(String remotePath) throws UserException {
+        if (closed.get()) {
+            throw new UserException("FileSystem is closed.");
+        }
+        if (dfsFileSystem == null) {
+            synchronized (this) {
+                if (closed.get()) {
+                    throw new UserException("FileSystem is closed.");
+                }
+                if (dfsFileSystem == null) {
+                    Configuration conf = hdfsProperties.getHadoopConfiguration();
+                    authenticator = HadoopAuthenticator.getHadoopAuthenticator(conf);
+                    try {
+                        dfsFileSystem = authenticator.doAs(() -> {
+                            try {
+                                return FileSystem.get(new Path(remotePath).toUri(), conf);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                        operations = new HDFSFileOperations(dfsFileSystem);
+                        RemoteFSPhantomManager.registerPhantomReference(this);
+                    } catch (Exception e) {
+                        throw new UserException("Failed to get dfs FileSystem for " + e.getMessage(), e);
+                    }
+                }
+            }
+        }
+        return dfsFileSystem;
+    }
+
+    protected RemoteIterator<LocatedFileStatus> getLocatedFiles(boolean recursive,
+                FileSystem fileSystem, Path locatedPath) throws IOException {
+        return authenticator.doAs(() -> fileSystem.listFiles(locatedPath, recursive));
+    }
+
+    protected FileStatus[] getFileStatuses(String remotePath, FileSystem fileSystem) throws IOException {
+        return authenticator.doAs(() -> fileSystem.listStatus(new Path(remotePath)));
+    }
+
+    public static Configuration getHdfsConf(boolean fallbackToSimpleAuth) {
+        Configuration hdfsConf = new HdfsConfiguration();
+        if (fallbackToSimpleAuth) {
+            // need support fallback to simple if the cluster is a mixture of  kerberos and simple auth.
+            hdfsConf.set(PROP_ALLOW_FALLBACK_TO_SIMPLE_AUTH, "true");
+        }
+        return hdfsConf;
+    }
+
+    @Override
+    public Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("download from {} to {}, file size: {}.", remoteFilePath, localFilePath, fileSize);
+        }
+        final long start = System.currentTimeMillis();
+        HDFSOpParams hdfsOpParams = OpParams.of(remoteFilePath);
+        Status st = operations.openReader(hdfsOpParams);
+        if (st != Status.OK) {
+            return st;
+        }
+        FSDataInputStream fsDataInputStream = hdfsOpParams.fsDataInputStream();
+        LOG.info("finished to open reader. download {} to {}.", remoteFilePath, localFilePath);
+
+        // delete local file if exist
+        File localFile = new File(localFilePath);
+        if (localFile.exists()) {
+            try {
+                Files.walk(Paths.get(localFilePath), FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder())
+                        .map(java.nio.file.Path::toFile).forEach(File::delete);
+            } catch (IOException e) {
+                return new Status(Status.ErrCode.COMMON_ERROR,
+                        "failed to delete exist local file: " + localFilePath + ", msg: " + e.getMessage());
+            }
+        }
+        // create local file
+        try {
+            if (!localFile.createNewFile()) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "failed to create local file: " + localFilePath);
+            }
+        } catch (IOException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to create local file: " + localFilePath + ", msg: " + e.getMessage());
+        }
+
+        String lastErrMsg;
+        Status status = Status.OK;
+        try (BufferedOutputStream out = new BufferedOutputStream(Files.newOutputStream(localFile.toPath()))) {
+            final long bufSize = 1024 * 1024; // 1MB
+            long leftSize = fileSize;
+            long readOffset = 0;
+            while (leftSize > 0) {
+                long readLen = Math.min(leftSize, bufSize);
+                try {
+                    ByteBuffer data = readStreamBuffer(fsDataInputStream, readOffset, readLen);
+                    if (readLen != data.array().length) {
+                        LOG.warn(
+                                "the actual read length does not equal to "
+                                        + "the expected read length: {} vs. {}, file: {}",
+                                data.array().length, readLen, remoteFilePath);
+                    }
+                    // write local file
+                    out.write(data.array());
+                    readOffset += data.array().length;
+                    leftSize -= data.array().length;
+                } catch (Exception e) {
+                    lastErrMsg = String.format(
+                            "failed to read. " + "current read offset: %d, read length: %d,"
+                                    + " file size: %d, file: %s. msg: %s",
+                            readOffset, readLen, fileSize, remoteFilePath, e.getMessage());
+                    LOG.warn(lastErrMsg);
+                    status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "Got exception: " + e.getMessage());
+        } finally {
+            Status closeStatus = operations.closeReader(OpParams.of(fsDataInputStream));
+            if (!closeStatus.ok()) {
+                LOG.warn(closeStatus.getErrMsg());
+                if (status.ok()) {
+                    // we return close write error only if no other error has been encountered.
+                    status = closeStatus;
+                }
+            }
+        }
+
+        LOG.info("finished to download from {} to {} with size: {}. cost {} ms", remoteFilePath, localFilePath,
+                fileSize, (System.currentTimeMillis() - start));
+        return status;
+    }
+
+    /**
+     * read data from fsDataInputStream.
+     *
+     * @param fsDataInputStream input stream for read.
+     * @param readOffset        read offset.
+     * @param length            read length.
+     * @return ByteBuffer
+     * @throws IOException when read data error.
+     */
+    private static ByteBuffer readStreamBuffer(FSDataInputStream fsDataInputStream, long readOffset, long length)
+            throws IOException {
+        synchronized (fsDataInputStream) {
+            long currentStreamOffset;
+            try {
+                currentStreamOffset = fsDataInputStream.getPos();
+            } catch (IOException e) {
+                LOG.warn("errors while get file pos from output stream", e);
+                throw new IOException("errors while get file pos from output stream", e);
+            }
+            if (currentStreamOffset != readOffset) {
+                // it's ok, when reading some format like parquet, it is not a sequential read
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("invalid offset, current read offset is " + currentStreamOffset
+                            + " is not equal to request offset " + readOffset + " seek to it");
+                }
+                try {
+                    fsDataInputStream.seek(readOffset);
+                } catch (IOException e) {
+                    throw new IOException(String.format(
+                            "current read offset %d is not equal to %d, and could not seek to it, msg: %s",
+                            currentStreamOffset, readOffset, e.getMessage()));
+                }
+            }
+            // Avoid using the ByteBuffer based read for Hadoop because some
+            // FSDataInputStream
+            // implementations are not ByteBufferReadable,
+            // See https://issues.apache.org/jira/browse/HADOOP-14603
+            byte[] buf;
+            if (length > HDFSFileOperations.READ_BUFFER_SIZE) {
+                buf = new byte[HDFSFileOperations.READ_BUFFER_SIZE];
+            } else {
+                buf = new byte[(int) length];
+            }
+            try {
+                int readLength = readBytesFully(fsDataInputStream, buf);
+                if (readLength < 0) {
+                    throw new IOException("end of file reached");
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "read buffer from input stream, buffer size:" + buf.length + ", read length:" + readLength);
+                }
+                return ByteBuffer.wrap(buf, 0, readLength);
+            } catch (IOException e) {
+                LOG.warn("errors while read data from stream", e);
+                throw new IOException("errors while read data from stream " + e.getMessage());
+            }
+        }
+    }
+
+    private static int readBytesFully(FSDataInputStream is, byte[] dest) throws IOException {
+        int readLength = 0;
+        while (readLength < dest.length) {
+            int availableReadLength = dest.length - readLength;
+            int n = is.read(dest, readLength, availableReadLength);
+            if (n <= 0) {
+                break;
+            }
+            readLength += n;
+        }
+        return readLength;
+    }
+
+    @Override
+    public Status exists(String remotePath) {
+        try {
+            URI pathUri = URI.create(remotePath);
+            Path inputFilePath = new Path(pathUri.getPath());
+            FileSystem fileSystem = nativeFileSystem(remotePath);
+            boolean isPathExist = authenticator.doAs(() -> fileSystem.exists(inputFilePath));
+            if (!isPathExist) {
+                return new Status(Status.ErrCode.NOT_FOUND, "remote path does not exist: " + remotePath);
+            }
+            return Status.OK;
+        } catch (Exception e) {
+            LOG.warn("errors while check path exist " + remotePath, e);
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to check remote path exist: " + remotePath + ". msg: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Status directUpload(String content, String remoteFile) {
+        HDFSOpParams hdfsOpParams = OpParams.of(remoteFile);
+        Status wst = operations.openWriter(hdfsOpParams);
+        if (wst != Status.OK) {
+            return wst;
+        }
+        FSDataOutputStream fsDataOutputStream = hdfsOpParams.fsDataOutputStream();
+        LOG.info("finished to open writer. directly upload to remote path {}.", remoteFile);
+
+        Status status = Status.OK;
+        try {
+            fsDataOutputStream.writeBytes(content);
+        } catch (IOException e) {
+            LOG.warn("errors while write data to output stream", e);
+            status = new Status(Status.ErrCode.COMMON_ERROR, "write exception: " + e.getMessage());
+        } finally {
+            Status closeStatus = operations.closeWriter(OpParams.of(fsDataOutputStream));
+            if (!closeStatus.ok()) {
+                LOG.warn(closeStatus.getErrMsg());
+                if (status.ok()) {
+                    status = closeStatus;
+                }
+            }
+        }
+        return status;
+    }
+
+    @Override
+    public Status upload(String localPath, String remotePath) {
+        long start = System.currentTimeMillis();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("local path {}, remote path {}", localPath, remotePath);
+        }
+        HDFSOpParams hdfsOpParams = OpParams.of(remotePath);
+        Status wst = operations.openWriter(hdfsOpParams);
+        if (wst != Status.OK) {
+            return wst;
+        }
+        FSDataOutputStream fsDataOutputStream = hdfsOpParams.fsDataOutputStream();
+        LOG.info("finished to open writer. directly upload to remote path {}.", remotePath);
+        // read local file and write remote
+        File localFile = new File(localPath);
+        long fileLength = localFile.length();
+        byte[] readBuf = new byte[1024];
+        Status status = new Status(Status.ErrCode.OK, "");
+        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(localFile))) {
+            // save the last err msg
+            String lastErrMsg = null;
+            // save the current write offset of remote file
+            long writeOffset = 0;
+            // read local file, 1MB at a time
+            int bytesRead;
+            while ((bytesRead = in.read(readBuf)) != -1) {
+                try {
+                    fsDataOutputStream.write(readBuf, 0, bytesRead);
+                } catch (IOException e) {
+                    LOG.warn("errors while write data to output stream", e);
+                    lastErrMsg = String.format(
+                            "failed to write hdfs. current write offset: %d, write length: %d, "
+                                    + "file length: %d, file: %s, msg: errors while write data to output stream",
+                            writeOffset, bytesRead, fileLength, remotePath);
+                    status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
+                    break;
+                }
+
+                // write succeed, update current write offset
+                writeOffset += bytesRead;
+            } // end of read local file loop
+        } catch (FileNotFoundException e1) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "encounter file not found exception: " + e1.getMessage());
+        } catch (IOException e1) {
+            return new Status(Status.ErrCode.COMMON_ERROR, "encounter io exception: " + e1.getMessage());
+        } finally {
+            Status closeStatus = operations.closeWriter(OpParams.of(fsDataOutputStream));
+            if (!closeStatus.ok()) {
+                LOG.warn(closeStatus.getErrMsg());
+                if (status.ok()) {
+                    // we return close write error only if no other error has been encountered.
+                    status = closeStatus;
+                }
+            }
+        }
+
+        if (status.ok()) {
+            LOG.info("finished to upload {} to remote path {}. cost: {} ms", localPath, remotePath,
+                    (System.currentTimeMillis() - start));
+        }
+        return status;
+    }
+
+    @Override
+    public Status rename(String srcPath, String destPath) {
+        long start = System.currentTimeMillis();
+        try {
+            URI srcPathUri = URI.create(srcPath);
+            URI destPathUri = URI.create(destPath);
+            if (!srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "only allow rename in same file system");
+            }
+            FileSystem fileSystem = nativeFileSystem(destPath);
+            Path srcfilePath = new Path(srcPathUri.getPath());
+            Path destfilePath = new Path(destPathUri.getPath());
+            boolean isRenameSuccess = authenticator.doAs(() -> fileSystem.rename(srcfilePath, destfilePath));
+            if (!isRenameSuccess) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "failed to rename " + srcPath + " to " + destPath);
+            }
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        } catch (IOException e) {
+            LOG.warn("errors while rename path from " + srcPath + " to " + destPath);
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to rename remote " + srcPath + " to " + destPath + ", msg: " + e.getMessage());
+        }
+        LOG.info("finished to rename {} to  {}. cost: {} ms", srcPath, destPath, (System.currentTimeMillis() - start));
+        return Status.OK;
+    }
+
+    @Override
+    public Status delete(String remotePath) {
+        try {
+            URI pathUri = URI.create(remotePath);
+            Path inputFilePath = new Path(pathUri.getPath());
+            FileSystem fileSystem = nativeFileSystem(remotePath);
+            authenticator.doAs(() -> fileSystem.delete(inputFilePath, true));
+        } catch (UserException e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        } catch (IOException e) {
+            LOG.warn("errors while delete path " + remotePath);
+            return new Status(Status.ErrCode.COMMON_ERROR,
+                    "failed to delete remote path: " + remotePath + ", msg: " + e.getMessage());
+        }
+        LOG.info("finished to delete remote path {}.", remotePath);
+        return Status.OK;
+    }
+
+    /**
+     * get files in remotePath of HDFS.
+     *
+     * @param remotePath   hdfs://namenode:port/path.
+     * @param result       files in remotePath.
+     * @param fileNameOnly means get file only in remotePath if true.
+     * @return Status.OK if success.
+     */
+    @Override
+    public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+        try {
+            URI pathUri = URI.create(remotePath);
+            FileSystem fileSystem = nativeFileSystem(remotePath);
+            Path pathPattern = new Path(pathUri.getPath());
+            FileStatus[] files = authenticator.doAs(() -> fileSystem.globStatus(pathPattern));
+            if (files == null) {
+                LOG.info("no files in path " + remotePath);
+                return Status.OK;
+            }
+            for (FileStatus fileStatus : files) {
+                RemoteFile remoteFile = new RemoteFile(
+                        fileNameOnly ? fileStatus.getPath().getName() : fileStatus.getPath().toString(),
+                        !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen(),
+                        fileStatus.getBlockSize(), fileStatus.getModificationTime());
+                result.add(remoteFile);
+            }
+        } catch (FileNotFoundException e) {
+            LOG.info("file not found: " + e.getMessage());
+            return new Status(Status.ErrCode.NOT_FOUND, "file not found: " + e.getMessage());
+        } catch (Exception e) {
+            LOG.warn("errors while get file status ", e);
+            return new Status(Status.ErrCode.COMMON_ERROR, "errors while get file status " + e.getMessage());
+        }
+        LOG.info("finish list path {}", remotePath);
+        return Status.OK;
+    }
+
+    @Override
+    public Status makeDir(String remotePath) {
+        try {
+            FileSystem fileSystem = nativeFileSystem(remotePath);
+            if (!authenticator.doAs(() -> fileSystem.mkdirs(new Path(remotePath)))) {
+                LOG.warn("failed to make dir for " + remotePath);
+                return new Status(Status.ErrCode.COMMON_ERROR, "failed to make dir for " + remotePath);
+            }
+        } catch (Exception e) {
+            LOG.warn("failed to make dir for " + remotePath);
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        }
+        return Status.OK;
+    }
+
+    @VisibleForTesting
+    public HadoopAuthenticator getAuthenticator() {
+        return authenticator;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/JFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/JFSFileSystem.java
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote.dfs;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.datasource.property.storage.HdfsCompatibleProperties;
+
+public class JFSFileSystem extends DFSFileSystem {
+    public JFSFileSystem(HdfsCompatibleProperties hdfsProperties) {
+        super(hdfsProperties, StorageBackend.StorageType.JFS);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/OFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/OFSFileSystem.java
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote.dfs;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.datasource.property.storage.HdfsCompatibleProperties;
+
+public class OFSFileSystem extends DFSFileSystem {
+    public OFSFileSystem(HdfsCompatibleProperties properties) {
+        super(properties, StorageBackend.StorageType.OFS);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/OSSHdfsFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fsv2/remote/dfs/OSSHdfsFileSystem.java
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fsv2.remote.dfs;
+
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.datasource.property.storage.OSSHdfsProperties;
+
+public class OSSHdfsFileSystem extends DFSFileSystem {
+    public OSSHdfsFileSystem(OSSHdfsProperties properties) {
+        super(properties, StorageBackend.StorageType.HDFS);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.property.storage;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.common.UserException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OSSHdfsPropertiesTest {
+    @Test
+    public void testValidOSSConfiguration() throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        origProps.put("oss.region", "cn-shanghai");
+        origProps.put("uri", "oss://my-bucket/path");
+
+        StorageProperties props = StorageProperties.createPrimary(origProps);
+        Assertions.assertInstanceOf(OSSHdfsProperties.class, props);
+
+        Configuration conf = ((OSSHdfsProperties) props).getHadoopConfiguration();
+        Assertions.assertEquals("cn-shanghai.oss-dls.aliyuncs.com", conf.get("fs.oss.endpoint"));
+        Assertions.assertEquals("testAccessKey", conf.get("fs.oss.accessKeyId"));
+        Assertions.assertEquals("testSecretKey", conf.get("fs.oss.accessKeySecret"));
+        Assertions.assertEquals("cn-shanghai", conf.get("fs.oss.region"));
+        Assertions.assertEquals("com.aliyun.jindodata.oss.JindoOssFileSystem", conf.get("fs.oss.impl"));
+    }
+
+    @Test
+    public void testReadConfigFromFile() throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        origProps.put("oss.region", "cn-shanghai");
+        origProps.put("uri", "oss://my-bucket/path");
+        origProps.put("hadoop.config.resources", "hdfs-site.xml,core-site.xml");
+        URL hdfsFileUrl = OSSHdfsPropertiesTest.class.getClassLoader().getResource("plugins");
+        Config.hadoop_config_dir = hdfsFileUrl.getPath().toString() + "/hadoop_conf/";
+        origProps.put("hadoop.config.resources", "osshdfs1/core-site.xml");
+        StorageProperties props = StorageProperties.createPrimary(origProps);
+        Assertions.assertInstanceOf(OSSHdfsProperties.class, props);
+        Configuration conf = ((OSSHdfsProperties) props).getHadoopConfiguration();
+        Assertions.assertEquals("cn-shanghai.oss-dls.aliyuncs.com", conf.get("fs.oss.endpoint"));
+        Assertions.assertEquals("testAccessKey", conf.get("fs.oss.accessKeyId"));
+        Assertions.assertEquals("testSecretKey", conf.get("fs.oss.accessKeySecret"));
+        Assertions.assertEquals("cn-shanghai", conf.get("fs.oss.region"));
+        Assertions.assertEquals("test", conf.get("fs.oss.test.key"));
+        Map<String, String> backendConfigProperties = props.getBackendConfigProperties();
+        Assertions.assertEquals("test", backendConfigProperties.get("fs.oss.test.key"));
+        Assertions.assertEquals("com.aliyun.jindodata.oss.JindoOssFileSystem", backendConfigProperties.get("fs.oss.impl"));
+        Assertions.assertEquals("com.aliyun.jindodata.oss.JindoOSS", backendConfigProperties.get("fs.AbstractFileSystem.oss.impl"));
+        Assertions.assertEquals("cn-shanghai.oss-dls.aliyuncs.com", backendConfigProperties.get("fs.oss.endpoint"));
+        Assertions.assertEquals("testAccessKey", backendConfigProperties.get("fs.oss.accessKeyId"));
+        Assertions.assertEquals("testSecretKey", backendConfigProperties.get("fs.oss.accessKeySecret"));
+        Assertions.assertEquals("cn-shanghai", backendConfigProperties.get("fs.oss.region"));
+    }
+
+    @Test
+    public void testInvalidEndpoint() {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "invalid.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        origProps.put("oss.region", "cn-shanghai");
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            StorageProperties.createPrimary(origProps);
+        });
+        origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        Assertions.assertDoesNotThrow(() -> {
+            StorageProperties.createPrimary(origProps);
+        });
+    }
+
+    @Test
+    public void testValidateUri() throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("uri", "oss://my-bucket/path");
+        OSSHdfsProperties props = new OSSHdfsProperties(origProps);
+        Assertions.assertEquals("oss://bucket/path", props.validateAndNormalizeUri("oss://bucket/path"));
+        Assertions.assertThrows(UserException.class, () -> props.validateAndNormalizeUri("hdfs://bucket"));
+        Assertions.assertThrows(UserException.class, () -> props.validateAndNormalizeUri(""));
+        Assertions.assertThrows(UserException.class, () -> props.validateAndNormalizeUri("test"));
+        Assertions.assertEquals("oss://bucket/path", props.validateAndNormalizeUri("oss://bucket/path"));
+        Assertions.assertEquals("oss://my-bucket/path", props.validateAndGetUri(origProps));
+    }
+
+    @Test
+    public void testGetStorageName() throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        origProps.put("oss.region", "cn-shanghai");
+
+        OSSHdfsProperties props = (OSSHdfsProperties) StorageProperties.createAll(origProps).get(0);
+        Assertions.assertEquals("HDFS", props.getStorageName());
+    }
+
+}

--- a/fe/fe-core/src/test/resources/plugins/hadoop_conf/osshdfs1/core-site.xml
+++ b/fe/fe-core/src/test/resources/plugins/hadoop_conf/osshdfs1/core-site.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!--OSS-HDFS Configuration-->
+<configuration>
+    <property>
+        <name>fs.oss.test.key</name>
+        <value>test</value>
+    </property>
+</configuration>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  #50238 

#### Background
In the context of #50238, we are introducing a new set of storage parameters aimed at improving flexibility, supporting additional object storage types, and simplifying protocol management. This PR focuses on adapting the filesystem layer to align with the new parameter set and unifying the usage of protocols across supported storage systems.

#### Key Changes

##### Protocol Unification

Historically, to support object storage systems like S3, we reused the HDFS protocol (e.g., s3a://) as a workaround. This approach has led to confusion and increased implementation complexity.

In this PR, the use of the HDFS protocol to interact with S3 storage is completely removed. From now on, S3-compatible storage only  using the S3 protocol exclusively, improving clarity and protocol consistency.

##### HDFS-Compatible Parameter Adapter

To ease future extensibility, a dedicated parameter adaptation layer is introduced for HDFS compatibility. This layer translates deprecated parameter keys to the new ones internally and acts as a bridge during the migration phase.

#### Package Structure (Transitional Phase)

To ensure smooth transition and compatibility, we temporarily maintain two filesystem implementation packages:

fs: legacy implementation with current logic

fsv2: new implementation adapted for the modern parameter and protocol system

Once the new system has been fully validated, the fsv2 package will be renamed to fs and become the primary implementation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

