### PR TITLE
[fix](blocking queue) introduce condition variable wait timeout to avoid blocking queue deadlock

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -715,6 +715,9 @@ DEFINE_mInt32(max_consumer_num_per_group, "3");
 // this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
 DEFINE_Int32(max_routine_load_thread_pool_size, "1024");
 
+// the timeout of condition variable wait in blocking_get and blocking_put
+DEFINE_mInt32(blocking_queue_cv_wait_timeout_ms, "1000");
+
 // max external scan cache batch count, means cache max_memory_cache_batch_count * batch_size row
 // default is 20, batch_size's default value is 1024 means 20 * 1024 rows will be cached
 DEFINE_mInt32(max_memory_sink_batch_count, "20");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -954,6 +954,9 @@ DECLARE_mString(kafka_debug);
 // Change this size to 0 to fix it temporarily.
 DECLARE_mInt32(routine_load_consumer_pool_size);
 
+// the timeout of condition variable wait in blocking_get and blocking_put
+DECLARE_mInt32(blocking_queue_cv_wait_timeout_ms);
+
 // Used in single-stream-multi-table load. When receive a batch of messages from kafka,
 // if the size of batch is more than this threshold, we will request plans for all related tables.
 DECLARE_Int32(multi_table_batch_plan_threshold);

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -243,7 +243,8 @@ Status KafkaDataConsumer::group_consume(BlockingQueue<RdKafka::Message*>* queue,
                 // ignore msg with length 0.
                 // put empty msg into queue will cause the load process shutting down.
                 break;
-            } else if (!queue->blocking_put(msg.get())) {
+            } else if (!queue->controlled_blocking_put(msg.get(),
+                                                       config::blocking_queue_cv_wait_timeout_ms)) {
                 // queue is shutdown
                 done = true;
             } else {
@@ -270,7 +271,8 @@ Status KafkaDataConsumer::group_consume(BlockingQueue<RdKafka::Message*>* queue,
             VLOG_NOTICE << "consumer meet partition eof: " << _id
                         << " partition offset: " << msg->offset();
             _consuming_partition_ids.erase(msg->partition());
-            if (!queue->blocking_put(msg.get())) {
+            if (!queue->controlled_blocking_put(msg.get(),
+                                                config::blocking_queue_cv_wait_timeout_ms)) {
                 done = true;
             } else if (_consuming_partition_ids.size() <= 0) {
                 LOG(INFO) << "all partitions meet eof: " << _id;

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -156,7 +156,7 @@ Status KafkaDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx,
         }
 
         RdKafka::Message* msg;
-        bool res = _queue.blocking_get(&msg);
+        bool res = _queue.controlled_blocking_get(&msg, config::blocking_queue_cv_wait_timeout_ms);
         if (res) {
             // conf has to be deleted finally
             Defer delete_msg {[msg]() { delete msg; }};


### PR DESCRIPTION
### What problem does this PR solve?

We found some routine load tasks are never finish, and these task hang for **blocking queue** is deadlock. We observed the stack using GDB and printed the values:
![image](https://github.com/user-attachments/assets/729de36d-3bcc-46e7-b749-90e1c781a9fa)
![image](https://github.com/user-attachments/assets/f5e68040-d936-468d-bdb9-266136026b70)

It is clear that both the get thread and put thread are waiting on the condition variable at the same time, causing a deadlock. 

However, unfortunately, we have not located the problem yet. we choose introducing timeout to avoid blocking queue deadlock temporarily.If anyone encounters this problem or has any ideas, please feel free to discuss under this PR.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

