### PR TITLE
[Chore](column) change ColumnFixedLengthObject log fatal to throw exception

### DIFF
--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -117,7 +117,9 @@ public:
         return {reinterpret_cast<const char*>(&_data[n * _item_size]), _item_size};
     }
 
-    void insert(const Field& x) override { LOG(FATAL) << "insert not supported"; }
+    void insert(const Field& x) override {
+        throw doris::Exception("ColumnFixedLengthObject do not support insert");
+    }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override {
         const auto& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
@@ -162,17 +164,18 @@ public:
         memset(&_data[old_size * _item_size], 0, _item_size);
     }
 
-    void pop_back(size_t n) override { LOG(FATAL) << "pop_back not supported"; }
+    void pop_back(size_t n) override {
+        throw doris::Exception("ColumnFixedLengthObject do not support pop_back");
+    }
 
     StringRef serialize_value_into_arena(size_t n, Arena& arena,
                                          char const*& begin) const override {
-        LOG(FATAL) << "serialize_value_into_arena not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support serialize_value_into_arena");
     }
 
     const char* deserialize_and_insert_from_arena(const char* pos) override {
-        LOG(FATAL) << "deserialize_and_insert_from_arena not supported";
-        __builtin_unreachable();
+        throw doris::Exception(
+                "ColumnFixedLengthObject do not support deserialize_and_insert_from_arena");
     }
 
     void update_hash_with_value(size_t n, SipHash& hash) const override {
@@ -181,41 +184,35 @@ public:
 
     [[noreturn]] ColumnPtr filter(const IColumn::Filter& filt,
                                   ssize_t result_size_hint) const override {
-        LOG(FATAL) << "filter not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support filter");
     }
 
     [[noreturn]] size_t filter(const IColumn::Filter&) override {
-        LOG(FATAL) << "filter not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support filter");
     }
 
     [[noreturn]] ColumnPtr permute(const IColumn::Permutation& perm, size_t limit) const override {
-        LOG(FATAL) << "permute not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support permute");
     }
 
     [[noreturn]] int compare_at(size_t n, size_t m, const IColumn& rhs,
                                 int nan_direction_hint) const override {
-        LOG(FATAL) << "compare_at not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support compare_at");
     }
 
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          IColumn::Permutation& res) const override {
-        LOG(FATAL) << "get_permutation not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support get_permutation");
     }
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override {
-        LOG(FATAL) << "index not supported";
-        __builtin_unreachable();
+        throw doris::Exception("ColumnFixedLengthObject do not support index");
     }
 
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
-        LOG(FATAL) << "get_indices_of_non_default_rows not supported in ColumnDictionary";
-        __builtin_unreachable();
+        throw doris::Exception(
+                "ColumnFixedLengthObject do not support get_indices_of_non_default_rows");
     }
 
     ColumnPtr replicate(const IColumn::Offsets& offsets) const override {
@@ -274,8 +271,8 @@ public:
     }
 
     void replace_column_data_default(size_t self_row = 0) override {
-        LOG(FATAL) << "replace_column_data_default not supported";
-        __builtin_unreachable();
+        throw doris::Exception(
+                "ColumnFixedLengthObject do not support replace_column_data_default");
     }
 
     void insert_many_continuous_binary_data(const char* data, const uint32_t* offsets,

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -175,8 +175,8 @@ public:
     }
 
     const char* deserialize_and_insert_from_arena(const char* pos) override {
-        throw doris::Exception(
-                "ColumnFixedLengthObject do not support deserialize_and_insert_from_arena");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support deserialize_and_insert_from_arena");
     }
 
     void update_hash_with_value(size_t n, SipHash& hash) const override {
@@ -215,8 +215,8 @@ public:
 
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,
                                          size_t limit) const override {
-        throw doris::Exception(
-                "ColumnFixedLengthObject do not support get_indices_of_non_default_rows");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support get_indices_of_non_default_rows");
     }
 
     ColumnPtr replicate(const IColumn::Offsets& offsets) const override {
@@ -275,8 +275,8 @@ public:
     }
 
     void replace_column_data_default(size_t self_row = 0) override {
-        throw doris::Exception(
-                "ColumnFixedLengthObject do not support replace_column_data_default");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support replace_column_data_default");
     }
 
     void insert_many_continuous_binary_data(const char* data, const uint32_t* offsets,

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -118,7 +118,7 @@ public:
     }
 
     void insert(const Field& x) override {
-        throw doris::Exception("ColumnFixedLengthObject do not support insert");
+        throw Exception(ErrorCode::INTERNAL_ERROR, "ColumnFixedLengthObject do not support insert");
     }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override {
@@ -130,11 +130,10 @@ public:
         }
 
         if (start + length > src_col._item_count) {
-            throw doris::Exception(
-                    doris::ErrorCode::INTERNAL_ERROR,
-                    "Parameters start = {}, length = {} are out of bound in "
-                    "ColumnFixedLengthObject::insert_range_from method (data.size() = {})",
-                    start, length, src_col._item_count);
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "Parameters start = {}, length = {} are out of bound in "
+                            "ColumnFixedLengthObject::insert_range_from method (data.size() = {})",
+                            start, length, src_col._item_count);
         }
 
         size_t old_size = size();
@@ -165,12 +164,14 @@ public:
     }
 
     void pop_back(size_t n) override {
-        throw doris::Exception("ColumnFixedLengthObject do not support pop_back");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support pop_back");
     }
 
     StringRef serialize_value_into_arena(size_t n, Arena& arena,
                                          char const*& begin) const override {
-        throw doris::Exception("ColumnFixedLengthObject do not support serialize_value_into_arena");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support serialize_value_into_arena");
     }
 
     const char* deserialize_and_insert_from_arena(const char* pos) override {
@@ -184,29 +185,32 @@ public:
 
     [[noreturn]] ColumnPtr filter(const IColumn::Filter& filt,
                                   ssize_t result_size_hint) const override {
-        throw doris::Exception("ColumnFixedLengthObject do not support filter");
+        throw Exception(ErrorCode::INTERNAL_ERROR, "ColumnFixedLengthObject do not support filter");
     }
 
     [[noreturn]] size_t filter(const IColumn::Filter&) override {
-        throw doris::Exception("ColumnFixedLengthObject do not support filter");
+        throw Exception(ErrorCode::INTERNAL_ERROR, "ColumnFixedLengthObject do not support filter");
     }
 
     [[noreturn]] ColumnPtr permute(const IColumn::Permutation& perm, size_t limit) const override {
-        throw doris::Exception("ColumnFixedLengthObject do not support permute");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support permute");
     }
 
     [[noreturn]] int compare_at(size_t n, size_t m, const IColumn& rhs,
                                 int nan_direction_hint) const override {
-        throw doris::Exception("ColumnFixedLengthObject do not support compare_at");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support compare_at");
     }
 
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                          IColumn::Permutation& res) const override {
-        throw doris::Exception("ColumnFixedLengthObject do not support get_permutation");
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "ColumnFixedLengthObject do not support get_permutation");
     }
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override {
-        throw doris::Exception("ColumnFixedLengthObject do not support index");
+        throw Exception(ErrorCode::INTERNAL_ERROR, "ColumnFixedLengthObject do not support index");
     }
 
     void get_indices_of_non_default_rows(IColumn::Offsets64& indices, size_t from,


### PR DESCRIPTION
### What problem does this PR solve?
change ColumnFixedLengthObject log fatal to throw exception
```cpp
F20250429 10:27:23.335721 2797999 column_fixed_length_object.h:194] permute not supported
*** Check failure stack trace: ***
F20250429 10:27:23.335723 2798003 column_fixed_length_object.h:194] permute not supportedF20250429 10:27:23.335752 2798000 column_fixed_length_object.h:194] permute not supportedF20250429 10:27:23.335762 2798009 column_fixed_length_object.h:194] permute not supported
*** Check failure stack trace: ***
F20250429 10:27:23.335723 2798003 column_fixed_length_object.h:194] permute not supportedF20250429 10:27:23.335752 2798000 column_fixed_length_object.h:194] permute not supportedF20250429 10:27:23.335762 2798009 column_fixed_length_object.h:194] permute not supported
*** Check failure stack trace: ***
F20250429 10:27:23.335723 2798003 column_fixed_length_object.h:194] permute not supportedF20250429 10:27:23.335752 2798000 column_fixed_length_object.h:194] permute not supportedF20250429 10:27:23.335762 2798009 column_fixed_length_object.h:194] permute not supported
*** Check failure stack trace: ***
    @     0x56124924dd96  google::LogMessage::SendToLog()
    @     0x56124924a7e0  google::LogMessage::Flush()
    @     0x56124924e5d9  google::LogMessageFatal::~LogMessageFatal()
    @     0x56123fbfe5b1  doris::vectorized::ColumnFixedLengthObject::permute()
    @     0x561242409fb6  doris::vectorized::sort_block()
    @     0x5612439dbac0  doris::vectorized::Sorter::partial_sort()
    @     0x5612439dc039  doris::vectorized::FullSorter::_do_sort()
    @     0x5612439dcd7f  doris::vectorized::FullSorter::prepare_for_read()
    @     0x561248cdbe39  doris::pipeline::SortSinkOperatorX::sink()
    @     0x56124921ef36  doris::pipeline::PipelineXTask::execute()
    @     0x5612492298ac  doris::pipeline::TaskScheduler::_do_work()
    @     0x56123f6bb698  doris::ThreadPool::dispatch_thread()
    @     0x56123f6b1d31  doris::Thread::supervise_thread()
    @     0x7ffb0a400ac3  (unknown)
    @     0x7ffb0a492850  (unknown)
    @              (nil)  (unknown)
*** Query id: e0ed062382194673-ae9825e56eeee3ff ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1745893643 (unix time) try "date -d @1745893643" if you are using GNU date ***
*** Current BE git commitID: b3e55d1064 ***
*** SIGABRT unknown detail explain (@0x2a99ef) received by PID 2791919 (TID 2797999 OR 0x7ff684735640) from PID 2791919; stack trace: ***
    @     0x56124924dd96  google::LogMessage::SendToLog()
    @     0x56124924dd96  google::LogMessage::SendToLog()
    @     0x56124924dd96  google::LogMessage::SendToLog()
    @     0x56124924a7e0  google::LogMessage::Flush()
    @     0x56124924a7e0  google::LogMessage::Flush()
    @     0x56124924e5d9  google::LogMessageFatal::~LogMessageFatal()
    @     0x56124924e5d9  google::LogMessageFatal::~LogMessageFatal()
    @     0x56124924a7e0  google::LogMessage::Flush()
    @     0x56123fbfe5b1  doris::vectorized::ColumnFixedLengthObject::permute()
    @     0x56123fbfe5b1  doris::vectorized::ColumnFixedLengthObject::permute()
    @     0x56124924e5d9  google::LogMessageFatal::~LogMessageFatal()
    @     0x56123fbfe5b1  doris::vectorized::ColumnFixedLengthObject::permute()
    @     0x561242409fb6  doris::vectorized::sort_block()
    @     0x561242409fb6  doris::vectorized::sort_block()
    @     0x5612439dbac0  doris::vectorized::Sorter::partial_sort()
    @     0x5612439dbac0  doris::vectorized::Sorter::partial_sort()
    @     0x561242409fb6  doris::vectorized::sort_block()
    @     0x5612439dc039  doris::vectorized::FullSorter::_do_sort()
    @     0x5612439dc039  doris::vectorized::FullSorter::_do_sort()
    @     0x5612439dcd7f  doris::vectorized::FullSorter::prepare_for_read()
    @     0x5612439dcd7f  doris::vectorized::FullSorter::prepare_for_read()
    @     0x5612439dbac0  doris::vectorized::Sorter::partial_sort()
    @     0x561248cdbe39  doris::pipeline::SortSinkOperatorX::sink()
    @     0x561248cdbe39  doris::pipeline::SortSinkOperatorX::sink()
    @     0x5612439dc039  doris::vectorized::FullSorter::_do_sort()
    @     0x56124921ef36  doris::pipeline::PipelineXTask::execute()
    @     0x5612439dcd7f  doris::vectorized::FullSorter::prepare_for_read()
    @     0x56124921ef36  doris::pipeline::PipelineXTask::execute()
    @     0x5612492298ac  doris::pipeline::TaskScheduler::_do_work()
    @     0x56123f6bb698  doris::ThreadPool::dispatch_thread()
    @     0x5612492298ac  doris::pipeline::TaskScheduler::_do_work()
    @     0x56123f6b1d31  doris::Thread::supervise_thread()
    @     0x7ffb0a400ac3  (unknown)
    @     0x56123f6bb698  doris::ThreadPool::dispatch_thread()
    @     0x561248cdbe39  doris::pipeline::SortSinkOperatorX::sink()
    @     0x7ffb0a492850  (unknown)
    @              (nil)  (unknown)
    @     0x56123f6b1d31  doris::Thread::supervise_thread()
    @     0x7ffb0a400ac3  (unknown)
    @     0x7ffb0a492850  (unknown)
    @              (nil)  (unknown)
    @     0x56124921ef36  doris::pipeline::PipelineXTask::execute()
    @     0x5612492298ac  doris::pipeline::TaskScheduler::_do_work()
    @     0x56123f6bb698  doris::ThreadPool::dispatch_thread()
    @     0x56123f6b1d31  doris::Thread::supervise_thread()
    @     0x7ffb0a400ac3  (unknown)
    @     0x7ffb0a492850  (unknown)
    @              (nil)  (unknown)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/common/signal_handler.h:421
 1# 0x00007FFB0A3AE520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x00005612492585AD in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
 6# 0x000056124924ACAA in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
10# doris::vectorized::ColumnFixedLengthObject::permute(doris::vectorized::PODArray<unsigned long, 4096ul, Allocator<false, false, false, DefaultMemoryAllocator>, 16ul, 16ul> const&, unsigned long) const in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
11# doris::vectorized::sort_block(doris::vectorized::Block&, doris::vectorized::Block&, std::vector<doris::vectorized::SortColumnDescription, std::allocator<doris::vectorized::SortColumnDescription> > const&, unsigned long) in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
12# doris::vectorized::Sorter::partial_sort(doris::vectorized::Block&, doris::vectorized::Block&) in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
13# doris::vectorized::FullSorter::_do_sort() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/sort/sorter.cpp:260
14# doris::vectorized::FullSorter::prepare_for_read() at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/vec/common/sort/sorter.cpp:243
15# doris::pipeline::SortSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/exec/sort_sink_operator.cpp:181
16# doris::pipeline::PipelineXTask::execute(bool*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:380
17# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/pipeline/task_scheduler.cpp:347
18# doris::ThreadPool::dispatch_thread() in /mnt/disk1/doris-clusters/doris-2.1/output/be/lib/doris_be
19# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.1/doris/be/src/util/thread.cpp:499
20# start_thread at ./nptl/pthread_create.c:442
21# 0x00007FFB0A492850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
 
```
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

