### PR TITLE
[fix](file cache) Fix BlockFileCache::get_stats

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -2122,7 +2122,7 @@ std::map<std::string, double> BlockFileCache::get_stats() {
     stats["hits_ratio_1h"] = (double)_hit_ratio_1h->get_value();
 
     stats["index_queue_max_size"] = (double)_index_queue.get_max_size();
-    stats["index_queue_curr_size"] = (double)_cur_index_queue_element_count_metrics->get_value();
+    stats["index_queue_curr_size"] = (double)_cur_index_queue_cache_size_metrics->get_value();
     stats["index_queue_max_elements"] = (double)_index_queue.get_max_element_size();
     stats["index_queue_curr_elements"] =
             (double)_cur_index_queue_element_count_metrics->get_value();
@@ -2134,14 +2134,14 @@ std::map<std::string, double> BlockFileCache::get_stats() {
             (double)_cur_ttl_cache_lru_queue_element_count_metrics->get_value();
 
     stats["normal_queue_max_size"] = (double)_normal_queue.get_max_size();
-    stats["normal_queue_curr_size"] = (double)_cur_normal_queue_element_count_metrics->get_value();
+    stats["normal_queue_curr_size"] = (double)_cur_normal_queue_cache_size_metrics->get_value();
     stats["normal_queue_max_elements"] = (double)_normal_queue.get_max_element_size();
     stats["normal_queue_curr_elements"] =
             (double)_cur_normal_queue_element_count_metrics->get_value();
 
     stats["disposable_queue_max_size"] = (double)_disposable_queue.get_max_size();
     stats["disposable_queue_curr_size"] =
-            (double)_cur_disposable_queue_element_count_metrics->get_value();
+            (double)_cur_disposable_queue_cache_size_metrics->get_value();
     stats["disposable_queue_max_elements"] = (double)_disposable_queue.get_max_element_size();
     stats["disposable_queue_curr_elements"] =
             (double)_cur_disposable_queue_element_count_metrics->get_value();

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -240,8 +240,8 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
                 total_size = value.GetInt64();
             } else {
                 total_size = 0;
-                LOG(WARNING) << "[FileCache] the value of " << CACHE_TOTAL_SIZE.c_str()  << " is not int64: " 
-                << value.GetString() << " , use 0 as default";
+                LOG(WARNING) << "[FileCache] the value of " << CACHE_TOTAL_SIZE.c_str()
+                             << " is not int64: " << value.GetString() << " , use 0 as default";
             }
         }
         if (config::enable_file_cache_query_limit) {
@@ -251,8 +251,8 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
                     query_limit_bytes = value.GetInt64();
                 } else {
                     query_limit_bytes = 0;
-                    LOG(WARNING) << "[FileCache] the value of " << CACHE_QUERY_LIMIT_SIZE.c_str()  << " is not int64: " 
-                    << value.GetString() << " , use 0 as default";
+                    LOG(WARNING) << "[FileCache] the value of " << CACHE_QUERY_LIMIT_SIZE.c_str()
+                                 << " is not int64: " << value.GetString() << " , use 0 as default";
                 }
             }
         }

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -240,6 +240,8 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
                 total_size = value.GetInt64();
             } else {
                 total_size = 0;
+                LOG(WARNING) << "[FileCache] the value of " << CACHE_TOTAL_SIZE.c_str()  << " is not int64: " 
+                << value.GetString() << " , use 0 as default";
             }
         }
         if (config::enable_file_cache_query_limit) {
@@ -249,6 +251,8 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
                     query_limit_bytes = value.GetInt64();
                 } else {
                     query_limit_bytes = 0;
+                    LOG(WARNING) << "[FileCache] the value of " << CACHE_QUERY_LIMIT_SIZE.c_str()  << " is not int64: " 
+                    << value.GetString() << " , use 0 as default";
                 }
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

1. use correct curr_size value for filecache statistics in BlockFileCache::get_stats. 
2. add warning if total size of file cache is ilegal 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

