### PR TITLE
[fix](partition)fix default partitionkey not persistent and keep default on some operator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
@@ -90,8 +90,12 @@ public class AddPartitionRecord {
             sb.append("\");");
         } else if (!this.listPartitionItem.equals(ListPartitionItem.DUMMY_ITEM)) {
             // list
-            sb.append("VALUES IN ");
-            sb.append(((ListPartitionItem) listPartitionItem).toSql());
+            String partitionSql = ((ListPartitionItem) listPartitionItem).toSql();
+            // the partition may default partition
+            if (!partitionSql.isEmpty()) {
+                sb.append("VALUES IN ");
+                sb.append(partitionSql);
+            }
             sb.append(" (\"version_info\" = \"");
             sb.append(partition.getVisibleVersion());
             sb.append("\");");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -207,21 +207,27 @@ public class ListPartitionInfo extends PartitionInfo {
             String partitionName = partition.getName();
             List<PartitionKey> partitionKeys = entry.getValue().getItems();
 
-            sb.append("PARTITION ").append(partitionName).append(" VALUES IN ");
-            sb.append("(");
+            sb.append("PARTITION ").append(partitionName);
+            StringBuilder partitionKeysBuilder = new StringBuilder();
             int idxInternal = 0;
             for (PartitionKey partitionKey : partitionKeys) {
                 String partitionKeyStr = partitionKey.toSql();
-                if (!isMultiColumnPartition) {
+                if (!isMultiColumnPartition && !partitionKeyStr.isEmpty()) {
                     partitionKeyStr = partitionKeyStr.substring(1, partitionKeyStr.length() - 1);
                 }
-                sb.append(partitionKeyStr);
+                partitionKeysBuilder.append(partitionKeyStr);
                 if (partitionKeys.size() > 1 && idxInternal != partitionKeys.size() - 1) {
-                    sb.append(",");
+                    partitionKeysBuilder.append(",");
                 }
                 idxInternal++;
             }
-            sb.append(")");
+
+            // length == 0 means it is a default partition
+            if (partitionKeysBuilder.length() > 0) {
+                sb.append(" VALUES IN ").append("(");
+                sb.append(partitionKeysBuilder.toString());
+                sb.append(")");
+            }
 
             if (!"".equals(getStoragePolicy(entry.getKey()))) {
                 sb.append("(\"storage_policy\" = \"").append(getStoragePolicy(entry.getKey())).append("\")");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionItem.java
@@ -188,6 +188,9 @@ public class ListPartitionItem extends PartitionItem {
     }
 
     public String toSql() {
+        if (isDefaultPartition) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder();
         sb.append("(");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
@@ -652,8 +652,8 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
                 }
                 JsonPrimitive extend = jsonArray.get(jsonArray.size() - 1).getAsJsonPrimitive();
                 String extendStr = extend.getAsString();
-                // for compatibility, extend takes up the previous "unused" position, so the last element needs to be checked here
-                // if it is unused ignore it
+                // for compatibility, extend takes up the previous "unused" position
+                // so the last element needs to be checked here, if it is unused ignore it
                 if (!extendStr.equals("unused")) {
                     // parse extend record
                     Gson gson = new Gson();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionKey.java
@@ -603,6 +603,8 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
             JsonArray extend = new JsonArray();
             extend.add(context.serialize(partitionKey.isDefaultListPartitionKey()));
 
+            // for compatibility in the future add item before unused
+            extend.add("unused");
             jsonArray.add(new JsonPrimitive(GsonUtils.GSON.toJson(extend)));
 
             return jsonArray;
@@ -650,11 +652,14 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
                 }
                 JsonPrimitive extend = jsonArray.get(jsonArray.size() - 1).getAsJsonPrimitive();
                 String extendStr = extend.getAsString();
+                // for compatibility, extend takes up the previous "unused" position, so the last element needs to be checked here
+                // if it is unused ignore it
                 if (!extendStr.equals("unused")) {
-                    // parse ununsed record
+                    // parse extend record
                     Gson gson = new Gson();
                     JsonArray pExtend = gson.fromJson(extendStr, JsonArray.class);
                     partitionKey.setDefaultListPartition(pExtend.get(0).getAsBoolean());
+                    // ignore the last element
                 }
 
                 return partitionKey;

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/PartitionKeyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/PartitionKeyTest.java
@@ -219,7 +219,9 @@ public class PartitionKeyTest {
         FakeEnv.setMetaVersion(FeConstants.meta_version);
 
         // 1. Write objects to file
-        Path path = Files.createFile(Paths.get("./keyRangePartition"));
+        Path dir = Paths.get("./keyRangePartition");
+        Files.deleteIfExists(dir);
+        Path path = Files.createFile(dir);
         DataOutputStream dos = new DataOutputStream(Files.newOutputStream(path));
 
         PartitionKey keyEmpty = new PartitionKey();
@@ -251,6 +253,13 @@ public class PartitionKeyTest {
         PartitionKey key = PartitionKey.createPartitionKey(keys, columns);
         key.write(dos);
 
+        keys.clear();
+        List<Type> types = new ArrayList<Type>();
+        types.add(ScalarType.createType(PrimitiveType.INT));
+        PartitionKey defaultKey = PartitionKey.createListPartitionKeyWithTypes(keys, types, false);
+        Assert.assertTrue(defaultKey.isDefaultListPartitionKey());
+        defaultKey.write(dos);
+
         dos.flush();
         dos.close();
 
@@ -263,6 +272,10 @@ public class PartitionKeyTest {
         Assert.assertEquals(key, rKey);
         Assert.assertEquals(key, key);
         Assert.assertNotEquals(key, this);
+
+        PartitionKey rDefaultKey = PartitionKey.read(dis);
+        Assert.assertEquals(defaultKey, rDefaultKey);
+        Assert.assertTrue(rDefaultKey.isDefaultListPartitionKey());
 
         // 3. delete files
         dis.close();

--- a/regression-test/suites/partition_p0/list_partition/test_list_default_partition_show_create.groovy
+++ b/regression-test/suites/partition_p0/list_partition/test_list_default_partition_show_create.groovy
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_list_default_partition_show_create") {
+    sql "drop table if exists list_default"
+    sql """
+        CREATE TABLE IF NOT EXISTS list_default ( 
+            k1 int NOT NULL, 
+            k2 int NOT NULL) 
+        UNIQUE KEY(k1)
+        PARTITION BY LIST(k1) ( 
+            PARTITION p1 VALUES IN ("1","2","3","4"), 
+            PARTITION p2 VALUES IN ("5","6","7","8"), 
+            PARTITION p3 ) 
+        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")
+        """
+
+    def res = sql "show create table list_default"
+    logger.info(res[0][1])
+    assertFalse(res[0][1].contains("VALUES IN (\"-2147483648\")"))
+}

--- a/regression-test/suites/partition_p0/list_partition/test_list_default_partition_show_create.groovy
+++ b/regression-test/suites/partition_p0/list_partition/test_list_default_partition_show_create.groovy
@@ -23,13 +23,11 @@ suite("test_list_default_partition_show_create") {
             k2 int NOT NULL) 
         UNIQUE KEY(k1)
         PARTITION BY LIST(k1) ( 
-            PARTITION p1 VALUES IN ("1","2","3","4"), 
-            PARTITION p2 VALUES IN ("5","6","7","8"), 
-            PARTITION p3 ) 
+            PARTITION p1 ) 
         DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")
         """
 
     def res = sql "show create table list_default"
     logger.info(res[0][1])
-    assertFalse(res[0][1].contains("VALUES IN (\"-2147483648\")"))
+    assertTrue(res[0][1].contains("(PARTITION p1)"))
 }


### PR DESCRIPTION
### What problem does this PR solve?

1. The default key's isD attribute was not persisted to disk, and the serialization was not done with the default Gson but with the overloaded PartitionKeySerializer, so after restarting the fe the partitionKey's isD attribute was lost
2. The show create table The default partition in show create table has been modified to no longer show values in
4. The sql in addpartitionrecord no longer records the values of the default key.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

