### PR TITLE
[chore](udf) when udf throw exception return RUNTIME_ERROR

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -300,7 +300,7 @@ Status JniUtil::GetJniExceptionMsg(JNIEnv* env, bool log_stack, const string& pr
             env->ExceptionClear();
             string oom_msg = absl::Substitute(oom_msg_template, "throwableToStackTrace");
             LOG(WARNING) << oom_msg;
-            return Status::InternalError(oom_msg);
+            return Status::RuntimeError(oom_msg);
         }
         JniUtfCharGuard c_stack_guard;
         RETURN_IF_ERROR(JniUtfCharGuard::create(env, stack, &c_stack_guard));
@@ -308,7 +308,7 @@ Status JniUtil::GetJniExceptionMsg(JNIEnv* env, bool log_stack, const string& pr
     }
 
     env->DeleteLocalRef(exc);
-    return Status::InternalError("{}{}", prefix, msg_str_guard.get());
+    return Status::RuntimeError("{}{}", prefix, msg_str_guard.get());
 }
 
 jobject JniUtil::convert_to_java_map(JNIEnv* env, const std::map<std::string, std::string>& map) {


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
when udf throw exception return RUNTIME_ERROR, not INTERNAL_ERROR
as INTERNAL_ERROR is serious error, need someone deal with it immediately for cloud mode.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

