### PR TITLE
[enhance](metrics)add metrics to show compaction task num

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -682,11 +682,19 @@ Status CloudStorageEngine::_submit_base_compaction_task(const CloudTabletSPtr& t
         _submitted_base_compactions[tablet->tablet_id()] = compaction;
     }
     st = _base_compaction_thread_pool->submit_func([=, this, compaction = std::move(compaction)]() {
+        DorisMetrics::instance()->base_compaction_task_running_total->set_value(
+                _base_compaction_thread_pool->num_active_threads());
+        DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
+                _base_compaction_thread_pool->get_queue_size());
         g_base_compaction_running_task_count << 1;
         signal::tablet_id = tablet->tablet_id();
         Defer defer {[&]() {
             g_base_compaction_running_task_count << -1;
             _submitted_base_compactions.erase(tablet->tablet_id());
+            DorisMetrics::instance()->base_compaction_task_running_total->set_value(
+                    _base_compaction_thread_pool->num_active_threads());
+            DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
+                    _base_compaction_thread_pool->get_queue_size());
         }};
         auto st = _request_tablet_global_compaction_lock(ReaderType::READER_BASE_COMPACTION, tablet,
                                                          compaction);
@@ -778,6 +786,10 @@ Status CloudStorageEngine::_submit_cumulative_compaction_task(const CloudTabletS
         }
     };
     st = _cumu_compaction_thread_pool->submit_func([=, this, compaction = std::move(compaction)]() {
+        DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
+                _cumu_compaction_thread_pool->num_active_threads());
+        DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
+                _cumu_compaction_thread_pool->get_queue_size());
         DBUG_EXECUTE_IF("CloudStorageEngine._submit_cumulative_compaction_task.wait_in_line",
                         { sleep(5); })
         signal::tablet_id = tablet->tablet_id();
@@ -793,6 +805,10 @@ Status CloudStorageEngine::_submit_cumulative_compaction_task(const CloudTabletS
             }
             g_cumu_compaction_running_task_count << -1;
             erase_submitted_cumu_compaction();
+            DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
+                    _cumu_compaction_thread_pool->num_active_threads());
+            DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
+                    _cumu_compaction_thread_pool->get_queue_size());
         }};
         auto st = _request_tablet_global_compaction_lock(ReaderType::READER_CUMULATIVE_COMPACTION,
                                                          tablet, compaction);

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -708,6 +708,10 @@ Status CloudStorageEngine::_submit_base_compaction_task(const CloudTabletSPtr& t
         std::lock_guard lock(_compaction_mtx);
         _executing_base_compactions.erase(tablet->tablet_id());
     });
+    DorisMetrics::instance()->base_compaction_task_running_total->set_value(
+            _base_compaction_thread_pool->num_active_threads());
+    DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
+            _base_compaction_thread_pool->get_queue_size());
     if (!st.ok()) {
         std::lock_guard lock(_compaction_mtx);
         _submitted_base_compactions.erase(tablet->tablet_id());
@@ -862,6 +866,10 @@ Status CloudStorageEngine::_submit_cumulative_compaction_task(const CloudTabletS
         }
         erase_executing_cumu_compaction();
     });
+    DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
+            _cumu_compaction_thread_pool->num_active_threads());
+    DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
+            _cumu_compaction_thread_pool->get_queue_size());
     if (!st.ok()) {
         erase_submitted_cumu_compaction();
         return Status::InternalError("failed to submit cumu compaction, tablet_id={}",

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -1051,13 +1051,11 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
         auto st = thread_pool->submit_func([tablet, compaction = std::move(compaction),
                                             compaction_type, permits, force, this]() {
             if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) [[likely]] {
-                DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
-                        _cumu_compaction_thread_pool->num_active_threads());
+                DorisMetrics::instance()->cumulative_compaction_task_running_total->increment(1);
                 DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
                         _cumu_compaction_thread_pool->get_queue_size());
             } else if (compaction_type == CompactionType::BASE_COMPACTION) {
-                DorisMetrics::instance()->base_compaction_task_running_total->set_value(
-                        _base_compaction_thread_pool->num_active_threads());
+                DorisMetrics::instance()->base_compaction_task_running_total->increment(1);
                 DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
                         _base_compaction_thread_pool->get_queue_size());
             }
@@ -1075,13 +1073,12 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
                     if (!is_large_task) {
                         _cumu_compaction_thread_pool_small_tasks_running--;
                     }
-                    DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
-                            _cumu_compaction_thread_pool->num_active_threads());
+                    DorisMetrics::instance()->cumulative_compaction_task_running_total->increment(
+                            -1);
                     DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
                             _cumu_compaction_thread_pool->get_queue_size());
                 } else if (compaction_type == CompactionType::BASE_COMPACTION) {
-                    DorisMetrics::instance()->base_compaction_task_running_total->set_value(
-                            _base_compaction_thread_pool->num_active_threads());
+                    DorisMetrics::instance()->base_compaction_task_running_total->increment(-1);
                     DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
                             _base_compaction_thread_pool->get_queue_size());
                 }
@@ -1143,13 +1140,9 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
             tablet->execute_compaction(*compaction);
         });
         if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) [[likely]] {
-            DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
-                    _cumu_compaction_thread_pool->num_active_threads());
             DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
                     _cumu_compaction_thread_pool->get_queue_size());
         } else if (compaction_type == CompactionType::BASE_COMPACTION) {
-            DorisMetrics::instance()->base_compaction_task_running_total->set_value(
-                    _base_compaction_thread_pool->num_active_threads());
             DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
                     _base_compaction_thread_pool->get_queue_size());
         }

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -82,6 +82,7 @@
 #include "util/debug_points.h"
 #include "util/doris_metrics.h"
 #include "util/mem_info.h"
+#include "util/metrics.h"
 #include "util/thread.h"
 #include "util/threadpool.h"
 #include "util/thrift_rpc_helper.h"
@@ -1049,6 +1050,17 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
                       << ", num_total_queued_tasks: " << thread_pool->get_queue_size();
         auto st = thread_pool->submit_func([tablet, compaction = std::move(compaction),
                                             compaction_type, permits, force, this]() {
+            if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) [[likely]] {
+                DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
+                        _cumu_compaction_thread_pool->num_active_threads());
+                DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
+                        _cumu_compaction_thread_pool->get_queue_size());
+            } else if (compaction_type == CompactionType::BASE_COMPACTION) {
+                DorisMetrics::instance()->base_compaction_task_running_total->set_value(
+                        _base_compaction_thread_pool->num_active_threads());
+                DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
+                        _base_compaction_thread_pool->get_queue_size());
+            }
             bool is_large_task = true;
             Defer defer {[&]() {
                 DBUG_EXECUTE_IF("StorageEngine._submit_compaction_task.sleep", { sleep(5); })
@@ -1063,6 +1075,15 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
                     if (!is_large_task) {
                         _cumu_compaction_thread_pool_small_tasks_running--;
                     }
+                    DorisMetrics::instance()->cumulative_compaction_task_running_total->set_value(
+                            _cumu_compaction_thread_pool->num_active_threads());
+                    DorisMetrics::instance()->cumulative_compaction_task_pending_total->set_value(
+                            _cumu_compaction_thread_pool->get_queue_size());
+                } else if (compaction_type == CompactionType::BASE_COMPACTION) {
+                    DorisMetrics::instance()->base_compaction_task_running_total->set_value(
+                            _base_compaction_thread_pool->num_active_threads());
+                    DorisMetrics::instance()->base_compaction_task_pending_total->set_value(
+                            _base_compaction_thread_pool->get_queue_size());
                 }
             }};
             do {

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -99,6 +99,15 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_bytes_total, MetricUn
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(full_compaction_bytes_total, MetricUnit::BYTES, "",
                                      compaction_bytes_total, Labels({{"type", "full"}}));
 
+DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(base_compaction_task_running_total, MetricUnit::ROWSETS, "",
+                                     compaction_deltas_total, Labels({{"type", "base"}}));
+DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(base_compaction_task_pending_total, MetricUnit::ROWSETS, "",
+                                     compaction_deltas_total, Labels({{"type", "base"}}));
+DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_task_running_total, MetricUnit::ROWSETS,
+                                     "", compaction_deltas_total, Labels({{"type", "cumulative"}}));
+DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_task_pending_total, MetricUnit::ROWSETS,
+                                     "", compaction_deltas_total, Labels({{"type", "cumulative"}}));
+
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(segment_read_total, MetricUnit::OPERATIONS,
                                      "(segment_v2) total number of segments read", segment_read,
                                      Labels({{"type", "segment_read_total"}}));
@@ -256,6 +265,11 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, cumulative_compaction_bytes_total);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, full_compaction_deltas_total);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, full_compaction_bytes_total);
+
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, base_compaction_task_running_total);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, base_compaction_task_pending_total);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, cumulative_compaction_task_running_total);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, cumulative_compaction_task_pending_total);
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, segment_read_total);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, segment_row_total);

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -104,9 +104,11 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(base_compaction_task_running_total, MetricU
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(base_compaction_task_pending_total, MetricUnit::ROWSETS, "",
                                      compaction_task_state_total, Labels({{"type", "base"}}));
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_task_running_total, MetricUnit::ROWSETS,
-                                     "", compaction_task_state_total, Labels({{"type", "cumulative"}}));
+                                     "", compaction_task_state_total,
+                                     Labels({{"type", "cumulative"}}));
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_task_pending_total, MetricUnit::ROWSETS,
-                                     "", compaction_task_state_total, Labels({{"type", "cumulative"}}));
+                                     "", compaction_task_state_total,
+                                     Labels({{"type", "cumulative"}}));
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(segment_read_total, MetricUnit::OPERATIONS,
                                      "(segment_v2) total number of segments read", segment_read,

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -100,13 +100,13 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(full_compaction_bytes_total, MetricUnit::BY
                                      compaction_bytes_total, Labels({{"type", "full"}}));
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(base_compaction_task_running_total, MetricUnit::ROWSETS, "",
-                                     compaction_deltas_total, Labels({{"type", "base"}}));
+                                     compaction_task_state_total, Labels({{"type", "base"}}));
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(base_compaction_task_pending_total, MetricUnit::ROWSETS, "",
-                                     compaction_deltas_total, Labels({{"type", "base"}}));
+                                     compaction_task_state_total, Labels({{"type", "base"}}));
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_task_running_total, MetricUnit::ROWSETS,
-                                     "", compaction_deltas_total, Labels({{"type", "cumulative"}}));
+                                     "", compaction_task_state_total, Labels({{"type", "cumulative"}}));
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(cumulative_compaction_task_pending_total, MetricUnit::ROWSETS,
-                                     "", compaction_deltas_total, Labels({{"type", "cumulative"}}));
+                                     "", compaction_task_state_total, Labels({{"type", "cumulative"}}));
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_5ARG(segment_read_total, MetricUnit::OPERATIONS,
                                      "(segment_v2) total number of segments read", segment_read,

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -95,6 +95,11 @@ public:
     IntCounter* full_compaction_deltas_total = nullptr;
     IntCounter* full_compaction_bytes_total = nullptr;
 
+    IntCounter* base_compaction_task_running_total = nullptr;
+    IntCounter* base_compaction_task_pending_total = nullptr;
+    IntCounter* cumulative_compaction_task_running_total = nullptr;
+    IntCounter* cumulative_compaction_task_pending_total = nullptr;
+
     IntCounter* publish_task_request_total = nullptr;
     IntCounter* publish_task_failed_total = nullptr;
 

--- a/be/test/olap/compaction_metrics_test.cpp
+++ b/be/test/olap/compaction_metrics_test.cpp
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <filesystem>
+#include <memory>
+
+#include "common/logging.h"
+#include "common/status.h"
+#include "cpp/sync_point.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/local_file_system.h"
+#include "olap/cumulative_compaction_policy.h"
+#include "olap/data_dir.h"
+#include "olap/rowset/rowset_factory.h"
+#include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
+#include "util/doris_metrics.h"
+#include "util/threadpool.h"
+
+namespace doris {
+using namespace config;
+
+class CompactionMetricsTest : public testing::Test {
+public:
+    void SetUp() override {
+        _engine_data_path = "./be/test/olap/test_data/converter_test_data/tmp";
+        auto st = io::global_local_filesystem()->delete_directory(_engine_data_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(_engine_data_path);
+        ASSERT_TRUE(st.ok()) << st;
+        EXPECT_TRUE(
+                io::global_local_filesystem()->create_directory(_engine_data_path + "/meta").ok());
+
+        EngineOptions options;
+        options.backend_uid = UniqueId::gen_uid();
+        _storage_engine = std::make_unique<StorageEngine>(options);
+        _data_dir = std::make_unique<DataDir>(*_storage_engine, _engine_data_path, 100000000);
+        static_cast<void>(_data_dir->init());
+    }
+
+    void TearDown() override {
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_engine_data_path).ok());
+        ExecEnv::GetInstance()->set_storage_engine(nullptr);
+    }
+
+    std::unique_ptr<StorageEngine> _storage_engine;
+    std::string _engine_data_path;
+    std::unique_ptr<DataDir> _data_dir;
+};
+
+static RowsetSharedPtr create_rowset(Version version, int num_segments, bool overlapping,
+                                     int data_size) {
+    auto rs_meta = std::make_shared<RowsetMeta>();
+    rs_meta->set_rowset_type(BETA_ROWSET); // important
+    rs_meta->_rowset_meta_pb.set_start_version(version.first);
+    rs_meta->_rowset_meta_pb.set_end_version(version.second);
+    rs_meta->set_num_segments(num_segments);
+    rs_meta->set_segments_overlap(overlapping ? OVERLAPPING : NONOVERLAPPING);
+    rs_meta->set_total_disk_size(data_size);
+    RowsetSharedPtr rowset;
+    Status st = RowsetFactory::create_rowset(nullptr, "", rs_meta, &rowset);
+    if (!st.ok()) {
+        return nullptr;
+    }
+    return rowset;
+}
+
+TEST_F(CompactionMetricsTest, TestCompactionTaskNumWithDiffStatus) {
+    auto st = ThreadPoolBuilder("BaseCompactionTaskThreadPool")
+                      .set_min_threads(2)
+                      .set_max_threads(2)
+                      .build(&_storage_engine->_base_compaction_thread_pool);
+    EXPECT_TRUE(st.ok());
+    st = ThreadPoolBuilder("CumuCompactionTaskThreadPool")
+                 .set_min_threads(2)
+                 .set_max_threads(2)
+                 .build(&_storage_engine->_cumu_compaction_thread_pool);
+    EXPECT_TRUE(st.ok());
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    sp->set_call_back("olap_server::execute_compaction", [](auto&& values) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        bool* pred = try_any_cast<bool*>(values.back());
+        *pred = true;
+    });
+
+    for (int tablet_cnt = 0; tablet_cnt < 10; ++tablet_cnt) {
+        TabletMetaSharedPtr tablet_meta;
+        tablet_meta.reset(new TabletMeta(1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}},
+                                         UniqueId(9, 10), TTabletType::TABLET_TYPE_DISK,
+                                         TCompressionType::LZ4F));
+        TabletSharedPtr tablet(new Tablet(*(_storage_engine.get()), tablet_meta, _data_dir.get(),
+                                          CUMULATIVE_SIZE_BASED_POLICY));
+        st = tablet->init();
+        EXPECT_TRUE(st.ok());
+
+        for (int i = 2; i < 30; ++i) {
+            RowsetSharedPtr rs = create_rowset({i, i}, 1, false, 1024);
+            tablet->_rs_version_map.emplace(rs->version(), rs);
+        }
+        tablet->_cumulative_point = 2;
+
+        st = _storage_engine->_submit_compaction_task(tablet, CompactionType::CUMULATIVE_COMPACTION,
+                                                      false);
+        EXPECT_TRUE(st.ok());
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        EXPECT_EQ(_storage_engine->_cumu_compaction_thread_pool->num_active_threads(),
+                  DorisMetrics::instance()->cumulative_compaction_task_running_total->value());
+        EXPECT_EQ(_storage_engine->_cumu_compaction_thread_pool->get_queue_size(),
+                  DorisMetrics::instance()->cumulative_compaction_task_pending_total->value());
+        EXPECT_EQ(_storage_engine->_base_compaction_thread_pool->num_active_threads(),
+                  DorisMetrics::instance()->base_compaction_task_running_total->value());
+        EXPECT_EQ(_storage_engine->_base_compaction_thread_pool->get_queue_size(),
+                  DorisMetrics::instance()->base_compaction_task_pending_total->value());
+    }
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

These metrics will be updated when the thread pool submits a task, the thread pool starts executing the task, and the thread pool is updated when the task is finished executing, where running uses increment to update instead of getting the number of running threads because the task executed by Defer is still part of the task Defer is finished executing the task before it is considered to be finished, and this leads to a situation where when the pool is finished executing the task, it is not considered to be finished until it is finished. When the last task finishes, the value of active_thread_num in Defer is 1, and the corresponding metric keeps 1, but it should actually be 0.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

