### PR TITLE
branch-2.1: [enhance](mtmv)add debug log for insert into plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -306,6 +306,10 @@ public class InsertIntoTableCommand extends Command implements ForwardWithSync, 
             // TODO: support other table types
             throw new AnalysisException("insert into command only support [olap, hive, iceberg, jdbc] table");
         }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("insert into plan for query_id: {} is: {}.", DebugUtil.printId(ctx.queryId()),
+                    planner.getPhysicalPlan().treeString());
+        }
         return new BuildInsertExecutorResult(planner, insertExecutor, sink, physicalSink);
     }
 


### PR DESCRIPTION
pick:https://github.com/apache/doris/pull/50842

2025-05-14 12:04:37,360 DEBUG (mtmv-task-execute-1-thread-2|348) [InsertIntoTableCommand.initPlanOnce():310] insert into plan for query_id: 109349a72c5b4541-9f47f0a97573495c is: LogicalOlapTableSink[93] ( outputExprs=[k2#6, k3#7], database=zd, targetTable=mv1, cols=[`k2` tinyint NULL, `k3` int NOT NULL], partitionIds=[11008], singleReplicaLoad=false, isPartialUpdate=false, dmlCommandType=NONE )
+--PhysicalEmptyRelation ( projects=[k2#4 AS `k2`#6, k3#5 AS `k3`#7] ).