### PR TITLE
[fix](memory) Fix `PODArray::add_num_element`

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -413,12 +413,12 @@ public:
     template <typename U, typename... TAllocatorParams>
     void add_num_element(U&& x, uint32_t num, TAllocatorParams&&... allocator_params) {
         if (num != 0) {
-            const auto new_end = this->c_end + this->byte_size(num);
-            if (UNLIKELY(new_end > this->c_end_of_storage)) {
+            const auto growth_size = this->byte_size(num);
+            if (UNLIKELY(this->c_end + growth_size > this->c_end_of_storage)) {
                 this->reserve(this->size() + num);
             }
             std::fill(t_end(), t_end() + num, x);
-            this->c_end = new_end;
+            this->c_end = this->c_end + growth_size;
         }
     }
 

--- a/be/test/vec/common/pod_array_test.cpp
+++ b/be/test/vec/common/pod_array_test.cpp
@@ -498,6 +498,40 @@ TEST(PODArrayTest, PODArrayInsert) {
 //     }
 // }
 
+TEST(PODArrayTest, PODArrayAddNumElement) {
+    static constexpr size_t initial_bytes = 32;
+    using Array = vectorized::PODArray<uint64_t, initial_bytes>;
+    size_t element_size = 8; // sizeof(uint64_t)
+    {
+        Array array;
+
+        array.add_num_element(1, 4);
+        ASSERT_EQ(array.size(), 4);
+        ASSERT_EQ(array.capacity(), 32 / element_size);
+        ASSERT_EQ(array, Array({1, 1, 1, 1}));
+
+        // call reserve
+        array.add_num_element(1, 2);
+        ASSERT_EQ(array.size(), 6);
+        ASSERT_EQ(array.capacity(), 64 / element_size);
+        ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1}));
+    }
+    {
+        Array array;
+
+        array.add_num_element_without_reserve(1, 4);
+        ASSERT_EQ(array.size(), 4);
+        ASSERT_EQ(array.capacity(), 32 / element_size);
+        ASSERT_EQ(array, Array({1, 1, 1, 1}));
+
+        // call reserve
+        array.add_num_element_without_reserve(1, 2);
+        ASSERT_EQ(array.size(), 6);
+        ASSERT_EQ(array.capacity(), 64 / element_size);
+        ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1}));
+    }
+}
+
 TEST(PODArrayTest, PODArrayAssign) {
     {
         vectorized::PaddedPODArray<uint64_t> array;

--- a/be/test/vec/common/pod_array_test.cpp
+++ b/be/test/vec/common/pod_array_test.cpp
@@ -515,20 +515,12 @@ TEST(PODArrayTest, PODArrayAddNumElement) {
         ASSERT_EQ(array.size(), 6);
         ASSERT_EQ(array.capacity(), 64 / element_size);
         ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1}));
-    }
-    {
-        Array array;
-
-        array.add_num_element_without_reserve(1, 4);
-        ASSERT_EQ(array.size(), 4);
-        ASSERT_EQ(array.capacity(), 32 / element_size);
-        ASSERT_EQ(array, Array({1, 1, 1, 1}));
 
         // call reserve
-        array.add_num_element_without_reserve(1, 2);
-        ASSERT_EQ(array.size(), 6);
+        array.add_num_element_without_reserve(1, 1);
+        ASSERT_EQ(array.size(), 7);
         ASSERT_EQ(array.capacity(), 64 / element_size);
-        ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1}));
+        ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1, 1}));
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

In `add_num_element`, after `reserve`, the value of `c_end` will be changed.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

