### PR TITLE
[enhacement](cloud) Make config::custom_conf_path default to use conf_path's value specified when started

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -54,9 +54,16 @@ CONF_Int32(log_verbose_level, "5");
 // Only works when starting Cloud with --console.
 CONF_Bool(enable_file_logger, "true");
 
-// Custom conf path is default the same as conf path, and configs will be append to it.
-// Otherwise, will a new custom conf file will be created.
-CONF_String(custom_conf_path, "./conf/doris_cloud.conf");
+// Custom conf path is default empty.
+// All mutable configs' modification needed to be persisted will be appended to conf path
+// specified when started.
+//
+// If it is set to equivalent value of conf path specified when started,
+// mutable configs' modification behavior will be the same as the description above.
+//
+// Otherwise, a new custom conf file will be created when mutable configs are modified
+// and persisted, with all modification written to it.
+CONF_String(custom_conf_path, "");
 
 // recycler config
 CONF_mInt64(recycle_interval_seconds, "3600");

--- a/cloud/src/main.cpp
+++ b/cloud/src/main.cpp
@@ -202,6 +202,9 @@ int main(int argc, char** argv) {
         std::cerr << "failed to init config file, conf=" << conf_file << std::endl;
         return -1;
     }
+    if (config::custom_conf_path.empty()) {
+        config::custom_conf_path = conf_file;
+    }
     if (!std::filesystem::equivalent(conf_file, config::custom_conf_path) &&
         !config::init(config::custom_conf_path.c_str(), false)) {
         std::cerr << "failed to init custom config file, conf=" << config::custom_conf_path


### PR DESCRIPTION
### What problem does this PR solve?

As title.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

