### PR TITLE
[fix](Nereids) we should also push down expr in join's mark conjuncts

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownExpressionsInHashCondition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownExpressionsInHashCondition.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.Alias;
@@ -62,8 +63,19 @@ public class PushDownExpressionsInHashCondition extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
         return logicalJoin()
-                .when(join -> join.getHashJoinConjuncts().stream().anyMatch(equalTo ->
-                        equalTo.children().stream().anyMatch(e -> !(e instanceof Slot))))
+                .when(join -> {
+                    boolean needProcessHashConjuncts = join.getHashJoinConjuncts().stream()
+                            .anyMatch(equalTo -> equalTo.children().stream()
+                                    .anyMatch(e -> !(e instanceof Slot)));
+                    List<Slot> leftSlots = join.left().getOutput();
+                    List<Slot> rightSlots = join.right().getOutput();
+                    Pair<List<Expression>, List<Expression>> pair = JoinUtils.extractExpressionForHashTable(
+                            leftSlots, rightSlots, join.getMarkJoinConjuncts());
+                    boolean needProcessMarkConjuncts = pair.first.stream()
+                            .anyMatch(equalTo -> equalTo.children().stream()
+                                    .anyMatch(e -> !(e instanceof Slot)));
+                    return needProcessHashConjuncts || needProcessMarkConjuncts;
+                })
                 .then(PushDownExpressionsInHashCondition::pushDownHashExpression)
                 .toRule(RuleType.PUSH_DOWN_EXPRESSIONS_IN_HASH_CONDITIONS);
     }
@@ -75,15 +87,20 @@ public class PushDownExpressionsInHashCondition extends OneRewriteRuleFactory {
             LogicalJoin<? extends Plan, ? extends Plan> join) {
         Set<NamedExpression> leftProjectExprs = Sets.newHashSet();
         Set<NamedExpression> rightProjectExprs = Sets.newHashSet();
-        Map<Expression, NamedExpression> exprReplaceMap = Maps.newHashMap();
+        Map<Expression, NamedExpression> replaceMap = Maps.newHashMap();
         join.getHashJoinConjuncts().forEach(conjunct -> {
             Preconditions.checkArgument(conjunct instanceof EqualPredicate);
             // sometimes: t1 join t2 on t2.a + 1 = t1.a + 2, so check the situation, but actually it
             // doesn't swap the two sides.
             conjunct = JoinUtils.swapEqualToForChildrenOrder((EqualPredicate) conjunct, join.left().getOutputSet());
-            generateReplaceMapAndProjectExprs(conjunct.child(0), exprReplaceMap, leftProjectExprs);
-            generateReplaceMapAndProjectExprs(conjunct.child(1), exprReplaceMap, rightProjectExprs);
+            generateReplaceMapAndProjectExprs(conjunct.child(0), replaceMap, leftProjectExprs);
+            generateReplaceMapAndProjectExprs(conjunct.child(1), replaceMap, rightProjectExprs);
         });
+        List<Expression> newHashConjuncts = join.getHashJoinConjuncts().stream()
+                .map(equalTo -> equalTo.withChildren(equalTo.children()
+                        .stream().map(expr -> replaceMap.get(expr).toSlot())
+                        .collect(ImmutableList.toImmutableList())))
+                .collect(ImmutableList.toImmutableList());
 
         // add other conjuncts used slots to project exprs
         Set<ExprId> leftExprIdSet = join.left().getOutputExprIdSet();
@@ -100,7 +117,28 @@ public class PushDownExpressionsInHashCondition extends OneRewriteRuleFactory {
         });
 
         // add mark conjuncts used slots to project exprs
-        join.getMarkJoinConjuncts().stream().flatMap(conjunct ->
+        // if mark conjuncts could be hash condition, normalize it
+        List<Slot> leftSlots = join.left().getOutput();
+        List<Slot> rightSlots = join.right().getOutput();
+        Pair<List<Expression>, List<Expression>> pair = JoinUtils.extractExpressionForHashTable(leftSlots,
+                rightSlots, join.getMarkJoinConjuncts());
+        pair.first.forEach(conjunct -> {
+            Preconditions.checkArgument(conjunct instanceof EqualPredicate);
+            // sometimes: t1 join t2 on t2.a + 1 = t1.a + 2, so check the situation, but actually it
+            // doesn't swap the two sides.
+            conjunct = JoinUtils.swapEqualToForChildrenOrder((EqualPredicate) conjunct, join.left().getOutputSet());
+            generateReplaceMapAndProjectExprs(conjunct.child(0), replaceMap, leftProjectExprs);
+            generateReplaceMapAndProjectExprs(conjunct.child(1), replaceMap, rightProjectExprs);
+        });
+        ImmutableList.Builder<Expression> newMarkConjunctsBuilder = ImmutableList.builder();
+        pair.first.stream()
+                .map(equalTo -> equalTo.withChildren(equalTo.children()
+                        .stream().map(expr -> replaceMap.get(expr).toSlot())
+                        .collect(ImmutableList.toImmutableList())))
+                .forEach(newMarkConjunctsBuilder::add);
+        newMarkConjunctsBuilder.addAll(pair.second);
+
+        pair.second.stream().flatMap(conjunct ->
                 conjunct.getInputSlots().stream()
         ).forEach(slot -> {
             if (leftExprIdSet.contains(slot.getExprId())) {
@@ -111,14 +149,9 @@ public class PushDownExpressionsInHashCondition extends OneRewriteRuleFactory {
                 rightProjectExprs.add(slot);
             }
         });
-
-        List<Expression> newHashConjuncts = join.getHashJoinConjuncts().stream()
-                .map(equalTo -> equalTo.withChildren(equalTo.children()
-                        .stream().map(expr -> exprReplaceMap.get(expr).toSlot())
-                        .collect(ImmutableList.toImmutableList())))
-                .collect(ImmutableList.toImmutableList());
-        return join.withHashJoinConjunctsAndChildren(
+        return join.withHashAndMarkJoinConjunctsAndChildren(
                 newHashConjuncts,
+                newMarkConjunctsBuilder.build(),
                 createChildProjectPlan(join.left(), join, leftProjectExprs),
                 createChildProjectPlan(join.right(), join, rightProjectExprs), join.getJoinReorderContext());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -426,8 +426,21 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
                 Optional.empty(), Optional.of(getLogicalProperties()), children, otherJoinReorderContext);
     }
 
-    public LogicalJoin<Plan, Plan> withHashJoinConjunctsAndChildren(
-            List<Expression> hashJoinConjuncts, Plan left, Plan right, JoinReorderContext otherJoinReorderContext) {
+    /**
+     * Creates a new LogicalJoin with updated hash join conjuncts, mark join conjuncts, and child plans.
+     *
+     * @param hashJoinConjuncts the list of hash join conjuncts used for hash-based join conditions.
+     * @param markJoinConjuncts the list of mark join conjuncts used for marking specific join conditions.
+     *                          These are typically used in semi-join or anti-join scenarios to track
+     *                          whether a condition is satisfied.
+     * @param left the left child plan.
+     * @param right the right child plan.
+     * @param otherJoinReorderContext the context for join reordering.
+     * @return a new LogicalJoin instance with the specified parameters.
+     */
+    public LogicalJoin<Plan, Plan> withHashAndMarkJoinConjunctsAndChildren(
+            List<Expression> hashJoinConjuncts, List<Expression> markJoinConjuncts,
+            Plan left, Plan right, JoinReorderContext otherJoinReorderContext) {
         Preconditions.checkArgument(children.size() == 2);
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,


### PR DESCRIPTION
### What problem does this PR solve?

mark conjuncts could also be hash join conditions, so we should also push down expr in them 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

