### PR TITLE
[fix](iceberg)Table operations are not supported for catalogs of the dlf type. 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
@@ -17,10 +17,17 @@
 
 package org.apache.doris.datasource.iceberg;
 
+import org.apache.doris.analysis.CreateDbStmt;
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.analysis.DropTableStmt;
+import org.apache.doris.analysis.TruncateTableStmt;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.iceberg.dlf.DLFCatalog;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.HMSProperties;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
 
 import java.util.Map;
 
@@ -44,5 +51,36 @@ public class IcebergDLFExternalCatalog extends IcebergExternalCatalog {
         String catalogName = getName();
         dlfCatalog.initialize(catalogName, catalogProperties);
         catalog = dlfCatalog;
+    }
+
+    @Override
+    public void createDb(CreateDbStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'create database'");
+    }
+
+    @Override
+    public void dropDb(String dbName, boolean ifExists, boolean force) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'drop database'");
+    }
+
+    @Override
+    public boolean createTable(CreateTableStmt stmt) throws UserException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'create table'");
+    }
+
+    @Override
+    public void dropTable(DropTableStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'drop table'");
+    }
+
+    @Override
+    public void dropTable(String dbName, String tableName, boolean isView, boolean isMtmv, boolean ifExists,
+                   boolean force) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'drop table'");
+    }
+
+    @Override
+    public void truncateTable(TruncateTableStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'truncate table'");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.datasource.iceberg.dlf.client;
 
+import org.apache.doris.datasource.iceberg.IcebergDLFExternalCatalog;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,5 +40,17 @@ public class IcebergDLFExternalCatalogTest {
         // so the object addresses of clients in different pools must be different
         Assert.assertNotSame(dlfClientPool1, dlfClientPool2);
 
+    }
+
+    @Test
+    public void testNotSupportOperation() {
+        HashMap<String, String> props = new HashMap<>();
+        IcebergDLFExternalCatalog catalog = new IcebergDLFExternalCatalog(1, "test", "test", props, "test");
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.createDb(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.dropDb("", true, true));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.createTable(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable("", "", true, true, true, true));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable(null));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Table operations are not supported for catalogs of the dlf type. 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

