### PR TITLE
[fix](storage vault) Fix two storage vault regression cases

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsStorageVault.java
@@ -200,11 +200,21 @@ public class HdfsStorageVault extends StorageVault {
             } else {
                 // Get rid of copy and paste from create s3 vault stmt
                 Preconditions.checkArgument(
+                        !property.getKey().toLowerCase().contains(S3StorageVault.PropertyKey.REGION),
+                        "Invalid argument %s", property.getKey());
+                Preconditions.checkArgument(
+                        !property.getKey().toLowerCase().contains(S3StorageVault.PropertyKey.ENDPOINT),
+                        "Invalid argument %s", property.getKey());
+                Preconditions.checkArgument(
                         !property.getKey().toLowerCase().contains(S3StorageVault.PropertyKey.ROOT_PATH),
                         "Invalid argument %s", property.getKey());
                 Preconditions.checkArgument(
                         !property.getKey().toLowerCase().contains(S3StorageVault.PropertyKey.PROVIDER),
                         "Invalid argument %s", property.getKey());
+                Preconditions.checkArgument(
+                        !property.getKey().toLowerCase().contains(S3StorageVault.PropertyKey.BUCKET),
+                        "Invalid argument %s", property.getKey());
+
                 if (!NON_HDFS_CONF_PROPERTY_KEYS.contains(property.getKey().toLowerCase())) {
                     Cloud.HdfsBuildConf.HdfsConfKVPair.Builder conf = Cloud.HdfsBuildConf.HdfsConfKVPair.newBuilder();
                     conf.setKey(property.getKey());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
@@ -67,6 +67,9 @@ public class S3StorageVault extends StorageVault {
         public static final String USE_PATH_STYLE = PropertyConverter.USE_PATH_STYLE;
         public static final String ROOT_PATH = S3Properties.ROOT_PATH;
         public static final String PROVIDER = S3Properties.PROVIDER;
+        public static final String REGION = S3Properties.REGION;
+        public static final String ENDPOINT = S3Properties.ENDPOINT;
+        public static final String BUCKET = S3Properties.BUCKET;
     }
 
     public static final HashSet<String> ALLOW_ALTER_PROPERTIES = new HashSet<>(Arrays.asList(

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java
@@ -181,10 +181,15 @@ public abstract class StorageVault {
      * @throws UserException
      */
     public void checkCreationProperties(Map<String, String> properties) throws UserException {
-        Preconditions.checkArgument(
-                properties.get(PropertyKey.TYPE) != null, "Missing property " + PropertyKey.TYPE);
-        Preconditions.checkArgument(
-                !properties.get(PropertyKey.TYPE).isEmpty(), "Property " + PropertyKey.TYPE + " cannot be empty");
+        String type = null;
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+            if (property.getKey().equalsIgnoreCase(StorageVault.PropertyKey.TYPE)) {
+                type = property.getValue();
+            }
+        }
+
+        Preconditions.checkArgument(type != null, "Missing property " + PropertyKey.TYPE);
+        Preconditions.checkArgument(!type.isEmpty(), "Property " + PropertyKey.TYPE + " cannot be empty");
     }
 
     protected void replaceIfEffectiveValue(Map<String, String> properties, String key, String value) {

--- a/regression-test/suites/vault_p0/create/test_create_vault.groovy
+++ b/regression-test/suites/vault_p0/create/test_create_vault.groovy
@@ -234,21 +234,6 @@ suite("test_create_vault", "nonConcurrent") {
     """
 
     sql """
-        CREATE STORAGE VAULT IF NOT EXISTS ${s3VaultName}
-        PROPERTIES (
-            "type"="S3",
-            "s3.endpoint"="${getS3Endpoint()}",
-            "s3.region" = "${getS3Region()}",
-            "s3.access_key" = "${getS3AK()}",
-            "s3.secret_key" = "${getS3SK()}",
-            "s3.root.path" = "${s3VaultName}",
-            "s3.bucket" = "${getS3BucketName()}",
-            "s3.external_endpoint" = "",
-            "provider" = "${getS3Provider()}"
-        );
-    """
-
-    sql """
         CREATE TABLE ${s3VaultName} (
             C_CUSTKEY     INTEGER NOT NULL,
             C_NAME        INTEGER NOT NULL


### PR DESCRIPTION
* move `not set use_path_style` case from `test_create_vault` to `test_minio_storage_vault` because aliyun oss don't allow path style, but default is path style

* fix `test_create_vault_with_case_sensitive` case fail, indroduced by code refactor by https://github.com/apache/doris/pull/50395

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

