### PR TITLE
[fix](stacktrace) Speed ​​up BE UT stacktrace

### DIFF
--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -25,13 +25,18 @@ Exception::Exception(int code, const std::string_view& msg) {
     _code = code;
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;
+#ifndef BE_TEST
     if (ErrorCode::error_states[abs(code)].stacktrace) {
         _err_msg->_stack = get_stack_trace();
     }
-#ifdef BE_TEST
+#else
+    if (ErrorCode::error_states[abs(code)].stacktrace) {
+        _err_msg->_stack = get_stack_trace(0, "DISABLED");
+    }
     // BE UT TEST exceptions thrown during execution cannot be caught
     // and the error `C++ exception with description "argument not found" thrown in the test body` will be printed.
-    std::cout << "Exception: " << code << ", " << msg << ", " << get_stack_trace() << std::endl;
+    std::cout << "Exception: " << code << ", " << msg << ", " << get_stack_trace(0, "DISABLED")
+              << std::endl;
 #endif
     if (config::exit_on_exception) {
         LOG(FATAL) << "[ExitOnException] error code: " << code << ", message: " << msg;

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -44,11 +44,8 @@ std::string get_stack_trace(int start_pointers_index, std::string dwarf_location
     if (dwarf_location_info_mode.empty()) {
         dwarf_location_info_mode = config::dwarf_location_info_mode;
     }
-#ifdef BE_TEST
-    auto tool = std::string {"boost"};
-#else
+
     auto tool = config::get_stack_trace_tool;
-#endif
     if (tool == "glog") {
         return get_stack_trace_by_glog();
     } else if (tool == "boost") {


### PR DESCRIPTION
### What problem does this PR solve?

Testing Doris stacktrace methods, `libunwind DISABLED` mode is the fastest (not parse debug information). 

except for the `libunwind FAST` mode (parses .debug_aranges), the other 4 methods do not have line numbers, including glog, boost, and glibc.

If you find that stacktrace is too slow, use `libunwind DISABLED`.

```
17382022 : libunwind FAST cost(ms)
2305 : libunwind DISABLED cost(ms)
4779629 : boost cost(ms)
142682336 : glog cost(ms)
28597 : glibc cost(ms)

libunwind FAST:
	0#  doris::get_stack_trace(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) at /mnt/disk2/zouxinyi/doris/core/be/src/util/stack_util.cpp:59
	1#  doris::ThreadMemTrackerMgrTest_test1_Test::TestBody() at /mnt/disk2/zouxinyi/doris/core/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp:597
	2#  void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
	3#  void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
	4#  testing::Test::Run()
	5#  testing::TestInfo::Run()
	6#  testing::TestSuite::Run()
	7#  testing::internal::UnitTestImpl::RunAllTests()
	8#  bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
	9#  bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
	10# testing::UnitTest::Run()
	11# RUN_ALL_TESTS() at /mnt/disk2/zouxinyi/doris/core/thirdparty/installed/include/gtest/gtest.h:2490
	12# main at /mnt/disk2/zouxinyi/doris/core/be/test/testutil/run_all_tests.cpp:104
	13# __libc_start_main
	14# _start

libunwind DISABLED:
	0#  doris::get_stack_trace(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
	1#  doris::ThreadMemTrackerMgrTest_test1_Test::TestBody()
	2#  void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
	3#  void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
	4#  testing::Test::Run()
	5#  testing::TestInfo::Run()
	6#  testing::TestSuite::Run()
	7#  testing::internal::UnitTestImpl::RunAllTests()
	8#  bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
	9#  bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
	10# testing::UnitTest::Run()
	11# RUN_ALL_TESTS()
	12# main
	13# __libc_start_main
	14# _start

boost:  0# doris::get_stack_trace_by_boost[abi:cxx11]() at /mnt/disk2/zouxinyi/doris/core/be/src/util/stack_util.cpp:72
 1# doris::ThreadMemTrackerMgrTest_test1_Test::TestBody() at /mnt/disk2/zouxinyi/doris/core/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp:599
 2# void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 3# void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 4# testing::Test::Run() in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 5# testing::TestInfo::Run() in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 6# testing::TestSuite::Run() in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 7# testing::internal::UnitTestImpl::RunAllTests() in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 8# bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
 9# bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
10# testing::UnitTest::Run() in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test
11# RUN_ALL_TESTS() at /mnt/disk2/zouxinyi/doris/core/thirdparty/installed/include/gtest/gtest.h:2490
12# main at /mnt/disk2/zouxinyi/doris/core/be/test/testutil/run_all_tests.cpp:104
13# __libc_start_main in /lib64/libc.so.6
14# _start in /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test

glog:     @     0x5601ff94622b  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x5601ff940089  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x5601ff916a5a  testing::Test::Run()
    @     0x5601ff91747e  testing::TestInfo::Run()
    @     0x5601ff917d3e  testing::TestSuite::Run()
    @     0x5601ff9273fe  testing::internal::UnitTestImpl::RunAllTests()
    @     0x5601ff947076  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x5601ff941081  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x5601ff925bf3  testing::UnitTest::Run()
    @     0x5601c1847113  RUN_ALL_TESTS()
    @     0x5601c183ac70  main
    @     0x7f18a9a9d7e5  __libc_start_main
    @     0x5601bdfaf02a  _start
    @              (nil)  (unknown)

glibc: /mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x26b5c7e9) [0x5601cb1907e9]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x1cbc4caf) [0x5601c11f8caf]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b31222b) [0x5601ff94622b]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b30c089) [0x5601ff940089]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b2e2a5a) [0x5601ff916a5a]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b2e347e) [0x5601ff91747e]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b2e3d3e) [0x5601ff917d3e]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b2f33fe) [0x5601ff9273fe]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b313076) [0x5601ff947076]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b30d081) [0x5601ff941081]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x5b2f1bf3) [0x5601ff925bf3]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x1d213113) [0x5601c1847113]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x1d206c70) [0x5601c183ac70]
/lib64/libc.so.6(__libc_start_main+0xe5) [0x7f18a9a9d7e5]
/mnt/disk2/zouxinyi/doris/core/be/ut_build_ASAN/test//doris_be_test(+0x1997b02a) [0x5601bdfaf02a]
```

```
 {
        MonotonicStopWatch watch;
        watch.start();
        for (int i = 0; i < 100; i++) {
            get_stack_trace(0, "FAST");
        }
        std::cout << watch.elapsed_time() / 1000 << " : libunwind FAST cost(ms)" << std::endl;
    }
    {
        MonotonicStopWatch watch;
        watch.start();
        for (int i = 0; i < 100; i++) {
            get_stack_trace(0, "DISABLED");
        }
        std::cout << watch.elapsed_time() / 1000 << " : libunwind DISABLED cost(ms)" << std::endl;
    }
    {
        MonotonicStopWatch watch;
        watch.start();
        for (int i = 0; i < 100; i++) {
            get_stack_trace_by_boost();
        }
        std::cout << watch.elapsed_time() / 1000 << " : boost cost(ms)" << std::endl;
    }
    {
        MonotonicStopWatch watch;
        watch.start();
        for (int i = 0; i < 100; i++) {
            get_stack_trace_by_glog();
        }
        std::cout << watch.elapsed_time() / 1000 << " : glog cost(ms)" << std::endl;
    }
    {
        MonotonicStopWatch watch;
        watch.start();
        for (int i = 0; i < 100; i++) {
            get_stack_trace_by_glibc();
        }
        std::cout << watch.elapsed_time() / 1000 << " : glibc cost(ms)" << std::endl;
    }
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

