### PR TITLE
[fix](statistics)Fix sample analyze agg/mor table doesn't remove new partition flag bug.

### DIFF
--- a/regression-test/suites/statistics/test_skip_agg_table_value_column.groovy
+++ b/regression-test/suites/statistics/test_skip_agg_table_value_column.groovy
@@ -94,6 +94,29 @@ suite("test_skip_agg_table_value_column") {
     createMV("create materialized view mv6 as select key1, sum(value1) from agg group by key1;")
     sql """insert into agg values (1, 2, 3, 4, 5), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
 
+    sql """CREATE TABLE agg_partition (
+            key1 bigint NOT NULL,
+            key2 bigint NOT NULL,
+            value1 int SUM NOT NULL,
+            value2 int MAX NOT NULL,
+            value3 int MIN NOT NULL
+        )ENGINE=OLAP
+        AGGREGATE KEY(`key1`, `key2`)
+        COMMENT "OLAP"
+        PARTITION BY RANGE(`key1`)
+        (PARTITION p1 VALUES [("0"), ("100")),
+        PARTITION p2 VALUES [("100"), ("10000")))
+        DISTRIBUTED BY HASH(`key1`) BUCKETS 2
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+    createMV("create materialized view mv1 as select key2 from agg_partition group by key2;")
+    createMV("create materialized view mv3 as select key1, key2, sum(value1), max(value2), min(value3) from agg_partition group by key1, key2;")
+    createMV("create materialized view mv6 as select key1, sum(value1) from agg_partition group by key1;")
+    sql """analyze table agg_partition(key1) with sync"""
+    sql """insert into agg_partition values (1, 2, 3, 4, 5), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
+
     // Test unique table
     sql """
         CREATE TABLE uni_mor (
@@ -111,6 +134,34 @@ suite("test_skip_agg_table_value_column") {
             "replication_num" = "1"
         );
     """
+    createMV("create materialized view mv1 as select key1, key2 from uni_mor;")
+    createMV("create materialized view mv6 as select key1, key2, value2, value3 from uni_mor;")
+    sql """insert into uni_mor values (1, 2, 3, 4, 5), (1, 2, 3, 7, 8), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
+
+    sql """
+        CREATE TABLE uni_mor_partition (
+            key1 bigint NOT NULL,
+            key2 bigint NOT NULL,
+            value1 int NOT NULL,
+            value2 int NOT NULL,
+            value3 int NOT NULL
+        )ENGINE=OLAP
+        UNIQUE KEY(`key1`, `key2`)
+        COMMENT "OLAP"
+        PARTITION BY RANGE(`key1`)
+        (PARTITION p1 VALUES [("0"), ("100")),
+        PARTITION p2 VALUES [("100"), ("10000")))
+        DISTRIBUTED BY HASH(`key1`) BUCKETS 2
+        PROPERTIES (
+            "enable_unique_key_merge_on_write" = false,
+            "replication_num" = "1"
+        );
+    """
+    createMV("create materialized view mv1 as select key1, key2 from uni_mor_partition;")
+    createMV("create materialized view mv6 as select key1, key2, value2, value3 from uni_mor_partition;")
+    sql """analyze table uni_mor_partition(key1) with sync"""
+    sql """insert into uni_mor_partition values (1, 2, 3, 4, 5), (1, 2, 3, 7, 8), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
+
     sql """
         CREATE TABLE uni_mow (
             key1 bigint NOT NULL,
@@ -127,9 +178,6 @@ suite("test_skip_agg_table_value_column") {
             "replication_num" = "1"
         );
     """
-    createMV("create materialized view mv1 as select key1, key2 from uni_mor;")
-    createMV("create materialized view mv6 as select key1, key2, value2, value3 from uni_mor;")
-    sql """insert into uni_mor values (1, 2, 3, 4, 5), (1, 2, 3, 7, 8), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
     createMV("create materialized view mv1 as select key1, key2 from uni_mow;")
     createMV("create materialized view mv6 as select key1, key2, value2, value3 from uni_mow;")
     sql """insert into uni_mow values (1, 2, 3, 4, 5), (1, 2, 3, 7, 8), (1, 11, 22, 33, 44), (10, 20, 30, 40, 50), (10, 20, 30, 40, 50), (100, 200, 300, 400, 500), (1001, 2001, 3001, 4001, 5001);"""
@@ -142,9 +190,16 @@ suite("test_skip_agg_table_value_column") {
     wait_row_count_reported("test_skip_agg_table_value_column", "agg", 1, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "agg", 2, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "agg", 3, 4, "4")
+    wait_row_count_reported("test_skip_agg_table_value_column", "agg_partition", 0, 4, "5")
+    wait_row_count_reported("test_skip_agg_table_value_column", "agg_partition", 1, 4, "5")
+    wait_row_count_reported("test_skip_agg_table_value_column", "agg_partition", 2, 4, "5")
+    wait_row_count_reported("test_skip_agg_table_value_column", "agg_partition", 3, 4, "4")
     wait_row_count_reported("test_skip_agg_table_value_column", "uni_mor", 0, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "uni_mor", 1, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "uni_mor", 2, 4, "5")
+    wait_row_count_reported("test_skip_agg_table_value_column", "uni_mor_partition", 0, 4, "5")
+    wait_row_count_reported("test_skip_agg_table_value_column", "uni_mor_partition", 1, 4, "5")
+    wait_row_count_reported("test_skip_agg_table_value_column", "uni_mor_partition", 2, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "uni_mow", 0, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "uni_mow", 1, 4, "5")
     wait_row_count_reported("test_skip_agg_table_value_column", "uni_mow", 2, 4, "5")
@@ -175,6 +230,14 @@ suite("test_skip_agg_table_value_column") {
     result = sql """show column stats agg"""
     assertEquals(0, result.size())
 
+    result = sql """show table stats agg_partition"""
+    assertEquals("true", result[0][6])
+    sql """analyze table agg_partition with sync with sample rows 400000"""
+    result = sql """show column stats agg_partition"""
+    assertEquals(6, result.size())
+    result = sql """show table stats agg_partition"""
+    assertEquals("false", result[0][6])
+
     sql """analyze table uni_mor with sync"""
     result = sql """show column stats uni_mor"""
     assertEquals(11, result.size())
@@ -187,6 +250,14 @@ suite("test_skip_agg_table_value_column") {
     sql """drop stats uni_mor"""
     result = sql """show column stats uni_mor"""
     assertEquals(0, result.size())
+
+    result = sql """show table stats uni_mor_partition"""
+    assertEquals("true", result[0][6])
+    sql """analyze table uni_mor_partition with sync with sample rows 400000"""
+    result = sql """show column stats uni_mor_partition"""
+    assertEquals(6, result.size())
+    result = sql """show table stats uni_mor_partition"""
+    assertEquals("false", result[0][6])
 
     sql """analyze table uni_mow with sync"""
     result = sql """show column stats uni_mow"""
@@ -225,4 +296,3 @@ suite("test_skip_agg_table_value_column") {
 
     sql """drop database if exists test_skip_agg_table_value_column"""
 }
-


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #49918

Problem Summary:

Fix sample analyze agg/mor table doesn't remove new partition flag bug.
When a new partition load data for the first time, we set a flag to this table's metadata, this flag indicate that the statistics data of this table is expired and not accurate, so it will trigger a new collection for this table. After collect all columns of this table, we remove this flag so it will not be analyzed again.
This pr (#49918) skip collecting value columns of agg and unique mor table, but didn't change the logic to remove the new partition flag. The old logic require all columns has been collected before remove the flag, but value columns are skipped, so the flag will never be removed. This will cause the table be analyzed repeatedly. This pr is to fix the bug.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

