### PR TITLE
[feature](restore) introduce AgentBoundedBatchTask to manage concurrent restore tasks

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3002,6 +3002,15 @@ public class Config extends ConfigBase {
     })
     public static int backup_restore_batch_task_num_per_rpc = 10000;
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+            "一个 BE 同时执行的恢复任务的并发数",
+            "The number of concurrent restore tasks per be"})
+    public static int restore_task_concurrency_per_be = 5000;
+
+    @ConfField(mutable = true, description = {"执行 agent task 时，BE心跳超过多长时间，认为BE不可用",
+            "The time after which BE is considered unavailable if the heartbeat is not received"})
+    public static int agent_task_be_unavailable_heartbeat_timeout_second = 300;
+
     @ConfField(description = {"是否开启通过http接口获取log文件的功能",
             "Whether to enable the function of getting log files through http interface"})
     public static boolean enable_get_log_file_api = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -274,6 +274,7 @@ public class MasterImpl {
                 createReplicaTask.countDownToZero(task.getBackendId() + ": "
                         + request.getTaskStatus().getErrorMsgs().toString());
             } else {
+                createReplicaTask.setFinished(true);
                 long tabletId = createReplicaTask.getTabletId();
 
                 if (request.isSetFinishTabletInfos()) {
@@ -612,6 +613,7 @@ public class MasterImpl {
 
     private void finishMakeSnapshot(AgentTask task, TFinishTaskRequest request) {
         SnapshotTask snapshotTask = (SnapshotTask) task;
+        task.setFinished(true);
         if (snapshotTask.isCopyTabletTask()) {
             snapshotTask.setResultSnapshotPath(request.getSnapshotPath());
             snapshotTask.countDown(task.getBackendId(), task.getTabletId());
@@ -631,6 +633,7 @@ public class MasterImpl {
 
     private void finishDownloadTask(AgentTask task, TFinishTaskRequest request) {
         DownloadTask downloadTask = (DownloadTask) task;
+        task.setFinished(true);
         if (Env.getCurrentEnv().getBackupHandler().handleDownloadSnapshotTask(downloadTask, request)) {
             AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.DOWNLOAD, task.getSignature());
         }
@@ -638,6 +641,7 @@ public class MasterImpl {
 
     private void finishMoveDirTask(AgentTask task, TFinishTaskRequest request) {
         DirMoveTask dirMoveTask = (DirMoveTask) task;
+        task.setFinished(true);
         if (Env.getCurrentEnv().getBackupHandler().handleDirMoveTask(dirMoveTask, request)) {
             AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.MOVE, task.getSignature());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
@@ -72,10 +72,10 @@ import java.util.stream.Collectors;
 public class AgentBatchTask implements Runnable {
     private static final Logger LOG = LogManager.getLogger(AgentBatchTask.class);
 
-    private int batchSize = Integer.MAX_VALUE;
+    protected int batchSize = Integer.MAX_VALUE;
 
     // backendId -> AgentTask List
-    private Map<Long, List<AgentTask>> backendIdToTasks;
+    protected Map<Long, List<AgentTask>> backendIdToTasks;
 
     public AgentBatchTask() {
         this.backendIdToTasks = new HashMap<Long, List<AgentTask>>();
@@ -246,7 +246,7 @@ public class AgentBatchTask implements Runnable {
         }
     }
 
-    private TAgentTaskRequest toAgentTaskRequest(AgentTask task) {
+    protected TAgentTaskRequest toAgentTaskRequest(AgentTask task) {
         TAgentTaskRequest tAgentTaskRequest = new TAgentTaskRequest();
         tAgentTaskRequest.setProtocolVersion(TAgentServiceVersion.V1);
         tAgentTaskRequest.setSignature(task.getSignature());

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentBoundedBatchTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentBoundedBatchTask.java
@@ -1,0 +1,281 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.task;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.ThriftUtils;
+import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.system.Backend;
+import org.apache.doris.thrift.BackendService;
+import org.apache.doris.thrift.TAgentTaskRequest;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TTaskType;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+
+/*
+ * Like AgentBatchTask, but this class is used to submit tasks to BE in a bounded way, to avoid BE OOM.
+ */
+public class AgentBoundedBatchTask extends AgentBatchTask {
+    private static final Logger LOG = LogManager.getLogger(AgentBoundedBatchTask.class);
+    private static final int RPC_MAX_RETRY_TIMES = 3;
+
+    private int taskConcurrency;
+    private Map<Long, Integer> backendIdToConsumedTaskIndex;
+    private int beUnavailableMaxLostTimeSecond;
+
+    /**
+     * NOTE:
+     * this class is used to submit tasks to BE in a bounded way,
+     * and it will automatically add to AgentTaskQueue.
+     *
+     * @param batchSize       the max number of tasks to submit to BE in one time
+     * @param taskConcurrency the max number of tasks to submit to BE in one time
+     */
+    public AgentBoundedBatchTask(int batchSize, int taskConcurrency) {
+        super(batchSize);
+        this.taskConcurrency = taskConcurrency;
+        this.backendIdToConsumedTaskIndex = new HashMap<>();
+        this.beUnavailableMaxLostTimeSecond = Config.agent_task_be_unavailable_heartbeat_timeout_second;
+    }
+
+    @Override
+    public void addTask(AgentTask agentTask) {
+        if (agentTask == null) {
+            return;
+        }
+        long backendId = agentTask.getBackendId();
+        if (backendIdToTasks.containsKey(backendId)) {
+            List<AgentTask> tasks = backendIdToTasks.get(backendId);
+            tasks.add(agentTask);
+        } else {
+            List<AgentTask> tasks = new ArrayList<>();
+            tasks.add(agentTask);
+            backendIdToTasks.put(backendId, tasks);
+        }
+    }
+
+    @Override
+    public void run() {
+        int taskNum = getTaskNum();
+        LOG.info("begin to submit tasks to BE. total {} tasks, be task concurrency: {}", taskNum, taskConcurrency);
+        boolean submitFinished = false;
+        while (getSubmitTaskNum() < taskNum && !submitFinished) {
+            for (Long backendId : backendIdToTasks.keySet()) {
+                int consumedTaskIndex = backendIdToConsumedTaskIndex.getOrDefault(backendId, 0);
+                if (consumedTaskIndex >= backendIdToTasks.get(backendId).size()) {
+                    LOG.info("backend {} has submitted all tasks, taskNum: {}",
+                            backendId, backendIdToTasks.get(backendId).size());
+                    continue;
+                }
+
+                boolean ok = false;
+                String errMsg = "";
+                Backend backend = null;
+                List<AgentTask> tasks = new ArrayList<>();
+                List<TAgentTaskRequest> agentTaskRequests = new ArrayList<>();
+                try {
+                    backend = Env.getCurrentSystemInfo().getBackend(backendId);
+                    tasks = this.backendIdToTasks.getOrDefault(backendId, new ArrayList<>());
+                    if (backend == null) {
+                        errMsg = String.format("backend %d is not found", backendId);
+                        throw new RuntimeException(errMsg);
+                    }
+                    if (!backend.isAlive()) {
+                        errMsg = String.format("backend %d is not alive", backendId);
+                        if (System.currentTimeMillis() - backend.getLastUpdateMs()
+                                > beUnavailableMaxLostTimeSecond * 1000) {
+                            errMsg = String.format("backend %d is not alive too long, last update time: %s",
+                                    backendId, TimeUtils.longToTimeString(backend.getLastUpdateMs()));
+                            throw new RuntimeException(errMsg);
+                        }
+                        continue;
+                    }
+
+                    int runningTaskNum = getRunningTaskNum(backendId);
+                    LOG.info("backend {} has {} running tasks, task concurrency: {}",
+                            backendId, runningTaskNum, taskConcurrency);
+                    int index = consumedTaskIndex;
+                    for (; index < tasks.size()
+                            && index < consumedTaskIndex + taskConcurrency - runningTaskNum; index++) {
+                        agentTaskRequests.add(toAgentTaskRequest(tasks.get(index)));
+                        // add to AgentTaskQueue
+                        AgentTaskQueue.addTask(tasks.get(index));
+                        if (agentTaskRequests.size() >= batchSize) {
+                            submitTasks(backend, agentTaskRequests);
+                            agentTaskRequests.clear();
+                        }
+                    }
+                    submitTasks(backend, agentTaskRequests);
+                    backendIdToConsumedTaskIndex.put(backendId, index);
+                    LOG.info("submit task to backend {} finished, already submitted task num: {}/{}",
+                            backendId, index, tasks.size());
+                    ok = true;
+                } catch (Exception e) {
+                    LOG.warn("task exec error. backend[{}]", backendId, e);
+                    errMsg = String.format("task exec error: %s. backend[%d]", e.getMessage(), backendId);
+                    if (!agentTaskRequests.isEmpty() && errMsg.contains("Broken pipe")) {
+                        // Log the task binary message size and the max task type, to help debug the
+                        // large thrift message size issue.
+                        List<Pair<TTaskType, Long>> taskTypeAndSize = agentTaskRequests.stream()
+                                .map(req -> Pair.of(req.getTaskType(), ThriftUtils.getBinaryMessageSize(req)))
+                                .collect(Collectors.toList());
+                        Pair<TTaskType, Long> maxTaskTypeAndSize = taskTypeAndSize.stream()
+                                .max((p1, p2) -> Long.compare(p1.value(), p2.value()))
+                                .orElse(null);  // taskTypeAndSize is not empty
+                        TTaskType maxType = maxTaskTypeAndSize.first;
+                        long maxSize = maxTaskTypeAndSize.second;
+                        long totalSize = taskTypeAndSize.stream().map(Pair::value).reduce(0L, Long::sum);
+                        LOG.warn("submit {} tasks to backend[{}], total size: {}, max task type: {}, size: {}. msg: {}",
+                                agentTaskRequests.size(), backendId, totalSize, maxType, maxSize, e.getMessage());
+                    }
+                } finally {
+                    if (!ok) {
+                        submitFinished = true;
+                        LOG.warn("submit task to backend {} failed, errMsg: {}, cancel all tasks", backendId, errMsg);
+                        cancelAllTasks(errMsg);
+                    }
+                }
+            }
+
+            try {
+                TimeUnit.SECONDS.sleep(3);
+            } catch (InterruptedException e) {
+                String errMsg = "submit task thread is interrupted";
+                LOG.warn(errMsg, e);
+                submitFinished = true;
+                cancelAllTasks(errMsg);
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    private static void submitTasks(Backend backend, List<TAgentTaskRequest> agentTaskRequests) throws Exception {
+        long start = System.currentTimeMillis();
+        if (agentTaskRequests.isEmpty()) {
+            return;
+        }
+
+        if (LOG.isDebugEnabled()) {
+            long size = agentTaskRequests.stream()
+                    .map(ThriftUtils::getBinaryMessageSize)
+                    .reduce(0L, Long::sum);
+            TTaskType firstTaskType = agentTaskRequests.get(0).getTaskType();
+            LOG.debug("submit {} tasks to backend[{}], total size: {}, first task type: {}",
+                    agentTaskRequests.size(), backend.getId(), size, firstTaskType);
+            for (TAgentTaskRequest req : agentTaskRequests) {
+                LOG.debug("send task: type[{}], backend[{}], signature[{}]",
+                        req.getTaskType(), backend.getId(), req.getSignature());
+            }
+        }
+
+        MetricRepo.COUNTER_AGENT_TASK_REQUEST_TOTAL.increase(1L);
+
+        BackendService.Client client = null;
+        TNetworkAddress address = null;
+        // create AgentClient
+        String host = FeConstants.runningUnitTest ? "127.0.0.1" : backend.getHost();
+        address = new TNetworkAddress(host, backend.getBePort());
+        long backendId = backend.getId();
+        boolean ok = false;
+        for (int attempt = 1; attempt <= RPC_MAX_RETRY_TIMES; attempt++) {
+            try {
+                if (client == null) {
+                    // borrow new client when previous client request failed
+                    client = ClientPool.backendPool.borrowObject(address);
+                }
+                client.submitTasks(agentTaskRequests);
+                ok = true;
+                break;
+            } catch (Exception e) {
+                if (attempt == RPC_MAX_RETRY_TIMES) {
+                    LOG.warn("submit task to agent failed. backend[{}], request size: {}, elapsed:{} ms error: {}",
+                            backendId, agentTaskRequests.size(), System.currentTimeMillis() - start,
+                            e.getMessage());
+                    throw e;
+                } else {
+                    LOG.warn("submit task attempt {} failed, retrying... backend[{}], error: {}",
+                            attempt, backendId, e.getMessage());
+                    try {
+                        Thread.sleep(200);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            } finally {
+                if (ok) {
+                    ClientPool.backendPool.returnObject(address, client);
+                } else {
+                    ClientPool.backendPool.invalidateObject(address, client);
+                    client = null;
+                }
+            }
+        }
+    }
+
+    private int getSubmitTaskNum() {
+        return backendIdToConsumedTaskIndex.values().stream()
+                .mapToInt(Integer::intValue)
+                .sum();
+    }
+
+    private int getFinishedTaskNum(long backendId) {
+        int count = 0;
+        for (AgentTask agentTask : this.backendIdToTasks.get(backendId)) {
+            if (agentTask.isFinished()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private int getRunningTaskNum(long backendId) {
+        int count = 0;
+        List<AgentTask> tasks = backendIdToTasks.get(backendId);
+        int consumedTaskIndex = backendIdToConsumedTaskIndex.getOrDefault(backendId, 0);
+        for (int i = 0; i < consumedTaskIndex; i++) {
+            if (!tasks.get(i).isFinished) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private void cancelAllTasks(String errMsg) {
+        for (List<AgentTask> beTasks : backendIdToTasks.values()) {
+            for (AgentTask task : beTasks) {
+                task.failedWithMsg(errMsg);
+            }
+        }
+    }
+}


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

- Added a new class `AgentBoundedBatchTask` to limit the number of concurrent tasks submitted to backends during restore operations.
- Updated `RestoreJob` to utilize `AgentBoundedBatchTask` instead of `AgentBatchTask`, incorporating a new configuration parameter for restore task concurrency.
- Introduced a new configuration field `restore_task_concurrency_per_be` to specify the maximum number of concurrent restore tasks per backend.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

