### PR TITLE
[Fix](iot-auto-detect) Fix insert overwrite auto detect transaction concurrent conflict

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1472,12 +1472,18 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         return Sets.newHashSet(nameToPartition.keySet());
     }
 
-    // for those elements equal in partiton ids, get their names.
-    public List<String> getEqualPartitionNames(List<Long> partitionIds1, List<Long> partitionIds2) {
+    // for those elements equal in partiton ids, get their names. if tables partition changed(drop or something) make
+    // finding failed, throw exception.
+    public List<String> getEqualPartitionNames(List<Long> originPartitionIds, List<Long> targetPartitionIds) throws
+            RuntimeException {
         List<String> names = new ArrayList<String>();
-        for (int i = 0; i < partitionIds1.size(); i++) {
-            if (partitionIds1.get(i).equals(partitionIds2.get(i))) {
-                names.add(getPartition(partitionIds1.get(i)).getName());
+        for (int i = 0; i < originPartitionIds.size(); i++) {
+            if (originPartitionIds.get(i).equals(targetPartitionIds.get(i))) {
+                Partition originPartition = getPartition(originPartitionIds.get(i));
+                if (originPartition == null) {
+                    throw new RuntimeException("origin partition missed: " + originPartitionIds.get(i));
+                }
+                names.add(originPartition.getName());
             }
         }
         return names;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertOverwriteTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertOverwriteTableCommand.java
@@ -180,7 +180,12 @@ public class InsertOverwriteTableCommand extends Command implements NeedAuditEnc
             // not we execute as overwrite every partitions.
             if (CollectionUtils.isEmpty(partitionNames)) {
                 wholeTable = true;
-                partitionNames = Lists.newArrayList(targetTable.getPartitionNames());
+                try { // avoid concurrent modification exception when get partition names
+                    targetTable.readLock();
+                    partitionNames = Lists.newArrayList(targetTable.getPartitionNames());
+                } finally {
+                    targetTable.readUnlock();
+                }
             }
         } else {
             // Do not create temp partition on FE


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Fix bug of:

1.
```
Caused by: java.util.ConcurrentModificationException
	at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1486) ~[?:?]
	at java.util.TreeMap$KeyIterator.next(TreeMap.java:1540) ~[?:?]
	at java.util.AbstractCollection.addAll(AbstractCollection.java:335) ~[?:?]
	at java.util.HashSet.<init>(HashSet.java:121) ~[?:?]
	at com.google.common.collect.Sets.newHashSet(Sets.java:226) ~[guava-33.2.1-jre.jar:?]
	at org.apache.doris.catalog.OlapTable.getPartitionNames(OlapTable.java:1288) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertOverwriteTableCommand.run(InsertOverwriteTableCommand.java:164) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:767) ~[doris-fe.jar:1.2-SNAPSHOT]
	... 12 more
```

2.
```
2025-04-11 03:25:13,208 ERROR (thrift-server-pool-5|171) [ProcessFunction.process():47] Internal error processing replacePartition
java.lang.reflect.UndeclaredThrowableException: null
at jdk.proxy2.$Proxy44.replacePartition(Unknown Source) ~[?:?]
at org.apache.doris.thrift.FrontendService$Processor$replacePartition.getResult(FrontendService.java:5118) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
at org.apache.doris.thrift.FrontendService$Processor$replacePartition.getResult(FrontendService.java:5098) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.16.0.jar:0.16.0]
at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.16.0.jar:0.16.0]
at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250) ~[libthrift-0.16.0.jar:0.16.0]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.reflect.InvocationTargetException
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60) ~[doris-fe.jar:1.2-SNAPSHOT]
... 9 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.doris.catalog.Partition.getName()" because the return value of "org.apache.doris.catalog.OlapTable.getPartition(long)" is null
at org.apache.doris.catalog.OlapTable.getEqualPartitionNames(OlapTable.java:1296) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.service.FrontendServiceImpl.replacePartition(FrontendServiceImpl.java:3787) ~[doris-fe.jar:1.2-SNAPSHOT]
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60) ~[doris-fe.jar:1.2-SNAPSHOT]
... 9 more
```

### Release note

Fix unexpected failure when insert overwrite auto detect conflict with other partition operations

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

