### PR TITLE
[Fix](Test)Increase test JVM heap size to avoid OOM when using JMockit and JaCoCo

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1084,6 +1084,10 @@ under the License.
                 </configuration>
             </plugin>
             <!-- jmockit -->
+            <!--fixme  Unify mocking framework usage across the project.
+            Currently, multiple mocking libraries (e.g., JMockit, Powermock) are used, 
+            which increases maintenance complexity and may cause agent conflicts (e.g., with JaCoCo).
+            Evaluate existing usages and standardize on a single framework where possible.-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -1094,7 +1098,7 @@ under the License.
                     <reuseForks>false</reuseForks>
                     <useFile>false</useFile>
                     <argLine>
-                        -Xmx512m -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar @{argLine}
+                        -Xmx1024m -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar @{argLine}
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION



### What problem does this PR solve?

The test JVM was previously configured with `-Xmx512m`, which is insufficient when running tests with both JMockit and JaCoCo agents enabled. This caused the forked JVM to crash without proper termination during `RemoteFileSystemTest`.

Increased the heap size (e.g., to `-Xmx1024m`) to ensure stable test execution.

```
[INFO] ------------------------------------------------------------------------
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118487&logView=flowAware&focusLine=118487)  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project fe-core: There are test failures.
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118488&logView=flowAware&focusLine=118488)  [ERROR]
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118489&logView=flowAware&focusLine=118489)  [ERROR] Please refer to /root/doris/fe/fe-core/target/surefire-reports for the individual test results.
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118490&logView=flowAware&focusLine=118490)  [ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118491&logView=flowAware&focusLine=118491)  [ERROR] ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118492&logView=flowAware&focusLine=118492)  [ERROR] Command was /bin/sh -c cd /root/doris/fe/fe-core && /usr/lib/jvm/jdk-17.0.2/bin/java -Xmx512m -javaagent:/root/.m2/repository/org/jmockit/jmockit/1.49/jmockit-1.49.jar -javaagent:/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.10/org.jacoco.agent-0.8.10-runtime.jar=destfile=/root/doris/fe/fe-core/target/jacoco.exec -jar /root/doris/fe/fe-core/target/surefire/surefirebooter3243791173086714250.jar /root/doris/fe/fe-core/target/surefire 2025-05-19T12-51-33_073-jvmRun1 surefire10293342097938602335tmp surefire_4476300908787769272952tmp
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118493&logView=flowAware&focusLine=118493)  [ERROR] Process Exit Code: 0
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118494&logView=flowAware&focusLine=118494)  [ERROR] Crashed tests:
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118495&logView=flowAware&focusLine=118495)  [ERROR] org.apache.doris.fs.remote.RemoteFileSystemTest
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118496&logView=flowAware&focusLine=118496)  [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118497&logView=flowAware&focusLine=118497)  [ERROR] Command was /bin/sh -c cd /root/doris/fe/fe-core && /usr/lib/jvm/jdk-17.0.2/bin/java -Xmx512m -javaagent:/root/.m2/repository/org/jmockit/jmockit/1.49/jmockit-1.49.jar -javaagent:/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.10/org.jacoco.agent-0.8.10-runtime.jar=destfile=/root/doris/fe/fe-core/target/jacoco.exec -jar /root/doris/fe/fe-core/target/surefire/surefirebooter3243791173086714250.jar /root/doris/fe/fe-core/target/surefire 2025-05-19T12-51-33_073-jvmRun1 surefire10293342097938602335tmp surefire_4476300908787769272952tmp
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118498&logView=flowAware&focusLine=118498)  [ERROR] Process Exit Code: 0
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118499&logView=flowAware&focusLine=118499)  [ERROR] Crashed tests:
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118500&logView=flowAware&focusLine=118500)  [ERROR] org.apache.doris.fs.remote.RemoteFileSystemTest
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118501&logView=flowAware&focusLine=118501)  [ERROR]   at org.apache.maven.plugin.surefire.booterclient.ForkStarter.awaitResultsDone(ForkStarter.java:510)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118502&logView=flowAware&focusLine=118502)  [ERROR]   at org.apache.maven.plugin.surefire.booterclient.ForkStarter.runSuitesForkPerTestSet(ForkStarter.java:457)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118503&logView=flowAware&focusLine=118503)  [ERROR]   at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:298)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118504&logView=flowAware&focusLine=118504)  [ERROR]   at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:246)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118505&logView=flowAware&focusLine=118505)  [ERROR]   at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1183)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118506&logView=flowAware&focusLine=118506)  [ERROR]   at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1011)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118507&logView=flowAware&focusLine=118507)  [ERROR]   at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:857)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118508&logView=flowAware&focusLine=118508)  [ERROR]   at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118509&logView=flowAware&focusLine=118509)  [ERROR]   at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118510&logView=flowAware&focusLine=118510)  [ERROR]   at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118511&logView=flowAware&focusLine=118511)  [ERROR]   at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118512&logView=flowAware&focusLine=118512)  [ERROR]   at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118513&logView=flowAware&focusLine=118513)  [ERROR]   at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118514&logView=flowAware&focusLine=118514)  [ERROR]   at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118515&logView=flowAware&focusLine=118515)  [ERROR]   at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[14:22:45 ](http://43.132.222.7:8111/buildConfiguration/Doris_Doris_FeUt/683280?buildTab=log&linesState=118516&logView=flowAware&focusLine=118516)  [ERROR]   at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

