### PR TITLE
[opt](cloud) Support cached cloud partition version for high frequency query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
@@ -166,7 +166,7 @@ public class Partition extends MetaObject {
     /* fromCache is only used in CloudPartition
      * make it overrided here to avoid rewrite all the usages with ugly Config.isCloudConfig() branches
      */
-    public long getVisibleVersion(Boolean fromCache) {
+    public long getCachedVisibleVersion() {
         return visibleVersion;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -117,7 +117,7 @@ public class CloudPartition extends Partition {
     }
 
     public boolean isCachedVersionExpired() {
-        long cacheExpirationMs = SessionVariable.cachedCloudPartitionVersionExpirationMs;
+        long cacheExpirationMs = SessionVariable.cloudPartitionVersionCacheTtlMs;
         if (cacheExpirationMs <= 0) { // always expired
             return true;
         }
@@ -247,7 +247,7 @@ public class CloudPartition extends Partition {
             return new ArrayList<>();
         }
 
-        if (SessionVariable.cachedCloudPartitionVersionExpirationMs <= 0) { // No cached versions will be used
+        if (SessionVariable.cloudPartitionVersionCacheTtlMs <= 0) { // No cached versions will be used
             return getSnapshotVisibleVersionFromMs(partitions);
         }
 
@@ -264,8 +264,8 @@ public class CloudPartition extends Partition {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("cachedCloudPartitionVersionExpirationMs={}, numPartitions={}, numFilteredPartitions={}",
-                    SessionVariable.cachedCloudPartitionVersionExpirationMs,
+            LOG.debug("cloudPartitionVersionCacheTtlMs={}, numPartitions={}, numFilteredPartitions={}",
+                    SessionVariable.cloudPartitionVersionCacheTtlMs,
                     partitions.size(), partitions.size() - expiredPartitions.size());
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -25,9 +25,11 @@ import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.proto.Cloud.MetaServiceCode;
 import org.apache.doris.cloud.rpc.VersionHelper;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.rpc.RpcException;
 
@@ -54,11 +56,15 @@ public class CloudPartition extends Partition {
     @SerializedName(value = "tableId")
     private long tableId;
 
+    // This value is set when get the version from meta-service, 0 means version is not cached yet
+    private long lastVersionCachedTimeMs = 0;
+
     private ReentrantLock lock = new ReentrantLock(true);
 
     public CloudPartition(long id, String name, MaterializedIndex baseIndex,
                           DistributionInfo distributionInfo, long dbId, long tableId) {
         super(id, name, baseIndex, distributionInfo);
+        super.setVisibleVersion(-1); // cloud partition version is not resident in FE memory, -1 mean unknown
         super.nextVersion = -1;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -100,17 +106,32 @@ public class CloudPartition extends Partition {
             super.setVisibleVersionAndTime(version, versionUpdateTimeMs);
         }
         lock.unlock();
+
+        // versionUpdateTimeMs is the version mtime in MS, which is unlikely equal to lastVersionCachedTimeMs in FE
+        lastVersionCachedTimeMs = System.currentTimeMillis();
     }
 
     @Override
-    public long getVisibleVersion(Boolean fromCache) {
+    public long getCachedVisibleVersion() {
         return super.getVisibleVersion();
+    }
+
+    public boolean isCachedVersionExpired() {
+        long cacheExpirationMs = SessionVariable.cachedCloudPartitionVersionExpirationMs;
+        if (cacheExpirationMs <= 0) { // always expired
+            return true;
+        }
+        return System.currentTimeMillis() - lastVersionCachedTimeMs > cacheExpirationMs;
     }
 
     @Override
     public long getVisibleVersion() {
         if (Env.isCheckpointThread() || Config.enable_check_compatibility_mode) {
             return super.getVisibleVersion();
+        }
+
+        if (!isCachedVersionExpired()) {
+            return getCachedVisibleVersion();
         }
 
         if (LOG.isDebugEnabled()) {
@@ -127,18 +148,20 @@ public class CloudPartition extends Partition {
         try {
             Cloud.GetVersionResponse resp = VersionHelper.getVersionFromMeta(request);
             long version = -1;
+            long mTime = -1;
             if (resp.getStatus().getCode() == MetaServiceCode.OK) {
                 version = resp.getVersion();
                 // Cache visible version, see hasData() for details.
-                long mTime = resp.getVersionUpdateTimeMsList().size() == 1 ? resp.getVersionUpdateTimeMs(0) : 0;
-                setCachedVisibleVersion(version, mTime);
+                mTime = resp.getVersionUpdateTimeMsList().size() == 1 ? resp.getVersionUpdateTimeMs(0) : 0;
             } else {
                 assert resp.getStatus().getCode() == MetaServiceCode.VERSION_NOT_FOUND;
                 version = Partition.PARTITION_INIT_VERSION;
+                mTime = System.currentTimeMillis();
             }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("get version from meta service, version: {}, partition: {}", version, super.getId());
             }
+            setCachedVisibleVersion(version, mTime);
             return version;
         } catch (RpcException e) {
             throw new RuntimeException("get version from meta service failed");
@@ -182,8 +205,8 @@ public class CloudPartition extends Partition {
 
     // Get visible version from the specified partitions;
     //
-    // Return the visible version in order of the specified partition ids, -1 means version NOT FOUND.
-    public static List<Long> getSnapshotVisibleVersion(List<CloudPartition> partitions) throws RpcException {
+    // Return the visible version in order of the specified partition ids
+    public static List<Long> getSnapshotVisibleVersionFromMs(List<CloudPartition> partitions) throws RpcException {
         if (partitions.isEmpty()) {
             return new ArrayList<>();
         }
@@ -208,16 +231,64 @@ public class CloudPartition extends Partition {
                 // For compatibility, the existing partitions may not have mtime
                 long mTime = versions.size() == versionUpdateTimesMs.size() ? versionUpdateTimesMs.get(i) : 0;
                 partitions.get(i).setCachedVisibleVersion(versions.get(i), mTime);
+            } else { // No data has been written to this partition
+                partitions.get(i).setCachedVisibleVersion(Partition.PARTITION_INIT_VERSION, System.currentTimeMillis());
             }
         }
 
         return versions;
     }
 
-    // Get visible versions for the specified partitions.
+    // Get visible version from the specified partitions;
     //
     // Return the visible version in order of the specified partition ids, -1 means version NOT FOUND.
-    public static List<Long> getSnapshotVisibleVersion(List<Long> dbIds, List<Long> tableIds, List<Long> partitionIds,
+    public static List<Long> getSnapshotVisibleVersion(List<CloudPartition> partitions) throws RpcException {
+        if (partitions.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        if (SessionVariable.cachedCloudPartitionVersionExpirationMs <= 0) { // No cached versions will be used
+            return getSnapshotVisibleVersionFromMs(partitions);
+        }
+
+        // partitionId -> cachedVersion
+        List<Pair<Long, Long>> allVersions = new ArrayList<>();
+        List<CloudPartition> expiredPartitions = new ArrayList<>();
+        for (CloudPartition partition : partitions) {
+            long ver = partition.getCachedVisibleVersion();
+            if (partition.isCachedVersionExpired()) {
+                expiredPartitions.add(partition);
+                ver = 0L; // 0 means to be get from meta-service
+            }
+            allVersions.add(Pair.of(partition.getId(), ver));
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("cachedCloudPartitionVersionExpirationMs={}, numPartitions={}, numFilteredPartitions={}",
+                    SessionVariable.cachedCloudPartitionVersionExpirationMs,
+                    partitions.size(), partitions.size() - expiredPartitions.size());
+        }
+
+        List<Long> versions = null;
+        if (!expiredPartitions.isEmpty()) { // Not all partition versions are from cache
+            versions = getSnapshotVisibleVersionFromMs(expiredPartitions); // Get the rest versions from meta-service
+        }
+        int verMsIdx = 0;
+        for (Pair<Long, Long> v : allVersions) { // ATTN: keep the assigning order!!!
+            if (v.second == 0L && versions != null) {
+                v.second = versions.get(verMsIdx++);
+            }
+        }
+        assert verMsIdx == versions.size() : "size not match, idx=" + verMsIdx + " verSize=" + versions.size();
+        versions = allVersions.stream().map(i -> i.second).collect(Collectors.toList());
+
+        return versions;
+    }
+
+    // Get visible versions for the specified partitions.
+    //
+    // Return the visible version in order of the specified partition ids
+    private static List<Long> getSnapshotVisibleVersion(List<Long> dbIds, List<Long> tableIds, List<Long> partitionIds,
             List<Long> versionUpdateTimesMs)
             throws RpcException {
         assert dbIds.size() == partitionIds.size() :
@@ -258,7 +329,7 @@ public class CloudPartition extends Partition {
         }
 
         ArrayList<Long> news = new ArrayList<>();
-        for (Long v : versions) {
+        for (Long v : versions) { // -1 means version NOT FOUND ==> no data has been written
             news.add(v == -1 ?  Partition.PARTITION_INIT_VERSION : v);
         }
         return news;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -279,7 +279,9 @@ public class CloudPartition extends Partition {
                 v.second = versions.get(verMsIdx++);
             }
         }
-        assert verMsIdx == versions.size() : "size not match, idx=" + verMsIdx + " verSize=" + versions.size();
+        if (!expiredPartitions.isEmpty()) { // Not all partition versions are from cache
+            assert verMsIdx == versions.size() : "size not match, idx=" + verMsIdx + " verSize=" + versions.size();
+        }
         versions = allVersions.stream().map(i -> i.second).collect(Collectors.toList());
 
         return versions;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -695,8 +695,8 @@ public class SessionVariable implements Serializable, Writable {
     // CLOUD_VARIABLES_BEGIN
     public static final String CLOUD_CLUSTER = "cloud_cluster";
     public static final String DISABLE_EMPTY_PARTITION_PRUNE = "disable_empty_partition_prune";
-    public static final String CACHED_CLOUD_PARTITION_VERSION_EXPIRATION_MS =
-            "cached_cloud_partition_version_expiration_ms";
+    public static final String CLOUD_PARTITION_VERSION_CACHE_TTL_MS =
+            "cloud_partition_version_cache_ttl_ms";
     // CLOUD_VARIABLES_BEGIN
 
     public static final String ENABLE_MATCH_WITHOUT_INVERTED_INDEX = "enable_match_without_inverted_index";
@@ -2366,8 +2366,8 @@ public class SessionVariable implements Serializable, Writable {
     public String cloudCluster = "";
     @VariableMgr.VarAttr(name = DISABLE_EMPTY_PARTITION_PRUNE)
     public boolean disableEmptyPartitionPrune = false;
-    @VariableMgr.VarAttr(name = CACHED_CLOUD_PARTITION_VERSION_EXPIRATION_MS)
-    public static long cachedCloudPartitionVersionExpirationMs = 0;
+    @VariableMgr.VarAttr(name = CLOUD_PARTITION_VERSION_CACHE_TTL_MS)
+    public static long cloudPartitionVersionCacheTtlMs = 0;
     // CLOUD_VARIABLES_END
 
     // fetch remote schema rpc timeout

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -695,6 +695,8 @@ public class SessionVariable implements Serializable, Writable {
     // CLOUD_VARIABLES_BEGIN
     public static final String CLOUD_CLUSTER = "cloud_cluster";
     public static final String DISABLE_EMPTY_PARTITION_PRUNE = "disable_empty_partition_prune";
+    public static final String CACHED_CLOUD_PARTITION_VERSION_EXPIRATION_MS =
+            "cached_cloud_partition_version_expiration_ms";
     // CLOUD_VARIABLES_BEGIN
 
     public static final String ENABLE_MATCH_WITHOUT_INVERTED_INDEX = "enable_match_without_inverted_index";
@@ -2364,6 +2366,8 @@ public class SessionVariable implements Serializable, Writable {
     public String cloudCluster = "";
     @VariableMgr.VarAttr(name = DISABLE_EMPTY_PARTITION_PRUNE)
     public boolean disableEmptyPartitionPrune = false;
+    @VariableMgr.VarAttr(name = CACHED_CLOUD_PARTITION_VERSION_EXPIRATION_MS)
+    public static long cachedCloudPartitionVersionExpirationMs = 0;
     // CLOUD_VARIABLES_END
 
     // fetch remote schema rpc timeout

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -714,7 +714,7 @@ public class CacheAnalyzer {
             if (partition.getVisibleVersionTime() >= cacheTable.latestPartitionTime) {
                 cacheTable.latestPartitionId = partition.getId();
                 cacheTable.latestPartitionTime = partition.getVisibleVersionTime();
-                cacheTable.latestPartitionVersion = partition.getVisibleVersion(true);
+                cacheTable.latestPartitionVersion = partition.getCachedVisibleVersion();
             }
         }
         return cacheTable;

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
@@ -46,11 +46,11 @@ public class CloudPartitionTest {
     public void testIsCachedVersionExpired() {
         // test isCachedVersionExpired
         CloudPartition part = createPartition(1, 2, 3);
-        SessionVariable.cachedCloudPartitionVersionExpirationMs = 0;
+        SessionVariable.cloudPartitionVersionCacheTtlMs = 0;
         Assertions.assertTrue(part.isCachedVersionExpired());
-        SessionVariable.cachedCloudPartitionVersionExpirationMs = -10086;
+        SessionVariable.cloudPartitionVersionCacheTtlMs = -10086;
         part.setCachedVisibleVersion(2, 10086L); // update version and last cache time
-        SessionVariable.cachedCloudPartitionVersionExpirationMs = 10000;
+        SessionVariable.cloudPartitionVersionCacheTtlMs = 10000;
         Assertions.assertFalse(part.isCachedVersionExpired()); // not expired due to long expiration duration
         Assertions.assertEquals(2, part.getCachedVisibleVersion());
 
@@ -87,7 +87,7 @@ public class CloudPartitionTest {
         };
         // CHECKSTYLE ON
 
-        SessionVariable.cachedCloudPartitionVersionExpirationMs = -1; // disable cache
+        SessionVariable.cloudPartitionVersionCacheTtlMs = -1; // disable cache
             {
                 // test single get version
                 Assertions.assertEquals(2, part.getVisibleVersion()); // should not get from cache
@@ -106,7 +106,7 @@ public class CloudPartitionTest {
             }
 
         // enable change expiration and make it cached in long duration
-        SessionVariable.cachedCloudPartitionVersionExpirationMs = 100000;
+        SessionVariable.cloudPartitionVersionCacheTtlMs = 100000;
             {
                 // test single get version
                 Assertions.assertEquals(2, part.getVisibleVersion()); // cached version
@@ -125,7 +125,7 @@ public class CloudPartitionTest {
             }
 
         // enable change expiration and make it expired
-        SessionVariable.cachedCloudPartitionVersionExpirationMs = 500;
+        SessionVariable.cloudPartitionVersionCacheTtlMs = 500;
         try {
             Thread.sleep(550);
         } catch (InterruptedException e) {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.catalog;
+
+import org.apache.doris.cloud.proto.Cloud;
+import org.apache.doris.cloud.rpc.VersionHelper;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.rpc.RpcException;
+
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CloudPartitionTest {
+
+    @Ignore
+    public void getCachedVisibleVersion() {
+    }
+
+    public static CloudPartition createPartition(long pId, long dbId, long tblId) {
+        return new CloudPartition(pId, "p" + pId, null, null, dbId, tblId);
+    }
+
+    @Test
+    public void testIsCachedVersionExpired() {
+        // test isCachedVersionExpired
+        CloudPartition part = createPartition(1, 2, 3);
+        SessionVariable.cachedCloudPartitionVersionExpirationMs = 0;
+        Assertions.assertTrue(part.isCachedVersionExpired());
+        SessionVariable.cachedCloudPartitionVersionExpirationMs = -10086;
+        part.setCachedVisibleVersion(2, 10086L); // update version and last cache time
+        SessionVariable.cachedCloudPartitionVersionExpirationMs = 10000;
+        Assertions.assertFalse(part.isCachedVersionExpired()); // not expired due to long expiration duration
+        Assertions.assertEquals(2, part.getCachedVisibleVersion());
+
+    }
+
+    @Test
+    public void testCachedVersion() throws RpcException {
+        CloudPartition part = createPartition(1, 2, 3);
+        List<CloudPartition> parts = new ArrayList<>();
+        for (long i = 0; i < 3; ++i) {
+            parts.add(createPartition(5 + i, 5 + i, 5 + i));
+        }
+        Assertions.assertEquals(-1, part.getCachedVisibleVersion()); // not initialized FE side version
+
+        // CHECKSTYLE OFF
+        final ArrayList<Long> singleVersions = new ArrayList<>(Arrays.asList(2L, 3L, 4L, 5L));
+        final ArrayList<ArrayList<Long>> batchVersions = new ArrayList<>(Arrays.asList(
+                new ArrayList<>(Arrays.asList(1L, 2L, -1L)),
+                new ArrayList<>(Arrays.asList(2L, 3L, -1L)),
+                new ArrayList<>(Arrays.asList(3L, 4L, -1L)),
+                new ArrayList<>(Arrays.asList(5L, -1L))
+        ));
+        final Integer[] callCount = {0};
+
+        new MockUp<VersionHelper>(VersionHelper.class) {
+            @Mock
+            public Cloud.GetVersionResponse getVersionFromMeta(Cloud.GetVersionRequest req) {
+                Cloud.GetVersionResponse.Builder builder = Cloud.GetVersionResponse.newBuilder();
+                builder.setVersion(singleVersions.get(callCount[0]));
+                builder.addAllVersions(batchVersions.get(callCount[0]));
+                ++callCount[0];
+                return builder.build();
+            }
+        };
+        // CHECKSTYLE ON
+
+        SessionVariable.cachedCloudPartitionVersionExpirationMs = -1; // disable cache
+            {
+                // test single get version
+                Assertions.assertEquals(2, part.getVisibleVersion()); // should not get from cache
+                Assertions.assertEquals(1, callCount[0]); // issue a rpc call to meta-service
+
+                // test snapshot versions
+                List<Long> versions = CloudPartition.getSnapshotVisibleVersion(parts); // should not get from cache
+                Assertions.assertEquals(2, callCount[0]); // issue a rpc call to meta-service
+                for (int i = 0; i < batchVersions.get(1).size(); ++i) {
+                    Long exp = batchVersions.get(1).get(i);
+                    if (exp == -1) {
+                        exp = CloudPartition.PARTITION_INIT_VERSION;
+                    }
+                    Assertions.assertEquals(exp, versions.get(i));
+                }
+            }
+
+        // enable change expiration and make it cached in long duration
+        SessionVariable.cachedCloudPartitionVersionExpirationMs = 100000;
+            {
+                // test single get version
+                Assertions.assertEquals(2, part.getVisibleVersion()); // cached version
+                Assertions.assertEquals(2, callCount[0]); // issue a rpc call to meta-service
+
+                // test snapshot versions
+                List<Long> versions = CloudPartition.getSnapshotVisibleVersion(parts); // should not get from cache
+                Assertions.assertEquals(2, callCount[0]); // issue a rpc call to meta-service
+                for (int i = 0; i < batchVersions.get(1).size(); ++i) {
+                    Long exp = batchVersions.get(1).get(i);
+                    if (exp == -1) {
+                        exp = CloudPartition.PARTITION_INIT_VERSION;
+                    }
+                    Assertions.assertEquals(exp, versions.get(i));
+                }
+            }
+
+        // enable change expiration and make it expired
+        SessionVariable.cachedCloudPartitionVersionExpirationMs = 500;
+        try {
+            Thread.sleep(550);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        // make some partition not expired, these partitions will not get version from meta-service
+        CloudPartition hotPartition = parts.get(0);
+        hotPartition.setCachedVisibleVersion(hotPartition.getCachedVisibleVersion(), 10086L);
+        Assertions.assertEquals(2, hotPartition.getCachedVisibleVersion());
+        Assertions.assertFalse(hotPartition.isCachedVersionExpired());
+        Assertions.assertTrue(parts.get(1).isCachedVersionExpired());
+        Assertions.assertTrue(parts.get(2).isCachedVersionExpired());
+
+            {
+                // test single get version
+                Assertions.assertEquals(4, part.getVisibleVersion()); // should not get from cache
+                Assertions.assertEquals(3, callCount[0]); // issue a rpc call to meta-service
+
+                // test snapshot versions
+                List<Long> versions = CloudPartition.getSnapshotVisibleVersion(parts); // should not get from cache
+                Assertions.assertEquals(versions.size(), parts.size());
+                Assertions.assertEquals(4, callCount[0]); // issue a rpc call to meta-service
+                for (int i = 0; i < batchVersions.get(3).size(); ++i) {
+                    Long exp = batchVersions.get(3).get(i);
+                    if (exp == -1) {
+                        exp = CloudPartition.PARTITION_INIT_VERSION;
+                    }
+                    Assertions.assertEquals(exp, versions.get(i + 1)); // exclude the first hot partition
+                }
+                // hot partition version not changed
+                Assertions.assertEquals(2, hotPartition.getCachedVisibleVersion());
+            }
+    }
+}

--- a/regression-test/suites/cloud_p0/version/test_fe_cached_partition_version.groovy
+++ b/regression-test/suites/cloud_p0/version/test_fe_cached_partition_version.groovy
@@ -40,10 +40,10 @@ suite("test_fe_cached_partition_version", 'docker') {
     options.connectToFollower = true
     for (def j = 0; j < 2; j++) {
         docker(options) {
-            def tbl = 'test_cached_cloud_partition_version_expiration_ms'
+            def tbl = 'test_cloud_partition_version_cache_ttl_ms'
             sql """ DROP TABLE IF EXISTS ${tbl} """
             try {
-                sql """set global cached_cloud_partition_version_expiration_ms=0"""
+                sql """set global cloud_partition_version_cache_ttl_ms=0"""
                 sql """
                     CREATE TABLE IF NOT EXISTS ${tbl} (
                         region VARCHAR(50) NOT NULL COMMENT "地区",
@@ -71,7 +71,7 @@ suite("test_fe_cached_partition_version", 'docker') {
                 assertEquals(2, result.size())
 
                 // very large expiration time, test it is old
-                sql """set global cached_cloud_partition_version_expiration_ms=10000000"""
+                sql """set global cloud_partition_version_cache_ttl_ms=10000000"""
                 // trigger cache version of shanghai
                 result = sql_return_maparray """ select * from ${tbl} where region = 'Shanghai' """
                 assertEquals(1, result.size())
@@ -103,7 +103,7 @@ suite("test_fe_cached_partition_version", 'docker') {
                 }
 
                 // test small expiration
-                sql """set global cached_cloud_partition_version_expiration_ms=1000"""
+                sql """set global cloud_partition_version_cache_ttl_ms=1000"""
                 Thread.sleep(1100)
                 // all 4 inserts should be seen after expiration, select and refresh expiration
                 result = sql_return_maparray """ select * from ${tbl} """
@@ -141,7 +141,7 @@ suite("test_fe_cached_partition_version", 'docker') {
 
                 // test no expiration, disable cache partition version 
                 insert_sql """INSERT INTO ${tbl} VALUES ('Guangzhou', 1})""", 1
-                sql """set global cached_cloud_partition_version_expiration_ms=0"""
+                sql """set global cloud_partition_version_cache_ttl_ms=0"""
                 result = sql_return_maparray """ select * from ${tbl} """
                 assertEquals(6, result.size())
 

--- a/regression-test/suites/cloud_p0/version/test_fe_cached_partition_version.groovy
+++ b/regression-test/suites/cloud_p0/version/test_fe_cached_partition_version.groovy
@@ -1,0 +1,160 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import com.mysql.cj.jdbc.StatementImpl
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_fe_cached_partition_version", 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+    def options = new ClusterOptions()
+    // one master, one observer
+    options.setFeNum(2)
+    options.setBeNum(1)
+    options.cloudMode = true
+
+    def insert_sql = { sql, expected_row_count ->
+        def stmt = prepareStatement """ ${sql}  """
+        def result = stmt.executeUpdate()
+        logger.info("insert result: " + result)
+        def serverInfo = (((StatementImpl) stmt).results).getServerInfo()
+        logger.info("result server info: " + serverInfo)
+        assertEquals(result, expected_row_count)
+        assertTrue(serverInfo.contains("'status':'VISIBLE'"))
+    }
+    // connect to follower/observer for testing, master will update
+    options.connectToFollower = true
+    for (def j = 0; j < 2; j++) {
+        docker(options) {
+            def tbl = 'test_cached_cloud_partition_version_expiration_ms'
+            sql """ DROP TABLE IF EXISTS ${tbl} """
+            try {
+                sql """set global cached_cloud_partition_version_expiration_ms=0"""
+                sql """
+                    CREATE TABLE IF NOT EXISTS ${tbl} (
+                        region VARCHAR(50) NOT NULL COMMENT "地区",
+                        sales INT NOT NULL COMMENT "销售额"
+                    )
+                    ENGINE = olap
+                    DUPLICATE KEY(region)
+                    PARTITION BY LIST (region) 
+                    (
+                        PARTITION p_east VALUES IN ("Shanghai", "Nanjing"),
+                        PARTITION p_south VALUES IN ("Guangzhou", "Shenzhen"),
+                        PARTITION p_north VALUES IN ("Beijing", "Tianjin")
+                    )
+                    DISTRIBUTED BY HASH(region) BUCKETS 10
+                    PROPERTIES (
+                        "replication_num" = "1"
+                    );
+                    """
+                def result = sql_return_maparray """ select * from ${tbl} """
+                assertEquals(0, result.size())
+
+                insert_sql """INSERT INTO ${tbl} VALUES ('Shanghai', 1})""", 1
+                insert_sql """INSERT INTO ${tbl} VALUES ('Guangzhou', 1})""", 1
+                result = sql_return_maparray """ select * from ${tbl} """
+                assertEquals(2, result.size())
+
+                // very large expiration time, test it is old
+                sql """set global cached_cloud_partition_version_expiration_ms=10000000"""
+                // trigger cache version of shanghai
+                result = sql_return_maparray """ select * from ${tbl} where region = 'Shanghai' """
+                assertEquals(1, result.size())
+
+                insert_sql """INSERT INTO ${tbl} VALUES ('Shanghai', 1})""", 1
+                result = sql_return_maparray """ select * from ${tbl} where region = 'Shanghai' """
+                // observer/follower cannot see update since large expiration
+                if (options.connectToFollower == true) {
+                    assertEquals(1, result.size())
+                } else { // master will always refresh cached verison after a load txn commit
+                    assertEquals(2, result.size())
+                }
+
+                result = sql_return_maparray """ select * from ${tbl} """
+                // observer/follower cannot see update since large expiration
+                if (options.connectToFollower == true) {
+                    assertEquals(2, result.size())
+                } else { // master will always refresh cached verison after a load txn commit
+                    assertEquals(3, result.size())
+                }
+
+                insert_sql """INSERT INTO ${tbl} VALUES ('Beijing', 1})""", 1
+                result = sql_return_maparray """ select * from ${tbl} where region = 'Beijing' """
+                // observer/follower cannot see update since large expiration
+                if (options.connectToFollower == true) {
+                    assertEquals(0, result.size())
+                } else { // master will always refresh cached verison after a load txn commit
+                    assertEquals(1, result.size())
+                }
+
+                // test small expiration
+                sql """set global cached_cloud_partition_version_expiration_ms=1000"""
+                Thread.sleep(1100)
+                // all 4 inserts should be seen after expiration, select and refresh expiration
+                result = sql_return_maparray """ select * from ${tbl} """
+                assertEquals(4, result.size())
+
+                insert_sql """INSERT INTO ${tbl} VALUES ('Beijing', 1})""", 1
+                // refresh expiration
+                result = sql_return_maparray """ select * from ${tbl} where region = 'Beijing' """
+                // observer/follower cannot see update since cache expiration no reached
+                if (options.connectToFollower == true) {
+                    assertEquals(1, result.size())
+                } else { // master will always refresh cached verison after a load txn commit
+                    assertEquals(2, result.size())
+                }
+
+                // use the cached version
+                result = sql_return_maparray """ select * from ${tbl} where region = 'Beijing' """
+                // observer/follower cannot see update since cache expiration no reached
+                if (options.connectToFollower == true) {
+                    assertEquals(1, result.size())
+                } else { // master will always refresh cached verison after a load txn commit
+                    assertEquals(2, result.size())
+                }
+
+                Thread.sleep(1100) // wait version cache for exiration again
+                insert_sql """INSERT INTO ${tbl} VALUES ('Beijing', 1})""", 1
+                // refresh expiration, the insert will be seen since the version has expired
+                result = sql_return_maparray """ select * from ${tbl} where region = 'Beijing' """
+                // observer/follower cannot see update since cache expiration no reached
+                assertEquals(3, result.size())
+
+                // all the insert will be seen since the version has expired, refresh expiration
+                result = sql_return_maparray """ select * from ${tbl} """
+                assertEquals(5, result.size())
+
+                // test no expiration, disable cache partition version 
+                insert_sql """INSERT INTO ${tbl} VALUES ('Guangzhou', 1})""", 1
+                sql """set global cached_cloud_partition_version_expiration_ms=0"""
+                result = sql_return_maparray """ select * from ${tbl} """
+                assertEquals(6, result.size())
+
+                insert_sql """INSERT INTO ${tbl} VALUES ('Shanghai', 1})""", 1
+                insert_sql """INSERT INTO ${tbl} VALUES ('Guangzhou', 1})""", 1
+                insert_sql """INSERT INTO ${tbl} VALUES ('Beijing', 1})""", 1
+                // data present immediately without any cached versions
+                result = sql_return_maparray """ select * from ${tbl} """
+                assertEquals(9, result.size())
+            } finally {
+            }
+        }
+        // 2. connect to master
+        options.connectToFollower = false
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Support new session variable to get rid of frequent get_version request to meta-service.
set `cloud_partition_version_cache_ttl_ms` with a suitable value as needed, it means a partition's version may be cached on FE at most X milliseconds.
pro: reduce RPC/IO to meta-service and fdb, increase query throughput and reduce query latency (plan phase)
con: visibility may be delayed when doing point query; data consistency (snapshot) may be broken when doing query wi involved multiple partitions and there is continuous data import;

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

