### PR TITLE
[improve](nereids)Remove use of session variable deprecated_group_by_and_having_use_alias_first 2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1490,11 +1490,7 @@ public class SelectStmt extends QueryStmt implements NotFallbackInParser {
                 groupingInfo.buildRepeat(groupingExprs, groupByClause.getGroupingSetList());
             }
 
-            boolean aliasFirst = false;
-            if (analyzer.getContext() != null) {
-                aliasFirst = analyzer.getContext().getSessionVariable().isGroupByAndHavingUseAliasFirst();
-            }
-            substituteOrdinalsAliases(groupingExprs, "GROUP BY", analyzer, aliasFirst);
+            substituteOrdinalsAliases(groupingExprs, "GROUP BY", analyzer, false);
             // the groupingExprs must substitute in the same way as resultExprs
             groupingExprs = Expr.substituteList(groupingExprs, countAllMap, analyzer, false);
 


### PR DESCRIPTION
Remove use of session variable deprecated_group_by_and_having_use_alias_first, because it is useless.
Related pr: https://github.com/apache/doris/pull/51015

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

