### PR TITLE
[bugfix](becore) pipeline core when workload group shutdown

### DIFF
--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -149,8 +149,6 @@ void MultiCoreTaskQueue::close() {
     for (int i = 0; i < _core_size; ++i) {
         (*_prio_task_queue_list)[i]->close();
     }
-    std::atomic_store(&_prio_task_queue_list,
-                      std::shared_ptr<std::vector<std::unique_ptr<PriorityTaskQueue>>>(nullptr));
 }
 
 PipelineTask* MultiCoreTaskQueue::take(int core_id) {


### PR DESCRIPTION
### What problem does this PR solve?

1. When workload group shutdown, it will shutdown pipeline task scheduler.
2. In pipelinetask scheduler, it will first call task queue.close, in this method it will deconstruct priority task queue.
3. But at this time, the pipeline task thread is not stopped. 
So that it will core.
Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

