### PR TITLE
branch-2.1: [fix](planner) return explicit error msg when falling back to old planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -134,6 +134,10 @@ public class HiveScanNode extends FileQueryScanNode {
             Collection<PartitionItem> partitionItems;
             // partitions has benn pruned by Nereids, in PruneFileScanPartition,
             // so just use the selected partitions.
+            if (selectedPartitions == null) {
+                throw new AnalysisException("Should use Nereids to prune partitions. "
+                        + "set enable_fallback_to_original_planner=false and try again");
+            }
             this.totalPartitionNum = selectedPartitions.totalPartitionNum;
             partitionItems = selectedPartitions.selectedPartitions.values();
             Preconditions.checkNotNull(partitionItems);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When fall back to old planner, the partition pruning of external table will fail,
and NPE will be throw like:
```
2025-04-14 16:22:33,427 WARN (mysql-nio-pool-19697|237161) [HiveScanNode.getSplits():189] get file split failed for table: dwd_log_fact_channel_track_result_hi
java.lang.NullPointerException: null
        at org.apache.doris.datasource.hive.source.HiveScanNode.getPartitions(HiveScanNode.java:137) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.source.HiveScanNode.getSplits(HiveScanNode.java:171) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.FileQueryScanNode.createScanRangeLocations(FileQueryScanNode.java:366) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.FileQueryScanNode.doFinalize(FileQueryScanNode.java:222) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.FileQueryScanNode.finalize(FileQueryScanNode.java:208) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.finalize(PlanNode.java:722) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.JoinNodeBase.finalize(JoinNodeBase.java:456) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.finalize(PlanNode.java:722) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.JoinNodeBase.finalize(JoinNodeBase.java:456) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.finalize(PlanNode.java:722) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.AggregationNode.finalize(AggregationNode.java:402) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.finalize(PlanNode.java:722) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.SetOperationNode.finalize(SetOperationNode.java:158) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.PlanNode.finalize(PlanNode.java:722) ~[doris-fe.jar:1.2-SNAPSHOT]
```

This error msg is very confusing. So this PR return a more explicit error msg.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

