### PR TITLE
[fix](jsonb) Avoid crashing caused by invalid path

### DIFF
--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -1499,6 +1499,10 @@ inline bool JsonbPath::parsePath(Stream* stream, JsonbPath* path) {
         // advance past the .
         stream->skip(1);
 
+        if (stream->exhausted()) {
+            return false;
+        }
+
         // $.[0]
         if (stream->peek() == BEGIN_ARRAY) {
             return parse_array(stream, path);
@@ -1523,6 +1527,10 @@ inline bool JsonbPath::parse_array(Stream* stream, JsonbPath* path) {
         stream->set_leg_ptr(const_cast<char*>(stream->position()));
         stream->add_leg_len();
         stream->skip(1);
+        if (stream->exhausted()) {
+            return false;
+        }
+
         if (stream->peek() == END_ARRAY) {
             std::unique_ptr<leg_info> leg(
                     new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, ARRAY_CODE));


### PR DESCRIPTION
### What problem does this PR solve?

```
*** SIGABRT unknown detail explain (@0x1d45) received by PID 7493 (TID 9664 OR 0x7f1a05f7d640) from PID 7493; stack trace: ***
doris_be: /root/doris/be/src/util/jsonb_document.h:273: char doris::Stream::peek() const: Assertion `!exhausted()' failed.
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:421
 1# 0x00007F23B6C2F520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# _nl_load_domain at ./intl/loadmsgcat.c:1177
 6# 0x00007F23B6C26E96 in /lib/x86_64-linux-gnu/libc.so.6
 7# doris::Stream::peek() const at /root/doris/be/src/util/jsonb_document.h:273
 8# doris::JsonbPath::seek(char const*, unsigned long) at /root/doris/be/src/util/jsonb_document.h:1427
 9# doris::vectorized::JsonbExtractImpl::vector_vector(doris::FunctionContext*, doris::vectorized::PODArray, 16ul, 15ul> const&, doris::vectorized::PODArray, 16ul, 15ul> const&, doris::vectorized::PODArray, 16ul, 15ul> const&, doris::vectorized::PODArray, 16ul, 15ul> const&, doris::vectorized::PODArray, 16ul, 15ul>&, doris::vectorized::PODArray, 16ul, 15ul>&, bool&) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
10# doris::vectorized::FunctionJsonbExtract::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long) const at /root/doris/be/src/vec/functions/function_jsonb.cpp:419
11# doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long) const at /root/doris/be/src/vec/functions/function.h:454
12# doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool) const in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
13# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool) const at /root/doris/be/src/vec/functions/function.cpp:244
14# doris::vectorized::PreparedFunctionImpl::default_implementation_for_nulls(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool, bool*) const at /root/doris/be/src/vec/functions/function.cpp:216
15# doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool) const at /root/doris/be/src/vec/functions/function.cpp:110
16# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool) const at /root/doris/be/src/vec/functions/function.cpp:244
17# doris::vectorized::PreparedFunctionImpl::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool) const at /root/doris/be/src/vec/functions/function.cpp:250
18# doris::vectorized::IFunctionBase::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector > const&, unsigned int, unsigned long, bool) const at /root/doris/be/src/vec/functions/function.h:196
19# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector >&) at /root/doris/be/src/vec/exprs/vectorized_fn_call.cpp:203
20# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /root/doris/be/src/vec/exprs/vectorized_fn_call.cpp:237
21# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector >&) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
22# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /root/doris/be/src/vec/exprs/vectorized_fn_call.cpp:237
23# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
24# doris::vectorized::VExprContext::execute_conjuncts(std::vector, std::allocator > > const&, std::vector, 16ul, 15ul>*, std::allocator, 16ul, 15ul>*> > const*, bool, doris::vectorized::Block*, doris::vectorized::PODArray, 16ul, 15ul>*, bool*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
25# doris::vectorized::VExprContext::execute_conjuncts_and_filter_block(std::vector, std::allocator > > const&, doris::vectorized::Block*, std::vector >&, int, doris::vectorized::PODArray, 16ul, 15ul>&) at /root/doris/be/src/vec/exprs/vexpr_context.cpp:377
26# doris::segment_v2::SegmentIterator::_execute_common_expr(unsigned short*, unsigned short&, doris::vectorized::Block*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
27# doris::segment_v2::SegmentIterator::_next_batch_internal(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:2228
28# doris::segment_v2::SegmentIterator::next_batch(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:1920
29# doris::segment_v2::LazyInitSegmentIterator::next_batch(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/segment_v2/lazy_init_segment_iterator.h:49
30# doris::BetaRowsetReader::next_block(doris::vectorized::Block*) at /root/doris/be/src/olap/rowset/beta_rowset_reader.cpp:346
31# doris::vectorized::VCollectIterator::Level0Iterator::_refresh() at /root/doris/be/src/vec/olap/vcollect_iterator.h:256
32# doris::vectorized::VCollectIterator::Level0Iterator::refresh_current_row() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
33# doris::vectorized::VCollectIterator::Level0Iterator::ensure_first_row_ref() at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:483
34# doris::vectorized::VCollectIterator::Level1Iterator::ensure_first_row_ref() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
35# doris::vectorized::VCollectIterator::build_heap(std::vector, std::allocator > >&) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
36# doris::vectorized::BlockReader::_init_collect_iter(doris::TabletReader::ReaderParams const&) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
37# doris::vectorized::BlockReader::init(doris::TabletReader::ReaderParams const&) at /root/doris/be/src/vec/olap/block_reader.cpp:222
38# doris::vectorized::OlapScanner::open(doris::RuntimeState*) at /root/doris/be/src/vec/exec/scan/olap_scanner.cpp:237
39# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr, std::shared_ptr) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
40# std::_Function_handler, std::shared_ptr)::$_1::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
41# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
42# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:496
43# start_thread at ./nptl/pthread_create.c:442
44# 0x00007F23B6D13850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

