### PR TITLE
[fix](lakesoul) fix partition key parser

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lakesoul/source/LakeSoulScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lakesoul/source/LakeSoulScanNode.java
@@ -254,8 +254,12 @@ public class LakeSoulScanNode extends FileQueryScanNode {
             }
         }
         List<String> pkKeys = null;
+        // partition;primary keys
         if (!tableInfo.getPartitions().equals(";")) {
-            pkKeys = Lists.newArrayList(tableInfo.getPartitions().split(";")[1].split(","));
+            String[] parts = tableInfo.getPartitions().split(";");
+            if (parts.length > 1) {
+                pkKeys = Lists.newArrayList(parts[1].split(","));
+            }
         }
 
         for (Map.Entry<String, Map<Integer, List<String>>> entry : splitByRangeAndHashPartition.entrySet()) {


### PR DESCRIPTION
### What problem does this PR solve?

The lakesoul's partition and primary key are stored as format: `part_col1,part_col2;pri_col1,pri_col2`
When there is a partitioned, non-primary key table, there is only `part_col1,part_col2;`.
So the split method should check if there is "primary key" part before visiting it.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

