### PR TITLE
[fix](schema-cache) make catalog level schema cache config work for "get_schema_from_table" mode

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -130,5 +130,9 @@ github:
     - shuke987
     - wm1581066
     - doris-robot
+    - echo-hhj
+    - yuanyuan8983
+    - yz-jayhua
+    - ixzc
 notifications:
   pullrequests_status:  commits@doris.apache.org

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -668,7 +668,7 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
         List<FieldSchema> schema = null;
         Map<String, String> colDefaultValues = Maps.newHashMap();
         if (getFromTable) {
-            schema = getSchemaFromRemoteTable(remoteTable);
+            schema = getSchemaFromRemoteTable();
         } else {
             HMSCachedClient client = ((HMSExternalCatalog) catalog).getClient();
             schema = client.getSchema(dbName, name);
@@ -686,10 +686,13 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
         return Optional.of(new HMSSchemaCacheValue(columns, partitionColumns));
     }
 
-    private static List<FieldSchema> getSchemaFromRemoteTable(Table table) {
+    private List<FieldSchema> getSchemaFromRemoteTable() {
+        // Here we should get a new remote table instead of using this.remoteTable
+        // Because we need to get the latest schema from HMS.
+        Table newTable = ((HMSExternalCatalog) catalog).getClient().getTable(dbName, name);
         List<FieldSchema> schema = Lists.newArrayList();
-        schema.addAll(table.getSd().getCols());
-        schema.addAll(table.getPartitionKeys());
+        schema.addAll(newTable.getSd().getCols());
+        schema.addAll(newTable.getPartitionKeys());
         return schema;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -713,7 +713,10 @@ public class HiveMetaStoreClientHelper {
         return Type.UNSUPPORTED;
     }
 
-    public static String showCreateTable(org.apache.hadoop.hive.metastore.api.Table remoteTable) {
+    public static String showCreateTable(HMSExternalTable hmsTable) {
+        // Always use the latest schema
+        HMSExternalCatalog catalog = (HMSExternalCatalog) hmsTable.getCatalog();
+        Table remoteTable = catalog.getClient().getTable(hmsTable.getDbName(), hmsTable.getRemoteName());
         StringBuilder output = new StringBuilder();
         if (remoteTable.isSetViewOriginalText() || remoteTable.isSetViewExpandedText()) {
             output.append(String.format("CREATE VIEW `%s` AS ", remoteTable.getTableName()));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateTableCommand.java
@@ -131,7 +131,7 @@ public class ShowCreateTableCommand extends ShowCommand {
         try {
             if (table.getType() == Table.TableType.HMS_EXTERNAL_TABLE) {
                 rows.add(Arrays.asList(table.getName(),
-                        HiveMetaStoreClientHelper.showCreateTable(((HMSExternalTable) table).getRemoteTable())));
+                        HiveMetaStoreClientHelper.showCreateTable((HMSExternalTable) table)));
                 return new ShowResultSet(META_DATA, rows);
             }
             List<String> createTableStmt = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1180,7 +1180,7 @@ public class ShowExecutor {
         try {
             if (table.getType() == TableType.HMS_EXTERNAL_TABLE) {
                 rows.add(Arrays.asList(table.getName(),
-                        HiveMetaStoreClientHelper.showCreateTable(((HMSExternalTable) table).getRemoteTable())));
+                        HiveMetaStoreClientHelper.showCreateTable((HMSExternalTable) table)));
                 resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
                 return;
             }

--- a/regression-test/data/external_table_p0/hive/test_hive_meta_cache.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_meta_cache.out
@@ -121,3 +121,40 @@ k4	text	Yes	true	\N
 k5	text	Yes	true	\N	
 year	int	Yes	true	\N	
 
+-- !sql_3col --
+id	int	Yes	true	\N	
+amount	double	Yes	true	\N	
+year	int	Yes	true	\N	
+
+-- !sql_sct01_3col --
+sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2')
+
+-- !sql_4col --
+id	int	Yes	true	\N	
+amount	double	Yes	true	\N	
+k1	text	Yes	true	\N	
+year	int	Yes	true	\N	
+
+-- !sql_sct01_4col --
+sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2',\n  'last_modified_time'='1747714021',\n  'last_modified_by'='root')
+
+-- !sql_5col --
+id	int	Yes	true	\N	
+amount	double	Yes	true	\N	
+k1	text	Yes	true	\N	
+k2	text	Yes	true	\N	
+year	int	Yes	true	\N	
+
+-- !sql_sct01_5col --
+sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2',\n  'last_modified_time'='1747714021',\n  'last_modified_by'='root')
+
+-- !sql_5col --
+id	int	Yes	true	\N	
+amount	double	Yes	true	\N	
+k1	text	Yes	true	\N	
+k2	text	Yes	true	\N	
+year	int	Yes	true	\N	
+
+-- !sql_sct01_5col --
+sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string,\n  `k3` string)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2',\n  'last_modified_time'='1747714021',\n  'last_modified_by'='root')
+

--- a/regression-test/data/external_table_p0/hive/test_hive_meta_cache.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_meta_cache.out
@@ -126,18 +126,12 @@ id	int	Yes	true	\N
 amount	double	Yes	true	\N	
 year	int	Yes	true	\N	
 
--- !sql_sct01_3col --
-sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2')
-
 -- !sql_4col --
 id	int	Yes	true	\N	
 amount	double	Yes	true	\N	
 k1	text	Yes	true	\N	
 year	int	Yes	true	\N	
 
--- !sql_sct01_4col --
-sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2',\n  'last_modified_time'='1747714021',\n  'last_modified_by'='root')
-
 -- !sql_5col --
 id	int	Yes	true	\N	
 amount	double	Yes	true	\N	
@@ -145,16 +139,10 @@ k1	text	Yes	true	\N
 k2	text	Yes	true	\N	
 year	int	Yes	true	\N	
 
--- !sql_sct01_5col --
-sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2',\n  'last_modified_time'='1747714021',\n  'last_modified_by'='root')
-
 -- !sql_5col --
 id	int	Yes	true	\N	
 amount	double	Yes	true	\N	
 k1	text	Yes	true	\N	
 k2	text	Yes	true	\N	
 year	int	Yes	true	\N	
-
--- !sql_sct01_5col --
-sales	CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string,\n  `k3` string)\nPARTITIONED BY (\n `year` int)\nROW FORMAT SERDE\n  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'\nWITH SERDEPROPERTIES (\n  'serialization.format' = '1')\nSTORED AS INPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'\nOUTPUTFORMAT\n  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'\nLOCATION\n  'hdfs://172.20.32.136:8320/user/hive/warehouse/test_hive_meta_cache_db.db/sales'\nTBLPROPERTIES (\n  'transient_lastDdlTime'='1747714021',\n  'bucketing_version'='2',\n  'last_modified_time'='1747714021',\n  'last_modified_by'='root')
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
@@ -324,13 +324,18 @@ suite("test_hive_meta_cache", "p0,external,hive,external_docker,external_docker_
             // desc table, 3 columns
             qt_sql_3col "desc test_hive_meta_cache_db.sales";
             // show create table , 3 columns
-            qt_sql_sct01_3col "show create table test_hive_meta_cache_db.sales";
+            def sql_sct01_3col = sql "show create table test_hive_meta_cache_db.sales"
+            println "${sql_sct01_3col}"
+            assertTrue(sql_sct01_3col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double)\nPARTITIONED BY (\n `year` int)"));
+            
             // add a new column in hive
             hive_docker "alter table test_hive_meta_cache_db.sales add columns(k1 string)"
             // desc table, 4 columns
             qt_sql_4col "desc test_hive_meta_cache_db.sales";
             // show create table, 4 columns
-            qt_sql_sct01_4col "show create table test_hive_meta_cache_db.sales";
+            def sql_sct01_4col = sql "show create table test_hive_meta_cache_db.sales"
+            println "${sql_sct01_4col}"
+            assertTrue(sql_sct01_4col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string)\nPARTITIONED BY (\n `year` int)"));
 
             // open schema cache
             sql """alter catalog ${catalog_name_no_cache} set properties ("schema.cache.ttl-second" = "120")"""
@@ -339,13 +344,17 @@ suite("test_hive_meta_cache", "p0,external,hive,external_docker,external_docker_
             // desc table, 5 columns
             qt_sql_5col "desc test_hive_meta_cache_db.sales";
             // show create table, 5 columns
-            qt_sql_sct01_5col "show create table test_hive_meta_cache_db.sales";
+            def sql_sct01_5col = sql "show create table test_hive_meta_cache_db.sales"
+            println "${sql_sct01_5col}"
+            assertTrue(sql_sct01_5col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string)\nPARTITIONED BY (\n `year` int)"));
             // add a new column in hive
             hive_docker "alter table test_hive_meta_cache_db.sales add columns(k3 string)"
             // desc table, still 5 columns
             qt_sql_5col "desc test_hive_meta_cache_db.sales";
             // show create table always see latest schema, 6 columns
-            qt_sql_sct01_5col "show create table test_hive_meta_cache_db.sales";
+            def sql_sct01_6col = sql "show create table test_hive_meta_cache_db.sales"
+            println "${sql_sct01_6col}"
+            assertTrue(sql_sct01_6col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string,\n  `k3` string)\nPARTITIONED BY (\n `year` int)"));
             sql """drop table test_hive_meta_cache_db.sales"""
         }
     }

--- a/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
@@ -296,6 +296,57 @@ suite("test_hive_meta_cache", "p0,external,hive,external_docker,external_docker_
             // desc table, 6 columns
             qt_sql_6col "desc test_hive_meta_cache_db.sales";
             sql """drop table test_hive_meta_cache_db.sales"""
+
+            // test schema cache with get_schema_from_table
+            sql """drop catalog if exists ${catalog_name_no_cache};"""
+            // 1. create catalog with schema cache off and get_schema_from_table
+            sql """
+            create catalog ${catalog_name_no_cache} properties (
+                'type'='hms',
+                'hadoop.username' = 'hadoop',
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hmsPort}',
+                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
+                'schema.cache.ttl-second' = '0',
+                'get_schema_from_table' = 'true'
+            );
+            """
+            sql """switch ${catalog_name_no_cache}"""
+            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
+            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """
+                CREATE TABLE test_hive_meta_cache_db.sales (
+                  id INT,
+                  amount DOUBLE
+                )
+                PARTITIONED BY (year INT)
+                STORED AS PARQUET;
+            """
+            // desc table, 3 columns
+            qt_sql_3col "desc test_hive_meta_cache_db.sales";
+            // show create table , 3 columns
+            qt_sql_sct01_3col "show create table test_hive_meta_cache_db.sales";
+            // add a new column in hive
+            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k1 string)"
+            // desc table, 4 columns
+            qt_sql_4col "desc test_hive_meta_cache_db.sales";
+            // show create table, 4 columns
+            qt_sql_sct01_4col "show create table test_hive_meta_cache_db.sales";
+
+            // open schema cache
+            sql """alter catalog ${catalog_name_no_cache} set properties ("schema.cache.ttl-second" = "120")"""
+            // add a new column in hive
+            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k2 string)"
+            // desc table, 5 columns
+            qt_sql_5col "desc test_hive_meta_cache_db.sales";
+            // show create table, 5 columns
+            qt_sql_sct01_5col "show create table test_hive_meta_cache_db.sales";
+            // add a new column in hive
+            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k3 string)"
+            // desc table, still 5 columns
+            qt_sql_5col "desc test_hive_meta_cache_db.sales";
+            // show create table always see latest schema, 6 columns
+            qt_sql_sct01_5col "show create table test_hive_meta_cache_db.sales";
+            sql """drop table test_hive_meta_cache_db.sales"""
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #50958

Problem Summary:

In #50958, I introduced the catalog level schema cache switch.
But if use also add `"get_schema_from_table" = "true"`, the schema will be fetched from
`Hive Table` instead of schema cache, so the schema cache config is broken.

This PR fix it:

1. Always get new `Hive Table` instance to get schema from table. To make schema change config work.
2. For `show create table xxx`, it will always show the latest schema of a hive table.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

