### PR TITLE
[Refactor](workload group)reset workload group check defaut interval to 2s

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2911,7 +2911,7 @@ public class Config extends ConfigBase {
     public static int workload_sched_policy_interval_ms = 10000; // 10s
 
     @ConfField(mutable = true, masterOnly = true)
-    public static int workload_group_check_interval_ms = 30000; // 30s
+    public static int workload_group_check_interval_ms = 2000; // 2s
 
     @ConfField(mutable = true, masterOnly = true)
     public static int workload_max_policy_num = 25;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -50,6 +50,8 @@ public class FeConstants {
     // set to false to disable internal schema db
     public static boolean enableInternalSchemaDb = true;
 
+    public static boolean disableWGCheckerForUT = false;
+
     // default scheduler interval is 10 seconds
     public static int default_scheduler_interval_millisecond = 10000;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropWorkloadGroupCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropWorkloadGroupCommand.java
@@ -60,6 +60,7 @@ public class DropWorkloadGroupCommand extends DropCommand {
         }
 
         if (Config.isCloudMode()) {
+            String originCgStr = computeGroup;
             if (StringUtils.isEmpty(computeGroup)) {
                 computeGroup = Tag.VALUE_DEFAULT_COMPUTE_GROUP_NAME;
             }
@@ -71,7 +72,9 @@ public class DropWorkloadGroupCommand extends DropCommand {
             if (StringUtils.isEmpty(clusterId)) {
                 WorkloadGroupKey wgKey = WorkloadGroupKey.get(computeGroup, workloadGroupName);
                 if (!Env.getCurrentEnv().getWorkloadGroupMgr().isWorkloadGroupExists(wgKey)) {
-                    throw new UserException("Can not find compute group " + computeGroup + ".");
+                    throw new UserException(
+                            "Can not find workload group  " + workloadGroupName + " in compute group " + originCgStr
+                                    + ".");
                 } // else case 2, input computeGroup is already a valid cluster id which has been dropped, so drop wg.
             } else {
                 computeGroup = clusterId;

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupChecker.java
@@ -19,6 +19,7 @@ package org.apache.doris.resource.workloadgroup;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.MasterDaemon;
 
 import org.apache.logging.log4j.LogManager;
@@ -29,7 +30,8 @@ public class WorkloadGroupChecker extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(WorkloadGroupChecker.class);
 
     public WorkloadGroupChecker() {
-        super("workloadgroup-checker-thread", Config.workload_group_check_interval_ms);
+        super("workloadgroup-checker-thread",
+                FeConstants.disableWGCheckerForUT ? 3600000 : Config.workload_group_check_interval_ms);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -158,6 +158,7 @@ public abstract class TestWithFeService {
         // this.enableAdvanceNextId may be reset by children classes
         Config.enable_advance_next_id = this.enableAdvanceNextId;
         FeConstants.enableInternalSchemaDb = false;
+        FeConstants.disableWGCheckerForUT = true;
         beforeCreatingConnectContext();
         connectContext = createDefaultCtx();
         beforeCluster();


### PR DESCRIPTION
### What problem does this PR solve?
Reset workload group checker's default interval to 2s, to create normal wg as fast as possible,  reduce the probability of query failure due to inability to find normal wg

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

