### PR TITLE
[feat](sql-convertor) support setting sql convertor's config by session variable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectConverterPlugin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectConverterPlugin.java
@@ -104,7 +104,7 @@ public class HttpDialectConverterPlugin extends Plugin implements DialectConvert
             return null;
         }
         return HttpDialectUtils.convertSql(targetURL, originSql, sessionVariable.getSqlDialect(),
-                sessionVariable.getSqlConvertorFeatures());
+                sessionVariable.getSqlConvertorFeatures(), sessionVariable.getSqlConvertorConfig());
     }
 
     // no need to override parseSqlWithDialect, just return null

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/dialect/HttpDialectUtils.java
@@ -39,8 +39,8 @@ public class HttpDialectUtils {
     private static final Logger LOG = LogManager.getLogger(HttpDialectUtils.class);
 
     public static String convertSql(String targetURL, String originStmt, String dialect,
-            String[] features) {
-        ConvertRequest convertRequest = new ConvertRequest(originStmt, dialect, features);
+            String[] features, String config) {
+        ConvertRequest convertRequest = new ConvertRequest(originStmt, dialect, features, config);
 
         HttpURLConnection connection = null;
         try {
@@ -112,8 +112,9 @@ public class HttpDialectUtils {
         private String source;  // CHECKSTYLE IGNORE THIS LINE
         private String case_sensitive;  // CHECKSTYLE IGNORE THIS LINE
         private String[] enable_sql_convertor_features; // CHECKSTYLE IGNORE THIS LINE
+        private String config; // CHECKSTYLE IGNORE THIS LINE
 
-        public ConvertRequest(String originStmt, String dialect, String[] features) {
+        public ConvertRequest(String originStmt, String dialect, String[] features, String config) {
             this.version = "v1";
             this.sql_query = originStmt;
             this.from = dialect;
@@ -121,6 +122,7 @@ public class HttpDialectUtils {
             this.source = "text";
             this.case_sensitive = "0";
             this.enable_sql_convertor_features = features;
+            this.config = config;
         }
 
         public String toJson() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -734,6 +734,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_SQL_CONVERTOR_FEATURES = "enable_sql_convertor_features";
 
+    public static final String SQL_CONVERTOR_CONFIG = "sql_convertor_config";
+
     /**
      * If set false, user couldn't submit analyze SQL and FE won't allocate any related resources.
      */
@@ -2585,6 +2587,13 @@ public class SessionVariable implements Serializable, Writable {
             })
     public String enableSqlConvertorFeatures = "";
 
+    @VariableMgr.VarAttr(name = SQL_CONVERTOR_CONFIG, needForward = true,
+            description = {
+                    "SQL 转换器的相关配置，使用 Json 格式。以 {} 为根元素。",
+                    "SQL convertor config, use Json format. The root element is {}"
+            })
+    public String sqlConvertorConfig = "{}";
+
     public void setEnableEsParallelScroll(boolean enableESParallelScroll) {
         this.enableESParallelScroll = enableESParallelScroll;
     }
@@ -3532,6 +3541,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public String[] getSqlConvertorFeatures() {
         return enableSqlConvertorFeatures.split(",");
+    }
+
+    public String getSqlConvertorConfig() {
+        return sqlConvertorConfig;
     }
 
     public Dialect getSqlParseDialect() {

--- a/fe/fe-core/src/test/java/org/apache/doris/plugin/HttpDialectUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/plugin/HttpDialectUtilsTest.java
@@ -54,20 +54,20 @@ public class HttpDialectUtilsTest {
         String expectedSql = "select * from t1 where `k1` = 1";
         String[] features = new String[] {"ctas"};
         String targetURL = "http://127.0.0.1:" + port + "/api/v1/convert";
-        String res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
+        String res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features, "{}");
         Assert.assertEquals(originSql, res);
         // test presto
         server.setResponse("{\"version\": \"v1\", \"data\": \"" + expectedSql + "\", \"code\": 0, \"message\": \"\"}");
-        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
+        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features, "{}");
         Assert.assertEquals(expectedSql, res);
         // test response version error
         server.setResponse("{\"version\": \"v2\", \"data\": \"" + expectedSql + "\", \"code\": 0, \"message\": \"\"}");
-        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
+        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features, "{}");
         Assert.assertEquals(originSql, res);
-        // 7. test response code error
+        // test response code error
         server.setResponse(
                 "{\"version\": \"v1\", \"data\": \"" + expectedSql + "\", \"code\": 400, \"message\": \"\"}");
-        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features);
+        res = HttpDialectUtils.convertSql(targetURL, originSql, "presto", features, "{}");
         Assert.assertEquals(originSql, res);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

There may be some configurations for sql convertor plugin.
So I added a new session variable `sql_convertor_config`, the format is a json string
with root element `{}`. So that we can easily extends its content.

eg:

```
set sql_convertor_config = '{"ignore_udf": ["func1", "func2", "fucn3"]}'
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

