### PR TITLE
[fix](Nereids) could not work well when check precision for null literal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/SearchSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/SearchSignature.java
@@ -152,7 +152,9 @@ public class SearchSignature {
                 finalType = DecimalV3Type.forType(arguments.get(i).getDataType());
             } else {
                 Expression arg = arguments.get(i);
-                if (arg.isLiteral() && arg.getDataType().isIntegralType()) {
+                if (arg.isNullLiteral()) {
+                    // do nothing
+                } else if (arg.isLiteral() && arg.getDataType().isIntegralType()) {
                     // create decimalV3 with minimum scale enough to hold the integral literal
                     finalType = DecimalV3Type.createDecimalV3Type(new BigDecimal(((Literal) arg).getStringValue()));
                 } else {

--- a/regression-test/suites/nereids_syntax_p0/decimal_percision_compute.groovy
+++ b/regression-test/suites/nereids_syntax_p0/decimal_percision_compute.groovy
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("decimal_precision") {
+
+    sql """
+        CREATE TABLE IF NOT EXISTS test_null_literal_compute (
+            id INT,
+            name VARCHAR(50),
+            age INT,
+            score DECIMAL(5,2),
+            create_time DATETIME,
+            is_active BOOLEAN
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 10
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    sql """
+        INSERT INTO test_null_literal_compute VALUES 
+        (1, 'Alice', 25, 89.5, '2023-01-01 10:00:00', true),
+        (2, 'Bob', 30, 76.2, '2023-01-02 11:00:00', true),
+        (3, 'Charlie', 22, 92.0, '2023-01-03 12:00:00', false),
+        (4, 'David', 28, 85.7, '2023-01-04 13:00:00', true),
+        (5, 'Eve', 35, 67.8, '2023-01-05 14:00:00', false);
+    """
+
+    sql """
+        SELECT name, age, LAG(age, 1) OVER (ORDER BY id) AS prev_age FROM test_null_literal_compute;
+    """
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

we use Literal#stringValue to generate decimal object. however, null literal could not return valid decimal string, so we should process it specially.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

