### PR TITLE
[fix](regression)remove unstable case

### DIFF
--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_date_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_date_arithmatic.groovy
@@ -89,7 +89,6 @@ suite("fold_constant_date_arithmatic") {
     testFoldConst("select unix_timestamp('3000/02/29','%Y/%m/%d');")
     testFoldConst("select unix_timestamp('01.Jan.1970','%d.%b.%Y');")
     testFoldConst("select unix_timestamp('0000-00-00 00:00:00');")
-    testFoldConst("select unix_timestamp();")
     testFoldConst("select unix_timestamp('2021-02-29', '%Y-%m-%d');")
     testFoldConst("select unix_timestamp('2023/04/31', '%Y/%m/%d');")
     testFoldConst("select unix_timestamp('2023-04-31 12:00:00');")


### PR DESCRIPTION
### What problem does this PR solve?
 the case  ' testFoldConst("select unix_timestamp();")'  is unstable, becase it is possible to get different results when evaluate unix_timestamp() twice.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

