### PR TITLE
[fix](cloud) Cloud tablet cache should not be pruned

### DIFF
--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -141,7 +141,7 @@ CloudTabletMgr::CloudTabletMgr(CloudStorageEngine& engine)
           _tablet_map(std::make_unique<TabletMap>()),
           _cache(std::make_unique<LRUCachePolicy>(
                   CachePolicy::CacheType::CLOUD_TABLET_CACHE, config::tablet_cache_capacity,
-                  LRUCacheType::NUMBER, 0, config::tablet_cache_shards)) {}
+                  LRUCacheType::NUMBER, 0, config::tablet_cache_shards, false /*enable_prune*/)) {}
 
 CloudTabletMgr::~CloudTabletMgr() = default;
 


### PR DESCRIPTION
Otherwise there may be severe performance issue for query associated to many tablets

Related PR:  #28940 #42281
