### PR TITLE
[opt](cloud) load data no call partition.getVisibleVersion in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -374,12 +374,10 @@ public class Tablet extends MetaObject {
         return allQueryableReplica;
     }
 
-    public String getDetailsStatusForQuery(Long visibleVersion) {
+    public String getDetailsStatusForQuery(long visibleVersion) {
         StringBuilder sb = new StringBuilder("Visible Replicas:");
-        if (visibleVersion != null) {
-            sb.append("Visible version: ").append(visibleVersion).append(", ");
-        }
-        sb.append("Replicas: ");
+        sb.append("Visible version: ").append(visibleVersion);
+        sb.append(", Replicas: ");
         sb.append(Joiner.on(", ").join(replicas.stream().map(replica -> replica.toStringSimple(true))
                 .collect(Collectors.toList())));
         sb.append(".");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -374,10 +374,12 @@ public class Tablet extends MetaObject {
         return allQueryableReplica;
     }
 
-    public String getDetailsStatusForQuery(long visibleVersion) {
+    public String getDetailsStatusForQuery(Long visibleVersion) {
         StringBuilder sb = new StringBuilder("Visible Replicas:");
-        sb.append("Visible version: ").append(visibleVersion);
-        sb.append(", Replicas: ");
+        if (visibleVersion != null) {
+            sb.append("Visible version: ").append(visibleVersion).append(", ");
+        }
+        sb.append("Replicas: ");
         sb.append(Joiner.on(", ").join(replicas.stream().map(replica -> replica.toStringSimple(true))
                 .collect(Collectors.toList())));
         sb.append(".");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -57,7 +57,6 @@ import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugPointUtil.DebugPoint;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertCommandContext;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.rpc.RpcException;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TColumn;


### PR DESCRIPTION
### What problem does this PR solve?

For olap sink, when available replica not enough, it will load failed,   and give a hint to desc the replicas' detail info.  The detail info  include partition's visible version.  But in cloud mode,  the partition's get visible version is a rpc,  and in cloud mode, the partition's visible version will not affect the succ or failure for the loading data.  So cloud mode will not need partition's visible version for hint,   then we remove it.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

