### PR TITLE
correct the profile count prompt on the FE webui /QueryProfile

### DIFF
--- a/ui/src/pages/query-profile/index.tsx
+++ b/ui/src/pages/query-profile/index.tsx
@@ -157,7 +157,7 @@ export default function QueryProfile(params: any) {
             <Row style={{ paddingBottom: '15px' }}>
                 <Col span={12}>
                     <Text strong={true}>
-                        This table lists the latest 100 queries
+                        This table lists the latest max_query_profile_num queries
                     </Text>
                 </Col>
                 <Col span={12} style={{ textAlign: 'right' }}>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

in fe webui /queryprofile page,  behind the "Finished Queries", it shows This table lists the latest 100 queries. but it is wrong, it is not 100, but max_query_profile_num which configed in fe 


this pr correct the profile count prompt on the FE webui /QueryProfile

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

