### PR TITLE
[fix](vault) fix UnsupportedOperationException if no `use_path_style` in CreateStorageVaultStmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
@@ -55,7 +56,15 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
     public CreateStorageVaultStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
         this.ifNotExists = ifNotExists;
         this.vaultName = vaultName;
-        this.properties = ImmutableMap.copyOf(properties);
+
+        if (!properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
+            this.properties = ImmutableMap.<String, String>builder()
+                .putAll(properties)
+                .put(PropertyConverter.USE_PATH_STYLE, "true")
+                .build();
+        } else {
+            this.properties = ImmutableMap.copyOf(properties);
+        }
         this.vaultType = vaultType.UNKNOWN;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -57,7 +57,8 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
         this.ifNotExists = ifNotExists;
         this.vaultName = vaultName;
 
-        if (!properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
+        if ("s3".equalsIgnoreCase(properties.get(StorageVault.PropertyKey.TYPE))
+                && !properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
             this.properties = ImmutableMap.<String, String>builder()
                 .putAll(properties)
                 .put(PropertyConverter.USE_PATH_STYLE, "true")

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateStorageVaultStmt.java
@@ -47,7 +47,7 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
 
     private final boolean ifNotExists;
     private final String vaultName;
-    private final ImmutableMap<String, String> properties;
+    private ImmutableMap<String, String> properties;
     private boolean setAsDefault;
     private int pathVersion = 0;
     private int numShard = 0;
@@ -56,16 +56,7 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
     public CreateStorageVaultStmt(boolean ifNotExists, String vaultName, Map<String, String> properties) {
         this.ifNotExists = ifNotExists;
         this.vaultName = vaultName;
-
-        if ("s3".equalsIgnoreCase(properties.get(StorageVault.PropertyKey.TYPE))
-                && !properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
-            this.properties = ImmutableMap.<String, String>builder()
-                .putAll(properties)
-                .put(PropertyConverter.USE_PATH_STYLE, "true")
-                .build();
-        } else {
-            this.properties = ImmutableMap.copyOf(properties);
-        }
+        this.properties = ImmutableMap.copyOf(properties);
         this.vaultType = vaultType.UNKNOWN;
     }
 
@@ -155,6 +146,14 @@ public class CreateStorageVaultStmt extends DdlStmt implements NotFallbackInPars
         }
         setAsDefault = Boolean.parseBoolean(properties.getOrDefault(SET_AS_DEFAULT, "false"));
         setStorageVaultType(StorageVault.StorageVaultType.fromString(type));
+
+        if (vaultType == StorageVault.StorageVaultType.S3
+                && !properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
+            properties = ImmutableMap.<String, String>builder()
+                .putAll(properties)
+                .put(PropertyConverter.USE_PATH_STYLE, "true")
+                .build();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -22,7 +22,6 @@ import org.apache.doris.analysis.CreateStorageVaultStmt;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.qe.ShowResultSetMetaData;
 
 import com.google.common.base.Preconditions;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -147,10 +147,6 @@ public abstract class StorageVault {
                 vault.modifyProperties(stmt.getProperties());
                 break;
             case S3:
-                if (!stmt.getProperties().containsKey(PropertyConverter.USE_PATH_STYLE)) {
-                    stmt.getProperties().put(PropertyConverter.USE_PATH_STYLE, "true");
-                }
-
                 CreateResourceStmt resourceStmt =
                         new CreateResourceStmt(false, ifNotExists, name, stmt.getProperties());
                 resourceStmt.analyzeResourceType();

--- a/regression-test/suites/vault_p0/create/test_create_vault.groovy
+++ b/regression-test/suites/vault_p0/create/test_create_vault.groovy
@@ -234,6 +234,21 @@ suite("test_create_vault", "nonConcurrent") {
     """
 
     sql """
+        CREATE STORAGE VAULT IF NOT EXISTS ${s3VaultName}
+        PROPERTIES (
+            "type"="S3",
+            "s3.endpoint"="${getS3Endpoint()}",
+            "s3.region" = "${getS3Region()}",
+            "s3.access_key" = "${getS3AK()}",
+            "s3.secret_key" = "${getS3SK()}",
+            "s3.root.path" = "${s3VaultName}",
+            "s3.bucket" = "${getS3BucketName()}",
+            "s3.external_endpoint" = "",
+            "provider" = "${getS3Provider()}"
+        );
+    """
+
+    sql """
         CREATE TABLE ${s3VaultName} (
             C_CUSTKEY     INTEGER NOT NULL,
             C_NAME        INTEGER NOT NULL


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #50356 #45155

Problem Summary:

```sql
CREATE STORAGE VAULT test PROPERTIES
    (
      "type"="S3",
      "s3.endpoint"="cos.ap-guangzhou.myqcloud.com",
      "s3.access_key" = "*****",
      "s3.secret_key" = "*****",
      "s3.region" = "ap-guangzhou",
      "s3.root.path" = "prefix",
      "s3.bucket" = "test",
      "provider" = "COS"
    )
```

throw Exception:
```java
2025-05-06 15:05:16,395 WARN (mysql-nio-pool-0|235) [StmtExecutor.handleDdlStmt():3216] DDL statement(CREATE STORAGE VAULT test PROPERTIES
    (
      "type"="S3",
      "s3.endpoint"="cos.ap-guangzhou.myqcloud.com",
      "s3.access_key" = "*****",
      "s3.secret_key" = "*****",
      "s3.region" = "ap-guangzhou",
      "s3.root.path" = "prefix",
      "s3.bucket" = "test",
      "provider" = "COS"
    )) process failed.
java.lang.UnsupportedOperationException: null
        at com.google.common.collect.ImmutableMap.put(ImmutableMap.java:814) ~[guava-33.2.1-jre.jar:?]
        at org.apache.doris.catalog.StorageVault.getStorageVaultInstance(StorageVault.java:151) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.StorageVault.fromStmt(StorageVault.java:103) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.StorageVaultMgr.createStorageVaultResource(StorageVaultMgr.java:69) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:440) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:3195) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:1124) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:644) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:574) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:559) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:349) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:249) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:233) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:261) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:444) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

