### PR TITLE
[check](pipeline)  Check the shared state is not set in the pipeline.

### DIFF
--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -526,6 +526,10 @@ Status PipelineXLocalState<SharedStateArg>::init(RuntimeState* state, LocalState
         }
     }
 
+    if (must_set_shared_state() && _shared_state == nullptr) {
+        return Status::InternalError("must set shared state, in {}", _parent->get_name());
+    }
+
     _rows_returned_counter =
             ADD_COUNTER_WITH_LEVEL(_runtime_profile, "RowsProduced", TUnit::UNIT, 1);
     _blocks_returned_counter =
@@ -611,6 +615,10 @@ Status PipelineXSinkLocalState<SharedState>::init(RuntimeState* state, LocalSink
         }
         _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
                 _profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
+    }
+
+    if (must_set_shared_state() && _shared_state == nullptr) {
+        return Status::InternalError("must set shared state, in {}", _parent->get_name());
     }
 
     _rows_input_counter = ADD_COUNTER_WITH_LEVEL(_profile, "InputRows", TUnit::UNIT, 1);

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -275,6 +275,10 @@ public:
     }
     Dependency* spill_dependency() const override { return _spill_dependency.get(); }
 
+    virtual bool must_set_shared_state() const {
+        return !std::is_same_v<SharedStateArg, FakeSharedState>;
+    }
+
 protected:
     Dependency* _dependency = nullptr;
     std::shared_ptr<Dependency> _spill_dependency;
@@ -527,6 +531,10 @@ public:
         return _dependency ? std::vector<Dependency*> {_dependency} : std::vector<Dependency*> {};
     }
     Dependency* spill_dependency() const override { return _spill_dependency.get(); }
+
+    virtual bool must_set_shared_state() const {
+        return !std::is_same_v<SharedStateArg, FakeSharedState>;
+    }
 
 protected:
     Dependency* _dependency = nullptr;

--- a/be/src/pipeline/exec/union_source_operator.cpp
+++ b/be/src/pipeline/exec/union_source_operator.cpp
@@ -55,6 +55,12 @@ Status UnionSourceLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     return Status::OK();
 }
 
+bool UnionSourceLocalState::must_set_shared_state() const {
+    auto& p = _parent->cast<Parent>();
+    // if this operator has no children, there is no shared state.(because no sink )
+    return p.get_child_count() != 0;
+}
+
 Status UnionSourceLocalState::open(RuntimeState* state) {
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_open_timer);

--- a/be/src/pipeline/exec/union_source_operator.h
+++ b/be/src/pipeline/exec/union_source_operator.h
@@ -47,6 +47,8 @@ public:
 
     [[nodiscard]] std::string debug_string(int indentation_level = 0) const override;
 
+    bool must_set_shared_state() const override;
+
 private:
     friend class UnionSourceOperatorX;
     friend class OperatorX<UnionSourceLocalState>;


### PR DESCRIPTION
### What problem does this PR solve?

In some cases, such as frontend planning errors, the shared state may not be initialized.
For example, when the concurrency of the source and sink do not match. 
If this issue isn't checked during initialization, it may cause a crash during execution, making the problem difficult to diagnose.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

