### PR TITLE
[fix](nereids) logical apply don't include right child's data trait

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
@@ -18,13 +18,13 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 
@@ -41,7 +41,7 @@ import java.util.Optional;
  * @param <RIGHT_CHILD_TYPE> subquery.
  */
 public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends Plan>
-        extends LogicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> implements PropagateFuncDeps {
+        extends LogicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
     /**
      * SubQueryType
      */
@@ -275,5 +275,25 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
         return new LogicalApply<>(groupExpression, logicalProperties, correlationSlot, subqueryType, isNot,
                 compareExpr, typeCoercionExpr, correlationFilter, markJoinSlotReference,
                 needAddSubOutputToProjects, inProject, isMarkJoinSlotNotNull, children.get(0), children.get(1));
+    }
+
+    @Override
+    public void computeUnique(DataTrait.Builder builder) {
+        builder.addUniqueSlot(left().getLogicalProperties().getTrait());
+    }
+
+    @Override
+    public void computeUniform(DataTrait.Builder builder) {
+        builder.addUniformSlot(left().getLogicalProperties().getTrait());
+    }
+
+    @Override
+    public void computeEqualSet(DataTrait.Builder builder) {
+        builder.addEqualSet(left().getLogicalProperties().getTrait());
+    }
+
+    @Override
+    public void computeFd(DataTrait.Builder builder) {
+        builder.addFuncDepsDG(left().getLogicalProperties().getTrait());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

logical apply shouldnot include right child's data trait, it's use to desc the subquery, but the subquery's data trait may not keep in upper plans. This PR fix this.

for example:

for sql 

`select * from t1 where t1.x = 1 or exists(select * from t2 where t2.y = 10 and t1.y = t2.y and t1.z = t1.u);`

the outer where will become a plan filter:

```
LogicalFilter1(t1.x = 1 or ifnull(xx, false)
|
|-- LogicalProject1
            |
            |-- LogicalApply
                         |
                         |-- LogicalOlapScan(t1) 
                         |
                         |-- LogicalProject2
                                     |
                                     |-- LogicalFitler2 (t2.y = 10 and t1.y = t2.y and t1.z = t1.u)
```

LogicalApply's right child LoggicalProject2 will contains equal set: t1.z = t1.u,   but LogicalApply should not include this equal set. If logical apply contains it, then logical apply's parent logical project1 will contains it,  then logical filter1 will contains it later.  But we known that, for logical filter 1,  the EXISTS expression(`exists(select * from t2 where t2.y = 10 and t1.y = t2.y and t1.z = t1.u)`) maynot be true,  so logical filter 1  must exclude equal set `t1.z = t1.u`



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

