### PR TITLE
[improve](nereids)Remove use of session variable deprecated_group_by_and_having_use_alias_first

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -578,11 +578,8 @@ public abstract class QueryStmt extends StatementBase implements Queriable, NotF
     }
 
 
-    public Expr getExprFromAliasSMap(Expr expr) throws AnalysisException {
-        if (!analyzer.getContext().getSessionVariable().isGroupByAndHavingUseAliasFirst()) {
-            return expr;
-        }
-        return getExprFromAliasSMapDirect(expr);
+    public Expr getExprFromAliasSMap(Expr expr) {
+        return expr;
     }
 
     // get tables used by this query.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1333,35 +1333,26 @@ public class SelectStmt extends QueryStmt implements NotFallbackInParser {
              *     select id, floor(v1) v, sum(v2) vsum from table group by id,v having(v>1 AND vsum>1);
              */
             if (groupByClause != null) {
-                boolean aliasFirst = false;
-                if (analyzer.getContext() != null) {
-                    aliasFirst = analyzer.getContext().getSessionVariable().isGroupByAndHavingUseAliasFirst();
-                }
-                if (!aliasFirst) {
-                    ExprSubstitutionMap excludeAliasSMap = aliasSMap.clone();
-                    List<Expr> havingSlots = Lists.newArrayList();
-                    havingClause.collect(SlotRef.class, havingSlots);
-                    for (Expr expr : havingSlots) {
-                        if (excludeAliasSMap.get(expr) == null) {
-                            continue;
-                        }
-                        try {
-                            // try to use column name firstly
-                            expr.clone().analyze(analyzer);
-                            // analyze success means column name exist, do not use alias name
-                            excludeAliasSMap.removeByLhsExpr(expr);
-                        } catch (AnalysisException ex) {
-                            // according to case3, column name do not exist, keep alias name inside alias map
-                            if (ConnectContext.get() != null) {
-                                ConnectContext.get().getState().reset();
-                            }
+                ExprSubstitutionMap excludeAliasSMap = aliasSMap.clone();
+                List<Expr> havingSlots = Lists.newArrayList();
+                havingClause.collect(SlotRef.class, havingSlots);
+                for (Expr expr : havingSlots) {
+                    if (excludeAliasSMap.get(expr) == null) {
+                        continue;
+                    }
+                    try {
+                        // try to use column name firstly
+                        expr.clone().analyze(analyzer);
+                        // analyze success means column name exist, do not use alias name
+                        excludeAliasSMap.removeByLhsExpr(expr);
+                    } catch (AnalysisException ex) {
+                        // according to case3, column name do not exist, keep alias name inside alias map
+                        if (ConnectContext.get() != null) {
+                            ConnectContext.get().getState().reset();
                         }
                     }
-                    havingClauseAfterAnalyzed = havingClause.substitute(excludeAliasSMap, analyzer, false);
-                } else {
-                    // If user set force using alias, then having clauses prefer using alias rather than column name
-                    havingClauseAfterAnalyzed = havingClause.substitute(aliasSMap, analyzer, false);
                 }
+                havingClauseAfterAnalyzed = havingClause.substitute(excludeAliasSMap, analyzer, false);
             } else {
                 // according to mysql
                 // if there is no group by clause, the having clause should use alias
@@ -2658,11 +2649,7 @@ public class SelectStmt extends QueryStmt implements NotFallbackInParser {
 
         // substitute group by
         if (groupByClause != null) {
-            boolean aliasFirst = false;
-            if (analyzer.getContext() != null) {
-                aliasFirst = analyzer.getContext().getSessionVariable().isGroupByAndHavingUseAliasFirst();
-            }
-            substituteOrdinalsAliases(groupByClause.getGroupingExprs(), "GROUP BY", analyzer, aliasFirst);
+            substituteOrdinalsAliases(groupByClause.getGroupingExprs(), "GROUP BY", analyzer, false);
         }
         // substitute having
         if (havingClause != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -100,7 +100,6 @@ import org.apache.doris.nereids.util.PlanUtils;
 import org.apache.doris.nereids.util.PlanUtils.CollectNonWindowedAggFuncs;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 import org.apache.doris.nereids.util.Utils;
-import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SqlModeHelper;
 
 import com.google.common.base.Preconditions;
@@ -1352,12 +1351,6 @@ public class BindExpression implements AnalysisRuleFactory {
             if (isGroupByContainAlias) {
                 break;
             }
-        }
-
-        if (isGroupByContainAlias
-                && ConnectContext.get() != null
-                && ConnectContext.get().getSessionVariable().isGroupByAndHavingUseAliasFirst()) {
-            throw new AnalysisException("group_by_and_having_use_alias=true is unsupported for Nereids");
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/UnsupportedTypeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/UnsupportedTypeTest.java
@@ -17,13 +17,11 @@
 
 package org.apache.doris.nereids;
 
-import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.utframe.TestWithFeService;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class UnsupportedTypeTest extends TestWithFeService {
@@ -69,28 +67,6 @@ public class UnsupportedTypeTest extends TestWithFeService {
         for (int i = 0; i < sqls.length; ++i) {
             runPlanner(sqls[i]);
         }
-    }
-
-    @Test
-    public void testGroupByAndHavingUseAliasFirstThrowException() {
-        String[] sqls = {"SELECT\n"
-                + "            date_format(date, '%x%v') AS `date`,\n"
-                + "            count(date) AS `diff_days`\n"
-                + "            FROM type_tb\n"
-                + "            GROUP BY date\n"
-                + "            HAVING date = 20221111\n"
-                + "            ORDER BY date;",
-                "SELECT\n"
-                        + "            date_format(date, '%x%v') AS `date`,\n"
-                        + "            count(date) AS `diff_days`\n"
-                        + "            FROM type_tb\n"
-                        + "            GROUP BY date\n"
-                        + "            HAVING date = 20221111\n"
-                        + "            ORDER BY date;"
-        };
-        runPlanner(sqls[0]);
-        connectContext.getSessionVariable().groupByAndHavingUseAliasFirst = true;
-        Assertions.assertThrows(AnalysisException.class, () -> runPlanner(sqls[1]));
     }
 
     private void runPlanner(String sql) {


### PR DESCRIPTION
### What problem does this PR solve?
Remove use of session variable deprecated_group_by_and_having_use_alias_first, because it is useless.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

