### PR TITLE
[Feature]support specify compute group for doris internal job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManagerUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManagerUtils.java
@@ -29,6 +29,7 @@ import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
@@ -127,7 +128,7 @@ public class CacheHotspotManagerUtils {
         String sql = stringSubstitutor.replace(CONTAINS_CLUSTER_TEMPLATE);
         List<ResultRow> result = null;
         try {
-            result = StatisticsUtil.execStatisticQuery(sql, false);
+            result = StatisticsUtil.execStatisticQuery(sql, false, GlobalVariable.warmUpCacheQueryComputeGroup);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -147,7 +148,7 @@ public class CacheHotspotManagerUtils {
         String sql = stringSubstitutor.replace(GET_CLUSTER_PARTITIONS_TEMPLATE);
         List<ResultRow> result = null;
         try {
-            result = StatisticsUtil.execStatisticQuery(sql, false);
+            result = StatisticsUtil.execStatisticQuery(sql, false, GlobalVariable.warmUpCacheQueryComputeGroup);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -65,6 +65,10 @@ public final class GlobalVariable {
     public static final String AUDIT_PLUGIN_MAX_BATCH_INTERVAL_SEC = "audit_plugin_max_batch_interval_sec";
     public static final String AUDIT_PLUGIN_MAX_SQL_LENGTH = "audit_plugin_max_sql_length";
     public static final String AUDIT_PLUGIN_LOAD_TIMEOUT = "audit_plugin_load_timeout";
+    public static final String AUDIT_PLUGIN_COMPUTE_GROUP = "audit_plugin_compute_group";
+
+    public static final String WARM_UP_CACHE_QUERY_COMPUTE_GROUP = "warm_up_cache_query_compute_group";
+    public static final String STATISTICS_QUERY_COMPUTE_GROUP = "statistics_query_compute_group";
 
     public static final String ENABLE_GET_ROW_COUNT_FROM_FILE_LIST = "enable_get_row_count_from_file_list";
     public static final String READ_ONLY = "read_only";
@@ -153,6 +157,15 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = AUDIT_PLUGIN_LOAD_TIMEOUT, flag = VariableMgr.GLOBAL)
     public static int auditPluginLoadTimeoutS = 600;
+
+    @VariableMgr.VarAttr(name = AUDIT_PLUGIN_COMPUTE_GROUP, flag = VariableMgr.GLOBAL)
+    public static String auditPluginComputeGroup = "";
+
+    @VariableMgr.VarAttr(name = WARM_UP_CACHE_QUERY_COMPUTE_GROUP, flag = VariableMgr.GLOBAL)
+    public static String warmUpCacheQueryComputeGroup = "";
+
+    @VariableMgr.VarAttr(name = STATISTICS_QUERY_COMPUTE_GROUP, flag = VariableMgr.GLOBAL)
+    public static String statisticsQueryComputeGroup = "";
 
     @VariableMgr.VarAttr(name = ENABLE_GET_ROW_COUNT_FROM_FILE_LIST, flag = VariableMgr.GLOBAL,
             description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/ComputeGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/ComputeGroupMgr.java
@@ -72,4 +72,13 @@ public class ComputeGroupMgr {
         return ret;
     }
 
+    public boolean isComputeGroupExists(String cgName) {
+        CloudSystemInfoService cloudSystemInfoService = (CloudSystemInfoService) systemInfoService;
+        if (!StringUtils.isEmpty(cloudSystemInfoService.getCloudClusterIdByName(cgName))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 }


### PR DESCRIPTION
Add session variable ```audit_plugin_compute_group```, ```warm_up_cache_query_compute_group```, ```statistics_query_compute_group``` to support specify compute group for doris internal job which means ```audit log load```, ```statistics query```, ```file cache warm up query```.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

