### PR TITLE
[enchement](orc) improve the read amplification problem caused by orc  tiny stripe optimization. 

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -704,6 +704,12 @@ private:
 
     std::pair<std::shared_ptr<segment_v2::RowIdColumnIteratorV2>, int>
             _row_id_column_iterator_pair = {nullptr, -1};
+
+    // When using the tiny stripe read optimization, if there are many columns in the orc file and only a
+    // few of them are used in a query, the tiny stripe optimization will cause serious read amplification.
+    // When the proportion of the actual number of bytes to be read in the entire stripe is greater than
+    // this parameter, read optimization is used.
+    double _orc_tiny_stripe_amplification_factor = 0.4;
 };
 
 class StripeStreamInputStream : public orc::InputStream, public ProfileCollector {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -395,6 +395,8 @@ struct TQueryOptions {
   164: optional bool check_orc_init_sargs_success = false
   165: optional i32 exchange_multi_blocks_byte_size = 262144 
 
+  166: optional double orc_tiny_stripe_amplification_factor = 0.4
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.

--- a/regression-test/suites/external_table_p0/tvf/orc_format/test_orc_exception_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_format/test_orc_exception_files.groovy
@@ -144,7 +144,7 @@ suite("test_orc_exception_files","external,hive,tvf,external_docker") {
                         "uri" = "${uri}",
                         "hadoop.username" = "${hdfsUserName}",
                         "format" = "orc"); """
-            exception "Orc row reader nextBatch failed. reason = bad StripeFooter from zlib"
+            exception "Failed to parse the stripe footer"
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Related PR: #42004
orc submodule pr: https://github.com/apache/doris-thirdparty/pull/313

Problem Summary:

In the previous PR #42004 , the optimization of orc tiny stripe was introduced. However, if there are many columns in the orc file and only a few of them are used in a query, the tiny stripe optimization will cause serious read amplification.
This PR introduces the `orc_tiny_stripe_amplification_factor` session variable to adjust the usage scenario of orc tiny stripe optimization. When the actual number of bytes to be read accounts for a larger proportion of the entire stripe than this parameter, read optimization is used. The default value of this parameter is 0.4, and the minimum value is 0.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

