### PR TITLE
[fix](cooldown) add mem tracker for Tablet::cooldown

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2030,6 +2030,12 @@ Status Tablet::cooldown(RowsetSharedPtr rowset) {
         return Status::InternalError("invalid cooldown_replica_id");
     }
 
+    auto mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::OTHER,
+            fmt::format("Tablet::cooldown#tableId={}:replicaId={}", std::to_string(tablet_id()),
+                        std::to_string(replica_id())));
+    SCOPED_ATTACH_TASK(mem_tracker);
+
     if (_cooldown_conf.cooldown_replica_id == replica_id()) {
         // this replica is cooldown replica
         RETURN_IF_ERROR(_cooldown_data(std::move(rowset)));


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

```
F 2025-05-09 17:39:54,931 15596 status.h:461] Current thread not exist ThreadContext, usually after the thread is started, using SCOPED_ATTACH_TASK macro to create a ThreadContext and bind a Task.
*** SIGABRT unknown detail explain (@0x3668) received by PID 13928 (TID 15596 OR 0x7f133ef4a640) from PID 13928; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007F16E3880520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x00005619FC73398D in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# 0x00005619FC725FCA in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
10# doris::Status doris::Status::FatalError<true, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>(std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) at /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:461
11# doris::io::S3FileReader::read_at_impl(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/s3_file_reader.cpp:131
12# doris::io::FileReader::read_at(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /home/zcp/repo_center/doris_master/doris/be/src/io/fs/file_reader.cpp:34
13# doris::Tablet::_read_cooldown_meta(doris::StorageResource const&, doris::TabletMetaPB*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:2143
14# doris::Tablet::_follow_cooldowned_data() at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:2262
15# doris::Tablet::cooldown(std::shared_ptr<doris::Rowset>) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
16# std::_Function_handler<void (), doris::StorageEngine::_cooldown_tasks_producer_callback()::$_1>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
17# doris::WorkThreadPool<true>::work_thread(int) at /home/zcp/repo_center/doris_master/doris/be/src/util/work_thread_pool.hpp:159
18# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
19# start_thread at ./nptl/pthread_create.c:442
20# 0x00007F16E3964850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

