### PR TITLE
[fix](compile)IcebergDLFExternalCatalogTest compile error

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
@@ -51,6 +51,6 @@ public class IcebergDLFExternalCatalogTest {
         Assert.assertThrows(NotSupportedException.class, () -> catalog.createTable(null));
         Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable(null));
         Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable("", "", true, true, true, true));
-        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable((TruncateTableStmt) null));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
intruduced from #50696
both method truncateTable(org.apache.doris.nereids.trees.plans.commands.TruncateTableCommand) in org.apache.doris.datasource.ExternalCatalog and method truncateTable(org.apache.doris.analysis.TruncateTableStmt) in org.apache.doris.datasource.iceberg.IcebergDLFExternalCatalog match
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [*] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

