### PR TITLE
[bugfix](be) exchange sink buffer may use wrong runtime state

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -77,7 +77,7 @@ bool StringFunctions::compile_regex(const StringRef& pattern, std::string* error
         auto options_split = split(options_value.to_string(), ",");
         for (const auto& option : options_split) {
             if (iequal("ignore_invalid_escape", option)) {
-                //options.set_ignore_replace_escape(true);
+                options.set_ignore_replace_escape(true);
             } else {
                 // "none" do nothing, and could add more options for future extensibility.
             }

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -77,7 +77,7 @@ bool StringFunctions::compile_regex(const StringRef& pattern, std::string* error
         auto options_split = split(options_value.to_string(), ",");
         for (const auto& option : options_split) {
             if (iequal("ignore_invalid_escape", option)) {
-                options.set_ignore_replace_escape(true);
+                //options.set_ignore_replace_escape(true);
             } else {
                 // "none" do nothing, and could add more options for future extensibility.
             }

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -310,6 +310,7 @@ private:
 
     PlanNodeId _node_id;
     std::atomic<int64_t> _rpc_count = 0;
+    // The state may be from PipelineFragmentContext if it is shared among multi instances.
     RuntimeState* _state = nullptr;
     QueryContext* _context = nullptr;
 

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -189,8 +189,6 @@ public:
                           const std::vector<TUniqueId>& fragment_instance_ids);
     Status init(const TDataSink& tsink) override;
 
-    RuntimeState* state() { return _state; }
-
     Status prepare(RuntimeState* state) override;
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
@@ -217,7 +215,8 @@ public:
     // Therefore, a shared sink buffer is used here to limit the number of concurrent RPCs.
     // (Note: This does not reduce the total number of RPCs.)
     // In a merge sort scenario, there are only n RPCs, so a shared sink buffer is not needed.
-    std::shared_ptr<ExchangeSinkBuffer> get_sink_buffer(InstanceLoId sender_ins_id);
+    std::shared_ptr<ExchangeSinkBuffer> get_sink_buffer(RuntimeState* state,
+                                                        InstanceLoId sender_ins_id);
     vectorized::VExprContextSPtrs& tablet_sink_expr_ctxs() { return _tablet_sink_expr_ctxs; }
 
 private:
@@ -232,7 +231,7 @@ private:
     // The sink buffer can be shared among multiple ExchangeSinkLocalState instances,
     // or each ExchangeSinkLocalState can have its own sink buffer.
     std::shared_ptr<ExchangeSinkBuffer> _create_buffer(
-            const std::vector<InstanceLoId>& sender_ins_ids);
+            RuntimeState* state const std::vector<InstanceLoId>& sender_ins_ids);
     std::shared_ptr<ExchangeSinkBuffer> _sink_buffer = nullptr;
     RuntimeState* _state = nullptr;
 

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -189,6 +189,10 @@ public:
                           const std::vector<TUniqueId>& fragment_instance_ids);
     Status init(const TDataSink& tsink) override;
 
+    // The state is from pipeline fragment context, it will be saved in ExchangeSinkOperator
+    // and it will be passed to exchange sink buffer. So that exchange sink buffer should not
+    // be used after pipeline fragment ctx. All operations in Exchange Sink Buffer should hold
+    // TaskExecutionContext.
     Status prepare(RuntimeState* state) override;
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -235,7 +235,7 @@ private:
     // The sink buffer can be shared among multiple ExchangeSinkLocalState instances,
     // or each ExchangeSinkLocalState can have its own sink buffer.
     std::shared_ptr<ExchangeSinkBuffer> _create_buffer(
-            RuntimeState* state const std::vector<InstanceLoId>& sender_ins_ids);
+            RuntimeState* state, const std::vector<InstanceLoId>& sender_ins_ids);
     std::shared_ptr<ExchangeSinkBuffer> _sink_buffer = nullptr;
     RuntimeState* _state = nullptr;
 

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -82,8 +82,6 @@ public:
 
     PipelinePtr add_pipeline(PipelinePtr parent = nullptr, int idx = -1);
 
-    RuntimeState* get_runtime_state() { return _runtime_state.get(); }
-
     QueryContext* get_query_ctx() { return _query_ctx.get(); }
     [[nodiscard]] bool is_canceled() const { return _query_ctx->is_cancelled(); }
 

--- a/be/test/pipeline/operator/exchange_sink_operator_test.cpp
+++ b/be/test/pipeline/operator/exchange_sink_operator_test.cpp
@@ -61,7 +61,7 @@ struct MockExchangeSinkOperatorX : public ExchangeSinkOperatorX {
 
     void _init_sink_buffer() override {
         std::vector<InstanceLoId> ins_ids {fragment_instance_id.lo};
-        _sink_buffer = _create_buffer(ins_ids);
+        _sink_buffer = _create_buffer(&ctx.state, ins_ids);
     }
 };
 

--- a/be/test/pipeline/operator/exchange_sink_operator_test.cpp
+++ b/be/test/pipeline/operator/exchange_sink_operator_test.cpp
@@ -61,7 +61,7 @@ struct MockExchangeSinkOperatorX : public ExchangeSinkOperatorX {
 
     void _init_sink_buffer() override {
         std::vector<InstanceLoId> ins_ids {fragment_instance_id.lo};
-        _sink_buffer = _create_buffer(&ctx.state, ins_ids);
+        _sink_buffer = _create_buffer(_state, ins_ids);
     }
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

1. exchange sink buffer maybe shared among different pipeline. In this case, it should use pipeline fragment ctx's runtime state.
2. In other case, it should use local runtime state.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

