### PR TITLE
[enhancement](cloud) support param to drop fe cluster not in safe time

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -94,7 +94,7 @@ CONF_mInt64(delete_bitmap_storage_optimize_check_version_gap, "1000");
 CONF_mInt32(scan_instances_interval_seconds, "60"); // 1min
 // interval for check object
 CONF_mInt32(check_object_interval_seconds, "43200"); // 12hours
-CONF_mInt32(sql_node_safe_drop_time_seconds, "300");// 5min
+CONF_mInt32(sql_node_safe_drop_time_seconds, "300"); // 5min
 
 CONF_mInt64(check_recycle_task_interval_seconds, "600"); // 10min
 CONF_mInt64(recycler_sleep_before_scheduling_seconds, "60");

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -94,6 +94,7 @@ CONF_mInt64(delete_bitmap_storage_optimize_check_version_gap, "1000");
 CONF_mInt32(scan_instances_interval_seconds, "60"); // 1min
 // interval for check object
 CONF_mInt32(check_object_interval_seconds, "43200"); // 12hours
+CONF_mInt32(sql_node_safe_drop_time_seconds, "300");// 5min
 
 CONF_mInt64(check_recycle_task_interval_seconds, "600"); // 10min
 CONF_mInt64(recycler_sleep_before_scheduling_seconds, "60");

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2073,7 +2073,8 @@ void MetaServiceImpl::alter_cluster(google::protobuf::RpcController* controller,
     } break;
     case AlterClusterRequest::DROP_CLUSTER: {
         bool safe_drop_on_sql_cluster = request->has_safe_drop_on_sql_cluster()
-                ? request->safe_drop_on_sql_cluster() : true;
+                                                ? request->safe_drop_on_sql_cluster()
+                                                : true;
         auto r = resource_mgr_->drop_cluster(instance_id, cluster, safe_drop_on_sql_cluster);
         code = r.first;
         msg = r.second;

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2072,7 +2072,9 @@ void MetaServiceImpl::alter_cluster(google::protobuf::RpcController* controller,
         msg = r.second;
     } break;
     case AlterClusterRequest::DROP_CLUSTER: {
-        auto r = resource_mgr_->drop_cluster(instance_id, cluster);
+        bool safe_drop_on_sql_cluster = request->has_safe_drop_on_sql_cluster()
+                ? request->safe_drop_on_sql_cluster() : true;
+        auto r = resource_mgr_->drop_cluster(instance_id, cluster, safe_drop_on_sql_cluster);
         code = r.first;
         msg = r.second;
     } break;

--- a/cloud/src/resource-manager/resource_manager.h
+++ b/cloud/src/resource-manager/resource_manager.h
@@ -78,12 +78,12 @@ public:
      * Drops a cluster
      *
      * @param cluster cluster to drop, only cluster name and cluster id are concered
-     * @param safe_drop if true, check if cluster is drop in safe time
+     * @param safe_drop_on_sql_cluster if true, check if sql-cluster is drop in safe time
      * @return empty string for success, otherwise failure reason returned
      */
-    virtual std::pair<MetaServiceCode, std::string> drop_cluster(const std::string& instance_id,
-                                                                 const ClusterInfo& cluster,
-                                                                 bool safe_drop_on_sql_cluster = true);
+    virtual std::pair<MetaServiceCode, std::string> drop_cluster(
+            const std::string& instance_id, const ClusterInfo& cluster,
+            bool safe_drop_on_sql_cluster = true);
 
     /**
      * Update a cluster

--- a/cloud/src/resource-manager/resource_manager.h
+++ b/cloud/src/resource-manager/resource_manager.h
@@ -78,10 +78,12 @@ public:
      * Drops a cluster
      *
      * @param cluster cluster to drop, only cluster name and cluster id are concered
+     * @param safe_drop if true, check if cluster is drop in safe time
      * @return empty string for success, otherwise failure reason returned
      */
     virtual std::pair<MetaServiceCode, std::string> drop_cluster(const std::string& instance_id,
-                                                                 const ClusterInfo& cluster);
+                                                                 const ClusterInfo& cluster,
+                                                                 bool safe_drop_on_sql_cluster = true);
 
     /**
      * Update a cluster

--- a/cloud/test/mock_resource_manager.h
+++ b/cloud/test/mock_resource_manager.h
@@ -46,8 +46,9 @@ public:
         return std::make_pair(MetaServiceCode::OK, "");
     }
 
-    std::pair<MetaServiceCode, std::string> drop_cluster(const std::string& instance_id,
-                                                         const ClusterInfo& cluster) override {
+    std::pair<MetaServiceCode, std::string> drop_cluster(
+            const std::string& instance_id, const ClusterInfo& cluster,
+            bool safe_drop_on_sql_cluster = true) override {
         return std::make_pair(MetaServiceCode::OK, "");
     }
 

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1119,6 +1119,8 @@ message AlterClusterRequest {
     optional Operation op = 4;
     // for SQL mode rename cluster, rename to cluster name eq instance empty cluster name, need drop empty cluster
     optional bool replace_if_existing_empty_target_cluster = 5;
+    // if true, check if drop_cluster op on sql type cluster is in safe time
+    optional bool safe_drop_on_sql_cluster = 6 [default = true];
 }
 
 message AlterClusterResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1120,7 +1120,7 @@ message AlterClusterRequest {
     // for SQL mode rename cluster, rename to cluster name eq instance empty cluster name, need drop empty cluster
     optional bool replace_if_existing_empty_target_cluster = 5;
     // if true, check if drop_cluster op on sql type cluster is in safe time
-    optional bool safe_drop_on_sql_cluster = 6 [default = true];
+    optional bool safe_drop_on_sql_cluster = 6;
 }
 
 message AlterClusterResponse {


### PR DESCRIPTION
### What problem does this PR solve?

related pr: #45255

Currently, when the MS drop node/drop cluster api is called to the drop sql node/sql cluster, there is a 5 minute safe drop protection mechanism, but it is not necessary when destroying a newly created doris instance.

1. Allow bypassing the safe-time-check when calling the drop cluster api of meta service by setting the safe_derop_on_sql_cluster param to false

2. Add a configuration for the safe-time-check (default 5 minutes) to adjust this value

Api call example:
curl -X POST -H "Content-Type: text/plain" -d '{"instance_id": "123333", "cluster": {"cluster_name": "RESERVED_CLUSTER_NAME_FOR_SQL_SERVER", "cluster_id": "RESERVED_CLUSTER_ID_FOR_SQL_SERVER"}, "safe_drop_on_sql_cluster": "false"}'  http://127.0.0.1:5000/MetaService/http/drop_cluster?token=xxxxxxxx

reopen #50535

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

