### PR TITLE
[fix](nereids) fix parse date time exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -2962,7 +2962,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     return Config.enable_date_conversion ? new DateTimeV2Literal(value) : new DateTimeLiteral(value);
                 } catch (Exception e) {
                     return new Cast(Literal.of(value),
-                            Config.enable_date_conversion ? DateTimeV2Type.MAX: DateTimeType.INSTANCE);
+                            Config.enable_date_conversion ? DateTimeV2Type.MAX : DateTimeType.INSTANCE);
                 }
             case "DATEV2":
                 try {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -2954,27 +2954,27 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                 try {
                     return Config.enable_date_conversion ? new DateV2Literal(value) : new DateLiteral(value);
                 } catch (Exception e) {
-                    return new Cast(Literal.of(value),
+                    return new Cast(new StringLiteral(value),
                             Config.enable_date_conversion ? DateV2Type.INSTANCE : DateType.INSTANCE);
                 }
             case "TIMESTAMP":
                 try {
                     return Config.enable_date_conversion ? new DateTimeV2Literal(value) : new DateTimeLiteral(value);
                 } catch (Exception e) {
-                    return new Cast(Literal.of(value),
+                    return new Cast(new StringLiteral(value),
                             Config.enable_date_conversion ? DateTimeV2Type.MAX : DateTimeType.INSTANCE);
                 }
             case "DATEV2":
                 try {
                     return new DateV2Literal(value);
                 } catch (Exception e) {
-                    return new Cast(Literal.of(value), DateV2Type.INSTANCE);
+                    return new Cast(new StringLiteral(value), DateV2Type.INSTANCE);
                 }
             case "DATEV1":
                 try {
                     return new DateLiteral(value);
                 } catch (Exception e) {
-                    return new Cast(Literal.of(value), DateType.INSTANCE);
+                    return new Cast(new StringLiteral(value), DateType.INSTANCE);
                 }
             default:
                 throw new ParseException("Unsupported data type : " + type, ctx);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -890,6 +890,10 @@ import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.types.DateType;
+import org.apache.doris.nereids.types.DateV2Type;
 import org.apache.doris.nereids.types.LargeIntType;
 import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.StructField;
@@ -2941,19 +2945,37 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     }
 
     @Override
-    public Literal visitTypeConstructor(TypeConstructorContext ctx) {
+    public Expression visitTypeConstructor(TypeConstructorContext ctx) {
         String value = ctx.STRING_LITERAL().getText();
         value = value.substring(1, value.length() - 1);
         String type = ctx.type.getText().toUpperCase();
         switch (type) {
             case "DATE":
-                return Config.enable_date_conversion ? new DateV2Literal(value) : new DateLiteral(value);
+                try {
+                    return Config.enable_date_conversion ? new DateV2Literal(value) : new DateLiteral(value);
+                } catch (Exception e) {
+                    return new Cast(Literal.of(value),
+                            Config.enable_date_conversion ? DateV2Type.INSTANCE : DateType.INSTANCE);
+                }
             case "TIMESTAMP":
-                return Config.enable_date_conversion ? new DateTimeV2Literal(value) : new DateTimeLiteral(value);
+                try {
+                    return Config.enable_date_conversion ? new DateTimeV2Literal(value) : new DateTimeLiteral(value);
+                } catch (Exception e) {
+                    return new Cast(Literal.of(value),
+                            Config.enable_date_conversion ? DateTimeV2Type.MAX: DateTimeType.INSTANCE);
+                }
             case "DATEV2":
-                return new DateV2Literal(value);
+                try {
+                    return new DateV2Literal(value);
+                } catch (Exception e) {
+                    return new Cast(Literal.of(value), DateV2Type.INSTANCE);
+                }
             case "DATEV1":
-                return new DateLiteral(value);
+                try {
+                    return new DateLiteral(value);
+                } catch (Exception e) {
+                    return new Cast(Literal.of(value), DateType.INSTANCE);
+                }
             default:
                 throw new ParseException("Unsupported data type : " + type, ctx);
         }

--- a/regression-test/suites/nereids_syntax_p0/test_cast_datetime.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_cast_datetime.groovy
@@ -53,6 +53,10 @@ suite("test_cast_datetime") {
     qt_3 "select a, '' = mydate, '' = mydatev2, '' = mydatetime, '' = mydatetimev2 from casttbl"
 
     def wrong_date_strs = [
+        "date '2020-01'",
+        "datev1 '2020-01'",
+        "datev2 '2020-01'",
+        "timestamp '2020-01'",
         "'' > date '2019-06-01'",
         "'' > date_sub('2019-06-01', -10)",
         "'' > cast('2019-06-01 00:00:00' as datetime)",

--- a/regression-test/suites/nereids_syntax_p0/test_cast_datetime.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_cast_datetime.groovy
@@ -576,5 +576,15 @@ suite("test_cast_datetime") {
             sql "select date_add('2023-11-05 01:30:00 America/New_York', INTERVAL 1 DAY)"
             result([[LocalDateTime.parse('2023-11-06T01:30:00')]])
         }
+
+        test {
+            sql "select date '2025年1月20日'"
+            result([[Date.valueOf('2025-01-20')]])
+        }
+
+        test {
+            sql "select timestamp '2025年1月20日10时20分5秒'"
+            result([[LocalDateTime.parse('2025-01-20T10:20:05')]])
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

before this pr:

```
MySQL root@127.0.0.1:(none)> select date '2025年1月20日';
(1105, 'errCode = 2, detailMessage = date/datetime literal [2025年1月20日] is invalid')
```

after this pr:

```
MySQL root@127.0.0.1:(none)> select date '2025年1月20日';
+----------------------+
| date '2025年1月20日' |
+----------------------+
| 2025-01-20           |
+----------------------+
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

