### PR TITLE
[fix](core) fix avg rate field always showing 0 in cluster_balance show proc (#51101)

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -2067,12 +2067,18 @@ void clone_callback(StorageEngine& engine, const ClusterInfo* cluster_info,
     } else {
         LOG_INFO("successfully clone tablet")
                 .tag("signature", req.signature)
-                .tag("tablet_id", clone_req.tablet_id);
+                .tag("tablet_id", clone_req.tablet_id)
+                .tag("copy_size", engine_task.get_copy_size())
+                .tag("copy_time_ms", engine_task.get_copy_time_ms());
+
         if (engine_task.is_new_tablet()) {
             increase_report_version();
             finish_task_request.__set_report_version(s_report_version);
         }
         finish_task_request.__set_finish_tablet_infos(tablet_infos);
+        finish_task_request.__set_copy_size(engine_task.get_copy_size());
+        finish_task_request.__set_copy_time_ms(engine_task.get_copy_time_ms());
+
     }
 
     finish_task(finish_task_request);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -2078,7 +2078,6 @@ void clone_callback(StorageEngine& engine, const ClusterInfo* cluster_info,
         finish_task_request.__set_finish_tablet_infos(tablet_infos);
         finish_task_request.__set_copy_size(engine_task.get_copy_size());
         finish_task_request.__set_copy_time_ms(engine_task.get_copy_time_ms());
-
     }
 
     finish_task(finish_task_request);

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -56,7 +56,7 @@ public:
     ~EngineCloneTask() override = default;
 
     bool is_new_tablet() const { return _is_new_tablet; }
-    
+
     int64_t get_copy_size() const { return _copy_size; }
     int64_t get_copy_time_ms() const { return _copy_time_ms; }
 

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -56,6 +56,9 @@ public:
     ~EngineCloneTask() override = default;
 
     bool is_new_tablet() const { return _is_new_tablet; }
+    
+    int64_t get_copy_size() const { return _copy_size; }
+    int64_t get_copy_time_ms() const { return _copy_time_ms; }
 
 private:
     Status _do_clone();


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #51101


Problem Summary:
The AvgRate field in the result returned by show proc '/cluster_balance/working_slots' is always 0.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

