### PR TITLE
[fix](parquet-writer) Fix logging crash during exception handling in parquet-writer.

### DIFF
--- a/be/src/util/arrow/block_convertor.cpp
+++ b/be/src/util/arrow/block_convertor.cpp
@@ -111,7 +111,7 @@ Status FromBlockConverter::convert(std::shared_ptr<arrow::RecordBatch>* out) {
         } catch (std::exception& e) {
             return Status::InternalError(
                     "Fail to convert block data to arrow data, type: {}, name: {}, error: {}",
-                    _cur_type->get_name(), e.what());
+                    _cur_type->get_name(), _block.get_by_position(idx).name, e.what());
         }
         arrow_st = _cur_builder->Finish(&_arrays[_cur_field_idx]);
         if (!arrow_st.ok()) {


### PR DESCRIPTION
### What problem does this PR solve?

related: #42888

Problem Summary:

```
*** Query id: 145152ee39e2480e-a8ee49559dff031d ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1745737995 (unix time) try "date -d @1745737995" if you are using GNU date ***
*** Current BE git commitID: 647e13eae0 ***
*** SIGABRT unknown detail explain (@0x1a47b3) received by PID 1722291 (TID 1723276 OR 0x7fa96bdfe640) from PID 1722291; stack trace: ***
terminate called recursively
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007FA9F1265520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 6# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 7# 0x0000557A985D0D71 in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
 8# 0x0000557A985D0EC4 in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
 9# fmt::v7::detail::error_handler::on_error(char const*) [clone .constprop.0] in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
10# char const* fmt::v7::detail::parse_replacement_field<char, fmt::v7::detail::format_handler<fmt::v7::detail::buffer_appender<char>, char, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char> >&>(char const*, char const*, fmt::v7::detail::format_handler<fmt::v7::detail::buffer_appender<char>, char, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char> >&) in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
11# void fmt::v7::detail::vformat_to<char>(fmt::v7::detail::buffer<char>&, fmt::v7::basic_string_view<char>, fmt::v7::basic_format_args<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<fmt::v7::type_identity<char>::type>, fmt::v7::type_identity<char>::type> >, fmt::v7::detail::locale_ref) in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
12# fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args) in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
13# doris::Status doris::Status::Error<6, true, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, char const*>(std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, char const*&&) at /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:427
14# doris::FromBlockConverter::convert(std::shared_ptr<arrow::RecordBatch>*) at /home/zcp/repo_center/doris_master/doris/be/src/util/arrow/block_convertor.cpp:112
15# doris::convert_to_arrow_batch(doris::vectorized::Block const&, std::shared_ptr<arrow::Schema> const&, arrow::MemoryPool*, std::shared_ptr<arrow::RecordBatch>*, cctz::time_zone const&) in /mnt/disk1/doris-clusters/doris-master/output/be/lib/doris_be
16# doris::vectorized::VParquetTransformer::write(doris::vectorized::Block const&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vparquet_transformer.cpp:281
17# doris::vectorized::VHivePartitionWriter::write(doris::vectorized::Block&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/writer/vhive_partition_writer.cpp:142
18# doris::vectorized::VHiveTableWriter::write(doris::RuntimeState*, doris::vectorized::Block&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/writer/vhive_table_writer.cpp:139
19# doris::vectorized::AsyncResultWriter::process_block(doris::RuntimeState*, doris::RuntimeProfile*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/writer/async_result_writer.cpp:162
20# std::_Function_handler<void (), doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
21# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:626
22# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:496
23# start_thread at ./nptl/pthread_create.c:442
24# 0x00007FA9F1349850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83 
```

### Release note

[fix] (parquet-writer) Fix logging crash during exception handling in parquet-writer.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

