### PR TITLE
[chore](load) adjust load_task_high_priority_threshold_second default value

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -907,7 +907,7 @@ DEFINE_Int32(multi_table_max_wait_tables, "5");
 // Doris treats it as a high priority task.
 // high priority tasks use a separate thread pool for flush and do not block rpc by memory cleanup logic.
 // this threshold is mainly used to identify routine load tasks and should not be modified if not necessary.
-DEFINE_mInt32(load_task_high_priority_threshold_second, "120");
+DEFINE_mInt32(load_task_high_priority_threshold_second, "600");
 
 // The min timeout of load rpc (add batch, close, etc.)
 // Because a load rpc may be blocked for a while.


### PR DESCRIPTION
### What problem does this PR solve?

High priority load task was introduced to avoid load timeout with short execution times, which mainly for routine load tasks, now the timeout time for routine load tasks has been is set to 10 times the max_match_interval (https://github.com/apache/doris/pull/40818), so the default value of load_task_high_priority_threshold_second should also be increased.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

