### PR TITLE
[fix](ubsan) fix ubsan error in DataTypeHLL::serialize

### DIFF
--- a/be/src/vec/data_types/data_type_hll.cpp
+++ b/be/src/vec/data_types/data_type_hll.cpp
@@ -36,18 +36,18 @@ namespace doris::vectorized {
 // first: const flag| row num | real_saved_num | hll1 size | hll2 size | ...
 // second: hll1 | hll2 | ...
 char* DataTypeHLL::serialize(const IColumn& column, char* buf, int be_exec_version) const {
-    // In the code below, if the column size is 0, an empty vector will be created. A vector with size 0 may return nullptr from data()
-    // https://en.cppreference.com/w/cpp/container/vector/data
-    // `If size() is ​0​, data() may or may not return a null pointer.`
-    // This would trigger a ubsan error: `null pointer passed as argument 2, which is declared to never be null`
-    // Other data types don't have this issue because they use Doris internal pod array that guarantees data won't be nullptr.
-    if (column.size() == 0) {
-        return buf;
-    }
     if (be_exec_version >= USE_CONST_SERDE) {
         const auto* hll_column = &column;
         size_t real_need_copy_num = 0;
         buf = serialize_const_flag_and_row_num(&hll_column, buf, &real_need_copy_num);
+        // In the code below, if the real_need_copy_num is 0, an empty vector will be created. A vector with size 0 may return nullptr from data()
+        // https://en.cppreference.com/w/cpp/container/vector/data
+        // `If size() is ​0​, data() may or may not return a null pointer.`
+        // This would trigger a ubsan error: `null pointer passed as argument 2, which is declared to never be null`
+        // Other data types don't have this issue because they use Doris internal pod array that guarantees data won't be nullptr.
+        if (real_need_copy_num == 0) {
+            return buf;
+        }
 
         const auto& data_column = assert_cast<const ColumnHLL&>(*hll_column);
         std::vector<size_t> hll_size_array(real_need_copy_num);

--- a/be/src/vec/data_types/data_type_hll.cpp
+++ b/be/src/vec/data_types/data_type_hll.cpp
@@ -36,6 +36,14 @@ namespace doris::vectorized {
 // first: const flag| row num | real_saved_num | hll1 size | hll2 size | ...
 // second: hll1 | hll2 | ...
 char* DataTypeHLL::serialize(const IColumn& column, char* buf, int be_exec_version) const {
+    // In the code below, if the column size is 0, an empty vector will be created. A vector with size 0 may return nullptr from data()
+    // https://en.cppreference.com/w/cpp/container/vector/data
+    // `If size() is ​0​, data() may or may not return a null pointer.`
+    // This would trigger a ubsan error: `null pointer passed as argument 2, which is declared to never be null`
+    // Other data types don't have this issue because they use Doris internal pod array that guarantees data won't be nullptr.
+    if (column.size() == 0) {
+        return buf;
+    }
     if (be_exec_version >= USE_CONST_SERDE) {
         const auto* hll_column = &column;
         size_t real_need_copy_num = 0;


### PR DESCRIPTION
### What problem does this PR solve?

In the code below, if the column size is 0, an empty vector will be created. A vector with size 0 may return nullptr from data()
https://en.cppreference.com/w/cpp/container/vector/data
`If size() is ​0​, data() may or may not return a null pointer.`
This would trigger a ubsan error: `null pointer passed as argument 2, which is declared to never be null`
Other data types don't have this issue because they use Doris internal pod array that guarantees data won't be nullptr.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

