### PR TITLE
[refine](DataTypeSerDe) Remove the level variable from FormatOptions and use _nesting_level.

### DIFF
--- a/be/src/vec/data_types/serde/data_type_array_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_array_serde.cpp
@@ -341,7 +341,6 @@ Status DataTypeArraySerDe::_write_column_to_mysql(const IColumn& column,
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {
-            ++options.level;
             if (is_nested_string && options.wrapper_len > 0) {
                 if (0 != result.push_string(options.nested_string_wrapper, options.wrapper_len)) {
                     return Status::InternalError("pack mysql buffer failed.");
@@ -355,7 +354,6 @@ Status DataTypeArraySerDe::_write_column_to_mysql(const IColumn& column,
                 RETURN_IF_ERROR(
                         nested_serde->write_column_to_mysql(data, result, j, false, options));
             }
-            --options.level;
         }
     }
     if (0 != result.push_string("]", 1)) {

--- a/be/src/vec/data_types/serde/data_type_map_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_map_serde.cpp
@@ -429,7 +429,6 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {
-            ++options.level;
             if (is_key_string && options.wrapper_len > 0) {
                 if (0 != result.push_string(options.nested_string_wrapper, options.wrapper_len)) {
                     return Status::InternalError("pack mysql buffer failed.");
@@ -443,7 +442,6 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
                 RETURN_IF_ERROR(key_serde->write_column_to_mysql(nested_keys_column, result, j,
                                                                  false, options));
             }
-            --options.level;
         }
         if (0 != result.push_string(&options.map_key_delim, 1)) {
             return Status::InternalError("pack mysql buffer failed.");
@@ -453,7 +451,6 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {
-            ++options.level;
             if (is_val_string && options.wrapper_len > 0) {
                 if (0 != result.push_string(options.nested_string_wrapper, options.wrapper_len)) {
                     return Status::InternalError("pack mysql buffer failed.");
@@ -467,7 +464,6 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
                 RETURN_IF_ERROR(value_serde->write_column_to_mysql(nested_values_column, result, j,
                                                                    false, options));
             }
-            --options.level;
         }
     }
     if (0 != result.push_string("}", 1)) {

--- a/be/src/vec/data_types/serde/data_type_number_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_number_serde.cpp
@@ -280,7 +280,7 @@ Status DataTypeNumberSerDe<T>::_write_column_to_mysql(const IColumn& column,
     if constexpr (std::is_same_v<T, Int8>) {
         buf_ret = result.push_tinyint(data[col_index]);
     } else if constexpr (std::is_same_v<T, UInt8>) {
-        if (options.level > 0 && !options.is_bool_value_num) {
+        if (_nesting_level > 1 && !options.is_bool_value_num) {
             std::string bool_value = data[col_index] ? "true" : "false";
             result.push_string(bool_value.c_str(), bool_value.size());
         } else {

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -195,11 +195,6 @@ public:
          */
         bool is_bool_value_num = true;
 
-        /**
-         * Indicate the nested level of column. It is used to control some behavior of serde
-         */
-        mutable int level = 0;
-
         [[nodiscard]] char get_collection_delimiter(
                 int hive_text_complex_type_delimiter_level) const {
             CHECK(0 <= hive_text_complex_type_delimiter_level &&

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -382,7 +382,6 @@ Status DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {
-            ++options.level;
             if (remove_nullable(col.get_column_ptr(j))->is_column_string() &&
                 options.wrapper_len > 0) {
                 if (0 != result.push_string(options.nested_string_wrapper, options.wrapper_len)) {
@@ -397,7 +396,6 @@ Status DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
                 RETURN_IF_ERROR(elem_serdes_ptrs[j]->write_column_to_mysql(
                         col.get_column(j), result, col_index, false, options));
             }
-            --options.level;
         }
         begin = false;
     }


### PR DESCRIPTION
### What problem does this PR solve?

We don't need to maintain a separate level; we can achieve the functionality of this  https://github.com/apache/doris/pull/49036 by directly using _nesting_level.

```C++
    // This parameter indicates what level the serde belongs to and is mainly used for complex types
    // The default level is 1, and each time you nest, the level increases by 1,
    // for example: struct<string>
    // The _nesting_level of StructSerde is 1
    // The _nesting_level of StringSerde is 2
    int _nesting_level = 1;
```

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

