### PR TITLE
[fix](serde)Fixed the issue that serde may cause be core when reading schema changed text table. (#50105)

### DIFF
--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -257,6 +257,12 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_hive_text(
         }
     }
     auto& struct_column = static_cast<ColumnStruct&>(column);
+
+    for (auto i = slices.size(); i < struct_column.get_columns().size(); ++i) {
+        // Hive schema change will cause the number of sub-columns in the file to
+        // be inconsistent with the number of sub-columns of the column in the table.
+        slices.emplace_back(options.null_format, options.null_len);
+    }
     for (size_t loc = 0; loc < struct_column.get_columns().size(); loc++) {
         Status st = elem_serdes_ptrs[loc]->deserialize_one_cell_from_hive_text(
                 struct_column.get_column(loc), slices[loc], options,

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -67,8 +67,6 @@ enum class FileCachePolicy : uint8_t;
 
 namespace doris::vectorized {
 
-const static Slice _s_null_slice = Slice("\\N");
-
 void EncloseCsvTextFieldSplitter::do_split(const Slice& line, std::vector<Slice>* splitted_values) {
     const char* data = line.data;
     const auto& column_sep_positions = _text_line_reader_ctx->column_sep_positions();
@@ -655,8 +653,9 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
     for (int i = 0; i < _file_slot_descs.size(); ++i) {
         int col_idx = _col_idxs[i];
         // col idx is out of range, fill with null.
-        const Slice& value =
-                col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
+        const Slice& value = col_idx < _split_values.size()
+                                     ? _split_values[col_idx]
+                                     : Slice {_options.null_format, _options.null_len};
         Slice slice {value.data, value.size};
 
         IColumn* col_ptr = columns[i];

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -653,9 +653,10 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
     for (int i = 0; i < _file_slot_descs.size(); ++i) {
         int col_idx = _col_idxs[i];
         // col idx is out of range, fill with null.
-        const Slice& value = col_idx < _split_values.size()
-                                     ? _split_values[col_idx]
-                                     : Slice {_options.null_format, _options.null_len};
+        const Slice& value =
+                col_idx < _split_values.size()
+                        ? _split_values[col_idx]
+                        : Slice {_options.null_format, static_cast<size_t>(_options.null_len)};
         Slice slice {value.data, value.size};
 
         IColumn* col_ptr = columns[i];


### PR DESCRIPTION
bp #50105

### What problem does this PR solve?

Problem Summary:
When reading a Hive text table that has undergone a schema change,

1. Hive :   add a subcolumn  to a struct
The number of struct subcolumns in the text file may not match the
number of struct subcolumns in the table. In this case, struct serde may
cause be core.
2. Hive ：add a column
The number of file in the text don't match the number of table schema ,
and set `serialization.null.format` ， `escape.delim` TBLPROPERTIES，serde
will modify const static data, cause be core.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

