### PR TITLE
[fix](iceberg)Fix the inconsistency between the data in pg and the data in MinIO. 

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/iceberg.yaml.tpl
+++ b/docker/thirdparties/docker-compose/iceberg/iceberg.yaml.tpl
@@ -107,6 +107,8 @@ services:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
       - MINIO_DOMAIN=minio
+    volumes:
+      - ./data/input/minio_data:/data
     networks:
       doris--iceberg:
         aliases:
@@ -130,11 +132,14 @@ services:
     entrypoint: >
       /bin/sh -c "
       until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse;
-      /usr/bin/mc mb minio/warehouse;
-      /usr/bin/mc policy set public minio/warehouse;
-      echo 'copy data';
-      mc cp -r /mnt/data/input/minio/warehouse/* minio/warehouse/;
+      if /usr/bin/mc ls minio/warehouse > /dev/null 2>&1; then
+        echo 'minio/warehouse already exists, skipping creation and copy.';
+      else
+        echo 'Creating minio/warehouse and copying data...';
+        /usr/bin/mc mb minio/warehouse;
+        /usr/bin/mc policy set public minio/warehouse;
+        /usr/bin/mc cp -r /mnt/data/input/minio/warehouse/* minio/warehouse/;
+      fi
       "
 
 networks:


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Part of the metadata of an Iceberg table is stored in PostgreSQL (PG), while the remaining data files are stored in MinIO. 

However, the data in PG is saved on the local disk, whereas the data in MinIO is not saved on the local disk. Therefore, when a user modifies the Iceberg table and then restarts Docker, at this time, the data in PG is the data after the user's modification, but the data in MinIO has not been updated to the modified version. 

So, the data in MinIO should also be saved on the local disk. In this way, we can ensure the consistency of the data between PG and MinIO.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

