### PR TITLE
[fix](lexer) fix unclosed comment handling

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
@@ -20,10 +20,6 @@
 lexer grammar DorisLexer;
 
 @members {
-  /**
-   * When true, parser should throw ParseExcetion for unclosed bracketed comment.
-   */
-  public boolean has_unclosed_bracketed_comment = false;
 
   /**
    * Verify whether current token is a valid decimal token (which contains dot).
@@ -47,15 +43,6 @@ lexer grammar DorisLexer;
     }
   }
 
-  /**
-   * This method will be called when the character stream ends and try to find out the
-   * unclosed bracketed comment.
-   * If the method be called, it means the end of the entire character stream match,
-   * and we set the flag and fail later.
-   */
-  public void markUnclosedComment() {
-    has_unclosed_bracketed_comment = true;
-  }
 }
 
 SEMICOLON: ';';
@@ -675,7 +662,7 @@ SIMPLE_COMMENT
     ;
 
 BRACKETED_COMMENT
-    : COMMENT_START ( BRACKETED_COMMENT | . )*? ('*/' | {markUnclosedComment();} EOF) -> channel(2)
+    : COMMENT_START ( BRACKETED_COMMENT | . )*? '*/' -> channel(2)
     ;
 
 


### PR DESCRIPTION
### What problem does this PR solve?

The previous lexer rule for `BRACKETED_COMMENT` in `DorisLexer.g4` incorrectly handled unclosed comments (comments starting with `/*` but not ending with `*/` before the end of the input).

When an unclosed comment occurred, the rule's alternative ending condition (`| {markUnclosedComment();} EOF`) allowed the rule to **successfully match** by consuming all subsequent characters up to the end of the file (EOF) into a single `BRACKETED_COMMENT` token. This effectively hid valid SQL code following the unclosed comment start from the parser.

For example, consider the following SQL:
```sql
select * from t1 /*this is /*a comment*/ limit 1;
```
Under the old rule:
1.  The lexer started matching `BRACKETED_COMMENT` at the first `/*`.
2.  It recursively handled the inner `/*a comment*/`.
3.  It continued trying to find the closing `*/` for the *outer* comment.
4.  Upon reaching EOF, it matched the `| {markUnclosedComment();} EOF` condition.
5.  The *entire* string `/*this is /*a comment*/ limit 1;` was consumed as **one** `BRACKETED_COMMENT` token.
6.  The parser only saw `SELECT * FROM t1`, leading to the incorrect result of returning all rows instead of just one.

Problem Summary:
The primary goal of this change is to correctly support **unclosed nested bracketed comments** (e.g., `/* outer /* inner */`) within SQL statements parsed by the Doris Nereids lexer. This aligns with standard SQL practices, including MySQL, which allows such nesting.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

```sql
-- setting
CREATE TABLE IF NOT EXISTS t1 (id INT) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
INSERT INTO t1 VALUES (1), (2), (3);

-- Test Case : Unclosed Comment (Original Bug Case - Nested)
select * from t1 /* outer /* inner */ limit 1;
-- EXPECTED: return 1 row
-- OBSERVED: return 3 rows

-- Test Case : Valid query using table after nested comment
select * from t1 /* outer /* inner */ limit 1;
-- EXPECTED: Returns 1 row.
-- OBSERVED: Returns 1 row.

```


- Behavior changed:
    - [ ] No.
    - [] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

