### PR TITLE
[fix](s3Client) Add `ca_cert_file_paths` conf for stsClient` and recycler

### DIFF
--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -158,7 +158,6 @@ private:
             const S3ClientConf& s3_conf);
 
     S3ClientFactory();
-    static std::string get_valid_ca_cert_path();
 
     Aws::SDKOptions _aws_options;
     std::mutex _lock;

--- a/be/test/io/fs/s3_obj_stroage_client_mock_test.cpp
+++ b/be/test/io/fs/s3_obj_stroage_client_mock_test.cpp
@@ -24,6 +24,7 @@
 #include "gmock/gmock.h"
 #include "io/fs/s3_obj_storage_client.h"
 #include "util/s3_util.h"
+#include "util/string_util.h"
 
 using namespace Aws::S3::Model;
 
@@ -117,5 +118,11 @@ TEST_F(S3ObjStorageClientMockTest, list_objects_with_pagination) {
     EXPECT_EQ(response.status.code, ErrorCode::OK);
     EXPECT_EQ(files.size(), 5);
     files.clear();
+}
+
+TEST_F(S3ObjStorageClientMockTest, test_ca_cert) {
+    auto path = doris::get_valid_ca_cert_path(doris::split(config::ca_cert_file_paths, ";"));
+    LOG(INFO) << "config:" << config::ca_cert_file_paths << " path:" << path;
+    ASSERT_FALSE(path.empty());
 }
 } // namespace doris::io

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -293,4 +293,10 @@ CONF_Strings(recycler_storage_vault_white_list, "");
 //    Trace = 6
 CONF_Int32(aws_log_level, "2");
 
+// ca_cert_file is in this path by default, Normally no modification is required
+// ca cert default path is different from different OS
+CONF_mString(ca_cert_file_paths,
+             "/etc/pki/tls/certs/ca-bundle.crt;/etc/ssl/certs/ca-certificates.crt;"
+             "/etc/ssl/ca-bundle.pem");
+
 } // namespace doris::cloud::config

--- a/cloud/src/recycler/s3_accessor.h
+++ b/cloud/src/recycler/s3_accessor.h
@@ -139,6 +139,7 @@ protected:
 
     S3Conf conf_;
     std::shared_ptr<ObjStorageClient> obj_client_;
+    std::string _ca_cert_file_path;
 };
 
 class GcsAccessor final : public S3Accessor {

--- a/cloud/test/util_test.cpp
+++ b/cloud/test/util_test.cpp
@@ -29,6 +29,7 @@
 #include "common/logging.h"
 #include "common/simple_thread_pool.h"
 #include "common/string_util.h"
+#include "cpp/aws_common.h"
 #include "cpp/sync_point.h"
 #include "gtest/gtest.h"
 #include "recycler/recycler.h"
@@ -324,4 +325,10 @@ TEST(UtilTest, test_sync_executor) {
     EXPECT_EQ(1, res.size());
     EXPECT_EQ(finished, true);
     std::for_each(res.begin(), res.end(), [](auto&& n) { EXPECT_EQ(0, n); });
+}
+
+TEST(UtilTest, test_split) {
+    auto path = doris::get_valid_ca_cert_path(doris::cloud::split(config::ca_cert_file_paths, ';'));
+    LOG(INFO) << "config:" << config::ca_cert_file_paths << " path:" << path;
+    ASSERT_FALSE(path.empty());
 }

--- a/common/cpp/aws_common.cpp
+++ b/common/cpp/aws_common.cpp
@@ -37,4 +37,12 @@ CredProviderType cred_provider_type_from_pb(cloud::CredProviderTypePB cred_provi
     }
 }
 
+std::string get_valid_ca_cert_path(const std::vector<std::string>& ca_cert_file_paths) {
+    for (const auto& path : ca_cert_file_paths) {
+        if (std::filesystem::exists(path)) {
+            return path;
+        }
+    }
+    return "";
+}
 }

--- a/common/cpp/aws_common.h
+++ b/common/cpp/aws_common.h
@@ -19,9 +19,14 @@
 
 #include <gen_cpp/cloud.pb.h>
 
+#include <filesystem>
+
 namespace doris {
     //AWS Credentials Provider Type
     enum class CredProviderType { Default = 0, Simple = 1, InstanceProfile = 2 };
 
     CredProviderType cred_provider_type_from_pb(cloud::CredProviderTypePB cred_provider_type);
-}
+
+    std::string get_valid_ca_cert_path(const std::vector<std::string>& ca_cert_file_paths);
+
+    } // namespace doris


### PR DESCRIPTION

* https://github.com/apache/doris/pull/32285 In previous, the pr add a `ca_cert_file_paths` config for be s3Client, but lack of recycler and stsClient

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

