### PR TITLE
[fix](cooldown) allow cooldown_ttl = 0 when altering storage policy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -304,6 +304,7 @@ public class StoragePolicy extends Policy {
             LOG.error("cooldownTtl can't be less than 0");
             throw new AnalysisException("cooldownTtl can't be less than 0");
         }
+
         return cooldownTtlSeconds;
     }
 
@@ -346,10 +347,10 @@ public class StoragePolicy extends Policy {
             }
         }
 
-        if (cooldownTtlMs > 0 && cooldownTimestampMs > 0) {
+        if (cooldownTtlMs >= 0 && cooldownTimestampMs >= 0) {
             throw new AnalysisException(COOLDOWN_DATETIME + " and " + COOLDOWN_TTL + " can't be set together.");
         }
-        if (cooldownTtlMs <= 0 && cooldownTimestampMs <= 0) {
+        if (cooldownTtlMs < 0 && cooldownTimestampMs < 0) {
             throw new AnalysisException(COOLDOWN_DATETIME + " or " + COOLDOWN_TTL + " must be set");
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -304,7 +304,6 @@ public class StoragePolicy extends Policy {
             LOG.error("cooldownTtl can't be less than 0");
             throw new AnalysisException("cooldownTtl can't be less than 0");
         }
-
         return cooldownTtlSeconds;
     }
 


### PR DESCRIPTION
mysql> ALTER STORAGE POLICY s3_db PROPERTIES ("cooldown_ttl" = "0");
ERROR 1105 (HY000): errCode = 2, detailMessage = cooldown_datetime or cooldown_ttl must be set

