### PR TITLE
[improvement](statistics)Improve fetch hive table row count.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -578,6 +578,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String HUGE_TABLE_LOWER_BOUND_SIZE_IN_BYTES = "huge_table_lower_bound_size_in_bytes";
     public static final String PARTITION_SAMPLE_COUNT = "partition_sample_count";
     public static final String PARTITION_SAMPLE_ROW_COUNT = "partition_sample_row_count";
+    public static final String FETCH_HIVE_ROW_COUNT_SYNC = "fetch_hive_row_count_sync";
 
     // for spill to disk
     public static final String ENABLE_SPILL = "enable_spill";
@@ -2177,6 +2178,10 @@ public class SessionVariable implements Serializable, Writable {
                     "大分区表采样的行数上限",
                     "The upper limit of the number of rows for sampling large partitioned tables.\n"})
     public long partitionSampleRowCount = 3_000_000_000L;
+
+    @VariableMgr.VarAttr(name = FETCH_HIVE_ROW_COUNT_SYNC,
+            description = {"同步获取Hive外表行数", "Fetch Hive external table row count synchronously"})
+    public boolean fetchHiveRowCountSync = true;
 
     @VariableMgr.VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE, needForward = true,
             description = {"是否开启基于结构信息的物化视图透明改写",

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
@@ -79,7 +79,7 @@ public class ExternalRowCountCacheTest {
             protected Optional<Long> doLoad(ExternalRowCountCache.RowCountKey rowCountKey) {
                 counter.incrementAndGet();
                 try {
-                    Thread.sleep(1000000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
@@ -87,10 +87,10 @@ public class ExternalRowCountCacheTest {
             }
         };
         cachedRowCount = cache.getCachedRowCount(2, 2, 2);
-        Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT, cachedRowCount);
+        Assertions.assertEquals(100, cachedRowCount);
         Thread.sleep(1000);
         cachedRowCount = cache.getCachedRowCount(2, 2, 2);
-        Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT, cachedRowCount);
+        Assertions.assertEquals(100, cachedRowCount);
         for (int i = 0; i < 60; i++) {
             if (counter.get() == 3) {
                 break;

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
@@ -28,6 +28,20 @@ suite("test_hive_statistics_p0", "all_types,p0,external,hive,external_docker,ext
             String catalog_name = "test_${hivePrefix}_statistics_p0"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
+            sql """drop catalog if exists ${catalog_name}_1"""
+            sql """create catalog if not exists ${catalog_name}_1 properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+            );"""
+            sql """set fetch_hive_row_count_sync=true"""
+            sql """use ${catalog_name}_1.stats_test"""
+            explain {
+                sql "select count(2) from `${catalog_name}_1`.`statistics`.`statistics`;"
+                contains "cardinality=66"
+            }
+            sql """drop catalog if exists ${catalog_name}_1"""
+
+            sql """set fetch_hive_row_count_sync=false"""
             sql """drop catalog if exists ${catalog_name}"""
             sql """create catalog if not exists ${catalog_name} properties (
                 "type"="hms",
@@ -303,4 +317,3 @@ suite("test_hive_statistics_p0", "all_types,p0,external,hive,external_docker,ext
         }
     }
 }
-


### PR DESCRIPTION
### What problem does this PR solve?
For external table, fetch row count synchronously by default when the cache missed.
User could change it to asynchronous using session variable fetch_hive_row_count_synchronous.
Also use spark table parameter when it contains row number.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

