### PR TITLE
[opt](docker) add a script flag to control load data or not

### DIFF
--- a/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl
+++ b/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl
@@ -53,3 +53,6 @@ YARN_CONF_yarn_timeline___service_hostname=historyserver
 YARN_CONF_yarn_resourcemanager_address=resourcemanager:8032
 YARN_CONF_yarn_resourcemanager_scheduler_address=resourcemanager:8030
 YARN_CONF_yarn_resourcemanager_resource__tracker_address=resourcemanager:8031
+
+NEED_LOAD_DATA=${NEED_LOAD_DATA}
+

--- a/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
@@ -18,6 +18,7 @@
 
 set -e -x
 
+
 parallel=$(getconf _NPROCESSORS_ONLN)
 
 AUX_LIB="/mnt/scripts/auxlib"
@@ -43,6 +44,13 @@ while ! $(nc -z localhost "${HMS_PORT:-9083}"); do
     sleep 5s
 done
 
+if [[ ${NEED_LOAD_DATA} = "0" ]]; then
+    rm -f "${lockfile1}"
+    echo "NEED_LOAD_DATA is 0, skip load data"
+    touch /mnt/SUCCESS
+    # Avoid container exit
+    tail -f /dev/null
+fi
 # create tables for other cases
 # new cases should use separate dir
 hadoop fs -mkdir -p /user/doris/suites/

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -36,6 +36,7 @@ Usage: $0 <options>
      -c mysql,hive3     start MySQL and Hive3
      --stop             stop the specified components
      --reserve-ports    reserve host ports by setting 'net.ipv4.ip_local_reserved_ports' to avoid port already bind error
+     --no-load-data     do not load data into the components
 
   All valid components:
     mysql,pg,oracle,sqlserver,clickhouse,es,hive2,hive3,iceberg,hudi,trino,kafka,mariadb,db2,oceanbase,lakesoul,kerberos,ranger
@@ -48,6 +49,7 @@ COMPONENTS=$2
 HELP=0
 STOP=0
 NEED_RESERVE_PORTS=0
+export NEED_LOAD_DATA=1
 
 if ! OPTS="$(getopt \
     -n "$0" \
@@ -55,6 +57,7 @@ if ! OPTS="$(getopt \
     -l 'help' \
     -l 'stop' \
     -l 'reserve-ports' \
+    -l 'no-load-data' \
     -o 'hc:' \
     -- "$@")"; then
     usage
@@ -86,6 +89,10 @@ else
             ;;
         --reserve-ports)
             NEED_RESERVE_PORTS=1
+            shift
+            ;;
+        --no-load-data)
+            export NEED_LOAD_DATA=0
             shift
             ;;
         --)


### PR DESCRIPTION
### What problem does this PR solve?
Currently the component loads test data by default, but in many cases only the environment is needed and not the test data. 
Because hive loading test data is very slow, first support hive components.
Other components to be supported on demand in the future.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

