### PR TITLE
[fix](export) remove task from map finally

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/TransientTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/TransientTaskManager.java
@@ -63,7 +63,7 @@ public class TransientTaskManager {
     }
 
     public void cancelMemoryTask(Long taskId) throws JobException {
-        TransientTaskExecutor transientTaskExecutor = taskExecutorMap.get(taskId);
+        TransientTaskExecutor transientTaskExecutor = taskExecutorMap.remove(taskId);
         if (transientTaskExecutor != null) {
             transientTaskExecutor.cancel();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #47974

Problem Summary:

When cancel task, the task should be removed from `taskExecutorMap`,
otherwise, if `tryPublishTask()` failed when `addMemoryTask`, the task will
be leaked in `taskExecutorMap`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

