### PR TITLE
[Refactor]refactor ConnectContext.getUserIdentity()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InformationFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InformationFunction.java
@@ -73,7 +73,7 @@ public class InformationFunction extends Expr {
             strValue = ClusterNamespace.getNameFromFullName(analyzer.getDefaultDb());
         } else if (funcType.equalsIgnoreCase("USER")) {
             type = Type.VARCHAR;
-            strValue = ConnectContext.get().getUserIdentity().toString();
+            strValue = ConnectContext.get().getUserWithLoginRemoteIpString();
         } else if (funcType.equalsIgnoreCase("CURRENT_USER")) {
             type = Type.VARCHAR;
             strValue = ConnectContext.get().getCurrentUserIdentity().toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
@@ -1036,7 +1036,7 @@ public class CloudSystemInfoService extends SystemInfoService {
         if (Cloud.ClusterStatus.valueOf(clusterStatus) != Cloud.ClusterStatus.NORMAL) {
             // ATTN: prevent `Automatic Analyzer` daemon threads from pulling up clusters
             // root ? see StatisticsUtil.buildConnectContext
-            if (ConnectContext.get() != null && ConnectContext.get().getUserIdentity().isRootUser()) {
+            if (ConnectContext.get() != null && ConnectContext.get().getCurrentUserIdentity().isRootUser()) {
                 LOG.warn("auto start daemon thread run in root, not resume cluster {}-{}", clusterName, clusterStatus);
                 return null;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetadataOps.java
@@ -193,7 +193,7 @@ public class HiveMetadataOps implements ExternalMetadataOps {
             // set default owner
             if (!props.containsKey("owner")) {
                 if (ConnectContext.get() != null) {
-                    props.put("owner", ConnectContext.get().getUserIdentity().getUser());
+                    props.put("owner", ConnectContext.get().getCurrentUserIdentity().getUser());
                 }
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -375,13 +375,13 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
 
     @Override
     public Expression visitUser(User user, ExpressionRewriteContext context) {
-        String res = context.cascadesContext.getConnectContext().getUserIdentity().toString();
+        String res = context.cascadesContext.getConnectContext().getUserWithLoginRemoteIpString();
         return new VarcharLiteral(res);
     }
 
     @Override
     public Expression visitSessionUser(SessionUser user, ExpressionRewriteContext context) {
-        String res = context.cascadesContext.getConnectContext().getUserIdentity().toString();
+        String res = context.cascadesContext.getConnectContext().getUserWithLoginRemoteIpString();
         return new VarcharLiteral(res);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
@@ -158,7 +158,7 @@ public class HiveTableSink extends BaseExternalTableDataSink {
     }
 
     private String createTempPath(String location) {
-        String user = ConnectContext.get().getUserIdentity().getUser();
+        String user = ConnectContext.get().getCurrentUserIdentity().getUser();
         return LocationPath.getTempWritePath(location, "/tmp/.doris_staging/" + user);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -653,13 +653,14 @@ public class ConnectContext {
         this.isTempUser = isTempUser;
     }
 
-    // for USER() function
-    public UserIdentity getUserIdentity() {
-        return UserIdentity.createAnalyzedUserIdentWithIp(qualifiedUser, remoteIP);
-    }
-
     public UserIdentity getCurrentUserIdentity() {
         return currentUserIdentity;
+    }
+
+    // used for select user(), select session_user();
+    // return string similar with user@127.0.0.1
+    public String getUserWithLoginRemoteIpString() {
+        return UserIdentity.createAnalyzedUserIdentWithIp(qualifiedUser, remoteIP).toString();
     }
 
     public void setCurrentUserIdentity(UserIdentity currentUserIdentity) {

--- a/regression-test/suites/nereids_syntax_p0/information_schema.groovy
+++ b/regression-test/suites/nereids_syntax_p0/information_schema.groovy
@@ -15,10 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.util.regex.Pattern;
+
 suite("information_schema") {
     List<List<Object>> table =  sql """ select * from backends(); """
     assertTrue(table.size() > 0)
-    assertTrue(table[0].size == 25)
+    assertTrue(table[0].size() == 25)
 
     sql "SELECT DATABASE();"
     sql "select USER();"
@@ -28,4 +30,44 @@ suite("information_schema") {
     // INFORMATION_SCHEMA
     sql "SELECT table_name FROM INFORMATION_SCHEMA.TABLES where table_schema=\"test%\" and TABLE_TYPE = \"BASE TABLE\" order by table_name"
     sql "SELECT COLUMNS.COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = \"test%\" AND column_name LIKE \"k%\""
+
+    def check_user_with_ip = { user_ret ->
+        logger.info("$user_ret")
+        String user_ret_str = user_ret[0][0]
+        String[] user_ret_array = user_ret_str.split("@");
+        if (user_ret_array.length != 2) {
+            Assert.fail()
+        }
+        String username = user_ret_array[0].replaceAll("'", "")
+        String user_ip = user_ret_array[1].replaceAll("'", "")
+
+        Pattern IPV4_PATTERN = Pattern.compile("^((25[0-5]|2[0-4]\\d|1\\d{2}|[1-9]?\\d)(\\.|\$)){4}\$")
+        Pattern IPV6_PATTERN = Pattern.compile("^((?:[\\da-fA-F]{1,4}(?::[\\da-fA-F]{1,4})*)?)::((?:[\\da-fA-F]{1,4}(?::[\\da-fA-F]{1,4})*)?)\$")
+        if (!IPV4_PATTERN.matcher(user_ip).matches() && !IPV6_PATTERN.matcher(user_ip).matches()) {
+            Assert.fail()
+        }
+
+        if (IPV4_PATTERN.matcher(username).matches() || IPV6_PATTERN.matcher(username).matches()) {
+            Assert.fail()
+        }
+    }
+    // check select user
+    def user_ret = sql "SELECT USER()"
+    check_user_with_ip.call(user_ret)
+
+    // check select session_user
+    def user_session_ret = sql "SELECT SESSION_USER()"
+    check_user_with_ip.call(user_session_ret)
+
+    // check select user
+    def current_user = sql "select CURRENT_USER()"
+    logger.info("$current_user")
+    String current_user_str = current_user[0][0]
+    String[] current_user_str_arr = current_user_str.split("@")
+    if (current_user_str_arr.length != 2) {
+        Assert.fail()
+    }
+    if (!"'%'".equals(current_user_str_arr[1])) {
+        Assert.fail()
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Remove ```getUserIdentity()``` from ```ConnectContext```.
The different between ```getUserIdentity()``` and ```getCurrentUserIdentity()``` is, ```getCurrentUserIdentity``` return  
```user@%```, ```getUserIdentity``` return ```user@ip```, Doris 's auth only replies ```user@%```, rather than ```user@ip```, ip is useless when doing authentication.
But both methods exist simultaneously maybe confused and may lead to misuse.
So this PR rename ```ConnectContext.getUserIdentity()``` to ```getUserWithLoginRemoteIpString```.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

