### PR TITLE
[Fix](cloud tablet stat) Fix show data return zero in cloud

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3504,7 +3504,11 @@ public class Config extends ConfigBase {
             "In cloud mode, the retry number when the FE requests the meta service times out is 1 by default"})
     public static int meta_service_rpc_timeout_retry_times = 1;
 
-    // ATTN: DONOT add any config not related to cloud mode here
+    @ConfField(description = {"存算分离模式下FE启动后，fe是否等待CloudTabletStatMgr从ms同步完成一次tablet stat信息，默认为true",
+        "After FE starts in cloud mode, does FE wait for CloudTabletStatMgr to synchronize the tablet stat information "
+            + "from MS once? The default value is true"})
+    public static boolean cloud_enable_wait_tablet_stat_sync = true;
+
     // ATTN: DONOT add any config not related to cloud mode here
     // ATTN: DONOT add any config not related to cloud mode here
     //==========================================================================

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -426,7 +426,7 @@ public class Env {
     protected boolean isElectable;
     // set to true after finished replay all meta and ready to serve
     // set to false when catalog is not ready.
-    private AtomicBoolean isReady = new AtomicBoolean(false);
+    protected AtomicBoolean isReady = new AtomicBoolean(false);
     // set to true after http server start
     private AtomicBoolean httpReady = new AtomicBoolean(false);
     // set to true if FE can offer READ service.
@@ -446,7 +446,7 @@ public class Env {
 
     private MetaIdGenerator idGenerator = new MetaIdGenerator(NEXT_ID_INIT_VALUE);
 
-    private EditLog editLog;
+    protected EditLog editLog;
     protected int clusterId;
     protected String token;
     // For checkpoint and observer memory replayed marker


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The statistical information on the cloud is obtained by FE actively sending RPC requests to MS after startup.

In the following scenario,
There are too many databases and tables, or there is a conflict in obtaining the readlock of a certain table,
CloudTabletStatMgr has been stuck for a while, showing data requests to fe, but runAfterCatalogReady has not completed one round, Show data returns 0
 
The repair method is to set a flag 
After completing one round of runAfterCatalogReady, let fe truly be ready

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

