### PR TITLE
[fix](coordinator) fix query cache throw CacheSourceOperator only support one scan range

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -2828,7 +2828,7 @@ public class Coordinator implements CoordInterface {
                     //the scan instance num should not larger than the tablets num
                     expectedInstanceNum = Math.min(scanRange.size(), parallelExecInstanceNum);
                 }
-                if (params.fragment.queryCacheParam != null) {
+                if (params.fragment != null && params.fragment.queryCacheParam != null) {
                     expectedInstanceNum = scanRange.size();
                 }
                 // 2. split how many scanRange one instance should scan

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -2828,6 +2828,9 @@ public class Coordinator implements CoordInterface {
                     //the scan instance num should not larger than the tablets num
                     expectedInstanceNum = Math.min(scanRange.size(), parallelExecInstanceNum);
                 }
+                if (params.fragment.queryCacheParam != null) {
+                    expectedInstanceNum = scanRange.size();
+                }
                 // 2. split how many scanRange one instance should scan
                 List<List<Pair<Integer, Map<Integer, List<TScanRangeParams>>>>> perInstanceScanRanges
                         = ListUtil.splitBySize(scanRange, expectedInstanceNum);

--- a/regression-test/data/query_p0/cache/query_cache.out
+++ b/regression-test/data/query_p0/cache/query_cache.out
@@ -28,3 +28,32 @@
 0	\N	\N	\N	\N
 1	6	6	6	6
 
+-- !query_cache1 --
+
+-- !query_cache2 --
+0	0	0
+1	1	1
+2	2	2
+
+-- !query_cache3 --
+
+-- !query_cache4 --
+0	0	0
+1	1	1
+2	2	2
+
+-- !query_cache5 --
+
+-- !query_cache6 --
+0	0	0
+1	1	1
+2	2	2
+
+-- !query_cache7 --
+\N	\N	\N	0	\N
+6	6	6	1	6
+
+-- !query_cache8 --
+0	\N	\N	\N	\N
+1	6	6	6	6
+


### PR DESCRIPTION
### What problem does this PR solve?

fix old coordinator use query cache maybe throw exception
```
CacheSourceOperator only support one scan range, plan error
```

this exception will be thrown when the aggregate key is the distribute key:
```sql
SELECT  `pk` AS field3 -- the tbl distributed by hash(pk)
FROM tbl
GROUP BY field3
```

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

