### PR TITLE
[fix](memory) Fix `PODArray::add_num_element` step2

### DIFF
--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -381,7 +381,8 @@ void AnalyticSinkLocalState::_insert_result_info(int64_t start, int64_t end) {
             } else {
                 auto* dst =
                         assert_cast<vectorized::ColumnNullable*>(_result_window_columns[i].get());
-                dst->get_null_map_data().add_num_element(0, static_cast<uint32_t>(end - start));
+                dst->get_null_map_data().resize_fill(
+                        dst->get_null_map_data().size() + static_cast<uint32_t>(end - start), 0);
                 _agg_functions[i]->function()->insert_result_into_range(
                         _fn_place_ptr + _offsets_of_aggregate_states[i], dst->get_nested_column(),
                         start, end);

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -482,7 +482,7 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets& offsets) const {
     }
 
     for (size_t i = 0; i < size; ++i) {
-        res_data.add_num_element_without_reserve(data[i], counts[i]);
+        res_data.resize_fill(res_data.size() + counts[i], data[i]);
     }
 
     return res;

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -484,28 +484,6 @@ public:
         this->c_end += this->byte_size(1);
     }
 
-    template <typename U, typename... TAllocatorParams>
-    void add_num_element(U&& x, uint32_t num, TAllocatorParams&&... allocator_params) {
-        if (num != 0) {
-            const auto growth_size = this->byte_size(num);
-            if (UNLIKELY(this->c_end + growth_size > this->c_end_of_storage)) {
-                this->reserve(this->size() + num);
-            }
-            this->reset_resident_memory(this->c_end + growth_size);
-            std::fill(t_end(), t_end() + num, x);
-            this->c_end = this->c_end + growth_size;
-        }
-    }
-
-    template <typename U, typename... TAllocatorParams>
-    void add_num_element_without_reserve(U&& x, uint32_t num,
-                                         TAllocatorParams&&... allocator_params) {
-        const auto growth_size = sizeof(T) * num;
-        this->reset_resident_memory(this->c_end + growth_size);
-        std::fill(t_end(), t_end() + num, x);
-        this->c_end += growth_size;
-    }
-
     /**
      * you must make sure to reserve podarray before calling this method
      * remove branch if can improve performance

--- a/be/test/vec/common/pod_array_test.cpp
+++ b/be/test/vec/common/pod_array_test.cpp
@@ -683,7 +683,7 @@ TEST(PODArrayTest, PaddedPODArrayTrackingMemory) {
         array.push_back_without_reserve(11);
         EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3 + 1);
         doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 6);
+        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
 
         array.resize_fill(PRE_GROWTH_SIZE / sizeof(uint64_t) * 6, 2);
         EXPECT_EQ(array.size(), PRE_GROWTH_SIZE / sizeof(uint64_t) * 6);

--- a/be/test/vec/common/pod_array_test.cpp
+++ b/be/test/vec/common/pod_array_test.cpp
@@ -680,18 +680,8 @@ TEST(PODArrayTest, PaddedPODArrayTrackingMemory) {
         doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
         EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 3);
 
-        array.add_num_element_without_reserve(1, 10);
-        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3 + 10);
-        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-        EXPECT_EQ(t->consumption(), array.allocated_bytes() - pad_left - pad_right);
-
-        array.add_num_element(1, (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 2);
-        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 5 + 10);
-        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 6);
-
         array.push_back_without_reserve(11);
-        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 5 + 11);
+        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 3 + 1);
         doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
         EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 6);
 
@@ -795,13 +785,8 @@ TEST(PODArrayTest, PaddedPODArrayTrackingMemory) {
         doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
         EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
 
-        array.add_num_element_without_reserve(1, PRE_GROWTH_SIZE / sizeof(uint64_t));
-        EXPECT_EQ(array.size(), (PRE_GROWTH_SIZE / sizeof(uint64_t)) * 1 + 100);
-        doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
-        EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
-
-        array.erase(array.begin() + 100, array.end());
-        EXPECT_EQ(array.size(), 100);
+        array.erase(array.begin() + 10, array.end());
+        EXPECT_EQ(array.size(), 10);
         doris::thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
         EXPECT_EQ(t->consumption(), PRE_GROWTH_SIZE * 21);
     }

--- a/be/test/vec/common/pod_array_test.cpp
+++ b/be/test/vec/common/pod_array_test.cpp
@@ -507,32 +507,6 @@ TEST(PODArrayTest, PODArrayInsert) {
 //     }
 // }
 
-TEST(PODArrayTest, PODArrayAddNumElement) {
-    static constexpr size_t initial_bytes = 32;
-    using Array = vectorized::PODArray<uint64_t, initial_bytes>;
-    size_t element_size = 8; // sizeof(uint64_t)
-    {
-        Array array;
-
-        array.add_num_element(1, 4);
-        ASSERT_EQ(array.size(), 4);
-        ASSERT_EQ(array.capacity(), 32 / element_size);
-        ASSERT_EQ(array, Array({1, 1, 1, 1}));
-
-        // call reserve
-        array.add_num_element(1, 2);
-        ASSERT_EQ(array.size(), 6);
-        ASSERT_EQ(array.capacity(), 64 / element_size);
-        ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1}));
-
-        // call reserve
-        array.add_num_element_without_reserve(1, 1);
-        ASSERT_EQ(array.size(), 7);
-        ASSERT_EQ(array.capacity(), 64 / element_size);
-        ASSERT_EQ(array, Array({1, 1, 1, 1, 1, 1, 1}));
-    }
-}
-
 TEST(PODArrayTest, PODArrayAssign) {
     {
         vectorized::PaddedPODArray<uint64_t> array;


### PR DESCRIPTION
### What problem does this PR solve?

Use `PODArray::resize_fill` instead of `PODArray::add_num_element`, not pick branch-2.1 and 3.0

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

