### PR TITLE
[bugfix](fold) Skip constant folding in from_base64 function to fix binary data handling

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -39,6 +39,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Match;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.FromBase64;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.NonNullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Sleep;
@@ -232,7 +233,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
         }
 
         // Skip from_base64 function to avoid incorrect binary data processing during constant folding
-        if (expr instanceof BoundFunction && ((BoundFunction) expr).getName().equalsIgnoreCase("from_base64")) {
+        if (expr instanceof FromBase64) {
             return true;
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
@@ -233,9 +233,7 @@ class LiteralTest {
         PValues.Builder resultContentBuilder = PValues.newBuilder();
         for (int i = 0; i < elementsArray.length; i = i + 2) {
             childBuilder1.addInt32Value(elementsArray[i]);
-            String strValue = "str" + (i + 1);
-            childBuilder2.addStringValue(strValue);
-            childBuilder2.addBytesValue(com.google.protobuf.ByteString.copyFromUtf8(strValue));
+            childBuilder2.addStringValue("str" + (i + 1));
         }
         childBuilder1.setType(childTypeBuilder1.build());
         childBuilder2.setType(childTypeBuilder2.build());
@@ -282,9 +280,7 @@ class LiteralTest {
         PValues.Builder resultContentBuilder = PValues.newBuilder();
         for (int i = 0; i < elementsArray.length; i = i + 2) {
             childBuilder1.addInt32Value(elementsArray[i]);
-            String strValue = "str" + (i + 1);
-            childBuilder2.addStringValue(strValue);
-            childBuilder2.addBytesValue(com.google.protobuf.ByteString.copyFromUtf8(strValue));
+            childBuilder2.addStringValue("str" + (i + 1));
         }
         childBuilder1.setType(childTypeBuilder1.build());
         childBuilder2.setType(childTypeBuilder2.build());


### PR DESCRIPTION
### What problem does this PR solve?

revert: #43410

1. `In PR 43410, I used getBytesValue, but bytes value had no data, so an error was reported when trying to get it, causing constant folding to fail. So the query result was correct in the end, but this fix was wrong. Now I undo my previous fix.`

2. `The current pr skips the from_base64 function in constant folding processing.`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

