### PR TITLE
[fix](iceberg)Table operations are not supported for catalogs of the dlf type for nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
@@ -28,6 +28,7 @@ import org.apache.doris.datasource.iceberg.dlf.DLFCatalog;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.HMSProperties;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
+import org.apache.doris.nereids.trees.plans.commands.TruncateTableCommand;
 
 import java.util.Map;
 
@@ -81,6 +82,11 @@ public class IcebergDLFExternalCatalog extends IcebergExternalCatalog {
 
     @Override
     public void truncateTable(TruncateTableStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'truncate table'");
+    }
+
+    @Override
+    public void truncateTable(TruncateTableCommand command) throws DdlException {
         throw new NotSupportedException("iceberg catalog with dlf type not supports 'truncate table'");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.datasource.iceberg.dlf.client;
 
+import org.apache.doris.analysis.TruncateTableStmt;
 import org.apache.doris.datasource.iceberg.IcebergDLFExternalCatalog;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
+import org.apache.doris.nereids.trees.plans.commands.TruncateTableCommand;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
@@ -51,6 +53,7 @@ public class IcebergDLFExternalCatalogTest {
         Assert.assertThrows(NotSupportedException.class, () -> catalog.createTable(null));
         Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable(null));
         Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable("", "", true, true, true, true));
-        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable((TruncateTableStmt) null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable((TruncateTableCommand) null));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

followUp: #50696

Problem Summary:

conflict with #50196

Table operations are not supported for catalogs of the dlf type for nereids.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

