### PR TITLE
[chore](cloud) Remove set -eo pipefail when start ms

### DIFF
--- a/cloud/script/start.sh
+++ b/cloud/script/start.sh
@@ -16,8 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -eo pipefail
-
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 DORIS_HOME="$(


### PR DESCRIPTION
It may introduce extra error handling if we set -eo globally
