### PR TITLE
[fix](view)fix reset view def for restore wrong replace

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/View.java
@@ -269,7 +269,8 @@ public class View extends Table implements GsonPostProcessable {
     public void resetViewDefForRestore(String srcDbName, String dbName) {
         // the source db name is not setted in old BackupMeta, keep compatible with the old one.
         if (srcDbName != null) {
-            inlineViewDef = inlineViewDef.replaceAll(srcDbName, dbName);
+            // replace dbName with a regular expression
+            inlineViewDef = inlineViewDef.replaceAll("(?<=`internal`\\.`)([^`]+)(?=`\\.`)", dbName);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
@@ -190,4 +190,14 @@ public class CreateViewTest {
                         + "ORDER BY `w1` ASC NULLS FIRST",
                 alter1.getInlineViewDef());
     }
+
+    @Test
+    public void testResetViewDefForRestore() {
+        View view = new View();
+        view.setInlineViewDefWithSqlMode("SELECT `internal`.`test`.`test`.`k2` AS `k1`, " +
+                "FROM `internal`.`test`.`test`;", 1);
+        view.resetViewDefForRestore("test", "test1");
+        Assert.assertEquals("SELECT `internal`.`test1`.`test`.`k2` AS `k1`, " +
+                "FROM `internal`.`test1`.`test`;", view.getInlineViewDef());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateViewTest.java
@@ -194,10 +194,10 @@ public class CreateViewTest {
     @Test
     public void testResetViewDefForRestore() {
         View view = new View();
-        view.setInlineViewDefWithSqlMode("SELECT `internal`.`test`.`test`.`k2` AS `k1`, " +
-                "FROM `internal`.`test`.`test`;", 1);
+        view.setInlineViewDefWithSqlMode("SELECT `internal`.`test`.`test`.`k2` AS `k1`, "
+                + "FROM `internal`.`test`.`test`;", 1);
         view.resetViewDefForRestore("test", "test1");
-        Assert.assertEquals("SELECT `internal`.`test1`.`test`.`k2` AS `k1`, " +
-                "FROM `internal`.`test1`.`test`;", view.getInlineViewDef());
+        Assert.assertEquals("SELECT `internal`.`test1`.`test`.`k2` AS `k1`, "
+                + "FROM `internal`.`test1`.`test`;", view.getInlineViewDef());
     }
 }

--- a/regression-test/suites/backup_restore/test_backup_restore_with_view.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_with_view.groovy
@@ -125,6 +125,8 @@ suite("test_backup_restore_with_view", "backup_restore") {
     restore_result.last()
     logger.info("show restore result: ${restore_result}")
     assertTrue(restore_result.last().State == "FINISHED")
+    def res = sql "SHOW VIEW FROM ${dbName1}.${tableName}"
+    assertTrue(res.size() > 0)
 
     sql "DROP TABLE ${dbName}.${tableName} FORCE"
     sql "DROP VIEW ${dbName}.${viewName}"


### PR DESCRIPTION
### What problem does this PR solve?

backup restore when the view will do resetViewDefForRestore, here directly replaceAll, did not accurately go to find the dbName, if the srcName is a substring of inlineViewDef or dbName, the replacement will be a big problem!

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

