### PR TITLE
branch-2.1: [Fix](mow) Fix `DeleteBitmap::cardinality`

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1067,9 +1067,12 @@ bool DeleteBitmap::empty() const {
 }
 
 uint64_t DeleteBitmap::cardinality() const {
+    std::shared_lock l {lock};
     uint64_t res = 0;
     for (auto entry : delete_bitmap) {
-        res += entry.second.cardinality();
+        if (std::get<1>(entry.first) != DeleteBitmap::INVALID_SEGMENT_ID) {
+            res += entry.second.cardinality();
+        }
     }
     return res;
 }


### PR DESCRIPTION
### What problem does this PR solve?


```
*** Query id: ce47f2673e782ef9-5581cc671c6e7c85 ***
*** is nereids: 0 ***
*** tablet id: 10196 ***
*** Aborted at 1745534277 (unix time) try "date -d @1745534277" if you are using GNU date ***
*** Current BE git commitID: e5a9c2552d ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 5684 (TID 117604 OR 0x7fe01cffd640) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007FF412552520 in /lib/x86_64-linux-gnu/libc.so.6
 4# memcpy at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/glibc-compatibility/memcpy/memcpy_x86_64.cpp:219
 5# array_container_clone in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# ra_overwrite in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 7# roaring::Roaring::Roaring(roaring::Roaring const&) at /home/zcp/repo_center/doris_branch-2.1/doris/thirdparty/installed/include/roaring/roaring.hh:99
 8# doris::DeleteBitmap::cardinality() const at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/tablet_meta.cpp:1072
 9# doris::BetaRowsetWriter::_generate_delete_bitmap(int) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/beta_rowset_writer.cpp:198
10# doris::BaseBetaRowsetWriter::add_segment(unsigned int, doris::SegmentStatistics const&, std::shared_ptr<doris::TabletSchema>) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/beta_rowset_writer.cpp:883
11# doris::BetaRowsetWriter::add_segment(unsigned int, doris::SegmentStatistics const&, std::shared_ptr<doris::TabletSchema>) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
12# doris::SegmentCollectorT<doris::BaseBetaRowsetWriter>::add(unsigned int, doris::SegmentStatistics&, std::shared_ptr<doris::TabletSchema>) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/segment_creator.h:82
13# doris::SegmentFlusher::_flush_segment_writer(std::unique_ptr<doris::segment_v2::VerticalSegmentWriter, std::default_delete<doris::segment_v2::VerticalSegmentWriter> >&, std::shared_ptr<doris::TabletSchema>, long*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/segment_creator.cpp:247
14# doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/segment_creator.cpp:78
15# doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/segment_creator.cpp:400
16# doris::BaseBetaRowsetWriter::flush_memtable(doris::vectorized::Block*, int, long*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/rowset/beta_rowset_writer.cpp:539
17# doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/memtable_flush_executor.cpp:158
18# doris::FlushToken::_flush_memtable(std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >, int, long) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
19# doris::MemtableFlushTask::run() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/olap/memtable_flush_executor.cpp:63
20# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
21# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:499
22# start_thread at ./nptl/pthread_create.c:442
23# 0x00007FF412636850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

