### PR TITLE
[Fix](function) Add lost check of function SHA2 in nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Sha2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Sha2.java
@@ -18,9 +18,11 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.StringType;
@@ -28,6 +30,7 @@ import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 
@@ -41,11 +44,29 @@ public class Sha2 extends ScalarFunction
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(VarcharType.SYSTEM_DEFAULT, IntegerType.INSTANCE),
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(StringType.INSTANCE, IntegerType.INSTANCE));
 
+    private static final List<Integer> validDigest = Lists.newArrayList(224, 256, 384, 512);
+
     /**
      * constructor with 2 arguments.
      */
     public Sha2(Expression arg0, Expression arg1) {
         super("sha2", arg0, arg1);
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        checkLegalityAfterRewrite();
+    }
+
+    @Override
+    public void checkLegalityAfterRewrite() {
+        if (!(child(1) instanceof IntegerLikeLiteral)) {
+            throw new AnalysisException("the second parameter of sha2 must be a literal but got: " + child(1).toSql());
+        }
+        final int constParam = ((IntegerLikeLiteral) child(1)).getIntValue();
+        if (!validDigest.contains(constParam)) {
+            throw new AnalysisException("sha2 functions only support digest length of " + validDigest.toString());
+        }
     }
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/24342

Problem Summary:

before:
```sql
select sha2(k0, k1) from str;
```
it works **but the result may doesn't match with the input!**

now:
```sql
ERROR 1105 (HY000): errCode = 2, detailMessage = sha2 needs two params, and the second is must be a integer constant: sha2(k0, k1)
```

### Release note

Fix lost arguments check of function SHA2

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/2406

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

