### PR TITLE
[feat](sql-convertor) support enable sql convertor's feature by session variable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectConverterPlugin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectConverterPlugin.java
@@ -103,7 +103,8 @@ public class HttpDialectConverterPlugin extends Plugin implements DialectConvert
         if (Strings.isNullOrEmpty(targetURL)) {
             return null;
         }
-        return HttpDialectUtils.convertSql(targetURL, originSql, sessionVariable.getSqlDialect());
+        return HttpDialectUtils.convertSql(targetURL, originSql, sessionVariable.getSqlDialect(),
+                sessionVariable.getSqlConvertorFeatures());
     }
 
     // no need to override parseSqlWithDialect, just return null

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectUtils.java
@@ -111,7 +111,7 @@ public class HttpDialectUtils {
         private String to;   // CHECKSTYLE IGNORE THIS LINE
         private String source;  // CHECKSTYLE IGNORE THIS LINE
         private String case_sensitive;  // CHECKSTYLE IGNORE THIS LINE
-        private String[] features; // CHECKSTYLE IGNORE THIS LINE
+        private String[] enable_sql_convertor_features; // CHECKSTYLE IGNORE THIS LINE
 
         public ConvertRequest(String originStmt, String dialect, String[] features) {
             this.version = "v1";
@@ -120,7 +120,7 @@ public class HttpDialectUtils {
             this.to = "doris";
             this.source = "text";
             this.case_sensitive = "0";
-            this.features = features;
+            this.enable_sql_convertor_features = features;
         }
 
         public String toJson() {

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectUtils.java
@@ -38,8 +38,9 @@ import java.nio.charset.StandardCharsets;
 public class HttpDialectUtils {
     private static final Logger LOG = LogManager.getLogger(HttpDialectUtils.class);
 
-    public static String convertSql(String targetURL, String originStmt, String dialect) {
-        ConvertRequest convertRequest = new ConvertRequest(originStmt, dialect);
+    public static String convertSql(String targetURL, String originStmt, String dialect,
+            String[] features) {
+        ConvertRequest convertRequest = new ConvertRequest(originStmt, dialect, features);
 
         HttpURLConnection connection = null;
         try {
@@ -110,14 +111,16 @@ public class HttpDialectUtils {
         private String to;   // CHECKSTYLE IGNORE THIS LINE
         private String source;  // CHECKSTYLE IGNORE THIS LINE
         private String case_sensitive;  // CHECKSTYLE IGNORE THIS LINE
+        private String[] features; // CHECKSTYLE IGNORE THIS LINE
 
-        public ConvertRequest(String originStmt, String dialect) {
+        public ConvertRequest(String originStmt, String dialect, String[] features) {
             this.version = "v1";
             this.sql_query = originStmt;
             this.from = dialect;
             this.to = "doris";
             this.source = "text";
             this.case_sensitive = "0";
+            this.features = features;
         }
 
         public String toJson() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -732,6 +732,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_TEXT_VALIDATE_UTF8 = "enable_text_validate_utf8";
 
+    public static final String ENABLE_SQL_CONVERTOR_FEATURES = "enable_sql_convertor_features";
+
     /**
      * If set false, user couldn't submit analyze SQL and FE won't allocate any related resources.
      */
@@ -2575,6 +2577,14 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean skipCheckingAcidVersionFile = false;
 
+    @VariableMgr.VarAttr(name = ENABLE_SQL_CONVERTOR_FEATURES, needForward = true,
+            checker = "checkSqlConvertorFeatures",
+            description = {
+                    "开启 SQL 转换器的指定功能。多个功能使用逗号分隔",
+                    "enable SQL convertor features. Multiple features are separated by commas"
+            })
+    public String enableSqlConvertorFeatures = "";
+
     public void setEnableEsParallelScroll(boolean enableESParallelScroll) {
         this.enableESParallelScroll = enableESParallelScroll;
     }
@@ -3518,6 +3528,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public String getSqlDialect() {
         return sqlDialect;
+    }
+
+    public String[] getSqlConvertorFeatures() {
+        return enableSqlConvertorFeatures.split(",");
     }
 
     public Dialect getSqlParseDialect() {
@@ -4794,6 +4808,20 @@ public class SessionVariable implements Serializable, Writable {
         }
     }
 
+    public void checkSqlConvertorFeatures(String features) {
+        if (Strings.isNullOrEmpty(features)) {
+            return;
+        }
+        String[] featureArray = features.split(",");
+        for (String feature : featureArray) {
+            if (!feature.equalsIgnoreCase("ctas")
+                    && !feature.equalsIgnoreCase("delete_all_comment")) {
+                throw new UnsupportedOperationException("Unknown sql convertor feature: " + feature
+                        + ", current support: ctas, delete_all_comment");
+            }
+        }
+    }
+
     public boolean getEnableLocalMergeSort() {
         return enableLocalMergeSort;
     }
@@ -4805,4 +4833,5 @@ public class SessionVariable implements Serializable, Writable {
     public boolean showSplitProfileInfo() {
         return enableProfile() && getProfileLevel() > 1;
     }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/plugin/HttpDialectUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/plugin/HttpDialectUtilsTest.java
@@ -52,22 +52,22 @@ public class HttpDialectUtilsTest {
     public void testSqlConvert() {
         String originSql = "select * from t1 where \"k1\" = 1";
         String expectedSql = "select * from t1 where `k1` = 1";
-
+        String[] features = new String[] {"ctas"};
         String targetURL = "http://127.0.0.1:" + port + "/api/v1/convert";
-        String res = HttpDialectUtils.convertSql(targetURL, originSql, "presto");
+        String res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
         Assert.assertEquals(originSql, res);
         // test presto
         server.setResponse("{\"version\": \"v1\", \"data\": \"" + expectedSql + "\", \"code\": 0, \"message\": \"\"}");
-        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto");
+        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
         Assert.assertEquals(expectedSql, res);
         // test response version error
         server.setResponse("{\"version\": \"v2\", \"data\": \"" + expectedSql + "\", \"code\": 0, \"message\": \"\"}");
-        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto");
+        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
         Assert.assertEquals(originSql, res);
         // 7. test response code error
         server.setResponse(
                 "{\"version\": \"v1\", \"data\": \"" + expectedSql + "\", \"code\": 400, \"message\": \"\"}");
-        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto");
+        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
         Assert.assertEquals(originSql, res);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -292,4 +292,36 @@ public class VariableMgrTest {
         Literal l = VariableMgr.getLiteral(sv, name, setType);
         Assert.assertEquals(BigIntType.INSTANCE, l.getDataType());
     }
+
+    @Test
+    public void testCheckSqlConvertorFeatures() throws DdlException {
+        // set wrong var
+        SetVar setVar = new SetVar(SetType.SESSION, SessionVariable.ENABLE_SQL_CONVERTOR_FEATURES,
+                new StringLiteral("wrong"));
+        SessionVariable var = new SessionVariable();
+        try {
+            VariableMgr.setVar(var, setVar);
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("Unknown sql convertor feature: wrong"));
+        }
+
+        // set one var
+        Assert.assertEquals(new String[] {""}, var.getSqlConvertorFeatures());
+        setVar = new SetVar(SetType.SESSION, SessionVariable.ENABLE_SQL_CONVERTOR_FEATURES,
+                new StringLiteral("ctas"));
+        VariableMgr.setVar(var, setVar);
+        Assert.assertEquals(new String[] {"ctas"}, var.getSqlConvertorFeatures());
+
+        // set multiple var
+        setVar = new SetVar(SetType.SESSION, SessionVariable.ENABLE_SQL_CONVERTOR_FEATURES,
+                new StringLiteral("ctas,delete_all_comment"));
+        VariableMgr.setVar(var, setVar);
+        Assert.assertEquals(new String[] {"ctas", "delete_all_comment"}, var.getSqlConvertorFeatures());
+
+        // set to empty
+        setVar = new SetVar(SetType.SESSION, SessionVariable.ENABLE_SQL_CONVERTOR_FEATURES,
+                new StringLiteral(""));
+        VariableMgr.setVar(var, setVar);
+        Assert.assertEquals(new String[] {""}, var.getSqlConvertorFeatures());
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Support new session variable `enable_sql_convertor_features`.
Some features of sql convertor is disable by default,
User can enable certain features of sql convertor by this variable.

eg:
```
// enable ctas statement conversion.
set enable_sql_convertor_features="ctas"

// enable ctas statement conversion, and will delete all comment in statement
set enable_sql_convertor_features="ctas,delete_all_comment"
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

