### PR TITLE
[improvement] (metadata cache) use expire after access strategy on meta cache

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2239,7 +2239,14 @@ public class Config extends ConfigBase {
      * For external schema cache and hive meta cache.
      */
     @ConfField(mutable = false, masterOnly = false)
-    public static long external_cache_expire_time_minutes_after_access = 10; // 10 mins
+    public static long external_cache_expire_time_minutes_after_access = 86400L; // 8 hours
+
+    /**
+     * The expiration time of a cache object after last access of it.
+     * For external schema cache and hive meta cache.
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static long external_cache_refresh_time_minutes = 10; // 10 mins
 
     /**
      * Github workflow test type, for setting some session variables

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2239,7 +2239,7 @@ public class Config extends ConfigBase {
      * For external schema cache and hive meta cache.
      */
     @ConfField(mutable = false, masterOnly = false)
-    public static long external_cache_expire_time_minutes_after_access = 86400L; // 8 hours
+    public static long external_cache_expire_time_seconds_after_access = 86400L; // 24 hours
 
     /**
      * The expiration time of a cache object after last access of it.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2234,18 +2234,16 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false, masterOnly = false)
     public static long max_external_schema_cache_num = 10000;
 
-    /**
-     * The expiration time of a cache object after last access of it.
-     * For external schema cache and hive meta cache.
-     */
-    @ConfField(mutable = false, masterOnly = false)
+    @ConfField(description = {
+            "外部表元数据缓存对象在最后访问后过期的时间。",
+            "The expiration time of a cache object after last access of it. For external meta cache."
+    })
     public static long external_cache_expire_time_seconds_after_access = 86400L; // 24 hours
 
-    /**
-     * The expiration time of a cache object after last access of it.
-     * For external schema cache and hive meta cache.
-     */
-    @ConfField(mutable = false, masterOnly = false)
+    @ConfField(description = {
+            "外部表元数据缓存对象的自动刷新时间",
+            "The auto refresh time of external meta cache."
+    })
     public static long external_cache_refresh_time_minutes = 10; // 10 mins
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ExecutorService;
  */
 public class CacheFactory {
 
-    private OptionalLong expireAfterWriteSec;
+    private OptionalLong expireAfterAccessSec;
     private OptionalLong refreshAfterWriteSec;
     private long maxSize;
     private boolean enableStats;
@@ -56,12 +56,12 @@ public class CacheFactory {
     private Ticker ticker;
 
     public CacheFactory(
-            OptionalLong expireAfterWriteSec,
+            OptionalLong expireAfterAccessSec,
             OptionalLong refreshAfterWriteSec,
             long maxSize,
             boolean enableStats,
             Ticker ticker) {
-        this.expireAfterWriteSec = expireAfterWriteSec;
+        this.expireAfterAccessSec = expireAfterAccessSec;
         this.refreshAfterWriteSec = refreshAfterWriteSec;
         this.maxSize = maxSize;
         this.enableStats = enableStats;
@@ -98,8 +98,8 @@ public class CacheFactory {
         Caffeine<Object, Object> builder = Caffeine.newBuilder();
         builder.maximumSize(maxSize);
 
-        if (expireAfterWriteSec.isPresent()) {
-            builder.expireAfterWrite(Duration.ofSeconds(expireAfterWriteSec.getAsLong()));
+        if (expireAfterAccessSec.isPresent()) {
+            builder.expireAfterAccess(Duration.ofSeconds(expireAfterAccessSec.getAsLong()));
         }
         if (refreshAfterWriteSec.isPresent()) {
             builder.refreshAfterWrite(Duration.ofSeconds(refreshAfterWriteSec.getAsLong()));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -314,8 +314,8 @@ public abstract class ExternalCatalog
                     if (metaCache == null) {
                         metaCache = Env.getCurrentEnv().getExtMetaCacheMgr().buildMetaCache(
                                 name,
-                                OptionalLong.of(86400L),
-                                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60L),
+                                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
+                                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
                                 Config.max_meta_object_cache_num,
                                 ignored -> getFilteredDatabaseNames(),
                                 localDbName -> Optional.ofNullable(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -163,8 +163,8 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                     if (metaCache == null) {
                         metaCache = Env.getCurrentEnv().getExtMetaCacheMgr().buildMetaCache(
                                 name,
-                                OptionalLong.of(86400L),
-                                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60L),
+                                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
+                                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
                                 Config.max_meta_object_cache_num,
                                 ignored -> listTableNames(),
                                 localTableName -> Optional.ofNullable(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -348,7 +348,8 @@ public class ExternalMetaCacheMgr {
             CacheLoader<String, List<Pair<String, String>>> namesCacheLoader,
             CacheLoader<String, Optional<T>> metaObjCacheLoader,
             RemovalListener<String, Optional<T>> removalListener) {
-        MetaCache<T> metaCache = new MetaCache<>(name, commonRefreshExecutor, expireAfterAccessSec, refreshAfterWriteSec,
+        MetaCache<T> metaCache = new MetaCache<>(
+                name, commonRefreshExecutor, expireAfterAccessSec, refreshAfterWriteSec,
                 maxSize, namesCacheLoader, metaObjCacheLoader, removalListener);
         return metaCache;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -344,11 +344,11 @@ public class ExternalMetaCacheMgr {
     }
 
     public <T> MetaCache<T> buildMetaCache(String name,
-            OptionalLong expireAfterWriteSec, OptionalLong refreshAfterWriteSec, long maxSize,
+            OptionalLong expireAfterAccessSec, OptionalLong refreshAfterWriteSec, long maxSize,
             CacheLoader<String, List<Pair<String, String>>> namesCacheLoader,
             CacheLoader<String, Optional<T>> metaObjCacheLoader,
             RemovalListener<String, Optional<T>> removalListener) {
-        MetaCache<T> metaCache = new MetaCache<>(name, commonRefreshExecutor, expireAfterWriteSec, refreshAfterWriteSec,
+        MetaCache<T> metaCache = new MetaCache<>(name, commonRefreshExecutor, expireAfterAccessSec, refreshAfterWriteSec,
                 maxSize, namesCacheLoader, metaObjCacheLoader, removalListener);
         return metaCache;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
@@ -43,7 +43,7 @@ public class ExternalRowCountCache {
         // 1. set expireAfterWrite to 1 day, avoid too many entries
         // 2. set refreshAfterWrite to 10min(default), so that the cache will be refreshed after 10min
         CacheFactory rowCountCacheFactory = new CacheFactory(
-                OptionalLong.of(86400L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_row_count_cache_num,
                 false,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
@@ -44,7 +44,7 @@ public class ExternalRowCountCache {
         // 2. set refreshAfterWrite to 10min(default), so that the cache will be refreshed after 10min
         CacheFactory rowCountCacheFactory = new CacheFactory(
                 OptionalLong.of(86400L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_row_count_cache_num,
                 false,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
@@ -56,8 +56,8 @@ public class ExternalSchemaCache {
                 (catalog.getProperties().get(ExternalCatalog.SCHEMA_CACHE_TTL_SECOND)), ExternalCatalog.CACHE_NO_TTL);
         CacheFactory schemaCacheFactory = new CacheFactory(
                 OptionalLong.of(schemaCacheTtlSecond >= ExternalCatalog.CACHE_TTL_DISABLE_CACHE
-                        ? schemaCacheTtlSecond : 86400),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                        ? schemaCacheTtlSecond : Config.external_cache_expire_time_seconds_after_access),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_schema_cache_num,
                 false,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -182,7 +182,7 @@ public class HiveMetaStoreCache {
         CacheFactory fileCacheFactory = new CacheFactory(
                 OptionalLong.of(fileMetaCacheTtlSecond >= ExternalCatalog.CACHE_TTL_DISABLE_CACHE
                         ? fileMetaCacheTtlSecond : 28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60L),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
                 Config.max_external_file_cache_num,
                 true,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -148,7 +148,7 @@ public class HiveMetaStoreCache {
                 refreshExecutor);
 
         CacheFactory partitionCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.empty(),
                 Config.max_hive_partition_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -139,8 +139,8 @@ public class HiveMetaStoreCache {
 
         CacheFactory partitionValuesCacheFactory = new CacheFactory(
                 OptionalLong.of(partitionCacheTtlSecond >= ExternalCatalog.CACHE_TTL_DISABLE_CACHE
-                        ? partitionCacheTtlSecond : 28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60L),
+                        ? partitionCacheTtlSecond : Config.external_cache_expire_time_seconds_after_access),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
                 Config.max_hive_partition_table_cache_num,
                 true,
                 null);
@@ -181,7 +181,7 @@ public class HiveMetaStoreCache {
 
         CacheFactory fileCacheFactory = new CacheFactory(
                 OptionalLong.of(fileMetaCacheTtlSecond >= ExternalCatalog.CACHE_TTL_DISABLE_CACHE
-                        ? fileMetaCacheTtlSecond : 28800L),
+                        ? fileMetaCacheTtlSecond : Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
                 Config.max_external_file_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedFsViewProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedFsViewProcessor.java
@@ -41,7 +41,7 @@ public class HudiCachedFsViewProcessor {
 
     public HudiCachedFsViewProcessor(ExecutorService executor) {
         CacheFactory partitionCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedFsViewProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedFsViewProcessor.java
@@ -42,7 +42,7 @@ public class HudiCachedFsViewProcessor {
     public HudiCachedFsViewProcessor(ExecutorService executor) {
         CacheFactory partitionCacheFactory = new CacheFactory(
                 OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedMetaClientProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedMetaClientProcessor.java
@@ -41,7 +41,7 @@ public class HudiCachedMetaClientProcessor {
 
     public HudiCachedMetaClientProcessor(ExecutorService executor) {
         CacheFactory partitionCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedMetaClientProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedMetaClientProcessor.java
@@ -42,7 +42,7 @@ public class HudiCachedMetaClientProcessor {
     public HudiCachedMetaClientProcessor(ExecutorService executor) {
         CacheFactory partitionCacheFactory = new CacheFactory(
                 OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
@@ -57,7 +57,7 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
         this.executor = executor;
         CacheFactory partitionCacheFactory = new CacheFactory(
                 OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
@@ -56,7 +56,7 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
         this.catalogId = catalogId;
         this.executor = executor;
         CacheFactory partitionCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
@@ -54,7 +54,7 @@ public class IcebergMetadataCache {
 
     public IcebergMetadataCache(ExecutorService executor) {
         CacheFactory snapshotListCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
@@ -62,7 +62,7 @@ public class IcebergMetadataCache {
         this.snapshotListCache = snapshotListCacheFactory.buildCache(key -> loadSnapshots(key), null, executor);
 
         CacheFactory tableCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
@@ -70,7 +70,7 @@ public class IcebergMetadataCache {
         this.tableCache = tableCacheFactory.buildCache(key -> loadTable(key), null, executor);
 
         CacheFactory snapshotCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
@@ -55,7 +55,7 @@ public class IcebergMetadataCache {
     public IcebergMetadataCache(ExecutorService executor) {
         CacheFactory snapshotListCacheFactory = new CacheFactory(
                 OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);
@@ -63,7 +63,7 @@ public class IcebergMetadataCache {
 
         CacheFactory tableCacheFactory = new CacheFactory(
                 OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);
@@ -71,7 +71,7 @@ public class IcebergMetadataCache {
 
         CacheFactory snapshotCacheFactory = new CacheFactory(
                 OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeMetadataCache.java
@@ -33,7 +33,7 @@ public class MaxComputeMetadataCache {
 
     public MaxComputeMetadataCache() {
         partitionValuesCache = Caffeine.newBuilder().maximumSize(Config.max_hive_partition_cache_num)
-                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
+                .expireAfterAccess(Config.external_cache_refresh_time_minutes, TimeUnit.MINUTES)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
@@ -45,7 +45,7 @@ public class MetaCache<T> {
 
     public MetaCache(String name,
             ExecutorService executor,
-            OptionalLong expireAfterWriteSec,
+            OptionalLong expireAfterAccessSec,
             OptionalLong refreshAfterWriteSec,
             long maxSize,
             CacheLoader<String, List<Pair<String, String>>> namesCacheLoader,
@@ -60,13 +60,13 @@ public class MetaCache<T> {
         // from remote datasource, it is just a local generated object to represent the meta info.
         // So it only need to be expired after specified duration.
         CacheFactory namesCacheFactory = new CacheFactory(
-                expireAfterWriteSec,
+                expireAfterAccessSec,
                 refreshAfterWriteSec,
                 1, // names cache has one and only one entry
                 true,
                 null);
         CacheFactory objCacheFactory = new CacheFactory(
-                expireAfterWriteSec,
+                expireAfterAccessSec,
                 OptionalLong.empty(),
                 maxSize,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonMetadataCache.java
@@ -48,8 +48,8 @@ public class PaimonMetadataCache {
 
     public PaimonMetadataCache(ExecutorService executor) {
         CacheFactory snapshotCacheFactory = new CacheFactory(
-                OptionalLong.of(28800L),
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access * 60),
+                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access),
+                OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,
                 null);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonMetadataCache.java
@@ -48,7 +48,7 @@ public class PaimonMetadataCache {
 
     public PaimonMetadataCache(ExecutorService executor) {
         CacheFactory snapshotCacheFactory = new CacheFactory(
-                OptionalLong.of(Config.external_cache_expire_time_minutes_after_access),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.of(Config.external_cache_refresh_time_minutes * 60),
                 Config.max_external_table_cache_num,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemCache.java
@@ -38,7 +38,7 @@ public class FileSystemCache {
     public FileSystemCache() {
         // no need to set refreshAfterWrite, because the FileSystem is created once and never changed
         CacheFactory fsCacheFactory = new CacheFactory(
-                OptionalLong.of(86400L),
+                OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                 OptionalLong.empty(),
                 Config.max_remote_file_system_cache_num,
                 false,

--- a/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
@@ -149,7 +149,7 @@ public class CacheFactoryTest {
         FakeTicker ticker = new FakeTicker();
         AtomicLong counter = new AtomicLong(0);
         CacheFactory cacheFactory = new CacheFactory(
-                OptionalLong.of(60L),
+                OptionalLong.of(20L),
                 OptionalLong.of(10),
                 1000,
                 false,
@@ -174,8 +174,8 @@ public class CacheFactoryTest {
         Assertions.assertEquals("value1", value.getValue());
         // refreshed, so counter +1
         Assertions.assertEquals(2, counter.get());
-        // advance 61 seconds to pass the expireAfterWrite
-        ticker.advance(61, TimeUnit.SECONDS);
+        // advance 21 seconds to pass the expireAfterAccess
+        ticker.advance(21, TimeUnit.SECONDS);
         value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         // expired, so counter +1
@@ -187,7 +187,7 @@ public class CacheFactoryTest {
         FakeTicker ticker = new FakeTicker();
         AtomicLong counter = new AtomicLong(0);
         CacheFactory cacheFactory = new CacheFactory(
-                OptionalLong.of(60L),
+                OptionalLong.of(6L),
                 OptionalLong.empty(),
                 1000,
                 false,
@@ -197,13 +197,13 @@ public class CacheFactoryTest {
         CacheValue value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         Assertions.assertEquals(1, counter.get());
-        // advance 30 seconds, key still not expired
-        ticker.advance(30, TimeUnit.SECONDS);
+        // advance 1 seconds, key still not expired
+        ticker.advance(1, TimeUnit.SECONDS);
         value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         Assertions.assertEquals(1, counter.get());
-        // advance 31 seconds to pass the expireAfterWrite
-        ticker.advance(31, TimeUnit.SECONDS);
+        // advance 7 seconds to pass the expireAfterAccess
+        ticker.advance(7, TimeUnit.SECONDS);
         value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         // expired, so counter +1
@@ -243,7 +243,7 @@ public class CacheFactoryTest {
         Assertions.assertEquals("value1", futureValue.get().get().getValue());
         // refreshed, so counter +1
         Assertions.assertEquals(2, counter.get());
-        // advance 61 seconds to pass the expireAfterWrite
+        // advance 61 seconds to pass the expireAfterAccess
         ticker.advance(61, TimeUnit.SECONDS);
         futureValue = loadingCache.get(1);
         Assertions.assertFalse(futureValue.isDone());


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Hot data should be cached for a long time, and its data freshness should be refreshed through refreshAfterWriteSec instead of expireAfterWriteSec. Its expiration time should be controlled by expireAfterAccessSec, which can solve the problem of lagging caused by hot data expiration.
At the same time, configure expireAfterAccessSec and allow users to manually adjust caching policies.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/2569

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

