### PR TITLE
[opt](analytic) opt the computation for ROWS UNBOUNDED PRECEDING AND XXX window function

### DIFF
--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -220,9 +220,7 @@ bool AnalyticSinkLocalState::_get_next_for_sliding_rows(int64_t batch_rows,
 
 bool AnalyticSinkLocalState::_get_next_for_unbounded_rows(int64_t batch_rows,
                                                           int64_t current_block_base_pos) {
-    int64_t pos = current_pos_in_block();
-    int64_t remain_size = batch_rows - pos;
-    DCHECK_GE(batch_rows, pos);
+    int64_t remain_size = batch_rows - current_pos_in_block();
     while (_current_row_position < _partition_by_pose.end && remain_size > 0) {
         int64_t current_row_end = _current_row_position + _rows_end_offset + 1;
         const bool is_n_following_frame = _rows_end_offset > 0;
@@ -240,6 +238,7 @@ bool AnalyticSinkLocalState::_get_next_for_unbounded_rows(int64_t batch_rows,
         }
         _execute_for_function(_partition_by_pose.start, _partition_by_pose.end, current_row_end - 1,
                               current_row_end);
+        int64_t pos = current_pos_in_block();
         _insert_result_info(pos, pos + 1);
         _current_row_position++;
         remain_size--;

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -231,7 +231,7 @@ bool AnalyticSinkLocalState::_get_next_for_unbounded_rows(int64_t batch_rows,
         // going on calculate, add up data, no need to reset state
         if (is_n_following_frame && !_partition_by_pose.is_ended &&
             current_row_end > _partition_by_pose.end) {
-            return false;
+            return _current_row_position - current_block_base_pos >= batch_rows;
         }
         if (is_n_following_frame && _current_row_position == _partition_by_pose.start) {
             _execute_for_function(_partition_by_pose.start, _partition_by_pose.end,
@@ -243,9 +243,6 @@ bool AnalyticSinkLocalState::_get_next_for_unbounded_rows(int64_t batch_rows,
         _current_row_position++;
         remain_size--;
         if (remain_size == 0) {
-            LOG(INFO) << "asd: " << _current_row_position << " " << current_block_base_pos << " "
-                      << batch_rows << " "
-                      << (_current_row_position - current_block_base_pos >= batch_rows);
             return true;
         }
     }

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -26,6 +26,7 @@
 
 #include "pipeline/exec/operator.h"
 #include "runtime/runtime_state.h"
+#include "util/uid_util.h"
 #include "vec/exprs/vectorized_agg_fn.h"
 
 namespace doris::pipeline {
@@ -368,6 +369,10 @@ void AnalyticSinkLocalState::_execute_for_function(int64_t partition_start, int6
     _current_window_empty =
             std::min(frame_end, partition_end) <= std::max(frame_start, partition_start);
 
+    if (_current_window_empty) {
+        LOG(INFO) << "asd " << print_id(state()->query_id());
+    }
+    _current_window_empty = false;
     for (size_t i = 0; i < _agg_functions_size; ++i) {
         if (_result_column_nullable_flags[i] && _current_window_empty) {
             continue;

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -146,6 +146,7 @@ private:
 
     bool _current_window_empty = false;
     bool _streaming_mode = false;
+    bool _need_more_data = false;
     int64_t _current_row_position = 0;
     int64_t _output_block_index = 0;
     std::vector<vectorized::MutableColumnPtr> _result_window_columns;

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -557,7 +557,11 @@ struct WindowFunctionLastImpl : Data {
         DCHECK_LE(frame_start, frame_end);
         if ((frame_end <= partition_start) ||
             (frame_start >= partition_end)) { //beyond or under partition, set null
-            this->set_is_null();
+            if ((this->has_set_value()) &&
+                (!arg_ignore_null || (arg_ignore_null && !this->is_null()))) {
+            } else {
+                this->set_is_null();
+            }
             return;
         }
         frame_end = std::min<int64_t>(frame_end, partition_end);


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
For window functions with the frame ROWS UNBOUNDED PRECEDING AND XXX, this PR enables incremental computation—avoiding redundant full-window recalculations by reusing prior results.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

