### PR TITLE
[fix](function) fix xpath_string to support xpath_query with string functions

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -4816,22 +4816,6 @@ public:
     }
 
 private:
-    // Build the text of the node and all its children.
-    static std::string get_text(const pugi::xml_node& node) {
-        std::string result;
-        build_text(node, result);
-        return result;
-    }
-
-    static void build_text(const pugi::xml_node& node, std::string& builder) {
-        if (node.type() == pugi::node_pcdata || node.type() == pugi::node_cdata) {
-            builder += node.value();
-        }
-        for (pugi::xml_node child : node.children()) {
-            build_text(child, builder);
-        }
-    }
-
     static Status parse_xml(const StringRef& xml_str, pugi::xml_document& xml_doc) {
         pugi::xml_parse_result result = xml_doc.load_buffer(xml_str.data, xml_str.size);
         if (!result) {
@@ -4841,19 +4825,32 @@ private:
         return Status::OK();
     }
 
+    static Status build_xpath_query(const StringRef& xpath_str, pugi::xpath_query& xpath_query) {
+        // xpath_query will throws xpath_exception on compilation errors.
+        try {
+            // NOTE!!!: don't use to_string_view(), because xpath_str maybe not null-terminated
+            xpath_query = pugi::xpath_query(xpath_str.to_string().c_str());
+        } catch (const pugi::xpath_exception& e) {
+            return Status::InvalidArgument("Function {} failed to build XPath query: {}", name,
+                                           e.what());
+        }
+        return Status::OK();
+    }
+
     template <bool left_const, bool right_const>
     static Status execute_vector(const size_t input_rows_count, const ColumnString& xml_col,
                                  const ColumnString& xpath_col, ColumnNullable& res_col) {
         pugi::xml_document xml_doc;
-        StringRef xpath_str;
+        pugi::xpath_query xpath_query;
         // first check right_const, because we want to check empty input first
         if constexpr (right_const) {
-            xpath_str = xpath_col.get_data_at(0);
+            auto xpath_str = xpath_col.get_data_at(0);
             if (xpath_str.empty()) {
                 // should return null if xpath_str is empty
                 res_col.insert_many_defaults(input_rows_count);
                 return Status::OK();
             }
+            RETURN_IF_ERROR(build_xpath_query(xpath_str, xpath_query));
         }
         if constexpr (left_const) {
             auto xml_str = xml_col.get_data_at(0);
@@ -4867,12 +4864,13 @@ private:
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             if constexpr (!right_const) {
-                xpath_str = xpath_col.get_data_at(i);
+                auto xpath_str = xpath_col.get_data_at(i);
                 if (xpath_str.empty()) {
                     // should return null if xpath_str is empty
                     res_col.insert_default();
                     continue;
                 }
+                RETURN_IF_ERROR(build_xpath_query(xpath_str, xpath_query));
             }
             if constexpr (!left_const) {
                 auto xml_str = xml_col.get_data_at(i);
@@ -4883,15 +4881,13 @@ private:
                 }
                 RETURN_IF_ERROR(parse_xml(xml_str, xml_doc));
             }
-            // NOTE!!!: don't use to_string_view(), because xpath_str maybe not null-terminated
-            pugi::xpath_node node = xml_doc.select_node(xpath_str.to_string().c_str());
-            if (!node) {
-                // should return empty string if not found
-                auto empty_str = std::string("");
-                res_col.insert_data(empty_str.data(), empty_str.size());
-                continue;
+            std::string text;
+            try {
+                text = xpath_query.evaluate_string(xml_doc);
+            } catch (const pugi::xpath_exception& e) {
+                return Status::InvalidArgument("Function {} failed to query XPath string: {}", name,
+                                               e.what());
             }
-            auto text = get_text(node.node());
             res_col.insert_data(text.data(), text.size());
         }
         return Status::OK();

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_xpath_string.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_xpath_string.out
@@ -283,3 +283,33 @@ Text
 -- !30 --
 Content
 
+-- !str_1 --
+J
+
+-- !str_2 --
+hn
+
+-- !str_3 --
+true
+
+-- !str_4 --
+true
+
+-- !str_5 --
+4
+
+-- !str_6 --
+John
+
+-- !str_7 --
+HELLO WORLD
+
+-- !str_8 --
+hello_test
+
+-- !str_9 --
+world
+
+-- !str_10 --
+hello
+

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_xpath_string.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_xpath_string.groovy
@@ -141,6 +141,18 @@ suite("test_xpath_string") {
     order_qt_29 "select xpath_string('<root><a><b>1</b></a><a><b>2</b></a></root>', '//a[b=\"2\"]/b')"
     order_qt_30 "select xpath_string('<doc><p class=\"main\">Content</p></doc>', '//p[@class=\"main\"]/text()')"
 
+    // string function cases for xpath_string
+    order_qt_str_1 "select xpath_string('<root><name>John</name><age>30</age></root>', 'substring-before(/root/name, \"o\")')"
+    order_qt_str_2 "select xpath_string('<root><name>John</name><age>30</age></root>', 'substring-after(/root/name, \"o\")')"
+    order_qt_str_3 "select xpath_string('<root><name>John</name></root>', 'contains(/root/name, \"oh\")')"
+    order_qt_str_4 "select xpath_string('<root><name>John</name></root>', 'starts-with(/root/name, \"Jo\")')"
+    order_qt_str_5 "select xpath_string('<root><name>John</name></root>', 'string-length(/root/name)')"
+    order_qt_str_6 "select xpath_string('<root><name>  John  </name></root>', 'normalize-space(/root/name)')"
+    order_qt_str_7 "select xpath_string('<root><desc>hello world</desc></root>', 'translate(/root/desc, \"helowrd\", \"HELOWRD\")')"
+    order_qt_str_8 "select xpath_string('<root><desc>hello world</desc></root>', 'concat(substring(/root/desc,1,5), \"_test\")')"
+    order_qt_str_9 "select xpath_string('<root><desc>hello world</desc></root>', 'substring(/root/desc,7)')"
+    order_qt_str_10 "select xpath_string('<root><desc>hello world</desc></root>', 'substring(/root/desc,1,5)')"
+
     /// error cases:
     test {
         sql """ select xpath_string('wrong xml', '//a/c') """


### PR DESCRIPTION
### What problem does this PR solve?
Related PR: #49262 

Problem Summary:
When query the xpath with string functions like:
```sql
select xpath_string('<root><name>John</name><age>30</age></root>', 'substring-before(/root/name, "o")');
```
Be will crash caused by xpath_exception: "Expression does not evaluate to node set".
We should use `xpath_query::evaluate_string` to impl xpath_string not `xml_node::select_node`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

