### PR TITLE
[Fix](function) Support encrypt empty string

### DIFF
--- a/be/src/vec/functions/function_encryption.cpp
+++ b/be/src/vec/functions/function_encryption.cpp
@@ -145,10 +145,6 @@ void execute_result(const char* src_raw, size_t src_size, const char* key_raw, s
                     size_t i, EncryptionMode& encryption_mode, const char* iv_raw, size_t iv_length,
                     ColumnString::Chars& result_data, ColumnString::Offsets& result_offset,
                     NullMap& null_map, const char* aad, size_t aad_length) {
-    if (src_size == 0) {
-        StringOP::push_null_string(i, result_data, result_offset, null_map);
-        return;
-    }
     auto cipher_len = src_size;
     if constexpr (is_encrypt) {
         cipher_len += 16;

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -1973,6 +1973,7 @@ TEST(function_string_test, function_sm3sum_test) {
 }
 
 TEST(function_string_test, function_aes_encrypt_test) {
+    //FIXME: these tests have no meaning because the result is from themselves.
     std::string func_name = "aes_encrypt";
     {
         InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR, PrimitiveType::TYPE_VARCHAR,
@@ -1981,9 +1982,9 @@ TEST(function_string_test, function_aes_encrypt_test) {
         const char* mode = "AES_128_ECB";
         const char* key = "doris";
         const char* src[6] = {"aaaaaa", "bbbbbb", "cccccc", "dddddd", "eeeeee", ""};
-        std::string r[5];
+        std::string r[6];
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 6; i++) {
             int cipher_len = strlen(src[i]) + 16;
             std::vector<char> p(cipher_len);
 
@@ -1998,7 +1999,7 @@ TEST(function_string_test, function_aes_encrypt_test) {
                             {{std::string(src[2]), std::string(key), std::string(mode)}, r[2]},
                             {{std::string(src[3]), std::string(key), std::string(mode)}, r[3]},
                             {{std::string(src[4]), std::string(key), std::string(mode)}, r[4]},
-                            {{std::string(src[5]), std::string(key), std::string(mode)}, Null()},
+                            {{std::string(src[5]), std::string(key), std::string(mode)}, r[5]},
                             {{Null(), std::string(key), std::string(mode)}, Null()}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
@@ -2010,9 +2011,9 @@ TEST(function_string_test, function_aes_encrypt_test) {
         const char* mode = "AES_256_ECB";
         const char* key = "vectorized";
         const char* src[6] = {"aaaaaa", "bbbbbb", "cccccc", "dddddd", "eeeeee", ""};
-        std::string r[5];
+        std::string r[6];
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 6; i++) {
             int cipher_len = strlen(src[i]) + 16;
             std::vector<char> p(cipher_len);
             int iv_len = 32;
@@ -2033,8 +2034,7 @@ TEST(function_string_test, function_aes_encrypt_test) {
                 {{std::string(src[2]), std::string(key), std::string(iv), std::string(mode)}, r[2]},
                 {{std::string(src[3]), std::string(key), std::string(iv), std::string(mode)}, r[3]},
                 {{std::string(src[4]), std::string(key), std::string(iv), std::string(mode)}, r[4]},
-                {{std::string(src[5]), std::string(key), std::string(iv), std::string(mode)},
-                 Null()},
+                {{std::string(src[5]), std::string(key), std::string(iv), std::string(mode)}, r[5]},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
@@ -2116,9 +2116,9 @@ TEST(function_string_test, function_sm4_encrypt_test) {
         const char* iv = "0123456789abcdef";
         const char* mode = "SM4_128_ECB";
         const char* src[6] = {"aaaaaa", "bbbbbb", "cccccc", "dddddd", "eeeeee", ""};
-        std::string r[5];
+        std::string r[6];
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 6; i++) {
             int cipher_len = strlen(src[i]) + 16;
             std::vector<char> p(cipher_len);
             int iv_len = 32;
@@ -2139,8 +2139,7 @@ TEST(function_string_test, function_sm4_encrypt_test) {
                 {{std::string(src[2]), std::string(key), std::string(iv), std::string(mode)}, r[2]},
                 {{std::string(src[3]), std::string(key), std::string(iv), std::string(mode)}, r[3]},
                 {{std::string(src[4]), std::string(key), std::string(iv), std::string(mode)}, r[4]},
-                {{std::string(src[5]), std::string(key), std::string(iv), std::string(mode)},
-                 Null()},
+                {{std::string(src[5]), std::string(key), std::string(iv), std::string(mode)}, r[5]},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);
@@ -2154,9 +2153,9 @@ TEST(function_string_test, function_sm4_encrypt_test) {
         const char* iv = "0123456789abcdef";
         const char* mode = "SM4_128_CTR";
         const char* src[6] = {"aaaaaa", "bbbbbb", "cccccc", "dddddd", "eeeeee", ""};
-        std::string r[5];
+        std::string r[6];
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 6; i++) {
             int cipher_len = strlen(src[i]) + 16;
             std::vector<char> p(cipher_len);
             int iv_len = 32;
@@ -2177,8 +2176,7 @@ TEST(function_string_test, function_sm4_encrypt_test) {
                 {{std::string(src[2]), std::string(key), std::string(iv), std::string(mode)}, r[2]},
                 {{std::string(src[3]), std::string(key), std::string(iv), std::string(mode)}, r[3]},
                 {{std::string(src[4]), std::string(key), std::string(iv), std::string(mode)}, r[4]},
-                {{std::string(src[5]), std::string(key), std::string(iv), std::string(mode)},
-                 Null()},
+                {{std::string(src[5]), std::string(key), std::string(iv), std::string(mode)}, r[5]},
                 {{Null(), std::string(key), std::string(iv), std::string(mode)}, Null()}};
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);

--- a/regression-test/data/nereids_p0/sql_functions/encryption_digest/test_encryption_function.out
+++ b/regression-test/data/nereids_p0/sql_functions/encryption_digest/test_encryption_function.out
@@ -82,3 +82,18 @@ Spark
 -- !sql_gcm_8 --
 Spark SQL
 
+-- !sql_empty1 --
+1AA197B230C9488519819C2D25AF4CB0
+
+-- !sql_empty2 --
+1AA197B230C9488519819C2D25AF4CB0
+
+-- !sql_empty3 --
+1AA197B230C9488519819C2D25AF4CB0
+
+-- !sql_empty4 --
+0D56319E329CDA9ABDF5870B9D5ACA57
+
+-- !sql_empty5 --
+
+

--- a/regression-test/suites/nereids_p0/sql_functions/encryption_digest/test_encryption_function.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/encryption_digest/test_encryption_function.groovy
@@ -89,4 +89,11 @@ suite("test_encryption_function") {
     // test for const opt branch, only first column is not const
     qt_sql_gcm_7 "SELECT id,TO_BASE64(AES_ENCRYPT(plain_txt, '1234567890abcdef', '123456789012', 'aes_128_gcm', 'Some AAD')) from aes_encrypt_decrypt_tbl where id=1"
     qt_sql_gcm_8 "SELECT AES_DECRYPT(FROM_BASE64(enc_txt), '1234567890abcdef', '', 'aes_128_gcm', 'Some AAD') from aes_encrypt_decrypt_tbl where id=1"
+
+    sql "unset variable block_encryption_mode;"
+    qt_sql_empty1 "select hex(aes_encrypt('', 'securekey456'));"
+    qt_sql_empty2 "select hex(aes_encrypt(rpad('', 16, ''), 'securekey456'));"
+    qt_sql_empty3 "select hex(aes_encrypt(rpad('', 17, ''), 'securekey456'));"
+    qt_sql_empty4 "select hex(sm4_encrypt('', 'securekey456'));"
+    qt_sql_empty5 "select sm4_decrypt(unhex('0D56319E329CDA9ABDF5870B9D5ACA57'), 'securekey456');"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

for empty string, we now treat it as a string with a length not a multiple of the blocksize. and pad it.

before:
```sql
mysql> select aes_encrypt('', 'securekey456');
+---------------------------------+
| aes_encrypt('', 'securekey456') |
+---------------------------------+
| NULL                            |
+---------------------------------+
1 row in set (1 min 27.38 sec)
```
now:
```sql
mysql> select aes_encrypt('', 'securekey456');
+---------------------------------+
| aes_encrypt('', 'securekey456') |
+---------------------------------+
| ???0?H???-%?L?                         |
+---------------------------------+
1 row in set (6.37 sec)
```

### Release note

Support encrypt empty string

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

