### PR TITLE
[fix](auth)Only treat admin@% and root@% as system users.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
@@ -182,11 +182,11 @@ public class UserIdentity implements Writable, GsonPostProcessable {
     }
 
     public boolean isRootUser() {
-        return user.equals(Auth.ROOT_USER);
+        return this.equals(ROOT);
     }
 
     public boolean isAdminUser() {
-        return user.equals(Auth.ADMIN_USER);
+        return this.equals(ADMIN);
     }
 
     public boolean isSystemUser() {

--- a/regression-test/suites/account_p0/test_system_user.groovy
+++ b/regression-test/suites/account_p0/test_system_user.groovy
@@ -62,4 +62,42 @@ suite("test_system_user","p0,auth") {
         revoke select_priv on *.*.* from  `admin`;
     """
 
+     sql """
+          create user `root`@'8.8.8.8';
+      """
+     sql """
+         grant select_priv on *.*.* to  `root`@'8.8.8.8';
+     """
+     sql """
+         revoke select_priv on *.*.* from  `root`@'8.8.8.8';
+     """
+     test {
+               sql """
+                   grant 'operator' to `root`@'8.8.8.8';
+               """
+               exception "Can not grant role: operator"
+         }
+    sql """
+            drop user `root`@'8.8.8.8';
+        """
+
+    sql """
+          create user `admin`@'8.8.8.8';
+      """
+     sql """
+         grant select_priv on *.*.* to  `admin`@'8.8.8.8';
+     """
+     sql """
+         revoke select_priv on *.*.* from  `admin`@'8.8.8.8';
+     """
+
+   sql """
+       grant 'admin' to `admin`@'8.8.8.8';
+   """
+    sql """
+           revoke 'admin' from `admin`@'8.8.8.8';
+       """
+    sql """
+            drop user `admin`@'8.8.8.8';
+        """
 }


### PR DESCRIPTION
### What problem does this PR solve?

not allow drop user `admin@%`

but should allow drop user `admin@'xxx.xxx.xxx'`

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Only treat admin@% and root@% as system users.

### Release note
Only treat admin@% and root@% as system users.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

