### PR TITLE
[chore](compile check) add compile option Wdeprecated-declarations

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -312,6 +312,7 @@ if (COMPILER_CLANG)
                         -Wunused-template
                         -Wunused-member-function
                         -Wunused-macros
+                        -Wdeprecated-declarations
                         -Wconversion)
     add_compile_options( -Wno-gnu-statement-expression
                         -Wno-implicit-float-conversion

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -69,7 +69,6 @@ AggregateFunctionPtr create_aggregate_function_single_value(const String& name,
         return creator_without_type::create<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<UInt64>>>>(
                 argument_types, result_is_nullable);
-    case PrimitiveType::TYPE_TIME:
     case PrimitiveType::TYPE_TIMEV2:
         return creator_without_type::create<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<Float64>>>>(

--- a/be/src/vec/core/call_on_type_index.h
+++ b/be/src/vec/core/call_on_type_index.h
@@ -186,8 +186,6 @@ bool call_on_index_and_data_type(PrimitiveType number, F&& f) {
         return f(TypePair<DataTypeNumber<Float32>, T>());
     case PrimitiveType::TYPE_DOUBLE:
         return f(TypePair<DataTypeNumber<Float64>, T>());
-    case PrimitiveType::TYPE_TIME:
-        return f(TypePair<DataTypeTimeV2, T>());
     case PrimitiveType::TYPE_TIMEV2:
         return f(TypePair<DataTypeTimeV2, T>());
     case PrimitiveType::TYPE_DECIMAL32:

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -163,8 +163,6 @@ PGenericType_TypeId IDataType::get_pdata_type(const IDataType* data_type) {
         return PGenericType::JSONB;
     case PrimitiveType::TYPE_MAP:
         return PGenericType::MAP;
-    case PrimitiveType::TYPE_TIME:
-        return PGenericType::TIME;
     case PrimitiveType::TYPE_AGG_STATE:
         return PGenericType::AGG_STATE;
     case PrimitiveType::TYPE_TIMEV2:


### PR DESCRIPTION
### What problem does this PR solve?

```
be/src/vec/core/call_on_type_index.h:189:25: warning: 'TYPE_TIME' is deprecated [-Wdeprecated-declarations]
  189 |     case PrimitiveType::TYPE_TIME:
      |                         ^
be/src/runtime/define_primitive_type.h:51:17: note: 'TYPE_TIME' has been explicitly marked deprecated here
   51 |     TYPE_TIME [[deprecated]], /*TYPE_TIMEV2*/
      |                 ^
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

