### PR TITLE
[fix](iceberg) Fix some issues in batch mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -84,6 +84,7 @@ public class ExternalMetaCacheMgr {
     private ExecutorService rowCountRefreshExecutor;
     private ExecutorService commonRefreshExecutor;
     private ExecutorService fileListingExecutor;
+    // This executor is used to schedule the getting split tasks
     private ExecutorService scheduleExecutor;
 
     // catalog id -> HiveMetaStoreCache

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -109,7 +109,7 @@ public class SplitAssignment {
             for (Split split : splits) {
                 locations.add(splitToScanRange.getScanRange(backend, locationProperties, split, pathPartitionKeys));
             }
-            while (true) {
+            while (needMoreSplit()) {
                 BlockingQueue<Collection<TScanRangeLocations>> queue =
                         assignment.computeIfAbsent(backend, be -> new LinkedBlockingQueue<>(10000));
                 try {
@@ -119,13 +119,6 @@ public class SplitAssignment {
                 } catch (InterruptedException e) {
                     addUserException(new UserException("Failed to offer batch split by interrupted", e));
                 }
-                // Throwing an exception here is to terminate the external thread.
-                // Otherwise, the external thread will still generate splits
-                //     and continue to add them to the queue.
-                if (exception != null) {
-                    throw exception;
-                }
-                break;
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -80,7 +80,7 @@ public class SplitAssignment {
             int waitIntervalTimeMillis = 100;
             int initTimeoutMillis = 5000; // 5s
             int waitTotalTime = 0;
-            while (sampleSplit == null && waitFirstSplit()) {
+            while (sampleSplit == null && needMoreSplit()) {
                 try {
                     assignLock.wait(waitIntervalTimeMillis);
                 } catch (InterruptedException e) {
@@ -97,7 +97,7 @@ public class SplitAssignment {
         }
     }
 
-    public boolean waitFirstSplit() {
+    public boolean needMoreSplit() {
         return !scheduleFinished.get() && !isStopped.get() && exception == null;
     }
 
@@ -118,7 +118,7 @@ public class SplitAssignment {
                 } catch (InterruptedException e) {
                     throw new UserException("Failed to offer batch split by interrupted", e);
                 }
-                if (waitFirstSplit()) {
+                if (needMoreSplit()) {
                     // Throwing an exception here is to terminate the external thread.
                     // Otherwise, the external thread will still generate splits
                     //     and continue to add them to the queue.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -180,12 +180,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
                     String.valueOf(Config.hive_metastore_client_timeout_second));
         }
         HiveMetadataOps hiveOps = ExternalMetadataOperations.newHiveMetadataOps(hiveConf, jdbcClientConfig, this);
-        threadPoolWithPreAuth = ThreadPoolManager.newDaemonFixedThreadPoolWithPreAuth(
-            ICEBERG_CATALOG_EXECUTOR_THREAD_NUM,
-            Integer.MAX_VALUE,
-            String.format("hms_iceberg_catalog_%s_executor_pool", name),
-            true,
-            preExecutionAuthenticator);
         FileSystemProvider fileSystemProvider = new FileSystemProviderImpl(Env.getCurrentEnv().getExtMetaCacheMgr(),
                 this.bindBrokerName(), this.catalogProperty.getHadoopProperties());
         this.fileSystemExecutor = ThreadPoolManager.newDaemonFixedThreadPool(FILE_SYSTEM_EXECUTOR_THREAD_NUM,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -180,6 +180,12 @@ public class HMSExternalCatalog extends ExternalCatalog {
                     String.valueOf(Config.hive_metastore_client_timeout_second));
         }
         HiveMetadataOps hiveOps = ExternalMetadataOperations.newHiveMetadataOps(hiveConf, jdbcClientConfig, this);
+        threadPoolWithPreAuth = ThreadPoolManager.newDaemonFixedThreadPoolWithPreAuth(
+                ICEBERG_CATALOG_EXECUTOR_THREAD_NUM,
+                Integer.MAX_VALUE,
+                String.format("hms_iceberg_catalog_%s_executor_pool", name),
+                true,
+                preExecutionAuthenticator);
         FileSystemProvider fileSystemProvider = new FileSystemProviderImpl(Env.getCurrentEnv().getExtMetaCacheMgr(),
                 this.bindBrokerName(), this.catalogProperty.getHadoopProperties());
         this.fileSystemExecutor = ThreadPoolManager.newDaemonFixedThreadPool(FILE_SYSTEM_EXECUTOR_THREAD_NUM,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -225,7 +225,9 @@ public class HiveScanNode extends FileQueryScanNode {
                             if (allFiles.size() > numSplitsPerPartition.get()) {
                                 numSplitsPerPartition.set(allFiles.size());
                             }
-                            splitAssignment.addToQueue(allFiles);
+                            if (splitAssignment.needMoreSplit()) {
+                                splitAssignment.addToQueue(allFiles);
+                            }
                         } catch (Exception e) {
                             batchException.set(new UserException(e.getMessage(), e));
                         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -77,6 +77,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -417,6 +418,7 @@ public class HudiScanNode extends HiveScanNode {
             return;
         }
         AtomicInteger numFinishedPartitions = new AtomicInteger(0);
+        ExecutorService scheduleExecutor = Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor();
         CompletableFuture.runAsync(() -> {
             for (HivePartition partition : prunedPartitions) {
                 if (batchException.get() != null || splitAssignment.isStop()) {
@@ -447,12 +449,12 @@ public class HudiScanNode extends HiveScanNode {
                             splitAssignment.finishSchedule();
                         }
                     }
-                });
+                }, scheduleExecutor);
             }
             if (batchException.get() != null) {
                 splitAssignment.setException(batchException.get());
             }
-        });
+        }, scheduleExecutor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -437,7 +437,9 @@ public class HudiScanNode extends HiveScanNode {
                         if (allFiles.size() > numSplitsPerPartition.get()) {
                             numSplitsPerPartition.set(allFiles.size());
                         }
-                        splitAssignment.addToQueue(allFiles);
+                        if (splitAssignment.needMoreSplit()) {
+                            splitAssignment.addToQueue(allFiles);
+                        }
                     } catch (Exception e) {
                         batchException.set(new UserException(e.getMessage(), e));
                     } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -438,7 +438,7 @@ public class HudiScanNode extends HiveScanNode {
                             numSplitsPerPartition.set(allFiles.size());
                         }
                         splitAssignment.addToQueue(allFiles);
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         batchException.set(new UserException(e.getMessage(), e));
                     } finally {
                         splittersOnFlight.release();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -236,7 +236,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                 preExecutionAuthenticator.execute(
                         () -> {
                             CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan);
-                            taskRef.set(planFileScanTask(scan));
+                            taskRef.set(fileScanTasks);
 
                             CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
                             while (splitAssignment.needMoreSplit() && iterator.hasNext()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -239,13 +239,14 @@ public class IcebergScanNode extends FileQueryScanNode {
                             // 2. if we want to stop this plan, we can close the fileScanTasks to stop
                             splitAssignment.addCloseable(fileScanTasks);
 
-                            fileScanTasks.forEach(fileScanTask -> {
+                            CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
+                            while (splitAssignment.waitFirstSplit() && !iterator.hasNext()) {
                                 try {
-                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(fileScanTask)));
+                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(iterator.next())));
                                 } catch (UserException e) {
                                     throw new RuntimeException(e);
                                 }
-                            });
+                            }
                         }
                 );
                 splitAssignment.finishSchedule();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -240,7 +240,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                             splitAssignment.addCloseable(fileScanTasks);
 
                             CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
-                            while (splitAssignment.waitFirstSplit() && !iterator.hasNext()) {
+                            while (splitAssignment.needMoreSplit() && iterator.hasNext()) {
                                 try {
                                     splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(iterator.next())));
                                 } catch (UserException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.TableSnapshot;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
@@ -237,7 +238,6 @@ public class IcebergScanNode extends FileQueryScanNode {
                             // 1. this task should stop when all splits are assigned
                             // 2. if we want to stop this plan, we can close the fileScanTasks to stop
                             splitAssignment.addCloseable(fileScanTasks);
-                            splitAssignment.addFetchSplitThread(Thread.currentThread());
 
                             fileScanTasks.forEach(fileScanTask ->
                                     splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(fileScanTask))));
@@ -254,7 +254,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                     splitAssignment.setException(new UserException(e.getMessage(), e));
                 }
             }
-        });
+        }, Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor());
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -237,6 +237,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                             // 1. this task should stop when all splits are assigned
                             // 2. if we want to stop this plan, we can close the fileScanTasks to stop
                             splitAssignment.addCloseable(fileScanTasks);
+                            splitAssignment.addFetchSplitThread(Thread.currentThread());
 
                             fileScanTasks.forEach(fileScanTask ->
                                     splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(fileScanTask))));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -239,10 +239,13 @@ public class IcebergScanNode extends FileQueryScanNode {
                             // 2. if we want to stop this plan, we can close the fileScanTasks to stop
                             splitAssignment.addCloseable(fileScanTasks);
 
-                            fileScanTasks.forEach(fileScanTask ->
-                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(fileScanTask))));
-
-                            return null;
+                            fileScanTasks.forEach(fileScanTask -> {
+                                try {
+                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(fileScanTask)));
+                                } catch (UserException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
                         }
                 );
                 splitAssignment.finishSchedule();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -268,7 +268,7 @@ public class MaxComputeScanNode extends FileQueryScanNode {
                             List<Split> batchSplit = getSplitByTableSession(tableBatchReadSession);
 
                             splitAssignment.addToQueue(batchSplit);
-                        } catch (IOException e) {
+                        } catch (Exception e) {
                             batchException.set(new UserException(e.getMessage(), e));
                         } finally {
                             if (batchException.get() != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -288,7 +288,7 @@ public class MaxComputeScanNode extends FileQueryScanNode {
                     splitAssignment.setException(batchException.get());
                 }
             }
-        });
+        }, scheduleExecutor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -267,7 +267,9 @@ public class MaxComputeScanNode extends FileQueryScanNode {
                                     createTableBatchReadSession(requiredBatchPartitionSpecs);
                             List<Split> batchSplit = getSplitByTableSession(tableBatchReadSession);
 
-                            splitAssignment.addToQueue(batchSplit);
+                            if (splitAssignment.needMoreSplit()) {
+                                splitAssignment.addToQueue(batchSplit);
+                            }
                         } catch (Exception e) {
                             batchException.set(new UserException(e.getMessage(), e));
                         } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
@@ -1,0 +1,400 @@
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.spi.Split;
+import org.apache.doris.system.Backend;
+import org.apache.doris.thrift.TScanRangeLocations;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.MockUp;
+import mockit.Mocked;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SplitAssignmentTest {
+
+    @Injectable
+    private FederationBackendPolicy mockBackendPolicy;
+
+    @Injectable
+    private SplitGenerator mockSplitGenerator;
+
+    @Injectable
+    private SplitToScanRange mockSplitToScanRange;
+
+    @Mocked
+    private Split mockSplit;
+
+    @Mocked
+    private Backend mockBackend;
+
+    @Mocked
+    private TScanRangeLocations mockScanRangeLocations;
+
+    private SplitAssignment splitAssignment;
+    private Map<String, String> locationProperties;
+    private List<String> pathPartitionKeys;
+
+    @BeforeEach
+    void setUp() {
+        locationProperties = new HashMap<>();
+        pathPartitionKeys = new ArrayList<>();
+
+        splitAssignment = new SplitAssignment(
+                mockBackendPolicy,
+                mockSplitGenerator,
+                mockSplitToScanRange,
+                locationProperties,
+                pathPartitionKeys
+        );
+    }
+
+    // ==================== init() method tests ====================
+
+    @Test
+    void testInitSuccess() throws Exception {
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
+
+        new Expectations() {{
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+        }};
+
+        // Start a thread to simulate split generation after a short delay
+        Thread splitGeneratorThread = new Thread(() -> {
+            try {
+                Thread.sleep(50); // Short delay to simulate async split generation
+                List<Split> splits = Collections.singletonList(mockSplit);
+                splitAssignment.addToQueue(splits);
+            } catch (Exception e) {
+                // Ignore for test
+            }
+        });
+
+        splitGeneratorThread.start();
+
+        // Test
+        assertDoesNotThrow(() -> splitAssignment.init());
+
+        // Verify sample split is set
+        assertNotNull(splitAssignment.getSampleSplit());
+
+        splitGeneratorThread.join(1000); // Wait for thread to complete
+    }
+
+    @Test
+    void testInitTimeout() throws Exception {
+        // Use MockUp to simulate timeout behavior quickly instead of waiting 30 seconds
+        SplitAssignment testAssignment = new SplitAssignment(
+                mockBackendPolicy,
+                mockSplitGenerator,
+                mockSplitToScanRange,
+                locationProperties,
+                pathPartitionKeys
+        );
+
+        new MockUp<SplitAssignment>() {
+            @mockit.Mock
+            public void init() throws UserException {
+                // Directly throw timeout exception to simulate the timeout scenario quickly
+                throw new UserException("Failed to get first split after waiting for 0 seconds.");
+            }
+        };
+
+        // Test & Verify - should timeout immediately now
+        UserException exception = assertThrows(UserException.class, () -> testAssignment.init());
+        assertTrue(exception.getMessage().contains("Failed to get first split after waiting for"));
+    }
+
+    @Test
+    void testInitInterrupted() throws Exception {
+        CountDownLatch initStarted = new CountDownLatch(1);
+        CountDownLatch shouldInterrupt = new CountDownLatch(1);
+
+        Thread initThread = new Thread(() -> {
+            try {
+                initStarted.countDown();
+                shouldInterrupt.await();
+                splitAssignment.init();
+            } catch (Exception e) {
+                // Expected interruption
+            }
+        });
+
+        initThread.start();
+        initStarted.await();
+
+        // Interrupt the init thread
+        initThread.interrupt();
+        shouldInterrupt.countDown();
+
+        initThread.join(1000);
+    }
+
+    @Test
+    void testInitWithPreExistingException() throws Exception {
+        UserException preException = new UserException("Pre-existing error");
+        splitAssignment.setException(preException);
+
+        // Test & Verify
+        UserException exception = assertThrows(UserException.class, () -> splitAssignment.init());
+        assertTrue(exception.getMessage().contains(" Pre-existing error"), exception.getMessage());
+    }
+
+    // ==================== addToQueue() method tests ====================
+
+    @Test
+    void testAddToQueueWithEmptyList() throws Exception {
+        // Test
+        assertDoesNotThrow(() -> splitAssignment.addToQueue(Collections.emptyList()));
+    }
+
+    @Test
+    void testAddToQueueSuccess() throws Exception {
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
+
+        new Expectations() {{
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+        }};
+
+        // Mock setup
+        List<Split> splits = Collections.singletonList(mockSplit);
+
+        // Test
+        assertDoesNotThrow(() -> splitAssignment.addToQueue(splits));
+
+        // Verify sample split is set
+        assertEquals(mockSplit, splitAssignment.getSampleSplit());
+
+        // Verify assignment queue is created and contains data
+        BlockingQueue<Collection<TScanRangeLocations>> queue = splitAssignment.getAssignedSplits(mockBackend);
+        assertNotNull(queue);
+    }
+
+    @Test
+    void testAddToQueueSampleSplitAlreadySet() throws Exception {
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
+
+        new Expectations() {{
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+            minTimes = 0;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+            minTimes = 0;
+        }};
+
+        // Setup: First call to set sample split
+        List<Split> firstSplits = Collections.singletonList(mockSplit);
+
+        splitAssignment.addToQueue(firstSplits);
+        Split firstSampleSplit = splitAssignment.getSampleSplit();
+
+        // Test: Second call should not change sample split
+        List<Split> secondSplits = Collections.singletonList(mockSplit);
+
+        splitAssignment.addToQueue(secondSplits);
+
+        // Verify sample split unchanged
+        assertEquals(firstSampleSplit, splitAssignment.getSampleSplit());
+    }
+
+    @Test
+    void testAddToQueueWithQueueBlockingScenario() throws Exception {
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
+
+        new Expectations() {{
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+        }};
+
+        // This test simulates a scenario where appendBatch might experience queue blocking
+        // by adding multiple batches rapidly
+
+        List<Split> splits = Collections.singletonList(mockSplit);
+
+        // First, fill up the queue by adding many batches
+        for (int i = 0; i < 10; i++) {
+            splitAssignment.addToQueue(splits);
+        }
+
+        // Verify the queue has data
+        BlockingQueue<Collection<TScanRangeLocations>> queue = splitAssignment.getAssignedSplits(mockBackend);
+        assertNotNull(queue);
+    }
+
+    @Test
+    void testAddToQueueConcurrentAccess() throws Exception {
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
+
+        new Expectations() {{
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+        }};
+
+        // Test concurrent access to addToQueue method
+        List<Split> splits = Collections.singletonList(mockSplit);
+
+        int threadCount = 5;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    splitAssignment.addToQueue(splits);
+                } catch (Exception e) {
+                    // Log but don't fail test for concurrency issues
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+            threads.add(thread);
+            thread.start();
+        }
+
+        startLatch.countDown(); // Start all threads
+        assertTrue(doneLatch.await(5, TimeUnit.SECONDS)); // Wait for completion
+
+        // Verify sample split is set
+        assertNotNull(splitAssignment.getSampleSplit());
+
+        // Cleanup
+        for (Thread thread : threads) {
+            thread.join(1000);
+        }
+    }
+
+    // ==================== Integration tests for init() and addToQueue() ====================
+
+    @Test
+    void testInitAndAddToQueueIntegration() throws Exception {
+        new Expectations() {{
+            Multimap<Backend, Split> batch = ArrayListMultimap.create();
+            batch.put(mockBackend, mockSplit);
+
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+        }};
+
+        List<Split> splits = Collections.singletonList(mockSplit);
+
+        // Start background thread to add splits after init starts
+        Thread splitsProvider = new Thread(() -> {
+            try {
+                Thread.sleep(100); // Small delay to ensure init is waiting
+                splitAssignment.addToQueue(splits);
+            } catch (Exception e) {
+                // Ignore
+            }
+        });
+
+        splitsProvider.start();
+
+        // Test init - should succeed once splits are added
+        assertDoesNotThrow(() -> splitAssignment.init());
+
+        // Verify
+        assertNotNull(splitAssignment.getSampleSplit());
+        assertEquals(mockSplit, splitAssignment.getSampleSplit());
+
+        BlockingQueue<Collection<TScanRangeLocations>> queue = splitAssignment.getAssignedSplits(mockBackend);
+        assertNotNull(queue);
+
+        splitsProvider.join(1000);
+    }
+
+    // ==================== appendBatch() behavior tests ====================
+
+    @Test
+    void testAppendBatchTimeoutBehavior() throws Exception {
+        new Expectations() {{
+            Multimap<Backend, Split> batch = ArrayListMultimap.create();
+            batch.put(mockBackend, mockSplit);
+
+            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+            result = batch;
+
+            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+            result = mockScanRangeLocations;
+        }};
+
+        // This test verifies that appendBatch properly handles queue offer timeouts
+        // We'll simulate this by first filling the assignment and then trying to add more
+
+        List<Split> splits = Collections.singletonList(mockSplit);
+
+        // Add multiple splits to potentially cause queue pressure
+        for (int i = 0; i < 50; i++) {
+            try {
+                splitAssignment.addToQueue(splits);
+            } catch (Exception e) {
+                // Expected if queue gets full and times out
+                break;
+            }
+        }
+
+        // Verify that splits were processed
+        assertNotNull(splitAssignment.getSampleSplit());
+    }
+
+    @Test
+    void testInitWhenNeedMoreSplitReturnsFalse() throws Exception {
+        // Test init behavior when needMoreSplit() returns false
+        splitAssignment.stop(); // This should make needMoreSplit() return false
+
+        // Init should complete immediately without waiting
+        assertDoesNotThrow(() -> splitAssignment.init());
+    }
+
+    @Test
+    void testInitWithScheduleFinished() throws Exception {
+        // Test init behavior when schedule is already finished
+        splitAssignment.finishSchedule();
+
+        // Init should complete immediately without waiting
+        assertDoesNotThrow(() -> splitAssignment.init());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.datasource;
 
 import org.apache.doris.common.UserException;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
@@ -28,11 +28,7 @@ import mockit.Expectations;
 import mockit.Injectable;
 import mockit.MockUp;
 import mockit.Mocked;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -91,13 +87,15 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {{
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
+        new Expectations() {
+            {
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+            }
+        };
 
         // Start a thread to simulate split generation after a short delay
         Thread splitGeneratorThread = new Thread(() -> {
@@ -113,10 +111,10 @@ public class SplitAssignmentTest {
         splitGeneratorThread.start();
 
         // Test
-        assertDoesNotThrow(() -> splitAssignment.init());
+        Assertions.assertDoesNotThrow(() -> splitAssignment.init());
 
         // Verify sample split is set
-        assertNotNull(splitAssignment.getSampleSplit());
+        Assertions.assertNotNull(splitAssignment.getSampleSplit());
 
         splitGeneratorThread.join(1000); // Wait for thread to complete
     }
@@ -141,8 +139,8 @@ public class SplitAssignmentTest {
         };
 
         // Test & Verify - should timeout immediately now
-        UserException exception = assertThrows(UserException.class, () -> testAssignment.init());
-        assertTrue(exception.getMessage().contains("Failed to get first split after waiting for"));
+        UserException exception = Assertions.assertThrows(UserException.class, () -> testAssignment.init());
+        Assertions.assertTrue(exception.getMessage().contains("Failed to get first split after waiting for"));
     }
 
     @Test
@@ -176,8 +174,8 @@ public class SplitAssignmentTest {
         splitAssignment.setException(preException);
 
         // Test & Verify
-        UserException exception = assertThrows(UserException.class, () -> splitAssignment.init());
-        assertTrue(exception.getMessage().contains(" Pre-existing error"), exception.getMessage());
+        UserException exception = Assertions.assertThrows(UserException.class, () -> splitAssignment.init());
+        Assertions.assertTrue(exception.getMessage().contains(" Pre-existing error"), exception.getMessage());
     }
 
     // ==================== addToQueue() method tests ====================
@@ -185,7 +183,7 @@ public class SplitAssignmentTest {
     @Test
     void testAddToQueueWithEmptyList() throws Exception {
         // Test
-        assertDoesNotThrow(() -> splitAssignment.addToQueue(Collections.emptyList()));
+        Assertions.assertDoesNotThrow(() -> splitAssignment.addToQueue(Collections.emptyList()));
     }
 
     @Test
@@ -193,26 +191,28 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {{
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
+        new Expectations() {
+            {
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+            }
+        };
 
         // Mock setup
         List<Split> splits = Collections.singletonList(mockSplit);
 
         // Test
-        assertDoesNotThrow(() -> splitAssignment.addToQueue(splits));
+        Assertions.assertDoesNotThrow(() -> splitAssignment.addToQueue(splits));
 
         // Verify sample split is set
-        assertEquals(mockSplit, splitAssignment.getSampleSplit());
+        Assertions.assertEquals(mockSplit, splitAssignment.getSampleSplit());
 
         // Verify assignment queue is created and contains data
         BlockingQueue<Collection<TScanRangeLocations>> queue = splitAssignment.getAssignedSplits(mockBackend);
-        assertNotNull(queue);
+        Assertions.assertNotNull(queue);
     }
 
     @Test
@@ -220,15 +220,17 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {{
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
-            minTimes = 0;
+        new Expectations() {
+            {
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
+                minTimes = 0;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-            minTimes = 0;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+                minTimes = 0;
+            }
+        };
 
         // Setup: First call to set sample split
         List<Split> firstSplits = Collections.singletonList(mockSplit);
@@ -242,7 +244,7 @@ public class SplitAssignmentTest {
         splitAssignment.addToQueue(secondSplits);
 
         // Verify sample split unchanged
-        assertEquals(firstSampleSplit, splitAssignment.getSampleSplit());
+        Assertions.assertEquals(firstSampleSplit, splitAssignment.getSampleSplit());
     }
 
     @Test
@@ -250,13 +252,15 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {{
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
+        new Expectations() {
+            {
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+            }
+        };
 
         // This test simulates a scenario where appendBatch might experience queue blocking
         // by adding multiple batches rapidly
@@ -270,7 +274,7 @@ public class SplitAssignmentTest {
 
         // Verify the queue has data
         BlockingQueue<Collection<TScanRangeLocations>> queue = splitAssignment.getAssignedSplits(mockBackend);
-        assertNotNull(queue);
+        Assertions.assertNotNull(queue);
     }
 
     @Test
@@ -278,13 +282,15 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {{
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
+        new Expectations() {
+            {
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+            }
+        };
 
         // Test concurrent access to addToQueue method
         List<Split> splits = Collections.singletonList(mockSplit);
@@ -310,10 +316,10 @@ public class SplitAssignmentTest {
         }
 
         startLatch.countDown(); // Start all threads
-        assertTrue(doneLatch.await(5, TimeUnit.SECONDS)); // Wait for completion
+        Assertions.assertTrue(doneLatch.await(5, TimeUnit.SECONDS)); // Wait for completion
 
         // Verify sample split is set
-        assertNotNull(splitAssignment.getSampleSplit());
+        Assertions.assertNotNull(splitAssignment.getSampleSplit());
 
         // Cleanup
         for (Thread thread : threads) {
@@ -325,16 +331,18 @@ public class SplitAssignmentTest {
 
     @Test
     void testInitAndAddToQueueIntegration() throws Exception {
-        new Expectations() {{
-            Multimap<Backend, Split> batch = ArrayListMultimap.create();
-            batch.put(mockBackend, mockSplit);
+        new Expectations() {
+            {
+                Multimap<Backend, Split> batch = ArrayListMultimap.create();
+                batch.put(mockBackend, mockSplit);
 
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+            }
+        };
 
         List<Split> splits = Collections.singletonList(mockSplit);
 
@@ -351,14 +359,14 @@ public class SplitAssignmentTest {
         splitsProvider.start();
 
         // Test init - should succeed once splits are added
-        assertDoesNotThrow(() -> splitAssignment.init());
+        Assertions.assertDoesNotThrow(() -> splitAssignment.init());
 
         // Verify
-        assertNotNull(splitAssignment.getSampleSplit());
-        assertEquals(mockSplit, splitAssignment.getSampleSplit());
+        Assertions.assertNotNull(splitAssignment.getSampleSplit());
+        Assertions.assertEquals(mockSplit, splitAssignment.getSampleSplit());
 
         BlockingQueue<Collection<TScanRangeLocations>> queue = splitAssignment.getAssignedSplits(mockBackend);
-        assertNotNull(queue);
+        Assertions.assertNotNull(queue);
 
         splitsProvider.join(1000);
     }
@@ -367,16 +375,18 @@ public class SplitAssignmentTest {
 
     @Test
     void testAppendBatchTimeoutBehavior() throws Exception {
-        new Expectations() {{
-            Multimap<Backend, Split> batch = ArrayListMultimap.create();
-            batch.put(mockBackend, mockSplit);
+        new Expectations() {
+            {
+                Multimap<Backend, Split> batch = ArrayListMultimap.create();
+                batch.put(mockBackend, mockSplit);
 
-            mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-            result = batch;
+                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
+                result = batch;
 
-            mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
-            result = mockScanRangeLocations;
-        }};
+                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys);
+                result = mockScanRangeLocations;
+            }
+        };
 
         // This test verifies that appendBatch properly handles queue offer timeouts
         // We'll simulate this by first filling the assignment and then trying to add more
@@ -394,7 +404,7 @@ public class SplitAssignmentTest {
         }
 
         // Verify that splits were processed
-        assertNotNull(splitAssignment.getSampleSplit());
+        Assertions.assertNotNull(splitAssignment.getSampleSplit());
     }
 
     @Test
@@ -403,7 +413,7 @@ public class SplitAssignmentTest {
         splitAssignment.stop(); // This should make needMoreSplit() return false
 
         // Init should complete immediately without waiting
-        assertDoesNotThrow(() -> splitAssignment.init());
+        Assertions.assertDoesNotThrow(() -> splitAssignment.init());
     }
 
     @Test
@@ -412,6 +422,6 @@ public class SplitAssignmentTest {
         splitAssignment.finishSchedule();
 
         // Init should complete immediately without waiting
-        assertDoesNotThrow(() -> splitAssignment.init());
+        Assertions.assertDoesNotThrow(() -> splitAssignment.init());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. When adding splits to the queue, a retry mechanism is added to prevent blocking and sticking.
2. We use a separate thread to fetch splits. When the SQL execution ends early (such as `limit`), this thread needs to be handled. Now it is exited by throwing an exception. Moreover, this thread should use an independent thread pool to prevent system freezes caused by resource contention.
3. When there are multiple exceptions, overwriting would occur previously. Now we use `addSuppressed` to prevent exception loss.
4. When initializing the split assignment, a timeout mechanism is added to prevent the situation where the system gets stuck due to failing to obtain splits.
5. When the split assignment stop, if an exception is not null, an exception should be thrown externally.



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

