### PR TITLE
[fix](external)Fix potential concurrency issues that may occur during the "show proc" operation

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/DbsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/DbsProcDirTest.java
@@ -21,11 +21,18 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.datasource.iceberg.IcebergExternalDatabase;
+import org.apache.doris.datasource.iceberg.IcebergHadoopExternalCatalog;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.collect.Lists;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
@@ -33,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 public class DbsProcDirTest {
@@ -251,5 +259,38 @@ public class DbsProcDirTest {
                 result.getColumnNames());
         List<List<String>> rows = Lists.newArrayList();
         Assert.assertEquals(rows, result.getRows());
+    }
+
+    @Test
+    public void testListTableNameFailed() throws AnalysisException {
+        HashMap<String, String> props = new HashMap<>();
+        props.put("warehouse", "file:///tmp");
+        IcebergHadoopExternalCatalog ctlg = new IcebergHadoopExternalCatalog(1, "iceberg", "iceberg", props, null);
+        new MockUp<ExternalCatalog>(ExternalCatalog.class) {
+            @Mock
+            public List<String> getDbNames() {
+                return Lists.newArrayList("db1");
+            }
+
+            @Mock
+            public ExternalDatabase<? extends ExternalTable> getDbNullable(String dbName) {
+                return new IcebergExternalDatabase(ctlg, 3L, "db1", "db1");
+            }
+        };
+
+        new MockUp<ExternalDatabase>(ExternalDatabase.class) {
+            @Mock
+            public List getTables() {
+                throw new RuntimeException("list table failed");
+            }
+        };
+        DbsProcDir dbsProcDir = new DbsProcDir(env, ctlg);
+        ProcResult procResult = dbsProcDir.fetchResult();
+        List<List<String>> rows = procResult.getRows();
+        Assert.assertEquals(1, rows.size());
+        List<String> strings = rows.get(0);
+        Assert.assertEquals("3", strings.get(0));  // id
+        Assert.assertEquals("db1", strings.get(1)); // name
+        Assert.assertEquals("-1", strings.get(2)); // tableNum
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In `show proc`, the code first retrieves all databases under the catalog and then fetches all tables within a specific database. However, between these two operations, another thread might delete the database, causing an exception when attempting to retrieve its tables.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

