### PR TITLE
[fix](pipelinex) fix null aware left anti join instance num

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -948,12 +948,4 @@ public class HashJoinNode extends JoinNodeBase {
             return slotRef;
         }
     }
-
-    @Override
-    public boolean isNullAwareLeftAntiJoin() {
-        if (joinOp == JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN) {
-            return true;
-        }
-        return children.stream().anyMatch(PlanNode::isNullAwareLeftAntiJoin);
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -21,6 +21,7 @@
 package org.apache.doris.planner;
 
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.JoinOperator;
 import org.apache.doris.analysis.QueryStmt;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotRef;
@@ -517,7 +518,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     }
 
     public boolean hasNullAwareLeftAntiJoin() {
-        return planRoot.isNullAwareLeftAntiJoin();
+        return planRoot.anyMatch(plan -> plan instanceof JoinNodeBase
+                && ((JoinNodeBase) plan).getJoinOp() == JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN);
     }
 
     public boolean useSerialSource(ConnectContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -281,10 +281,6 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         this.fragment = fragment;
     }
 
-    public boolean isNullAwareLeftAntiJoin() {
-        return children.stream().anyMatch(PlanNode::isNullAwareLeftAntiJoin);
-    }
-
     public PlanFragment getFragment() {
         return fragment;
     }


### PR DESCRIPTION
### What problem does this PR solve?

introduce by #39480,  when pipelinex calculate instance number,  it need to check a plan contains null aware left anti join node. The related function is `isNullAwareLeftAntiJoin`, but only hash join node implements this function,  but nested loop join forgets to  implement it.  Then nested loop join for null aware left anti join will calculate a wrong instance num,  and cause be core.

Make their parent class JoinNodeBase to check it. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

