### PR TITLE
[opt](memtracker) Optimize  `PODArray` memory tracking accuracy

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -149,7 +149,8 @@ Status FlushToken::_try_reserve_memory(const std::shared_ptr<ResourceContext>& r
     int32_t max_waiting_time = config::memtable_wait_for_memory_sleep_time_s;
     do {
         // only try to reserve process memory
-        st = thread_context->thread_mem_tracker_mgr->try_reserve(size, true);
+        st = thread_context->thread_mem_tracker_mgr->try_reserve(
+                size, ThreadMemTrackerMgr::TryReserveChecker::CHECK_PROCESS);
         if (st.ok()) {
             memtable_flush_executor->inc_flushing_task();
             break;

--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -90,6 +90,7 @@ public:
         return msg;
     }
 
+    static bool reserve_process_memory(int64_t bytes);
     static bool try_reserve_process_memory(int64_t bytes);
     static void shrink_process_reserved(int64_t bytes);
 

--- a/be/src/runtime/memory/mem_counter.h
+++ b/be/src/runtime/memory/mem_counter.h
@@ -83,11 +83,6 @@ public:
     int64_t current_value() const { return _current_value.load(std::memory_order_relaxed); }
     int64_t peak_value() const { return _peak_value.load(std::memory_order_relaxed); }
 
-    static std::string print_bytes(int64_t bytes) {
-        return bytes >= 0 ? PrettyPrinter::print(bytes, TUnit::BYTES)
-                          : "-" + PrettyPrinter::print(std::abs(bytes), TUnit::BYTES);
-    }
-
 private:
     std::atomic<int64_t> _current_value {0};
     std::atomic<int64_t> _peak_value {0};

--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -47,8 +47,8 @@ public:
     const std::string& label() const { return _label; }
     std::string log_usage() const {
         return fmt::format("MemTracker name={}, Used={}({} B), Peak={}({} B)", _label,
-                           MemCounter::print_bytes(consumption()), consumption(),
-                           MemCounter::print_bytes(peak_consumption()), peak_consumption());
+                           PrettyPrinter::print_bytes(consumption()), consumption(),
+                           PrettyPrinter::print_bytes(peak_consumption()), peak_consumption());
     }
 
 private:

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -360,9 +360,10 @@ std::string MemTrackerLimiter::tracker_limit_exceeded_str() {
     std::string err_msg = fmt::format(
             "memory tracker limit exceeded, tracker label:{}, type:{}, limit "
             "{}, peak used {}, current used {}. backend {}, {}.",
-            label(), type_string(_type), MemCounter::print_bytes(limit()),
-            MemCounter::print_bytes(peak_consumption()), MemCounter::print_bytes(consumption()),
-            BackendOptions::get_localhost(), GlobalMemoryArbitrator::process_memory_used_str());
+            label(), type_string(_type), PrettyPrinter::print_bytes(limit()),
+            PrettyPrinter::print_bytes(peak_consumption()),
+            PrettyPrinter::print_bytes(consumption()), BackendOptions::get_localhost(),
+            GlobalMemoryArbitrator::process_memory_used_str());
     if (_type == Type::QUERY || _type == Type::LOAD) {
         err_msg += fmt::format(
                 " exec node:<{}>, can `set exec_mem_limit` to change limit, details see be.INFO.",

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -311,7 +311,7 @@ inline Status MemTrackerLimiter::check_limit(int64_t bytes) {
     // it will not take effect.
     if (consumption() + bytes > _limit) {
         return Status::MemoryLimitExceeded(fmt::format("failed alloc size {}, {}",
-                                                       MemCounter::print_bytes(bytes),
+                                                       PrettyPrinter::print_bytes(bytes),
                                                        tracker_limit_exceeded_str()));
     }
     return Status::OK();

--- a/be/src/runtime/memory/memory_reclamation.cpp
+++ b/be/src/runtime/memory/memory_reclamation.cpp
@@ -183,7 +183,7 @@ bool MemoryReclamation::revoke_process_memory(const std::string& revoke_reason) 
     LOG(INFO) << fmt::format(
             "[MemoryGC] start MemoryReclamation::revoke_process_memory, {}, need free size: {}.",
             GlobalMemoryArbitrator::process_mem_log_str(),
-            MemCounter::print_bytes(MemInfo::process_full_gc_size()));
+            PrettyPrinter::print_bytes(MemInfo::process_full_gc_size()));
     Defer defer {[&]() {
         std::stringstream ss;
         profile->pretty_print(&ss);
@@ -191,8 +191,8 @@ bool MemoryReclamation::revoke_process_memory(const std::string& revoke_reason) 
                 "[MemoryGC] end MemoryReclamation::revoke_process_memory, {}, need free size: {}, "
                 "free Memory {}. cost(us): {}, details: {}",
                 GlobalMemoryArbitrator::process_mem_log_str(),
-                MemCounter::print_bytes(MemInfo::process_full_gc_size()),
-                MemCounter::print_bytes(freed_mem), watch.elapsed_time() / 1000, ss.str());
+                PrettyPrinter::print_bytes(MemInfo::process_full_gc_size()),
+                PrettyPrinter::print_bytes(freed_mem), watch.elapsed_time() / 1000, ss.str());
     }};
 
     // step1: start canceling from the query with the largest memory usage until the memory of process_full_gc_size is freed.

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -323,10 +323,10 @@ inline doris::Status ThreadMemTrackerMgr::try_reserve(int64_t size, TryReserveCh
                     "reserve memory failed, size: {}, because query memory exceeded, memory "
                     "tracker: {}, "
                     "consumption: {}, limit: {}, peak: {}",
-                    MemCounter::print_bytes(size), _limiter_tracker->label(),
-                    MemCounter::print_bytes(_limiter_tracker->consumption()),
-                    MemCounter::print_bytes(_limiter_tracker->limit()),
-                    MemCounter::print_bytes(_limiter_tracker->peak_consumption()));
+                    PrettyPrinter::print_bytes(size), _limiter_tracker->label(),
+                    PrettyPrinter::print_bytes(_limiter_tracker->consumption()),
+                    PrettyPrinter::print_bytes(_limiter_tracker->limit()),
+                    PrettyPrinter::print_bytes(_limiter_tracker->peak_consumption()));
             return doris::Status::Error<ErrorCode::QUERY_MEMORY_EXCEEDED>(err_msg);
         }
     } else {
@@ -339,7 +339,7 @@ inline doris::Status ThreadMemTrackerMgr::try_reserve(int64_t size, TryReserveCh
                 auto err_msg = fmt::format(
                         "reserve memory failed, size: {}, because workload group memory exceeded, "
                         "workload group: {}",
-                        MemCounter::print_bytes(size), wg_ptr->memory_debug_string());
+                        PrettyPrinter::print_bytes(size), wg_ptr->memory_debug_string());
                 _limiter_tracker->release(size);         // rollback
                 _limiter_tracker->shrink_reserved(size); // rollback
                 return doris::Status::Error<ErrorCode::WORKLOAD_GROUP_MEMORY_EXCEEDED>(err_msg);
@@ -353,7 +353,8 @@ inline doris::Status ThreadMemTrackerMgr::try_reserve(int64_t size, TryReserveCh
         if (!doris::GlobalMemoryArbitrator::try_reserve_process_memory(size)) {
             auto err_msg = fmt::format(
                     "reserve memory failed, size: {}, because proccess memory exceeded, {}",
-                    MemCounter::print_bytes(size), GlobalMemoryArbitrator::process_mem_log_str());
+                    PrettyPrinter::print_bytes(size),
+                    GlobalMemoryArbitrator::process_mem_log_str());
             _limiter_tracker->release(size);         // rollback
             _limiter_tracker->shrink_reserved(size); // rollback
             if (wg_ptr) {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -202,9 +202,9 @@ QueryContext::~QueryContext() {
         mem_tracker_msg = fmt::format(
                 "deregister query/load memory tracker, queryId={}, Limit={}, CurrUsed={}, "
                 "PeakUsed={}",
-                print_id(_query_id), MemCounter::print_bytes(query_mem_tracker()->limit()),
-                MemCounter::print_bytes(query_mem_tracker()->consumption()),
-                MemCounter::print_bytes(query_mem_tracker()->peak_consumption()));
+                print_id(_query_id), PrettyPrinter::print_bytes(query_mem_tracker()->limit()),
+                PrettyPrinter::print_bytes(query_mem_tracker()->consumption()),
+                PrettyPrinter::print_bytes(query_mem_tracker()->peak_consumption()));
     }
     [[maybe_unused]] uint64_t group_id = 0;
     if (workload_group()) {

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -257,18 +257,18 @@ int64_t WorkloadGroup::revoke_memory(int64_t need_free_mem, const std::string& r
 
     auto group_revoke_reason = fmt::format(
             "{}, revoke group id:{}, name:{}, used:{}, limit:{}", revoke_reason, _id, _name,
-            MemCounter::print_bytes(used_memory), MemCounter::print_bytes(_memory_limit));
+            PrettyPrinter::print_bytes(used_memory), PrettyPrinter::print_bytes(_memory_limit));
     LOG(INFO) << fmt::format(
             "[MemoryGC] start WorkloadGroup::revoke_memory, {}, need free size: {}.",
-            group_revoke_reason, MemCounter::print_bytes(need_free_mem));
+            group_revoke_reason, PrettyPrinter::print_bytes(need_free_mem));
     Defer defer {[&]() {
         std::stringstream ss;
         group_revoke_profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
                 "[MemoryGC] end WorkloadGroup::revoke_memory, {}, need free size: {}, free Memory "
                 "{}. cost(us): {}, details: {}",
-                group_revoke_reason, MemCounter::print_bytes(need_free_mem),
-                MemCounter::print_bytes(freed_mem), watch.elapsed_time() / 1000, ss.str());
+                group_revoke_reason, PrettyPrinter::print_bytes(need_free_mem),
+                PrettyPrinter::print_bytes(freed_mem), watch.elapsed_time() / 1000, ss.str());
     }};
 
     // step 1. free top overcommit query

--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -699,14 +699,14 @@ int64_t WorkloadGroupMgr::revoke_memory_from_other_overcommited_groups_(
             "[MemoryGC] start WorkloadGroupMgr::revoke_memory_from_other_overcommited_groups_, {}, "
             "number of overcommited groups: {}, total exceeded memory: {}.",
             revoke_reason, exceeded_memory_heap.size(),
-            MemCounter::print_bytes(total_exceeded_memory));
+            PrettyPrinter::print_bytes(total_exceeded_memory));
     Defer defer {[&]() {
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
                 "[MemoryGC] end WorkloadGroupMgr::revoke_memory_from_other_overcommited_groups_, "
                 "{}, number of overcommited groups: {}, free memory {}. cost(us): {}, details: {}",
-                revoke_reason, exceeded_memory_heap.size(), MemCounter::print_bytes(freed_mem),
+                revoke_reason, exceeded_memory_heap.size(), PrettyPrinter::print_bytes(freed_mem),
                 watch.elapsed_time() / 1000, ss.str());
     }};
 

--- a/be/src/runtime/workload_management/memory_context.cpp
+++ b/be/src/runtime/workload_management/memory_context.cpp
@@ -25,9 +25,9 @@ namespace doris {
 std::string MemoryContext::debug_string() {
     return fmt::format("TaskId={}, Memory(Used={}, Limit={}, Peak={})",
                        print_id(resource_ctx_->task_controller()->task_id()),
-                       MemCounter::print_bytes(current_memory_bytes()),
-                       MemCounter::print_bytes(mem_limit()),
-                       MemCounter::print_bytes(peak_memory_bytes()));
+                       PrettyPrinter::print_bytes(current_memory_bytes()),
+                       PrettyPrinter::print_bytes(mem_limit()),
+                       PrettyPrinter::print_bytes(peak_memory_bytes()));
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/runtime/workload_management/task_controller.cpp
+++ b/be/src/runtime/workload_management/task_controller.cpp
@@ -42,9 +42,9 @@ std::string TaskController::debug_string() {
             "TaskId={}, Memory(Used={}, Limit={}, Peak={}), Spill(RunningSpillTaskCnt={}, "
             "TotalPausedPeriodSecs={}, LatestPausedReason={})",
             print_id(task_id_),
-            MemCounter::print_bytes(resource_ctx_->memory_context()->current_memory_bytes()),
-            MemCounter::print_bytes(resource_ctx_->memory_context()->mem_limit()),
-            MemCounter::print_bytes(resource_ctx_->memory_context()->peak_memory_bytes()),
+            PrettyPrinter::print_bytes(resource_ctx_->memory_context()->current_memory_bytes()),
+            PrettyPrinter::print_bytes(resource_ctx_->memory_context()->mem_limit()),
+            PrettyPrinter::print_bytes(resource_ctx_->memory_context()->peak_memory_bytes()),
             revoking_tasks_count_, memory_sufficient_time() / NANOS_PER_SEC,
             paused_reason_.status().to_string());
 }

--- a/be/src/util/pretty_printer.h
+++ b/be/src/util/pretty_printer.h
@@ -186,7 +186,8 @@ public:
 
     /// Convenience method
     static std::string print_bytes(int64_t value) {
-        return PrettyPrinter::print(value, TUnit::BYTES);
+        return value >= 0 ? PrettyPrinter::print(value, TUnit::BYTES)
+                          : "-" + PrettyPrinter::print(std::abs(value), TUnit::BYTES);
     }
 
 private:

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -48,6 +48,11 @@ std::mutex RecordSizeMemoryAllocator::_mutex;
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_memory_exceed(
         size_t size, std::string* err_msg) const {
+#ifdef BE_TEST
+    if (!doris::pthread_context_ptr_init) {
+        return false;
+    }
+#endif
     auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
     if (thread_mem_ctx->skip_memory_check != 0) {
         return false;
@@ -82,6 +87,11 @@ bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc_fault_probability()
         const {
+#ifdef BE_TEST
+    if (!doris::pthread_context_ptr_init) {
+        return;
+    }
+#endif
     auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
     if (thread_mem_ctx->skip_memory_check != 0) {
         return;
@@ -182,6 +192,11 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_tracker_exceed(
         size_t size, std::string* err_msg) const {
+#ifdef BE_TEST
+    if (!doris::pthread_context_ptr_init) {
+        return false;
+    }
+#endif
     auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
     if (thread_mem_ctx->skip_memory_check != 0) {
         return false;
@@ -434,6 +449,15 @@ template class Allocator<false, true, true, DefaultMemoryAllocator>;
 template class Allocator<false, true, false, DefaultMemoryAllocator>;
 template class Allocator<false, false, true, DefaultMemoryAllocator>;
 template class Allocator<false, false, false, DefaultMemoryAllocator>;
+
+template class Allocator<true, true, true, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<true, true, false, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<true, false, true, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<true, false, false, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<false, true, true, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<false, true, false, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<false, false, true, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>;
 
 /** It would be better to put these Memory Allocators where they are used, such as in the orc memory pool and arrow memory pool.
   * But currently allocators use templates in .cpp instead of all in .h, so they can only be placed here.

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -46,14 +46,44 @@ std::unordered_map<void*, size_t> RecordSizeMemoryAllocator::_allocated_sizes;
 std::mutex RecordSizeMemoryAllocator::_mutex;
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_memory_check(
-        size_t size) const {
-#ifdef BE_TEST
-    if (!doris::ExecEnv::ready()) {
-        return;
+bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_memory_exceed(
+        size_t size, std::string* err_msg) const {
+    auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
+    if (thread_mem_ctx->skip_memory_check != 0) {
+        return false;
     }
-#endif
-    if (doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0) {
+
+    if (doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(size)) {
+        // Only thread attach task, and has not completely waited for thread_wait_gc_max_milliseconds,
+        // will wait for gc. otherwise, if the outside will catch the exception, throwing an exception.
+        *err_msg += fmt::format(
+                "Allocator sys memory check failed: Cannot alloc:{}, consuming "
+                "tracker:<{}>, peak used {}, current used {}, reserved {}, exec node:<{}>, {}.",
+                doris::PrettyPrinter::print_bytes(size),
+                thread_mem_ctx->limiter_mem_tracker()->label(),
+                doris::PrettyPrinter::print_bytes(
+                        thread_mem_ctx->limiter_mem_tracker()->peak_consumption()),
+                doris::PrettyPrinter::print_bytes(
+                        thread_mem_ctx->limiter_mem_tracker()->consumption()),
+                doris::PrettyPrinter::print_bytes(
+                        thread_mem_ctx->limiter_mem_tracker()->reserved_consumption()),
+                thread_mem_ctx->last_consumer_tracker_label(),
+                doris::GlobalMemoryArbitrator::process_mem_log_str());
+
+        if (doris::config::stacktrace_in_alloc_large_memory_bytes > 0 &&
+            size > doris::config::stacktrace_in_alloc_large_memory_bytes) {
+            *err_msg += "\nAlloc Stacktrace:\n" + doris::get_stack_trace();
+        }
+        return true;
+    }
+    return false;
+}
+
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc_fault_probability()
+        const {
+    auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
+    if (thread_mem_ctx->skip_memory_check != 0) {
         return;
     }
 
@@ -65,9 +95,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
             const std::string injection_err_msg = fmt::format(
                     "[MemAllocInjectFault] Task {} alloc memory failed due to fault "
                     "injection.",
-                    doris::thread_context()
-                            ->thread_mem_tracker_mgr->limiter_mem_tracker()
-                            ->label());
+                    thread_mem_ctx->limiter_mem_tracker()->label());
             // Print stack trace for debug.
             [[maybe_unused]] auto stack_trace_st =
                     doris::Status::Error<doris::ErrorCode::MEM_ALLOC_FAILED, true>(
@@ -80,41 +108,19 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
             }
         }
     }
+}
 
-    if (doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(size)) {
-        // Only thread attach task, and has not completely waited for thread_wait_gc_max_milliseconds,
-        // will wait for gc. otherwise, if the outside will catch the exception, throwing an exception.
-        std::string err_msg;
-        err_msg += fmt::format(
-                "Allocator sys memory check failed: Cannot alloc:{}, consuming "
-                "tracker:<{}>, peak used {}, current used {}, reserved {}, exec node:<{}>, {}.",
-                doris::PrettyPrinter::print_bytes(size),
-                doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
-                doris::PrettyPrinter::print_bytes(
-                        doris::thread_context()
-                                ->thread_mem_tracker_mgr->limiter_mem_tracker()
-                                ->peak_consumption()),
-                doris::PrettyPrinter::print_bytes(
-                        doris::thread_context()
-                                ->thread_mem_tracker_mgr->limiter_mem_tracker()
-                                ->consumption()),
-                doris::PrettyPrinter::print_bytes(
-                        doris::thread_context()
-                                ->thread_mem_tracker_mgr->limiter_mem_tracker()
-                                ->reserved_consumption()),
-                doris::thread_context()->thread_mem_tracker_mgr->last_consumer_tracker_label(),
-                doris::GlobalMemoryArbitrator::process_mem_log_str());
-
-        if (doris::config::stacktrace_in_alloc_large_memory_bytes > 0 &&
-            size > doris::config::stacktrace_in_alloc_large_memory_bytes) {
-            err_msg += "\nAlloc Stacktrace:\n" + doris::get_stack_trace();
-        }
-
-        if (doris::thread_context()->thread_mem_tracker_mgr->wait_gc()) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_memory_check(
+        size_t size) const {
+    std::string err_msg;
+    if (sys_memory_exceed(size, &err_msg)) {
+        auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
+        if (thread_mem_ctx->wait_gc()) {
             int64_t wait_milliseconds = 0;
             LOG(INFO) << fmt::format(
                     "Task:{} waiting for enough memory in thread id:{}, maximum {}ms, {}.",
-                    doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
+                    thread_mem_ctx->limiter_mem_tracker()->label(),
                     doris::ThreadContext::get_thread_id(),
                     doris::config::thread_wait_gc_max_milliseconds, err_msg);
 
@@ -144,7 +150,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
             // else, enough memory is available, the task continues execute.
             if (wait_milliseconds >= doris::config::thread_wait_gc_max_milliseconds) {
                 // Make sure to completely wait thread_wait_gc_max_milliseconds only once.
-                doris::thread_context()->thread_mem_tracker_mgr->disable_wait_gc();
+                thread_mem_ctx->disable_wait_gc();
                 doris::ProcessProfile::instance()->memory_profile()->print_log_process_usage();
 
                 // If the outside will catch the exception, after throwing an exception,
@@ -153,62 +159,56 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
                     LOG(INFO) << fmt::format(
                             "Task:{} sys memory check failed, throw exception, after waiting for "
                             "memory {}ms, {}.",
-                            doris::thread_context()
-                                    ->thread_mem_tracker_mgr->limiter_mem_tracker()
-                                    ->label(),
-                            wait_milliseconds, err_msg);
+                            thread_mem_ctx->limiter_mem_tracker()->label(), wait_milliseconds,
+                            err_msg);
                     throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err_msg);
                 } else {
                     LOG(INFO) << fmt::format(
                             "Task:{} sys memory check failed, will continue to execute, cannot "
                             "throw exception, after waiting for memory {}ms, {}.",
-                            doris::thread_context()
-                                    ->thread_mem_tracker_mgr->limiter_mem_tracker()
-                                    ->label(),
-                            wait_milliseconds, err_msg);
+                            thread_mem_ctx->limiter_mem_tracker()->label(), wait_milliseconds,
+                            err_msg);
                 }
             }
         } else if (doris::enable_thread_catch_bad_alloc) {
-            LOG(INFO) << fmt::format("sys memory check failed, throw exception, {}.", err_msg);
+            LOG(INFO) << fmt::format("{}, throw exception.", err_msg);
             throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err_msg);
         } else {
-            LOG(INFO) << fmt::format("sys memory check failed, no throw exception, {}.", err_msg);
+            LOG(INFO) << fmt::format("{}, no throw exception.", err_msg);
         }
     }
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
+bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_tracker_exceed(
+        size_t size, std::string* err_msg) const {
+    auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
+    if (thread_mem_ctx->skip_memory_check != 0) {
+        return false;
+    }
+
+    auto st = thread_mem_ctx->limiter_mem_tracker()->check_limit(size);
+    if (!st) {
+        *err_msg += fmt::format("Allocator mem tracker check failed, {}", st.to_string());
+        thread_mem_ctx->limiter_mem_tracker()->print_log_usage(*err_msg);
+        return true;
+    }
+    return false;
+}
+
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_tracker_check(
         size_t size) const {
-#ifdef BE_TEST
-    if (!doris::ExecEnv::ready()) {
-        return;
-    }
-#endif
-    if (doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0) {
-        return;
-    }
-    auto st = doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->check_limit(
-            size);
-    if (!st) {
-        auto err_msg = fmt::format("Allocator mem tracker check failed, {}", st.to_string());
-        doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->print_log_usage(
-                err_msg);
+    std::string err_msg;
+    if (memory_tracker_exceed(size, &err_msg)) {
         doris::thread_context()->thread_mem_tracker_mgr->disable_wait_gc();
         // If the outside will catch the exception, after throwing an exception,
         // the task will actively cancel itself.
         if (doris::enable_thread_catch_bad_alloc) {
-            LOG(INFO) << fmt::format(
-                    "Task:{} memory tracker check failed, throw exception, {}.",
-                    doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
-                    err_msg);
+            LOG(INFO) << fmt::format("{}, throw exception.", err_msg);
             throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err_msg);
         } else {
-            LOG(INFO) << fmt::format(
-                    "Task:{} memory tracker check failed, will continue to execute, no throw "
-                    "exception, {}.",
-                    doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->label(),
-                    err_msg);
+            LOG(INFO) << fmt::format("{}, will continue to execute, no throw exception.", err_msg);
         }
     }
 }
@@ -217,6 +217,7 @@ template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename Memory
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_check(
         size_t size) const {
     if (MemoryAllocator::need_check_and_tracking_memory()) {
+        alloc_fault_probability();
         sys_memory_check(size);
         memory_tracker_check(size);
     }
@@ -252,11 +253,6 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::throw_b
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_address_sanitizers(
         void* buf, size_t size) const {
-#ifdef BE_TEST
-    if (!doris::ExecEnv::ready()) {
-        return;
-    }
-#endif
     if (!doris::config::crash_in_memory_tracker_inaccurate) {
         return;
     }
@@ -267,11 +263,6 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_add
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_address_sanitizers(
         void* buf, size_t size) const {
-#ifdef BE_TEST
-    if (!doris::ExecEnv::ready()) {
-        return;
-    }
-#endif
     if (!doris::config::crash_in_memory_tracker_inaccurate) {
         return;
     }
@@ -283,13 +274,156 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc(size_t size,
                                                                                 size_t alignment) {
-    return alloc_impl(size, alignment);
+    memory_check(size);
+    // consume memory in tracker before alloc, similar to early declaration.
+    consume_memory(size);
+    void* buf;
+    size_t record_size = size;
+
+    if (use_mmap && size >= doris::config::mmap_threshold) {
+        if (alignment > MMAP_MIN_ALIGNMENT) {
+            throw doris::Exception(
+                    doris::ErrorCode::INVALID_ARGUMENT,
+                    "Too large alignment {}: more than page size when allocating {}.", alignment,
+                    size);
+        }
+
+        buf = mmap(nullptr, size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
+        if (MAP_FAILED == buf) {
+            release_memory(size);
+            throw_bad_alloc(fmt::format("Allocator: Cannot mmap {}.", size));
+        }
+        if constexpr (MemoryAllocator::need_record_actual_size()) {
+            record_size = MemoryAllocator::allocated_size(buf);
+        }
+
+        /// No need for zero-fill, because mmap guarantees it.
+    } else {
+        if (alignment <= MALLOC_MIN_ALIGNMENT) {
+            if constexpr (clear_memory) {
+                buf = MemoryAllocator::calloc(size, 1);
+            } else {
+                buf = MemoryAllocator::malloc(size);
+            }
+
+            if (nullptr == buf) {
+                release_memory(size);
+                throw_bad_alloc(fmt::format("Allocator: Cannot malloc {}.", size));
+            }
+            if constexpr (MemoryAllocator::need_record_actual_size()) {
+                record_size = MemoryAllocator::allocated_size(buf);
+            }
+            add_address_sanitizers(buf, record_size);
+        } else {
+            buf = nullptr;
+            int res = MemoryAllocator::posix_memalign(&buf, alignment, size);
+
+            if (0 != res) {
+                release_memory(size);
+                throw_bad_alloc(fmt::format("Cannot allocate memory (posix_memalign) {}.", size));
+            }
+
+            if constexpr (clear_memory) {
+                memset(buf, 0, size);
+            }
+
+            if constexpr (MemoryAllocator::need_record_actual_size()) {
+                record_size = MemoryAllocator::allocated_size(buf);
+            }
+            add_address_sanitizers(buf, record_size);
+        }
+    }
+    if constexpr (MemoryAllocator::need_record_actual_size()) {
+        consume_memory(record_size - size);
+    }
+    return buf;
+}
+
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::free(void* buf,
+                                                                              size_t size) {
+    if (use_mmap && size >= doris::config::mmap_threshold) {
+        if (0 != munmap(buf, size)) {
+            throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
+        }
+    } else {
+        remove_address_sanitizers(buf, size);
+        MemoryAllocator::free(buf);
+    }
+    release_memory(size);
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::realloc(
         void* buf, size_t old_size, size_t new_size, size_t alignment) {
-    return realloc_impl(buf, old_size, new_size, alignment);
+    if (old_size == new_size) {
+        /// nothing to do.
+        /// BTW, it's not possible to change alignment while doing realloc.
+        return buf;
+    }
+    memory_check(new_size);
+    // Realloc can do 2 possible things:
+    // - expand existing memory region
+    // - allocate new memory block and free the old one
+    // Because we don't know which option will be picked we need to make sure there is enough
+    // memory for all options.
+    consume_memory(new_size);
+
+    if (!use_mmap ||
+        (old_size < doris::config::mmap_threshold && new_size < doris::config::mmap_threshold &&
+         alignment <= MALLOC_MIN_ALIGNMENT)) {
+        remove_address_sanitizers(buf, old_size);
+        /// Resize malloc'd memory region with no special alignment requirement.
+        void* new_buf = MemoryAllocator::realloc(buf, new_size);
+        if (nullptr == new_buf) {
+            release_memory(new_size);
+            throw_bad_alloc(
+                    fmt::format("Allocator: Cannot realloc from {} to {}.", old_size, new_size));
+        }
+        // usually, buf addr = new_buf addr, asan maybe not equal.
+        add_address_sanitizers(new_buf, new_size);
+
+        buf = new_buf;
+        release_memory(old_size);
+        if constexpr (clear_memory) {
+            if (new_size > old_size) {
+                memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
+            }
+        }
+    } else if (old_size >= doris::config::mmap_threshold &&
+               new_size >= doris::config::mmap_threshold) {
+        /// Resize mmap'd memory region.
+        // On apple and freebsd self-implemented mremap used (common/mremap.h)
+        buf = clickhouse_mremap(buf, old_size, new_size, MREMAP_MAYMOVE, PROT_READ | PROT_WRITE,
+                                mmap_flags, -1, 0);
+        if (MAP_FAILED == buf) {
+            release_memory(new_size);
+            throw_bad_alloc(fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
+                                        old_size, new_size));
+        }
+        release_memory(old_size);
+
+        /// No need for zero-fill, because mmap guarantees it.
+
+        if constexpr (mmap_populate) {
+            // MAP_POPULATE seems have no effect for mremap as for mmap,
+            // Clear enlarged memory range explicitly to pre-fault the pages
+            if (new_size > old_size) {
+                memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
+            }
+        }
+    } else {
+        // Big allocs that requires a copy.
+        void* new_buf = alloc(new_size, alignment);
+        memcpy(new_buf, buf, std::min(old_size, new_size));
+        add_address_sanitizers(new_buf, new_size);
+        remove_address_sanitizers(buf, old_size);
+        free(buf, old_size);
+        buf = new_buf;
+        release_memory(old_size);
+    }
+
+    return buf;
 }
 
 template class Allocator<true, true, true, DefaultMemoryAllocator>;

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -216,20 +216,26 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_check(
         size_t size) const {
-    sys_memory_check(size);
-    memory_tracker_check(size);
+    if (MemoryAllocator::need_check_and_tracking_memory()) {
+        sys_memory_check(size);
+        memory_tracker_check(size);
+    }
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::consume_memory(
         size_t size) const {
-    CONSUME_THREAD_MEM_TRACKER(size);
+    if (MemoryAllocator::need_check_and_tracking_memory()) {
+        CONSUME_THREAD_MEM_TRACKER(size);
+    }
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release_memory(
         size_t size) const {
-    RELEASE_THREAD_MEM_TRACKER(size);
+    if (MemoryAllocator::need_check_and_tracking_memory()) {
+        RELEASE_THREAD_MEM_TRACKER(size);
+    }
 }
 
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -251,11 +251,14 @@ public:
 
     void release_unused() { MemoryAllocator::release_unused(); }
 
+    bool sys_memory_exceed(size_t size, std::string* err_msg) const;
+
+    bool memory_tracker_exceed(size_t size, std::string* err_msg) const;
+
 protected:
     static constexpr size_t get_stack_threshold() { return 0; }
 
-    bool sys_memory_exceed(size_t size, std::string* err_msg) const;
-    bool memory_tracker_exceed(size_t size, std::string* err_msg) const;
+    static constexpr bool clear_memory = clear_memory_;
 
 private:
     void sys_memory_check(size_t size) const;
@@ -278,8 +281,6 @@ private:
     void throw_bad_alloc(const std::string& err) const;
     void add_address_sanitizers(void* buf, size_t size) const;
     void remove_address_sanitizers(void* buf, size_t size) const;
-
-    static constexpr bool clear_memory = clear_memory_;
 
     // Freshly mmapped pages are copy-on-write references to a global zero page.
     // On the first write, a page fault occurs, and an actual writable page is
@@ -335,6 +336,14 @@ public:
         void* new_buf = Base::alloc(new_size, Alignment);
         memcpy(new_buf, buf, old_size);
         return new_buf;
+    }
+
+    bool sys_memory_exceed(size_t size, std::string* err_msg) const {
+        return Base::sys_memory_exceed(size, err_msg);
+    }
+
+    bool memory_tracker_exceed(size_t size, std::string* err_msg) const {
+        return Base::memory_tracker_exceed(size, err_msg);
     }
 
 protected:

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -255,6 +255,10 @@ public:
 
     bool memory_tracker_exceed(size_t size, std::string* err_msg) const;
 
+    static constexpr bool need_check_and_tracking_memory() {
+        return MemoryAllocator::need_check_and_tracking_memory();
+    }
+
 protected:
     static constexpr size_t get_stack_threshold() { return 0; }
 
@@ -344,6 +348,10 @@ public:
 
     bool memory_tracker_exceed(size_t size, std::string* err_msg) const {
         return Base::memory_tracker_exceed(size, err_msg);
+    }
+
+    static constexpr bool need_check_and_tracking_memory() {
+        return Base::need_check_and_tracking_memory();
     }
 
 protected:

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -237,11 +237,34 @@ private:
 template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
 class Allocator {
 public:
+    // Allocate memory range.
+    void* alloc(size_t size, size_t alignment = 0);
+
+    /** Enlarge memory range.
+      * Data from old range is moved to the beginning of new range.
+      * Address of memory range could change.
+      */
+    void* realloc(void* buf, size_t old_size, size_t new_size, size_t alignment = 0);
+
+    // Free memory range.
+    void free(void* buf, size_t size);
+
+    void release_unused() { MemoryAllocator::release_unused(); }
+
+protected:
+    static constexpr size_t get_stack_threshold() { return 0; }
+
+    bool sys_memory_exceed(size_t size, std::string* err_msg) const;
+    bool memory_tracker_exceed(size_t size, std::string* err_msg) const;
+
+private:
     void sys_memory_check(size_t size) const;
     void memory_tracker_check(size_t size) const;
     // If sys memory or tracker exceeds the limit, but there is no external catch bad_alloc,
     // alloc will continue to execute, so the consume memtracker is forced.
     void memory_check(size_t size) const;
+    void alloc_fault_probability() const;
+
     // Increases consumption of this tracker by 'bytes'.
     // some special cases:
     // 1. objects that inherit Allocator will not be shared by multiple queries.
@@ -255,163 +278,6 @@ public:
     void throw_bad_alloc(const std::string& err) const;
     void add_address_sanitizers(void* buf, size_t size) const;
     void remove_address_sanitizers(void* buf, size_t size) const;
-
-    void* alloc(size_t size, size_t alignment = 0);
-    void* realloc(void* buf, size_t old_size, size_t new_size, size_t alignment = 0);
-
-    /// Allocate memory range.
-    void* alloc_impl(size_t size, size_t alignment = 0) {
-        memory_check(size);
-        // consume memory in tracker before alloc, similar to early declaration.
-        consume_memory(size);
-        void* buf;
-        size_t record_size = size;
-
-        if (use_mmap && size >= doris::config::mmap_threshold) {
-            if (alignment > MMAP_MIN_ALIGNMENT)
-                throw doris::Exception(
-                        doris::ErrorCode::INVALID_ARGUMENT,
-                        "Too large alignment {}: more than page size when allocating {}.",
-                        alignment, size);
-
-            buf = mmap(nullptr, size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
-            if (MAP_FAILED == buf) {
-                release_memory(size);
-                throw_bad_alloc(fmt::format("Allocator: Cannot mmap {}.", size));
-            }
-            if constexpr (MemoryAllocator::need_record_actual_size()) {
-                record_size = MemoryAllocator::allocated_size(buf);
-            }
-
-            /// No need for zero-fill, because mmap guarantees it.
-        } else {
-            if (alignment <= MALLOC_MIN_ALIGNMENT) {
-                if constexpr (clear_memory)
-                    buf = MemoryAllocator::calloc(size, 1);
-                else
-                    buf = MemoryAllocator::malloc(size);
-
-                if (nullptr == buf) {
-                    release_memory(size);
-                    throw_bad_alloc(fmt::format("Allocator: Cannot malloc {}.", size));
-                }
-                if constexpr (MemoryAllocator::need_record_actual_size()) {
-                    record_size = MemoryAllocator::allocated_size(buf);
-                }
-                add_address_sanitizers(buf, record_size);
-            } else {
-                buf = nullptr;
-                int res = MemoryAllocator::posix_memalign(&buf, alignment, size);
-
-                if (0 != res) {
-                    release_memory(size);
-                    throw_bad_alloc(
-                            fmt::format("Cannot allocate memory (posix_memalign) {}.", size));
-                }
-
-                if constexpr (clear_memory) memset(buf, 0, size);
-
-                if constexpr (MemoryAllocator::need_record_actual_size()) {
-                    record_size = MemoryAllocator::allocated_size(buf);
-                }
-                add_address_sanitizers(buf, record_size);
-            }
-        }
-        if constexpr (MemoryAllocator::need_record_actual_size()) {
-            consume_memory(record_size - size);
-        }
-        return buf;
-    }
-
-    /// Free memory range.
-    void free(void* buf, size_t size) {
-        if (use_mmap && size >= doris::config::mmap_threshold) {
-            if (0 != munmap(buf, size)) {
-                throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
-            }
-        } else {
-            remove_address_sanitizers(buf, size);
-            MemoryAllocator::free(buf);
-        }
-        release_memory(size);
-    }
-
-    void release_unused() { MemoryAllocator::release_unused(); }
-
-    /** Enlarge memory range.
-      * Data from old range is moved to the beginning of new range.
-      * Address of memory range could change.
-      */
-    void* realloc_impl(void* buf, size_t old_size, size_t new_size, size_t alignment = 0) {
-        if (old_size == new_size) {
-            /// nothing to do.
-            /// BTW, it's not possible to change alignment while doing realloc.
-            return buf;
-        }
-        memory_check(new_size);
-        // Realloc can do 2 possible things:
-        // - expand existing memory region
-        // - allocate new memory block and free the old one
-        // Because we don't know which option will be picked we need to make sure there is enough
-        // memory for all options.
-        consume_memory(new_size);
-
-        if (!use_mmap ||
-            (old_size < doris::config::mmap_threshold && new_size < doris::config::mmap_threshold &&
-             alignment <= MALLOC_MIN_ALIGNMENT)) {
-            remove_address_sanitizers(buf, old_size);
-            /// Resize malloc'd memory region with no special alignment requirement.
-            void* new_buf = MemoryAllocator::realloc(buf, new_size);
-            if (nullptr == new_buf) {
-                release_memory(new_size);
-                throw_bad_alloc(fmt::format("Allocator: Cannot realloc from {} to {}.", old_size,
-                                            new_size));
-            }
-            // usually, buf addr = new_buf addr, asan maybe not equal.
-            add_address_sanitizers(new_buf, new_size);
-
-            buf = new_buf;
-            release_memory(old_size);
-            if constexpr (clear_memory)
-                if (new_size > old_size)
-                    memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
-        } else if (old_size >= doris::config::mmap_threshold &&
-                   new_size >= doris::config::mmap_threshold) {
-            /// Resize mmap'd memory region.
-            // On apple and freebsd self-implemented mremap used (common/mremap.h)
-            buf = clickhouse_mremap(buf, old_size, new_size, MREMAP_MAYMOVE, PROT_READ | PROT_WRITE,
-                                    mmap_flags, -1, 0);
-            if (MAP_FAILED == buf) {
-                release_memory(new_size);
-                throw_bad_alloc(fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
-                                            old_size, new_size));
-            }
-            release_memory(old_size);
-
-            /// No need for zero-fill, because mmap guarantees it.
-
-            if constexpr (mmap_populate) {
-                // MAP_POPULATE seems have no effect for mremap as for mmap,
-                // Clear enlarged memory range explicitly to pre-fault the pages
-                if (new_size > old_size)
-                    memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
-            }
-        } else {
-            // Big allocs that requires a copy.
-            void* new_buf = alloc(new_size, alignment);
-            memcpy(new_buf, buf, std::min(old_size, new_size));
-            add_address_sanitizers(new_buf, new_size);
-            remove_address_sanitizers(buf, old_size);
-            free(buf, old_size);
-            buf = new_buf;
-            release_memory(old_size);
-        }
-
-        return buf;
-    }
-
-protected:
-    static constexpr size_t get_stack_threshold() { return 0; }
 
     static constexpr bool clear_memory = clear_memory_;
 

--- a/be/src/vec/common/allocator_fwd.h
+++ b/be/src/vec/common/allocator_fwd.h
@@ -26,6 +26,8 @@
 #include <cstddef>
 namespace doris {
 class DefaultMemoryAllocator;
+class NoTrackingDefaultMemoryAllocator;
+
 template <bool clear_memory_, bool mmap_populate = false, bool use_mmap = false,
           typename MemoryAllocator = DefaultMemoryAllocator>
 class Allocator;

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -171,7 +171,8 @@ protected:
     }
 
     inline void reset_resident_memory(const char* c_end_new) {
-        DCHECK(!TAllocator::need_check_and_tracking_memory());
+        static_assert(!TAllocator::need_check_and_tracking_memory(),
+                      "TAllocator should specify `NoTrackingDefaultMemoryAllocator`");
         if (UNLIKELY(c_end_new - c_res_mem > 0)) {
             // - allocated_bytes = c_end_of_storage - c_start = 4 MB;
             // - used_bytes = c_end_new - c_start = 2.1 MB;

--- a/be/src/vec/common/pod_array_fwd.h
+++ b/be/src/vec/common/pod_array_fwd.h
@@ -32,7 +32,8 @@ inline constexpr size_t integerRoundUp(size_t value, size_t dividend) {
     return ((value + dividend - 1) / dividend) * dividend;
 }
 
-template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>,
+template <typename T, size_t initial_bytes = 4096,
+          typename TAllocator = Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
           size_t pad_right_ = 0, size_t pad_left_ = 0>
 class PODArray;
 
@@ -40,7 +41,8 @@ class PODArray;
   * TODO, Adapt internal data structures to 512-bit era https://github.com/ClickHouse/ClickHouse/pull/42564
   *       Padding in internal data structures increased to 64 bytes., support AVX-512 simd.
   */
-template <typename T, size_t initial_bytes = 4096, typename TAllocator = Allocator<false>>
+template <typename T, size_t initial_bytes = 4096,
+          typename TAllocator = Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>>
 using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 16, 15>;
 
 /** A helper for declaring PODArray that uses inline memory.

--- a/be/src/vec/common/pod_array_fwd.h
+++ b/be/src/vec/common/pod_array_fwd.h
@@ -51,8 +51,9 @@ using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 16, 15>;
   */
 template <typename T, size_t inline_bytes,
           size_t rounded_bytes = integerRoundUp(inline_bytes, sizeof(T))>
-using PODArrayWithStackMemory =
-        PODArray<T, rounded_bytes,
-                 AllocatorWithStackMemory<Allocator<false>, rounded_bytes, alignof(T)>>;
+using PODArrayWithStackMemory = PODArray<
+        T, rounded_bytes,
+        AllocatorWithStackMemory<Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
+                                 rounded_bytes, alignof(T)>>;
 
 } // namespace doris::vectorized

--- a/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
+++ b/be/test/runtime/memory/thread_mem_tracker_mgr_test.cpp
@@ -341,7 +341,7 @@ TEST_F(ThreadMemTrackerMgrTest, NestedReserveMemory) {
     int64_t size3 = size2 * 2;
 
     thread_context->attach_task(rc);
-    auto st = thread_context->thread_mem_tracker_mgr->try_reserve(size3, false);
+    auto st = thread_context->thread_mem_tracker_mgr->try_reserve(size3);
     EXPECT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(t->consumption(), size3);
     EXPECT_EQ(doris::GlobalMemoryArbitrator::process_reserved_memory(), size3);

--- a/be/test/testutil/mock/mock_thread_mem_tracker_mgr.h
+++ b/be/test/testutil/mock/mock_thread_mem_tracker_mgr.h
@@ -23,7 +23,10 @@ namespace doris {
 class MockThreadMemTrackerMgr : public ThreadMemTrackerMgr {
 public:
     MockThreadMemTrackerMgr() : ThreadMemTrackerMgr() {}
-    Status try_reserve(int64_t size, bool only_check_process_memory = false) override {
+    Status try_reserve(
+            int64_t size,
+            TryReserveChecker checker =
+                    TryReserveChecker::CHECK_TASK_AND_WORKLOAD_GROUP_AND_PROCESS) override {
         return _test_low_memory ? Status::Error<ErrorCode::QUERY_MEMORY_EXCEEDED>("")
                                 : Status::OK();
     }

--- a/be/test/vec/common/pod_array_test.cpp
+++ b/be/test/vec/common/pod_array_test.cpp
@@ -28,8 +28,11 @@ namespace doris {
 
 TEST(PODArrayTest, PODArrayBasicMove) {
     static constexpr size_t initial_bytes = 32;
-    using Array = vectorized::PODArray<uint64_t, initial_bytes,
-                                       AllocatorWithStackMemory<Allocator<false>, initial_bytes>>;
+    using Array = vectorized::PODArray<
+            uint64_t, initial_bytes,
+            AllocatorWithStackMemory<
+                    Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
+                    initial_bytes>>;
 
     {
         Array arr;
@@ -141,8 +144,11 @@ TEST(PODArrayTest, PODArrayBasicMove) {
 
 TEST(PODArrayTest, PODArrayBasicSwap) {
     static constexpr size_t initial_bytes = 32;
-    using Array = vectorized::PODArray<uint64_t, initial_bytes,
-                                       AllocatorWithStackMemory<Allocator<false>, initial_bytes>>;
+    using Array = vectorized::PODArray<
+            uint64_t, initial_bytes,
+            AllocatorWithStackMemory<
+                    Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
+                    initial_bytes>>;
 
     {
         Array arr;
@@ -383,8 +389,11 @@ TEST(PODArrayTest, PODArrayBasicSwap) {
 
 TEST(PODArrayTest, PODArrayBasicSwapMoveConstructor) {
     static constexpr size_t initial_bytes = 32;
-    using Array = vectorized::PODArray<uint64_t, initial_bytes,
-                                       AllocatorWithStackMemory<Allocator<false>, initial_bytes>>;
+    using Array = vectorized::PODArray<
+            uint64_t, initial_bytes,
+            AllocatorWithStackMemory<
+                    Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
+                    initial_bytes>>;
 
     {
         Array arr;
@@ -626,59 +635,274 @@ TEST(PODArrayTest, PODErase) {
     }
 }
 
+TEST(PODArrayTest, PaddedPODArrayTrackingMemory) {
+    auto t = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "UT");
+    //  PaddedPODArray
+    {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(t);
+        EXPECT_EQ(t->consumption(), 0);
+        static constexpr size_t PRE_GROWTH_SIZE = (1ULL << 20); // 1M
+
+        vectorized::PaddedPODArray<uint64_t, 4096> array;
+        size_t pad_right = vectorized::integerRoundUp(16, sizeof(uint64_t));
+        size_t pad_left =
+                vectorized::integerRoundUp(vectorized::integerRoundUp(15, sizeof(uint64_t)), 16);
+        EXPECT_EQ(t->consumption(), 0);
+
+        array.push_back(1);
+        EXPECT_EQ(array.size(), 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
+
+        array.push_back(2);
+        EXPECT_EQ(array.size(), 2);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
+
+        array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t));
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t));
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE);
+
+        array.push_back(3);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) + 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        // c_end_of_storage - c_start < integerRoundUp(c_end_new - c_start, PRE_GROWTH_SIZE)
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
+
+        array.assign({1, 2, 3});
+        EXPECT_EQ(array.size(), 3);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
+
+        array.resize((PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
+
+        array.add_num_element_without_reserve(1, 10);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3 + 10);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
+
+        array.add_num_element(1, (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 2);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 5 + 10);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 6);
+
+        array.push_back_without_reserve(11);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 5 + 11);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 6);
+
+        array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t) * 6, 2);
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 6);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 6);
+
+        array.push_back_without_reserve(22);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 6 + 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 7);
+
+        array.emplace_back(33);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 6 + 2);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 7);
+
+        array.pop_back();
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 6 + 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 7);
+
+        for (int i = 0; i < (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 2; i++) {
+            array.push_back(2);
+            array.pop_back();
+            array.pop_back();
+        }
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 4 + 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 7);
+
+        array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t) * 7, 3);
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 7);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 7);
+
+        {
+            vectorized::PaddedPODArray<uint64_t, 32> array2;
+            array2.push_back(3);
+            array2.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t), 3);
+            array.insert(array2.begin(), array2.end());
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 9);
+        }
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 8);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 8);
+
+        {
+            vectorized::PaddedPODArray<uint64_t, 32> array2;
+            array2.resize_fill((PRE_GROWTH_SIZE / sizeof(uint64_t)) * 7, 3);
+            array.insert_small_allow_read_write_overflow15(array2.begin(), array2.end());
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 22);
+        }
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 15);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 15);
+
+        {
+            vectorized::PaddedPODArray<uint64_t, 32> array2;
+            array2.push_back(3);
+            array.insert(array2.begin(), array2.end());
+        }
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 15 + 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
+
+        array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t) * 16, 4);
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 16);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 16);
+
+        {
+            vectorized::PaddedPODArray<uint64_t, 32> array2;
+            array2.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t), 3);
+            array.insert(array.begin(), array2.begin(), array2.end());
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 18);
+        }
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 17);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 17);
+
+        {
+            vectorized::PaddedPODArray<uint64_t, 32> array2;
+            array2.resize_fill((PRE_GROWTH_SIZE / sizeof(uint64_t) * 2), 3);
+            array.insert_assume_reserved(array2.begin(), array2.end());
+            array.insert_assume_reserved_and_allow_overflow(array2.begin(), array2.end());
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 23);
+        }
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 21);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
+
+        size_t n = 100;
+        array.assign(n, (uint64_t)0);
+        EXPECT_EQ(array.size(), 100);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
+
+        array.add_num_element_without_reserve(1, PRE_GROWTH_SIZE / sizeof(uint64_t));
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 1 + 100);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
+
+        array.erase(array.begin() + 100, array.end());
+        EXPECT_EQ(array.size(), 100);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
+    }
+    EXPECT_EQ(t->consumption(), 0);
+}
+
 TEST(PODArrayTest, PODArrayTrackingMemory) {
     auto t = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL, "UT");
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(t);
+
+    // PODArray with AllocatorWithStackMemory
+    {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(t);
+        EXPECT_EQ(t->consumption(), 0);
+        static constexpr size_t PRE_GROWTH_SIZE = (1ULL << 20); // 1M
+
+        static constexpr size_t initial_bytes = 32;
+        using Array = vectorized::PODArray<
+                uint64_t, initial_bytes,
+                AllocatorWithStackMemory<
+                        Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>>>;
+        Array array;
+
+        array.push_back(1);
+        EXPECT_EQ(array.size(), 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes());
+
+        array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t), 1);
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t));
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE);
+
+        // test swap
+        size_t new_capacity = 0;
+        size_t new_size = 0;
+        {
+            Array array2;
+            array2.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t) * 2, 1);
+            EXPECT_EQ(array2.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 2);
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
+            new_capacity = array2.capacity();
+            new_size = array2.size();
+
+            array.swap(array2);
+            EXPECT_EQ(array2.size(), PRE_GROWTH_SIZE / sizeof(uint64_t));
+            EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 2);
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
+            EXPECT_EQ(array.capacity(), new_capacity);
+            EXPECT_EQ(array.size(), new_size);
+        }
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 2);
+    }
     EXPECT_EQ(t->consumption(), 0);
-    static constexpr size_t PRE_GROWTH_SIZE = (1ULL << 20); // 1M
 
-    vectorized::PaddedPODArray<uint64_t, 4096> array1;
-    size_t pad_right = vectorized::integerRoundUp(16, sizeof(uint64_t));
-    size_t pad_left =
-            vectorized::integerRoundUp(vectorized::integerRoundUp(15, sizeof(uint64_t)), 16);
+    // PODArray with Allocator
+    {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(t);
+        EXPECT_EQ(t->consumption(), 0);
+        static constexpr size_t PRE_GROWTH_SIZE = (1ULL << 20); // 1M
+
+        static constexpr size_t initial_bytes = 32;
+        using Array = vectorized::PODArray<
+                uint64_t, initial_bytes,
+                Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>>;
+        Array array;
+
+        array.push_back(1);
+        EXPECT_EQ(array.size(), 1);
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), array.allocated_bytes());
+
+        array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t), 1);
+        EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t));
+        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE);
+
+        // test swap
+        size_t new_capacity = 0;
+        size_t new_size = 0;
+        {
+            Array array2;
+            array2.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t) * 2, 1);
+            EXPECT_EQ(array2.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 2);
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
+            new_capacity = array2.capacity();
+            new_size = array2.size();
+
+            array.swap(array2);
+            EXPECT_EQ(array2.size(), PRE_GROWTH_SIZE / sizeof(uint64_t));
+            EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 2);
+            doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+            EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
+            EXPECT_EQ(array.capacity(), new_capacity);
+            EXPECT_EQ(array.size(), new_size);
+        }
+        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 2);
+    }
     EXPECT_EQ(t->consumption(), 0);
-
-    array1.push_back(1);
-    EXPECT_EQ(array1.size(), 1);
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    EXPECT_EQ(t->consumption(), array1.allocated_bytes() - pad_left - pad_right);
-
-    array1.push_back(2);
-    EXPECT_EQ(array1.size(), 2);
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    EXPECT_EQ(t->consumption(), array1.allocated_bytes() - pad_left - pad_right);
-
-    array1.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t));
-    EXPECT_EQ(array1.size(), PRE_GROWTH_SIZE / sizeof(uint64_t));
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE);
-
-    array1.push_back(3);
-    EXPECT_EQ(array1.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) + 1);
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    // c_end_of_storage - c_start < integerRoundUp(c_end_new - c_start, PRE_GROWTH_SIZE)
-    EXPECT_EQ(t->consumption(), array1.allocated_bytes() - pad_left - pad_right);
-
-    array1.assign({1, 2, 3});
-    EXPECT_EQ(array1.size(), 3);
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    EXPECT_EQ(t->consumption(), array1.allocated_bytes() - pad_left - pad_right);
-
-    array1.resize((PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3);
-    EXPECT_EQ(array1.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3);
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
-
-    array1.add_num_element_without_reserve(1, 10);
-    EXPECT_EQ(array1.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3 + 10);
-    doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    EXPECT_EQ(t->consumption(), array1.allocated_bytes() - pad_left - pad_right);
-
-    // TODO
-    // array1.add_num_element(1, (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 2);
-    // EXPECT_EQ(array1.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 5);
-    // doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-    // EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 5);
 }
 
 } // end namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Based on #11740

The memory size tracked in Allocator is virtual memory. If the allocated memory is not fully used, the tracked virtual memory may be larger than the actual physical memory.

`PODArray` does not memset 0 when allocated memory, the memory blocks allocated by `PODArray` (such as VOlapScanNode::_free_blocks) are usually used for memory reuse and will not be fully used.

After this PR, the unused memory in `PODArray` is recorded in reserve to indicate that this part of the memory is not actually used.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

