### PR TITLE
[hotfix](jdbc catalog) Fix jdbcclient repeated initialization

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -342,9 +342,13 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     public void configureJdbcTable(JdbcTable jdbcTable, String tableName) {
         makeSureInitialized();
+        setCommonJdbcTableProperties(jdbcTable, tableName, this.jdbcClient);
+    }
+
+    private void setCommonJdbcTableProperties(JdbcTable jdbcTable, String tableName, JdbcClient jdbcClient) {
         jdbcTable.setCatalogId(this.getId());
         jdbcTable.setExternalTableName(tableName);
-        jdbcTable.setJdbcTypeName(this.getDatabaseTypeName());
+        jdbcTable.setJdbcTypeName(jdbcClient.getDbType());
         jdbcTable.setJdbcUrl(this.getJdbcUrl());
         jdbcTable.setJdbcUser(this.getJdbcUser());
         jdbcTable.setJdbcPasswd(this.getJdbcPasswd());
@@ -426,21 +430,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     private JdbcTable getTestConnectionJdbcTable(JdbcClient testClient) throws DdlException {
         JdbcTable testTable = new JdbcTable(0, "test_jdbc_connection", Lists.newArrayList(),
                 TableType.JDBC_EXTERNAL_TABLE);
-        testTable.setCatalogId(this.getId());
-        testTable.setExternalTableName("test_jdbc_connection");
-        testTable.setJdbcTypeName(testClient.getDbType());
-        testTable.setJdbcUrl(this.getJdbcUrl());
-        testTable.setJdbcUser(this.getJdbcUser());
-        testTable.setJdbcPasswd(this.getJdbcPasswd());
-        testTable.setDriverClass(this.getDriverClass());
-        testTable.setDriverUrl(this.getDriverUrl());
-        testTable.setCheckSum(this.getCheckSum());
-        testTable.setResourceName(this.getResource());
-        testTable.setConnectionPoolMinSize(this.getConnectionPoolMinSize());
-        testTable.setConnectionPoolMaxSize(this.getConnectionPoolMaxSize());
-        testTable.setConnectionPoolMaxLifeTime(this.getConnectionPoolMaxLifeTime());
-        testTable.setConnectionPoolMaxWaitTime(this.getConnectionPoolMaxWaitTime());
-        testTable.setConnectionPoolKeepAlive(this.isConnectionPoolKeepAlive());
+        setCommonJdbcTableProperties(testTable, "test_jdbc_connection", testClient);
         // Special checksum computation
         testTable.setCheckSum(JdbcResource.computeObjectChecksum(this.getDriverUrl()));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -221,6 +221,10 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     @Override
     protected void initLocalObjectsImpl() {
+        jdbcClient = createJdbcClient();
+    }
+
+    private JdbcClient createJdbcClient() {
         JdbcClientConfig jdbcClientConfig = new JdbcClientConfig()
                 .setCatalog(this.name)
                 .setUser(getJdbcUser())
@@ -237,7 +241,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
                 .setConnectionPoolMaxWaitTime(getConnectionPoolMaxWaitTime())
                 .setConnectionPoolKeepAlive(isConnectionPoolKeepAlive());
 
-        jdbcClient = JdbcClient.createJdbcClient(jdbcClientConfig);
+        return JdbcClient.createJdbcClient(jdbcClientConfig);
     }
 
     @Override
@@ -361,22 +365,23 @@ public class JdbcExternalCatalog extends ExternalCatalog {
             return;
         }
         if (isTestConnection()) {
+            JdbcClient testClient = null;
             try {
-                initLocalObjectsImpl();
-                testFeToJdbcConnection();
-                testBeToJdbcConnection();
+                testClient = createJdbcClient();
+                testFeToJdbcConnection(testClient);
+                testBeToJdbcConnection(testClient);
             } finally {
-                if (jdbcClient != null) {
-                    jdbcClient.closeClient();
-                    jdbcClient = null;
+                if (testClient != null) {
+                    testClient.closeClient();
+                    testClient = null;
                 }
             }
         }
     }
 
-    private void testFeToJdbcConnection() throws DdlException {
+    private void testFeToJdbcConnection(JdbcClient testClient) throws DdlException {
         try {
-            jdbcClient.testConnection();
+            testClient.testConnection();
         } catch (JdbcClientException e) {
             String errorMessage = "Test FE Connection to JDBC Failed: " + e.getMessage();
             LOG.warn(errorMessage, e);
@@ -384,7 +389,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
         }
     }
 
-    private void testBeToJdbcConnection() throws DdlException {
+    private void testBeToJdbcConnection(JdbcClient testClient) throws DdlException {
         Backend aliveBe = null;
         try {
             for (Backend be : Env.getCurrentSystemInfo().getAllBackendsByAllCluster().values()) {
@@ -400,11 +405,11 @@ public class JdbcExternalCatalog extends ExternalCatalog {
         }
         TNetworkAddress address = new TNetworkAddress(aliveBe.getHost(), aliveBe.getBrpcPort());
         try {
-            JdbcTable jdbcTable = getTestConnectionJdbcTable();
+            JdbcTable testTable = getTestConnectionJdbcTable(testClient);
             PJdbcTestConnectionRequest request = InternalService.PJdbcTestConnectionRequest.newBuilder()
-                    .setJdbcTable(ByteString.copyFrom(new TSerializer().serialize(jdbcTable.toThrift())))
-                    .setJdbcTableType(jdbcTable.getJdbcTableType().getValue())
-                    .setQueryStr(jdbcClient.getTestQuery()).build();
+                    .setJdbcTable(ByteString.copyFrom(new TSerializer().serialize(testTable.toThrift())))
+                    .setJdbcTableType(testTable.getJdbcTableType().getValue())
+                    .setQueryStr(testClient.getTestQuery()).build();
             InternalService.PJdbcTestConnectionResult result = null;
             Future<PJdbcTestConnectionResult> future = BackendServiceProxy.getInstance()
                     .testJdbcConnection(address, request);
@@ -418,14 +423,27 @@ public class JdbcExternalCatalog extends ExternalCatalog {
         }
     }
 
-    private JdbcTable getTestConnectionJdbcTable() throws DdlException {
-        JdbcTable jdbcTable = new JdbcTable(0, "test_jdbc_connection", Lists.newArrayList(),
+    private JdbcTable getTestConnectionJdbcTable(JdbcClient testClient) throws DdlException {
+        JdbcTable testTable = new JdbcTable(0, "test_jdbc_connection", Lists.newArrayList(),
                 TableType.JDBC_EXTERNAL_TABLE);
-        this.configureJdbcTable(jdbcTable, "test_jdbc_connection");
-
+        testTable.setCatalogId(this.getId());
+        testTable.setExternalTableName("test_jdbc_connection");
+        testTable.setJdbcTypeName(testClient.getDbType());
+        testTable.setJdbcUrl(this.getJdbcUrl());
+        testTable.setJdbcUser(this.getJdbcUser());
+        testTable.setJdbcPasswd(this.getJdbcPasswd());
+        testTable.setDriverClass(this.getDriverClass());
+        testTable.setDriverUrl(this.getDriverUrl());
+        testTable.setCheckSum(this.getCheckSum());
+        testTable.setResourceName(this.getResource());
+        testTable.setConnectionPoolMinSize(this.getConnectionPoolMinSize());
+        testTable.setConnectionPoolMaxSize(this.getConnectionPoolMaxSize());
+        testTable.setConnectionPoolMaxLifeTime(this.getConnectionPoolMaxLifeTime());
+        testTable.setConnectionPoolMaxWaitTime(this.getConnectionPoolMaxWaitTime());
+        testTable.setConnectionPoolKeepAlive(this.isConnectionPoolKeepAlive());
         // Special checksum computation
-        jdbcTable.setCheckSum(JdbcResource.computeObjectChecksum(this.getDriverUrl()));
+        testTable.setCheckSum(JdbcResource.computeObjectChecksum(this.getDriverUrl()));
 
-        return jdbcTable;
+        return testTable;
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #50901

Problem Summary:

In the previous PR, I added makeSureInitialized() to configureJdbcTable, which will create the jdbcclient if it does not exist. However, in the testJdbcConnection process, makeSureInitialized() is bypassed and initLocalObjectsImpl is used directly. This will cause a jdbcclient to be created again when configureJdbcTable is used in testJdbcConnection, and the previous jdbcclient is not closed, resulting in a connection leak.

In the modification of this PR, I used a completely independent testClient for the TestConnection process to avoid this problem.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

