### PR TITLE
[chore](codeowner)Set a CodeOwner for the FS module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,3 +35,5 @@ cloud/ @gavinchou @dataroaring @w41ter
 be/src/cloud/ @gavinchou @dataroaring
 gensrc/proto/olap_file.proto @gavinchou @dataroaring @yiguolei
 gensrc/proto/cloud.proto @gavinchou @dataroaring @w41ter
+fe/fe-core/src/main/java/org/apache/doris/fs @CalvinKirs
+fe/fe-core/src/main/java/org/apache/doris/fsv2 @CalvinKirs


### PR DESCRIPTION
I'm currently refactoring the new FS parameters. Since the integration needs to be done gradually, the old FS will still have ongoing code changes during this period. I'd like to set myself as the CodeOwner to ensure I don't miss any updates to the old FS.

