### PR TITLE
[refactor](fe) make timeout unit more clear

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterLightSchChangeHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterLightSchChangeHelper.java
@@ -81,7 +81,7 @@ public class AlterLightSchChangeHelper {
         if (connectContext == null) {
             rpcTimoutMs = DEFAULT_RPC_TIMEOUT * 1000L;
         } else {
-            rpcTimoutMs = connectContext.getExecTimeout() * 1000L;
+            rpcTimoutMs = connectContext.getExecTimeoutS() * 1000L;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -393,7 +393,7 @@ public class NativeInsertStmt extends InsertStmt {
         createDataSink();
 
         // create label and begin transaction
-        long timeoutSecond = ConnectContext.get().getExecTimeout();
+        long timeoutSecond = ConnectContext.get().getExecTimeoutS();
         if (label == null || Strings.isNullOrEmpty(label.getLabelName())) {
             label = new LabelName(db.getFullName(),
                     insertType.labePrefix + DebugUtil.printId(analyzer.getContext().queryId()).replace("-", "_"));

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CloudLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CloudLoadManager.java
@@ -104,7 +104,7 @@ public class CloudLoadManager extends LoadManager {
                     stmt.getObjectInfo(), stmt.isForce(), stmt.getUserName());
             loadJob.setJobProperties(stmt.getProperties());
             loadJob.checkAndSetDataSourceInfo(database, stmt.getDataDescriptions());
-            loadJob.setTimeout(ConnectContext.get().getExecTimeout());
+            loadJob.setTimeout(ConnectContext.get().getExecTimeoutS());
             createLoadJob(loadJob);
         } catch (MetaNotFoundException e) {
             throw new DdlException(e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -299,7 +299,7 @@ public abstract class ExternalCatalog
             } else {
                 if (!Env.getCurrentEnv().isMaster()) {
                     // Forward to master and wait the journal to replay.
-                    int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeout();
+                    int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeoutS();
                     MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(waitTimeOut * 1000);
                     try {
                         remoteExecutor.forward(id, -1);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -174,7 +174,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             } else {
                 if (!Env.getCurrentEnv().isMaster()) {
                     // Forward to master and wait the journal to replay.
-                    int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeout();
+                    int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeoutS();
                     MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(waitTimeOut * 1000);
                     try {
                         remoteExecutor.forward(extCatalog.getId(), id);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -585,7 +585,7 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             deleteJob.setCountDownLatch(new MarkedCountDownLatch<>((int) replicaNum));
             ConnectContext connectContext = ConnectContext.get();
             if (connectContext != null) {
-                deleteJob.setTimeoutS(connectContext.getExecTimeout());
+                deleteJob.setTimeoutS(connectContext.getExecTimeoutS());
             }
             return deleteJob;
         }
@@ -622,7 +622,7 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             deleteJob.setCountDownLatch(new MarkedCountDownLatch<>((int) replicaNum));
             ConnectContext connectContext = ConnectContext.get();
             if (connectContext != null) {
-                deleteJob.setTimeoutS(connectContext.getExecTimeout());
+                deleteJob.setTimeoutS(connectContext.getExecTimeoutS());
             }
             return deleteJob;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -333,7 +333,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
                 break;
             case INSERT:
                 timeout = Optional.ofNullable(ConnectContext.get())
-                                    .map(ConnectContext::getExecTimeout)
+                                    .map(ConnectContext::getExecTimeoutS)
                                     .orElse(Config.insert_load_default_timeout_second);
                 break;
             case MINI:

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
@@ -213,7 +213,7 @@ public class LoadingTaskPlanner {
                 ? false : Config.enable_single_replica_load;
         OlapTableSink olapTableSink = new OlapTableSink(table, destTupleDesc, partitionIds,
                 enableSingleReplicaLoad);
-        long txnTimeout = timeoutS == 0 ? ConnectContext.get().getExecTimeout() : timeoutS;
+        long txnTimeout = timeoutS == 0 ? ConnectContext.get().getExecTimeoutS() : timeoutS;
         olapTableSink.init(loadId, txnId, dbId, timeoutS, sendBatchParallelism, singleTabletLoadPerSink, strictMode,
                 txnTimeout);
         olapTableSink.setPartialUpdateInputColumns(isPartialUpdate, partialUpdateInputColumns);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -167,7 +167,7 @@ public class MysqlLoadManager {
         List<String> filePaths = dataDesc.getFilePaths();
         String database = ClusterNamespace.getNameFromFullName(dataDesc.getDbName());
         String table = dataDesc.getTableName();
-        int oldTimeout = context.getExecTimeout();
+        int oldTimeout = context.getExecTimeoutS();
         int newTimeOut = extractTimeOut(dataDesc);
         if (newTimeOut > oldTimeout) {
             // set query timeout avoid by killed TimeoutChecker

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadingTaskPlanner.java
@@ -148,7 +148,7 @@ public class NereidsLoadingTaskPlanner {
         PartitionNames partitionNames = getPartitionNames();
         LogicalPlan streamLoadPlan = NereidsLoadUtils.createLoadPlan(fileGroupInfo, partitionNames, context,
                 isPartialUpdate);
-        long txnTimeout = timeoutS == 0 ? ConnectContext.get().getExecTimeout() : timeoutS;
+        long txnTimeout = timeoutS == 0 ? ConnectContext.get().getExecTimeoutS() : timeoutS;
         if (txnTimeout > Integer.MAX_VALUE) {
             txnTimeout = Integer.MAX_VALUE;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -143,7 +143,7 @@ public abstract class AbstractInsertExecutor {
         QeProcessorImpl.INSTANCE.registerQuery(ctx.queryId(), queryInfo);
         executor.updateProfile(false);
         coordinator.exec();
-        int execTimeout = ctx.getExecTimeout();
+        int execTimeout = ctx.getExecTimeoutS();
         if (LOG.isDebugEnabled()) {
             LOG.debug("insert [{}] with query id {} execution timeout is {}", labelName, queryId, execTimeout);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
@@ -191,7 +191,7 @@ public class InsertUtils {
         }
         TTxnParams txnConf = txnEntry.getTxnConf();
         SessionVariable sessionVariable = ctx.getSessionVariable();
-        long timeoutSecond = ctx.getExecTimeout();
+        long timeoutSecond = ctx.getExecTimeoutS();
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         Database dbObj = Env.getCurrentInternalCatalog()
                 .getDbOrException(dbName, s -> new AnalysisException("database is invalid for dbName: " + s));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -97,7 +97,7 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
                     new TxnCoordinator(TxnSourceType.FE, 0,
                             FrontendOptions.getLocalHostAddress(),
                             ExecuteEnv.getInstance().getStartupTime()),
-                    LoadJobSourceType.INSERT_STREAMING, ctx.getExecTimeout());
+                    LoadJobSourceType.INSERT_STREAMING, ctx.getExecTimeoutS());
         } catch (Exception e) {
             throw new AnalysisException("begin transaction failed. " + e.getMessage(), e);
         }
@@ -306,7 +306,7 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
     }
 
     public long getTimeout() {
-        return ctx.getExecTimeout();
+        return ctx.getExecTimeoutS();
     }
 
     private boolean isGroupCommitHttpStream() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -324,7 +324,7 @@ public class StreamLoadPlanner {
         } else {
             olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds, enableSingleReplicaLoad);
         }
-        int txnTimeout = timeout == 0 ? ConnectContext.get().getExecTimeout() : timeout;
+        int txnTimeout = timeout == 0 ? ConnectContext.get().getExecTimeoutS() : timeout;
         olapTableSink.init(loadId, taskInfo.getTxnId(), db.getId(), timeout, taskInfo.getSendBatchParallelism(),
                 taskInfo.isLoadToSingleTablet(), taskInfo.isStrictMode(), txnTimeout);
         olapTableSink.setPartialUpdateInfo(uniquekeyUpdateMode, partialUpdateInputColumns);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1077,9 +1077,9 @@ public class ConnectContext {
                 timeoutTag = "insert";
             }
             // to ms
-            long timeout = getExecTimeout() * 1000L;
+            long timeout = getExecTimeoutS() * 1000L;
             if (delta > timeout) {
-                LOG.warn("kill {} timeout, remote: {}, query timeout: {}, query id: {}",
+                LOG.warn("kill {} timeout, remote: {}, query timeout: {}ms, query id: {}",
                         timeoutTag, getRemoteHostPortString(), timeout, DebugUtil.printId(queryId));
                 killFlag = true;
             }
@@ -1121,7 +1121,7 @@ public class ConnectContext {
      *
      * @return exact execution timeout
      */
-    public int getExecTimeout() {
+    public int getExecTimeoutS() {
         if (executor != null && executor.isSyncLoadKindStmt()) {
             // particular for insert stmt, we can expand other type of timeout in the same way
             return Math.max(getInsertTimeoutS(), getQueryTimeoutS());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -411,8 +411,8 @@ public class Coordinator implements CoordInterface {
 
     private void initQueryOptions(ConnectContext context) {
         this.queryOptions = context.getSessionVariable().toThrift();
-        this.queryOptions.setQueryTimeout(context.getExecTimeout());
-        this.queryOptions.setExecutionTimeout(context.getExecTimeout());
+        this.queryOptions.setQueryTimeout(context.getExecTimeoutS());
+        this.queryOptions.setExecutionTimeout(context.getExecTimeoutS());
         if (this.queryOptions.getExecutionTimeout() < 1) {
             LOG.info("try set timeout less than 1", new RuntimeException(""));
         }
@@ -948,7 +948,7 @@ public class Coordinator implements CoordInterface {
             long currentTimeMillis = System.currentTimeMillis();
             long elapsed = (currentTimeMillis - timeoutDeadline) / 1000 + queryOptions.getExecutionTimeout();
             String msg = String.format(
-                    "timeout before waiting %s rpc, query timeout:%d, already elapsed:%d, left for this:%d",
+                    "timeout before waiting %s rpc, query timeout:%d seconds, already elapsed:%d seconds, left for this:%d ms",
                     operation, queryOptions.getExecutionTimeout(), elapsed, leftTimeMs);
             LOG.warn("Query {} {}", DebugUtil.printId(queryId), msg);
             if (!queryOptions.isSetExecutionTimeout() || !queryOptions.isSetQueryTimeout()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -948,7 +948,7 @@ public class Coordinator implements CoordInterface {
             long currentTimeMillis = System.currentTimeMillis();
             long elapsed = (currentTimeMillis - timeoutDeadline) / 1000 + queryOptions.getExecutionTimeout();
             String msg = String.format(
-                    "timeout before waiting %s rpc, query timeout:%d seconds, already elapsed:%d seconds, left for this:%d ms",
+                    "timeout before waiting %s rpc, query timeout:%d sec, already elapsed:%d sec, left for this:%d ms",
                     operation, queryOptions.getExecutionTimeout(), elapsed, leftTimeMs);
             LOG.warn("Query {} {}", DebugUtil.printId(queryId), msg);
             if (!queryOptions.isSetExecutionTimeout() || !queryOptions.isSetQueryTimeout()) {
@@ -1006,7 +1006,7 @@ public class Coordinator implements CoordInterface {
             } catch (TimeoutException e) {
                 exception = e;
                 errMsg = String.format(
-                    "timeout when waiting for %s rpc, query timeout:%d, left timeout for this operation:%d",
+                    "timeout when waiting for %s rpc, query timeout:%d sec, timeout for this operation:%d sec",
                                             operation, queryOptions.getExecutionTimeout(), timeoutMs / 1000);
                 LOG.warn("Query {} {}", DebugUtil.printId(queryId), errMsg);
                 code = TStatusCode.TIMEOUT;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
@@ -328,8 +328,8 @@ public class CoordinatorContext {
     private static TQueryOptions initQueryOptions(ConnectContext context) {
         TQueryOptions queryOptions = context.getSessionVariable().toThrift();
         queryOptions.setBeExecVersion(Config.be_exec_version);
-        queryOptions.setQueryTimeout(context.getExecTimeout());
-        queryOptions.setExecutionTimeout(context.getExecTimeout());
+        queryOptions.setQueryTimeout(context.getExecTimeoutS());
+        queryOptions.setExecutionTimeout(context.getExecTimeoutS());
         if (queryOptions.getExecutionTimeout() < 1) {
             LOG.info("try set timeout less than 1", new RuntimeException(""));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
@@ -68,7 +68,7 @@ public class FEOpExecutor {
         this.feAddr = feAddress;
         this.originStmt = originStmt;
         this.ctx = ctx;
-        this.thriftTimeoutMs = (int) (ctx.getExecTimeout() * 1000 * RPC_TIMEOUT_COEFFICIENT);
+        this.thriftTimeoutMs = (int) (ctx.getExecTimeoutS() * 1000 * RPC_TIMEOUT_COEFFICIENT);
         // if isQuery=false, we shouldn't retry twice when catch exception because of Idempotency
         this.shouldNotRetry = !isQuery;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -40,7 +40,7 @@ public class MasterOpExecutor extends FEOpExecutor {
         super(new TNetworkAddress(ctx.getEnv().getMasterHost(), ctx.getEnv().getMasterRpcPort()),
                 originStmt, ctx, isQuery);
         if (status.isNeedToWaitJournalSync()) {
-            this.journalWaitTimeoutMs = (int) (ctx.getExecTimeout() * 1000 * RPC_TIMEOUT_COEFFICIENT);
+            this.journalWaitTimeoutMs = (int) (ctx.getExecTimeoutS() * 1000 * RPC_TIMEOUT_COEFFICIENT);
         } else {
             this.journalWaitTimeoutMs = 0;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterTxnExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterTxnExecutor.java
@@ -41,8 +41,8 @@ public class MasterTxnExecutor {
 
     public MasterTxnExecutor(ConnectContext ctx) {
         this.ctx = ctx;
-        this.waitTimeoutMs = ctx.getExecTimeout() * 1000;
-        this.thriftTimeoutMs = ctx.getExecTimeout() * 1000;
+        this.waitTimeoutMs = ctx.getExecTimeoutS() * 1000;
+        this.thriftTimeoutMs = ctx.getExecTimeoutS() * 1000;
     }
 
     private TNetworkAddress getMasterAddress() throws TException {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2322,7 +2322,7 @@ public class StmtExecutor {
         TransactionEntry txnEntry = context.getTxnEntry();
         TTxnParams txnConf = txnEntry.getTxnConf();
         SessionVariable sessionVariable = context.getSessionVariable();
-        long timeoutSecond = context.getExecTimeout();
+        long timeoutSecond = context.getExecTimeoutS();
 
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         Database dbObj = Env.getCurrentInternalCatalog()
@@ -2500,9 +2500,9 @@ public class StmtExecutor {
                     coord.getQueryOptions().setEnableMemtableOnSinkNode(isEnableMemtableOnSinkNode);
                 }
                 coord.exec();
-                int execTimeout = context.getExecTimeout();
+                int execTimeout = context.getExecTimeoutS();
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Insert {} execution timeout:{}", DebugUtil.printId(context.queryId()), execTimeout);
+                    LOG.debug("Insert {} execution timeout:{}ms", DebugUtil.printId(context.queryId()), execTimeout);
                 }
                 boolean notTimeout = coord.join(execTimeout);
                 if (!coord.isDone()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/PipelineExecutionTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/PipelineExecutionTask.java
@@ -154,7 +154,8 @@ public class PipelineExecutionTask extends AbstractRuntimeTask<Long, MultiFragme
             long currentTimeMillis = System.currentTimeMillis();
             long elapsed = (currentTimeMillis - timeoutDeadline) / 1000 + queryOptions.getExecutionTimeout();
             String msg = String.format(
-                    "timeout before waiting %s rpc, query timeout:%d seconds, already elapsed:%d seconds, left for this:%d ms",
+                    "timeout before waiting %s rpc, query timeout:%d sec, already elapsed:%d sec, "
+                    + "left for this:%d ms",
                     operation, queryOptions.getExecutionTimeout(), elapsed, leftTimeMs);
             LOG.warn("Query {} {}", DebugUtil.printId(queryId), msg);
             if (!queryOptions.isSetExecutionTimeout() || !queryOptions.isSetQueryTimeout()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/PipelineExecutionTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/PipelineExecutionTask.java
@@ -154,7 +154,7 @@ public class PipelineExecutionTask extends AbstractRuntimeTask<Long, MultiFragme
             long currentTimeMillis = System.currentTimeMillis();
             long elapsed = (currentTimeMillis - timeoutDeadline) / 1000 + queryOptions.getExecutionTimeout();
             String msg = String.format(
-                    "timeout before waiting %s rpc, query timeout:%d, already elapsed:%d, left for this:%d",
+                    "timeout before waiting %s rpc, query timeout:%d seconds, already elapsed:%d seconds, left for this:%d ms",
                     operation, queryOptions.getExecutionTimeout(), elapsed, leftTimeMs);
             LOG.warn("Query {} {}", DebugUtil.printId(queryId), msg);
             if (!queryOptions.isSetExecutionTimeout() || !queryOptions.isSetQueryTimeout()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/query/QueryStatsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/query/QueryStatsUtil.java
@@ -177,7 +177,7 @@ public class QueryStatsUtil {
             }
             FrontendService.Client client = null;
             try {
-                int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeout();
+                int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeoutS();
                 client = ClientPool.frontendPool.borrowObject(new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
                         waitTimeOut * 1000);
                 TQueryStatsResult other = client.getQueryStats(request);

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -786,7 +786,7 @@ public class MetadataGenerator {
         List<Pair<String, Integer>> frontends = FrontendsProcNode.getFrontendWithRpcPort(Env.getCurrentEnv(), false);
 
         FrontendService.Client client = null;
-        int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeout();
+        int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeoutS();
         for (Pair<String, Integer> fe : frontends) {
             TNetworkAddress thriftAddress = new TNetworkAddress(fe.key(), fe.value());
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionEntry.java
@@ -206,7 +206,7 @@ public class TransactionEntry {
         }
         DatabaseIf database = table.getDatabase();
         if (!isTransactionBegan) {
-            long timeoutSecond = ConnectContext.get().getExecTimeout();
+            long timeoutSecond = ConnectContext.get().getExecTimeoutS();
             this.timeoutTimestamp = System.currentTimeMillis() + timeoutSecond * 1000;
             if (Env.getCurrentEnv().isMaster() || Config.isCloudMode()) {
                 this.transactionId = Env.getCurrentGlobalTransactionMgr().beginTransaction(

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -178,13 +178,13 @@ public class ConnectContextTest {
         // sleep no time out
         Assert.assertFalse(ctx.isKilled());
         ctx.setExecutor(executor);
-        long now = ctx.getExecTimeout() * 1000L - 1;
+        long now = ctx.getExecTimeoutS() * 1000L - 1;
         ctx.checkTimeout(now);
         Assert.assertFalse(ctx.isKilled());
 
         // Timeout
         ctx.setExecutor(executor);
-        now = ctx.getExecTimeout() * 1000L + 1;
+        now = ctx.getExecTimeoutS() * 1000L + 1;
         ctx.checkTimeout(now);
         Assert.assertFalse(ctx.isKilled());
 


### PR DESCRIPTION
### What problem does this PR solve?

timeout unit in FE have different values, sometimes it is Second, sometimes it is milliseconds. We should add the unit info in API and print it in log.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

