### PR TITLE
[fix](mtmv)The change to the max_persistence_task_count configuration applies retroactively to existing MTMV

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobInfo.java
@@ -47,7 +47,7 @@ public class MTMVJobInfo {
             return;
         }
         historyTasks.add(task);
-        if (historyTasks.size() > Config.max_persistence_task_count) {
+        while (historyTasks.size() > Config.max_persistence_task_count) {
             historyTasks.poll();
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVJobInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVJobInfoTest.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mtmv;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.job.extensions.mtmv.MTMVTask;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MTMVJobInfoTest {
+
+    @Test
+    public void testAddHistoryTask() {
+        int originalCount = Config.max_persistence_task_count;
+        Config.max_persistence_task_count = 0;
+        MTMVJobInfo jobInfo = new MTMVJobInfo("dummyJob");
+        jobInfo.addHistoryTask(new MTMVTask());
+        Assert.assertEquals(0, jobInfo.getHistoryTasks().size());
+        Config.max_persistence_task_count = 2;
+        for (int i = 0; i < 3; i++) {
+            jobInfo.addHistoryTask(new MTMVTask());
+        }
+        Assert.assertEquals(2, jobInfo.getHistoryTasks().size());
+        Config.max_persistence_task_count = 1;
+        jobInfo.addHistoryTask(new MTMVTask());
+        Assert.assertEquals(1, jobInfo.getHistoryTasks().size());
+        Config.max_persistence_task_count = originalCount;
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Previously, only one old task would be deleted at most after each new task generation. As a result, even after modifying the configuration, the number of historical tasks could not be effectively reduced.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
The change to the max_persistence_task_count configuration applies retroactively to existing MTMV
### Release note

The change to the max_persistence_task_count configuration applies retroactively to existing MTMV

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

