### PR TITLE
[opt][fe/be.conf]optimise system environment replacing rule in conf file

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1972,7 +1972,7 @@ bool init(const char* conf_file, bool fill_conf_map, bool must_exist, bool set_t
 #define UPDATE_FIELD(FIELD, VALUE, TYPE, PERSIST)                                                  \
     if (strcmp((FIELD).type, #TYPE) == 0) {                                                        \
         TYPE new_value;                                                                            \
-        if (!convert((FIELD).name, (VALUE), new_value)) {                                                        \
+        if (!convert((FIELD).name, (VALUE), new_value)) {                                          \
             return Status::Error<ErrorCode::INVALID_ARGUMENT, false>("convert '{}' as {} failed",  \
                                                                      VALUE, #TYPE);                \
         }                                                                                          \

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1629,7 +1629,7 @@ void splitkv(const std::string& s, std::string& k, std::string& v) {
 }
 
 // replace env variables
-bool replaceenv(std::string key, std::string& s) {
+bool replaceenv(std::string_view key, std::string& s) {
     size_t pos = 0;
     bool modified = false;
 
@@ -1776,7 +1776,7 @@ bool strtox(const std::string& valstr, std::string& retval) {
 }
 
 template <typename T>
-bool convert(const std::string key, const std::string& value, T& retval) {
+bool convert(std::string_view key, const std::string& value, T& retval) {
     std::string valstr(value);
     trim(valstr);
     if (!replaceenv(key, valstr)) {
@@ -1852,7 +1852,7 @@ bool Properties::get_or_default(const char* key, const char* defstr, T& retval, 
     }
     rawval = valstr;
     *is_retval_set = true;
-    return convert(std::string(key), valstr, retval);
+    return convert(key, valstr, retval);
 }
 
 void Properties::set(const std::string& key, const std::string& val) {

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1629,23 +1629,65 @@ void splitkv(const std::string& s, std::string& k, std::string& v) {
 }
 
 // replace env variables
-bool replaceenv(std::string& s) {
-    std::size_t pos = 0;
-    std::size_t start = 0;
-    while ((start = s.find("${", pos)) != std::string::npos) {
-        std::size_t end = s.find('}', start + 2);
-        if (end == std::string::npos) {
-            return false;
+bool replaceenv(std::string key, std::string& s) {
+    size_t pos = 0;
+    bool modified = false;
+
+    while (pos < s.size()) {
+        size_t start = s.find('$', pos);
+        if (start == std::string::npos) break;
+
+        if (start > 0 && s[start - 1] == '$') {
+            s.erase(start - 1, 1);
+            pos = start;
+            modified = true;
+            continue;
         }
-        std::string envkey = s.substr(start + 2, end - start - 2);
+
+        bool has_brace = false;
+        size_t var_start = start + 1;
+        size_t end = std::string::npos;
+
+        // format: ${VAR}
+        if (var_start < s.size() && s[var_start] == '{') {
+            has_brace = true;
+            var_start++;
+            end = s.find('}', var_start);
+            if (end == std::string::npos) return false;
+        } else {
+            // format: $VAR
+            if (var_start >= s.size()) {
+                pos = var_start;
+                continue;
+            }
+            char first_char = s[var_start];
+            if (!std::isalpha(first_char) && first_char != '_') {
+                pos = var_start;
+                continue;
+            }
+            end = var_start;
+            while (end < s.size() && (std::isalnum(s[end]) || s[end] == '_')) {
+                end++;
+            }
+        }
+
+        std::string envkey = s.substr(var_start, end - var_start);
         const char* envval = std::getenv(envkey.c_str());
-        if (envval == nullptr) {
-            return false;
-        }
-        s.erase(start, end - start + 1);
-        s.insert(start, envval);
-        pos = start + strlen(envval);
+        if (envval == nullptr) return false;
+        // replace env
+        size_t replace_start = start;
+        size_t replace_length = has_brace ? (end - start + 1) : (end - start);
+        s.erase(replace_start, replace_length);
+        s.insert(replace_start, envval);
+        // reset
+        pos = replace_start + strlen(envval);
+        modified = true;
     }
+
+    if (modified) {
+        std::cout << "replace env conf " << key << "=" << s << std::endl;
+    }
+
     return true;
 }
 
@@ -1734,10 +1776,10 @@ bool strtox(const std::string& valstr, std::string& retval) {
 }
 
 template <typename T>
-bool convert(const std::string& value, T& retval) {
+bool convert(const std::string key, const std::string& value, T& retval) {
     std::string valstr(value);
     trim(valstr);
-    if (!replaceenv(valstr)) {
+    if (!replaceenv(key, valstr)) {
         return false;
     }
     return strtox(valstr, retval);
@@ -1810,7 +1852,7 @@ bool Properties::get_or_default(const char* key, const char* defstr, T& retval, 
     }
     rawval = valstr;
     *is_retval_set = true;
-    return convert(valstr, retval);
+    return convert(std::string(key), valstr, retval);
 }
 
 void Properties::set(const std::string& key, const std::string& val) {
@@ -1930,7 +1972,7 @@ bool init(const char* conf_file, bool fill_conf_map, bool must_exist, bool set_t
 #define UPDATE_FIELD(FIELD, VALUE, TYPE, PERSIST)                                                  \
     if (strcmp((FIELD).type, #TYPE) == 0) {                                                        \
         TYPE new_value;                                                                            \
-        if (!convert((VALUE), new_value)) {                                                        \
+        if (!convert((FIELD).name, (VALUE), new_value)) {                                                        \
             return Status::Error<ErrorCode::INVALID_ARGUMENT, false>("convert '{}' as {} failed",  \
                                                                      VALUE, #TYPE);                \
         }                                                                                          \

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1661,7 +1661,7 @@ bool replaceenv(std::string key, std::string& s) {
                 continue;
             }
             char first_char = s[var_start];
-            if (!std::isalpha(first_char) && first_char != '_') {
+            if (!std::isalnum(first_char) && first_char != '_') {
                 pos = var_start;
                 continue;
             }

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -74,6 +74,7 @@ TEST_F(ConfigTest, UpdateConfigs) {
     DEFINE_mInt32(cfg_int32_t, "65536123");
     DEFINE_mInt64(cfg_int64_t, "4294967296123");
     DEFINE_String(cfg_std_string, "doris_config_test_string");
+    DEFINE_String(cfg_conf_path, "doris_config_test_conf_path");
 
     EXPECT_TRUE(config::init(nullptr, true));
 
@@ -145,6 +146,23 @@ TEST_F(ConfigTest, UpdateConfigs) {
     EXPECT_TRUE(s.to_string().find("'cfg_std_string' is not support to modify") !=
                 std::string::npos);
     EXPECT_EQ(cfg_std_string, "doris_config_test_string");
+
+    // replace
+    setenv("TEST_CONF_ENV", "test_dir1", true);
+    s = config::set_config("cfg_conf_path", "${TEST_CONF_ENV}/test");
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(cfg_conf_path, "test_dir1/test");
+
+    setenv("TEST_CONF_ENV", "test_dir2", true);
+    s = config::set_config("cfg_conf_path", "$TEST_CONF_ENV/test");
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(cfg_conf_path, "test_dir2/test");
+
+    setenv("TEST_CONF_ENV", "test_dir3", true);
+    s = config::set_config("cfg_conf_path", "$$TEST_CONF_ENV/test");
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(cfg_conf_path, "$TEST_CONF_ENV/test");
+
 }
 
 } // namespace doris

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -162,6 +162,16 @@ TEST_F(ConfigTest, UpdateConfigs) {
     s = config::set_config("cfg_conf_path", "$$TEST_CONF_ENV/test");
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(cfg_conf_path, "$TEST_CONF_ENV/test");
+
+    setenv("TEST_CONF_ENV", "test_dir3", true);
+    s = config::set_config("cfg_conf_path", "${TEST_CONF_ENV/}/test");
+    EXPECT_FALSE(s.ok());
+    EXPECT_TRUE(s.to_string().find("INVALID_ARGUMENT") != std::string::npos);
+
+    setenv("123TEST_conf_ENV123", "test_dir3", true);
+    s = config::set_config("cfg_conf_path", "$123TEST_conf_ENV123/test");
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(cfg_conf_path, "test_dir3/test");
 }
 
 } // namespace doris

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -150,7 +150,6 @@ TEST_F(ConfigTest, UpdateConfigs) {
     // replace
     setenv("TEST_CONF_ENV", "test_dir1", true);
     s = config::set_config("cfg_conf_path", "${TEST_CONF_ENV}/test");
-    EXPECT_EQ(s.to_string(), "");
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(cfg_conf_path, "test_dir1/test");
 

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -150,6 +150,7 @@ TEST_F(ConfigTest, UpdateConfigs) {
     // replace
     setenv("TEST_CONF_ENV", "test_dir1", true);
     s = config::set_config("cfg_conf_path", "${TEST_CONF_ENV}/test");
+    EXPECT_EQ(s.to_string(), "");
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(cfg_conf_path, "test_dir1/test");
 

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -162,7 +162,6 @@ TEST_F(ConfigTest, UpdateConfigs) {
     s = config::set_config("cfg_conf_path", "$$TEST_CONF_ENV/test");
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(cfg_conf_path, "$TEST_CONF_ENV/test");
-
 }
 
 } // namespace doris

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -74,7 +74,7 @@ TEST_F(ConfigTest, UpdateConfigs) {
     DEFINE_mInt32(cfg_int32_t, "65536123");
     DEFINE_mInt64(cfg_int64_t, "4294967296123");
     DEFINE_String(cfg_std_string, "doris_config_test_string");
-    DEFINE_String(cfg_conf_path, "doris_config_test_conf_path");
+    DEFINE_mString(cfg_conf_path, "doris_config_test_conf_path");
 
     EXPECT_TRUE(config::init(nullptr, true));
 
@@ -150,7 +150,6 @@ TEST_F(ConfigTest, UpdateConfigs) {
     // replace
     setenv("TEST_CONF_ENV", "test_dir1", true);
     s = config::set_config("cfg_conf_path", "${TEST_CONF_ENV}/test");
-    EXPECT_EQ(s.to_string(), "");
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(cfg_conf_path, "test_dir1/test");
 

--- a/cloud/src/common/configbase.cpp
+++ b/cloud/src/common/configbase.cpp
@@ -69,7 +69,7 @@ void splitkv(const std::string& s, std::string& k, std::string& v) {
 }
 
 // replace env variables
-bool replaceenv(std::string key, std::string& s) {
+bool replaceenv(std::string_view key, std::string& s) {
     size_t pos = 0;
     bool modified = false;
 
@@ -216,7 +216,7 @@ bool strtox(const std::string& valstr, std::string& retval) {
 }
 
 template <typename T>
-bool convert(const std::string key, const std::string& value, T& retval) {
+bool convert(std::string_view key, const std::string& value, T& retval) {
     std::string valstr(value);
     trim(valstr);
     if (!replaceenv(key, valstr)) {
@@ -322,7 +322,7 @@ bool Properties::get_or_default(const char* key, const char* defstr, T& retval,
         valstr = it->second;
     }
     *is_retval_set = true;
-    return convert(std::string(key), valstr, retval);
+    return convert(key, valstr, retval);
 }
 
 void Properties::set(const std::string& key, const std::string& val) {

--- a/cloud/src/common/configbase.cpp
+++ b/cloud/src/common/configbase.cpp
@@ -101,7 +101,7 @@ bool replaceenv(std::string key, std::string& s) {
                 continue;
             }
             char first_char = s[var_start];
-            if (!std::isalpha(first_char) && first_char != '_') {
+            if (!std::isalnum(first_char) && first_char != '_') {
                 pos = var_start;
                 continue;
             }

--- a/cloud/src/common/configbase.cpp
+++ b/cloud/src/common/configbase.cpp
@@ -381,7 +381,7 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
 #define UPDATE_FIELD(FIELD, VALUE, TYPE, PERSIST)                                           \
     if (strcmp((FIELD).type, #TYPE) == 0) {                                                 \
         TYPE new_value;                                                                     \
-        if (!convert((FIELD).name, (VALUE), new_value)) {                                                 \
+        if (!convert((FIELD).name, (VALUE), new_value)) {                                   \
             std::cerr << "convert " << VALUE << "as" << #TYPE << "failed";                  \
             return false;                                                                   \
         }                                                                                   \

--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -206,6 +206,15 @@ under the License.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        -DDORIS_HOME_key_123_env=test_dir_env
+                    </argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -225,7 +225,7 @@ public class ConfigBase {
                 } else {
                     throw new Exception("no such env variable: " + m.group(1));
                 }
-                LOG.info("replace conf ");
+                LOG.info("replace conf {}={}", key, value);
             }
             props.setProperty(key, value);
         }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -217,7 +217,7 @@ public class ConfigBase {
             while (m.find()) {
                 String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
                 String envValue = System.getProperty(varName);
-                envValue = (envValue != null) ? envValue : System.getenv(m.group(1));
+                envValue = (envValue != null) ? envValue : System.getenv(varName);
 
                 if (envValue != null) {
                     String originalPattern = (m.group(1) != null) ? "${" + varName + "}" : "$" + varName;

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 public class ConfigBaseTest {
+
     @Test
     public void testReplacedByEnv() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         ConfigBase configBase = new ConfigBase();

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -52,6 +52,14 @@ public class ConfigBaseTest {
         Assert.assertThrows("no such env variable", Exception.class,
                 () -> replacedByEnvMethod.invoke(configBase, properties));
 
+        // format: $env, get value from system env
+        envName = "DORIS_HOME_key_123_env";
+        System.getenv().put(envName, "test_dir_env");
+
+        properties.setProperty(confKeyName, "$" + envName + "/conf");
+        replacedByEnvMethod.invoke(configBase, properties);
+        Assert.assertEquals("test_dir_env/conf", properties.getProperty(confKeyName));
+
     }
 
 }

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -57,6 +57,10 @@ public class ConfigBaseTest {
         properties.setProperty(confKeyName, "$" + envName + "/conf");
         replacedByEnvMethod.invoke(configBase, properties);
         Assert.assertEquals("test_dir_env/conf", properties.getProperty(confKeyName));
+
+        properties.setProperty(confKeyName, "$" + envName + "/conf");
+        replacedByEnvMethod.invoke(configBase, properties);
+        Assert.assertEquals("test_dir_env/conf", properties.getProperty(confKeyName));
     }
 
 }

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 public class ConfigBaseTest {
-
     @Test
     public void testReplacedByEnv() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         ConfigBase configBase = new ConfigBase();
@@ -58,7 +57,6 @@ public class ConfigBaseTest {
         properties.setProperty(confKeyName, "$" + envName + "/conf");
         replacedByEnvMethod.invoke(configBase, properties);
         Assert.assertEquals("test_dir_env/conf", properties.getProperty(confKeyName));
-
     }
 
 }

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 public class ConfigBaseTest {
-
     @Test
     public void testReplacedByEnv() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         ConfigBase configBase = new ConfigBase();

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+public class ConfigBaseTest {
+    @Test
+    public void testReplacedByEnv() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        ConfigBase configBase = new ConfigBase();
+        Method replacedByEnvMethod = ConfigBase.class.getDeclaredMethod("replacedByEnv", Properties.class);
+        replacedByEnvMethod.setAccessible(true);
+
+        final String confKeyName = "LOG_DIRS";
+        Properties properties = new Properties();
+
+        String envName = "DORIS_HOME_key_123";
+        System.setProperty(envName, "test_dir");
+
+        // format: $env
+        properties.setProperty(confKeyName, "$" + envName + "/conf");
+        replacedByEnvMethod.invoke(configBase, properties);
+        Assert.assertEquals("test_dir/conf", properties.getProperty(confKeyName));
+
+        // format: ${env}
+        properties.setProperty(confKeyName, "${" + envName + "}/conf");
+        replacedByEnvMethod.invoke(configBase, properties);
+        Assert.assertEquals("test_dir/conf", properties.getProperty(confKeyName));
+
+        // format: ${env/}
+        properties.setProperty(confKeyName, "${" + envName + "/}/conf");
+        Assert.assertThrows("no such env variable", Exception.class,
+                () -> replacedByEnvMethod.invoke(configBase, properties));
+
+    }
+
+}

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigBaseTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 public class ConfigBaseTest {
+
     @Test
     public void testReplacedByEnv() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         ConfigBase configBase = new ConfigBase();
@@ -54,8 +55,6 @@ public class ConfigBaseTest {
 
         // format: $env, get value from system env
         envName = "DORIS_HOME_key_123_env";
-        System.getenv().put(envName, "test_dir_env");
-
         properties.setProperty(confKeyName, "$" + envName + "/conf");
         replacedByEnvMethod.invoke(configBase, properties);
         Assert.assertEquals("test_dir_env/conf", properties.getProperty(confKeyName));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51200

Related PR: #xxx

Problem Summary:

It does not support `$xx` format in conf file. If we set `ssl_certificate_path=$DORIS_HOME/conf/cert.pem` the value of the key `ssl_certificate_path` is `$DORIS_HOME/conf/cert.pem`. But in fact the value of `$DORIS_HOME` must be replaced by the system environment.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

