### PR TITLE
[feat] VirtualColumn & ANNTopN & AnnRangeSearch

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -762,9 +762,9 @@ Status Compaction::do_inverted_index_compaction() {
             }
             for (int dest_segment_id = 0; dest_segment_id < dest_segment_num; dest_segment_id++) {
                 auto res = index_file_writers[dest_segment_id]->open(index_meta);
-                DBUG_EXECUTE_IF("Compaction::open_x_index_file_writer", {
+                DBUG_EXECUTE_IF("Compaction::open_index_file_writer", {
                     res = ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                            "debug point: Compaction::open_x_index_file_writer error"));
+                            "debug point: Compaction::open_index_file_writer error"));
                 })
                 if (!res.has_value()) {
                     LOG(WARNING) << "failed to do index compaction, open inverted index file "

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -29,6 +29,7 @@
 #include "olap/tablet_schema.h"
 #include "runtime/runtime_state.h"
 #include "vec/core/block.h"
+#include "vec/exprs/vann_topn_predicate.h"
 #include "vec/exprs/vexpr.h"
 
 namespace doris {
@@ -119,6 +120,11 @@ public:
     std::map<std::string, TypeDescriptor> target_cast_type_for_variants;
     RowRanges row_ranges;
     size_t topn_limit = 0;
+
+    std::map<ColumnId, vectorized::VExprContextSPtr> virtual_column_exprs;
+    std::shared_ptr<vectorized::AnnTopNDescriptor> ann_topn_descriptor;
+    std::map<ColumnId, size_t> vir_cid_to_idx_in_block;
+    std::map<size_t, vectorized::DataTypePtr> vir_col_idx_to_type;
 };
 
 struct CompactionSampleInfo {

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -23,6 +23,7 @@
 #include "olap/olap_common.h"
 #include "olap/rowid_conversion.h"
 #include "runtime/runtime_state.h"
+#include "vec/exprs/vann_topn_predicate.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 
@@ -50,7 +51,7 @@ struct RowsetReaderContext {
     // filter_block arguments
     vectorized::VExprContextSPtrs filter_block_conjuncts;
     // projection columns: the set of columns rowset reader should return
-    const std::vector<uint32_t>* return_columns = nullptr;
+    const std::vector<ColumnId>* return_columns = nullptr;
     TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
     // column name -> column predicate
     // adding column_name for predicate to make use of column selectivity
@@ -83,6 +84,11 @@ struct RowsetReaderContext {
     // slots that cast may be eliminated in storage layer
     std::map<std::string, TypeDescriptor> target_cast_type_for_variants;
     int64_t ttl_seconds = 0;
+    std::map<ColumnId, vectorized::VExprContextSPtr> virtual_column_exprs;
+    std::map<ColumnId, size_t> vir_cid_to_idx_in_block;
+    std::map<size_t, vectorized::DataTypePtr> vir_col_idx_to_type;
+
+    std::shared_ptr<vectorized::AnnTopNDescriptor> ann_topn_descriptor;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/segment_creator.cpp
+++ b/be/src/olap/rowset/segment_creator.cpp
@@ -141,9 +141,9 @@ Status SegmentFlusher::_create_segment_writer(std::unique_ptr<segment_v2::Segmen
     io::FileWriterPtr segment_file_writer;
     RETURN_IF_ERROR(_context.file_writer_creator->create(segment_id, segment_file_writer));
 
-    IndexFileWriterPtr x_index_file_writer;
+    IndexFileWriterPtr index_file_writer;
     if (_context.tablet_schema->has_extra_index()) {
-        RETURN_IF_ERROR(_context.file_writer_creator->create(segment_id, &x_index_file_writer));
+        RETURN_IF_ERROR(_context.file_writer_creator->create(segment_id, &index_file_writer));
     }
 
     segment_v2::SegmentWriterOptions writer_options;
@@ -158,10 +158,10 @@ Status SegmentFlusher::_create_segment_writer(std::unique_ptr<segment_v2::Segmen
 
     writer = std::make_unique<segment_v2::SegmentWriter>(
             segment_file_writer.get(), segment_id, _context.tablet_schema, _context.tablet,
-            _context.data_dir, writer_options, x_index_file_writer.get());
+            _context.data_dir, writer_options, index_file_writer.get());
     RETURN_IF_ERROR(_seg_files.add(segment_id, std::move(segment_file_writer)));
     if (_context.tablet_schema->has_extra_index()) {
-        RETURN_IF_ERROR(_idx_files.add(segment_id, std::move(x_index_file_writer)));
+        RETURN_IF_ERROR(_idx_files.add(segment_id, std::move(index_file_writer)));
     }
     auto s = writer->init();
     if (!s.ok()) {
@@ -178,9 +178,9 @@ Status SegmentFlusher::_create_segment_writer(
     io::FileWriterPtr segment_file_writer;
     RETURN_IF_ERROR(_context.file_writer_creator->create(segment_id, segment_file_writer));
 
-    IndexFileWriterPtr x_index_file_writer;
+    IndexFileWriterPtr index_file_writer;
     if (_context.tablet_schema->has_extra_index()) {
-        RETURN_IF_ERROR(_context.file_writer_creator->create(segment_id, &x_index_file_writer));
+        RETURN_IF_ERROR(_context.file_writer_creator->create(segment_id, &index_file_writer));
     }
 
     segment_v2::VerticalSegmentWriterOptions writer_options;
@@ -194,10 +194,10 @@ Status SegmentFlusher::_create_segment_writer(
 
     writer = std::make_unique<segment_v2::VerticalSegmentWriter>(
             segment_file_writer.get(), segment_id, _context.tablet_schema, _context.tablet,
-            _context.data_dir, writer_options, x_index_file_writer.get());
+            _context.data_dir, writer_options, index_file_writer.get());
     RETURN_IF_ERROR(_seg_files.add(segment_id, std::move(segment_file_writer)));
     if (_context.tablet_schema->has_extra_index()) {
-        RETURN_IF_ERROR(_idx_files.add(segment_id, std::move(x_index_file_writer)));
+        RETURN_IF_ERROR(_idx_files.add(segment_id, std::move(index_file_writer)));
     }
     auto s = writer->init();
     if (!s.ok()) {

--- a/be/src/olap/rowset/segment_v2/ann_index_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index_iterator.cpp
@@ -24,7 +24,7 @@ namespace doris::segment_v2 {
 AnnIndexIterator::AnnIndexIterator(const io::IOContext& io_ctx, OlapReaderStatistics* stats,
                                    RuntimeState* runtime_state, const IndexReaderPtr& reader)
         : IndexIterator(io_ctx, stats, runtime_state) {
-    _ann_reader = std::static_pointer_cast<AnnIndexReader>(reader);
+    _ann_reader = std::dynamic_pointer_cast<AnnIndexReader>(reader);
 }
 
 Status AnnIndexIterator::read_from_index(const IndexParam& param) {
@@ -32,9 +32,18 @@ Status AnnIndexIterator::read_from_index(const IndexParam& param) {
     if (a_param == nullptr) {
         return Status::Error<ErrorCode::INDEX_INVALID_PARAMETERS>("a_param is null");
     }
-    (void)a_param->column_name;
 
-    return _ann_reader->query(a_param);
+    return _ann_reader->query(&_io_ctx, a_param);
+}
+
+Status AnnIndexIterator::range_search(const RangeSearchParams& params,
+                                      const CustomSearchParams& custom_params,
+                                      RangeSearchResult* result) {
+    if (_ann_reader == nullptr) {
+        return Status::Error<ErrorCode::INDEX_INVALID_PARAMETERS>("_ann_reader is null");
+    }
+
+    return _ann_reader->range_search(params, custom_params, result, &_io_ctx);
 }
 
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/ann_index_iterator.h
+++ b/be/src/olap/rowset/segment_v2/ann_index_iterator.h
@@ -17,15 +17,48 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
+#include "gutil/integral_types.h"
 #include "olap/rowset/segment_v2/ann_index_reader.h"
 #include "olap/rowset/segment_v2/index_iterator.h"
 
 namespace doris::segment_v2 {
 
 struct AnnIndexParam {
-    const std::string& column_name;
+    const float* query_value;
+    const size_t query_value_size;
+    size_t limit;
+    roaring::Roaring* roaring;
+    std::unique_ptr<std::vector<float>> distance = nullptr;
+    std::unique_ptr<std::vector<uint64_t>> row_ids = nullptr;
 };
 
+struct RangeSearchParams {
+    bool is_le_or_lt = true;
+    float* query_value = nullptr;
+    float radius = -1;
+    roaring::Roaring* roaring; // roaring from segment_iterator
+    std::string to_string() const {
+        DCHECK(roaring != nullptr);
+        return fmt::format("is_le_or_lt: {}, radius: {}, input rows {}", is_le_or_lt, radius,
+                           roaring->cardinality());
+    }
+    virtual ~RangeSearchParams() = default;
+};
+
+struct CustomSearchParams {
+    int ef_search = 16;
+};
+
+struct RangeSearchResult {
+    std::shared_ptr<roaring::Roaring> roaring;
+    std::unique_ptr<std::vector<uint64_t>> row_ids;
+    std::unique_ptr<float[]> distance;
+};
+
+// IndexIterator 与 IndexReader 的角色似乎有点重复，未来可以重构后删除一层概念
 class AnnIndexIterator : public IndexIterator {
 public:
     AnnIndexIterator(const io::IOContext& io_ctx, OlapReaderStatistics* stats,
@@ -34,9 +67,11 @@ public:
 
     IndexType type() override { return IndexType::ANN; }
 
-    IndexReaderPtr get_reader() override { return _ann_reader; }
+    IndexReaderPtr get_reader() override {
+        return std::static_pointer_cast<IndexReader>(_ann_reader);
+    }
 
-    Status read_from_index(const IndexParam& param) override;
+    MOCK_FUNCTION Status read_from_index(const IndexParam& param) override;
 
     Status read_null_bitmap(InvertedIndexQueryCacheHandle* cache_handle) override {
         return Status::OK();
@@ -44,8 +79,12 @@ public:
 
     bool has_null() override { return true; }
 
+    MOCK_FUNCTION Status range_search(const RangeSearchParams& params,
+                                      const CustomSearchParams& custom_params,
+                                      RangeSearchResult* result);
+
 private:
-    AnnIndexReaderPtr _ann_reader;
+    std::shared_ptr<AnnIndexReader> _ann_reader;
 
     ENABLE_FACTORY_CREATOR(AnnIndexIterator);
 };

--- a/be/src/olap/rowset/segment_v2/ann_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index_reader.cpp
@@ -17,18 +17,129 @@
 
 #include "ann_index_reader.h"
 
+#include <cstddef>
+#include <memory>
+
 #include "ann_index_iterator.h"
+#include "common/config.h"
+#include "olap/rowset/segment_v2/index_file_reader.h"
+#include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
+#include "vector/faiss_vector_index.h"
+#include "vector/vector_index.h"
 
 namespace doris::segment_v2 {
 
+void AnnIndexReader::update_result(const IndexSearchResult& search_result,
+                                   std::vector<float>& distance, roaring::Roaring& roaring) {
+    DCHECK(search_result.distances != nullptr);
+    DCHECK(search_result.roaring != nullptr);
+    size_t limit = search_result.roaring->cardinality();
+    // Use search result to update distance and row_id
+    distance.resize(limit);
+    for (size_t i = 0; i < limit; ++i) {
+        distance[i] = search_result.distances[i];
+    }
+    // Use the search result's row_ids to update the input row_id
+    // by calculating the union in-place
+    roaring &= *search_result.roaring;
+}
+
 AnnIndexReader::AnnIndexReader(const TabletIndex* index_meta,
                                std::shared_ptr<IndexFileReader> index_file_reader)
-        : _index_meta(*index_meta), _index_file_reader(std::move(index_file_reader)) {}
+        : _index_meta(*index_meta), _index_file_reader(index_file_reader) {
+    const auto index_properties = _index_meta.properties();
+    auto it = index_properties.find("index_type");
+    DCHECK(it != index_properties.end());
+    _index_type = it->second;
+}
 
 Status AnnIndexReader::new_iterator(const io::IOContext& io_ctx, OlapReaderStatistics* stats,
                                     RuntimeState* runtime_state,
                                     std::unique_ptr<IndexIterator>* iterator) {
     *iterator = AnnIndexIterator::create_unique(io_ctx, stats, runtime_state, shared_from_this());
+    return Status::OK();
+}
+
+Status AnnIndexReader::load_index(io::IOContext* io_ctx) {
+    Result<std::unique_ptr<DorisCompoundReader>> compound_dir =
+            _index_file_reader->open(&_index_meta, io_ctx);
+    if (!compound_dir.has_value()) {
+        return Status::IOError("Failed to open index file: {}", compound_dir.error().to_string());
+    }
+    _vector_index = std::make_unique<FaissVectorIndex>();
+
+    RETURN_IF_ERROR(_vector_index->load(compound_dir->get()));
+    return Status::OK();
+}
+
+Status AnnIndexReader::query(io::IOContext* io_ctx, AnnIndexParam* param) {
+    RETURN_IF_ERROR(_index_file_reader->init(config::inverted_index_read_buffer_size, io_ctx));
+    RETURN_IF_ERROR(load_index(io_ctx));
+    DCHECK(_vector_index != nullptr);
+    const float* query_vec = param->query_value;
+    const int limit = param->limit;
+    IndexSearchParameters index_search_params;
+    IndexSearchResult index_search_result;
+    index_search_params.roaring = param->roaring;
+    RETURN_IF_ERROR(_vector_index->ann_topn_search(query_vec, limit, index_search_params,
+                                                   index_search_result));
+    DCHECK(index_search_result.roaring != nullptr);
+    DCHECK(index_search_result.distances != nullptr);
+    DCHECK(index_search_result.row_ids != nullptr);
+    param->distance = std::make_unique<std::vector<float>>();
+    update_result(index_search_result, *param->distance, *param->roaring);
+    param->row_ids = std::move(index_search_result.row_ids);
+
+    return Status::OK();
+}
+
+Status AnnIndexReader::range_search(const RangeSearchParams& params,
+                                    const CustomSearchParams& custom_params,
+                                    RangeSearchResult* result, io::IOContext* io_ctx) {
+    RETURN_IF_ERROR(_index_file_reader->init(config::inverted_index_read_buffer_size, io_ctx));
+    RETURN_IF_ERROR(load_index(io_ctx));
+    DCHECK(_vector_index != nullptr);
+    IndexSearchResult search_result;
+    std::unique_ptr<IndexSearchParameters> search_param = nullptr;
+
+    if (_index_type == "hnsw") {
+        auto hnsw_param = std::make_unique<HNSWSearchParameters>();
+        hnsw_param->ef_search = custom_params.ef_search;
+        search_param = std::move(hnsw_param);
+    } else {
+        throw Status::NotSupported("Unsupported index type: {}", _index_type);
+    }
+
+    search_param->is_le_or_lt = params.is_le_or_lt;
+    search_param->roaring = params.roaring;
+    DCHECK(search_param->roaring != nullptr);
+
+    RETURN_IF_ERROR(_vector_index->range_search(params.query_value, params.radius, *search_param,
+                                                search_result));
+
+    DCHECK(search_result.roaring != nullptr);
+    result->roaring = search_result.roaring;
+
+    if (params.is_le_or_lt == false) {
+        DCHECK(search_result.distances == nullptr);
+        DCHECK(search_result.row_ids == nullptr);
+    }
+
+    if (search_result.row_ids != nullptr) {
+        DCHECK(search_result.row_ids->size() == search_result.roaring->cardinality())
+                << "Row ids size: " << search_result.row_ids->size()
+                << ", roaring size: " << search_result.roaring->cardinality();
+        result->row_ids = std::move(search_result.row_ids);
+    } else {
+        result->row_ids = nullptr;
+    }
+
+    if (search_result.distances != nullptr) {
+        result->distance = std::move(search_result.distances);
+    } else {
+        result->distance = nullptr;
+    }
+
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index_writer.h
@@ -71,18 +71,14 @@ public:
     Status finish() override;
 
 private:
-    Status open_index_directory();
-    Status init_ann_index();
-
-private:
-    rowid_t _rid = 0;
-    // bool _single_field = true;
-    std::shared_ptr<DorisFSDirectory> _dir = nullptr;
-    std::shared_ptr<VectorIndex> _vector_index_writer;
+    // VectorIndex shoule be managed by some cache.
+    // VectorIndex should be weak shared by AnnIndexWriter and VectorIndexReader
+    // This should be a weak_ptr
+    std::shared_ptr<VectorIndex> _vector_index;
     IndexFileWriter* _index_file_writer;
-    // uint32_t _ignore_above;
     std::wstring _field_name;
     const TabletIndex* _index_meta;
+    std::shared_ptr<DorisFSDirectory> _dir;
 };
 
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -482,7 +482,7 @@ Status ScalarColumnWriter::init() {
             });
 
             RETURN_IF_ERROR(IndexColumnWriter::create(get_field(), &_inverted_index_builder,
-                                                      _opts.x_index_file_writer,
+                                                      _opts._index_file_writer,
                                                       _opts.inverted_index));
         } while (false);
     }
@@ -897,7 +897,7 @@ Status ArrayColumnWriter::init() {
         auto* writer = dynamic_cast<ScalarColumnWriter*>(_item_writer.get());
         if (writer != nullptr) {
             RETURN_IF_ERROR(IndexColumnWriter::create(get_field(), &_inverted_index_builder,
-                                                      _opts.x_index_file_writer,
+                                                      _opts._index_file_writer,
                                                       _opts.inverted_index));
         }
     }
@@ -905,7 +905,7 @@ Status ArrayColumnWriter::init() {
         auto* writer = dynamic_cast<ScalarColumnWriter*>(_item_writer.get());
         if (writer != nullptr) {
             RETURN_IF_ERROR(IndexColumnWriter::create(get_field(), &_ann_index_builder,
-                                                      _opts.x_index_file_writer, _opts.ann_index));
+                                                      _opts._index_file_writer, _opts.ann_index));
         }
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -69,7 +69,7 @@ struct ColumnWriterOptions {
     std::vector<const TabletIndex*> indexes; // unused
     const TabletIndex* inverted_index = nullptr;
     const TabletIndex* ann_index = nullptr;
-    IndexFileWriter* x_index_file_writer;
+    IndexFileWriter* _index_file_writer;
     std::string to_string() const {
         std::stringstream ss;
         ss << std::boolalpha << "meta=" << meta->DebugString()

--- a/be/src/olap/rowset/segment_v2/index_file_reader.h
+++ b/be/src/olap/rowset/segment_v2/index_file_reader.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 
+#include "common/be_mock_util.h"
 #include "common/config.h"
 #include "io/fs/file_system.h"
 #include "olap/rowset/segment_v2/index_file_writer.h"
@@ -54,11 +55,12 @@ public:
               _index_path_prefix(std::move(index_path_prefix)),
               _storage_format(storage_format),
               _idx_file_info(idx_file_info) {}
+    MOCK_FUNCTION ~IndexFileReader() = default;
 
-    Status init(int32_t read_buffer_size = config::inverted_index_read_buffer_size,
-                const io::IOContext* io_ctx = nullptr);
-    Result<std::unique_ptr<DorisCompoundReader>> open(const TabletIndex* index_meta,
-                                                      const io::IOContext* io_ctx = nullptr) const;
+    MOCK_FUNCTION Status init(int32_t read_buffer_size = config::inverted_index_read_buffer_size,
+                              const io::IOContext* io_ctx = nullptr);
+    MOCK_FUNCTION Result<std::unique_ptr<DorisCompoundReader>> open(
+            const TabletIndex* index_meta, const io::IOContext* io_ctx = nullptr) const;
     void debug_file_entries();
     std::string get_index_file_cache_key(const TabletIndex* index_meta) const;
     std::string get_index_file_path(const TabletIndex* index_meta) const;

--- a/be/src/olap/rowset/segment_v2/index_file_writer.h
+++ b/be/src/olap/rowset/segment_v2/index_file_writer.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 
+#include "common/be_mock_util.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
@@ -52,7 +53,8 @@ public:
                     io::FileWriterPtr file_writer = nullptr, bool can_use_ram_dir = true);
     virtual ~IndexFileWriter() = default;
 
-    Result<std::shared_ptr<DorisFSDirectory>> open(const TabletIndex* index_meta);
+    MOCK_FUNCTION Result<std::shared_ptr<DorisFSDirectory>> open(const TabletIndex* index_meta);
+
     Status delete_index(const TabletIndex* index_meta);
     Status initialize(InvertedIndexDirectoryMap& indices_dirs);
     Status add_into_searcher_cache();

--- a/be/src/olap/rowset/segment_v2/index_reader.h
+++ b/be/src/olap/rowset/segment_v2/index_reader.h
@@ -32,9 +32,6 @@ class IndexIterator;
 class InvertedIndexReader;
 using InvertedIndexReaderPtr = std::shared_ptr<InvertedIndexReader>;
 
-class AnnIndexReader;
-using AnnIndexReaderPtr = std::shared_ptr<AnnIndexReader>;
-
 class IndexReader : public std::enable_shared_from_this<IndexReader>,
                     public MetadataAdder<IndexReader> {
 public:
@@ -50,7 +47,6 @@ public:
     virtual bool is_fulltext_index() { return false; }
     virtual bool is_string_index() { return false; }
     virtual bool is_bkd_index() { return false; }
-
     virtual bool is_support_phrase() { return false; }
 };
 using IndexReaderPtr = std::shared_ptr<IndexReader>;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <numeric>
@@ -56,6 +57,7 @@
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
 #include "olap/rowset/segment_v2/row_ranges.h"
 #include "olap/rowset/segment_v2/segment.h"
+#include "olap/rowset/segment_v2/virtual_column_iterator.h"
 #include "olap/schema.h"
 #include "olap/short_key_index.h"
 #include "olap/tablet_schema.h"
@@ -72,6 +74,7 @@
 #include "util/simd/bits.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
+#include "vec/columns/column_nothing.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_object.h"
 #include "vec/columns/column_string.h"
@@ -87,8 +90,10 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_number.h"
+#include "vec/exprs/vann_topn_predicate.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/virtual_slot_ref.h"
 #include "vec/exprs/vliteral.h"
 #include "vec/exprs/vslot_ref.h"
 #include "vec/functions/array/function_array_index.h"
@@ -260,7 +265,6 @@ private:
 SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr schema)
         : _segment(std::move(segment)),
           _schema(schema),
-          _column_iterators(_schema->num_columns()),
           _bitmap_index_iterators(_schema->num_columns()),
           _index_iterators(_schema->num_columns()),
           _cur_rowid(0),
@@ -304,6 +308,16 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
     if (_schema->rowid_col_idx() > 0) {
         _record_rowids = true;
     }
+    // The final return block contains normal_column & virtual_column
+    // _schema->num_columns is the size of normal columns
+    // opts.vir_cid_to_idx_in_block.size is the the is virtual columns
+    _column_iterators.resize(_schema->num_columns() + opts.vir_cid_to_idx_in_block.size());
+    LOG_INFO("Read tablet schema num_columns: {}, virtual columns num: {}", _schema->num_columns(),
+             opts.vir_cid_to_idx_in_block.size());
+
+    _virtual_column_exprs = _opts.virtual_column_exprs;
+    _ann_topn_descriptor = _opts.ann_topn_descriptor;
+    _vir_cid_to_idx_in_block = _opts.vir_cid_to_idx_in_block;
 
     RETURN_IF_ERROR(init_iterators());
 
@@ -312,6 +326,7 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
     }
 
     _storage_name_and_type.resize(_schema->columns().size());
+
     auto storage_format = _opts.tablet_schema->get_inverted_index_storage_format();
     for (int i = 0; i < _schema->columns().size(); ++i) {
         const Field* col = _schema->column(i);
@@ -325,7 +340,8 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
                     },
                     _opts.io_ctx.reader_type != ReaderType::READER_QUERY);
             if (storage_type == nullptr) {
-                storage_type = vectorized::DataTypeFactory::instance().create_data_type(*col);
+                storage_type = vectorized::DataTypeFactory::instance().create_data_type(
+                        col->get_desc(), col->is_nullable());
             }
             // Currently, when writing a lucene index, the field of the document is column_name, and the column name is
             // bound to the index field. Since version 1.2, the data file storage has been changed from column_name to
@@ -352,6 +368,11 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
 
     RETURN_IF_ERROR(_construct_compound_expr_context());
     _enable_common_expr_pushdown = !_common_expr_ctxs_push_down.empty();
+    LOG_INFO(
+            "Segment iterator init, virtual_column_exprs size: {}, has ann_topn_descriptor: {}, "
+            "_vir_cid_to_idx_in_block size: {}, common_expr_pushdown size: {}",
+            _opts.virtual_column_exprs.size(), _opts.ann_topn_descriptor != nullptr,
+            _opts.vir_cid_to_idx_in_block.size(), _common_expr_ctxs_push_down.size());
     _initialize_predicate_results();
     return Status::OK();
 }
@@ -484,6 +505,12 @@ Status SegmentIterator::_prepare_seek(const StorageReadOptions::KeyRange& key_ra
     // create used column iterator
     for (auto cid : _seek_schema->column_ids()) {
         if (_column_iterators[cid] == nullptr) {
+            // TODO: Do we need this?
+            if (_virtual_column_exprs.contains(cid)) {
+                _column_iterators[cid] = std::make_unique<VirtualColumnIterator>();
+                continue;
+            }
+
             RETURN_IF_ERROR(_segment->new_column_iterator(_opts.tablet_schema->column(cid),
                                                           &_column_iterators[cid], &_opts));
             ColumnIteratorOptions iter_opts {
@@ -523,6 +550,7 @@ Status SegmentIterator::_get_row_ranges_by_column_conditions() {
                     if (result != nullptr) {
                         _row_bitmap &= *result->get_data_bitmap();
                         auto root = (*it)->root();
+                        // _remaining_conjunct_roots 与 common_expr_ctxs_push_down 的区别是啥
                         auto iter_find = std::find(_remaining_conjunct_roots.begin(),
                                                    _remaining_conjunct_roots.end(), root);
                         if (iter_find != _remaining_conjunct_roots.end()) {
@@ -554,8 +582,50 @@ Status SegmentIterator::_get_row_ranges_by_column_conditions() {
         _opts.stats->rows_conditions_filtered += (pre_size - _row_bitmap.cardinality());
     }
 
+    RETURN_IF_ERROR(_apply_ann_topn_predicate());
+
     // TODO(hkp): calculate filter rate to decide whether to
     // use zone map/bloom filter/secondary index or not.
+    return Status::OK();
+}
+
+Status SegmentIterator::_apply_ann_topn_predicate() {
+    if (_ann_topn_descriptor == nullptr) {
+        return Status::OK();
+    }
+
+    LOG_INFO("Ann topn descriptor: {}", _ann_topn_descriptor->debug_string());
+    size_t src_col_idx = _ann_topn_descriptor->get_src_column_idx();
+    ColumnId src_cid = _schema->column_id(src_col_idx);
+    LOG_INFO("Ann topn src column id: {}", src_cid);
+    IndexIterator* ann_index_iterator = _index_iterators[src_cid].get();
+
+    if (ann_index_iterator == nullptr || !_common_expr_ctxs_push_down.empty() ||
+        !_col_predicates.empty()) {
+        LOG_INFO(
+                "Can not apply ann topn, has index iterators: {}, has common expr ctxs "
+                "push down: {}, has column predicates: {}",
+                _index_iterators.size(), !_common_expr_ctxs_push_down.empty(),
+                !_col_predicates.empty());
+        return Status::OK();
+    }
+    size_t pre_size = _row_bitmap.cardinality();
+    size_t dst_col_idx = _ann_topn_descriptor->get_dest_column_idx();
+    vectorized::IColumn::MutablePtr result_column;
+    std::unique_ptr<std::vector<uint64_t>> result_row_ids;
+    RETURN_IF_ERROR(_ann_topn_descriptor->evaluate_vector_ann_search(
+            ann_index_iterator, _row_bitmap, result_column, result_row_ids));
+    // TODO: 处理 nullable
+    LOG_INFO("Ann topn filtered {} - {} = {} rows", pre_size, _row_bitmap.cardinality(),
+             pre_size - _row_bitmap.cardinality());
+    ColumnIterator* column_iter =
+            _column_iterators[_schema->num_columns() + dst_col_idx - _schema->num_column_ids()]
+                    .get();
+    DCHECK(column_iter != nullptr);
+    VirtualColumnIterator* virtual_column_iter = dynamic_cast<VirtualColumnIterator*>(column_iter);
+    DCHECK(virtual_column_iter != nullptr);
+    virtual_column_iter->prepare_materialization(std::move(result_column),
+                                                 std::move(result_row_ids));
     return Status::OK();
 }
 
@@ -735,6 +805,7 @@ bool SegmentIterator::_is_literal_node(const TExprNodeType::type& node_type) {
     }
 }
 
+// TODO:Unit test.
 Status SegmentIterator::_extract_common_expr_columns(const vectorized::VExprSPtr& expr) {
     auto& children = expr->children();
     for (int i = 0; i < children.size(); ++i) {
@@ -746,6 +817,11 @@ Status SegmentIterator::_extract_common_expr_columns(const vectorized::VExprSPtr
         auto slot_expr = std::dynamic_pointer_cast<doris::vectorized::VSlotRef>(expr);
         _is_common_expr_column[_schema->column_id(slot_expr->column_id())] = true;
         _common_expr_columns.insert(_schema->column_id(slot_expr->column_id()));
+    } else if (node_type == TExprNodeType::VIRTUAL_SLOT_REF) {
+        std::shared_ptr<vectorized::VirtualSlotRef> virtual_slot_ref =
+                std::dynamic_pointer_cast<vectorized::VirtualSlotRef>(expr);
+        auto column_expr = virtual_slot_ref->get_virtual_column_expr();
+        RETURN_IF_ERROR(_extract_common_expr_columns(column_expr->root()));
     }
 
     return Status::OK();
@@ -814,6 +890,31 @@ Status SegmentIterator::_apply_index_expr() {
             }
         }
     }
+
+    // Apply ann range search
+    std::vector<ColumnId> idx_to_cids;
+    idx_to_cids.resize(_schema->num_columns() + _virtual_column_exprs.size());
+    for (int i = 0; i < _schema->num_columns(); ++i) {
+        idx_to_cids[i] = _schema->column_id(i);
+    }
+
+    for (const auto pair : _vir_cid_to_idx_in_block) {
+        idx_to_cids[pair.second] = pair.first;
+    }
+
+    for (const auto& expr_ctx : _common_expr_ctxs_push_down) {
+        RETURN_IF_ERROR(expr_ctx->root()->evaluate_ann_range_search(
+                _index_iterators, idx_to_cids, _column_iterators, _row_bitmap));
+    }
+
+    for (auto it = _common_expr_ctxs_push_down.begin(); it != _common_expr_ctxs_push_down.end();) {
+        if ((*it)->root()->has_been_executed()) {
+            it = _common_expr_ctxs_push_down.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
     return Status::OK();
 }
 
@@ -1057,6 +1158,13 @@ Status SegmentIterator::_init_return_column_iterators() {
             RETURN_IF_ERROR(_column_iterators[cid]->init(iter_opts));
         }
     }
+
+    for (auto pair : _vir_cid_to_idx_in_block) {
+        ColumnId vir_col_cid = pair.first;
+        LOG_INFO("create virtual column iterator for column id: {}", vir_col_cid);
+        _column_iterators[vir_col_cid] = std::make_unique<VirtualColumnIterator>();
+    }
+
     return Status::OK();
 }
 
@@ -1079,6 +1187,7 @@ Status SegmentIterator::_init_index_iterators() {
     if (_cur_rowid >= num_rows()) {
         return Status::OK();
     }
+
     for (auto cid : _schema->column_ids()) {
         // Use segment’s own index_meta, for compatibility with future indexing needs to default to lowercase.
         if (_index_iterators[cid] == nullptr) {
@@ -1092,6 +1201,19 @@ Status SegmentIterator::_init_index_iterators() {
                     column,
                     _segment->_tablet_schema->inverted_index(col_unique_id, column.suffix_path()),
                     _opts, &_index_iterators[cid]));
+        }
+    }
+
+    // TODO: tablet_schema 管理 index_meta 的逻辑很乱很奇怪，需要重构
+    for (auto cid : _schema->column_ids()) {
+        if (_index_iterators[cid] == nullptr) {
+            const auto& column = _opts.tablet_schema->column(cid);
+            int32_t col_unique_id =
+                    column.is_extracted_column() ? column.parent_unique_id() : column.unique_id();
+            RETURN_IF_ERROR(_segment->new_index_iterator(
+                    column,
+                    _segment->_tablet_schema->ann_index(col_unique_id, column.suffix_path()), _opts,
+                    &_index_iterators[cid]));
         }
     }
     return Status::OK();
@@ -1384,6 +1506,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
     }
 
     // make _schema_block_id_map
+    // ColumnId to column index in block
     _schema_block_id_map.resize(_schema->columns().size());
     for (int i = 0; i < _schema->num_column_ids(); i++) {
         auto cid = _schema->column_id(i);
@@ -1396,6 +1519,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
         for (auto expr : _remaining_conjunct_roots) {
             RETURN_IF_ERROR(_extract_common_expr_columns(expr));
         }
+
         if (!_common_expr_columns.empty()) {
             _is_need_expr_eval = true;
             for (auto cid : _schema->column_ids()) {
@@ -1406,6 +1530,11 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
                     auto loc = _schema_block_id_map[cid];
                     _columns_to_filter.push_back(loc);
                 }
+            }
+
+            // TODO: NOT FOR SURE
+            for (auto pair : _vir_cid_to_idx_in_block) {
+                _columns_to_filter.push_back(pair.second);
             }
         }
     }
@@ -1477,6 +1606,17 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
             }
         }
     }
+
+    LOG_INFO(
+            "Laze materialization end. "
+            "lazy_materialization_read: {}, "
+            "predicate_column_ids: [{}], "
+            "non_predicate_columns: [{}], "
+            "non_predicate_column_ids: [{}], "
+            "columns_to_filter: [{}]",
+            _lazy_materialization_read, fmt::join(_predicate_column_ids, ","),
+            fmt::join(_non_predicate_columns, ","), fmt::join(_non_predicate_column_ids, ","),
+            fmt::join(_columns_to_filter, ","));
     return Status::OK();
 }
 
@@ -1589,10 +1729,8 @@ Status SegmentIterator::_read_columns(const std::vector<ColumnId>& column_ids,
     return Status::OK();
 }
 
-Status SegmentIterator::_init_current_block(
-        vectorized::Block* block, std::vector<vectorized::MutableColumnPtr>& current_columns,
-        uint32_t nrows_read_limit) {
-    block->clear_column_data(_schema->num_column_ids());
+Status SegmentIterator::_init_return_columns(vectorized::Block* block, uint32_t nrows_read_limit) {
+    block->clear_column_data(_schema->num_column_ids() + _virtual_column_exprs.size());
 
     for (size_t i = 0; i < _schema->num_column_ids(); i++) {
         auto cid = _schema->column_id(i);
@@ -1610,30 +1748,37 @@ Status SegmentIterator::_init_current_block(
                     column_desc->name(),
                     column_desc->path() == nullptr ? "" : column_desc->path()->get_path());
             // TODO reuse
-            current_columns[cid] = file_column_type->create_column();
-            current_columns[cid]->reserve(nrows_read_limit);
+            _current_return_columns[cid] = file_column_type->create_column();
+            _current_return_columns[cid]->reserve(nrows_read_limit);
         } else {
             // the column in block must clear() here to insert new data
             if (_is_pred_column[cid] ||
                 i >= block->columns()) { //todo(wb) maybe we can release it after output block
-                if (current_columns[cid].get() == nullptr) {
+                if (_current_return_columns[cid].get() == nullptr) {
                     return Status::InternalError(
                             "SegmentIterator meet invalid column, id={}, name={}", cid,
                             _schema->column(cid)->name());
                 }
-                current_columns[cid]->clear();
+                _current_return_columns[cid]->clear();
             } else { // non-predicate column
-                current_columns[cid] = std::move(*block->get_by_position(i).column).mutate();
+                _current_return_columns[cid] =
+                        std::move(*block->get_by_position(i).column).mutate();
 
                 if (column_desc->type() == FieldType::OLAP_FIELD_TYPE_DATE) {
-                    current_columns[cid]->set_date_type();
+                    _current_return_columns[cid]->set_date_type();
                 } else if (column_desc->type() == FieldType::OLAP_FIELD_TYPE_DATETIME) {
-                    current_columns[cid]->set_datetime_type();
+                    _current_return_columns[cid]->set_datetime_type();
                 }
-                current_columns[cid]->reserve(nrows_read_limit);
+                _current_return_columns[cid]->reserve(nrows_read_limit);
             }
         }
     }
+
+    for (auto entry : _virtual_column_exprs) {
+        auto cid = entry.first;
+        _current_return_columns[cid] = vectorized::ColumnNothing::create(nrows_read_limit);
+    }
+
     return Status::OK();
 }
 
@@ -1670,8 +1815,7 @@ void SegmentIterator::_output_non_pred_columns(vectorized::Block* block) {
  * This approach optimizes reading performance by leveraging batch processing for continuous
  * rowid sequences and handling discontinuities gracefully in smaller chunks.
  */
-Status SegmentIterator::_read_columns_by_index(uint32_t nrows_read_limit, uint32_t& nrows_read,
-                                               bool set_block_rowid) {
+Status SegmentIterator::_read_columns_by_index(uint32_t nrows_read_limit, uint32_t& nrows_read) {
     SCOPED_RAW_TIMER(&_opts.stats->predicate_column_read_ns);
 
     nrows_read = _range_iter->read_batch_rowids(_block_rowids.data(), nrows_read_limit);
@@ -1934,10 +2078,64 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
 }
 
 Status SegmentIterator::next_batch(vectorized::Block* block) {
+    // Append virtual columns to block
+    if (block->columns() < _schema->num_column_ids() + _virtual_column_exprs.size()) {
+        std::vector<size_t> vir_col_pos;
+        for (auto pair1 : _vir_cid_to_idx_in_block) {
+            vir_col_pos.push_back(pair1.second);
+        }
+        std::sort(vir_col_pos.begin(), vir_col_pos.end());
+        for (size_t i = 0; i < vir_col_pos.size(); ++i) {
+            DCHECK(_opts.vir_col_idx_to_type.find(vir_col_pos[i]) !=
+                   _opts.vir_col_idx_to_type.end());
+            block->insert({vectorized::ColumnNothing::create(0),
+                           _opts.vir_col_idx_to_type[vir_col_pos[i]],
+                           fmt::format("_VIR_COL_{}", i)});
+        }
+    } else {
+        // Before get next batch. make sure all virtual columns has type ColumnNothing.
+        std::vector<size_t> vir_col_pos;
+        for (const auto& pair : _vir_cid_to_idx_in_block) {
+            vir_col_pos.push_back(pair.second);
+            block->replace_by_position(pair.second, vectorized::ColumnNothing::create(0));
+        }
+    }
+
     auto status = [&]() {
         RETURN_IF_CATCH_EXCEPTION({
-            RETURN_IF_ERROR(_next_batch_internal(block));
+            auto res = _next_batch_internal(block);
 
+            if (res.is<END_OF_FILE>() && block->rows() == 0) {
+                // replace column nothing with real column
+                const auto idx_to_datatype = _opts.vir_col_idx_to_type;
+                for (const auto& pair : _vir_cid_to_idx_in_block) {
+                    size_t idx = pair.second;
+                    auto type = idx_to_datatype.find(idx)->second;
+
+                    block->replace_by_position(idx, type->create_column());
+                    LOG_INFO(
+                            "SegmentIterator next block replace column nothing with real column "
+                            "idx {}, type {}",
+                            idx, type->get_name());
+                }
+
+                size_t idx = 0;
+                for (const auto& entry : *block) {
+                    if (vectorized::check_and_get_column<vectorized::ColumnNothing>(
+                                entry.column.get())) {
+                        LOG_ERROR(
+                                "Column in idx {} is nothing, block columns {}, normal_columns "
+                                "{}, ",
+                                idx, block->columns(), _schema->column_ids().size());
+
+                        throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                               "Column in idx {} is nothing", idx);
+                    }
+                    idx++;
+                }
+
+                return res;
+            }
             // reverse block row order if read_orderby_key_reverse is true for key topn
             // it should be processed for all success _next_batch_internal
             if (_opts.read_orderby_key_reverse) {
@@ -2033,14 +2231,16 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         if (_lazy_materialization_read || _opts.record_rowids || _is_need_expr_eval) {
             _block_rowids.resize(_opts.block_row_max);
         }
-        _current_return_columns.resize(_schema->columns().size());
+        _current_return_columns.resize(_schema->columns().size() + _virtual_column_exprs.size());
         _converted_column_ids.resize(_schema->columns().size(), 0);
         if (_char_type_idx.empty() && _char_type_idx_no_0.empty()) {
             _is_char_type.resize(_schema->columns().size(), false);
             _vec_init_char_column_id(block);
         }
-        for (size_t i = 0; i < _schema->num_column_ids(); i++) {
-            auto cid = _schema->column_id(i);
+        // 这里的 for loop 的作用不明
+        // 在后续的 _init_return_columns 里面会把 block 里面的 column 清空，所以这里的初始化好像没有意义
+        for (size_t i = 0; i < _schema->column_ids().size(); i++) {
+            ColumnId cid = _schema->column_ids()[i];
             auto column_desc = _schema->column(cid);
             if (_is_pred_column[cid]) {
                 auto storage_column_type = _storage_name_and_type[cid].second;
@@ -2048,6 +2248,8 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
                 // both are DataTypeString, but DataTypeString only return FieldType::OLAP_FIELD_TYPE_STRING
                 // in get_storage_field_type.
                 RETURN_IF_CATCH_EXCEPTION(
+                        // 这里 cid 不会越界
+                        // 因为 _current_return_columns 的 size 等于 _schema->tablet_columns().size()
                         _current_return_columns[cid] = Schema::get_predicate_column_ptr(
                                 _is_char_type[cid] ? FieldType::OLAP_FIELD_TYPE_CHAR
                                                    : storage_column_type->get_storage_field_type(),
@@ -2056,6 +2258,7 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
                         {_segment->rowset_id(), _segment->id()});
                 _current_return_columns[cid]->reserve(nrows_reserve_limit);
             } else if (i >= block->columns()) {
+                // 这个列需要 scan，但是不需要向上返回。（delete sign）
                 // if i >= block->columns means the column and not the pred_column means `column i` is
                 // a delete condition column. but the column is not effective in the segment. so we just
                 // create a column to hold the data.
@@ -2099,13 +2302,12 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         }
     })
 
-    RETURN_IF_ERROR(_init_current_block(block, _current_return_columns, nrows_read_limit));
+    // 为什么每次都需要init return columns
+    RETURN_IF_ERROR(_init_return_columns(block, nrows_read_limit));
     _converted_column_ids.assign(_schema->columns().size(), 0);
 
     _current_batch_rows_read = 0;
-    RETURN_IF_ERROR(_read_columns_by_index(
-            nrows_read_limit, _current_batch_rows_read,
-            _lazy_materialization_read || _opts.record_rowids || _is_need_expr_eval));
+    RETURN_IF_ERROR(_read_columns_by_index(nrows_read_limit, _current_batch_rows_read));
     if (std::find(_predicate_column_ids.begin(), _predicate_column_ids.end(),
                   _schema->version_col_idx()) != _predicate_column_ids.end()) {
         _replace_version_col(_current_batch_rows_read);
@@ -2117,12 +2319,18 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
     if (_current_batch_rows_read == 0) {
         // Convert all columns in _current_return_columns to schema column
         RETURN_IF_ERROR(_convert_to_expected_type(_schema->column_ids()));
-        for (int i = 0; i < block->columns(); i++) {
+        for (int i = 0; i < block->columns() - _vir_cid_to_idx_in_block.size(); i++) {
+            // TODO: 虚拟列是否需要处理
             auto cid = _schema->column_id(i);
             // todo(wb) abstract make column where
             if (!_is_pred_column[cid]) {
                 block->replace_by_position(i, std::move(_current_return_columns[cid]));
             }
+        }
+        for (auto& pair : _vir_cid_to_idx_in_block) {
+            auto cid = pair.first;
+            auto loc = pair.second;
+            block->replace_by_position(loc, std::move(_current_return_columns[cid]));
         }
         block->clear_column_data();
         // clear and release iterators memory footprint in advance
@@ -2231,6 +2439,8 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
             // Here we just use col0 as row_number indicator. when reach here, we will calculate the predicates first.
             //  then use the result to reduce our data read(that is, expr push down). there's now row in block means the first
             //  column is not in common expr. so it's safe to replace it temporarily to provide correct `selected_size`.
+            LOG_INFO("Execute common expr. block rows {}, selected size {}", block->rows(),
+                     selected_size);
             if (block->rows() == 0) {
                 vectorized::MutableColumnPtr col0 =
                         std::move(*block->get_by_position(0).column).mutate();
@@ -2251,6 +2461,8 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
                 block->shrink_char_type_column_suffix_zero(_char_type_idx);
                 RETURN_IF_ERROR(_execute_common_expr(_sel_rowid_idx.data(), selected_size, block));
             }
+            LOG_INFO("Execute common expr end. block rows {}, selected size {}", block->rows(),
+                     selected_size);
         }
 
         if (UNLIKELY(_opts.record_rowids)) {
@@ -2280,20 +2492,47 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         _output_non_pred_columns(block);
     }
 
+    RETURN_IF_ERROR(_materialization_of_virtual_column(block));
+
     // shrink char_type suffix zero data
     block->shrink_char_type_column_suffix_zero(_char_type_idx);
 
-#ifndef NDEBUG
+    // #ifndef NDEBUG
     size_t rows = block->rows();
+    size_t idx = 0;
     for (const auto& entry : *block) {
-        if (entry.column->size() != rows) {
-            throw doris::Exception(ErrorCode::INTERNAL_ERROR,
-                                   "unmatched size {}, expected {}, column: {}, type: {}",
-                                   entry.column->size(), rows, entry.column->get_name(),
-                                   entry.type->get_name());
+        if (!entry.column) {
+            return Status::InternalError(
+                    "Column in idx {} is null, block columns {}, normal_columns {}, "
+                    "virtual_columns {}",
+                    idx, block->columns(), _schema->num_column_ids(), _virtual_column_exprs.size());
+        } else if (vectorized::check_and_get_column<vectorized::ColumnNothing>(
+                           entry.column.get())) {
+            std::vector<std::string> vcid_to_idx;
+            for (const auto& pair : _vir_cid_to_idx_in_block) {
+                vcid_to_idx.push_back(fmt::format("{}-{}", pair.first, pair.second));
+            }
+            std::string vir_cid_to_idx_in_block_msg =
+                    fmt::format("_vir_cid_to_idx_in_block:[{}]", fmt::join(vcid_to_idx, ","));
+            LOG_ERROR(
+                    "Column in idx {} is nothing, block columns {}, normal_columns {}, "
+                    "vir_cid_to_idx_in_block_msg {}",
+                    idx, block->columns(), _schema->num_column_ids(), vir_cid_to_idx_in_block_msg);
+
+            return Status::InternalError(
+                    "Column in idx {} is nothing, block columns {}, normal_columns {}, "
+                    "virtual_columns {}",
+                    idx, block->columns(), _schema->num_column_ids(), _virtual_column_exprs.size());
+        } else if (entry.column->size() != rows) {
+            throw doris::Exception(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Unmatched size {}, expected {}, column: {}, type: {}, idx_in_block: {}",
+                    entry.column->size(), rows, entry.column->get_name(), entry.type->get_name(),
+                    idx);
         }
+        idx++;
     }
-#endif
+    // #endif
     VLOG_DEBUG << "dump block " << block->dump_data(0, block->rows());
 
     return Status::OK();
@@ -2572,6 +2811,35 @@ bool SegmentIterator::_can_opt_topn_reads() {
     })
 
     return all_true;
+}
+
+Status SegmentIterator::_materialization_of_virtual_column(vectorized::Block* block) {
+    size_t prev_block_columns = block->columns();
+    LOG_INFO("Materialize all {} virtual columns", _virtual_column_exprs.size());
+    for (const auto& cid_and_expr : _virtual_column_exprs) {
+        auto cid = cid_and_expr.first;
+        auto column_expr = cid_and_expr.second;
+        size_t idx_in_block = _vir_cid_to_idx_in_block[cid];
+
+        if (vectorized::check_and_get_column<const vectorized::ColumnNothing>(
+                    block->get_by_position(idx_in_block).column.get())) {
+            int result_cid = -1;
+            RETURN_IF_ERROR(column_expr->execute(block, &result_cid));
+
+            block->replace_by_position(idx_in_block,
+                                       std::move(block->get_by_position(result_cid).column));
+            if (block->get_by_position(idx_in_block).column->size() == 0) {
+                LOG_WARNING(
+                        "Result of expr column {} is empty. cid {}, idx_in_block {}, result_cid",
+                        column_expr->root()->debug_string(), cid, idx_in_block, result_cid);
+            }
+        }
+    }
+    // During execution of expr, some columns may be added to the end of the block.
+    // Remove them to keep consistent with current block.
+    block->erase_tail(prev_block_columns);
+    LOG_INFO("Materialize all {} virtual columns end.", _virtual_column_exprs.size());
+    return Status::OK();
 }
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -146,12 +146,12 @@ public:
 
     Status close_inverted_index(int64_t* inverted_index_file_size) {
         // no inverted index
-        if (_x_index_file_writer == nullptr) {
+        if (_index_file_writer == nullptr) {
             *inverted_index_file_size = 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_x_index_file_writer->close());
-        *inverted_index_file_size = _x_index_file_writer->get_index_file_total_size();
+        RETURN_IF_ERROR(_index_file_writer->close());
+        *inverted_index_file_size = _index_file_writer->get_index_file_total_size();
         return Status::OK();
     }
 
@@ -214,7 +214,7 @@ private:
     // Not owned. owned by RowsetWriter or SegmentFlusher
     io::FileWriter* _file_writer = nullptr;
     // Not owned. owned by RowsetWriter or SegmentFlusher
-    IndexFileWriter* _x_index_file_writer = nullptr;
+    IndexFileWriter* _index_file_writer = nullptr;
 
     SegmentFooterPB _footer;
     // for mow tables with cluster key, the sort key is the cluster keys not unique keys

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -98,7 +98,7 @@ VerticalSegmentWriter::VerticalSegmentWriter(io::FileWriter* file_writer, uint32
           _data_dir(data_dir),
           _opts(opts),
           _file_writer(file_writer),
-          _x_index_file_writer(inverted_file_writer),
+          _index_file_writer(inverted_file_writer),
           _mem_tracker(std::make_unique<MemTracker>(
                   vertical_segment_writer_mem_tracker_name(segment_id))),
           _mow_context(std::move(opts.mow_ctx)) {
@@ -221,16 +221,16 @@ Status VerticalSegmentWriter::_create_column_writer(uint32_t cid, const TabletCo
         index != nullptr && !skip_inverted_index) {
         opts.inverted_index = index;
         opts.need_inverted_index = true;
-        DCHECK(_x_index_file_writer != nullptr);
-        opts.x_index_file_writer = _x_index_file_writer;
+        DCHECK(_index_file_writer != nullptr);
+        opts._index_file_writer = _index_file_writer;
         // TODO support multiple inverted index
     }
 
     if (const auto& index = tablet_schema->ann_index(column); index != nullptr) {
         opts.ann_index = index;
         opts.need_ann_index = true;
-        DCHECK(_x_index_file_writer != nullptr);
-        opts.x_index_file_writer = _x_index_file_writer;
+        DCHECK(_index_file_writer != nullptr);
+        opts._index_file_writer = _index_file_writer;
         // TODO support multiple inverted index
     }
 

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
@@ -125,12 +125,12 @@ public:
 
     Status close_inverted_index(int64_t* inverted_index_file_size) {
         // no inverted index
-        if (_x_index_file_writer == nullptr) {
+        if (_index_file_writer == nullptr) {
             *inverted_index_file_size = 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_x_index_file_writer->close());
-        *inverted_index_file_size = _x_index_file_writer->get_index_file_total_size();
+        RETURN_IF_ERROR(_index_file_writer->close());
+        *inverted_index_file_size = _index_file_writer->get_index_file_total_size();
         return Status::OK();
     }
 
@@ -224,7 +224,7 @@ private:
     // Not owned. owned by RowsetWriter
     io::FileWriter* _file_writer = nullptr;
     // Not owned. owned by RowsetWriter or SegmentFlusher
-    IndexFileWriter* _x_index_file_writer = nullptr;
+    IndexFileWriter* _index_file_writer = nullptr;
 
     SegmentFooterPB _footer;
     // for mow tables with cluster key, the sort key is the cluster keys not unique keys

--- a/be/src/olap/rowset/segment_v2/virtual_column_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/virtual_column_iterator.cpp
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "virtual_column_iterator.h"
+
+#include <cstring>
+#include <memory>
+
+#include "vec/columns/column.h"
+#include "vec/columns/column_nothing.h"
+
+namespace doris::segment_v2 {
+
+VirtualColumnIterator::VirtualColumnIterator()
+        : _materialized_column_ptr(vectorized::ColumnNothing::create(0)) {}
+
+// Init implementation
+Status VirtualColumnIterator::init(const ColumnIteratorOptions& opts) {
+    // Virtual column doesn't need special initialization
+    return Status::OK();
+}
+
+void VirtualColumnIterator::prepare_materialization(vectorized::IColumn::Ptr column,
+                                                    std::unique_ptr<std::vector<uint64_t>> labels) {
+    _materialized_column_ptr = column;
+    _row_id_to_idx.clear();
+    DCHECK(labels->size() == _materialized_column_ptr->size())
+            << "labels size: " << labels->size()
+            << ", materialized column size: " << _materialized_column_ptr->size();
+    _size = _materialized_column_ptr->size();
+    for (size_t i = 0; i < _size; ++i) {
+        _row_id_to_idx[(*labels)[i]] = i;
+    }
+
+    _filter = doris::vectorized::IColumn::Filter(_size, 0);
+}
+
+// Next batch implementation
+Status VirtualColumnIterator::next_batch(size_t* n, vectorized::MutableColumnPtr& dst,
+                                         bool* has_null) {
+    if (vectorized::check_and_get_column<vectorized::ColumnNothing>(*_materialized_column_ptr)) {
+        return Status::OK();
+    }
+
+    return Status::OK();
+}
+
+Status VirtualColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t count,
+                                             vectorized::MutableColumnPtr& dst) {
+    if (vectorized::check_and_get_column<vectorized::ColumnNothing>(*_materialized_column_ptr)) {
+        return Status::OK();
+    }
+
+    memset(_filter.data(), 0, _size);
+
+    // Convert rowids to filter
+    for (size_t i = 0; i < count; ++i) {
+        _filter[_row_id_to_idx[rowids[i]]] = 1;
+    }
+
+    // Count one of the filter
+    size_t count_one = 0;
+    for (size_t i = 0; i < _size; ++i) {
+        if (_filter[i] == 1) {
+            count_one++;
+        }
+    }
+    std::cout << "count_one: " << count_one << std::endl;
+
+    // Apply filter to materialized column
+    doris::vectorized::IColumn::Ptr res_col = _materialized_column_ptr->filter(_filter, 0);
+    // Update dst column
+    dst->clear();
+    dst->insert_range_from(*res_col, 0, res_col->size());
+
+    return Status::OK();
+}
+
+} // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/virtual_column_iterator.h
+++ b/be/src/olap/rowset/segment_v2/virtual_column_iterator.h
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "column_reader.h"
+#include "common/be_mock_util.h"
+#include "vec/columns/column.h"
+
+namespace doris::segment_v2 {
+
+class VirtualColumnIterator : public ColumnIterator {
+public:
+    VirtualColumnIterator();
+    ~VirtualColumnIterator() override = default;
+
+    MOCK_FUNCTION void prepare_materialization(vectorized::IColumn::Ptr column,
+                                               std::unique_ptr<std::vector<uint64_t>> labels);
+
+    Status init(const ColumnIteratorOptions& opts) override;
+
+    Status seek_to_first() override { return Status::OK(); }
+
+    Status seek_to_ordinal(ordinal_t ord_idx) override { return Status::OK(); }
+
+    Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override;
+
+    Status read_by_rowids(const rowid_t* rowids, const size_t count,
+                          vectorized::MutableColumnPtr& dst) override;
+
+    ordinal_t get_current_ordinal() const override { return 0; }
+
+#ifdef BE_TEST
+    vectorized::IColumn::Ptr get_materialized_column() const { return _materialized_column_ptr; }
+    const std::map<uint64_t, uint64_t>& get_row_id_to_idx() const { return _row_id_to_idx; }
+#endif
+private:
+    vectorized::IColumn::Ptr _materialized_column_ptr;
+    // segment rowid to index in column.
+    std::map<uint64_t, uint64_t> _row_id_to_idx;
+
+    doris::vectorized::IColumn::Filter _filter;
+    size_t _size = 0;
+};
+
+} // namespace doris::segment_v2

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -170,9 +170,9 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
     RETURN_IF_ERROR(BaseBetaRowsetWriter::create_file_writer(seg_id, segment_file_writer));
     DCHECK(segment_file_writer != nullptr);
 
-    IndexFileWriterPtr x_index_file_writer;
+    IndexFileWriterPtr index_file_writer;
     if (context.tablet_schema->has_inverted_index()) {
-        RETURN_IF_ERROR(RowsetWriter::create_index_file_writer(seg_id, &x_index_file_writer));
+        RETURN_IF_ERROR(RowsetWriter::create_index_file_writer(seg_id, &index_file_writer));
     }
 
     segment_v2::SegmentWriterOptions writer_options;
@@ -182,11 +182,11 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
     // TODO if support VerticalSegmentWriter, also need to handle cluster key primary key index
     *writer = std::make_unique<segment_v2::SegmentWriter>(
             segment_file_writer.get(), seg_id, context.tablet_schema, context.tablet,
-            context.data_dir, writer_options, x_index_file_writer.get());
+            context.data_dir, writer_options, index_file_writer.get());
 
     RETURN_IF_ERROR(this->_seg_files.add(seg_id, std::move(segment_file_writer)));
     if (context.tablet_schema->has_inverted_index()) {
-        RETURN_IF_ERROR(this->_idx_files.add(seg_id, std::move(x_index_file_writer)));
+        RETURN_IF_ERROR(this->_idx_files.add(seg_id, std::move(index_file_writer)));
     }
 
     auto s = (*writer)->init(column_ids, is_key);

--- a/be/src/olap/schema.cpp
+++ b/be/src/olap/schema.cpp
@@ -78,6 +78,7 @@ void Schema::_init(const std::vector<TabletColumnPtr>& cols, const std::vector<C
     size_t offset = 0;
     std::unordered_set<uint32_t> col_id_set(col_ids.begin(), col_ids.end());
     for (int cid = 0; cid < cols.size(); ++cid) {
+        // 如果没有在col_ids中找到cid, 说明这个列不需要被读取
         if (col_id_set.find(cid) == col_id_set.end()) {
             continue;
         }

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -84,6 +84,8 @@ public:
     }
 
     // All the columns of one table may exist in the columns param, but col_ids is only a subset.
+    // arg 1 columns is the columns of the table
+    // arg 2 col_ids is the columns to read
     Schema(const std::vector<TabletColumnPtr>& columns, const std::vector<ColumnId>& col_ids) {
         size_t num_key_columns = 0;
         _unique_ids.resize(columns.size());

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1770,12 +1770,12 @@ Status Tablet::prepare_compaction_and_calculate_permits(
             // return OK if OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSION, so that we don't need to
             // print too much useless logs.
             // And because we set permits to 0, so even if we return OK here, nothing will be done.
-            LOG_INFO(
-                    "cumulative compaction meet delete rowset, increase cumu point without other "
-                    "operation.")
-                    .tag("tablet id:", tablet->tablet_id())
-                    .tag("after cumulative compaction, cumu point:",
-                         tablet->cumulative_layer_point());
+            // VLOG_DEBUG << fmt::format(
+            //         "cumulative compaction meet delete rowset, increase cumu point without other "
+            //         "operation.")
+            //         .tag("tablet id:", tablet->tablet_id())
+            //         .tag("after cumulative compaction, cumu point:",
+            //              tablet->cumulative_layer_point());
             return Status::OK();
         }
     } else if (compaction_type == CompactionType::BASE_COMPACTION) {

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -68,7 +68,7 @@ void TabletReader::ReaderParams::check_validation() const {
 std::string TabletReader::ReaderParams::to_string() const {
     std::stringstream ss;
     ss << "tablet=" << tablet->tablet_id() << " reader_type=" << int(reader_type)
-       << " aggregation=" << aggregation << " version=" << version
+       << " aggregation=" << is_pre_aggregation << " version=" << version
        << " start_key_include=" << start_key_include << " end_key_include=" << end_key_include;
 
     for (const auto& key : start_key) {
@@ -260,6 +260,10 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params) {
     _reader_context.is_key_column_group = read_params.is_key_column_group;
     _reader_context.remaining_conjunct_roots = read_params.remaining_conjunct_roots;
     _reader_context.common_expr_ctxs_push_down = read_params.common_expr_ctxs_push_down;
+    _reader_context.virtual_column_exprs = read_params.virtual_column_exprs;
+    _reader_context.ann_topn_descriptor = read_params.ann_topn_descriptor;
+    _reader_context.vir_cid_to_idx_in_block = read_params.vir_cid_to_idx_in_block;
+    _reader_context.vir_col_idx_to_type = read_params.vir_col_idx_to_type;
     _reader_context.output_columns = &read_params.output_columns;
     _reader_context.push_down_agg_type_opt = read_params.push_down_agg_type_opt;
     _reader_context.ttl_seconds = _tablet->ttl_seconds();
@@ -286,7 +290,7 @@ Status TabletReader::_init_params(const ReaderParams& read_params) {
     read_params.check_validation();
 
     _direct_mode = read_params.direct_mode;
-    _aggregation = read_params.aggregation;
+    _aggregation = read_params.is_pre_aggregation;
     _reader_type = read_params.reader_type;
     _tablet = read_params.tablet;
     _tablet_schema = read_params.tablet_schema;

--- a/be/src/olap/tablet_reader.h
+++ b/be/src/olap/tablet_reader.h
@@ -127,7 +127,7 @@ public:
         TabletSchemaSPtr tablet_schema;
         ReaderType reader_type = ReaderType::READER_QUERY;
         bool direct_mode = false;
-        bool aggregation = false;
+        bool is_pre_aggregation = false;
         // for compaction, schema_change, check_sum: we don't use page cache
         // for query and config::disable_storage_page_cache is false, we use page cache
         bool use_page_cache = false;
@@ -152,14 +152,14 @@ public:
         DeleteBitmap* delete_bitmap = nullptr;
 
         // return_columns is init from query schema
-        std::vector<uint32_t> return_columns;
+        std::vector<ColumnId> return_columns;
         // output_columns only contain columns in OrderByExprs and outputExprs
         std::set<int32_t> output_columns;
         RuntimeProfile* profile = nullptr;
         RuntimeState* runtime_state = nullptr;
 
         // use only in vec exec engine
-        std::vector<uint32_t>* origin_return_columns = nullptr;
+        std::vector<ColumnId>* origin_return_columns = nullptr;
         std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr;
         TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
         vectorized::VExpr* remaining_vconjunct_root = nullptr;
@@ -195,6 +195,11 @@ public:
         std::string to_string() const;
 
         int64_t batch_size = -1;
+
+        std::map<ColumnId, vectorized::VExprContextSPtr> virtual_column_exprs;
+        std::shared_ptr<vectorized::AnnTopNDescriptor> ann_topn_descriptor;
+        std::map<ColumnId, size_t> vir_cid_to_idx_in_block;
+        std::map<size_t, vectorized::DataTypePtr> vir_col_idx_to_type;
     };
 
     TabletReader() = default;
@@ -280,7 +285,7 @@ protected:
     const TabletSchema& tablet_schema() { return *_tablet_schema; }
 
     std::unique_ptr<vectorized::Arena> _predicate_arena;
-    std::vector<uint32_t> _return_columns;
+    std::vector<ColumnId> _return_columns;
     // used for special optimization for query : ORDER BY key [ASC|DESC] LIMIT n
     // columns for orderby keys
     std::vector<uint32_t> _orderby_key_columns;

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -72,6 +72,11 @@ public:
     TabletColumn(FieldAggregationMethod agg, FieldType filed_type, bool is_nullable);
     TabletColumn(FieldAggregationMethod agg, FieldType filed_type, bool is_nullable,
                  int32_t unique_id, size_t length);
+
+#ifdef BE_TEST
+    virtual ~TabletColumn() = default;
+#endif
+
     void init_from_pb(const ColumnPB& column);
     void init_from_thrift(const TColumn& column);
     void to_schema_pb(ColumnPB* column) const;
@@ -84,7 +89,7 @@ public:
         _col_name = col_name;
         _col_name_lower_case = to_lower(_col_name);
     }
-    FieldType type() const { return _type; }
+    MOCK_FUNCTION FieldType type() const { return _type; }
     void set_type(FieldType type) { _type = type; }
     bool is_key() const { return _is_key; }
     bool is_nullable() const { return _is_nullable; }
@@ -143,7 +148,7 @@ public:
     void add_sub_column(TabletColumn& sub_column);
 
     uint32_t get_subtype_count() const { return _sub_column_count; }
-    const TabletColumn& get_sub_column(uint32_t i) const { return *_sub_columns[i]; }
+    MOCK_FUNCTION const TabletColumn& get_sub_column(uint32_t i) const { return *_sub_columns[i]; }
     const std::vector<TabletColumnPtr>& get_sub_columns() const { return _sub_columns; }
 
     friend bool operator==(const TabletColumn& a, const TabletColumn& b);
@@ -262,9 +267,9 @@ public:
 
     int64_t index_id() const { return _index_id; }
     const std::string& index_name() const { return _index_name; }
-    IndexType index_type() const { return _index_type; }
+    MOCK_FUNCTION IndexType index_type() const { return _index_type; }
     const vector<int32_t>& col_unique_ids() const { return _col_unique_ids; }
-    const std::map<string, string>& properties() const { return _properties; }
+    MOCK_FUNCTION const std::map<string, string>& properties() const { return _properties; }
     int32_t get_gram_size() const {
         if (_properties.contains("gram_size")) {
             return std::stoi(_properties.at("gram_size"));
@@ -417,6 +422,10 @@ public:
 
             if (index->index_type() == IndexType::INVERTED) {
                 //if index_id == -1, ignore it.
+                if (!index->col_unique_ids().empty() && index->col_unique_ids()[0] >= 0) {
+                    return true;
+                }
+            } else if (index->index_type() == IndexType::ANN) {
                 if (!index->col_unique_ids().empty() && index->col_unique_ids()[0] >= 0) {
                     return true;
                 }

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -317,17 +317,17 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                                  << ", err: " << st;
                     return st;
                 }
-                auto x_index_file_writer = std::make_unique<IndexFileWriter>(
+                auto index_file_writer = std::make_unique<IndexFileWriter>(
                         fs, std::move(index_path_prefix),
                         output_rowset_meta->rowset_id().to_string(), seg_ptr->id(),
                         output_rowset_schema->get_inverted_index_storage_format(),
                         std::move(file_writer));
-                RETURN_IF_ERROR(x_index_file_writer->initialize(dirs));
+                RETURN_IF_ERROR(index_file_writer->initialize(dirs));
                 // create inverted index writer
                 for (auto& index_meta : _dropped_inverted_indexes) {
-                    RETURN_IF_ERROR(x_index_file_writer->delete_index(&index_meta));
+                    RETURN_IF_ERROR(index_file_writer->delete_index(&index_meta));
                 }
-                _index_file_writers.emplace(seg_ptr->id(), std::move(x_index_file_writer));
+                _index_file_writers.emplace(seg_ptr->id(), std::move(index_file_writer));
             }
             for (auto&& [seg_id, inverted_index_writer] : _index_file_writers) {
                 auto st = inverted_index_writer->close();
@@ -356,11 +356,11 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                     InvertedIndexDescriptor::get_index_file_path_prefix(local_segment_path(
                             _tablet->tablet_path(), output_rowset_meta->rowset_id().to_string(),
                             seg_ptr->id()))};
-            std::vector<ColumnId> return_columns;
+
             std::vector<std::pair<int64_t, int64_t>> inverted_index_writer_signs;
             _olap_data_convertor->reserve(_alter_inverted_indexes.size());
+            std::unique_ptr<IndexFileWriter> index_file_writer = nullptr;
 
-            std::unique_ptr<IndexFileWriter> x_index_file_writer = nullptr;
             if (output_rowset_schema->get_inverted_index_storage_format() >=
                 InvertedIndexStorageFormatPB::V2) {
                 auto idx_file_reader_iter = _index_file_readers.find(
@@ -382,16 +382,17 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                     return st;
                 }
                 auto dirs = DORIS_TRY(idx_file_reader_iter->second->get_all_directories());
-                x_index_file_writer = std::make_unique<IndexFileWriter>(
+                index_file_writer = std::make_unique<IndexFileWriter>(
                         fs, index_path_prefix, output_rowset_meta->rowset_id().to_string(),
                         seg_ptr->id(), output_rowset_schema->get_inverted_index_storage_format(),
                         std::move(file_writer));
-                RETURN_IF_ERROR(x_index_file_writer->initialize(dirs));
+                RETURN_IF_ERROR(index_file_writer->initialize(dirs));
             } else {
-                x_index_file_writer = std::make_unique<IndexFileWriter>(
+                index_file_writer = std::make_unique<IndexFileWriter>(
                         fs, index_path_prefix, output_rowset_meta->rowset_id().to_string(),
                         seg_ptr->id(), output_rowset_schema->get_inverted_index_storage_format());
             }
+            std::vector<ColumnId> return_columns;
             // create inverted index writer
             for (auto inverted_index : _alter_inverted_indexes) {
                 DCHECK_EQ(inverted_index.columns.size(), 1);
@@ -427,7 +428,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 std::unique_ptr<segment_v2::IndexColumnWriter> inverted_index_builder;
                 try {
                     RETURN_IF_ERROR(segment_v2::IndexColumnWriter::create(
-                            field.get(), &inverted_index_builder, x_index_file_writer.get(),
+                            field.get(), &inverted_index_builder, index_file_writer.get(),
                             index_meta));
                     DBUG_EXECUTE_IF(
                             "IndexBuilder::handle_single_rowset_index_column_writer_create_error", {
@@ -449,7 +450,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
             }
 
             // DO NOT forget inverted_index_file_writer for the segment, otherwise, original inverted index will be deleted.
-            _index_file_writers.emplace(seg_ptr->id(), std::move(x_index_file_writer));
+            _index_file_writers.emplace(seg_ptr->id(), std::move(index_file_writer));
             if (return_columns.empty()) {
                 // no columns to read
                 continue;
@@ -525,8 +526,8 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
 
             _olap_data_convertor->reset();
         }
-        for (auto&& [seg_id, x_index_file_writer] : _index_file_writers) {
-            auto st = x_index_file_writer->close();
+        for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
+            auto st = index_file_writer->close();
             DBUG_EXECUTE_IF("IndexBuilder::handle_single_rowset_file_writer_close_error", {
                 st = Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                         "debug point: handle_single_rowset_file_writer_close_error");
@@ -535,7 +536,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 LOG(ERROR) << "close inverted_index_writer error:" << st;
                 return st;
             }
-            inverted_index_size += x_index_file_writer->get_index_file_total_size();
+            inverted_index_size += index_file_writer->get_index_file_total_size();
         }
         _inverted_index_builders.clear();
         _index_file_writers.clear();

--- a/be/src/olap/task/index_builder.h
+++ b/be/src/olap/task/index_builder.h
@@ -84,6 +84,7 @@ private:
     // "<segment_id, index_id>" -> IndexColumnWriter
     std::unordered_map<std::pair<int64_t, int64_t>, std::unique_ptr<segment_v2::IndexColumnWriter>>
             _inverted_index_builders;
+    // segmentid -> index_file_writer
     std::unordered_map<int64_t, std::unique_ptr<IndexFileWriter>> _index_file_writers;
     // <rowset_id, segment_id>
     std::unordered_map<std::pair<std::string, int64_t>, std::unique_ptr<IndexFileReader>>

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -310,8 +310,8 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
                                                       std::move(send_remote_block_closure),
                                                       request.channel->_brpc_dest_addr));
             } else {
-                transmit_blockv2(*request.channel->_brpc_stub,
-                                 std::move(send_remote_block_closure));
+                ::doris::transmit_blockv2(*request.channel->_brpc_stub,
+                                          std::move(send_remote_block_closure));
             }
         }
         if (request.block) {
@@ -399,8 +399,8 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
                                                       std::move(send_remote_block_closure),
                                                       request.channel->_brpc_dest_addr));
             } else {
-                transmit_blockv2(*request.channel->_brpc_stub,
-                                 std::move(send_remote_block_closure));
+                ::doris::transmit_blockv2(*request.channel->_brpc_stub,
+                                          std::move(send_remote_block_closure));
             }
         }
         if (request.block_holder->get_block()) {

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -18,6 +18,7 @@
 #include "pipeline/exec/olap_scan_operator.h"
 
 #include <fmt/format.h>
+#include <thrift/protocol/TDebugProtocol.h>
 
 #include <memory>
 
@@ -28,18 +29,16 @@
 #include "cloud/config.h"
 #include "olap/parallel_scanner_builder.h"
 #include "olap/storage_engine.h"
-#include "olap/tablet_manager.h"
 #include "pipeline/exec/scan_operator.h"
 #include "pipeline/query_cache/query_cache.h"
-#include "runtime_filter/runtime_filter_consumer_helper.h"
-#include "service/backend_options.h"
+#include "runtime/runtime_state.h"
 #include "util/to_string.h"
 #include "vec/exec/scan/olap_scanner.h"
+#include "vec/exprs/vann_topn_predicate.h"
 #include "vec/exprs/vectorized_fn_call.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 #include "vec/exprs/vslot_ref.h"
-#include "vec/functions/in.h"
 
 namespace doris::pipeline {
 #include "common/compile_check_begin.h"
@@ -285,6 +284,10 @@ bool OlapScanLocalState::_storage_no_merge() {
 }
 
 Status OlapScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* scanners) {
+    // auto& p = _parent->cast<OlapScanOperatorX>();
+    // if (p._olap_scan_node.keyType != TKeysType::DUP_KEYS) {
+    //     return Status::NotSupported("Now only dup keys table is supported");
+    // }
     if (_scan_ranges.empty()) {
         _eos = true;
         _scan_dependency->set_ready();
@@ -322,6 +325,7 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
                          state()->query_options().resource_limit.__isset.cpu_limit;
 
     RETURN_IF_ERROR(hold_tablets());
+    LOG_INFO("ScanNode is_preaggregation: {}", p._olap_scan_node.is_preaggregation);
     if (enable_parallel_scan && !p._should_run_serial && !has_cpu_limit &&
         p._push_down_agg_type == TPushAggOp::NONE &&
         (_storage_no_merge() || p._olap_scan_node.is_preaggregation)) {
@@ -473,6 +477,68 @@ Status OlapScanLocalState::hold_tablets() {
                 cost_secs, print_id(PipelineXLocalState<>::_state->query_id()), _parent->node_id(),
                 _scan_ranges.size());
     }
+    return Status::OK();
+}
+
+Status OlapScanLocalState::init(RuntimeState* state, LocalStateInfo& info) {
+    const TOlapScanNode& olap_scan_node = _parent->cast<OlapScanOperatorX>()._olap_scan_node;
+
+    if (olap_scan_node.__isset.ann_sort_info || olap_scan_node.__isset.ann_sort_limit) {
+        DCHECK(olap_scan_node.__isset.ann_sort_info);
+        DCHECK(olap_scan_node.__isset.ann_sort_limit);
+        DCHECK(olap_scan_node.ann_sort_info.ordering_exprs.size() == 1);
+        const doris::TExpr& ordering_expr = olap_scan_node.ann_sort_info.ordering_exprs.front();
+        // order by 的表达式需要是一个 slot_ref，并且类型需要是虚拟列
+        DCHECK(ordering_expr.nodes[0].__isset.slot_ref);
+        DCHECK(ordering_expr.nodes[0].slot_ref.is_virtual_slot);
+        size_t limit = olap_scan_node.ann_sort_limit;
+        std::shared_ptr<vectorized::VExprContext> ordering_expr_ctx;
+        RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(ordering_expr, ordering_expr_ctx));
+        LOG_INFO("Ann thrift expr: {}", apache::thrift::ThriftDebugString(ordering_expr));
+        _ann_topn_descriptor =
+                vectorized::AnnTopNDescriptor::create_shared(limit, ordering_expr_ctx);
+    }
+
+    return ScanLocalState<OlapScanLocalState>::init(state, info);
+}
+
+Status OlapScanLocalState::open(RuntimeState* state) {
+    auto& p = _parent->cast<OlapScanOperatorX>();
+    for (const auto& pair : p._slot_id_to_slot_desc) {
+        const SlotDescriptor* slot_desc = pair.second;
+        std::shared_ptr<doris::TExpr> virtual_col_expr = slot_desc->get_virtual_column_expr();
+        if (virtual_col_expr) {
+            std::shared_ptr<doris::vectorized::VExprContext> virtual_column_expr_ctx;
+            RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*virtual_col_expr,
+                                                                virtual_column_expr_ctx));
+            RETURN_IF_ERROR(virtual_column_expr_ctx->prepare(state, p.intermediate_row_desc()));
+            RETURN_IF_ERROR(virtual_column_expr_ctx->open(state));
+
+            _slot_id_to_virtual_column_expr[slot_desc->id()] = virtual_column_expr_ctx;
+            _slot_id_to_col_type[slot_desc->id()] = slot_desc->get_data_type_ptr();
+            int cid = p.intermediate_row_desc().get_column_id(slot_desc->id());
+            if (cid < 0) {
+                return Status::InternalError(
+                        "Invalid virtual slot, can not find its information. Slot desc:\n{}\nRow "
+                        "desc:\n{}",
+                        slot_desc->debug_string(), p.row_desc().debug_string());
+            } else {
+                _slot_id_to_index_in_block[slot_desc->id()] = cid;
+            }
+
+            LOG_INFO(
+                    "OlapScanLocalState opening, virtual column expr slot id: {}, cid: {}, expr: "
+                    "{}",
+                    slot_desc->id(), cid, virtual_column_expr_ctx->root()->debug_string());
+        }
+    }
+
+    if (_ann_topn_descriptor) {
+        RETURN_IF_ERROR(_ann_topn_descriptor->prepare(state, p.intermediate_row_desc()));
+    }
+
+    RETURN_IF_ERROR(ScanLocalState<OlapScanLocalState>::open(state));
+
     return Status::OK();
 }
 
@@ -679,6 +745,7 @@ OlapScanOperatorX::OlapScanOperatorX(ObjectPool* pool, const TPlanNode& tnode, i
         : ScanOperatorX<OlapScanLocalState>(pool, tnode, operator_id, descs, parallel_tasks),
           _olap_scan_node(tnode.olap_scan_node),
           _cache_param(param) {
+    // _output_tuple_id of olap scan operator
     _output_tuple_id = tnode.olap_scan_node.tuple_id;
     if (_olap_scan_node.__isset.sort_info && _olap_scan_node.__isset.sort_limit) {
         _limit_per_scanner = _olap_scan_node.sort_limit;

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -53,6 +53,9 @@ public:
     }
     Status hold_tablets();
 
+    Status init(RuntimeState* state, LocalStateInfo& info) override;
+    Status open(RuntimeState* state) override;
+
 private:
     friend class vectorized::OlapScanner;
 
@@ -220,6 +223,11 @@ private:
     std::mutex _profile_mtx;
     std::vector<TabletWithVersion> _tablets;
     std::vector<TabletReader::ReadSource> _read_sources;
+
+    std::map<SlotId, vectorized::VExprContextSPtr> _slot_id_to_virtual_column_expr;
+    std::map<SlotId, size_t> _slot_id_to_index_in_block;
+    // this map is needed for scanner opening.
+    std::map<SlotId, vectorized::DataTypePtr> _slot_id_to_col_type;
 };
 
 class OlapScanOperatorX final : public ScanOperatorX<OlapScanLocalState> {

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -17,6 +17,8 @@
 
 #include "operator.h"
 
+#include <thrift/protocol/TDebugProtocol.h>
+
 #include "common/status.h"
 #include "pipeline/dependency.h"
 #include "pipeline/exec/aggregation_sink_operator.h"
@@ -179,14 +181,25 @@ Status OperatorXBase::init(const TPlanNode& tnode, RuntimeState* /*state*/) {
     auto substr = node_name.substr(0, node_name.find("_NODE"));
     _op_name = substr + "_OPERATOR";
 
+    LOG_INFO("Conjunct size of {} is {}", _op_name,
+             tnode.__isset.conjuncts ? tnode.conjuncts.size() : 0);
+
     if (tnode.__isset.vconjunct) {
         vectorized::VExprContextSPtr context;
         RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(tnode.vconjunct, context));
+        LOG_INFO("Conjunct of {} is\n{}", _op_name,
+                 apache::thrift::ThriftDebugString(tnode.vconjunct));
         _conjuncts.emplace_back(context);
     } else if (tnode.__isset.conjuncts) {
         for (auto& conjunct : tnode.conjuncts) {
             vectorized::VExprContextSPtr context;
             RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(conjunct, context));
+            LOG_INFO("Conjunct of {} is\n{}", _op_name,
+                     apache::thrift::ThriftDebugString(conjunct));
+            // // Write the conjunct to a file for debugging
+            // doris::vectorized::write_to_json(
+            //         "/mnt/disk4/hezhiqiang/workspace/doris/cmaster/RELEASE/be1", "conjunct.json",
+            //         conjunct);
             _conjuncts.emplace_back(context);
         }
     }

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -50,7 +50,8 @@ class RuntimeState;
 class TDataSink;
 namespace vectorized {
 class AsyncResultWriter;
-}
+class AnnTopNDescriptor;
+} // namespace vectorized
 } // namespace doris
 
 namespace doris::pipeline {
@@ -241,6 +242,7 @@ protected:
     RuntimeState* _state = nullptr;
     vectorized::VExprContextSPtrs _conjuncts;
     vectorized::VExprContextSPtrs _projections;
+    std::shared_ptr<vectorized::AnnTopNDescriptor> _ann_topn_descriptor;
     // Used in common subexpression elimination to compute intermediate results.
     std::vector<vectorized::VExprContextSPtrs> _intermediate_projections;
 
@@ -777,8 +779,6 @@ public:
               _limit(tnode.limit) {
         if (tnode.__isset.output_tuple_id) {
             _output_row_descriptor.reset(new RowDescriptor(descs, {tnode.output_tuple_id}, {true}));
-            _output_row_descriptor = std::make_unique<RowDescriptor>(
-                    descs, std::vector {tnode.output_tuple_id}, std::vector {true});
         }
         if (!tnode.intermediate_output_tuple_id_list.empty()) {
             // common subexpression elimination

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -136,8 +136,9 @@ class ScanLocalState : public ScanLocalStateBase {
             : ScanLocalStateBase(state, parent) {}
     ~ScanLocalState() override = default;
 
-    Status init(RuntimeState* state, LocalStateInfo& info) override;
-    Status open(RuntimeState* state) override;
+    virtual Status init(RuntimeState* state, LocalStateInfo& info) override;
+
+    virtual Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
     std::string debug_string(int indentation_level) const final;
 

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -25,16 +25,19 @@
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/descriptors.pb.h>
 #include <stddef.h>
+#include <thrift/protocol/TDebugProtocol.h>
 
 #include <algorithm>
 #include <boost/algorithm/string/join.hpp>
-#include <memory>
 
+#include "common/exception.h"
 #include "common/object_pool.h"
-#include "runtime/primitive_type.h"
 #include "util/string_util.h"
 #include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column_nothing.h"
 #include "vec/data_types/data_type_factory.hpp"
+#include "vec/exprs/vexpr.h"
+#include "vec/utils/util.hpp"
 
 namespace doris {
 
@@ -55,7 +58,11 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
           _is_key(tdesc.is_key),
           _column_paths(tdesc.column_paths),
           _is_auto_increment(tdesc.__isset.is_auto_increment ? tdesc.is_auto_increment : false),
-          _col_default_value(tdesc.__isset.col_default_value ? tdesc.col_default_value : "") {}
+          _col_default_value(tdesc.__isset.col_default_value ? tdesc.col_default_value : "") {
+    if (tdesc.__isset.virtual_column_expr) {
+        this->virtual_column_expr = std::make_shared<doris::TExpr>(tdesc.virtual_column_expr);
+    }
+}
 
 SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
         : _id(pdesc.id()),
@@ -109,6 +116,10 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
 }
 
 vectorized::MutableColumnPtr SlotDescriptor::get_empty_mutable_column() const {
+    if (this->get_virtual_column_expr() != nullptr) {
+        return vectorized::ColumnNothing::create(0);
+    }
+
     auto data_type = get_data_type_ptr();
     if (data_type) {
         return data_type->create_column();
@@ -121,10 +132,10 @@ vectorized::DataTypePtr SlotDescriptor::get_data_type_ptr() const {
 }
 
 std::string SlotDescriptor::debug_string() const {
-    std::stringstream out;
-    out << "Slot(id=" << _id << " type=" << _type << " col=" << _col_pos
-        << ", colname=" << _col_name << ", nullable=" << is_nullable() << ")";
-    return out.str();
+    const bool is_virtual = this->get_virtual_column_expr() != nullptr;
+    return fmt::format(
+            "SlotDescriptor(id={}, type={}, col_pos={}, col_name={}, nullable={}, is_virtual={})",
+            _id, _type.debug_string(), _col_pos, _col_name, is_nullable(), is_virtual);
 }
 
 TableDescriptor::TableDescriptor(const TTableDescriptor& tdesc)
@@ -621,6 +632,8 @@ Status DescriptorTbl::create(ObjectPool* pool, const TDescriptorTable& thrift_tb
         entry->second->add_slot(slot_d);
     }
 
+    // vectorized::write_to_json("/mnt/disk4/hezhiqiang/workspace/doris/cmaster/RELEASE/be1",
+    //                           fmt::format("{}.json", pool->size()), thrift_tbl);
     return Status::OK();
 }
 

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
 #include <gen_cpp/Types_types.h>
 #include <glog/logging.h>
 #include <google/protobuf/stubs/port.h>
@@ -41,6 +42,7 @@
 #include "runtime/define_primitive_type.h"
 #include "runtime/types.h"
 #include "vec/data_types/data_type.h"
+#include "vec/exprs/vexpr_fwd.h"
 namespace google::protobuf {
 template <typename Element>
 class RepeatedField;
@@ -90,6 +92,11 @@ public:
     const std::string& col_default_value() const { return _col_default_value; }
     PrimitiveType col_type() const { return _type.type; }
 
+    std::shared_ptr<doris::TExpr> get_virtual_column_expr() const {
+        // virtual_column_expr need do prepare.
+        return virtual_column_expr;
+    }
+
 private:
     friend class DescriptorTbl;
     friend class TupleDescriptor;
@@ -126,6 +133,8 @@ private:
 
     const bool _is_auto_increment;
     const std::string _col_default_value;
+
+    std::shared_ptr<doris::TExpr> virtual_column_expr = nullptr;
 
     SlotDescriptor(const TSlotDescriptor& tdesc);
     SlotDescriptor(const PSlotDescriptor& pdesc);

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -33,6 +33,8 @@ if (OpenMP_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+list(APPEND DORIS_LINK_LIBS OpenMP::OpenMP_CXX)
+
 if (${MAKE_TEST} STREQUAL "OFF" AND ${BUILD_BENCHMARK} STREQUAL "OFF")
     add_executable(doris_be
         doris_main.cpp

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -47,6 +47,7 @@
 #include "util/slice.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
+#include "vec/columns/column_nothing.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
 #include "vec/common/assert_cast.h"
@@ -95,6 +96,11 @@ Block::Block(const std::vector<SlotDescriptor*>& slots, size_t block_size,
             continue;
         }
         auto column_ptr = slot_desc->get_empty_mutable_column();
+        if (slot_desc->get_virtual_column_expr() != nullptr) {
+            // Make sure virtual column is assigend with a ColumnNothing
+            std::ignore = assert_cast<const ColumnNothing*>(column_ptr.get());
+        }
+
         column_ptr->reserve(block_size);
         insert(ColumnWithTypeAndName(std::move(column_ptr), slot_desc->get_data_type_ptr(),
                                      slot_desc->col_name()));

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -59,9 +59,11 @@
 #include "service/backend_options.h"
 #include "util/doris_metrics.h"
 #include "util/runtime_profile.h"
+#include "vec/columns/column_nothing.h"
 #include "vec/common/schema_util.h"
 #include "vec/core/block.h"
 #include "vec/exec/scan/scan_node.h"
+#include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 #include "vec/json/path_in_data.h"
 #include "vec/olap/block_reader.h"
@@ -76,7 +78,7 @@ OlapScanner::OlapScanner(pipeline::ScanLocalStateBase* parent, OlapScanner::Para
           _tablet_reader_params({
                   .tablet = std::move(params.tablet),
                   .tablet_schema {},
-                  .aggregation = params.aggregation,
+                  .is_pre_aggregation = params.is_pre_aggregation,
                   .version = {0, params.version},
                   .start_key {},
                   .end_key {},
@@ -95,6 +97,10 @@ OlapScanner::OlapScanner(pipeline::ScanLocalStateBase* parent, OlapScanner::Para
                   .topn_filter_source_node_ids {},
                   .filter_block_conjuncts {},
                   .key_group_cluster_key_idxes {},
+                  .virtual_column_exprs {},
+                  .ann_topn_descriptor {},
+                  .vir_cid_to_idx_in_block {},
+                  .vir_col_idx_to_type {},
           }) {
     _tablet_reader_params.set_read_source(std::move(params.read_source));
     _is_init = false;
@@ -125,15 +131,34 @@ static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,
 }
 
 Status OlapScanner::init() {
+    const TOlapScanNode& olap_scan_node =
+            _local_state->cast<pipeline::OlapScanLocalState>().olap_scan_node();
+    if (olap_scan_node.__isset.keyType) {
+        if (olap_scan_node.keyType != TKeysType::DUP_KEYS) {
+            return Status::InternalError<false>("Currently only support DUP_KEYS, but got {}",
+                                                olap_scan_node.keyType);
+        }
+    }
     _is_init = true;
     auto* local_state = static_cast<pipeline::OlapScanLocalState*>(_local_state);
     auto& tablet = _tablet_reader_params.tablet;
     auto& tablet_schema = _tablet_reader_params.tablet_schema;
-    for (auto& ctx : local_state->_common_expr_ctxs_push_down) {
+    for (auto ctx : local_state->_common_expr_ctxs_push_down) {
         VExprContextSPtr context;
         RETURN_IF_ERROR(ctx->clone(_state, context));
         _common_expr_ctxs_push_down.emplace_back(context);
+        RETURN_IF_ERROR(context->prepare_ann_range_search());
     }
+
+    for (auto pair : local_state->_slot_id_to_virtual_column_expr) {
+        VExprContextSPtr context;
+        RETURN_IF_ERROR(pair.second->clone(_state, context));
+        _slot_id_to_virtual_column_expr[pair.first] = context;
+    }
+
+    _slot_id_to_index_in_block = local_state->_slot_id_to_index_in_block;
+    _slot_id_to_col_type = local_state->_slot_id_to_col_type;
+    _ann_topn_descriptor = local_state->_ann_topn_descriptor;
 
     // set limit to reduce end of rowset and segment mem use
     _tablet_reader = std::make_unique<BlockReader>();
@@ -254,13 +279,20 @@ Status OlapScanner::_init_tablet_reader_params(
 
     if (_state->skip_storage_engine_merge()) {
         _tablet_reader_params.direct_mode = true;
-        _tablet_reader_params.aggregation = true;
+        _tablet_reader_params.is_pre_aggregation = true;
     } else {
         auto push_down_agg_type = _local_state->get_push_down_agg_type();
-        _tablet_reader_params.direct_mode = _tablet_reader_params.aggregation || single_version ||
+        _tablet_reader_params.direct_mode = _tablet_reader_params.is_pre_aggregation ||
+                                            single_version ||
                                             (push_down_agg_type != TPushAggOp::NONE &&
                                              push_down_agg_type != TPushAggOp::COUNT_ON_INDEX);
     }
+    LOG_INFO(
+            "Direct mode {}, pre-aggregation {}, skip_storage_engine_merge: {}, single_version: "
+            "{}, push_down_agg_type {}",
+            _tablet_reader_params.direct_mode, _tablet_reader_params.is_pre_aggregation,
+            _state->skip_storage_engine_merge(), single_version,
+            _local_state->get_push_down_agg_type());
 
     RETURN_IF_ERROR(_init_variant_columns());
     RETURN_IF_ERROR(_init_return_columns());
@@ -280,6 +312,10 @@ Status OlapScanner::_init_tablet_reader_params(
     }
 
     _tablet_reader_params.common_expr_ctxs_push_down = _common_expr_ctxs_push_down;
+    _tablet_reader_params.virtual_column_exprs = _virtual_column_exprs;
+    _tablet_reader_params.ann_topn_descriptor = _ann_topn_descriptor;
+    _tablet_reader_params.vir_cid_to_idx_in_block = _vir_cid_to_idx_in_block;
+    _tablet_reader_params.vir_col_idx_to_type = _vir_col_idx_to_type;
     _tablet_reader_params.output_columns =
             ((pipeline::OlapScanLocalState*)_local_state)->_maybe_read_column_ids;
     _tablet_reader_params.target_cast_type_for_variants =
@@ -439,6 +475,15 @@ Status OlapScanner::_init_variant_columns() {
 }
 
 Status OlapScanner::_init_return_columns() {
+    size_t virtual_column_index = 0;
+    std::vector<std::string> debug_strings;
+    for (const auto* slot : _output_tuple_desc->slots()) {
+        debug_strings.push_back(slot->debug_string());
+    }
+
+    LOG_INFO("OlapScanner init return columns, output tuple slots:\n{}",
+             fmt::join(debug_strings, ",\n"));
+
     for (auto* slot : _output_tuple_desc->slots()) {
         if (!slot->is_materialized()) {
             continue;
@@ -447,7 +492,25 @@ Status OlapScanner::_init_return_columns() {
         // variant column using path to index a column
         int32_t index = 0;
         auto& tablet_schema = _tablet_reader_params.tablet_schema;
-        if (slot->type().is_variant_type()) {
+        if (slot->get_virtual_column_expr()) {
+            // 如果这个列是一个虚拟列，那么给它一个特殊的 cid
+            // 这个 cid 是在 tablet_schema 中不存在的
+            size_t virtual_column_cid = tablet_schema->num_columns() + virtual_column_index;
+
+            // 这两个 map 都会向下传递到 segment iterator
+            _virtual_column_exprs[virtual_column_cid] = _slot_id_to_virtual_column_expr[slot->id()];
+            size_t idx_in_block = _slot_id_to_index_in_block[slot->id()];
+            _vir_cid_to_idx_in_block[virtual_column_cid] = idx_in_block;
+            _vir_col_idx_to_type[idx_in_block] = _slot_id_to_col_type[slot->id()];
+
+            virtual_column_index++;
+
+            LOG_INFO("Add virtual column, slot id: {}, cid {}, column index: {}, type: {}",
+                     slot->id(), virtual_column_cid, _vir_cid_to_idx_in_block[virtual_column_cid],
+                     _vir_col_idx_to_type[idx_in_block]->get_name());
+            // Virtual column is not included in columns in read-schema.
+            continue;
+        } else if (slot->type().is_variant_type()) {
             index = tablet_schema->field_index(PathInData(
                     tablet_schema->column_by_uid(slot->col_unique_id()).name_lower_case(),
                     slot->column_paths()));
@@ -461,6 +524,7 @@ Status OlapScanner::_init_return_columns() {
                     "field name is invalid. field={}, field_name_to_index={}, col_unique_id={}",
                     slot->col_name(), tablet_schema->get_all_field_names(), slot->col_unique_id());
         }
+        // _return_columns 中只保留 normal_columns
         _return_columns.push_back(index);
         if (slot->is_nullable() && !tablet_schema->column(index).is_nullable()) {
             _tablet_columns_convert_to_null_set.emplace(index);
@@ -475,7 +539,14 @@ Status OlapScanner::_init_return_columns() {
 
     if (_return_columns.empty()) {
         return Status::InternalError("failed to build storage scanner, no materialized slot!");
+    } else {
+        std::string msg = "";
+        for (auto& column : _return_columns) {
+            msg += fmt::format("{}, ", column);
+        }
+        LOG_INFO("OlapScanner init return columns, return columns cid: [{}]", msg);
     }
+
     return Status::OK();
 }
 

--- a/be/src/vec/exec/scan/olap_scanner.h
+++ b/be/src/vec/exec/scan/olap_scanner.h
@@ -20,6 +20,8 @@
 #include <gen_cpp/PaloInternalService_types.h>
 #include <stdint.h>
 
+#include <cstddef>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -34,6 +36,7 @@
 #include "olap/tablet.h"
 #include "olap/tablet_reader.h"
 #include "olap/tablet_schema.h"
+#include "vec/data_types/data_type.h"
 #include "vec/exec/scan/scanner.h"
 
 namespace doris {
@@ -64,7 +67,7 @@ public:
         int64_t version;
         TabletReader::ReadSource read_source;
         int64_t limit;
-        bool aggregation;
+        bool is_pre_aggregation;
     };
 
     OlapScanner(pipeline::ScanLocalStateBase* parent, Params&& params);
@@ -89,16 +92,32 @@ private:
                                       const pipeline::FilterPredicates& filter_predicates,
                                       const std::vector<FunctionFilter>& function_filters);
 
-    [[nodiscard]] Status _init_return_columns();
-    [[nodiscard]] Status _init_variant_columns();
+    Status _init_return_columns();
+    Status _init_variant_columns();
 
     std::vector<OlapScanRange*> _key_ranges;
 
     TabletReader::ReaderParams _tablet_reader_params;
     std::unique_ptr<TabletReader> _tablet_reader;
 
-    std::vector<uint32_t> _return_columns;
+public:
+    std::vector<ColumnId> _return_columns;
+
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
+
+    // This three fields are copied from OlapScanLocalState.
+    std::map<SlotId, vectorized::VExprContextSPtr> _slot_id_to_virtual_column_expr;
+    std::map<SlotId, size_t> _slot_id_to_index_in_block;
+    std::map<SlotId, vectorized::DataTypePtr> _slot_id_to_col_type;
+
+    // ColumnId of virtual column to its expr context
+    std::map<ColumnId, vectorized::VExprContextSPtr> _virtual_column_exprs;
+    // ColumnId of virtual column to its index in block
+    std::map<ColumnId, size_t> _vir_cid_to_idx_in_block;
+    // The idx of vir_col in block to its data type.
+    std::map<size_t, vectorized::DataTypePtr> _vir_col_idx_to_type;
+
+    std::shared_ptr<vectorized::AnnTopNDescriptor> _ann_topn_descriptor;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -24,6 +24,7 @@
 #include "runtime/descriptors.h"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
+#include "vec/columns/column_nothing.h"
 #include "vec/core/column_with_type_and_name.h"
 #include "vec/exec/scan/scan_node.h"
 #include "vec/exprs/vexpr_context.h"
@@ -76,11 +77,11 @@ Status Scanner::get_block_after_projects(RuntimeState* state, vectorized::Block*
     auto& row_descriptor = _local_state->_parent->row_descriptor();
     if (_output_row_descriptor) {
         _origin_block.clear_column_data(row_descriptor.num_materialized_slots());
-        auto status = get_block(state, &_origin_block, eos);
-        if (UNLIKELY(!status.ok())) return status;
+        RETURN_IF_ERROR(get_block(state, &_origin_block, eos));
         return _do_projections(&_origin_block, block);
+    } else {
+        return get_block(state, block, eos);
     }
-    return get_block(state, block, eos);
 }
 
 Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
@@ -99,6 +100,7 @@ Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
                                                 slot_desc->get_data_type_ptr(),
                                                 slot_desc->col_name()));
         }
+        LOG_INFO("Block columns count: {}", block->columns());
     }
 
 #ifndef BE_TEST
@@ -205,6 +207,9 @@ Status Scanner::_do_projections(vectorized::Block* origin_block, vectorized::Blo
             reinterpret_cast<ColumnNullable*>(mutable_columns[i].get())
                     ->insert_range_from_not_nullable(*column_ptr, 0, rows);
         } else {
+            LOG_INFO(" Projections {} insert_range_from {} to {}",
+                     _projections[i]->root()->debug_string(), column_ptr->get_name(),
+                     mutable_columns[i]->get_name());
             mutable_columns[i]->insert_range_from(*column_ptr, 0, rows);
         }
     }

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -233,6 +233,10 @@ vectorized::BlockUPtr ScannerContext::get_free_block(bool force) {
         _newly_create_free_blocks_num->update(1);
         block = vectorized::Block::create_unique(_output_tuple_desc->slots(), 0,
                                                  true /*ignore invalid slots*/);
+        std::vector<size_t> col_sizes;
+        for (const auto& c : block->get_columns()) {
+            col_sizes.push_back(c->size());
+        }
     }
     return block;
 }

--- a/be/src/vec/exprs/ann_range_search_params.h
+++ b/be/src/vec/exprs/ann_range_search_params.h
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gen_cpp/Opcodes_types.h>
+
+#include <string>
+
+#include "olap/rowset/segment_v2/ann_index_iterator.h"
+
+namespace doris::vectorized {
+struct AnnRangeSearchParams {
+    bool is_ann_range_search = false;
+    bool is_le_or_lt = true;
+    size_t src_col_idx = 0;
+    int64_t dst_col_idx = -1;
+    double radius = 0.0;
+    int ef_search = 0;
+    std::unique_ptr<float[]> query_value;
+
+    segment_v2::RangeSearchParams toRangeSearchParams() {
+        segment_v2::RangeSearchParams params;
+        params.query_value = query_value.get();
+        params.radius = static_cast<float>(radius);
+        params.roaring = nullptr;
+        params.is_le_or_lt = is_le_or_lt;
+        return params;
+    }
+
+    segment_v2::CustomSearchParams toCustomSearchParams() {
+        segment_v2::CustomSearchParams params;
+        params.ef_search = ef_search;
+        return params;
+    }
+
+    std::string to_string() const {
+        return fmt::format(
+                "is_ann_range_search: {}, is_le_or_lt: {}, src_col_idx: {}, "
+                "dst_col_idx: {}, radius: {}, ef_search: {}",
+                is_ann_range_search, is_le_or_lt, src_col_idx, dst_col_idx, radius, ef_search);
+    }
+};
+} // namespace doris::vectorized

--- a/be/src/vec/exprs/vann_topn_predicate.cpp
+++ b/be/src/vec/exprs/vann_topn_predicate.cpp
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exprs/vann_topn_predicate.h"
+
+#include <cstdint>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "common/logging.h"
+#include "olap/rowset/segment_v2/ann_index_iterator.h"
+#include "runtime/runtime_state.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_array.h"
+#include "vec/columns/column_const.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/columns_number.h"
+#include "vec/common/assert_cast.h"
+#include "vec/exprs/varray_literal.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/vexpr_fwd.h"
+#include "vec/exprs/virtual_slot_ref.h"
+#include "vec/exprs/vslot_ref.h"
+
+namespace doris::vectorized {
+
+Status AnnTopNDescriptor::prepare(RuntimeState* state, const RowDescriptor& row_desc) {
+    RETURN_IF_ERROR(_order_by_expr_ctx->prepare(state, row_desc));
+    RETURN_IF_ERROR(_order_by_expr_ctx->open(state));
+
+    // Check the structure of the _order_by_expr_ctx
+
+    /*
+        VirtualSlotRef
+        |
+        |
+        FuncationCall
+        |----------------
+        |               |
+        |               |
+        CastToArray     ArrayLiteral
+        |
+        |
+        SlotRef
+    */
+    std::shared_ptr<VirtualSlotRef> vir_slot_ref =
+            std::dynamic_pointer_cast<VirtualSlotRef>(_order_by_expr_ctx->root());
+    DCHECK(vir_slot_ref != nullptr);
+    if (vir_slot_ref == nullptr) {
+        return Status::InternalError(
+                "root of order by expr of ann topn must be a VirtualSlotRef, got\n{}",
+                _order_by_expr_ctx->root()->debug_string());
+    }
+    DCHECK(vir_slot_ref->column_id() >= 0);
+    _dest_column_idx = vir_slot_ref->column_id();
+    auto vir_col_expr = vir_slot_ref->get_virtual_column_expr();
+    std::shared_ptr<VectorizedFnCall> distance_fn_call =
+            std::dynamic_pointer_cast<VectorizedFnCall>(vir_col_expr->root());
+
+    if (distance_fn_call == nullptr) {
+        return Status::InternalError("Ann topn expr expect FuncationCall, got\n{}",
+                                     vir_col_expr->root()->debug_string());
+    }
+
+    std::shared_ptr<VCastExpr> cast_to_array_expr =
+            std::dynamic_pointer_cast<VCastExpr>(distance_fn_call->children()[0]);
+
+    if (cast_to_array_expr == nullptr) {
+        return Status::InternalError("Ann topn expr expect cast_to_array_expr, got\n{}",
+                                     distance_fn_call->children()[0]->debug_string());
+    }
+
+    std::shared_ptr<VSlotRef> slot_ref =
+            std::dynamic_pointer_cast<VSlotRef>(cast_to_array_expr->children()[0]);
+    if (slot_ref == nullptr) {
+        return Status::InternalError("Ann topn expr expect SlotRef, got\n{}",
+                                     cast_to_array_expr->children()[0]->debug_string());
+    }
+
+    // slot_ref->column_id() is acutually the columnd idx in block.
+    _src_column_idx = slot_ref->column_id();
+
+    std::shared_ptr<VArrayLiteral> array_literal =
+            std::dynamic_pointer_cast<VArrayLiteral>(distance_fn_call->children()[1]);
+    if (array_literal == nullptr) {
+        return Status::InternalError("Ann topn expr expect ArrayLiteral, got\n{}",
+                                     distance_fn_call->children()[1]->debug_string());
+    }
+    _query_array = array_literal->get_column_ptr();
+
+    VLOG_DEBUG << "AnnTopNDescriptor: {}" << this->debug_string();
+    return Status::OK();
+}
+
+Status AnnTopNDescriptor::evaluate_vector_ann_search(
+        segment_v2::IndexIterator* ann_index_iterator, roaring::Roaring& roaring,
+        vectorized::IColumn::MutablePtr& result_column,
+        std::unique_ptr<std::vector<uint64_t>>& row_ids) {
+    DCHECK(ann_index_iterator != nullptr);
+    DCHECK(_order_by_expr_ctx != nullptr);
+    DCHECK(_order_by_expr_ctx->root() != nullptr);
+
+    const ColumnConst* const_column = assert_cast<const ColumnConst*>(_query_array.get());
+    const ColumnArray* column_array =
+            assert_cast<const ColumnArray*>(const_column->get_data_column_ptr().get());
+    const ColumnNullable* column_nullable =
+            assert_cast<const ColumnNullable*>(column_array->get_data_ptr().get());
+    const ColumnFloat64* cf64 =
+            assert_cast<const ColumnFloat64*>(column_nullable->get_nested_column_ptr().get());
+
+    const double* query_value = cf64->get_data().data();
+    const size_t query_value_size = cf64->get_data().size();
+
+    std::unique_ptr<float[]> query_value_f32 = std::make_unique<float[]>(query_value_size);
+    for (size_t i = 0; i < query_value_size; ++i) {
+        query_value_f32[i] = static_cast<float>(query_value[i]);
+    }
+
+    segment_v2::AnnIndexParam ann_query_params {
+            .query_value = query_value_f32.get(),
+            .query_value_size = query_value_size,
+            .limit = _limit,
+            .roaring = &roaring,
+            .distance = nullptr,
+            .row_ids = nullptr,
+    };
+
+    RETURN_IF_ERROR(ann_index_iterator->read_from_index(&ann_query_params));
+    DCHECK(ann_query_params.distance != nullptr);
+    DCHECK(ann_query_params.row_ids != nullptr);
+
+    result_column = ColumnFloat64::create();
+    ColumnFloat64* result_column_float = assert_cast<ColumnFloat64*>(result_column.get());
+
+    result_column_float->resize(ann_query_params.distance->size());
+    for (size_t i = 0; i < ann_query_params.distance->size(); ++i) {
+        result_column_float->get_data()[i] = (*ann_query_params.distance)[i];
+    }
+    row_ids = std::move(ann_query_params.row_ids);
+    return Status::OK();
+}
+
+std::string AnnTopNDescriptor::debug_string() const {
+    return "AnnTopNDescriptor: limit=" + std::to_string(_limit) +
+           ", src_col_idx=" + std::to_string(_src_column_idx) +
+           ", dest_col_idx=" + std::to_string(_dest_column_idx) +
+           ", order_by_expr=" + _order_by_expr_ctx->root()->debug_string();
+}
+} // namespace doris::vectorized

--- a/be/src/vec/exprs/vann_topn_predicate.h
+++ b/be/src/vec/exprs/vann_topn_predicate.h
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/columns/column.h"
+#include "vec/exprs/varray_literal.h"
+#include "vec/exprs/vcast_expr.h"
+#include "vec/exprs/vectorized_fn_call.h"
+#include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/vexpr_fwd.h"
+#include "vec/exprs/vslot_ref.h"
+
+namespace doris::vectorized {
+
+class AnnTopNDescriptor {
+    ENABLE_FACTORY_CREATOR(AnnTopNDescriptor);
+
+public:
+    AnnTopNDescriptor(size_t limit, VExprContextSPtr order_by_expr_ctx)
+            : _limit(limit), _order_by_expr_ctx(order_by_expr_ctx) {};
+
+    Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
+
+    VExprContextSPtr get_order_by_expr_ctx() const { return _order_by_expr_ctx; }
+
+    Status evaluate_vector_ann_search(segment_v2::IndexIterator* ann_index_iterator,
+                                      roaring::Roaring& row_bitmap,
+                                      vectorized::IColumn::MutablePtr& result_column,
+                                      std::unique_ptr<std::vector<uint64_t>>& row_ids);
+
+    std::string debug_string() const;
+
+    size_t get_src_column_idx() const { return _src_column_idx; }
+
+    size_t get_dest_column_idx() const { return _dest_column_idx; }
+
+private:
+    // limit N
+    const size_t _limit;
+    // order by distance(xxx, [1,2])
+    VExprContextSPtr _order_by_expr_ctx;
+
+    std::string _name = "AnnTopNDescriptor";
+    size_t _src_column_idx = -1;
+    size_t _dest_column_idx = -1;
+    IColumn::Ptr _query_array;
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -19,20 +19,37 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h> // IWYU pragma: keep
+#include <gen_cpp/Opcodes_types.h>
 #include <gen_cpp/Types_types.h>
 
+#include <memory>
 #include <ostream>
 
 #include "common/config.h"
+#include "common/logging.h"
 #include "common/status.h"
+#include "olap/rowset/segment_v2/ann_index_iterator.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/rowset/segment_v2/index_reader.h"
+#include "olap/rowset/segment_v2/virtual_column_iterator.h"
 #include "pipeline/pipeline_task.h"
 #include "runtime/runtime_state.h"
 #include "udf/udf.h"
 #include "vec/columns/column.h"
+#include "vec/columns/column_array.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/columns_number.h"
 #include "vec/core/block.h"
+#include "vec/core/column_numbers.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_agg_state.h"
+#include "vec/exprs/varray_literal.h"
+#include "vec/exprs/vcast_expr.h"
 #include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/virtual_slot_ref.h"
+#include "vec/exprs/vliteral.h"
+#include "vec/functions/array/function_array_distance.h"
 #include "vec/functions/function_agg_state.h"
 #include "vec/functions/function_fake.h"
 #include "vec/functions/function_java_udf.h"
@@ -129,6 +146,7 @@ Status VectorizedFnCall::open(RuntimeState* state, VExprContext* context,
     if (scope == FunctionContext::FRAGMENT_LOCAL) {
         RETURN_IF_ERROR(VExpr::get_const_col(context, nullptr));
     }
+
     _open_finished = true;
     return Status::OK();
 }
@@ -273,6 +291,220 @@ bool VectorizedFnCall::equals(const VExpr& other) {
         }
     }
     return true;
+}
+
+/*
+    FuncationCall(LE/LT/GE/GT)
+    |----------------
+    |               |
+    |               |
+    VirtualSlotRef  Float64Literal 
+    |
+    |
+    FuncationCall
+    |----------------
+    |               |
+    |               |
+    CastToArray     ArrayLiteral
+    |
+    |
+    SlotRef
+*/
+
+Status VectorizedFnCall::prepare_ann_range_search() {
+    std::set<TExprOpcode::type> ops = {TExprOpcode::GE, TExprOpcode::LE, TExprOpcode::LE,
+                                       TExprOpcode::GT, TExprOpcode::LT};
+    if (ops.find(this->op()) == ops.end()) {
+        LOG_INFO("Not a range search function.");
+        return Status::OK();
+    }
+
+    _ann_range_search_params.is_le_or_lt =
+            (this->op() == TExprOpcode::LE || this->op() == TExprOpcode::LT);
+
+    DCHECK(_children.size() == 2);
+
+    auto left_child = get_child(0);
+    auto right_child = get_child(1);
+
+    // Return type of L2Distance is always double.
+    auto right_literal = std::dynamic_pointer_cast<VLiteral>(right_child);
+    if (right_literal == nullptr) {
+        LOG_INFO("Right child is not a literal.");
+        return Status::OK();
+    }
+
+    auto right_col = right_literal->get_column_ptr()->convert_to_full_column_if_const();
+    auto right_type = right_literal->get_data_type();
+    if (right_type->get_type_id() != vectorized::TypeIndex::Float64) {
+        LOG_INFO("Right child is not a Float64Literal.");
+        return Status::OK();
+    }
+
+    const ColumnFloat64* cf64_right = assert_cast<const ColumnFloat64*>(right_col.get());
+    _ann_range_search_params.radius = cf64_right->get_data()[0];
+
+    std::shared_ptr<VectorizedFnCall> function_call;
+    auto vir_slot_ref = std::dynamic_pointer_cast<VirtualSlotRef>(left_child);
+    if (vir_slot_ref != nullptr) {
+        DCHECK(vir_slot_ref->get_virtual_column_expr() != nullptr);
+        DCHECK(vir_slot_ref->get_virtual_column_expr()->root() != nullptr);
+        function_call = std::dynamic_pointer_cast<VectorizedFnCall>(
+                vir_slot_ref->get_virtual_column_expr()->root());
+    } else {
+        function_call = std::dynamic_pointer_cast<VectorizedFnCall>(left_child);
+    }
+
+    if (function_call == nullptr) {
+        LOG_INFO("Left child is not a function call.");
+        return Status::OK();
+    }
+
+    // Now left child is a function call, we need to check if it is a distance function
+    if (function_call->_function_name != L2Distance::name) {
+        LOG_INFO("Left child is not a distance function. Got {}", function_call->_function_name);
+        return Status::OK();
+    }
+
+    if (function_call->get_num_children() != 2) {
+        return Status::OK();
+    }
+
+    UInt16 idx_of_cast_to_array = 0;
+    UInt16 idx_of_array_literal = 0;
+    for (UInt16 i = 0; i < function_call->get_num_children(); ++i) {
+        auto child = function_call->get_child(i);
+        if (std::dynamic_pointer_cast<VCastExpr>(child) != nullptr) {
+            idx_of_cast_to_array = i;
+        } else if (std::dynamic_pointer_cast<VArrayLiteral>(child) != nullptr) {
+            idx_of_array_literal = i;
+        }
+    }
+
+    std::shared_ptr<VCastExpr> cast_to_array_expr =
+            std::dynamic_pointer_cast<VCastExpr>(function_call->get_child(idx_of_cast_to_array));
+    std::shared_ptr<VArrayLiteral> array_literal = std::dynamic_pointer_cast<VArrayLiteral>(
+            function_call->get_child(idx_of_array_literal));
+
+    if (cast_to_array_expr == nullptr || array_literal == nullptr) {
+        LOG_INFO("Cast to array expr or array literal is null.");
+        return Status::OK();
+    }
+
+    // One of the children is a slot ref, and the other is an array literal, now begin to create search params.
+    std::shared_ptr<VSlotRef> slot_ref =
+            std::dynamic_pointer_cast<VSlotRef>(cast_to_array_expr->get_child(0));
+    if (slot_ref == nullptr) {
+        LOG_INFO("Cast to array expr's child is not a slot ref.");
+        return Status::OK();
+    }
+
+    _ann_range_search_params.src_col_idx = slot_ref->column_id();
+    _ann_range_search_params.dst_col_idx = vir_slot_ref == nullptr ? -1 : vir_slot_ref->column_id();
+    auto col_const = array_literal->get_column_ptr();
+    auto col_array = col_const->convert_to_full_column_if_const();
+    const ColumnArray* array_col = assert_cast<const ColumnArray*>(col_array.get());
+    DCHECK(array_col->size() == 1);
+    size_t dim = array_col->get_offsets()[0];
+    _ann_range_search_params.query_value = std::make_unique<float[]>(dim);
+
+    const ColumnNullable* cn = assert_cast<const ColumnNullable*>(array_col->get_data_ptr().get());
+    const ColumnFloat64* cf64 =
+            assert_cast<const ColumnFloat64*>(cn->get_nested_column_ptr().get());
+    for (size_t i = 0; i < dim; ++i) {
+        _ann_range_search_params.query_value[i] = static_cast<Float32>(cf64->get_data()[i]);
+    }
+    _ann_range_search_params.is_ann_range_search = true;
+    LOG_INFO("Ann range search params: {}", _ann_range_search_params.to_string());
+    return Status::OK();
+}
+
+Status VectorizedFnCall::evaluate_ann_range_search(
+        const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
+        const std::vector<ColumnId>& idx_to_cid,
+        const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
+        roaring::Roaring& row_bitmap) {
+    if (_ann_range_search_params.is_ann_range_search == false) {
+        return Status::OK();
+    }
+    LOG_INFO("Try apply ann range search. Local search params: {}",
+             _ann_range_search_params.to_string());
+    size_t origin_num = row_bitmap.cardinality();
+
+    int idx_in_block = static_cast<int>(_ann_range_search_params.src_col_idx);
+    DCHECK(idx_in_block < idx_to_cid.size())
+            << "idx_in_block: " << idx_in_block << ", idx_to_cid.size(): " << idx_to_cid.size();
+
+    ColumnId src_col_cid = idx_to_cid[idx_in_block];
+    DCHECK(src_col_cid < cid_to_index_iterators.size());
+    segment_v2::IndexIterator* index_iterators = cid_to_index_iterators[src_col_cid].get();
+    if (index_iterators == nullptr) {
+        LOG_INFO("No index iterator for column cid {}", src_col_cid);
+        return Status::OK();
+    }
+
+    segment_v2::AnnIndexIterator* ann_index_iterators =
+            dynamic_cast<segment_v2::AnnIndexIterator*>(index_iterators);
+    if (ann_index_iterators == nullptr) {
+        LOG_INFO("No index iterator for column cid {}", src_col_cid);
+        return Status::OK();
+    }
+
+    RangeSearchParams params = _ann_range_search_params.toRangeSearchParams();
+    CustomSearchParams custom_params = _ann_range_search_params.toCustomSearchParams();
+
+    params.roaring = &row_bitmap;
+    DCHECK(params.roaring != nullptr);
+    RangeSearchResult result;
+    RETURN_IF_ERROR(ann_index_iterators->range_search(params, custom_params, &result));
+
+#ifndef NDEBUG
+    if (this->_ann_range_search_params.is_le_or_lt == false) {
+        DCHECK(result.distance == nullptr) << "Should not have distance";
+    }
+#endif
+
+    DCHECK(result.roaring != nullptr);
+    row_bitmap = *result.roaring;
+
+    if (params.is_le_or_lt == false) {
+        DCHECK(result.distance == nullptr);
+        DCHECK(result.row_ids == nullptr);
+    }
+
+    // Process virtual column
+    if (_ann_range_search_params.dst_col_idx >= 0) {
+        // Prepare materialization if we can use result from index.
+        // Typical situation: range search and operator is LE or LT.
+        if (result.distance != nullptr) {
+            DCHECK(result.row_ids != nullptr);
+            ColumnId dst_col_cid = idx_to_cid[_ann_range_search_params.dst_col_idx];
+            DCHECK(dst_col_cid < column_iterators.size());
+            DCHECK(column_iterators[dst_col_cid] != nullptr);
+            segment_v2::ColumnIterator* column_iterator = column_iterators[dst_col_cid].get();
+            DCHECK(column_iterator != nullptr);
+            segment_v2::VirtualColumnIterator* virtual_column_iterator =
+                    dynamic_cast<segment_v2::VirtualColumnIterator*>(column_iterator);
+            DCHECK(virtual_column_iterator != nullptr);
+            // Now convert distance to column
+            size_t size = result.roaring->cardinality();
+            // TODO: need to consider nullable column.
+            auto distance_col = ColumnFloat32::create();
+
+            distance_col->insert_many_raw_data(reinterpret_cast<char*>(result.distance.get()),
+                                               size);
+            virtual_column_iterator->prepare_materialization(std::move(distance_col),
+                                                             std::move(result.row_ids));
+        } else {
+            DCHECK(this->op() != TExprOpcode::LE && this->op() != TExprOpcode::LT)
+                    << "Should not have distance";
+        }
+    }
+
+    _has_been_executed = true;
+    LOG_INFO("Ann range search filtered {} rows, origin {} rows",
+             origin_num - row_bitmap.cardinality(), origin_num);
+    return Status::OK();
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -24,6 +24,7 @@
 #include "common/status.h"
 #include "udf/udf.h"
 #include "vec/core/column_numbers.h"
+#include "vec/exprs/ann_range_search_params.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vliteral.h"
 #include "vec/exprs/vslot_ref.h"
@@ -72,10 +73,19 @@ public:
 
     size_t estimate_memory(const size_t rows) override;
 
+    MOCK_FUNCTION Status evaluate_ann_range_search(
+            const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
+            const std::vector<ColumnId>& idx_to_cid,
+            const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
+            roaring::Roaring& row_bitmap) override;
+
+    Status prepare_ann_range_search() override;
+
 protected:
     FunctionBasePtr _function;
     std::string _expr_name;
     std::string _function_name;
+    AnnRangeSearchParams _ann_range_search_params;
 
 private:
     Status _do_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -40,6 +40,7 @@
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
+#include "vec/exprs/vann_topn_predicate.h"
 #include "vec/exprs/varray_literal.h"
 #include "vec/exprs/vcase_expr.h"
 #include "vec/exprs/vcast_expr.h"
@@ -47,8 +48,10 @@
 #include "vec/exprs/vcompound_pred.h"
 #include "vec/exprs/vectorized_fn_call.h"
 #include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/vexpr_fwd.h"
 #include "vec/exprs/vin_predicate.h"
 #include "vec/exprs/vinfo_func.h"
+#include "vec/exprs/virtual_slot_ref.h"
 #include "vec/exprs/vlambda_function_call_expr.h"
 #include "vec/exprs/vlambda_function_expr.h"
 #include "vec/exprs/vliteral.h"
@@ -178,7 +181,9 @@ bool VExpr::is_acting_on_a_slot(const VExpr& expr) {
     auto is_a_slot = std::any_of(children.begin(), children.end(),
                                  [](const auto& child) { return is_acting_on_a_slot(*child); });
 
-    return is_a_slot ? true : (expr.node_type() == TExprNodeType::SLOT_REF);
+    return is_a_slot ? true
+                     : (expr.node_type() == TExprNodeType::SLOT_REF ||
+                        expr.node_type() == TExprNodeType::VIRTUAL_SLOT_REF);
 }
 
 VExpr::VExpr(const TExprNode& node)
@@ -223,7 +228,9 @@ Status VExpr::prepare(RuntimeState* state, const RowDescriptor& row_desc, VExprC
         RETURN_IF_ERROR(i->prepare(state, row_desc, context));
     }
     --context->_depth_num;
+#ifndef BE_TEST
     _enable_inverted_index_query = state->query_options().enable_inverted_index_query;
+#endif
     return Status::OK();
 }
 
@@ -275,7 +282,12 @@ Status VExpr::create_expr(const TExprNode& expr_node, VExprSPtr& expr) {
             break;
         }
         case TExprNodeType::SLOT_REF: {
-            expr = VSlotRef::create_shared(expr_node);
+            if (expr_node.slot_ref.__isset.is_virtual_slot && expr_node.slot_ref.is_virtual_slot) {
+                expr = VirtualSlotRef::create_shared(expr_node);
+                expr->_node_type = TExprNodeType::VIRTUAL_SLOT_REF;
+            } else {
+                expr = VSlotRef::create_shared(expr_node);
+            }
             break;
         }
         case TExprNodeType::COLUMN_REF: {
@@ -780,6 +792,25 @@ bool VExpr::fast_execute(doris::vectorized::VExprContext* context, doris::vector
 
 bool VExpr::equals(const VExpr& other) {
     return false;
+}
+
+Status VExpr::evaluate_ann_range_search(
+        const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& index_iterators,
+        const std::vector<ColumnId>& idx_to_cid,
+        const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
+        roaring::Roaring& row_bitmap) {
+    return Status::OK();
+}
+
+Status VExpr::prepare_ann_range_search() {
+    for (auto& child : _children) {
+        RETURN_IF_ERROR(child->prepare_ann_range_search());
+    }
+    return Status::OK();
+}
+
+bool VExpr::has_been_executed() {
+    return _has_been_executed;
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -431,6 +431,13 @@ void VExprContext::_reset_memory_usage(const VExprContextSPtrs& contexts) {
                   [](auto&& context) { context->_memory_usage = 0; });
 }
 
+Status VExprContext::prepare_ann_range_search() {
+    if (_root == nullptr) {
+        return Status::OK();
+    }
+    return _root->prepare_ann_range_search();
+}
+
 #include "common/compile_check_end.h"
 
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -279,6 +279,8 @@ public:
 
     [[nodiscard]] size_t get_memory_usage() const { return _memory_usage; }
 
+    Status prepare_ann_range_search();
+
 private:
     // Close method is called in vexpr context dector, not need call expicility
     void close();

--- a/be/src/vec/exprs/virtual_slot_ref.cpp
+++ b/be/src/vec/exprs/virtual_slot_ref.cpp
@@ -1,0 +1,240 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exprs/virtual_slot_ref.h"
+
+#include <gen_cpp/Exprs_types.h>
+#include <glog/logging.h>
+#include <thrift/protocol/TDebugProtocol.h>
+
+#include <ostream>
+#include <vector>
+
+#include "common/exception.h"
+#include "common/logging.h"
+#include "common/status.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nothing.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/exprs/vectorized_fn_call.h"
+#include "vec/exprs/vexpr_context.h"
+
+namespace doris::vectorized {
+
+VirtualSlotRef::VirtualSlotRef(const doris::TExprNode& node)
+        : VExpr(node),
+          _column_id(-1),
+          _slot_id(node.slot_ref.slot_id),
+          _column_name(nullptr),
+          _column_label(node.label) {}
+
+VirtualSlotRef::VirtualSlotRef(const SlotDescriptor* desc)
+        : VExpr(desc->type(), true, desc->is_nullable()),
+          _column_id(-1),
+          _slot_id(desc->id()),
+          _column_name(nullptr) {}
+
+Status VirtualSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor& desc,
+                               VExprContext* context) {
+    RETURN_IF_ERROR_OR_PREPARED(VExpr::prepare(state, desc, context));
+    DCHECK_EQ(_children.size(), 0);
+    if (_slot_id == -1) {
+        _prepare_finished = true;
+        return Status::OK();
+    }
+
+    const SlotDescriptor* slot_desc = state->desc_tbl().get_slot_descriptor(_slot_id);
+    if (slot_desc == nullptr) {
+        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                "couldn't resolve slot descriptor {}, desc: {}", _slot_id,
+                state->desc_tbl().debug_string());
+    }
+
+    if (slot_desc->get_virtual_column_expr() == nullptr) {
+        return Status::InternalError(
+                "VirtualSlotRef {} has no virtual column expr, slot_id: {}, desc: {}, "
+                "slot_desc: {}, desc_tbl: {}",
+                *_column_name, _slot_id, desc.debug_string(), slot_desc->debug_string(),
+                state->desc_tbl().debug_string());
+    }
+
+    _column_name = &slot_desc->col_name();
+    _column_data_type = slot_desc->get_data_type_ptr();
+    DCHECK(_column_data_type != nullptr);
+    if (!context->force_materialize_slot() && !slot_desc->is_materialized()) {
+        // slot should be ignored manually
+        _column_id = -1;
+        _prepare_finished = true;
+        return Status::OK();
+    }
+
+    _column_id = desc.get_column_id(_slot_id, context->force_materialize_slot());
+    if (_column_id < 0) {
+        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                "VirtualSlotRef {} has invalid slot id: {}, desc: {}, slot_desc: {}, desc_tbl: {}",
+                *_column_name, _slot_id, desc.debug_string(), slot_desc->debug_string(),
+                state->desc_tbl().debug_string());
+    }
+    const TExpr& expr = *slot_desc->get_virtual_column_expr();
+    LOG_INFO("Virtual column expr is {}", apache::thrift::ThriftDebugString(expr));
+    RETURN_IF_ERROR(VExpr::create_expr_tree(expr, _virtual_column_expr));
+    RETURN_IF_ERROR(_virtual_column_expr->prepare(state, desc));
+
+    _prepare_finished = true;
+    return Status::OK();
+}
+
+Status VirtualSlotRef::open(RuntimeState* state, VExprContext* context,
+                            FunctionContext::FunctionStateScope scope) {
+    DCHECK(_prepare_finished);
+    RETURN_IF_ERROR(_virtual_column_expr->open(state));
+    RETURN_IF_ERROR(VExpr::open(state, context, scope));
+    _open_finished = true;
+    return Status::OK();
+}
+
+Status VirtualSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
+    if (_column_id >= 0 && _column_id >= block->columns()) {
+        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                "input block not contain slot column {}, column_id={}, block={}", *_column_name,
+                _column_id, block->dump_structure());
+    }
+
+    ColumnWithTypeAndName col_type_name = block->get_by_position(_column_id);
+
+    if (!col_type_name.column) {
+        // Maybe we need to create a column in this situation.
+        return Status::InternalError(
+                "VirtualSlotRef column is null, column_id: {}, column_name: {}", _column_id,
+                *_column_name);
+    }
+
+    const vectorized::ColumnNothing* col_nothing =
+            check_and_get_column<ColumnNothing>(col_type_name.column.get());
+
+    if (this->_virtual_column_expr != nullptr) {
+        if (col_nothing != nullptr) {
+            LOG_INFO("Virtual slot {} is not materialized, going to materialize it", _slot_id);
+            // Virtual column is not materialized, so we need to materialize it.
+            // 注意，在执行 execute 之后，后续代码里不能在用 120 行的 column 了，因为 execute 的时候 vector 可能发生
+            // resize，导致之前的引用实效。
+            int tmp_column_id = -1;
+            RETURN_IF_ERROR(_virtual_column_expr->execute(block, &tmp_column_id));
+
+            // Maybe do clone.
+            block->replace_by_position(_column_id,
+                                       std::move(block->get_by_position(tmp_column_id).column));
+            auto tmp_column = block->get_by_position(_column_id).column;
+            LOG_INFO(
+                    "Materialization of virtual column finished, slot_id {}, column_id {}, "
+                    "tmp_column_id {}, "
+                    "column_name {}, column size {}",
+                    _slot_id, _column_id, tmp_column_id, *_column_name, tmp_column->size());
+        }
+
+#ifndef NDEBUG
+        // get_by_position again since vector in block may be resized
+        col_type_name = block->get_by_position(_column_id);
+        DCHECK(col_type_name.type != nullptr);
+        if (!_column_data_type->equals(*col_type_name.type)) {
+            throw doris::Exception(doris::ErrorCode::FATAL_ERROR,
+                                   "Virtual column type not match, column_id: {}, "
+                                   "column_name: {}, column_type: {}, virtual_column_type: {}",
+                                   _column_id, *_column_name, col_type_name.type->get_name(),
+                                   _column_data_type->get_name());
+        }
+#endif
+    } else {
+        // This is a virtual slot ref that not pushed to segment_iterator
+        if (col_nothing == nullptr) {
+            return Status::InternalError("Logical error, virtual column can not be materialized");
+        } else {
+            return Status::OK();
+        }
+    }
+
+    *result_column_id = _column_id;
+    LOG_INFO("VirtualSlotRef execute, slot_id {}, column_id {}, column_name {}", _slot_id,
+             _column_id, *_column_name);
+    return Status::OK();
+}
+
+const std::string& VirtualSlotRef::expr_name() const {
+    return *_column_name;
+}
+std::string VirtualSlotRef::expr_label() {
+    return _column_label;
+}
+
+std::string VirtualSlotRef::debug_string() const {
+    std::stringstream out;
+    out << "VirtualSlotRef(slot_id=" << _slot_id << VExpr::debug_string() << ")";
+    return out.str();
+}
+
+bool VirtualSlotRef::equals(const VExpr& other) {
+    if (!VExpr::equals(other)) {
+        return false;
+    }
+    const auto* other_ptr = dynamic_cast<const VirtualSlotRef*>(&other);
+    if (!other_ptr) {
+        return false;
+    }
+    if (this->_slot_id != other_ptr->_slot_id || this->_column_id != other_ptr->_column_id ||
+        this->_column_name != other_ptr->_column_name ||
+        this->_column_label != other_ptr->_column_label) {
+        return false;
+    }
+    return true;
+}
+
+// void VirtualSlotRef::prepare_virtual_slots(
+//         const std::map<SlotId, vectorized::VExprContextSPtr>& _slot_id_to_virtual_column_expr) {
+//     DCHECK(_children.empty());
+
+//     if (_slot_id_to_virtual_column_expr.find(_slot_id) != _slot_id_to_virtual_column_expr.end()) {
+//         _virtual_column_expr = _slot_id_to_virtual_column_expr.at(_slot_id);
+//     } else {
+//         // TODO: FIX debug_string 函数有core dump 的可能
+//         std::string msg;
+//         for (auto& it : _slot_id_to_virtual_column_expr) {
+//             msg += fmt::format("slot_id: {}, virtual_column_expr: {}, ", it.first,
+//                                it.second->root()->debug_string());
+//         }
+//         throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR,
+//                                "VirtualSlotRef {} has no virtual column expr, slot_id: {}, "
+//                                "slot_id_to_virtual_column_expr: {}",
+//                                *_column_name, _slot_id, msg);
+//     }
+// }
+
+Status VirtualSlotRef::evaluate_ann_range_search(
+        const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
+        const std::vector<ColumnId>& idx_to_cid,
+        const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
+        roaring::Roaring& row_bitmap) {
+    if (_virtual_column_expr != nullptr) {
+        return _virtual_column_expr->root()->evaluate_ann_range_search(
+                cid_to_index_iterators, idx_to_cid, column_iterators, row_bitmap);
+    }
+    return Status::OK();
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/exprs/virtual_slot_ref.h
+++ b/be/src/vec/exprs/virtual_slot_ref.h
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+#include <cstdint>
+
+#include "vec/exprs/vexpr.h"
+
+namespace doris::vectorized {
+
+class VirtualSlotRef MOCK_REMOVE(final) : public VExpr {
+    ENABLE_FACTORY_CREATOR(VirtualSlotRef);
+
+public:
+    VirtualSlotRef(const TExprNode& node);
+    VirtualSlotRef(const SlotDescriptor* desc);
+
+    Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
+    Status open(RuntimeState* state, VExprContext* context,
+                FunctionContext::FunctionStateScope scope) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    const std::string& expr_name() const override;
+    std::string expr_label() override;
+    std::string debug_string() const override;
+    bool is_constant() const override { return false; }
+    int column_id() const { return _column_id; }
+    int slot_id() const { return _slot_id; }
+    bool equals(const VExpr& other) override;
+    size_t estimate_memory(const size_t rows) override { return 0; }
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        column_ids.insert(_column_id);
+    }
+    std::shared_ptr<VExprContext> get_virtual_column_expr() const { return _virtual_column_expr; }
+    // void prepare_virtual_slots(const std::map<SlotId, vectorized::VExprContextSPtr>&
+    //                                    _slot_id_to_virtual_column_expr) override;
+
+    /*
+    select * from tbl where distance_function(columnA, ArrayLiterat) > 100
+    1. should not happen.
+    VirtualSlotRef
+    |
+    BINARY_PRED
+    |---------------------------------------|
+    |                                       |
+    FUNCTION_CALL(l2_distance)              IntLiteral
+    |
+    |-----------------------|
+    |                       |
+    SlotRef                 ArrayLiteral
+
+    2.
+    select distance_function(columnA, ArrayLiterat) as dis from tbl where dis > 100
+    BINARY_PRED
+    |
+    |---------------------------------------|
+    |                                       |
+    VIRTUAL_SLOT_REF                        IntLiteral
+    |
+    FUNCTION_CALL(l2_distance)
+    |
+    |-----------------------|
+    |                       |
+    SlotRef                 ArrayLiteral
+    */
+    Status evaluate_ann_range_search(
+            const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
+            const std::vector<ColumnId>& idx_to_cid,
+            const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
+            roaring::Roaring& row_bitmap) override;
+
+#ifdef BE_TEST
+    void set_column_id(int column_id) { _column_id = column_id; }
+    void set_slot_id(int slot_id) { _slot_id = slot_id; }
+    void set_column_name(const std::string* column_name) { _column_name = column_name; }
+    void set_column_data_type(DataTypePtr column_data_type) {
+        _column_data_type = std::move(column_data_type);
+    }
+    void set_virtual_column_expr(std::shared_ptr<VExprContext> virtual_column_expr) {
+        _virtual_column_expr = virtual_column_expr;
+    }
+#endif
+
+private:
+    int _column_id;
+    int _slot_id;
+    const std::string* _column_name;
+    const std::string _column_label;
+    std::shared_ptr<VExprContext> _virtual_column_expr;
+    DataTypePtr _column_data_type;
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -38,17 +38,10 @@ class VExprContext;
 namespace doris::vectorized {
 
 VSlotRef::VSlotRef(const doris::TExprNode& node)
-        : VExpr(node),
-          _slot_id(node.slot_ref.slot_id),
-          _column_id(-1),
-          _column_name(nullptr),
-          _column_label(node.label) {}
+        : VExpr(node), _slot_id(node.slot_ref.slot_id), _column_id(-1), _column_label(node.label) {}
 
 VSlotRef::VSlotRef(const SlotDescriptor* desc)
-        : VExpr(desc->type(), true, desc->is_nullable()),
-          _slot_id(desc->id()),
-          _column_id(-1),
-          _column_name(nullptr) {}
+        : VExpr(desc->type(), true, desc->is_nullable()), _slot_id(desc->id()), _column_id(-1) {}
 
 Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor& desc,
                          VExprContext* context) {
@@ -64,7 +57,7 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
                 "couldn't resolve slot descriptor {}, desc: {}", _slot_id,
                 state->desc_tbl().debug_string());
     }
-    _column_name = &slot_desc->col_name();
+    _column_name = slot_desc->col_name();
     if (!context->force_materialize_slot() && !slot_desc->is_materialized()) {
         // slot should be ignored manually
         _column_id = -1;
@@ -75,7 +68,7 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
     if (_column_id < 0) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "VSlotRef {} have invalid slot id: {}, desc: {}, slot_desc: {}, desc_tbl: {}",
-                *_column_name, _slot_id, desc.debug_string(), slot_desc->debug_string(),
+                _column_name, _slot_id, desc.debug_string(), slot_desc->debug_string(),
                 state->desc_tbl().debug_string());
     }
     _prepare_finished = true;
@@ -93,7 +86,7 @@ Status VSlotRef::open(RuntimeState* state, VExprContext* context,
 Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
-                "input block not contain slot column {}, column_id={}, block={}", *_column_name,
+                "input block not contain slot column {}, column_id={}, block={}", _column_name,
                 _column_id, block->dump_structure());
     }
     *result_column_id = _column_id;
@@ -101,16 +94,15 @@ Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column
 }
 
 const std::string& VSlotRef::expr_name() const {
-    return *_column_name;
+    return this->_expr_name;
 }
 std::string VSlotRef::expr_label() {
     return _column_label;
 }
 
 std::string VSlotRef::debug_string() const {
-    std::stringstream out;
-    out << "SlotRef(slot_id=" << _slot_id << VExpr::debug_string() << ")";
-    return out.str();
+    std::string out = fmt::format("VSlotRef(slot_id={}, column_id={})", _slot_id, _column_id);
+    return out;
 }
 
 bool VSlotRef::equals(const VExpr& other) {
@@ -122,7 +114,6 @@ bool VSlotRef::equals(const VExpr& other) {
         return false;
     }
     if (this->_slot_id != other_ptr->_slot_id || this->_column_id != other_ptr->_column_id ||
-        this->_column_name != other_ptr->_column_name ||
         this->_column_label != other_ptr->_column_label) {
         return false;
     }

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -40,6 +40,8 @@ public:
     VSlotRef(const SlotDescriptor* desc);
 #ifdef BE_TEST
     VSlotRef() = default;
+    void set_column_id(int column_id) { _column_id = column_id; }
+    void set_slot_id(int slot_id) { _slot_id = slot_id; }
 #endif
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
@@ -66,8 +68,9 @@ public:
 private:
     int _slot_id;
     int _column_id;
-    const std::string* _column_name = nullptr;
     const std::string _column_label;
+    const std::string _expr_name = "SlotRef";
+    std::string _column_name;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -40,10 +40,6 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_nullable.h"
 
-namespace doris::segment_v2 {
-struct FuncExprParams;
-} // namespace doris::segment_v2
-
 namespace doris::vectorized {
 
 struct FunctionAttr {

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -142,7 +142,7 @@ Status BlockReader::_init_collect_iter(const ReaderParams& read_params) {
             }
         }
     }
-
+    // read_params.vir_cid_to_idx_in_block
     {
         SCOPED_RAW_TIMER(&_stats.block_reader_build_heap_init_timer_ns);
         RETURN_IF_ERROR(_vcollect_iter.build_heap(valid_rs_readers));
@@ -202,9 +202,12 @@ Status BlockReader::init(const ReaderParams& read_params) {
     RETURN_IF_ERROR(TabletReader::init(read_params));
 
     int32_t return_column_size = read_params.origin_return_columns->size();
+    // _return_columns_loc is a mapping.
+    // 记录了 _return_columns 中的每个 cid 在 _origin_return_columns 中的位置
     _return_columns_loc.resize(read_params.return_columns.size());
     for (int i = 0; i < return_column_size; ++i) {
         auto cid = read_params.origin_return_columns->at(i);
+        // For each original cid, find the index in return_columns
         for (int j = 0; j < read_params.return_columns.size(); ++j) {
             if (read_params.return_columns[j] == cid) {
                 if (j < _tablet->num_key_columns() || _tablet->keys_type() != AGG_KEYS) {
@@ -217,7 +220,10 @@ Status BlockReader::init(const ReaderParams& read_params) {
             }
         }
     }
-
+    /*
+    where abs()
+    */
+    LOG_INFO("Direct_mode: {}, key type: {}", _direct_mode, tablet()->keys_type());
     auto status = _init_collect_iter(read_params);
     if (!status.ok()) [[unlikely]] {
         if (!config::is_cloud_mode()) {
@@ -232,6 +238,7 @@ Status BlockReader::init(const ReaderParams& read_params) {
     }
 
     switch (tablet()->keys_type()) {
+        // What is the difference between direct_mode and DUP_KEYS?
     case KeysType::DUP_KEYS:
         _next_block_func = &BlockReader::_direct_next_block;
         break;
@@ -291,7 +298,13 @@ Status BlockReader::_agg_key_next_block(Block* block, bool* eof) {
     RETURN_IF_ERROR(_insert_data_normal(target_columns));
     target_block_row++;
     _append_agg_data(target_columns);
+    /*
+    colK, cloA
+    select colA from tbl where abs(colA) > 10;
 
+    block: colA
+
+    */
     while (true) {
         auto res = _vcollect_iter.next(&_next_row);
         if (UNLIKELY(res.is<END_OF_FILE>())) {

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -95,7 +95,8 @@ private:
     std::vector<AggregateFunctionPtr> _agg_functions;
     std::vector<AggregateDataPtr> _agg_places;
 
-    std::vector<int> _normal_columns_idx; // key column on agg mode, all column on uniq mode
+    // key column on agg mode, all column on uniq mode
+    std::vector<int> _normal_columns_idx;
     std::vector<int> _agg_columns_idx;
     std::vector<int> _return_columns_loc;
 

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -144,19 +144,19 @@ Status VerticalBlockReader::_init_collect_iter(const ReaderParams& read_params,
             seq_col_idx = read_params.tablet->tablet_schema()->sequence_col_idx();
         }
         if (read_params.tablet->tablet_schema()->num_key_columns() == 0) {
-            _vcollect_iter = new_vertical_fifo_merge_iterator(
+            _rowwise_iter = new_vertical_fifo_merge_iterator(
                     std::move(*segment_iters_ptr), iterator_init_flag, rowset_ids,
                     ori_return_col_size, read_params.tablet->keys_type(), seq_col_idx,
                     _row_sources_buffer);
         } else {
-            _vcollect_iter = new_vertical_heap_merge_iterator(
+            _rowwise_iter = new_vertical_heap_merge_iterator(
                     std::move(*segment_iters_ptr), iterator_init_flag, rowset_ids,
                     ori_return_col_size, read_params.tablet->keys_type(), seq_col_idx,
                     _row_sources_buffer, read_params.key_group_cluster_key_idxes);
         }
     } else {
-        _vcollect_iter = new_vertical_mask_merge_iterator(std::move(*segment_iters_ptr),
-                                                          ori_return_col_size, _row_sources_buffer);
+        _rowwise_iter = new_vertical_mask_merge_iterator(std::move(*segment_iters_ptr),
+                                                         ori_return_col_size, _row_sources_buffer);
     }
     // init collect iterator
     StorageReadOptions opts;
@@ -164,11 +164,11 @@ Status VerticalBlockReader::_init_collect_iter(const ReaderParams& read_params,
     if (read_params.batch_size > 0) {
         opts.block_row_max = read_params.batch_size;
     }
-    RETURN_IF_ERROR(_vcollect_iter->init(opts, sample_info));
+    RETURN_IF_ERROR(_rowwise_iter->init(opts, sample_info));
 
     // In agg keys value columns compact, get first row for _init_agg_state
     if (!read_params.is_key_column_group && read_params.tablet->keys_type() == KeysType::AGG_KEYS) {
-        auto st = _vcollect_iter->next_row(&_next_row);
+        auto st = _rowwise_iter->next_row(&_next_row);
         if (!st.ok() && !st.is<END_OF_FILE>()) {
             LOG(WARNING) << "failed to init first row for agg key";
             return st;
@@ -261,14 +261,14 @@ Status VerticalBlockReader::init(const ReaderParams& read_params,
 }
 
 Status VerticalBlockReader::_direct_next_block(Block* block, bool* eof) {
-    auto res = _vcollect_iter->next_batch(block);
+    auto res = _rowwise_iter->next_batch(block);
     if (UNLIKELY(!res.ok() && !res.is<END_OF_FILE>())) {
         return res;
     }
     *eof = (res.is<END_OF_FILE>());
     _eof = *eof;
     if (_reader_context.is_key_column_group && UNLIKELY(_reader_context.record_rowids)) {
-        res = _vcollect_iter->current_block_row_locations(&_block_row_locations);
+        res = _rowwise_iter->current_block_row_locations(&_block_row_locations);
         if (UNLIKELY(!res.ok() && res != Status::Error<END_OF_FILE>(""))) {
             return res;
         }
@@ -375,7 +375,7 @@ size_t VerticalBlockReader::_copy_agg_data() {
 Status VerticalBlockReader::_agg_key_next_block(Block* block, bool* eof) {
     if (_reader_context.is_key_column_group) {
         // collect_iter will filter agg keys
-        auto res = _vcollect_iter->next_batch(block);
+        auto res = _rowwise_iter->next_batch(block);
         if (UNLIKELY(!res.ok() && !res.is<END_OF_FILE>())) {
             return res;
         }
@@ -396,7 +396,7 @@ Status VerticalBlockReader::_agg_key_next_block(Block* block, bool* eof) {
     target_block_row++;
 
     do {
-        Status res = _vcollect_iter->next_row(&_next_row);
+        Status res = _rowwise_iter->next_row(&_next_row);
         if (UNLIKELY(!res.ok())) {
             if (UNLIKELY(res.is<END_OF_FILE>())) {
                 *eof = true;
@@ -436,15 +436,15 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
                     << ", buffer size: " << _row_sources_buffer->buffered_size();
         uint64_t row_source_idx = _row_sources_buffer->buffered_size();
         uint64_t row_buffer_size_start = row_source_idx;
-        uint64_t merged_rows_start = _vcollect_iter->merged_rows();
+        uint64_t merged_rows_start = _rowwise_iter->merged_rows();
         uint64_t filtered_rows_start = _stats.rows_del_filtered;
 
-        auto res = _vcollect_iter->next_batch(block);
+        auto res = _rowwise_iter->next_batch(block);
         if (UNLIKELY(!res.ok() && !res.is<END_OF_FILE>())) {
             return res;
         }
         if (UNLIKELY(_reader_context.record_rowids)) {
-            auto ret = _vcollect_iter->current_block_row_locations(&_block_row_locations);
+            auto ret = _rowwise_iter->current_block_row_locations(&_block_row_locations);
             if (UNLIKELY(!ret.ok() && !ret.is<END_OF_FILE>())) {
                 return res;
             }
@@ -529,7 +529,7 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
         }
         filtered_rows_in_rs_buffer -= merged_rows_in_rs_buffer;
 
-        auto merged_rows_cur_batch = _vcollect_iter->merged_rows() - merged_rows_start;
+        auto merged_rows_cur_batch = _rowwise_iter->merged_rows() - merged_rows_start;
         auto filtered_rows_cur_batch = _stats.rows_del_filtered - filtered_rows_start;
 
         DCHECK_EQ(merged_rows_in_rs_buffer, merged_rows_cur_batch);
@@ -542,7 +542,7 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
     auto target_columns = block->mutate_columns();
     size_t column_count = block->columns();
     do {
-        Status res = _vcollect_iter->unique_key_next_row(&_next_row);
+        Status res = _rowwise_iter->unique_key_next_row(&_next_row);
         if (UNLIKELY(!res.ok())) {
             if (UNLIKELY(res.is<END_OF_FILE>())) {
                 *eof = true;

--- a/be/src/vec/olap/vertical_block_reader.h
+++ b/be/src/vec/olap/vertical_block_reader.h
@@ -61,8 +61,8 @@ public:
     Status next_block_with_aggregation(Block* block, bool* eof) override;
 
     uint64_t merged_rows() const override {
-        DCHECK(_vcollect_iter);
-        return _vcollect_iter->merged_rows();
+        DCHECK(_rowwise_iter);
+        return _rowwise_iter->merged_rows();
     }
 
     std::vector<RowLocation> current_block_row_locations() { return _block_row_locations; }
@@ -95,7 +95,7 @@ private:
 
 private:
     size_t _id;
-    std::shared_ptr<RowwiseIterator> _vcollect_iter;
+    std::shared_ptr<RowwiseIterator> _rowwise_iter;
     IteratorRowRef _next_row {{}, -1, false};
 
     bool _eof = false;

--- a/be/src/vec/utils/util.hpp
+++ b/be/src/vec/utils/util.hpp
@@ -230,6 +230,33 @@ inline size_t calculate_false_number(ColumnPtr column) {
     }
 }
 
+template <typename T>
+T read_from_json(const std::string& json_str) {
+    auto memBufferIn = std::make_shared<apache::thrift::transport::TMemoryBuffer>(
+            reinterpret_cast<uint8_t*>(const_cast<char*>(json_str.data())),
+            static_cast<uint32_t>(json_str.size()));
+    auto jsonProtocolIn = std::make_shared<apache::thrift::protocol::TJSONProtocol>(memBufferIn);
+    T params;
+    params.read(jsonProtocolIn.get());
+    return params;
+}
+
+template <typename T>
+void write_to_json(const std::string& path, std::string name, const T& expr) {
+    auto memBuffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+    auto jsonProtocol = std::make_shared<apache::thrift::protocol::TJSONProtocol>(memBuffer);
+
+    expr.write(jsonProtocol.get());
+    uint8_t* buf;
+    uint32_t size;
+    memBuffer->getBuffer(&buf, &size);
+    std::string file_path = fmt::format("{}/{}.json", path, name);
+    std::ofstream ofs(file_path, std::ios::binary);
+    ofs.write(reinterpret_cast<const char*>(buf), size);
+    ofs.close();
+    std::cout << fmt::format("Serialized JSON written to {}\n", file_path);
+}
+
 } // namespace doris::vectorized
 
 namespace apache::thrift {

--- a/be/src/vector/CMakeLists.txt
+++ b/be/src/vector/CMakeLists.txt
@@ -42,7 +42,3 @@ target_include_directories(vector INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-
-# If you need to install these headers
-# install(FILES ${HEADER_FILES} DESTINATION include/vector)
-

--- a/be/src/vector/faiss_vector_index.cpp
+++ b/be/src/vector/faiss_vector_index.cpp
@@ -19,14 +19,44 @@
 
 #include <faiss/index_io.h>
 
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 
+#include "CLucene/store/IndexInput.h"
 #include "CLucene/store/IndexOutput.h"
 #include "common/exception.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "faiss/IndexHNSW.h"
 #include "faiss/impl/io.h"
+#include "vector/vector_index.h"
+
+namespace doris::segment_v2 {
+
+std::unique_ptr<faiss::IDSelector> FaissVectorIndex::roaring_to_faiss_selector(
+        const roaring::Roaring& roaring) {
+    std::vector<faiss::idx_t> ids;
+    ids.reserve(roaring.cardinality());
+
+    for (roaring::Roaring::const_iterator it = roaring.begin(); it != roaring.end(); ++it) {
+        ids.push_back(static_cast<faiss::idx_t>(*it));
+    }
+
+    return std::make_unique<faiss::IDSelectorBatch>(ids.size(), ids.data());
+}
+
+void FaissVectorIndex::update_roaring(const faiss::idx_t* labels, const size_t n,
+                                      roaring::Roaring& roaring) {
+    // make sure roaring is empty before adding new elements
+    DCHECK(roaring.cardinality() == 0);
+    for (size_t i = 0; i < n; ++i) {
+        if (labels[i] >= 0) {
+            roaring.add(labels[i]);
+        }
+    }
+}
 
 struct FaissIndexWriter : faiss::IOWriter {
 public:
@@ -55,39 +85,180 @@ public:
     lucene::store::IndexOutput* _output = nullptr;
 };
 
+struct FaissIndexReader : faiss::IOReader {
+public:
+    FaissIndexReader() = default;
+    FaissIndexReader(lucene::store::IndexInput* input) : _input(input) {}
+    ~FaissIndexReader() override {
+        if (_input != nullptr) {
+            _input->close();
+            delete _input;
+        }
+    }
+    size_t operator()(void* ptr, size_t size, size_t nitems) override {
+        size_t bytes = size * nitems;
+        if (bytes > 0) {
+            try {
+                _input->readBytes(reinterpret_cast<uint8_t*>(ptr), bytes);
+            } catch (const std::exception& e) {
+                throw doris::Exception(doris::ErrorCode::IO_ERROR, "Failed to read vector index {}",
+                                       e.what());
+            }
+        }
+        return nitems;
+    };
+
+    lucene::store::IndexInput* _input = nullptr;
+};
+
+/** Add n vectors of dimension d to the index.
+*
+* Vectors are implicitly assigned labels ntotal .. ntotal + n - 1
+* This function slices the input vectors in chunks smaller than
+* blocksize_add and calls add_core.
+* @param n      number of vectors
+* @param x      input matrix, size n * d
+*/
 doris::Status FaissVectorIndex::add(int n, const float* vec) {
     DCHECK(vec != nullptr);
-
+    DCHECK(_index != nullptr);
     _index->add(n, vec);
-
     return doris::Status::OK();
 }
 
 void FaissVectorIndex::set_build_params(const FaissBuildParameter& params) {
+    _dimension = params.d;
     if (params.index_type == FaissBuildParameter::IndexType::BruteForce) {
-        _index = std::make_shared<faiss::IndexFlatL2>(params.d);
+        _index = std::make_unique<faiss::IndexFlatL2>(params.d);
     } else if (params.index_type == FaissBuildParameter::IndexType::HNSW) {
-        _index = std::make_shared<faiss::IndexHNSWFlat>(params.d, params.m);
+        _index = std::make_unique<faiss::IndexHNSWFlat>(params.d, params.m);
     } else {
         throw doris::Exception(doris::ErrorCode::INVALID_ARGUMENT, "Unsupported index type: {}",
                                static_cast<int>(params.index_type));
     }
 }
 
-doris::Status FaissVectorIndex::search(const float* query_vec, int k, SearchResult* result,
-                                       const SearchParameters* params) {
+// TODO: Support batch search
+doris::Status FaissVectorIndex::ann_topn_search(const float* query_vec, int k,
+                                                const IndexSearchParameters& params,
+                                                IndexSearchResult& result) {
+    std::unique_ptr<float[]> distances_ptr = std::make_unique<float[]>(k);
+    float* distances = distances_ptr.get();
+
+    // Initialize labels with -1
+    // Even if there are N vectors in the index, limit N search in faiss could return less than N(eg, HNSW)
+    // so we need to initialize labels with -1 to tell the end of the result ids.
+    std::unique_ptr<std::vector<faiss::idx_t>> labels_ptr =
+            std::make_unique<std::vector<faiss::idx_t>>(k, -1);
+    faiss::idx_t* labels = (*labels_ptr).data();
+
+    if (params.roaring == nullptr) {
+        _index->search(1, query_vec, k, distances, labels);
+    } else {
+        std::unique_ptr<faiss::IDSelector> id_sel = nullptr;
+        id_sel = roaring_to_faiss_selector(*params.roaring);
+        faiss::SearchParametersHNSW param;
+        param.sel = id_sel.get();
+
+        _index->search(1, query_vec, k, distances, labels, &param);
+    }
+
+    result.roaring = std::make_shared<roaring::Roaring>();
+    update_roaring(labels, k, *result.roaring);
+    result.distances = std::move(distances_ptr);
+
+    result.row_ids = std::make_unique<std::vector<uint64_t>>();
+    for (size_t i = 0; i < k; ++i) {
+        if (labels[i] >= 0) {
+            result.row_ids->push_back(labels[i]);
+        }
+    }
+
+    DCHECK(result.row_ids->size() == result.roaring->cardinality())
+            << "Row ids size: " << result.row_ids->size()
+            << ", roaring size: " << result.roaring->cardinality();
     return doris::Status::OK();
 }
 
-doris::Status FaissVectorIndex::save() {
-    lucene::store::IndexOutput* idx_output = _dir->createOutput("faiss.idx");
+doris::Status FaissVectorIndex::range_search(const float* query_vec, const float& radius,
+                                             const IndexSearchParameters& params,
+                                             IndexSearchResult& result) {
+    DCHECK(_index != nullptr);
+    std::unique_ptr<faiss::IDSelector> sel = nullptr;
+    if (params.roaring != nullptr) {
+        sel = roaring_to_faiss_selector(*params.roaring);
+    }
+    faiss::RangeSearchResult native_search_result(1, true);
+    const HNSWSearchParameters* hnsw_params = dynamic_cast<const HNSWSearchParameters*>(&params);
+    if (hnsw_params != nullptr) {
+        faiss::SearchParametersHNSW param;
+        param.efSearch = hnsw_params->ef_search;
+        param.sel = sel ? sel.get() : nullptr;
+        _index->range_search(1, query_vec, radius * radius, &native_search_result, &param);
+    } else {
+        faiss::SearchParameters param;
+        param.sel = sel ? sel.get() : nullptr;
+        _index->range_search(1, query_vec, radius * radius, &native_search_result, &param);
+    }
+
+    size_t begin = native_search_result.lims[0];
+    size_t end = native_search_result.lims[1];
+    auto row_ids = std::make_unique<std::vector<uint64_t>>();
+    row_ids->resize(end - begin);
+    LOG_INFO("Range search result: begin {}, end {}", begin, end);
+    if (params.is_le_or_lt) {
+        std::unique_ptr<float[]> distances_ptr = std::make_unique<float[]>(end - begin);
+        float* distances = distances_ptr.get();
+        auto roaring = std::make_shared<roaring::Roaring>();
+        for (size_t i = begin; i < end; ++i) {
+            (*row_ids)[i] = native_search_result.labels[i];
+            roaring->add(native_search_result.labels[i]);
+            distances[i] = sqrt(native_search_result.distances[i]);
+        }
+
+        result.distances = std::move(distances_ptr);
+        result.row_ids = std::move(row_ids);
+        result.roaring = roaring;
+
+        DCHECK(result.row_ids->size() == result.roaring->cardinality())
+                << "row_ids size: " << result.row_ids->size()
+                << ", roaring size: " << result.roaring->cardinality();
+    } else {
+        // Faiss can only return labels in the range of radius.
+        // If the precidate is not less than, we need to to a convertion.
+        DCHECK(params.roaring != nullptr);
+        if (params.roaring == nullptr) {
+            return doris::Status::InvalidArgument("Row ids should not be null");
+        } else {
+            const roaring::Roaring& origin_row_ids = *params.roaring;
+            std::shared_ptr<roaring::Roaring> roaring = std::make_shared<roaring::Roaring>();
+            for (size_t i = begin; i < end; ++i) {
+                roaring->add(native_search_result.labels[i]);
+            }
+            result.roaring = std::make_shared<roaring::Roaring>();
+            *(result.roaring) = origin_row_ids - *roaring;
+            result.distances = nullptr;
+            result.row_ids = nullptr;
+        }
+    }
+
+    return Status::OK();
+}
+
+doris::Status FaissVectorIndex::save(lucene::store::Directory* dir) {
+    lucene::store::IndexOutput* idx_output = dir->createOutput("faiss.idx");
     auto writer = std::make_unique<FaissIndexWriter>(idx_output);
     faiss::write_index(_index.get(), writer.get());
     VLOG_DEBUG << fmt::format("Faiss index saved to faiss.idx, rows {}", _index->ntotal);
     return doris::Status::OK();
 }
-doris::Status FaissVectorIndex::load(Metric type) {
-    // Load the index from the directory
-    // This is a placeholder for actual implementation
+
+doris::Status FaissVectorIndex::load(lucene::store::Directory* dir) {
+    lucene::store::IndexInput* idx_input = dir->openInput("faiss.idx");
+    auto reader = std::make_unique<FaissIndexReader>(idx_input);
+    faiss::Index* idx = faiss::read_index(reader.get());
+    _index.reset(idx);
     return doris::Status::OK();
 }
+
+} // namespace doris::segment_v2

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -99,7 +99,6 @@ find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 add_executable(doris_be_test ${UT_FILES})
 
-target_link_libraries(doris_be_test ${TEST_LINK_LIBS})
 target_link_libraries(doris_be_test ${TEST_LINK_LIBS} OpenMP::OpenMP_CXX)
 set_target_properties(doris_be_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 

--- a/be/test/olap/vector_search/ann_index_reader_test.cpp
+++ b/be/test/olap/vector_search/ann_index_reader_test.cpp
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/rowset/segment_v2/ann_index_reader.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "vector_search_utils.h"
+
+namespace doris::segment_v2 {
+
+using namespace vec_search_mock;
+class AnnIndexReaderTest : public testing::Test {};
+
+TEST_F(AnnIndexReaderTest, TestLoadIndex) {
+    MockTabletSchema tablet_schema;
+    std::shared_ptr<MockIndexFileReader> index_file_reader =
+            std::make_shared<MockIndexFileReader>();
+    auto ann_index_reader = std::make_unique<AnnIndexReader>(&tablet_schema, index_file_reader);
+
+    EXPECT_TRUE(ann_index_reader->load_index(nullptr).ok());
+}
+
+TEST_F(AnnIndexReaderTest, TestQuery) {
+    MockTabletSchema tablet_schema;
+    std::shared_ptr<MockIndexFileReader> index_file_reader =
+            std::make_shared<MockIndexFileReader>();
+    auto ann_index_reader = std::make_unique<AnnIndexReader>(&tablet_schema, index_file_reader);
+}
+} // namespace doris::segment_v2

--- a/be/test/olap/vector_search/ann_index_smoke_test.cpp
+++ b/be/test/olap/vector_search/ann_index_smoke_test.cpp
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// Add CLucene RAM Directory header
+#include <olap/field.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "faiss_vector_index.h"
+#include "olap/olap_common.h"
+#include "olap/rowset/segment_v2/ann_index_writer.h"
+#include "olap/rowset/segment_v2/index_file_writer.h"
+#include "vector_index.h"
+#include "vector_search_utils.h"
+
+using namespace doris::vec_search_mock;
+
+namespace doris {
+
+class AnnIndexTest : public testing::Test {
+protected:
+    void SetUp() override {
+        // Create a tmp_file_dirs, this will be used by
+        const std::string testDir = "./ut_dir/AnnIndexTest";
+        ASSERT_TRUE(io::global_local_filesystem()->delete_directory(testDir).ok());
+        ASSERT_TRUE(io::global_local_filesystem()->create_directory(testDir).ok());
+        std::vector<StorePath> paths;
+        paths.emplace_back(testDir, 1024);
+        auto tmp_file_dirs = std::make_unique<segment_v2::TmpFileDirs>(paths);
+        ASSERT_TRUE(tmp_file_dirs->init());
+        ExecEnv::GetInstance()->set_tmp_file_dir(std::move(tmp_file_dirs));
+
+        _ram_dir = std::make_shared<segment_v2::DorisRAMFSDirectory>();
+        auto fs = io::global_local_filesystem();
+        _index_file_writer = std::make_unique<MockIndexFileWriter>(fs);
+        _index_meta = std::make_unique<MockTabletIndex>();
+        _tablet_column_array = std::make_unique<MockTabletColumn>();
+        _tablet_column_float = std::make_unique<MockTabletColumn>();
+
+        EXPECT_CALL(*_tablet_column_array, type())
+                .WillRepeatedly(testing::Return(FieldType::OLAP_FIELD_TYPE_ARRAY));
+        EXPECT_CALL(*_tablet_column_array, get_sub_column(0))
+                .WillOnce(testing::ReturnRef(*_tablet_column_float));
+        EXPECT_CALL(*_tablet_column_float, type())
+                .WillOnce(testing::Return(FieldType::OLAP_FIELD_TYPE_FLOAT));
+
+        EXPECT_CALL(*_index_meta, index_type()).WillOnce(testing::Return(IndexType::ANN));
+
+        Field field(*_tablet_column_array);
+
+        EXPECT_CALL(*_index_file_writer, open(_index_meta.get()))
+                .WillOnce(testing::Return(_ram_dir));
+
+        std::map<std::string, std::string> properties = {
+                {segment_v2::AnnIndexColumnWriter::INDEX_TYPE, "hnsw"},
+                {segment_v2::AnnIndexColumnWriter::DIM, "10"},
+                {segment_v2::AnnIndexColumnWriter::MAX_DEGREE, "32"},
+                {segment_v2::AnnIndexColumnWriter::QUANTILIZER, "flat"}};
+
+        EXPECT_CALL(*_index_meta, properties()).WillOnce(testing::ReturnRef(properties));
+
+        EXPECT_TRUE(segment_v2::IndexColumnWriter::create(&field, &_ann_index_col_writer,
+                                                          _index_file_writer.get(),
+                                                          _index_meta.get())
+                            .ok());
+    }
+
+    void TearDown() override {}
+
+    std::unique_ptr<segment_v2::IndexColumnWriter> _ann_index_col_writer;
+    std::shared_ptr<segment_v2::DorisFSDirectory> _ram_dir;
+    std::unique_ptr<MockTabletColumn> _tablet_column_array;
+    std::unique_ptr<MockTabletColumn> _tablet_column_float;
+    std::unique_ptr<MockIndexFileWriter> _index_file_writer;
+    std::unique_ptr<MockTabletIndex> _index_meta;
+};
+
+TEST_F(AnnIndexTest, SmokeTest) {
+    segment_v2::AnnIndexColumnWriter* ann_index_writer =
+            dynamic_cast<segment_v2::AnnIndexColumnWriter*>(_ann_index_col_writer.get());
+    ASSERT_NE(ann_index_writer, nullptr);
+
+    // Add some dummy data
+    /*
+    [0,1,2,3,4,5,6,7,8,9]
+    [10,11,12,13,14,15,16,17,18,19]
+    [20,21,22,23,24,25,26,27,28,29]
+    [30,31,32,33,34,35,36,37,38,39]
+    [40,41,42,43,44,45,46,47,48,49]
+    [50,...]
+    */
+    std::unique_ptr<float[]> data(new float[10 * 10]);
+    for (int i = 0; i < 10 * 10; ++i) {
+        data[i] = static_cast<float>(i);
+    }
+
+    // Create offsets_data
+    std::unique_ptr<size_t[]> offsets_data(new size_t[10]);
+    size_t* offsets = offsets_data.get();
+
+    for (int i = 0; i < 10; ++i) {
+        offsets[i] = i * 10;
+    }
+
+    auto st = ann_index_writer->add_array_values(
+            0, data.get(), nullptr, reinterpret_cast<uint8_t*>(offsets_data.get()), 10);
+    EXPECT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_TRUE(ann_index_writer->finish().ok());
+
+    // Read the index file
+    auto index2 = std::make_unique<segment_v2::FaissVectorIndex>();
+    // Step 6: Load the index
+    auto load_status = index2->load(_ram_dir.get());
+    // [0,1,2,3,4,5,6,7,8,9]
+    std::unique_ptr<float[]> query_vec(new float[10]);
+    for (int i = 0; i < 10; ++i) {
+        query_vec[i] = static_cast<float>(i);
+    }
+
+    segment_v2::IndexSearchParameters params;
+    segment_v2::IndexSearchResult result;
+    ASSERT_TRUE(index2->ann_topn_search(query_vec.get(), 1, params, result));
+    EXPECT_TRUE(result.roaring->cardinality() == 1);
+    EXPECT_TRUE(result.roaring->contains(0));
+
+    std::shared_ptr<segment_v2::IndexFileReader> index_file_reader =
+            std::make_shared<MockIndexFileReader>();
+    //     EXPECT_CALL(*index_file_reader, init(_, _));
+    //     EXPECT_CALL(*index_file_reader, open(_, _))
+    //     auto ann_index_reader =
+    //             std::make_unique<segment_v2::AnnIndexReader>(_index_meta.get(), index_file_reader);
+
+} // namespace doris
+
+} // namespace doris

--- a/be/test/olap/vector_search/ann_range_search_test.cpp
+++ b/be/test/olap/vector_search/ann_range_search_test.cpp
@@ -1,0 +1,1035 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest.h>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include "common/object_pool.h"
+#include "olap/rowset/segment_v2/ann_index_iterator.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/rowset/segment_v2/virtual_column_iterator.h"
+#include "olap/vector_search/vector_search_utils.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nothing.h"
+#include "vec/columns/columns_number.h"
+#include "vec/exprs/vectorized_fn_call.h"
+#include "vec/exprs/vexpr_fwd.h"
+#include "vec/functions/functions_comparison.h"
+
+namespace doris::vectorized {
+/*
+TExpr {
+  01: nodes (list) = list<struct>[3] {
+    [0] = TExprNode {
+      01: node_type (i32) = 2,
+      02: type (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 2,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      03: opcode (i32) = 14,
+      04: num_children (i32) = 2,
+      20: output_scale (i32) = -1,
+      26: fn (struct) = TFunction {
+        01: name (struct) = TFunctionName {
+          02: function_name (string) = "ge",
+        },
+        02: binary_type (i32) = 0,
+        03: arg_types (list) = list<struct>[2] {
+          [0] = TTypeDesc {
+            01: types (list) = list<struct>[1] {
+              [0] = TTypeNode {
+                01: type (i32) = 0,
+                02: scalar_type (struct) = TScalarType {
+                  01: type (i32) = 8,
+                },
+              },
+            },
+            03: byte_size (i64) = -1,
+          },
+          [1] = TTypeDesc {
+            01: types (list) = list<struct>[1] {
+              [0] = TTypeNode {
+                01: type (i32) = 0,
+                02: scalar_type (struct) = TScalarType {
+                  01: type (i32) = 8,
+                },
+              },
+            },
+            03: byte_size (i64) = -1,
+          },
+        },
+        04: ret_type (struct) = TTypeDesc {
+          01: types (list) = list<struct>[1] {
+            [0] = TTypeNode {
+              01: type (i32) = 0,
+              02: scalar_type (struct) = TScalarType {
+                01: type (i32) = 2,
+              },
+            },
+          },
+          03: byte_size (i64) = -1,
+        },
+        05: has_var_args (bool) = false,
+        07: signature (string) = "ge(double, double)",
+        11: id (i64) = 0,
+        13: vectorized (bool) = true,
+        14: is_udtf_function (bool) = false,
+        15: is_static_load (bool) = false,
+        16: expiration_time (i64) = 360,
+      },
+      28: child_type (i32) = 8,
+      29: is_nullable (bool) = true,
+    },
+    [1] = TExprNode {
+      01: node_type (i32) = 16,
+      02: type (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 8,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: num_children (i32) = 0,
+      15: slot_ref (struct) = TSlotRef {
+        01: slot_id (i32) = 3,
+        02: tuple_id (i32) = 0,
+        03: col_unique_id (i32) = -1,
+        04: is_virtual_slot (bool) = true,
+      },
+      20: output_scale (i32) = -1,
+      29: is_nullable (bool) = true,
+      36: label (string) = "dis",
+    },
+    [2] = TExprNode {
+      01: node_type (i32) = 8,
+      02: type (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 8,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: num_children (i32) = 0,
+      09: float_literal (struct) = TFloatLiteral {
+        01: value (double) = 10,
+      },
+      20: output_scale (i32) = -1,
+      29: is_nullable (bool) = false,
+    },
+  },
+}
+*/
+const std::string ann_range_search_thrift =
+        R"xxx({"1":{"lst":["rec",3,{"1":{"i32":2},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":2}}}}]},"3":{"i64":-1}}},"3":{"i32":14},"4":{"i32":2},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"ge"}}},"2":{"i32":0},"3":{"lst":["rec",2,{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}},{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}]},"4":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":2}}}}]},"3":{"i64":-1}}},"5":{"tf":0},"7":{"str":"ge(double, double)"},"11":{"i64":0},"13":{"tf":1},"14":{"tf":0},"15":{"tf":0},"16":{"i64":360}}},"28":{"i32":8},"29":{"tf":1}},{"1":{"i32":16},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"15":{"rec":{"1":{"i32":3},"2":{"i32":0},"3":{"i32":-1},"4":{"tf":1}}},"20":{"i32":-1},"29":{"tf":1},"36":{"str":"dis"}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":10}}},"20":{"i32":-1},"29":{"tf":0}}]}})xxx";
+/*
+TDescriptorTable {
+  01: slotDescriptors (list) = list<struct>[8] {
+    [0] = TSlotDescriptor {
+      01: id (i32) = 0,
+      02: parent (i32) = 0,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 5,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = 0,
+      08: colName (string) = "siteid",
+      09: slotIdx (i32) = 0,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = 0,
+      12: is_key (bool) = true,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      16: col_default_value (string) = "10",
+      17: primitive_type (i32) = 5,
+    },
+    [1] = TSlotDescriptor {
+      01: id (i32) = 1,
+      02: parent (i32) = 0,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[2] {
+          [0] = TTypeNode {
+            01: type (i32) = 1,
+            04: contains_null (bool) = true,
+            05: contains_nulls (list) = list<bool>[1] {
+              [0] = true,
+            },
+          },
+          [1] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 7,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = -1,
+      08: colName (string) = "embedding",
+      09: slotIdx (i32) = 3,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = 1,
+      12: is_key (bool) = false,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      17: primitive_type (i32) = 20,
+    },
+    [2] = TSlotDescriptor {
+      01: id (i32) = 2,
+      02: parent (i32) = 0,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 23,
+              02: len (i32) = 2147483643,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = 0,
+      08: colName (string) = "comment",
+      09: slotIdx (i32) = 2,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = 2,
+      12: is_key (bool) = false,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      17: primitive_type (i32) = 23,
+    },
+    [3] = TSlotDescriptor {
+      01: id (i32) = 3,
+      02: parent (i32) = 0,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 8,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = 0,
+      08: colName (string) = "",
+      09: slotIdx (i32) = 1,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = -1,
+      12: is_key (bool) = false,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      17: primitive_type (i32) = 0,
+      18: virtual_column_expr (struct) = TExpr {
+        01: nodes (list) = list<struct>[12] {
+          [0] = TExprNode {
+            01: node_type (i32) = 20,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 2,
+            20: output_scale (i32) = -1,
+            26: fn (struct) = TFunction {
+              01: name (struct) = TFunctionName {
+                02: function_name (string) = "l2_distance",
+              },
+              02: binary_type (i32) = 0,
+              03: arg_types (list) = list<struct>[2] {
+                [0] = TTypeDesc {
+                  01: types (list) = list<struct>[2] {
+                    [0] = TTypeNode {
+                      01: type (i32) = 1,
+                      04: contains_null (bool) = true,
+                      05: contains_nulls (list) = list<bool>[1] {
+                        [0] = true,
+                      },
+                    },
+                    [1] = TTypeNode {
+                      01: type (i32) = 0,
+                      02: scalar_type (struct) = TScalarType {
+                        01: type (i32) = 8,
+                      },
+                    },
+                  },
+                  03: byte_size (i64) = -1,
+                },
+                [1] = TTypeDesc {
+                  01: types (list) = list<struct>[2] {
+                    [0] = TTypeNode {
+                      01: type (i32) = 1,
+                      04: contains_null (bool) = true,
+                      05: contains_nulls (list) = list<bool>[1] {
+                        [0] = true,
+                      },
+                    },
+                    [1] = TTypeNode {
+                      01: type (i32) = 0,
+                      02: scalar_type (struct) = TScalarType {
+                        01: type (i32) = 8,
+                      },
+                    },
+                  },
+                  03: byte_size (i64) = -1,
+                },
+              },
+              04: ret_type (struct) = TTypeDesc {
+                01: types (list) = list<struct>[1] {
+                  [0] = TTypeNode {
+                    01: type (i32) = 0,
+                    02: scalar_type (struct) = TScalarType {
+                      01: type (i32) = 8,
+                    },
+                  },
+                },
+                03: byte_size (i64) = -1,
+              },
+              05: has_var_args (bool) = false,
+              07: signature (string) = "l2_distance(array<double>, array<double>)",
+              09: scalar_fn (struct) = TScalarFunction {
+                01: symbol (string) = "",
+              },
+              11: id (i64) = 0,
+              13: vectorized (bool) = true,
+              14: is_udtf_function (bool) = false,
+              15: is_static_load (bool) = false,
+              16: expiration_time (i64) = 360,
+            },
+            29: is_nullable (bool) = true,
+          },
+          [1] = TExprNode {
+            01: node_type (i32) = 5,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[2] {
+                [0] = TTypeNode {
+                  01: type (i32) = 1,
+                  04: contains_null (bool) = true,
+                  05: contains_nulls (list) = list<bool>[1] {
+                    [0] = true,
+                  },
+                },
+                [1] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            03: opcode (i32) = 4,
+            04: num_children (i32) = 1,
+            20: output_scale (i32) = -1,
+            26: fn (struct) = TFunction {
+              01: name (struct) = TFunctionName {
+                02: function_name (string) = "casttoarray",
+              },
+              02: binary_type (i32) = 0,
+              03: arg_types (list) = list<struct>[1] {
+                [0] = TTypeDesc {
+                  01: types (list) = list<struct>[2] {
+                    [0] = TTypeNode {
+                      01: type (i32) = 1,
+                      04: contains_null (bool) = true,
+                      05: contains_nulls (list) = list<bool>[1] {
+                        [0] = true,
+                      },
+                    },
+                    [1] = TTypeNode {
+                      01: type (i32) = 0,
+                      02: scalar_type (struct) = TScalarType {
+                        01: type (i32) = 7,
+                      },
+                    },
+                  },
+                  03: byte_size (i64) = -1,
+                },
+              },
+              04: ret_type (struct) = TTypeDesc {
+                01: types (list) = list<struct>[2] {
+                  [0] = TTypeNode {
+                    01: type (i32) = 1,
+                    04: contains_null (bool) = true,
+                    05: contains_nulls (list) = list<bool>[1] {
+                      [0] = true,
+                    },
+                  },
+                  [1] = TTypeNode {
+                    01: type (i32) = 0,
+                    02: scalar_type (struct) = TScalarType {
+                      01: type (i32) = 8,
+                    },
+                  },
+                },
+                03: byte_size (i64) = -1,
+              },
+              05: has_var_args (bool) = false,
+              07: signature (string) = "casttoarray(array<float>)",
+              09: scalar_fn (struct) = TScalarFunction {
+                01: symbol (string) = "",
+              },
+              11: id (i64) = 0,
+              13: vectorized (bool) = true,
+              14: is_udtf_function (bool) = false,
+              15: is_static_load (bool) = false,
+              16: expiration_time (i64) = 360,
+            },
+            29: is_nullable (bool) = false,
+          },
+          [2] = TExprNode {
+            01: node_type (i32) = 16,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[2] {
+                [0] = TTypeNode {
+                  01: type (i32) = 1,
+                  04: contains_null (bool) = true,
+                  05: contains_nulls (list) = list<bool>[1] {
+                    [0] = true,
+                  },
+                },
+                [1] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 7,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            15: slot_ref (struct) = TSlotRef {
+              01: slot_id (i32) = 1,
+              02: tuple_id (i32) = 0,
+              03: col_unique_id (i32) = 1,
+              04: is_virtual_slot (bool) = false,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+            36: label (string) = "embedding",
+          },
+          [3] = TExprNode {
+            01: node_type (i32) = 21,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[2] {
+                [0] = TTypeNode {
+                  01: type (i32) = 1,
+                  04: contains_null (bool) = true,
+                  05: contains_nulls (list) = list<bool>[1] {
+                    [0] = true,
+                  },
+                },
+                [1] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 8,
+            20: output_scale (i32) = -1,
+            28: child_type (i32) = 8,
+            29: is_nullable (bool) = false,
+          },
+          [4] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 1,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [5] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 2,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [6] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 3,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [7] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 4,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [8] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 5,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [9] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 6,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [10] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 7,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+          [11] = TExprNode {
+            01: node_type (i32) = 8,
+            02: type (struct) = TTypeDesc {
+              01: types (list) = list<struct>[1] {
+                [0] = TTypeNode {
+                  01: type (i32) = 0,
+                  02: scalar_type (struct) = TScalarType {
+                    01: type (i32) = 8,
+                  },
+                },
+              },
+              03: byte_size (i64) = -1,
+            },
+            04: num_children (i32) = 0,
+            09: float_literal (struct) = TFloatLiteral {
+              01: value (double) = 20,
+            },
+            20: output_scale (i32) = -1,
+            29: is_nullable (bool) = false,
+          },
+        },
+      },
+    },
+    [4] = TSlotDescriptor {
+      01: id (i32) = 4,
+      02: parent (i32) = 1,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 5,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = 0,
+      08: colName (string) = "siteid",
+      09: slotIdx (i32) = 0,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = 0,
+      12: is_key (bool) = true,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      16: col_default_value (string) = "10",
+      17: primitive_type (i32) = 5,
+    },
+    [5] = TSlotDescriptor {
+      01: id (i32) = 5,
+      02: parent (i32) = 1,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[2] {
+          [0] = TTypeNode {
+            01: type (i32) = 1,
+            04: contains_null (bool) = true,
+            05: contains_nulls (list) = list<bool>[1] {
+              [0] = true,
+            },
+          },
+          [1] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 7,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = -1,
+      08: colName (string) = "embedding",
+      09: slotIdx (i32) = 3,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = 1,
+      12: is_key (bool) = false,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      17: primitive_type (i32) = 20,
+    },
+    [6] = TSlotDescriptor {
+      01: id (i32) = 6,
+      02: parent (i32) = 1,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 23,
+              02: len (i32) = 2147483643,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = 0,
+      08: colName (string) = "comment",
+      09: slotIdx (i32) = 2,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = 2,
+      12: is_key (bool) = false,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      17: primitive_type (i32) = 23,
+    },
+    [7] = TSlotDescriptor {
+      01: id (i32) = 7,
+      02: parent (i32) = 1,
+      03: slotType (struct) = TTypeDesc {
+        01: types (list) = list<struct>[1] {
+          [0] = TTypeNode {
+            01: type (i32) = 0,
+            02: scalar_type (struct) = TScalarType {
+              01: type (i32) = 8,
+            },
+          },
+        },
+        03: byte_size (i64) = -1,
+      },
+      04: columnPos (i32) = -1,
+      05: byteOffset (i32) = -1,
+      06: nullIndicatorByte (i32) = 0,
+      07: nullIndicatorBit (i32) = 0,
+      08: colName (string) = "",
+      09: slotIdx (i32) = 1,
+      10: isMaterialized (bool) = true,
+      11: col_unique_id (i32) = -1,
+      12: is_key (bool) = false,
+      13: need_materialize (bool) = true,
+      14: is_auto_increment (bool) = false,
+      17: primitive_type (i32) = 0,
+    },
+  },
+  02: tupleDescriptors (list) = list<struct>[2] {
+    [0] = TTupleDescriptor {
+      01: id (i32) = 0,
+      02: byteSize (i32) = 0,
+      03: numNullBytes (i32) = 0,
+      04: tableId (i64) = -1273902531,
+    },
+    [1] = TTupleDescriptor {
+      01: id (i32) = 1,
+      02: byteSize (i32) = 0,
+      03: numNullBytes (i32) = 0,
+    },
+  },
+  03: tableDescriptors (list) = list<struct>[1] {
+    [0] = TTableDescriptor {
+      01: id (i64) = 1746777786941,
+      02: tableType (i32) = 1,
+      03: numCols (i32) = 3,
+      04: numClusteringCols (i32) = 0,
+      07: tableName (string) = "vector_table_3",
+      08: dbName (string) = "",
+      11: olapTable (struct) = TOlapTable {
+        01: tableName (string) = "vector_table_3",
+      },
+    },
+  },
+}
+*/
+const std::string thrift_table_desc =
+        R"xxx({"1":{"lst":["rec",8,{"1":{"i32":0},"2":{"i32":0},"3":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":5}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":0},"8":{"str":"siteid"},"9":{"i32":0},"10":{"tf":1},"11":{"i32":0},"12":{"tf":1},"13":{"tf":1},"14":{"tf":0},"16":{"str":"10"},"17":{"i32":5}},{"1":{"i32":1},"2":{"i32":0},"3":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":7}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":-1},"8":{"str":"embedding"},"9":{"i32":3},"10":{"tf":1},"11":{"i32":1},"12":{"tf":0},"13":{"tf":1},"14":{"tf":0},"17":{"i32":20}},{"1":{"i32":2},"2":{"i32":0},"3":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":23},"2":{"i32":2147483643}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":0},"8":{"str":"comment"},"9":{"i32":2},"10":{"tf":1},"11":{"i32":2},"12":{"tf":0},"13":{"tf":1},"14":{"tf":0},"17":{"i32":23}},{"1":{"i32":3},"2":{"i32":0},"3":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":0},"8":{"str":""},"9":{"i32":1},"10":{"tf":1},"11":{"i32":-1},"12":{"tf":0},"13":{"tf":1},"14":{"tf":0},"17":{"i32":0},"18":{"rec":{"1":{"lst":["rec",12,{"1":{"i32":20},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":2},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"l2_distance"}}},"2":{"i32":0},"3":{"lst":["rec",2,{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}},{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}]},"4":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"5":{"tf":0},"7":{"str":"l2_distance(array<double>, array<double>)"},"9":{"rec":{"1":{"str":""}}},"11":{"i64":0},"13":{"tf":1},"14":{"tf":0},"15":{"tf":0},"16":{"i64":360}}},"29":{"tf":1}},{"1":{"i32":5},"2":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"3":{"i32":4},"4":{"i32":1},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"casttoarray"}}},"2":{"i32":0},"3":{"lst":["rec",1,{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":7}}}}]},"3":{"i64":-1}}]},"4":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"5":{"tf":0},"7":{"str":"casttoarray(array<float>)"},"9":{"rec":{"1":{"str":""}}},"11":{"i64":0},"13":{"tf":1},"14":{"tf":0},"15":{"tf":0},"16":{"i64":360}}},"29":{"tf":0}},{"1":{"i32":16},"2":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":7}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"15":{"rec":{"1":{"i32":1},"2":{"i32":0},"3":{"i32":1},"4":{"tf":0}}},"20":{"i32":-1},"29":{"tf":0},"36":{"str":"embedding"}},{"1":{"i32":21},"2":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":8},"20":{"i32":-1},"28":{"i32":8},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":1}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":2}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":3}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":4}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":5}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":6}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":7}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":20}}},"20":{"i32":-1},"29":{"tf":0}}]}}}},{"1":{"i32":4},"2":{"i32":1},"3":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":5}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":0},"8":{"str":"siteid"},"9":{"i32":0},"10":{"tf":1},"11":{"i32":0},"12":{"tf":1},"13":{"tf":1},"14":{"tf":0},"16":{"str":"10"},"17":{"i32":5}},{"1":{"i32":5},"2":{"i32":1},"3":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":7}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":-1},"8":{"str":"embedding"},"9":{"i32":3},"10":{"tf":1},"11":{"i32":1},"12":{"tf":0},"13":{"tf":1},"14":{"tf":0},"17":{"i32":20}},{"1":{"i32":6},"2":{"i32":1},"3":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":23},"2":{"i32":2147483643}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":0},"8":{"str":"comment"},"9":{"i32":2},"10":{"tf":1},"11":{"i32":2},"12":{"tf":0},"13":{"tf":1},"14":{"tf":0},"17":{"i32":23}},{"1":{"i32":7},"2":{"i32":1},"3":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":-1},"5":{"i32":-1},"6":{"i32":0},"7":{"i32":0},"8":{"str":""},"9":{"i32":1},"10":{"tf":1},"11":{"i32":-1},"12":{"tf":0},"13":{"tf":1},"14":{"tf":0},"17":{"i32":0}}]},"2":{"lst":["rec",2,{"1":{"i32":0},"2":{"i32":0},"3":{"i32":0},"4":{"i64":-1273902531}},{"1":{"i32":1},"2":{"i32":0},"3":{"i32":0}}]},"3":{"lst":["rec",1,{"1":{"i64":1746777786941},"2":{"i32":1},"3":{"i32":3},"4":{"i32":0},"7":{"str":"vector_table_3"},"8":{"str":""},"11":{"rec":{"1":{"str":"vector_table_3"}}}}]}})xxx";
+
+TEST_F(VectorSearchTest, TestPrepareAnnRangeSearch) {
+    TExpr texpr = read_from_json<TExpr>(ann_range_search_thrift);
+    // std::cout << "range_search thrift:\n" << apache::thrift::ThriftDebugString(texpr) << std::endl;
+    // TExpr distance_function_call =
+    //         read_from_json<TExpr>(distance_function_call_thrift);
+    TDescriptorTable table1 = read_from_json<TDescriptorTable>(thrift_table_desc);
+    // std::cout << "table thrift:\n" << apache::thrift::ThriftDebugString(table1) << std::endl;
+    std::unique_ptr<doris::ObjectPool> pool = std::make_unique<doris::ObjectPool>();
+    auto desc_tbl = std::make_unique<DescriptorTbl>();
+    DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
+    ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
+    state->set_desc_tbl(desc_tbl_ptr);
+
+    VExprContextSPtr range_search_ctx;
+    ASSERT_TRUE(vectorized::VExpr::create_expr_tree(texpr, range_search_ctx).ok());
+    ASSERT_TRUE(range_search_ctx->prepare(state.get(), row_desc).ok());
+    ASSERT_TRUE(range_search_ctx->open(state.get()).ok());
+    ASSERT_TRUE(range_search_ctx->prepare_ann_range_search().ok());
+    std::shared_ptr<VectorizedFnCall> fn_call =
+            std::dynamic_pointer_cast<VectorizedFnCall>(range_search_ctx->root());
+
+    ASSERT_TRUE(fn_call->_ann_range_search_params.is_ann_range_search == true);
+    ASSERT_EQ(fn_call->_ann_range_search_params.is_le_or_lt, false);
+    ASSERT_EQ(fn_call->_ann_range_search_params.dst_col_idx, 3);
+    ASSERT_EQ(fn_call->_ann_range_search_params.src_col_idx, 1);
+    ASSERT_EQ(fn_call->_ann_range_search_params.radius, 10);
+
+    doris::segment_v2::RangeSearchParams range_search_params =
+            fn_call->_ann_range_search_params.toRangeSearchParams();
+    EXPECT_EQ(range_search_params.radius, 10.0f);
+    std::vector<int> query_array_groud_truth = {1, 2, 3, 4, 5, 6, 7, 20};
+    std::vector<int> query_array_f32;
+    for (int i = 0; i < query_array_groud_truth.size(); ++i) {
+        query_array_f32.push_back(static_cast<int>(range_search_params.query_value[i]));
+    }
+    for (int i = 0; i < query_array_f32.size(); ++i) {
+        EXPECT_EQ(query_array_f32[i], query_array_groud_truth[i]);
+    }
+}
+
+TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch) {
+    TExpr texpr = read_from_json<TExpr>(ann_range_search_thrift);
+    TDescriptorTable table1 = read_from_json<TDescriptorTable>(thrift_table_desc);
+    std::unique_ptr<doris::ObjectPool> pool = std::make_unique<doris::ObjectPool>();
+    auto desc_tbl = std::make_unique<DescriptorTbl>();
+    DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
+    ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
+    state->set_desc_tbl(desc_tbl_ptr);
+
+    VExprContextSPtr range_search_ctx;
+    ASSERT_TRUE(vectorized::VExpr::create_expr_tree(texpr, range_search_ctx).ok());
+    ASSERT_TRUE(range_search_ctx->prepare(state.get(), row_desc).ok());
+    ASSERT_TRUE(range_search_ctx->open(state.get()).ok());
+    ASSERT_TRUE(range_search_ctx->prepare_ann_range_search().ok());
+
+    std::shared_ptr<VectorizedFnCall> fn_call =
+            std::dynamic_pointer_cast<VectorizedFnCall>(range_search_ctx->root());
+
+    ASSERT_TRUE(fn_call->_ann_range_search_params.is_ann_range_search == true);
+    ASSERT_EQ(fn_call->_ann_range_search_params.is_le_or_lt, false);
+    ASSERT_EQ(fn_call->_ann_range_search_params.src_col_idx, 1);
+    ASSERT_EQ(fn_call->_ann_range_search_params.dst_col_idx, 3);
+    ASSERT_EQ(fn_call->_ann_range_search_params.radius, 10);
+
+    std::vector<ColumnId> idx_to_cid;
+    idx_to_cid.resize(4);
+    idx_to_cid[0] = 0;
+    idx_to_cid[1] = 1;
+    idx_to_cid[2] = 2;
+    idx_to_cid[3] = 3;
+    std::vector<std::unique_ptr<segment_v2::IndexIterator>> cid_to_index_iterators;
+    cid_to_index_iterators.resize(4);
+    cid_to_index_iterators[1] = std::make_unique<doris::vec_search_mock::MockAnnIndexIterator>();
+    std::vector<std::unique_ptr<segment_v2::ColumnIterator>> column_iterators;
+    column_iterators.resize(4);
+    column_iterators[3] = std::make_unique<doris::segment_v2::VirtualColumnIterator>();
+
+    roaring::Roaring row_bitmap;
+    doris::vec_search_mock::MockAnnIndexIterator* mock_ann_index_iter =
+            dynamic_cast<doris::vec_search_mock::MockAnnIndexIterator*>(
+                    cid_to_index_iterators[1].get());
+
+    // Explain:
+    // 1. predicate is dist >= 10, so it is not a within range search
+    // 2. return 10 results
+    EXPECT_CALL(*mock_ann_index_iter,
+                range_search(testing::Truly([](const doris::segment_v2::RangeSearchParams& params) {
+                                 return params.is_le_or_lt == false && params.radius == 10.0f;
+                             }),
+                             testing::_, testing::_))
+            .WillOnce(testing::Invoke([](const doris::segment_v2::RangeSearchParams& params,
+                                         const doris::segment_v2::CustomSearchParams& custom_params,
+                                         doris::segment_v2::RangeSearchResult* result) {
+                // size_t num_results = 10;
+                result->roaring = std::make_shared<roaring::Roaring>();
+                result->row_ids = nullptr;
+                result->distance = nullptr;
+                // result->row_ids = std::make_unique<std::vector<uint64_t>>();
+                // for (size_t i = 0; i < num_results; ++i) {
+                //     result->roaring->add(i * 10);
+                //     result->row_ids->push_back(i * 10);
+                // }
+                // result->distance = std::make_unique<float[]>(10);
+                return Status::OK();
+            }));
+
+    ASSERT_TRUE(range_search_ctx->root()
+                        ->evaluate_ann_range_search(cid_to_index_iterators, idx_to_cid,
+                                                    column_iterators, row_bitmap)
+                        .ok());
+
+    doris::segment_v2::VirtualColumnIterator* virtual_column_iter =
+            dynamic_cast<doris::segment_v2::VirtualColumnIterator*>(column_iterators[3].get());
+    vectorized::IColumn::Ptr column = virtual_column_iter->get_materialized_column();
+    const vectorized::ColumnFloat32* float_column =
+            check_and_get_column<const vectorized::ColumnFloat32>(column.get());
+    const vectorized::ColumnNothing* nothing_column =
+            check_and_get_column<const vectorized::ColumnNothing>(column.get());
+    ASSERT_EQ(float_column, nullptr);
+    ASSERT_NE(nothing_column, nullptr);
+    EXPECT_EQ(column->size(), 0);
+
+    const auto& get_row_id_to_idx = virtual_column_iter->get_row_id_to_idx();
+    EXPECT_EQ(get_row_id_to_idx.size(), 0);
+}
+
+TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch2) {
+    // Modify expr from dis >= 10 to dis < 10
+    TExpr texpr = read_from_json<TExpr>(ann_range_search_thrift);
+    TExprNode& opNode = texpr.nodes[0];
+    opNode.opcode = TExprOpcode::LT;
+    opNode.fn.name.function_name = doris::vectorized::NameLess::name;
+    TDescriptorTable table1 = read_from_json<TDescriptorTable>(thrift_table_desc);
+    std::unique_ptr<doris::ObjectPool> pool = std::make_unique<doris::ObjectPool>();
+    auto desc_tbl = std::make_unique<DescriptorTbl>();
+    DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
+    ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
+    state->set_desc_tbl(desc_tbl_ptr);
+
+    VExprContextSPtr range_search_ctx;
+    ASSERT_TRUE(vectorized::VExpr::create_expr_tree(texpr, range_search_ctx).ok());
+    ASSERT_TRUE(range_search_ctx->prepare(state.get(), row_desc).ok());
+    ASSERT_TRUE(range_search_ctx->open(state.get()).ok());
+    ASSERT_TRUE(range_search_ctx->prepare_ann_range_search().ok());
+
+    std::shared_ptr<VectorizedFnCall> fn_call =
+            std::dynamic_pointer_cast<VectorizedFnCall>(range_search_ctx->root());
+
+    ASSERT_TRUE(fn_call->_ann_range_search_params.is_ann_range_search == true);
+    ASSERT_EQ(fn_call->_ann_range_search_params.is_le_or_lt, true);
+    ASSERT_EQ(fn_call->_ann_range_search_params.src_col_idx, 1);
+    ASSERT_EQ(fn_call->_ann_range_search_params.dst_col_idx, 3);
+    ASSERT_EQ(fn_call->_ann_range_search_params.radius, 10);
+
+    std::vector<ColumnId> idx_to_cid;
+    idx_to_cid.resize(4);
+    idx_to_cid[0] = 0;
+    idx_to_cid[1] = 1;
+    idx_to_cid[2] = 2;
+    idx_to_cid[3] = 3;
+    std::vector<std::unique_ptr<segment_v2::IndexIterator>> cid_to_index_iterators;
+    cid_to_index_iterators.resize(4);
+    cid_to_index_iterators[1] = std::make_unique<doris::vec_search_mock::MockAnnIndexIterator>();
+    std::vector<std::unique_ptr<segment_v2::ColumnIterator>> column_iterators;
+    column_iterators.resize(4);
+    column_iterators[3] = std::make_unique<doris::segment_v2::VirtualColumnIterator>();
+
+    roaring::Roaring row_bitmap;
+    doris::vec_search_mock::MockAnnIndexIterator* mock_ann_index_iter =
+            dynamic_cast<doris::vec_search_mock::MockAnnIndexIterator*>(
+                    cid_to_index_iterators[1].get());
+
+    // Explain:
+    // 1. predicate is dist >= 10, so it is not a within range search
+    // 2. return 10 results
+    EXPECT_CALL(*mock_ann_index_iter,
+                range_search(testing::Truly([](const doris::segment_v2::RangeSearchParams& params) {
+                                 return params.is_le_or_lt == true && params.radius == 10.0f;
+                             }),
+                             testing::_, testing::_))
+            .WillOnce(testing::Invoke([](const doris::segment_v2::RangeSearchParams& params,
+                                         const doris::segment_v2::CustomSearchParams& custom_params,
+                                         doris::segment_v2::RangeSearchResult* result) {
+                size_t num_results = 10;
+                result->roaring = std::make_shared<roaring::Roaring>();
+                result->row_ids = std::make_unique<std::vector<uint64_t>>();
+                for (size_t i = 0; i < num_results; ++i) {
+                    result->roaring->add(i * 10);
+                    result->row_ids->push_back(i * 10);
+                }
+                result->distance = std::make_unique<float[]>(10);
+                return Status::OK();
+            }));
+
+    ASSERT_TRUE(range_search_ctx->root()
+                        ->evaluate_ann_range_search(cid_to_index_iterators, idx_to_cid,
+                                                    column_iterators, row_bitmap)
+                        .ok());
+
+    doris::segment_v2::VirtualColumnIterator* virtual_column_iter =
+            dynamic_cast<doris::segment_v2::VirtualColumnIterator*>(column_iterators[3].get());
+
+    vectorized::IColumn::Ptr column = virtual_column_iter->get_materialized_column();
+    const vectorized::ColumnFloat32* float_column =
+            check_and_get_column<const vectorized::ColumnFloat32>(column.get());
+    const vectorized::ColumnNothing* nothing_column =
+            check_and_get_column<const vectorized::ColumnNothing>(column.get());
+    ASSERT_NE(float_column, nullptr);
+    ASSERT_EQ(nothing_column, nullptr);
+    EXPECT_EQ(float_column->size(), 10);
+    EXPECT_EQ(row_bitmap.cardinality(), 10);
+
+    const auto& get_row_id_to_idx = virtual_column_iter->get_row_id_to_idx();
+    EXPECT_EQ(get_row_id_to_idx.size(), 10);
+}
+
+} // namespace doris::vectorized

--- a/be/test/olap/vector_search/ann_topn_descriptor_test.cpp
+++ b/be/test/olap/vector_search/ann_topn_descriptor_test.cpp
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <thrift/protocol/TDebugProtocol.h>
+#include <thrift/protocol/TJSONProtocol.h>
+
+#include <iostream>
+#include <memory>
+
+#include "vec/exprs/vann_topn_predicate.h"
+#include "vec/exprs/virtual_slot_ref.h"
+#include "vector_search_utils.h"
+
+using ::testing::_;
+using ::testing::SetArgPointee;
+using ::testing::Return;
+
+namespace doris::vectorized {
+
+TEST_F(VectorSearchTest, AnnTopNDescriptorConstructor) {
+    int limit = 10;
+    std::shared_ptr<VExprContext> distanc_calcu_fn_call_ctx;
+    ASSERT_TRUE(vectorized::VExpr::create_expr_tree(_distance_function_call_thrift,
+                                                    distanc_calcu_fn_call_ctx)
+                        .ok());
+
+    std::shared_ptr<VExprContext> virtual_slot_expr_ctx;
+    ASSERT_TRUE(vectorized::VExpr::create_expr_tree(_virtual_slot_ref_expr, virtual_slot_expr_ctx)
+                        .ok());
+    std::shared_ptr<VirtualSlotRef> v =
+            std::dynamic_pointer_cast<VirtualSlotRef>(virtual_slot_expr_ctx->root());
+    if (v == nullptr) {
+        LOG(FATAL) << "VAnnTopNDescriptor::SetUp() failed";
+    }
+
+    v->set_virtual_column_expr(distanc_calcu_fn_call_ctx);
+
+    std::shared_ptr<AnnTopNDescriptor> predicate;
+    predicate = AnnTopNDescriptor::create_shared(limit, virtual_slot_expr_ctx);
+    ASSERT_TRUE(predicate != nullptr) << "AnnTopNDescriptor::create_shared() failed";
+}
+
+TEST_F(VectorSearchTest, AnnTopNDescriptorPrepare) {
+    int limit = 10;
+    std::shared_ptr<VExprContext> distanc_calcu_fn_call_ctx;
+    Status st = vectorized::VExpr::create_expr_tree(_distance_function_call_thrift,
+                                                    distanc_calcu_fn_call_ctx);
+
+    std::shared_ptr<VExprContext> virtual_slot_expr_ctx;
+    st = vectorized::VExpr::create_expr_tree(_virtual_slot_ref_expr, virtual_slot_expr_ctx);
+    std::shared_ptr<VirtualSlotRef> v =
+            std::dynamic_pointer_cast<VirtualSlotRef>(virtual_slot_expr_ctx->root());
+    if (v == nullptr) {
+        LOG(FATAL) << "VAnnTopNDescriptor::SetUp() failed";
+    }
+
+    v->set_virtual_column_expr(distanc_calcu_fn_call_ctx);
+    std::shared_ptr<AnnTopNDescriptor> predicate;
+    predicate = AnnTopNDescriptor::create_shared(limit, virtual_slot_expr_ctx);
+    st = predicate->prepare(&_runtime_state, _row_desc);
+    ASSERT_TRUE(st.ok()) << fmt::format("st: {}, expr {}", st.to_string(),
+                                        predicate->get_order_by_expr_ctx()->root()->debug_string());
+
+    std::cout << "predicate: " << predicate->debug_string() << std::endl;
+}
+
+TEST_F(VectorSearchTest, AnnTopNDescriptorEvaluateTopN) {
+    int limit = 10;
+    std::shared_ptr<VExprContext> distanc_calcu_fn_call_ctx;
+    Status st = vectorized::VExpr::create_expr_tree(_distance_function_call_thrift,
+                                                    distanc_calcu_fn_call_ctx);
+
+    std::shared_ptr<VExprContext> virtual_slot_expr_ctx;
+    st = vectorized::VExpr::create_expr_tree(_virtual_slot_ref_expr, virtual_slot_expr_ctx);
+    std::shared_ptr<VirtualSlotRef> v =
+            std::dynamic_pointer_cast<VirtualSlotRef>(virtual_slot_expr_ctx->root());
+    if (v == nullptr) {
+        LOG(FATAL) << "VAnnTopNDescriptor::SetUp() failed";
+    }
+
+    v->set_virtual_column_expr(distanc_calcu_fn_call_ctx);
+    std::shared_ptr<AnnTopNDescriptor> predicate;
+    predicate = AnnTopNDescriptor::create_shared(limit, virtual_slot_expr_ctx);
+    st = predicate->prepare(&_runtime_state, _row_desc);
+    ASSERT_TRUE(st.ok()) << fmt::format("st: {}, expr {}", st.to_string(),
+                                        predicate->get_order_by_expr_ctx()->root()->debug_string());
+
+    std::shared_ptr<std::vector<float>> query_value = std::make_shared<std::vector<float>>(10, 0.0);
+    for (size_t i = 0; i < 10; ++i) {
+        (*query_value)[i] = static_cast<float>(i);
+    }
+
+    EXPECT_CALL(*_ann_index_iterator, read_from_index(testing::_))
+            .Times(1)
+            .WillOnce(testing::Invoke([](const segment_v2::IndexParam& value) {
+                auto* ann_param = std::get<segment_v2::AnnIndexParam*>(value);
+                ann_param->distance = std::make_unique<std::vector<float>>();
+                ann_param->row_ids = std::make_unique<std::vector<uint64_t>>();
+                for (size_t i = 0; i < 10; ++i) {
+                    ann_param->distance->push_back(static_cast<float>(i));
+                    ann_param->row_ids->push_back(i);
+                }
+                return Status::OK();
+            }));
+
+    _result_column = ColumnFloat64::create(0, 0);
+    std::unique_ptr<std::vector<uint64_t>> row_ids = std::make_unique<std::vector<uint64_t>>();
+    // roaring is empry
+    roaring::Roaring roaring;
+    st = predicate->evaluate_vector_ann_search(_ann_index_iterator.get(), roaring, _result_column,
+                                               row_ids);
+    ColumnFloat64* result_column_float = assert_cast<ColumnFloat64*>(_result_column.get());
+    for (size_t i = 0; i < query_value->size(); ++i) {
+        EXPECT_EQ(result_column_float->get_data()[i], (*query_value)[i]);
+    }
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(row_ids->size(), 0);
+    ASSERT_EQ(row_ids->size(), roaring.cardinality());
+}
+
+} // namespace doris::vectorized

--- a/be/test/olap/vector_search/faiss_vector_index_test.cpp
+++ b/be/test/olap/vector_search/faiss_vector_index_test.cpp
@@ -1,0 +1,765 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "faiss_vector_index.h"
+
+#include <faiss/IndexHNSW.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "vector_index.h"
+#include "vector_search_utils.h"
+
+// Generate random vectors for testing
+std::vector<float> generate_random_vector(int dim) {
+    std::vector<float> vector(dim);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<float> dis(-1.0f, 1.0f);
+
+    for (int i = 0; i < dim; i++) {
+        vector[i] = dis(gen);
+    }
+    return vector;
+}
+
+using namespace doris::segment_v2;
+
+namespace doris::vectorized {
+
+// Helper function to create and configure a Doris Faiss index
+static std::unique_ptr<FaissVectorIndex> create_doris_index(
+        int dimension, int m,
+        FaissBuildParameter::IndexType index_type = FaissBuildParameter::IndexType::HNSW,
+        FaissBuildParameter::Quantilizer quantilizer = FaissBuildParameter::Quantilizer::FLAT) {
+    auto index = std::make_unique<FaissVectorIndex>();
+
+    FaissBuildParameter params;
+    params.d = dimension;
+    params.m = m;
+    params.index_type = index_type;
+    params.quantilizer = quantilizer;
+    index->set_build_params(params);
+
+    return index;
+}
+
+// Helper function to create a native Faiss HNSW index
+static std::unique_ptr<faiss::IndexHNSWFlat> create_native_index(int dimension, int m) {
+    return std::make_unique<faiss::IndexHNSWFlat>(dimension, m);
+}
+
+// Helper function to generate a batch of random vectors
+static std::vector<std::vector<float>> generate_test_vectors(int num_vectors, int dimension) {
+    std::vector<std::vector<float>> vectors;
+    vectors.reserve(num_vectors);
+
+    for (int i = 0; i < num_vectors; i++) {
+        vectors.push_back(generate_random_vector(dimension));
+    }
+
+    return vectors;
+}
+
+// Helper function to add vectors to both Doris and native indexes
+static void add_vectors_to_indexes(FaissVectorIndex* doris_index,
+                                   faiss::IndexHNSWFlat* native_index,
+                                   const std::vector<std::vector<float>>& vectors) {
+    for (size_t i = 0; i < vectors.size(); i++) {
+        auto status = doris_index->add(1, vectors[i].data());
+        ASSERT_TRUE(status.ok()) << "Failed to add vector to Doris index: " << status.to_string();
+
+        native_index->add(1, vectors[i].data());
+    }
+}
+
+// Helper function to print search results for comparison
+[[maybe_unused]] static void print_search_results(const IndexSearchResult& doris_results,
+                                                  const std::vector<float>& native_distances,
+                                                  const std::vector<faiss::idx_t>& native_indices,
+                                                  int query_idx) {
+    std::cout << "Query vector index: " << query_idx << std::endl;
+
+    std::cout << "Doris Index Results:" << std::endl;
+    for (int i = 0; i < doris_results.roaring->cardinality(); i++) {
+        std::cout << "ID: " << doris_results.roaring->getIndex(i)
+                  << ", Distance: " << doris_results.distances[i] << std::endl;
+    }
+
+    std::cout << "Native Faiss Results:" << std::endl;
+    for (size_t i = 0; i < native_indices.size(); i++) {
+        if (native_indices[i] == -1) continue;
+        std::cout << "ID: " << native_indices[i] << ", Distance: " << native_distances[i]
+                  << std::endl;
+    }
+}
+
+// Helper function to compare search results between Doris and native Faiss
+static void compare_search_results(const IndexSearchResult& doris_results,
+                                   const std::vector<float>& native_distances,
+                                   const std::vector<faiss::idx_t>& native_indices,
+                                   float epsilon = 1e-5) {
+    EXPECT_EQ(doris_results.roaring->cardinality(),
+              std::count_if(native_indices.begin(), native_indices.end(),
+                            [](faiss::idx_t id) { return id != -1; }));
+
+    for (size_t i = 0; i < native_indices.size(); i++) {
+        if (native_indices[i] == -1) continue;
+
+        EXPECT_TRUE(doris_results.roaring->contains(native_indices[i]))
+                << "ID mismatch at rank " << i;
+        EXPECT_NEAR(doris_results.distances[i], native_distances[i], epsilon)
+                << "Distance mismatch at rank " << i;
+    }
+}
+
+// Test saving and loading an index
+TEST_F(VectorSearchTest, TestSaveAndLoad) {
+    // Step 1: Create first index instance
+    auto index1 = std::make_unique<FaissVectorIndex>();
+
+    // Step 2: Set build parameters
+    FaissBuildParameter params;
+    params.d = 128; // Vector dimension
+    params.m = 16;  // HNSW max connections
+    params.index_type = FaissBuildParameter::IndexType::HNSW;
+    params.quantilizer = FaissBuildParameter::Quantilizer::FLAT;
+    index1->set_build_params(params);
+
+    // Step 3: Add vectors to the index
+    const int num_vectors = 100;
+    std::vector<float> vectors;
+    for (int i = 0; i < num_vectors; i++) {
+        auto tmp = generate_random_vector(params.d);
+        vectors.insert(vectors.end(), tmp.begin(), tmp.end());
+    }
+
+    std::ignore = index1->add(num_vectors, vectors.data());
+
+    // Step 4: Save the index
+    auto save_status = index1->save(_ram_dir.get());
+    ASSERT_TRUE(save_status.ok()) << "Failed to save index: " << save_status.to_string();
+
+    // Step 5: Create a new index instance
+    auto index2 = std::make_unique<FaissVectorIndex>();
+
+    // Step 6: Load the index
+    auto load_status = index2->load(_ram_dir.get());
+    ASSERT_TRUE(load_status.ok()) << "Failed to load index: " << load_status.to_string();
+
+    // Step 7: Verify the loaded index works by searching
+    auto query_vec = generate_random_vector(params.d);
+    const int top_k = 10;
+
+    IndexSearchParameters search_params;
+    IndexSearchResult search_result1;
+    IndexSearchResult search_result2;
+
+    std::ignore = index1->ann_topn_search(query_vec.data(), top_k, search_params, search_result1);
+
+    std::ignore = index2->ann_topn_search(query_vec.data(), top_k, search_params, search_result2);
+
+    // Compare the results
+    EXPECT_EQ(search_result1.roaring->cardinality(), search_result2.roaring->cardinality())
+            << "Row ID cardinality mismatch";
+    for (size_t i = 0; i < search_result1.roaring->cardinality(); ++i) {
+        EXPECT_EQ(search_result1.distances[i], search_result2.distances[i])
+                << "Distance mismatch at index " << i;
+    }
+
+    HNSWSearchParameters hnsw_params;
+    IndexSearchResult range_search_result1;
+    std::ignore = index1->range_search(vectors.data(), 10, hnsw_params, range_search_result1);
+    IndexSearchResult range_search_result2;
+    std::ignore = index2->range_search(vectors.data(), 10, hnsw_params, range_search_result2);
+    EXPECT_EQ(range_search_result1.roaring->cardinality(),
+              range_search_result2.roaring->cardinality())
+            << "Row ID cardinality mismatch";
+    for (size_t i = 0; i < range_search_result1.roaring->cardinality(); ++i) {
+        EXPECT_EQ(range_search_result1.distances[i], range_search_result2.distances[i])
+                << "Distance mismatch at index " << i;
+    }
+}
+
+TEST_F(VectorSearchTest, UpdateRoaring) {
+    // Create a roaring bitmap
+    roaring::Roaring roaring_bitmap;
+    // Create some dummy labels
+    const size_t n = 5;
+    faiss::idx_t labels[n] = {1, 2, 3, 4, 5};
+
+    // Call the update_roaring function
+    FaissVectorIndex::update_roaring(labels, n, roaring_bitmap);
+
+    EXPECT_EQ(roaring_bitmap.cardinality(), n) << "Roaring bitmap size mismatch";
+
+    for (size_t i = 0; i < n; ++i) {
+        EXPECT_EQ(roaring_bitmap.contains(labels[i]), true)
+                << "Label " << labels[i] << " not found";
+    }
+}
+
+TEST_F(VectorSearchTest, CompareResultWithNativeFaiss1) {
+    // Step 1: Create indexes
+    const int dimension = 64;
+    const int max_connections = 16;
+    auto doris_index = create_doris_index(dimension, max_connections);
+    auto native_index = create_native_index(dimension, max_connections);
+
+    // Step 2: Generate vectors and add to indexes
+    const int num_vectors = 200;
+    auto vectors = generate_test_vectors(num_vectors, dimension);
+    add_vectors_to_indexes(doris_index.get(), native_index.get(), vectors);
+
+    // Step 3: Search
+    int query_idx = num_vectors / 2;
+    const float* query_vec = vectors[query_idx].data();
+    const int top_k = 10;
+
+    // Search in Doris index
+    IndexSearchParameters search_params;
+    IndexSearchResult doris_results;
+    auto search_status =
+            doris_index->ann_topn_search(query_vec, top_k, search_params, doris_results);
+    ASSERT_EQ(search_status.ok(), true);
+
+    // Search in native Faiss index
+    std::vector<float> native_distances(top_k);
+    std::vector<faiss::idx_t> native_indices(top_k);
+    native_index->search(1, query_vec, top_k, native_distances.data(), native_indices.data());
+
+    // Step 4: Print and compare results
+    // print_search_results(doris_results, native_distances, native_indices, query_idx);
+    compare_search_results(doris_results, native_distances, native_indices);
+}
+
+TEST_F(VectorSearchTest, CompareResultWithNativeFaiss2) {
+    // Step 1: Create indexes
+    const int dimension = 64;
+    const int max_connections = 16;
+    auto doris_index = create_doris_index(dimension, max_connections);
+    auto native_index = create_native_index(dimension, max_connections);
+
+    // Step 2: Generate vectors and add to indexes
+    const int num_vectors = 500;
+    auto vectors = generate_test_vectors(num_vectors, dimension);
+    add_vectors_to_indexes(doris_index.get(), native_index.get(), vectors);
+
+    // Step 3: Search
+    int query_idx = num_vectors / 2;
+    const float* query_vec = vectors[query_idx].data();
+    const int top_k = num_vectors;
+
+    // Search in Doris index
+    IndexSearchParameters search_params;
+    IndexSearchResult doris_results;
+    auto search_status =
+            doris_index->ann_topn_search(query_vec, top_k, search_params, doris_results);
+    ASSERT_EQ(search_status.ok(), true);
+
+    // Search in native Faiss index
+    std::vector<float> native_distances(top_k, -1);
+    std::vector<faiss::idx_t> native_indices(top_k, -1);
+    native_index->search(1, query_vec, top_k, native_distances.data(), native_indices.data());
+
+    // Step 4: Print and compare results
+    // print_search_results(doris_results, native_distances, native_indices, query_idx);
+    compare_search_results(doris_results, native_distances, native_indices);
+}
+
+TEST_F(VectorSearchTest, SearchAllVectors) {
+    // Step 1: Create and build index
+    auto index1 = std::make_unique<FaissVectorIndex>();
+
+    FaissBuildParameter params;
+    params.d = 64;
+    params.m = 32;
+    params.index_type = FaissBuildParameter::IndexType::HNSW;
+    params.quantilizer = FaissBuildParameter::Quantilizer::FLAT;
+    index1->set_build_params(params);
+
+    // Add 500 vectors
+    const int num_vectors = 500;
+    std::vector<float> vectors;
+    for (int i = 0; i < num_vectors * params.m; i++) {
+        auto vec = generate_random_vector(params.d);
+        vectors.insert(vectors.end(), vec.begin(), vec.end());
+    }
+
+    ASSERT_EQ(index1->add(500, vectors.data()).ok(), true);
+
+    // Save index
+    ASSERT_TRUE(index1->save(_ram_dir.get()).ok());
+
+    // Step 2: Load index
+    auto index2 = std::make_unique<FaissVectorIndex>();
+    ASSERT_TRUE(index2->load(_ram_dir.get()).ok());
+
+    // Step 3: Search all vectors
+    IndexSearchParameters search_params;
+    IndexSearchResult search_result;
+
+    // Search for all vectors - use a vector we know is in the index
+    std::vector<float> query_vec {vectors.begin(),
+                                  vectors.begin() + params.d}; // Use the first vector we added
+    const int top_k = num_vectors;                             // Get all vectors
+
+    ASSERT_EQ(index2->ann_topn_search(query_vec.data(), top_k, search_params, search_result).ok(),
+              true);
+    std::cout << "Search returned " << search_result.roaring->cardinality() << " results\n";
+    // Step 4: Verify we got all vectors back
+    // Note: In practical ANN search with approximate algorithms like HNSW,
+    // we might not get exactly all vectors due to the nature of approximate search.
+    // So we verify we got a reasonable number back.
+    EXPECT_GE(search_result.roaring->cardinality(), num_vectors * 0.60)
+            << "Expected to find at least 60% of all vectors";
+
+    // Also verify the first result is the query vector itself (it should be an exact match)
+    ASSERT_EQ(search_result.roaring->isEmpty(), false) << "Search result should not be empty";
+    size_t first = search_result.roaring->getIndex(0);
+    std::vector<float> first_result_vec(vectors.begin() + first * params.d,
+                                        vectors.begin() + (first + 1) * params.d);
+    std::string query_vec_str = fmt::format("[{}]", fmt::join(query_vec, ","));
+    std::string first_result_vec_str = fmt::format("[{}]", fmt::join(first_result_vec, ","));
+    EXPECT_EQ(first_result_vec, query_vec) << "First result should be the query vector itself";
+}
+
+TEST_F(VectorSearchTest, CompRangeSearch) {
+    size_t iterations = 50;
+    for (size_t i = 0; i < iterations; ++i) {
+        // Random parameters for each test iteration
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        size_t random_d =
+                std::uniform_int_distribution<>(1, 1024)(gen); // Random dimension from 32 to 256
+        size_t random_m =
+                4 << std::uniform_int_distribution<>(1, 4)(gen); // Random M (4, 8, 16, 32, 64)
+        size_t random_n =
+                std::uniform_int_distribution<>(500, 2000)(gen); // Random number of vectors
+        // Step 1: Create and build index
+        auto index1 = std::make_unique<FaissVectorIndex>();
+
+        FaissBuildParameter params;
+        params.d = random_d;
+        params.m = random_m;
+        params.index_type = FaissBuildParameter::IndexType::HNSW;
+        index1->set_build_params(params);
+
+        const int num_vectors = random_n;
+        std::vector<float> vectors;
+        for (int i = 0; i < num_vectors; i++) {
+            auto vec = generate_random_vector(params.d);
+            vectors.insert(vectors.end(), vec.begin(), vec.end());
+        }
+        std::unique_ptr<faiss::Index> native_index =
+                std::make_unique<faiss::IndexHNSWFlat>(params.d, params.m);
+        native_index->add(num_vectors, vectors.data());
+        std::ignore = index1->add(num_vectors, vectors.data());
+
+        std::vector<float> query_vec {vectors.begin(),
+                                      vectors.begin() + params.d}; // Use the first vector we added
+
+        std::vector<std::pair<size_t, float>> distances(num_vectors);
+        for (int i = 0; i < num_vectors; i++) {
+            double sum = 0;
+            for (int j = 0; j < params.d; j++) {
+                accumulate(vectors[i * params.m + j], query_vec[j], sum);
+            }
+            distances[i] = std::make_pair(i, finalize(sum));
+        }
+        std::sort(distances.begin(), distances.end(),
+                  [](const auto& a, const auto& b) { return a.second < b.second; });
+        // Use the median distance as the radius
+        float radius = distances[num_vectors / 2].second;
+
+        HNSWSearchParameters hnsw_params;
+        hnsw_params.ef_search = 16;    // Set efSearch for better accuracy
+        hnsw_params.roaring = nullptr; // No selector for this test
+        IndexSearchResult doris_result;
+        std::ignore = index1->range_search(query_vec.data(), radius, hnsw_params, doris_result);
+
+        faiss::SearchParametersHNSW search_params_native;
+        search_params_native.efSearch = hnsw_params.ef_search;
+        faiss::RangeSearchResult search_result_native(1, true);
+        native_index->range_search(1, query_vec.data(), radius * radius, &search_result_native,
+                                   &search_params_native);
+        std::vector<std::pair<int, float>> native_results;
+        size_t begin = search_result_native.lims[0];
+        size_t end = search_result_native.lims[1];
+        for (size_t i = begin; i < end; i++) {
+            native_results.push_back(
+                    {search_result_native.labels[i], search_result_native.distances[i]});
+        }
+
+        // Make sure result is same
+        ASSERT_NEAR(doris_result.roaring->cardinality(), native_results.size(), 1)
+                << fmt::format("\nd: {}, m: {}, n: {}", random_d, random_m, random_n);
+        ASSERT_EQ(doris_result.distances != nullptr, true);
+        if (doris_result.roaring->cardinality() == native_results.size()) {
+            for (size_t i = 0; i < native_results.size(); i++) {
+                const size_t rowid = native_results[i].first;
+                const float dis = native_results[i].second;
+                ASSERT_EQ(doris_result.roaring->contains(rowid), true)
+                        << "Row ID mismatch at rank " << i;
+                ASSERT_FLOAT_EQ(doris_result.distances[i], sqrt(dis))
+                        << "Distance mismatch at rank " << i;
+            }
+        }
+    }
+}
+
+TEST_F(VectorSearchTest, RangeSearchNoSelector1) {
+    size_t iterations = 5;
+    // Random parameters for each test iteration
+
+    for (size_t i = 0; i < iterations; ++i) {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        size_t random_d =
+                std::uniform_int_distribution<>(1, 1024)(gen); // Random dimension from 32 to 256
+        size_t random_m =
+                4 << std::uniform_int_distribution<>(1, 4)(gen); // Random M (4, 8, 16, 32, 64)
+        size_t random_n =
+                std::uniform_int_distribution<>(500, 2000)(gen); // Random number of vectors
+        // Step 1: Create and build index
+        auto index1 = std::make_unique<FaissVectorIndex>();
+
+        FaissBuildParameter params;
+        params.d = random_d;
+        params.m = random_m;
+        params.index_type = FaissBuildParameter::IndexType::HNSW;
+        index1->set_build_params(params);
+
+        const int num_vectors = random_n;
+        std::vector<float> vectors;
+        for (int i = 0; i < num_vectors; i++) {
+            auto vec = generate_random_vector(params.d);
+            vectors.insert(vectors.end(), vec.begin(), vec.end());
+        }
+
+        std::vector<std::pair<size_t, float>> distances(num_vectors);
+        for (int i = 0; i < num_vectors; i++) {
+            double sum = 0;
+            for (int j = 0; j < params.d; j++) {
+                accumulate(vectors[i * params.m + j], vectors[j], sum);
+            }
+            distances[i] = std::make_pair(i, finalize(sum));
+        }
+        std::sort(distances.begin(), distances.end(),
+                  [](const auto& a, const auto& b) { return a.second < b.second; });
+        // Use the median distance as the radius
+        float radius = distances[num_vectors / 2].second;
+
+        std::unique_ptr<faiss::Index> native_index =
+                std::make_unique<faiss::IndexHNSWFlat>(params.d, params.m, faiss::METRIC_L2);
+        native_index->add(num_vectors, vectors.data());
+        std::ignore = index1->add(num_vectors, vectors.data());
+
+        // Save index
+        ASSERT_TRUE(index1->save(_ram_dir.get()).ok());
+
+        // Step 2: Load index
+        auto index2 = std::make_unique<FaissVectorIndex>();
+        ASSERT_TRUE(index2->load(_ram_dir.get()).ok());
+
+        // Step 3: Range search
+        // Use a vector we know is in the index
+        std::vector<float> query_vec {vectors.begin(),
+                                      vectors.begin() + params.d}; // Use the first vector we added
+
+        faiss::SearchParametersHNSW search_params;
+        search_params.efSearch = 16; // Set efSearch for better accuracy
+        faiss::RangeSearchResult native_search_result(1, true);
+        native_index->range_search(1, query_vec.data(), radius * radius, &native_search_result,
+                                   &search_params);
+
+        std::vector<std::pair<int, float>> native_results;
+        size_t begin = native_search_result.lims[0];
+        size_t end = native_search_result.lims[1];
+        for (size_t i = begin; i < end; i++) {
+            native_results.push_back(
+                    {native_search_result.labels[i], native_search_result.distances[i]});
+        }
+
+        HNSWSearchParameters doris_search_params;
+        doris_search_params.ef_search = 16; // Set efSearch for better accuracy
+        IndexSearchResult search_result1;
+        IndexSearchResult search_result2;
+
+        ASSERT_EQ(
+                index1->range_search(query_vec.data(), radius, doris_search_params, search_result1)
+                        .ok(),
+                true);
+        ASSERT_EQ(
+                index2->range_search(query_vec.data(), radius, doris_search_params, search_result2)
+                        .ok(),
+                true);
+
+        ASSERT_EQ(search_result1.roaring->cardinality(), search_result2.roaring->cardinality());
+        for (size_t i = 0; i < search_result1.roaring->cardinality(); i++) {
+            ASSERT_EQ(search_result1.distances[i], search_result2.distances[i])
+                    << "Distance mismatch at rank " << i;
+        }
+
+        ASSERT_EQ(search_result2.roaring->cardinality(), native_results.size());
+
+        ASSERT_EQ(search_result2.distances != nullptr, true);
+        for (size_t i = 0; i < native_results.size(); i++) {
+            const size_t rowid = native_results[i].first;
+            const float dis = native_results[i].second;
+            ASSERT_EQ(search_result2.roaring->contains(rowid), true)
+                    << "Row ID mismatch at rank " << i;
+            ASSERT_FLOAT_EQ(search_result2.distances[i], sqrt(dis))
+                    << "Distance mismatch at rank " << i;
+        }
+
+        doris_search_params.is_le_or_lt = false;
+        std::unique_ptr<roaring::Roaring> all_rows = std::make_unique<roaring::Roaring>();
+        doris_search_params.roaring = all_rows.get();
+        for (size_t i = 0; i < num_vectors; ++i) {
+            doris_search_params.roaring->add(i);
+        }
+        IndexSearchResult search_result3;
+        std::ignore =
+                index1->range_search(query_vec.data(), radius, doris_search_params, search_result3);
+        roaring::Roaring ge_rows;
+        ASSERT_EQ(search_result3.distances == nullptr, true);
+        for (size_t i = 0; i < native_results.size(); ++i) {
+            ge_rows.add(native_results[i].first);
+        }
+        roaring::Roaring and_row_id = ge_rows & *search_result3.roaring;
+        roaring::Roaring or_row_id = ge_rows | *search_result3.roaring;
+        ASSERT_EQ(and_row_id.cardinality(), 0);
+        ASSERT_EQ(or_row_id.cardinality(), num_vectors);
+    }
+}
+
+TEST_F(VectorSearchTest, RangeSearchWithSelector1) {
+    size_t iterations = 5;
+    for (size_t i = 0; i < iterations; ++i) {
+        // Step 1: Create and build index
+        auto index1 = std::make_unique<FaissVectorIndex>();
+
+        FaissBuildParameter params;
+        params.d = 100;
+        params.m = 32;
+        params.index_type = FaissBuildParameter::IndexType::HNSW;
+        index1->set_build_params(params);
+
+        const int num_vectors = 1000;
+        std::vector<float> vectors;
+        for (int i = 0; i < num_vectors; i++) {
+            auto vec = generate_random_vector(params.d);
+            vectors.insert(vectors.end(), vec.begin(), vec.end());
+        }
+
+        std::vector<std::pair<size_t, float>> distances(num_vectors);
+        for (int i = 0; i < num_vectors; i++) {
+            double sum = 0;
+            for (int j = 0; j < params.d; j++) {
+                accumulate(vectors[i * params.m + j], vectors[j], sum);
+            }
+            distances[i] = std::make_pair(i, finalize(sum));
+        }
+        std::sort(distances.begin(), distances.end(),
+                  [](const auto& a, const auto& b) { return a.second < b.second; });
+        // Use the median distance as the radius
+        float radius = distances[num_vectors / 2].second;
+
+        std::unique_ptr<faiss::Index> native_index =
+                std::make_unique<faiss::IndexHNSWFlat>(params.d, params.m, faiss::METRIC_L2);
+        native_index->add(num_vectors, vectors.data());
+        std::ignore = index1->add(num_vectors, vectors.data());
+
+        std::unique_ptr<roaring::Roaring> all_rows = std::make_unique<roaring::Roaring>();
+        std::unique_ptr<roaring::Roaring> sel_rows = std::make_unique<roaring::Roaring>();
+        for (size_t i = 0; i < num_vectors; ++i) {
+            all_rows->add(i);
+            if (i % 2 == 0) {
+                sel_rows->add(i);
+            }
+        }
+        // Step 3: Range search
+        // Use a vector we know is in the index
+        std::vector<float> query_vec {vectors.begin(),
+                                      vectors.begin() + params.d}; // Use the first vector we added
+
+        faiss::SearchParametersHNSW search_params;
+        search_params.efSearch = 16; // Set efSearch for better accuracy
+        auto faiss_selector = segment_v2::FaissVectorIndex::roaring_to_faiss_selector(*sel_rows);
+        search_params.sel = faiss_selector.get();
+        faiss::RangeSearchResult native_search_result(1, true);
+        native_index->range_search(1, query_vec.data(), radius * radius, &native_search_result,
+                                   &search_params);
+
+        std::vector<std::pair<int, float>> native_results;
+        size_t begin = native_search_result.lims[0];
+        size_t end = native_search_result.lims[1];
+        for (size_t i = begin; i < end; i++) {
+            native_results.push_back(
+                    {native_search_result.labels[i], native_search_result.distances[i]});
+        }
+
+        HNSWSearchParameters doris_search_params;
+        doris_search_params.ef_search = 16; // Set efSearch for better accuracy
+        doris_search_params.is_le_or_lt = true;
+        doris_search_params.roaring = sel_rows.get();
+        IndexSearchResult doris_search_result;
+
+        ASSERT_EQ(index1->range_search(query_vec.data(), radius, doris_search_params,
+                                       doris_search_result)
+                          .ok(),
+                  true);
+
+        ASSERT_EQ(native_results.size(), doris_search_result.roaring->cardinality());
+        ASSERT_EQ(doris_search_result.distances != nullptr, true);
+        for (size_t i = 0; i < native_results.size(); i++) {
+            const size_t rowid = native_results[i].first;
+            const float dis = native_results[i].second;
+            ASSERT_EQ(doris_search_result.roaring->contains(rowid), true)
+                    << "Row ID mismatch at rank " << i;
+            ASSERT_FLOAT_EQ(doris_search_result.distances[i], sqrt(dis))
+                    << "Distance mismatch at rank " << i;
+        }
+
+        doris_search_params.is_le_or_lt = false;
+        roaring::Roaring ge_rows = *doris_search_params.roaring;
+        roaring::Roaring less_rows;
+        for (size_t i = 0; i < native_results.size(); ++i) {
+            less_rows.add(native_results[i].first);
+        }
+        roaring::Roaring and_row_id = ge_rows & less_rows;
+        roaring::Roaring or_row_id = ge_rows | less_rows;
+        ASSERT_NEAR(and_row_id.cardinality(), 0, 1);
+        ASSERT_EQ(or_row_id.cardinality(), sel_rows->cardinality());
+        ASSERT_EQ(or_row_id, *sel_rows);
+    }
+}
+
+TEST_F(VectorSearchTest, RangeSearchEmptyResult) {
+    for (size_t i = 0; i < 10; ++i) {
+        auto index1 = std::make_unique<FaissVectorIndex>();
+        FaissBuildParameter params;
+        params.d = 10;
+        params.m = 32;
+        params.index_type = FaissBuildParameter::IndexType::HNSW;
+        index1->set_build_params(params);
+
+        const int num_vectors = 1000;
+        std::vector<float> vectors;
+        // Create 1000 vectors and make sure their l2_distance with [1,2,3,4,5,6,7,8,9,10] is less than 100
+        // [1,2,3,4,5,6,7,8,9,10]
+        // [2,3,4,5,6,7,8,9,10,1]
+        // [3,4,5,6,7,8,9,10,1,2]
+        // ...
+        for (int i = 0; i < num_vectors; i++) {
+            int rowid = i;
+            while (rowid >= 10) {
+                rowid = rowid % 10;
+            }
+
+            std::vector<float> vec(params.d);
+            for (int colid = 0; colid < params.d; colid++) {
+                vec[colid] = (rowid + colid) % 10 + 1;
+            }
+            vectors.insert(vectors.end(), vec.begin(), vec.end());
+        }
+        // Find the min
+        float radius = 5.0f;
+
+        std::unique_ptr<faiss::Index> native_index =
+                std::make_unique<faiss::IndexHNSWFlat>(params.d, params.m, faiss::METRIC_L2);
+
+        native_index->add(num_vectors, vectors.data());
+        std::ignore = index1->add(num_vectors, vectors.data());
+
+        std::vector<float> query_vec;
+        for (int i = 0; i < params.d; i++) {
+            query_vec.push_back(5.0f);
+        }
+        // L2 distance between [5,5,5,5,5,5,5,5,5,5] with any vector add added is large than 5 and less than 250.
+
+        faiss::SearchParametersHNSW search_params;
+        search_params.efSearch = 1000; // Set efSearch for better accuracy
+        faiss::RangeSearchResult native_search_result(1, true);
+        native_index->range_search(1, query_vec.data(), radius * radius, &native_search_result);
+
+        std::vector<std::pair<int, float>> native_results;
+        size_t begin = native_search_result.lims[0];
+        size_t end = native_search_result.lims[1];
+        for (size_t i = begin; i < end; i++) {
+            native_results.push_back(
+                    {native_search_result.labels[i], native_search_result.distances[i]});
+        }
+
+        HNSWSearchParameters doris_search_params;
+        doris_search_params.ef_search = 1000; // Set efSearch for better accuracy
+        doris_search_params.is_le_or_lt = true;
+        std::unique_ptr<roaring::Roaring> sel_rows = std::make_unique<roaring::Roaring>();
+        for (size_t i = 0; i < num_vectors; ++i) {
+            sel_rows->add(i);
+        }
+
+        // Search all rows.
+        doris_search_params.roaring = sel_rows.get();
+        IndexSearchResult doris_search_result;
+
+        ASSERT_EQ(index1->range_search(query_vec.data(), radius, doris_search_params,
+                                       doris_search_result)
+                          .ok(),
+                  true);
+
+        ASSERT_EQ(native_results.size(), doris_search_result.roaring->cardinality());
+        ASSERT_EQ(doris_search_result.distances != nullptr, true);
+        for (size_t i = 0; i < native_results.size(); i++) {
+            const size_t rowid = native_results[i].first;
+            const float dis = native_results[i].second;
+            ASSERT_EQ(doris_search_result.roaring->contains(rowid), true)
+                    << "Row ID mismatch at rank " << i;
+            ASSERT_FLOAT_EQ(doris_search_result.distances[i], sqrt(dis))
+                    << "Distance mismatch at rank " << i;
+        }
+
+        doris_search_params.is_le_or_lt = false;
+        roaring::Roaring ge_rows = *doris_search_params.roaring;
+        roaring::Roaring less_rows;
+        for (size_t i = 0; i < native_results.size(); ++i) {
+            less_rows.add(native_results[i].first);
+        }
+        roaring::Roaring and_row_id = ge_rows & less_rows;
+        roaring::Roaring or_row_id = ge_rows | less_rows;
+        ASSERT_NEAR(and_row_id.cardinality(), 0, 1);
+        ASSERT_EQ(or_row_id.cardinality(), sel_rows->cardinality());
+        ASSERT_EQ(or_row_id, *sel_rows);
+    }
+}
+
+TEST_F(VectorSearchTest, TestIdSelectorWithEmptyRoaring) {
+    auto roaring = std::make_unique<roaring::Roaring>();
+    auto sel = FaissVectorIndex::roaring_to_faiss_selector(*roaring);
+    for (size_t i = 0; i < 10000; ++i) {
+        ASSERT_EQ(sel->is_member(i), false) << "Selector should be empty";
+    }
+}
+} // namespace doris::vectorized

--- a/be/test/olap/vector_search/native_faiss_test.cpp
+++ b/be/test/olap/vector_search/native_faiss_test.cpp
@@ -1,0 +1,478 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <faiss/IndexHNSW.h>
+#include <faiss/MetricType.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <omp.h> // Add this header for OpenMP functions
+
+#include <cstddef>
+#include <iomanip>
+#include <roaring/roaring.hh>
+
+#include "vector/faiss_vector_index.h"
+
+std::vector<float> generate_random_vector(int dim);
+
+class NativeFaissTest : public ::testing::Test {
+public:
+    static void accumulate(double x, double y, double& sum) { sum += (x - y) * (x - y); }
+    static double finalize(double sum) { return sqrt(sum); }
+
+    // Function for brute force range search calculation
+    static std::vector<std::pair<int, float>> calculate_brute_force_range_search(
+            const std::vector<float>& data_vectors, const std::vector<float>& query_vector,
+            float radius, int dim) {
+        std::vector<std::pair<int, float>> results;
+        int n = data_vectors.size() / dim;
+        const double target_radius = radius * radius;
+
+        for (int i = 0; i < n; ++i) {
+            double sum = 0;
+            for (int j = 0; j < dim; ++j) {
+                accumulate(data_vectors[i * dim + j], query_vector[j], sum);
+            }
+
+            if (sum < target_radius && finalize(sum) < radius) {
+                results.push_back({i, finalize(sum)});
+            }
+        }
+
+        std::sort(results.begin(), results.end(),
+                  [](const auto& a, const auto& b) { return a.first < b.first; });
+        return results;
+    }
+
+    // Enum for different index types
+    enum class IndexType {
+        FLAT_L2,
+        HNSW,
+        // Add more index types as needed
+    };
+
+    // Function for index-based range search
+    static std::vector<std::pair<int, float>> perform_index_range_search(
+            const std::vector<float>& data_vectors, const std::vector<float>& query_vector,
+            float radius, int dim, IndexType index_type) {
+        int n = data_vectors.size() / dim;
+        std::unique_ptr<faiss::Index> index = nullptr;
+
+        // Create the appropriate index based on the type
+        switch (index_type) {
+        case IndexType::FLAT_L2:
+            index = std::make_unique<faiss::IndexFlatL2>(dim);
+            break;
+        case IndexType::HNSW: {
+            index = std::make_unique<faiss::IndexHNSWFlat>(dim, 32, faiss::METRIC_L2);
+            // // Disable multi-threading to avoid memory leaks with OpenMP
+            // hnsw_index->hnsw.efSearch = 32;
+            // hnsw_index->hnsw.efConstruction = 40;
+            //  = std::move(hnsw_index);
+            break;
+        }
+            // Add more cases for other index types
+        }
+
+        if (!index) {
+            throw std::runtime_error("Invalid index type");
+        }
+
+        // Add vectors to the index
+        index->add(n, data_vectors.data());
+
+        // Perform range search
+        std::vector<std::pair<int, float>> results;
+        {
+            faiss::RangeSearchResult result(1);
+            if (index_type == IndexType::HNSW) {
+                // Use HNSW-specific search parameters
+                faiss::SearchParametersHNSW search_params;
+                search_params.efSearch = 100000; // Set efSearch for better accuracy
+                index->range_search(1, query_vector.data(), radius * radius, &result,
+                                    &search_params);
+            } else {
+                // Use default search parameters for other index types
+                index->range_search(1, query_vector.data(), radius * radius, &result);
+            }
+
+            // Extract results
+            size_t begin = result.lims[0];
+            size_t end = result.lims[1];
+            results.reserve(end - begin);
+            for (size_t j = begin; j < end; ++j) {
+                results.push_back({result.labels[j], sqrt(result.distances[j])});
+            }
+        }
+
+        // Sort results by ID
+        std::sort(results.begin(), results.end(),
+                  [](const auto& a, const auto& b) { return a.first < b.first; });
+
+        return results;
+    }
+
+    // Calculate precision and recall for search results
+    static std::pair<double, double> calculate_precision_recall(
+            const std::vector<std::pair<int, float>>& expected_results,
+            const std::vector<std::pair<int, float>>& actual_results) {
+        // Calculate the number of true positives (TP)
+        size_t tp = 0;
+        for (const auto& expected_result : expected_results) {
+            for (const auto& actual_result : actual_results) {
+                if (expected_result.first == actual_result.first) {
+                    tp++;
+                    break;
+                }
+            }
+        }
+        // Calculate the number of false positives (FP)
+        size_t fp = 0;
+        for (const auto& actual_result : actual_results) {
+            bool found = false;
+            for (const auto& expected_result : expected_results) {
+                if (actual_result.first == expected_result.first) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                fp++;
+            }
+        }
+        // Calculate the number of false negatives (FN)
+        size_t fn = 0;
+        for (const auto& expected_result : expected_results) {
+            bool found = false;
+            for (const auto& actual_result : actual_results) {
+                if (expected_result.first == actual_result.first) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                fn++;
+            }
+        }
+
+        // Calculate precision and recall
+        double precision = (tp + fp) > 0 ? static_cast<double>(tp) / (tp + fp) : 1.0;
+        double recall = (tp + fn) > 0 ? static_cast<double>(tp) / (tp + fn) : 1.0;
+
+        return {precision, recall};
+    }
+
+    // Calculate average precision and recall across multiple iterations
+    static std::pair<double, double> calculate_average_metrics(
+            const std::vector<std::pair<double, double>>& metrics) {
+        double total_precision = 0.0;
+        double total_recall = 0.0;
+
+        for (const auto& metric : metrics) {
+            total_precision += metric.first;
+            total_recall += metric.second;
+        }
+
+        size_t count = metrics.size();
+        return {count > 0 ? total_precision / count : 0.0, count > 0 ? total_recall / count : 0.0};
+    }
+};
+
+TEST_F(NativeFaissTest, RangeSearchBasic) {
+    // Test setup
+    int dim = 10;
+    int n = 10;
+    std::vector<float> data_vectors(n * dim);
+    for (int i = 0; i < n; ++i) {
+        for (int j = 0; j < dim; ++j) {
+            data_vectors[i * dim + j] = static_cast<float>(i + j);
+        }
+    }
+
+    // Create query vector [0, 1, 2, ..., 9]
+    std::vector<float> query_vector(dim);
+    for (int j = 0; j < dim; ++j) {
+        query_vector[j] = static_cast<float>(j);
+    }
+
+    float radius = 15.0f;
+
+    // Get brute force results
+    auto expected_results =
+            calculate_brute_force_range_search(data_vectors, query_vector, radius, dim);
+
+    // Get index-based results using HNSW index
+    auto actual_results =
+            perform_index_range_search(data_vectors, query_vector, radius, dim, IndexType::HNSW);
+
+    // Assert that brute force and index search results match
+    ASSERT_EQ(expected_results.size(), actual_results.size());
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i].first, actual_results[i].first);
+        ASSERT_EQ(expected_results[i].second, actual_results[i].second);
+    }
+}
+
+TEST_F(NativeFaissTest, TestRangeSearch10000Random) {
+    // Test setup
+    int dim = 100;
+    int n = 1000;
+    std::vector<float> data_vectors;
+    for (int i = 0; i < n; ++i) {
+        auto random_vector = generate_random_vector(dim);
+        data_vectors.insert(data_vectors.end(), random_vector.begin(), random_vector.end());
+    }
+
+    // Create query vector [0, 1, 2, ..., 9]
+    std::vector<float> query_vector(dim);
+    for (int j = 0; j < dim; ++j) {
+        query_vector[j] = static_cast<float>(j);
+    }
+
+    float radius = 15.0f;
+
+    // Get brute force results
+    auto expected_results =
+            calculate_brute_force_range_search(data_vectors, query_vector, radius, dim);
+
+    // Get index-based results using HNSW index
+    auto actual_results =
+            perform_index_range_search(data_vectors, query_vector, radius, dim, IndexType::HNSW);
+
+    // Assert that brute force and index search results match
+    ASSERT_NEAR(expected_results.size(), actual_results.size(), 1);
+    if (expected_results.size() == actual_results.size()) {
+        for (size_t i = 0; i < expected_results.size(); ++i) {
+            ASSERT_EQ(expected_results[i].first, actual_results[i].first);
+            ASSERT_NEAR(expected_results[i].second, actual_results[i].second, 1e-5)
+                    << "Distance mismatch at rank " << i;
+        }
+    }
+}
+
+TEST_F(NativeFaissTest, TestRangeSearchRandomVectorsSearchMedian) {
+    // Define the dimensions and vector counts to test
+    std::vector<int> dimensions = {16, 64, 128, 512, 1024};
+    std::vector<int> vector_counts = {10, 100, 1000, 10000};
+
+    // Number of iterations per configuration
+    const size_t iterations_per_config = 5;
+
+    std::cout << "=== Precision/Recall Test Results ===" << std::endl;
+    std::cout << "Dim\tVectors\tPrecis\tRecall" << std::endl;
+
+    // Iterate over all combinations of dimensions and vector counts
+    for (int dim : dimensions) {
+        for (int n : vector_counts) {
+            // Skip the largest combinations to avoid excessive memory usage
+            if (dim == 1024 && n == 10000) continue;
+
+            std::vector<std::pair<double, double>> metrics;
+
+            for (size_t iteration = 0; iteration < iterations_per_config; iteration++) {
+                // Generate random vectors
+                std::vector<float> data_vectors;
+                for (int i = 0; i < n; ++i) {
+                    auto random_vector = generate_random_vector(dim);
+                    data_vectors.insert(data_vectors.end(), random_vector.begin(),
+                                        random_vector.end());
+                }
+
+                // Use first vector as query
+                std::vector<float> query_vector(data_vectors.begin(), data_vectors.begin() + dim);
+
+                // Calculate distances to all vectors
+                std::vector<std::pair<size_t, float>> distances(n);
+                for (int i = 0; i < n; i++) {
+                    double sum = 0;
+                    for (int j = 0; j < dim; j++) {
+                        accumulate(data_vectors[i * dim + j], query_vector[j], sum);
+                    }
+                    distances[i] = std::make_pair(i, finalize(sum));
+                }
+
+                // Sort distances and use median as radius
+                std::sort(distances.begin(), distances.end(),
+                          [](const auto& a, const auto& b) { return a.second < b.second; });
+                float radius = distances[n / 2].second;
+
+                // Get brute force results
+                auto expected_results =
+                        calculate_brute_force_range_search(data_vectors, query_vector, radius, dim);
+
+                // Get HNSW index results
+                auto actual_results = perform_index_range_search(data_vectors, query_vector, radius,
+                                                                 dim, IndexType::HNSW);
+
+                // Calculate precision and recall
+                auto [precision, recall] =
+                        calculate_precision_recall(expected_results, actual_results);
+                metrics.push_back({precision, recall});
+
+                // Validate that all returned results are within radius
+                for (size_t i = 0; i < actual_results.size(); ++i) {
+                    ASSERT_LE(actual_results[i].second, radius)
+                            << "Distance to result " << actual_results[i].first
+                            << " exceeds radius";
+                }
+            }
+
+            // Calculate and print average metrics for this configuration
+            auto [avg_precision, avg_recall] = calculate_average_metrics(metrics);
+            std::cout << dim << "\t" << n << "\t" << std::fixed << std::setprecision(3)
+                      << avg_precision << "\t" << avg_recall << std::endl;
+        }
+    }
+}
+
+TEST_F(NativeFaissTest, TestTopNRandomVectorSearchMedian) {
+    // Define the dimensions and vector counts to test
+    std::vector<int> dimensions = {16, 64, 128, 512, 1024};
+    std::vector<int> vector_counts = {10, 100, 1000, 10000};
+    std::vector<int> k_values = {5, 10, 20, 50, 100};
+
+    // Number of iterations per configuration
+    const size_t iterations_per_config = 3;
+
+    std::cout << "=== TopN Search Test Results ===" << std::endl;
+    std::cout << "Dim\tVectors\tK\tPrecis\tRecall" << std::endl;
+
+    // Iterate over all combinations of dimensions, vector counts, and k values
+    for (int dim : dimensions) {
+        for (int n : vector_counts) {
+            // Skip the largest combinations to avoid excessive memory usage
+            if (dim == 1024 && n == 10000) continue;
+
+            for (int k : k_values) {
+                // Skip invalid k values (k > n)
+                if (k > n) continue;
+
+                std::vector<std::pair<double, double>> metrics;
+
+                for (size_t iteration = 0; iteration < iterations_per_config; iteration++) {
+                    // Generate random vectors
+                    std::vector<float> data_vectors;
+                    for (int i = 0; i < n; ++i) {
+                        auto random_vector = generate_random_vector(dim);
+                        data_vectors.insert(data_vectors.end(), random_vector.begin(),
+                                            random_vector.end());
+                    }
+
+                    // Use a random vector as query
+                    std::vector<float> query_vector = generate_random_vector(dim);
+
+                    // Brute force search to find ground truth top-k
+                    std::vector<std::pair<int, float>> all_distances(n);
+                    for (int i = 0; i < n; i++) {
+                        double sum = 0;
+                        for (int j = 0; j < dim; j++) {
+                            double diff = data_vectors[i * dim + j] - query_vector[j];
+                            sum += diff * diff;
+                        }
+                        all_distances[i] = {i, sqrt(sum)};
+                    }
+
+                    // Sort by distance to get top-k
+                    std::sort(all_distances.begin(), all_distances.end(),
+                              [](const auto& a, const auto& b) { return a.second < b.second; });
+
+                    // Take top-k as ground truth
+                    std::vector<std::pair<int, float>> expected_results(all_distances.begin(),
+                                                                        all_distances.begin() + k);
+
+                    // HNSW index-based search
+                    std::unique_ptr<faiss::Index> index =
+                            std::make_unique<faiss::IndexHNSWFlat>(dim, 32, faiss::METRIC_L2);
+                    index->add(n, data_vectors.data());
+
+                    // Perform search
+                    std::vector<float> distances(k);
+                    std::vector<faiss::idx_t> indices(k);
+                    faiss::SearchParametersHNSW search_params;
+                    search_params.efSearch = 100000; // Set efSearch for better accuracy
+                    index->search(1, query_vector.data(), k, distances.data(), indices.data());
+
+                    // Format results
+                    std::vector<std::pair<int, float>> actual_results;
+                    for (int i = 0; i < k; i++) {
+                        if (indices[i] != -1) { // -1 indicates not enough results
+                            actual_results.push_back({indices[i], sqrt(distances[i])});
+                        }
+                    }
+
+                    // Calculate precision and recall between brute force and HNSW results
+                    auto [precision, recall] =
+                            calculate_precision_recall(expected_results, actual_results);
+                    metrics.push_back({precision, recall});
+                }
+
+                // Calculate and print average metrics for this configuration
+                auto [avg_precision, avg_recall] = calculate_average_metrics(metrics);
+                std::cout << dim << "\t" << n << "\t" << k << "\t" << std::fixed
+                          << std::setprecision(3) << avg_precision << "\t" << avg_recall
+                          << std::endl;
+            }
+        }
+    }
+}
+
+TEST_F(NativeFaissTest, SameTypeIndexDiffObject) {
+    // Test setup
+    int dim = 100;
+    int n = 1000;
+    std::vector<float> data_vectors;
+    for (int i = 0; i < n; ++i) {
+        auto random_vector = generate_random_vector(dim);
+        data_vectors.insert(data_vectors.end(), random_vector.begin(), random_vector.end());
+    }
+
+    // Create query vector [0, 1, 2, ..., 9]
+    std::vector<float> query_vector(data_vectors.begin(),
+                                    data_vectors.begin() + dim); // Use the first vector we added
+
+    std::vector<std::pair<size_t, float>> distances(n);
+    for (int i = 0; i < n; i++) {
+        double sum = 0;
+        for (int j = 0; j < dim; j++) {
+            accumulate(data_vectors[i * dim + j], query_vector[j], sum);
+        }
+        distances[i] = std::make_pair(i, finalize(sum));
+    }
+    std::sort(distances.begin(), distances.end(),
+              [](const auto& a, const auto& b) { return a.second < b.second; });
+    // Use the median distance as the radius
+    float radius = distances[n / 2].second;
+
+    // Get index-based results using HNSW index
+    auto actual_results1 =
+            perform_index_range_search(data_vectors, query_vector, radius, dim, IndexType::HNSW);
+
+    auto actual_results2 =
+            perform_index_range_search(data_vectors, query_vector, radius, dim, IndexType::HNSW);
+    auto actual_results3 =
+            perform_index_range_search(data_vectors, query_vector, radius, dim, IndexType::HNSW);
+
+    // ASSERT three result is same
+    ASSERT_EQ(actual_results1.size(), actual_results2.size());
+    ASSERT_EQ(actual_results1.size(), actual_results3.size());
+    for (size_t i = 0; i < actual_results1.size(); ++i) {
+        ASSERT_EQ(actual_results1[i].first, actual_results2[i].first);
+        ASSERT_EQ(actual_results1[i].first, actual_results3[i].first);
+        ASSERT_FLOAT_EQ(actual_results1[i].second, actual_results2[i].second);
+        ASSERT_FLOAT_EQ(actual_results1[i].second, actual_results3[i].second);
+    }
+}

--- a/be/test/olap/vector_search/vector_search_utils.h
+++ b/be/test/olap/vector_search/vector_search_utils.h
@@ -1,0 +1,229 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <thrift/protocol/TDebugProtocol.h>
+#include <thrift/protocol/TJSONProtocol.h>
+
+#include <iostream>
+#include <memory>
+
+#include "common/object_pool.h"
+#include "olap/rowset/segment_v2/ann_index_iterator.h"
+#include "olap/rowset/segment_v2/index_file_reader.h"
+#include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
+#include "olap/tablet_schema.h"
+#include "runtime/descriptors.h"
+#include "vec/exprs/vexpr_context.h"
+// Add CLucene RAM Directory header
+#include <CLucene/store/RAMDirectory.h>
+
+using doris::segment_v2::DorisCompoundReader;
+
+namespace doris::vec_search_mock {
+
+class MockIndexFileReader : public ::doris::segment_v2::IndexFileReader {
+public:
+    MockIndexFileReader()
+            : IndexFileReader(doris::io::global_local_filesystem(), "",
+                              doris::InvertedIndexStorageFormatPB::V2) {}
+
+    MOCK_METHOD2(init, doris::Status(int, const doris::io::IOContext* io_ctx));
+
+    MOCK_CONST_METHOD2(open, doris::Result<std::unique_ptr<DorisCompoundReader>>(
+                                     const doris::TabletIndex*, const doris::io::IOContext*));
+};
+
+class MockTabletSchema : public doris::TabletIndex {};
+
+class MockTabletColumn : public doris::TabletColumn {
+    MOCK_METHOD(doris::FieldType, type, (), (const));
+    MOCK_METHOD((const TabletColumn&), get_sub_column, (uint32_t), (const));
+};
+
+class MockTabletIndex : public doris::TabletIndex {
+    MOCK_METHOD(doris::IndexType, index_type, (), (const));
+    MOCK_METHOD((const std::map<string, string>&), properties, (), (const));
+};
+
+class MockIndexFileWriter : public doris::segment_v2::IndexFileWriter {
+public:
+    MockIndexFileWriter(doris::io::FileSystemSPtr fs)
+            : doris::segment_v2::IndexFileWriter(fs, "test_index", "rowset_id", 1,
+                                                 doris::InvertedIndexStorageFormatPB::V2) {}
+
+    MOCK_METHOD(doris::Result<std::shared_ptr<doris::segment_v2::DorisFSDirectory>>, open,
+                (const doris::TabletIndex* index_meta), (override));
+};
+
+class MockAnnIndexIterator : public doris::segment_v2::AnnIndexIterator {
+public:
+    MockAnnIndexIterator()
+            : doris::segment_v2::AnnIndexIterator(_io_ctx_mock, nullptr, nullptr, nullptr) {}
+
+    ~MockAnnIndexIterator() override = default;
+
+    IndexType type() override { return IndexType::ANN; }
+
+    MOCK_METHOD(Status, read_from_index, (const doris::segment_v2::IndexParam& param), (override));
+    MOCK_METHOD(Status, range_search,
+                (const segment_v2::RangeSearchParams& params,
+                 const segment_v2::CustomSearchParams& custom_params,
+                 segment_v2::RangeSearchResult* result),
+                (override));
+
+private:
+    io::IOContext _io_ctx_mock;
+};
+} // namespace doris::vec_search_mock
+
+namespace doris::vectorized {
+static std::string order_by_expr_thrift =
+        R"xxx({"1":{"lst":["rec",12,{"1":{"i32":20},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":2},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"l2_distance"}}},"2":{"i32":0},"3":{"lst":["rec",2,{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}},{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}]},"4":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"5":{"tf":0},"7":{"str":"l2_distance(array<double>, array<double>)"},"9":{"rec":{"1":{"str":""}}},"11":{"i64":0},"13":{"tf":1},"14":{"tf":0},"15":{"tf":0},"16":{"i64":360}}},"29":{"tf":1}},{"1":{"i32":5},"2":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"3":{"i32":4},"4":{"i32":1},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"casttoarray"}}},"2":{"i32":0},"3":{"lst":["rec",1,{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":7}}}}]},"3":{"i64":-1}}]},"4":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"5":{"tf":0},"7":{"str":"casttoarray(array<float>)"},"9":{"rec":{"1":{"str":""}}},"11":{"i64":0},"13":{"tf":1},"14":{"tf":0},"15":{"tf":0},"16":{"i64":360}}},"29":{"tf":0}},{"1":{"i32":16},"2":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":7}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"15":{"rec":{"1":{"i32":1},"2":{"i32":0},"3":{"i32":1}}},"20":{"i32":-1},"29":{"tf":0},"36":{"str":"embedding"}},{"1":{"i32":21},"2":{"rec":{"1":{"lst":["rec",2,{"1":{"i32":1},"4":{"tf":1},"5":{"lst":["tf",1,1]}},{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":8},"20":{"i32":-1},"28":{"i32":8},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":1}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":2}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":3}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":4}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":5}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":6}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":7}}},"20":{"i32":-1},"29":{"tf":0}},{"1":{"i32":8},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":8}}}}]},"3":{"i64":-1}}},"4":{"i32":0},"9":{"rec":{"1":{"dbl":20}}},"20":{"i32":-1},"29":{"tf":0}}]}})xxx";
+template <typename T>
+T read_from_json(const std::string& json_str) {
+    auto memBufferIn = std::make_shared<apache::thrift::transport::TMemoryBuffer>(
+            reinterpret_cast<uint8_t*>(const_cast<char*>(json_str.data())),
+            static_cast<uint32_t>(json_str.size()));
+    auto jsonProtocolIn = std::make_shared<apache::thrift::protocol::TJSONProtocol>(memBufferIn);
+    T params;
+    params.read(jsonProtocolIn.get());
+    return params;
+}
+
+template <typename T>
+void write_to_json(const std::string& path, std::string name, const T& expr) {
+    auto memBuffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+    auto jsonProtocol = std::make_shared<apache::thrift::protocol::TJSONProtocol>(memBuffer);
+
+    expr.write(jsonProtocol.get());
+    uint8_t* buf;
+    uint32_t size;
+    memBuffer->getBuffer(&buf, &size);
+    std::string file_path = fmt::format("{}/{}.json", path, name);
+    std::ofstream ofs(file_path, std::ios::binary);
+    ofs.write(reinterpret_cast<const char*>(buf), size);
+    ofs.close();
+    std::cout << fmt::format("Serialized JSON written to {}\n", file_path);
+}
+
+class VectorSearchTest : public ::testing::Test {
+public:
+    static void accumulate(double x, double y, double& sum) { sum += (x - y) * (x - y); }
+    static double finalize(double sum) { return sqrt(sum); }
+
+protected:
+    void SetUp() override {
+        TExpr _distance_function_call_thrift = read_from_json<TExpr>(order_by_expr_thrift);
+        // std::cout << "distance function call thrift:\n"
+        //           << apache::thrift::ThriftDebugString(_distance_function_call_thrift)
+        //           << std::endl;
+
+        TDescriptorTable thrift_tbl;
+        TTableDescriptor thrift_table_desc;
+        thrift_table_desc.id = 0;
+        thrift_tbl.tableDescriptors.push_back(thrift_table_desc);
+        TTupleDescriptor tuple_desc;
+        tuple_desc.__isset.tableId = true;
+        tuple_desc.id = 0;
+        tuple_desc.tableId = 0;
+        thrift_tbl.tupleDescriptors.push_back(tuple_desc);
+        TSlotDescriptor slot_desc;
+        slot_desc.id = 0;
+        slot_desc.parent = 0;
+        slot_desc.isMaterialized = true;
+        slot_desc.need_materialize = true;
+        slot_desc.__isset.need_materialize = true;
+        TTypeNode type_node;
+        type_node.type = TTypeNodeType::type::SCALAR;
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::DOUBLE);
+        type_node.__set_scalar_type(scalar_type);
+        slot_desc.slotType.types.push_back(type_node);
+        slot_desc.virtual_column_expr = _distance_function_call_thrift;
+        slot_desc.__isset.virtual_column_expr = true;
+        thrift_tbl.slotDescriptors.push_back(slot_desc);
+        slot_desc.id = 1;
+        slot_desc.__isset.virtual_column_expr = false;
+        thrift_tbl.slotDescriptors.push_back(slot_desc);
+        thrift_tbl.__isset.slotDescriptors = true;
+        // std::cout << "+++++++++++++++++++ thrift table descriptor:\n"
+        //           << apache::thrift::ThriftDebugString(thrift_tbl) << std::endl;
+        // std::cout << "+++++++++++++++++++ thrift table descriptor end\n";
+        ASSERT_TRUE(DescriptorTbl::create(&obj_pool, thrift_tbl, &_desc_tbl).ok());
+        // std::cout << "+++++++++++++++++++ desc tbl\n" << _desc_tbl->debug_string() << std::endl;
+        // std::cout << "+++++++++++++++++++ desc tbl end\n";
+        _runtime_state.set_desc_tbl(_desc_tbl);
+
+        config::max_depth_of_expr_tree = 1000;
+        doris::TSlotRef slot_ref;
+        slot_ref.slot_id = 0;
+        slot_ref.__isset.is_virtual_slot = true;
+        slot_ref.is_virtual_slot = true;
+
+        doris::TExprNode virtual_slot_ref_node;
+        virtual_slot_ref_node.slot_ref = slot_ref;
+        virtual_slot_ref_node.label = "virtual_slot_ref";
+        virtual_slot_ref_node.node_type = TExprNodeType::SLOT_REF;
+        virtual_slot_ref_node.type = TTypeDesc();
+        type_node.type = TTypeNodeType::type::SCALAR;
+        type_node.scalar_type.type = TPrimitiveType::DOUBLE;
+        type_node.__isset.scalar_type = true;
+
+        virtual_slot_ref_node.type.types.push_back(type_node);
+        virtual_slot_ref_node.__isset.slot_ref = true;
+        virtual_slot_ref_node.__isset.label = true;
+        virtual_slot_ref_node.__isset.opcode = false;
+
+        _virtual_slot_ref_expr.nodes.push_back(virtual_slot_ref_node);
+        _ann_index_iterator = std::make_unique<vec_search_mock::MockAnnIndexIterator>();
+
+        _row_desc = RowDescriptor(*_desc_tbl, {0}, {false});
+
+        // Create CLucene RAM directory instead of mock
+        _ram_dir = std::make_shared<lucene::store::RAMDirectory>();
+
+        // Optional: Create test file to simulate index presence
+        auto output = _ram_dir->createOutput("index_file");
+        // Write some dummy data
+        const char* dummy_data = "dummy data";
+        output->writeBytes((const uint8_t*)dummy_data, strlen(dummy_data));
+        output->close();
+        delete output; // CLucene requires manual delete
+    }
+
+    void TearDown() override {}
+
+private:
+    doris::ObjectPool obj_pool;
+    RowDescriptor _row_desc;
+    std::unique_ptr<vec_search_mock::MockAnnIndexIterator> _ann_index_iterator;
+    vectorized::IColumn::MutablePtr _result_column;
+    doris::TExpr _distance_function_call_thrift;
+    doris::TExpr _virtual_slot_ref_expr;
+    DescriptorTbl* _desc_tbl;
+    doris::RuntimeState _runtime_state;
+    std::shared_ptr<lucene::store::RAMDirectory> _ram_dir;
+};
+} // namespace doris::vectorized

--- a/be/test/olap/vector_search/virtual_column_iterator_test.cpp
+++ b/be/test/olap/vector_search/virtual_column_iterator_test.cpp
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/rowset/segment_v2/virtual_column_iterator.h"
+
+#include <gtest/gtest.h>
+
+#include "vec/columns/column.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/core/types.h"
+#include "vector_search_utils.h"
+
+using namespace doris::segment_v2;
+
+namespace doris::vectorized {
+
+// Test the default constructor with ColumnNothing
+TEST_F(VectorSearchTest, TestDefaultConstructor) {
+    VirtualColumnIterator iterator;
+    vectorized::MutableColumnPtr dst = vectorized::ColumnString::create();
+
+    // Create some rowids
+    rowid_t rowids[] = {0, 1, 2, 3, 4};
+    size_t count = sizeof(rowids) / sizeof(rowids[0]);
+
+    // Since default is ColumnNothing, this should return OK immediately with no changes to dst
+    Status status = iterator.read_by_rowids(rowids, count, dst);
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(dst->size(), 0);
+}
+
+// Test with a materialized int32_t column
+TEST_F(VectorSearchTest, TestWithint32_tColumn) {
+    VirtualColumnIterator iterator;
+
+    // Create a materialized int32_t column with values [10, 20, 30, 40, 50]
+    auto int_column = vectorized::ColumnVector<int32_t>::create();
+    std::unique_ptr<std::vector<uint64_t>> labels = std::make_unique<std::vector<uint64_t>>();
+    for (int i = 0; i < 5; i++) {
+        int_column->insert(10 * (i + 1));
+        labels->push_back(i);
+    }
+    // Set the materialized column
+
+    iterator.prepare_materialization(std::move(int_column), std::move(labels));
+
+    // Create destination column
+    vectorized::MutableColumnPtr dst = vectorized::ColumnVector<int32_t>::create();
+
+    // Select rowids 0, 2, 4 (values 10, 30, 50)
+    rowid_t rowids[] = {0, 2, 4};
+    size_t count = sizeof(rowids) / sizeof(rowids[0]);
+    DCHECK(count == 3);
+    // Read selected rows
+    Status status = iterator.read_by_rowids(rowids, count, dst);
+    ASSERT_TRUE(status.ok());
+
+    // Verify results
+    EXPECT_EQ(dst->size(), 3);
+    EXPECT_EQ(dst->get_int(0), 10);
+    EXPECT_EQ(dst->get_int(1), 30);
+    EXPECT_EQ(dst->get_int(2), 50);
+}
+
+// Test with a String column
+TEST_F(VectorSearchTest, TestWithStringColumn) {
+    VirtualColumnIterator iterator;
+
+    // Create a materialized String column
+    auto string_column = vectorized::ColumnString::create();
+    string_column->insert("apple");
+    string_column->insert("banana");
+    string_column->insert("cherry");
+    string_column->insert("date");
+    string_column->insert("elderberry");
+    auto labels = std::make_unique<std::vector<uint64_t>>();
+    for (int i = 0; i < 5; i++) {
+        labels->push_back(i);
+    }
+
+    // Set the materialized column
+    iterator.prepare_materialization(std::move(string_column), std::move(labels));
+
+    // Create destination column
+    vectorized::MutableColumnPtr dst = vectorized::ColumnString::create();
+
+    // Select rowids 1, 3 (values "banana", "date")
+    rowid_t rowids[] = {1, 3};
+    size_t count = sizeof(rowids) / sizeof(rowids[0]);
+
+    // Read selected rows
+    Status status = iterator.read_by_rowids(rowids, count, dst);
+    ASSERT_TRUE(status.ok());
+
+    // Verify results
+    ASSERT_EQ(dst->size(), 2);
+    ASSERT_EQ(dst->get_data_at(0).to_string(), "banana");
+    ASSERT_EQ(dst->get_data_at(1).to_string(), "date");
+}
+
+// Test with empty rowids array
+TEST_F(VectorSearchTest, TestEmptyRowIds) {
+    VirtualColumnIterator iterator;
+
+    // Create a materialized int32_t column with values [10, 20, 30, 40, 50]
+    auto int_column = vectorized::ColumnVector<int32_t>::create();
+    auto labels = std::make_unique<std::vector<uint64_t>>();
+    for (int i = 0; i < 5; i++) {
+        int_column->insert(10 * (i + 1));
+        labels->push_back(i);
+    }
+
+    // Set the materialized column
+    iterator.prepare_materialization(std::move(int_column), std::move(labels));
+
+    // Create destination column
+    vectorized::MutableColumnPtr dst = vectorized::ColumnVector<int32_t>::create();
+
+    // Empty rowids array
+    rowid_t rowids[1];
+    size_t count = 0;
+
+    // Read with empty rowids
+    Status status = iterator.read_by_rowids(rowids, count, dst);
+    ASSERT_TRUE(status.ok());
+
+    // Verify empty result
+    ASSERT_EQ(dst->size(), 0);
+}
+
+// Test with large number of rows
+TEST_F(VectorSearchTest, TestLargeRowset) {
+    VirtualColumnIterator iterator;
+
+    // Create a large materialized int32_t column (1000 values)
+    auto int_column = vectorized::ColumnVector<int32_t>::create();
+    auto labels = std::make_unique<std::vector<uint64_t>>();
+
+    for (int i = 0; i < 1000; i++) {
+        int_column->insert(i);
+        labels->push_back(i);
+    }
+
+    // Set the materialized column
+    iterator.prepare_materialization(std::move(int_column), std::move(labels));
+
+    // Create destination column
+    vectorized::MutableColumnPtr dst = vectorized::ColumnVector<int32_t>::create();
+
+    // Select every 100th row (0, 100, 200, ... 900)
+    const int step = 100;
+    std::vector<rowid_t> rowids;
+    for (int i = 0; i < 1000; i += step) {
+        rowids.push_back(i);
+    }
+
+    // Read selected rows
+    Status status = iterator.read_by_rowids(rowids.data(), rowids.size(), dst);
+    ASSERT_TRUE(status.ok());
+
+    // Verify results
+    ASSERT_EQ(dst->size(), 10);
+    for (int i = 0; i < 10; i++) {
+        ASSERT_EQ(dst->get_int(i), i * step);
+    }
+}
+
+TEST_F(VectorSearchTest, TestNoContinueRowIds) {
+    // Create a column with 1000 values (0-999)
+    auto column = ColumnVector<int32_t>::create();
+    auto labels = std::make_unique<std::vector<uint64_t>>();
+
+    // Generate non-consecutive row IDs by multiplying by 2 (0,2,4,...)
+    for (size_t i = 0; i < 1000; i++) {
+        column->insert(i);
+        labels->push_back(i * 2); // Non-consecutive row IDs
+    }
+
+    VirtualColumnIterator iterator;
+    iterator.prepare_materialization(std::move(column), std::move(labels));
+
+    // Verify row_id_to_idx mapping is correct
+    for (size_t i = 0; i < 1000; i++) {
+        const auto& row_id_to_idx = iterator.get_row_id_to_idx();
+        ASSERT_EQ(row_id_to_idx.find(i * 2)->second, i);
+    }
+
+    // Create destination column for results
+    vectorized::MutableColumnPtr dest_col = ColumnVector<int32_t>::create();
+
+    // Test with various non-consecutive row IDs
+    {
+        // Select some random non-consecutive row IDs (0, 100, 500, 998)
+        rowid_t rowids[] = {0, 200, 1000, 1996};
+        size_t count = sizeof(rowids) / sizeof(rowids[0]);
+
+        // Read values by row IDs
+        Status status = iterator.read_by_rowids(rowids, count, dest_col);
+        ASSERT_TRUE(status.ok());
+
+        // Verify results - values should be 0, 100, 500, 998
+        ASSERT_EQ(dest_col->size(), count);
+        ASSERT_EQ(dest_col->get_int(0), 0);
+        ASSERT_EQ(dest_col->get_int(1), 100);
+        ASSERT_EQ(dest_col->get_int(2), 500);
+        ASSERT_EQ(dest_col->get_int(3), 998);
+    }
+
+    // Test with reversed order row IDs
+    {
+        dest_col->clear();
+
+        // Row IDs in reverse order
+        rowid_t rowids[] = {1998, 1500, 1000, 500, 0};
+        size_t count = sizeof(rowids) / sizeof(rowids[0]);
+
+        Status status = iterator.read_by_rowids(rowids, count, dest_col);
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(dest_col->size(), count);
+        ASSERT_EQ(dest_col->get_int(4), 999);
+        ASSERT_EQ(dest_col->get_int(3), 750);
+        ASSERT_EQ(dest_col->get_int(2), 500);
+        ASSERT_EQ(dest_col->get_int(1), 250);
+        ASSERT_EQ(dest_col->get_int(0), 0);
+    }
+
+    // Test with duplicate row IDs
+    {
+        dest_col->clear();
+
+        // Duplicate row IDs
+        rowid_t rowids[] = {100, 100, 100};
+        size_t count = sizeof(rowids) / sizeof(rowids[0]);
+
+        Status status = iterator.read_by_rowids(rowids, count, dest_col);
+        ASSERT_TRUE(status.ok());
+
+        // Verify results - should contain 3 copies of value 50
+        ASSERT_EQ(dest_col->size(), 1); // Note: filter will deduplicate the rows
+        ASSERT_EQ(dest_col->get_int(0), 50);
+    }
+
+    // Test with out-of-order and scattered row IDs
+    {
+        dest_col->clear();
+
+        // Scattered row IDs
+        rowid_t rowids[] = {8, 24, 46, 100, 1998};
+        size_t count = sizeof(rowids) / sizeof(rowids[0]);
+
+        Status status = iterator.read_by_rowids(rowids, count, dest_col);
+        ASSERT_TRUE(status.ok());
+
+        // Verify results
+        ASSERT_EQ(dest_col->size(), count);
+        ASSERT_EQ(dest_col->get_int(0), 4);
+        ASSERT_EQ(dest_col->get_int(1), 12);
+        ASSERT_EQ(dest_col->get_int(2), 23);
+        ASSERT_EQ(dest_col->get_int(3), 50);
+        ASSERT_EQ(dest_col->get_int(4), 999);
+    }
+}
+
+} // namespace doris::vectorized

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gflags/gflags.h>
+#include <unistd.h>
+
 #include <memory>
 #include <string>
 
@@ -37,6 +40,8 @@
 #include "util/cpu_info.h"
 #include "util/disk_info.h"
 #include "util/mem_info.h"
+
+DEFINE_bool(wait, false, "Wait user to start test");
 
 int main(int argc, char** argv) {
     doris::ThreadLocalHandle::create_thread_local_if_not_exits();
@@ -97,6 +102,10 @@ int main(int argc, char** argv) {
     doris::ExecEnv::GetInstance()->set_tracking_memory(false);
 
     google::ParseCommandLineFlags(&argc, &argv, false);
+    // a infinite loop to wait for the http service to start
+    while (FLAGS_wait) {
+        sleep(1);
+    }
     int res = RUN_ALL_TESTS();
 
     doris::ExecEnv::GetInstance()->set_non_block_close_thread_pool(nullptr);

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -82,6 +82,8 @@ enum TExprNodeType {
   // to prevent push to storage layer
   NULL_AWARE_IN_PRED,
   NULL_AWARE_BINARY_PRED,
+
+  VIRTUAL_SLOT_REF,
 }
 
 //enum TAggregationOp {

--- a/gensrc/thrift/Makefile
+++ b/gensrc/thrift/Makefile
@@ -31,7 +31,7 @@ all: ${GEN_OBJECTS} ${OBJECTS}
 
 $(shell mkdir -p ${BUILD_DIR}/gen_java)
 
-THRIFT_CPP_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --gen cpp:moveable_types -out ${BUILD_DIR}/gen_cpp --allow-64bit-consts -strict
+THRIFT_CPP_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --gen cpp:moveable_types,no_skeleton -out ${BUILD_DIR}/gen_cpp --allow-64bit-consts -strict
 THRIFT_JAVA_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --gen java:fullcamel -out ${BUILD_DIR}/gen_java --allow-64bit-consts -strict
 
 ${BUILD_DIR}/gen_cpp:

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -52,12 +52,14 @@ Usage: $0 <options>
      --run --filter=xx  build and run specified ut
      --run --gen_out    generate expected check data for test
      --coverage         coverage after run ut
+     --wait       wait before run ut, user can use debugger to tell the process to continue
      -j                 build parallel
      -h                 print this help message
 
   Eg.
     $0                                                              build tests
     $0 --run                                                        build and run all tests
+    $0 --run --wait=true                                           wait before run ut, user can use debugger to tell the process to continue
     $0 --run --filter=*                                             also runs everything
     $0 --run --filter=FooTest.*                                     runs everything in test suite FooTest
     $0 --run --filter=*Null*:*Constructor*                          runs any test whose full name contains either 'Null' or 'Constructor'
@@ -71,7 +73,7 @@ Usage: $0 <options>
     exit 1
 }
 
-if ! OPTS="$(getopt -n "$0" -o vhj:f: -l gen_out,coverage,benchmark,run,clean,filter: -- "$@")"; then
+if ! OPTS="$(getopt -n "$0" -o vhj:f: -l gen_out,coverage,benchmark,run,clean,wait:,filter: -- "$@")"; then
     usage
 fi
 
@@ -83,6 +85,7 @@ DENABLE_CLANG_COVERAGE='OFF'
 BUILD_AZURE='ON'
 FILTER=""
 GEN_OUT=""
+WAIT="false"
 if [[ "$#" != 1 ]]; then
     while true; do
         case "$1" in
@@ -101,6 +104,10 @@ if [[ "$#" != 1 ]]; then
         --gen_out)
             GEN_OUT='--gen_out'
             shift
+            ;;
+        --wait)
+            WAIT="$2"
+            shift 2
             ;;
         -f | --filter)
             FILTER="--gtest_filter=$2"
@@ -479,7 +486,7 @@ if [[ -f "${test}" ]]; then
         echo "${cmd2}"
         eval "${cmd2}"
     else
-        "${test}" --gtest_output="xml:${GTEST_OUTPUT_DIR}/${file_name}.xml" --gtest_print_time=true "${FILTER}" "${GEN_OUT}"
+        "${test}" --gtest_output="xml:${GTEST_OUTPUT_DIR}/${file_name}.xml" --gtest_print_time=true "${FILTER}" --wait="${WAIT}" "${GEN_OUT}"
     fi
     echo "=== Finished. Gtest output: ${GTEST_OUTPUT_DIR}"
 else


### PR DESCRIPTION
This is the first version with relatively stable behavior:

* Pass the TPC-H test without crashes.

* Perform range search without crashes.

* Perform ANN Top-N search without crashes.

* Perform compound search (range + Top-N) without crashes.

Some unit tests are unstable; they may be related to the Faiss library.

```text
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] VectorSearchTest.AnnTopNDescriptorEvaluateTopN
[  FAILED  ] VectorSearchTest.CompRangeSearch
[  FAILED  ] VectorSearchTest.RangeSearchNoSelector1
[  FAILED  ] VectorSearchTest.RangeSearchWithSelector1
```

tpch test has some unstable failure:
```text
q13	Error: Failed to execute query q13 (cold run). Output:
ERROR 1105 (HY000) at line 18: errCode = 2, detailMessage = (10.16.10.2)[INTERNAL_ERROR]Parameters start = 0, length = 4064, are out of bound in ColumnVector<T>::insert_range_from method (data.size() = 0).
```