### PR TITLE
[Improvement](function) make datev2/datetimev2's comparison use numric compare

### DIFF
--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -283,7 +283,10 @@ struct WhichDataType {
     bool is_aggregate_function() const { return idx == TypeIndex::AggregateFunction; }
     bool is_variant_type() const { return idx == TypeIndex::VARIANT; }
     bool is_simple() const { return is_int() || is_uint() || is_float() || is_string(); }
-    bool is_num_can_compare() const { return is_int_or_uint() || is_float() || is_ip(); }
+    // Compare datev2 and datetimev2 direct use the numric compare.
+    bool is_num_can_compare() const {
+        return is_int_or_uint() || is_float() || is_ip() || is_date_v2_or_datetime_v2();
+    }
 };
 
 /// IDataType helpers (alternative for IDataType virtual methods with single point of truth)

--- a/be/src/vec/functions/functions_comparison.h
+++ b/be/src/vec/functions/functions_comparison.h
@@ -644,11 +644,6 @@ public:
         const bool left_is_string = which_left.is_string_or_fixed_string();
         const bool right_is_string = which_right.is_string_or_fixed_string();
 
-        // Compare date and datetime direct use the Int64 compare. Keep the comment
-        // may we should refactor the code.
-        //        bool date_and_datetime = (left_type != right_type) && which_left.is_date_or_datetime() &&
-        //                                 which_right.is_date_or_datetime();
-
         if (left_is_num_can_compare && right_is_num_can_compare) {
             if (!(execute_num_left_type<UInt8>(block, result, col_left_untyped,
                                                col_right_untyped) ||


### PR DESCRIPTION
### What problem does this PR solve?
make datev2/datetimev2's comparison use numric compare

```sql
SELECT
    sum(
        mmrda.report_date >= maz.start_date
        and mmrda.report_date < maz.end_date
    )
from
   mmrda LEFT JOIN maz ON mmrda.account_id = maz.account_id;

before:
-  ProjectionTime:  6sec960ms
-  RowsProduced:  811.9128M  (811912800)
after:
-  ProjectionTime:  3sec413ms
-  RowsProduced:  811.9128M  (811912800)

```
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

