### PR TITLE
[fix](jdbc catalog) fix a jdbc catalog npe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -337,6 +337,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     }
 
     public void configureJdbcTable(JdbcTable jdbcTable, String tableName) {
+        makeSureInitialized();
         jdbcTable.setCatalogId(this.getId());
         jdbcTable.setExternalTableName(tableName);
         jdbcTable.setJdbcTypeName(this.getDatabaseTypeName());


### PR DESCRIPTION
We must add makeSureInitialized() in the fetchRowCount() method to ensure the initialization of catalog related resources.

```
java.lang.NullPointerException: Cannot invoke "org.apache.doris.datasource.jdbc.client.JdbcClient.getDbType()" because "this.jdbcClient" is null
    at org.apache.doris.datasource.jdbc.JdbcExternalCatalog.getDatabaseTypeName(JdbcExternalCatalog.java:160) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.datasource.jdbc.JdbcExternalCatalog.configureJdbcTable(JdbcExternalCatalog.java:342) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.tablefunction.JdbcQueryTableValueFunction.getScanNode(JdbcQueryTableValueFunction.java:55) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalTVFRelation(PhysicalPlanTranslator.java:942) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalTVFRelation(PhysicalPlanTranslator.java:245) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.trees.plans.physical.PhysicalTVFRelation.accept(PhysicalTVFRelation.java:117) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalResultSink(PhysicalPlanTranslator.java:403) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalResultSink(PhysicalPlanTranslator.java:245) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.trees.plans.physical.PhysicalResultSink.accept(PhysicalResultSink.java:72) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.translatePlan(PhysicalPlanTranslator.java:273) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.NereidsPlanner.splitFragments(NereidsPlanner.java:480) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.NereidsPlanner.distribute(NereidsPlanner.java:569) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.NereidsPlanner.lambda$plan$0(NereidsPlanner.java:158) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.NereidsPlanner.planWithLock(NereidsPlanner.java:233) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.NereidsPlanner.plan(NereidsPlanner.java:154) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.StmtExecutor.executeInternalQuery(StmtExecutor.java:3529) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.datasource.jdbc.JdbcExternalTable.getRowCount(JdbcExternalTable.java:231) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.datasource.jdbc.JdbcExternalTable.fetchRowCount(JdbcExternalTable.java:210) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.datasource.ExternalRowCountCache$RowCountCacheLoader.doLoad(ExternalRowCountCache.java:87) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.datasource.ExternalRowCountCache$RowCountCacheLoader.doLoad(ExternalRowCountCache.java:82) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.statistics.BasicAsyncCacheLoader.lambda$asyncLoad$0(BasicAsyncCacheLoader.java:39) ~[doris-fe.jar:1.2-SNAPSHOT]
    at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
    at java.lang.Thread.run(Thread.java:833) ~[?:?]
2025-04-29 07:30:25,586 WARN (NotCheckpointRowCountRefreshExecutor-48|190) [JdbcExternalTable.getRowCount():257] Failed to fetch row count for table test_lower_case_mtmv.external_lower_mtmv.table_test. Reason [Failed to execute internal SQL. java.lang.NullPointerException: Cannot invoke "org.apache.doris.datasource.jdbc.client.JdbcClient.getDbType()" because "this.jdbcClient" is null]
2025-04-29 07:30:25,587 WARN (mtmv-task-execute-1-thread-2|190) [CollectRelation.collectFromUnboundRelation():190] collect insert target table '[internal, EXTERNAL_LOWER_MTMV, MTMV_TEST]' more than once.
2025-04-29 07:30:25,588 WARN (mtmv-task-execute-1-thread-2|190) [InsertOverwriteTableCommand.run():241] insert into overwrite failed with task(or group) id 1745880283332
2025-04-29 07:30:25,603 ERROR (mtmv-task-execute-1-thread-2|190) [MTMVTask.run():234] Execution failed after retries: Cannot invoke "org.apache.doris.datasource.jdbc.client.JdbcClient.getColumnsFromJdbc(String, String)" because "this.jdbcClient" is null
```