### PR TITLE
[fix](create-resource) fix potential concurrent modification exception when creating resource

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateResourceStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateResourceStmt.java
@@ -31,6 +31,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -42,7 +43,7 @@ public class CreateResourceStmt extends DdlStmt implements NotFallbackInParser {
     private final boolean isExternal;
     private final boolean ifNotExists;
     private final String resourceName;
-    private final Map<String, String> properties;
+    private final ImmutableMap<String, String> properties;
     private ResourceType resourceType;
 
     public CreateResourceStmt(boolean isExternal, boolean ifNotExists, String resourceName,
@@ -50,7 +51,7 @@ public class CreateResourceStmt extends DdlStmt implements NotFallbackInParser {
         this.isExternal = isExternal;
         this.ifNotExists = ifNotExists;
         this.resourceName = resourceName;
-        this.properties = properties;
+        this.properties = ImmutableMap.copyOf(properties);
         this.resourceType = ResourceType.UNKNOWN;
     }
 
@@ -62,7 +63,7 @@ public class CreateResourceStmt extends DdlStmt implements NotFallbackInParser {
         return resourceName;
     }
 
-    public Map<String, String> getProperties() {
+    public ImmutableMap<String, String> getProperties() {
         return properties;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -32,6 +32,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -48,7 +49,7 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
 
     private final boolean ifNotExists;
     private final String vaultName;
-    private final Map<String, String> properties;
+    private final ImmutableMap<String, String> properties;
     private boolean setAsDefault;
     private int pathVersion = 0;
     private int numShard = 0;
@@ -57,7 +58,7 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
     public CreateStorageVaultStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
         this.ifNotExists = ifNotExists;
         this.vaultName = vaultName;
-        this.properties = properties;
+        this.properties = ImmutableMap.copyOf(properties);
         this.vaultType = vaultType.UNKNOWN;
     }
 
@@ -81,7 +82,7 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
         return pathVersion;
     }
 
-    public Map<String, String> getProperties() {
+    public ImmutableMap<String, String> getProperties() {
         return properties;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AzureResource.java
@@ -27,6 +27,7 @@ import org.apache.doris.fs.obj.ObjStorage;
 import org.apache.doris.fs.obj.RemoteObjects;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
@@ -52,32 +53,32 @@ public class AzureResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> newProperties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> newProperties) throws DdlException {
         Preconditions.checkState(newProperties != null);
+        this.properties = Maps.newHashMap(newProperties);
         // check properties
-        S3Properties.requiredS3PingProperties(newProperties);
+        S3Properties.requiredS3PingProperties(this.properties);
         // default need check resource conf valid, so need fix ut and regression case
-        boolean needCheck = isNeedCheck(newProperties);
+        boolean needCheck = isNeedCheck(this.properties);
         if (LOG.isDebugEnabled()) {
             LOG.debug("azure info need check validity : {}", needCheck);
         }
 
         // the endpoint for ping need add uri scheme.
-        String pingEndpoint = newProperties.get(S3Properties.ENDPOINT);
+        String pingEndpoint = this.properties.get(S3Properties.ENDPOINT);
         if (!pingEndpoint.startsWith("http://")) {
-            pingEndpoint = "http://" + newProperties.get(S3Properties.ENDPOINT);
-            newProperties.put(S3Properties.ENDPOINT, pingEndpoint);
-            newProperties.put(S3Properties.Env.ENDPOINT, pingEndpoint);
+            pingEndpoint = "http://" + this.properties.get(S3Properties.ENDPOINT);
+            this.properties.put(S3Properties.ENDPOINT, pingEndpoint);
+            this.properties.put(S3Properties.Env.ENDPOINT, pingEndpoint);
         }
 
         if (needCheck) {
-            String bucketName = newProperties.get(S3Properties.BUCKET);
-            String rootPath = newProperties.get(S3Properties.ROOT_PATH);
-            pingAzure(bucketName, rootPath, newProperties);
+            String bucketName = this.properties.get(S3Properties.BUCKET);
+            String rootPath = this.properties.get(S3Properties.ROOT_PATH);
+            pingAzure(bucketName, rootPath, this.properties);
         }
         // optional
-        S3Properties.optionalS3Property(newProperties);
-        this.properties = newProperties;
+        S3Properties.optionalS3Property(this.properties);
     }
 
     protected static void pingAzure(String bucketName, String rootPath,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EsResource.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.datasource.es.EsUtil;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -96,7 +97,7 @@ public class EsResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> properties) throws DdlException {
         valid(properties, false);
         this.properties = processCompatibleProperties(properties);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HMSResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HMSResource.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.HMSProperties;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -63,7 +64,7 @@ public class HMSResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> properties) throws DdlException {
         for (String field : HMSProperties.REQUIRED_FIELDS) {
             if (!properties.containsKey(field)) {
                 throw new DdlException("Missing [" + field + "] in properties.");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.security.authentication.AuthenticationConfig;
 import org.apache.doris.thrift.THdfsConf;
 import org.apache.doris.thrift.THdfsParams;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -73,13 +74,13 @@ public class HdfsResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> newProperties) throws DdlException {
         // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
         // We should disable short circuit read if they are not both set because it will cause performance down.
+        this.properties = Maps.newHashMap(newProperties);
         if (!(enableShortCircuitRead(properties))) {
-            properties.put(HADOOP_SHORT_CIRCUIT, "false");
+            this.properties.put(HADOOP_SHORT_CIRCUIT, "false");
         }
-        this.properties = properties;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -27,6 +27,7 @@ import org.apache.doris.fs.remote.dfs.DFSFileSystem;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -90,7 +91,7 @@ public class HdfsStorageVault extends StorageVault {
     }
 
     @Override
-    public void modifyProperties(Map<String, String> newProperties) throws DdlException {
+    public void modifyProperties(ImmutableMap<String, String> newProperties) throws DdlException {
         for (Map.Entry<String, String> kv : newProperties.entrySet()) {
             replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -197,7 +197,7 @@ public class JdbcResource extends Resource {
     protected void setProperties(Map<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null);
         validateProperties(properties);
-        configs = properties;
+        configs = Maps.newHashMap(properties);
         applyDefaultProperties();
         String currentDateTime = LocalDateTime.now(ZoneId.systemDefault()).toString().replace("T", " ");
         configs.put(CREATE_TIME, currentDateTime);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -29,6 +29,7 @@ import org.apache.doris.datasource.ExternalCatalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -194,10 +195,10 @@ public class JdbcResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null);
-        validateProperties(properties);
-        configs = Maps.newHashMap(properties);
+        this.configs = Maps.newHashMap(properties);
+        validateProperties(this.configs);
         applyDefaultProperties();
         String currentDateTime = LocalDateTime.now(ZoneId.systemDefault()).toString().replace("T", " ");
         configs.put(CREATE_TIME, currentDateTime);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcCatalogResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcCatalogResource.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.proc.BaseProcResult;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -167,10 +168,10 @@ public class OdbcCatalogResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null);
 
-        configs = properties;
+        configs = Maps.newHashMap(properties);
 
         checkProperties(HOST);
         checkProperties(PORT);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -31,6 +31,7 @@ import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
@@ -242,7 +243,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     /**
      * Set and check the properties in child resources
      */
-    protected abstract void setProperties(Map<String, String> properties) throws DdlException;
+    protected abstract void setProperties(ImmutableMap<String, String> properties) throws DdlException;
 
     public abstract Map<String, String> getCopiedProperties();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -28,6 +28,7 @@ import org.apache.doris.fs.obj.RemoteObjects;
 import org.apache.doris.fs.obj.S3ObjStorage;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -85,8 +86,10 @@ public class S3Resource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
-        Preconditions.checkState(properties != null);
+    protected void setProperties(ImmutableMap<String, String> newProperties) throws DdlException {
+        Preconditions.checkState(newProperties != null);
+        this.properties = Maps.newHashMap(newProperties);
+
         // check properties
         S3Properties.requiredS3PingProperties(properties);
         // default need check resource conf valid, so need fix ut and regression case
@@ -112,7 +115,6 @@ public class S3Resource extends Resource {
         }
         // optional
         S3Properties.optionalS3Property(properties);
-        this.properties = properties;
     }
 
     protected static void pingS3(String bucketName, String rootPath, Map<String, String> newProperties)

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.S3Properties;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Arrays;
@@ -77,7 +78,7 @@ public class S3StorageVault extends StorageVault {
     }
 
     @Override
-    public void modifyProperties(Map<String, String> properties) throws DdlException {
+    public void modifyProperties(ImmutableMap<String, String> properties) throws DdlException {
         resource.setProperties(properties);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SparkResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SparkResource.java
@@ -29,6 +29,7 @@ import org.apache.doris.load.loadv2.SparkRepository;
 import org.apache.doris.load.loadv2.SparkYarnConfigFiles;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -282,7 +283,7 @@ public class SparkResource extends Resource {
     }
 
     @Override
-    protected void setProperties(Map<String, String> properties) throws DdlException {
+    protected void setProperties(ImmutableMap<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null);
 
         // get spark configs

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -27,6 +27,7 @@ import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.TextFormat;
 
 import java.util.ArrayList;
@@ -172,7 +173,7 @@ public abstract class StorageVault {
      * @param properties
      * @throws DdlException
      */
-    public abstract void modifyProperties(Map<String, String> properties) throws DdlException;
+    public abstract void modifyProperties(ImmutableMap<String, String> properties) throws DdlException;
 
     /**
      * Check properties in child resources

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -6771,7 +6771,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     @Override
     public LogicalPlan visitCreateResource(DorisParser.CreateResourceContext ctx) {
         String resourceName = visitIdentifierOrText(ctx.name);
-        Map<String, String> properties = new HashMap<>(visitPropertyClause(ctx.properties));
+        ImmutableMap<String, String> properties = ImmutableMap.copyOf(visitPropertyClause(ctx.properties));
 
         CreateResourceInfo createResourceInfo = new CreateResourceInfo(
                 ctx.EXTERNAL() != null,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateResourceInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateResourceInfo.java
@@ -31,6 +31,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -42,14 +43,14 @@ public class CreateResourceInfo {
     private final boolean isExternal;
     private final boolean ifNotExists;
     private final String resourceName;
-    private final Map<String, String> properties;
+    private ImmutableMap<String, String> properties;
     private ResourceType resourceType;
 
     /**
      * CreateResourceInfo
      */
     public CreateResourceInfo(boolean isExternal, boolean ifNotExists, String resourceName,
-            Map<String, String> properties) {
+            com.google.common.collect.ImmutableMap<String, String> properties) {
         this.isExternal = isExternal;
         this.ifNotExists = ifNotExists;
         this.resourceName = resourceName;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateResourceInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateResourceInfo.java
@@ -50,7 +50,7 @@ public class CreateResourceInfo {
      * CreateResourceInfo
      */
     public CreateResourceInfo(boolean isExternal, boolean ifNotExists, String resourceName,
-            com.google.common.collect.ImmutableMap<String, String> properties) {
+            ImmutableMap<String, String> properties) {
         this.isExternal = isExternal;
         this.ifNotExists = ifNotExists;
         this.resourceName = resourceName;
@@ -122,7 +122,7 @@ public class CreateResourceInfo {
         return resourceName;
     }
 
-    public Map<String, String> getProperties() {
+    public ImmutableMap<String, String> getProperties() {
         return properties;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OdbcCatalogResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OdbcCatalogResourceTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -42,7 +43,6 @@ import java.io.DataOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.Map;
 
 public class OdbcCatalogResourceTest {
@@ -125,11 +125,13 @@ public class OdbcCatalogResourceTest {
         OdbcCatalogResource odbcCatalogResource1 = new OdbcCatalogResource("odbc1");
         odbcCatalogResource1.write(dos);
 
-        Map<String, String> configs = new HashMap<>();
-        configs.put("host", "host");
-        configs.put("port", "port");
-        configs.put("user", "user");
-        configs.put("password", "password");
+        ImmutableMap<String, String> configs = ImmutableMap.of(
+                "host", "host",
+                "port", "port",
+                "user", "user",
+                "password", "password"
+        );
+
         OdbcCatalogResource odbcCatalogResource2 = new OdbcCatalogResource("odbc2");
         odbcCatalogResource2.setProperties(configs);
         odbcCatalogResource2.write(dos);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -172,14 +173,15 @@ public class S3ResourceTest {
         S3Resource s3Resource1 = new S3Resource("s3_1");
         s3Resource1.write(s3Dos);
 
-        Map<String, String> properties = new HashMap<>();
-        properties.put("AWS_ENDPOINT", "aaa");
-        properties.put("AWS_REGION", "bbb");
-        properties.put("AWS_ROOT_PATH", "/path/to/root");
-        properties.put("AWS_ACCESS_KEY", "xxx");
-        properties.put("AWS_SECRET_KEY", "yyy");
-        properties.put("AWS_BUCKET", "test-bucket");
-        properties.put("s3_validity_check", "false");
+        ImmutableMap<String, String> properties = ImmutableMap.of(
+                "AWS_ENDPOINT", "aaa",
+                "AWS_REGION", "bbb",
+                "AWS_ROOT_PATH", "/path/to/root",
+                "AWS_ACCESS_KEY", "xxx",
+                "AWS_SECRET_KEY", "yyy",
+                "AWS_BUCKET", "test-bucket",
+                "s3_validity_check", "false"
+        );
         S3Resource s3Resource2 = new S3Resource("s3_2");
         s3Resource2.setProperties(properties);
         s3Resource2.write(s3Dos);
@@ -211,14 +213,15 @@ public class S3ResourceTest {
 
     @Test
     public void testModifyProperties() throws Exception {
-        Map<String, String> properties = new HashMap<>();
-        properties.put("AWS_ENDPOINT", "aaa");
-        properties.put("AWS_REGION", "bbb");
-        properties.put("AWS_ROOT_PATH", "/path/to/root");
-        properties.put("AWS_ACCESS_KEY", "xxx");
-        properties.put("AWS_SECRET_KEY", "yyy");
-        properties.put("AWS_BUCKET", "test-bucket");
-        properties.put("s3_validity_check", "false");
+        ImmutableMap<String, String> properties = ImmutableMap.of(
+                "AWS_ENDPOINT", "aaa",
+                "AWS_REGION", "bbb",
+                "AWS_ROOT_PATH", "/path/to/root",
+                "AWS_ACCESS_KEY", "xxx",
+                "AWS_SECRET_KEY", "yyy",
+                "AWS_BUCKET", "test-bucket",
+                "s3_validity_check", "false"
+        );
         S3Resource s3Resource = new S3Resource("t_source");
         s3Resource.setProperties(properties);
         FeConstants.runningUnitTest = true;
@@ -231,14 +234,15 @@ public class S3ResourceTest {
     @Test
     public void testHttpScheme() throws DdlException {
         // if https:// is set, it should be replaced with http://
-        Map<String, String> properties = new HashMap<>();
-        properties.put("AWS_ENDPOINT", "https://aaa");
-        properties.put("AWS_REGION", "bbb");
-        properties.put("AWS_ROOT_PATH", "/path/to/root");
-        properties.put("AWS_ACCESS_KEY", "xxx");
-        properties.put("AWS_SECRET_KEY", "yyy");
-        properties.put("AWS_BUCKET", "test-bucket");
-        properties.put("s3_validity_check", "false");
+        ImmutableMap<String, String> properties = ImmutableMap.of(
+                "AWS_ENDPOINT", "https://aaa",
+                "AWS_REGION", "bbb",
+                "AWS_ROOT_PATH", "/path/to/root",
+                "AWS_ACCESS_KEY", "xxx",
+                "AWS_SECRET_KEY", "yyy",
+                "AWS_BUCKET", "test-bucket",
+                "s3_validity_check", "false"
+        );
         S3Resource s3Resource = new S3Resource("s3_2");
         s3Resource.setProperties(properties);
         Assert.assertEquals(s3Resource.getProperty(S3Properties.ENDPOINT), "https://aaa");

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -237,10 +236,11 @@ public class HdfsStorageVaultTest {
             Assumptions.assumeTrue(!Strings.isNullOrEmpty(hadoopFsName), "HADOOP_FS_NAME isNullOrEmpty.");
             Assumptions.assumeTrue(!Strings.isNullOrEmpty(hadoopUser), "HADOOP_USER isNullOrEmpty.");
 
-            Map<String, String> properties = new HashMap<>();
-            properties.put(HdfsStorageVault.HADOOP_FS_NAME, hadoopFsName);
-            properties.put(AuthenticationConfig.HADOOP_USER_NAME, hadoopUser);
-            properties.put(HdfsStorageVault.VAULT_PATH_PREFIX, "testCheckConnectivityUtPrefix");
+            ImmutableMap<String, String> properties = ImmutableMap.of(
+                    HdfsStorageVault.HADOOP_FS_NAME, hadoopFsName,
+                    AuthenticationConfig.HADOOP_USER_NAME, hadoopUser,
+                    HdfsStorageVault.VAULT_PATH_PREFIX, "testCheckConnectivityUtPrefix"
+            );
 
             HdfsStorageVault vault = new HdfsStorageVault("testHdfsVault", false, false);
             vault.modifyProperties(properties);
@@ -252,10 +252,11 @@ public class HdfsStorageVaultTest {
 
     @Test
     public void testCheckConnectivityException() {
-        Map<String, String> properties = new HashMap<>();
-        properties.put(HdfsStorageVault.HADOOP_FS_NAME, "hdfs://localhost:10000");
-        properties.put(AuthenticationConfig.HADOOP_USER_NAME, "notExistUser");
-        properties.put(HdfsStorageVault.VAULT_PATH_PREFIX, "testCheckConnectivityUtPrefix");
+        ImmutableMap<String, String> properties = ImmutableMap.of(
+                HdfsStorageVault.HADOOP_FS_NAME, "hdfs://localhost:10000",
+                AuthenticationConfig.HADOOP_USER_NAME, "notExistUser",
+                HdfsStorageVault.VAULT_PATH_PREFIX, "testCheckConnectivityUtPrefix"
+        );
 
         HdfsStorageVault vault = new HdfsStorageVault("testHdfsVault", false, false);
         Assertions.assertThrows(DdlException.class, () -> {
@@ -265,11 +266,12 @@ public class HdfsStorageVaultTest {
 
     @Test
     public void testIgnoreCheckConnectivity() throws DdlException {
-        Map<String, String> properties = new HashMap<>();
-        properties.put(HdfsStorageVault.HADOOP_FS_NAME, "hdfs://localhost:10000");
-        properties.put(AuthenticationConfig.HADOOP_USER_NAME, "notExistUser");
-        properties.put(HdfsStorageVault.VAULT_PATH_PREFIX, "testCheckConnectivityUtPrefix");
-        properties.put(S3Properties.VALIDITY_CHECK, "false");
+        ImmutableMap<String, String> properties = ImmutableMap.of(
+                HdfsStorageVault.HADOOP_FS_NAME, "hdfs://localhost:10000",
+                AuthenticationConfig.HADOOP_USER_NAME, "notExistUser",
+                HdfsStorageVault.VAULT_PATH_PREFIX, "testCheckConnectivityUtPrefix",
+                S3Properties.VALIDITY_CHECK, "false"
+        );
 
         HdfsStorageVault vault = new HdfsStorageVault("testHdfsVault", false, false);
         vault.modifyProperties(properties);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateResourceCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateResourceCommandTest.java
@@ -33,8 +33,6 @@ import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 public class CreateResourceCommandTest extends TestWithFeService {
     @Test
     public void testValidate(@Mocked Env env, @Mocked AccessControllerManager accessManager) {
@@ -48,7 +46,7 @@ public class CreateResourceCommandTest extends TestWithFeService {
         };
 
         // test validate normal
-        Map<String, String> properties = ImmutableMap.of("type", "spark", "host", "http://127.0.0.1:29200");
+        ImmutableMap<String, String> properties = ImmutableMap.of("type", "spark", "host", "http://127.0.0.1:29200");
         CreateResourceInfo info = new CreateResourceInfo(true, false, "test", properties);
         CreateResourceCommand createResourceCommand = new CreateResourceCommand(info);
         Assertions.assertDoesNotThrow(() -> createResourceCommand.getInfo().validate());


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #48424

Problem Summary:

The `CreateResourceCommandTest` may throw concurrent modification exception.
This is because in `JdbcResource`, the origin property map may be modified.

This PR changes；
1. Change the origin property map to ImmutableMap, to avoid potential exception.
2. Copy the map to the jdbc resource to avoid modifying the origin map

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

