### PR TITLE
[vector search] Step forward on stability and functionality

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -146,6 +146,9 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         _read_options.column_predicates.insert(_read_options.column_predicates.end(),
                                                _read_context->predicates->begin(),
                                                _read_context->predicates->end());
+        LOG_INFO("Rowset reader, read options column predicates size: {}",
+                 _read_options.column_predicates.size());
+
         for (auto pred : *(_read_context->predicates)) {
             if (_read_options.col_id_to_predicates.count(pred->column_id()) < 1) {
                 _read_options.col_id_to_predicates.insert(
@@ -185,6 +188,10 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
             _read_options.column_predicates.insert(_read_options.column_predicates.end(),
                                                    _read_context->value_predicates->begin(),
                                                    _read_context->value_predicates->end());
+            LOG_INFO(
+                    "Rowset reader, read options add value predicates, column predicates size now: "
+                    "{}",
+                    _read_options.column_predicates.size());
             for (auto pred : *(_read_context->value_predicates)) {
                 if (_read_options.col_id_to_predicates.count(pred->column_id()) < 1) {
                     _read_options.col_id_to_predicates.insert(

--- a/be/src/olap/rowset/segment_v2/ann_index_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index_iterator.cpp
@@ -37,7 +37,7 @@ Status AnnIndexIterator::read_from_index(const IndexParam& param) {
 }
 
 Status AnnIndexIterator::range_search(const RangeSearchParams& params,
-                                      const CustomSearchParams& custom_params,
+                                      const VectorSearchUserParams& custom_params,
                                       RangeSearchResult* result) {
     if (_ann_reader == nullptr) {
         return Status::Error<ErrorCode::INDEX_INVALID_PARAMETERS>("_ann_reader is null");

--- a/be/src/olap/rowset/segment_v2/ann_index_iterator.h
+++ b/be/src/olap/rowset/segment_v2/ann_index_iterator.h
@@ -23,6 +23,7 @@
 #include "gutil/integral_types.h"
 #include "olap/rowset/segment_v2/ann_index_reader.h"
 #include "olap/rowset/segment_v2/index_iterator.h"
+#include "runtime/runtime_state.h"
 
 namespace doris::segment_v2 {
 
@@ -30,6 +31,7 @@ struct AnnIndexParam {
     const float* query_value;
     const size_t query_value_size;
     size_t limit;
+    doris::VectorSearchUserParams _user_params;
     roaring::Roaring* roaring;
     std::unique_ptr<std::vector<float>> distance = nullptr;
     std::unique_ptr<std::vector<uint64_t>> row_ids = nullptr;
@@ -46,10 +48,6 @@ struct RangeSearchParams {
                            roaring->cardinality());
     }
     virtual ~RangeSearchParams() = default;
-};
-
-struct CustomSearchParams {
-    int ef_search = 16;
 };
 
 struct RangeSearchResult {
@@ -80,7 +78,7 @@ public:
     bool has_null() override { return true; }
 
     MOCK_FUNCTION Status range_search(const RangeSearchParams& params,
-                                      const CustomSearchParams& custom_params,
+                                      const VectorSearchUserParams& custom_params,
                                       RangeSearchResult* result);
 
 private:

--- a/be/src/olap/rowset/segment_v2/ann_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/ann_index_reader.h
@@ -19,13 +19,13 @@
 
 #include "olap/rowset/segment_v2/index_reader.h"
 #include "olap/tablet_schema.h"
+#include "runtime/runtime_state.h"
 #include "vector/vector_index.h"
 
 namespace doris::segment_v2 {
 
 struct AnnIndexParam;
 struct RangeSearchParams;
-struct CustomSearchParams;
 struct RangeSearchResult;
 
 class IndexFileReader;
@@ -44,14 +44,16 @@ public:
 
     Status query(io::IOContext* io_ctx, AnnIndexParam* param);
 
-    Status range_search(const RangeSearchParams& params, const CustomSearchParams& custom_params,
-                        RangeSearchResult* result, io::IOContext* io_ctx = nullptr);
+    Status range_search(const RangeSearchParams& params,
+                        const VectorSearchUserParams& custom_params, RangeSearchResult* result,
+                        io::IOContext* io_ctx = nullptr);
 
     uint64_t get_index_id() const override { return _index_meta.index_id(); }
 
     Status new_iterator(const io::IOContext& io_ctx, OlapReaderStatistics* stats,
                         RuntimeState* runtime_state,
                         std::unique_ptr<IndexIterator>* iterator) override;
+    VectorIndex::Metric get_metric_type() const { return _metric_type; }
 
 private:
     TabletIndex _index_meta;
@@ -59,6 +61,7 @@ private:
     std::unique_ptr<VectorIndex> _vector_index;
     // TODO: Use integer.
     std::string _index_type;
+    VectorIndex::Metric _metric_type;
 };
 
 using AnnIndexReaderPtr = std::shared_ptr<AnnIndexReader>;

--- a/be/src/olap/rowset/segment_v2/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index_writer.h
@@ -50,6 +50,7 @@ public:
     static constexpr const char* INDEX_TYPE = "index_type";
     static constexpr const char* METRIC_TYPE = "metric_type";
     static constexpr const char* QUANTILIZER = "quantilizer";
+    static constexpr const char* PQ_M = "pq_m";
     static constexpr const char* DIM = "dim";
     static constexpr const char* MAX_DEGREE = "max_degree";
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2389,7 +2389,8 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
             is_nothing = true;
         }
 
-        LOG_INFO("SegmentIterator next block replace virtual column, cid {}, position {}, still "
+        LOG_INFO(
+                "SegmentIterator next block replace virtual column, cid {}, position {}, still "
                 "nothing {}",
                 cid, position, is_nothing);
     }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <memory>
@@ -98,6 +99,7 @@
 #include "vec/exprs/vslot_ref.h"
 #include "vec/functions/array/function_array_index.h"
 #include "vec/json/path_in_data.h"
+#include "vector/vector_index.h"
 
 namespace doris {
 using namespace ErrorCode;
@@ -299,6 +301,7 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
         }
         _col_predicates.emplace_back(predicate);
     }
+    LOG_INFO("Segment iterator init, column predicates size: {}", _col_predicates.size());
     _tablet_id = opts.tablet_id;
     // Read options will not change, so that just resize here
     _block_rowids.resize(_opts.block_row_max);
@@ -632,6 +635,32 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
                 !_col_predicates.empty());
         return Status::OK();
     }
+
+    // Process asc & desc according to the type of metric
+    auto index_reader = ann_index_iterator->get_reader();
+    auto ann_index_reader = dynamic_cast<AnnIndexReader*>(index_reader.get());
+    DCHECK(ann_index_reader != nullptr);
+    if (ann_index_reader->get_metric_type() == VectorIndex::Metric::INNER_PRODUCT) {
+        if (_ann_topn_descriptor->is_asc()) {
+            LOG_INFO("asc topn for inner product can not be evaluated by ann index");
+            return Status::OK();
+        }
+    } else {
+        if (!_ann_topn_descriptor->is_asc()) {
+            LOG_INFO("desc topn for l2/cosine can not be evaluated by ann index");
+            return Status::OK();
+        }
+    }
+
+    if (ann_index_reader->get_metric_type() != _ann_topn_descriptor->get_metric_type()) {
+        LOG_INFO(
+                "Ann topn metric type {} not match index metric type {}, can not be evaluated by "
+                "ann index",
+                VectorIndex::metric_to_string(_ann_topn_descriptor->get_metric_type()),
+                VectorIndex::metric_to_string(ann_index_reader->get_metric_type()));
+        return Status::OK();
+    }
+
     size_t pre_size = _row_bitmap.cardinality();
     size_t dst_col_idx = _ann_topn_descriptor->get_dest_column_idx();
     vectorized::IColumn::MutablePtr result_column;
@@ -647,6 +676,8 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     DCHECK(column_iter != nullptr);
     VirtualColumnIterator* virtual_column_iter = dynamic_cast<VirtualColumnIterator*>(column_iter);
     DCHECK(virtual_column_iter != nullptr);
+    LOG_INFO("Virtual column iterator, column_idx {}, is materialized with {} rows", dst_col_idx,
+             result_row_ids->size());
     virtual_column_iter->prepare_materialization(std::move(result_column),
                                                  std::move(result_row_ids));
     return Status::OK();
@@ -936,6 +967,7 @@ Status SegmentIterator::_apply_index_expr() {
             ++it;
         }
     }
+    // TODO：remove expr root from _remaining_conjunct_roots
 
     return Status::OK();
 }
@@ -1040,6 +1072,10 @@ bool SegmentIterator::_need_read_data(ColumnId cid) {
             _opts.enable_unique_key_merge_on_write)))) {
         return true;
     }
+    if (this->_vir_cid_to_idx_in_block.contains(cid)) {
+        return true;
+    }
+
     // if there is delete predicate, we always need to read data
     if (_has_delete_predicate(cid)) {
         return true;
@@ -1450,7 +1486,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
     _is_pred_column.resize(_schema->columns().size(), false);
 
     // including short/vec/delete pred
-    std::set<ColumnId> pred_column_ids;
+    std::set<ColumnId> cols_read_by_column_predicate;
     _lazy_materialization_read = false;
 
     std::set<ColumnId> del_cond_id_set;
@@ -1490,7 +1526,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
         for (auto* predicate : _col_predicates) {
             auto cid = predicate->column_id();
             _is_pred_column[cid] = true;
-            pred_column_ids.insert(cid);
+            cols_read_by_column_predicate.insert(cid);
 
             // check pred using short eval or vec eval
             if (_can_evaluated_by_vectorized(predicate)) {
@@ -1508,7 +1544,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
         // handle delete_condition
         if (!del_cond_id_set.empty()) {
             short_cir_pred_col_id_set.insert(del_cond_id_set.begin(), del_cond_id_set.end());
-            pred_column_ids.insert(del_cond_id_set.begin(), del_cond_id_set.end());
+            cols_read_by_column_predicate.insert(del_cond_id_set.begin(), del_cond_id_set.end());
 
             for (auto cid : del_cond_id_set) {
                 _is_pred_column[cid] = true;
@@ -1566,7 +1602,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
     // all columns are lazy materialization columns without non predicte column.
     // If common expr pushdown exists, and expr column is not contained in lazy materialization columns,
     // add to second read column, which will be read after lazy materialization
-    if (_schema->column_ids().size() > pred_column_ids.size()) {
+    if (_schema->column_ids().size() > cols_read_by_column_predicate.size()) {
         // pred_column_ids maybe empty, so that could not set _lazy_materialization_read = true here
         // has to check there is at least one predicate column
         for (auto cid : _schema->column_ids()) {
@@ -1574,10 +1610,10 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
                 if (_is_need_vec_eval || _is_need_short_eval) {
                     _lazy_materialization_read = true;
                 }
-                if (!_is_common_expr_column[cid]) {
-                    _non_predicate_columns.push_back(cid);
+                if (_is_common_expr_column[cid]) {
+                    _cols_read_by_common_expr.push_back(cid);
                 } else {
-                    _non_predicate_column_ids.push_back(cid);
+                    _cols_not_included_by_any_predicates.push_back(cid);
                 }
             }
         }
@@ -1586,16 +1622,20 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
     // Step 4: fill first read columns
     if (_lazy_materialization_read) {
         // insert pred cid to first_read_columns
-        for (auto cid : pred_column_ids) {
-            _predicate_column_ids.push_back(cid);
+        for (auto cid : cols_read_by_column_predicate) {
+            _cols_read_by_column_predicate.push_back(cid);
         }
-    } else if (!_is_need_vec_eval && !_is_need_short_eval &&
-               !_is_need_expr_eval) { // no pred exists, just read and output column
+    } else if (!_is_need_vec_eval && !_is_need_short_eval && !_is_need_expr_eval) {
+        // no pred exists, just read and output column
+        // 这代码也很迷惑啊，既然没有任何谓词列，那就不要改变流程啊，就按照正常的输出 non-predicates-columns 就好了啊
+        // 为什么要强行把所有的列当作 predicate 列去处理呢
         for (int i = 0; i < _schema->num_column_ids(); i++) {
             auto cid = _schema->column_id(i);
-            _predicate_column_ids.push_back(cid);
+            _cols_read_by_column_predicate.push_back(cid);
         }
     } else {
+        // 不延迟物化，但是有谓词
+        // 说明除了 column_predicates 的列之外，还有其他列需要读
         if (_is_need_vec_eval || _is_need_short_eval) {
             // TODO To refactor, because we suppose lazy materialization is better performance.
             // pred exits, but we can eliminate lazy materialization
@@ -1605,12 +1645,12 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
                                _short_cir_pred_column_ids.end());
             pred_id_set.insert(_vec_pred_column_ids.begin(), _vec_pred_column_ids.end());
 
-            DCHECK(_non_predicate_column_ids.empty());
+            DCHECK(_cols_read_by_common_expr.empty());
             // _non_predicate_column_ids must be empty. Otherwise _lazy_materialization_read must not false.
             for (int i = 0; i < _schema->num_column_ids(); i++) {
                 auto cid = _schema->column_id(i);
                 if (pred_id_set.find(cid) != pred_id_set.end()) {
-                    _predicate_column_ids.push_back(cid);
+                    _cols_read_by_column_predicate.push_back(cid);
                 }
                 // In the past, if schema columns > pred columns, the _lazy_materialization_read maybe == false, but
                 // we make sure using _lazy_materialization_read= true now, so these logic may never happens. I comment
@@ -1624,21 +1664,22 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
         } else if (_is_need_expr_eval) {
             DCHECK(!_is_need_vec_eval && !_is_need_short_eval);
             for (auto cid : _common_expr_columns) {
-                _predicate_column_ids.push_back(cid);
+                // 这代码太 track 了，很迷糊啊，完全概念混到一起了
+                _cols_read_by_column_predicate.push_back(cid);
             }
         }
     }
 
     LOG_INFO(
-            "Laze materialization end. "
+            "Laze materialization init end. "
             "lazy_materialization_read: {}, "
-            "predicate_column_ids: [{}], "
-            "non_predicate_columns: [{}], "
-            "non_predicate_column_ids: [{}], "
+            "_cols_read_by_column_predicate: [{}], "
+            "_cols_not_included_by_any_predicates: [{}], "
+            "_cols_read_by_common_expr: [{}], "
             "columns_to_filter: [{}]",
-            _lazy_materialization_read, fmt::join(_predicate_column_ids, ","),
-            fmt::join(_non_predicate_columns, ","), fmt::join(_non_predicate_column_ids, ","),
-            fmt::join(_columns_to_filter, ","));
+            _lazy_materialization_read, fmt::join(_cols_read_by_column_predicate, ","),
+            fmt::join(_cols_not_included_by_any_predicates, ","),
+            fmt::join(_cols_read_by_common_expr, ","), fmt::join(_columns_to_filter, ","));
     return Status::OK();
 }
 
@@ -1806,7 +1847,7 @@ Status SegmentIterator::_init_return_columns(vectorized::Block* block, uint32_t 
 
 void SegmentIterator::_output_non_pred_columns(vectorized::Block* block) {
     SCOPED_RAW_TIMER(&_opts.stats->output_col_ns);
-    for (auto cid : _non_predicate_columns) {
+    for (auto cid : _cols_not_included_by_any_predicates) {
         auto loc = _schema_block_id_map[cid];
         // if loc > block->columns() means the column is delete column and should
         // not output by block, so just skip the column.
@@ -1841,31 +1882,46 @@ Status SegmentIterator::_read_columns_by_index(uint32_t nrows_read_limit, uint32
     SCOPED_RAW_TIMER(&_opts.stats->predicate_column_read_ns);
 
     nrows_read = _range_iter->read_batch_rowids(_block_rowids.data(), nrows_read_limit);
+    LOG_INFO("nrows_read from range iterator: {}", nrows_read);
     bool is_continuous = (nrows_read > 1) &&
                          (_block_rowids[nrows_read - 1] - _block_rowids[0] == nrows_read - 1);
+    std::vector<ColumnId> predicate_column_ids_and_virtual_columns;
+    predicate_column_ids_and_virtual_columns.reserve(_cols_read_by_column_predicate.size() +
+                                                     _virtual_column_exprs.size());
+    predicate_column_ids_and_virtual_columns.insert(predicate_column_ids_and_virtual_columns.end(),
+                                                    _cols_read_by_column_predicate.begin(),
+                                                    _cols_read_by_column_predicate.end());
 
-    for (auto cid : _predicate_column_ids) {
+    for (const auto& entry : _virtual_column_exprs) {
+        // virtual column id is not in _predicate_column_ids
+        predicate_column_ids_and_virtual_columns.push_back(entry.first);
+    }
+
+    for (auto cid : predicate_column_ids_and_virtual_columns) {
         auto& column = _current_return_columns[cid];
-        if (_no_need_read_key_data(cid, column, nrows_read)) {
-            continue;
-        }
-        if (_prune_column(cid, column, true, nrows_read)) {
-            continue;
-        }
+        if (!_virtual_column_exprs.contains(cid)) {
+            if (_no_need_read_key_data(cid, column, nrows_read)) {
+                continue;
+            }
+            if (_prune_column(cid, column, true, nrows_read)) {
+                continue;
+            }
 
-        DBUG_EXECUTE_IF("segment_iterator._read_columns_by_index", {
-            auto col_name = _opts.tablet_schema->column(cid).name();
-            auto debug_col_name = DebugPoints::instance()->get_debug_param_or_default<std::string>(
-                    "segment_iterator._read_columns_by_index", "column_name", "");
-            if (debug_col_name.empty() && col_name != "__DORIS_DELETE_SIGN__") {
-                return Status::Error<ErrorCode::INTERNAL_ERROR>("does not need to read data, {}",
-                                                                col_name);
-            }
-            if (debug_col_name.find(col_name) != std::string::npos) {
-                return Status::Error<ErrorCode::INTERNAL_ERROR>("does not need to read data, {}",
-                                                                col_name);
-            }
-        })
+            DBUG_EXECUTE_IF("segment_iterator._read_columns_by_index", {
+                auto col_name = _opts.tablet_schema->column(cid).name();
+                auto debug_col_name =
+                        DebugPoints::instance()->get_debug_param_or_default<std::string>(
+                                "segment_iterator._read_columns_by_index", "column_name", "");
+                if (debug_col_name.empty() && col_name != "__DORIS_DELETE_SIGN__") {
+                    return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                            "does not need to read data, {}", col_name);
+                }
+                if (debug_col_name.find(col_name) != std::string::npos) {
+                    return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                            "does not need to read data, {}", col_name);
+                }
+            })
+        }
 
         if (is_continuous) {
             size_t rows_read = nrows_read;
@@ -2321,8 +2377,25 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
 
     _current_batch_rows_read = 0;
     RETURN_IF_ERROR(_read_columns_by_index(nrows_read_limit, _current_batch_rows_read));
-    if (std::find(_predicate_column_ids.begin(), _predicate_column_ids.end(),
-                  _schema->version_col_idx()) != _predicate_column_ids.end()) {
+
+    // 把从索引物化得到的虚拟列放到 block 中
+    for (const auto pair : _vir_cid_to_idx_in_block) {
+        ColumnId cid = pair.first;
+        size_t position = pair.second;
+        block->replace_by_position(position, std::move(_current_return_columns[cid]));
+        bool is_nothing = false;
+        if (vectorized::check_and_get_column<vectorized::ColumnNothing>(
+                    block->get_by_position(position).column.get())) {
+            is_nothing = true;
+        }
+
+        LOG_INFO("SegmentIterator next block replace virtual column, cid {}, position {}, still "
+                "nothing {}",
+                cid, position, is_nothing);
+    }
+
+    if (std::find(_cols_read_by_column_predicate.begin(), _cols_read_by_column_predicate.end(),
+                  _schema->version_col_idx()) != _cols_read_by_column_predicate.end()) {
         _replace_version_col(_current_batch_rows_read);
     }
 
@@ -2333,18 +2406,19 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         // Convert all columns in _current_return_columns to schema column
         RETURN_IF_ERROR(_convert_to_expected_type(_schema->column_ids()));
         for (int i = 0; i < block->columns() - _vir_cid_to_idx_in_block.size(); i++) {
-            // TODO: 虚拟列是否需要处理
             auto cid = _schema->column_id(i);
             // todo(wb) abstract make column where
             if (!_is_pred_column[cid]) {
                 block->replace_by_position(i, std::move(_current_return_columns[cid]));
             }
         }
+
         for (auto& pair : _vir_cid_to_idx_in_block) {
             auto cid = pair.first;
             auto loc = pair.second;
             block->replace_by_position(loc, std::move(_current_return_columns[cid]));
         }
+
         block->clear_column_data();
         // clear and release iterators memory footprint in advance
         _clear_iterators();
@@ -2352,11 +2426,15 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
     }
 
     if (!_is_need_vec_eval && !_is_need_short_eval && !_is_need_expr_eval) {
-        if (_non_predicate_columns.empty()) {
+        if (_cols_not_included_by_any_predicates.empty()) {
             return Status::InternalError("_non_predicate_columns is empty");
         }
-        RETURN_IF_ERROR(_convert_to_expected_type(_predicate_column_ids));
-        RETURN_IF_ERROR(_convert_to_expected_type(_non_predicate_columns));
+        RETURN_IF_ERROR(_convert_to_expected_type(_cols_read_by_column_predicate));
+        RETURN_IF_ERROR(_convert_to_expected_type(_cols_not_included_by_any_predicates));
+        LOG_INFO(
+                "No need to evaluate any predicates or filter, output non-predicate columns, "
+                "block rows {}, selected size {}",
+                block->rows(), _current_batch_rows_read);
         _output_non_pred_columns(block);
     } else {
         uint16_t selected_size = _current_batch_rows_read;
@@ -2379,33 +2457,41 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
                 // when lazy materialization enables, _predicate_column_ids = distinct(_short_cir_pred_column_ids + _vec_pred_column_ids)
                 // see _vec_init_lazy_materialization
                 // todo(wb) need to tell input columnids from output columnids
-                RETURN_IF_ERROR(_output_column_by_sel_idx(block, _predicate_column_ids,
+                RETURN_IF_ERROR(_output_column_by_sel_idx(block, _cols_read_by_column_predicate,
                                                           _sel_rowid_idx.data(), selected_size));
 
                 // step 3.2: read remaining expr column and evaluate it.
                 if (_is_need_expr_eval) {
                     // The predicate column contains the remaining expr column, no need second read.
-                    if (!_non_predicate_column_ids.empty()) {
+                    if (_cols_read_by_common_expr.size() > 0) {
                         SCOPED_RAW_TIMER(&_opts.stats->non_predicate_read_ns);
                         RETURN_IF_ERROR(_read_columns_by_rowids(
-                                _non_predicate_column_ids, _block_rowids, _sel_rowid_idx.data(),
+                                _cols_read_by_common_expr, _block_rowids, _sel_rowid_idx.data(),
                                 selected_size, &_current_return_columns));
-                        if (std::find(_non_predicate_column_ids.begin(),
-                                      _non_predicate_column_ids.end(),
+                        if (std::find(_cols_read_by_common_expr.begin(),
+                                      _cols_read_by_common_expr.end(),
                                       _schema->version_col_idx()) !=
-                            _non_predicate_column_ids.end()) {
+                            _cols_read_by_common_expr.end()) {
                             _replace_version_col(selected_size);
                         }
-                        RETURN_IF_ERROR(_convert_to_expected_type(_non_predicate_column_ids));
-                        for (auto cid : _non_predicate_column_ids) {
+                        RETURN_IF_ERROR(_convert_to_expected_type(_cols_read_by_common_expr));
+                        for (auto cid : _cols_read_by_common_expr) {
                             auto loc = _schema_block_id_map[cid];
+                            block->replace_by_position(loc,
+                                                       std::move(_current_return_columns[cid]));
+                        }
+
+                        for (const auto pair : _vir_cid_to_idx_in_block) {
+                            auto cid = pair.first;
+                            auto loc = pair.second;
                             block->replace_by_position(loc,
                                                        std::move(_current_return_columns[cid]));
                         }
                     }
 
                     DCHECK(block->columns() > _schema_block_id_map[*_common_expr_columns.begin()]);
-                    // block->rows() takes the size of the first column by default. If the first column is no predicate column,
+                    // block->rows() takes the size of the first column by default.
+                    // If the first column is not predicate column,
                     // it has not been read yet. add a const column that has been read to calculate rows().
                     if (block->rows() == 0) {
                         vectorized::MutableColumnPtr col0 =
@@ -2430,17 +2516,23 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
                     }
                 }
             } else if (_is_need_expr_eval) {
-                RETURN_IF_ERROR(_convert_to_expected_type(_non_predicate_column_ids));
-                for (auto cid : _non_predicate_column_ids) {
+                RETURN_IF_ERROR(_convert_to_expected_type(_cols_read_by_common_expr));
+                for (auto cid : _cols_read_by_common_expr) {
                     auto loc = _schema_block_id_map[cid];
+                    block->replace_by_position(loc, std::move(_current_return_columns[cid]));
+                }
+
+                for (const auto pair : _vir_cid_to_idx_in_block) {
+                    auto cid = pair.first;
+                    auto loc = pair.second;
                     block->replace_by_position(loc, std::move(_current_return_columns[cid]));
                 }
             }
         } else if (_is_need_expr_eval) {
-            DCHECK(!_predicate_column_ids.empty());
-            RETURN_IF_ERROR(_convert_to_expected_type(_predicate_column_ids));
+            DCHECK(!_cols_read_by_column_predicate.empty());
+            RETURN_IF_ERROR(_convert_to_expected_type(_cols_read_by_column_predicate));
             // first read all rows are insert block, initialize sel_rowid_idx to all rows.
-            for (auto cid : _predicate_column_ids) {
+            for (auto cid : _cols_read_by_column_predicate) {
                 auto loc = _schema_block_id_map[cid];
                 block->replace_by_position(loc, std::move(_current_return_columns[cid]));
             }
@@ -2482,7 +2574,7 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
             _selected_size = selected_size;
         }
 
-        if (_non_predicate_columns.empty()) {
+        if (_cols_not_included_by_any_predicates.empty()) {
             // shrink char_type suffix zero data
             block->shrink_char_type_column_suffix_zero(_char_type_idx);
 
@@ -2490,16 +2582,17 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         }
         // step4: read non_predicate column
         if (selected_size > 0) {
-            RETURN_IF_ERROR(_read_columns_by_rowids(_non_predicate_columns, _block_rowids,
-                                                    _sel_rowid_idx.data(), selected_size,
-                                                    &_current_return_columns));
-            if (std::find(_non_predicate_columns.begin(), _non_predicate_columns.end(),
-                          _schema->version_col_idx()) != _non_predicate_columns.end()) {
+            RETURN_IF_ERROR(_read_columns_by_rowids(_cols_not_included_by_any_predicates,
+                                                    _block_rowids, _sel_rowid_idx.data(),
+                                                    selected_size, &_current_return_columns));
+            if (std::find(_cols_not_included_by_any_predicates.begin(),
+                          _cols_not_included_by_any_predicates.end(), _schema->version_col_idx()) !=
+                _cols_not_included_by_any_predicates.end()) {
                 _replace_version_col(selected_size);
             }
         }
 
-        RETURN_IF_ERROR(_convert_to_expected_type(_non_predicate_columns));
+        RETURN_IF_ERROR(_convert_to_expected_type(_cols_not_included_by_any_predicates));
         // step5: output columns
         _output_non_pred_columns(block);
     }
@@ -2836,6 +2929,8 @@ Status SegmentIterator::_materialization_of_virtual_column(vectorized::Block* bl
 
         if (vectorized::check_and_get_column<const vectorized::ColumnNothing>(
                     block->get_by_position(idx_in_block).column.get())) {
+            LOG_INFO("Virtual column is doing materialization, cid {}, column_expr {}", cid,
+                     column_expr->root()->debug_string());
             int result_cid = -1;
             RETURN_IF_ERROR(column_expr->execute(block, &result_cid));
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -396,7 +396,7 @@ private:
     // whether lazy materialization read should be used.
     bool _lazy_materialization_read;
     // columns to read after predicate evaluation and remaining expr execute
-    std::vector<ColumnId> _non_predicate_columns;
+    std::vector<ColumnId> _cols_not_included_by_any_predicates;
     std::set<ColumnId> _common_expr_columns;
     // remember the rowids we've read for the current row block.
     // could be a local variable of next_batch(), kept here to reuse vector memory
@@ -410,7 +410,7 @@ private:
             _vec_pred_column_ids; // keep columnId of columns for vectorized predicate evaluation
     std::vector<ColumnId>
             _short_cir_pred_column_ids; // keep columnId of columns for short circuit predicate evaluation
-    std::vector<bool> _is_pred_column; // columns hold _init segmentIter
+
     std::map<uint32_t, bool> _need_read_data_indices;
     std::vector<bool> _is_common_expr_column;
     vectorized::MutableColumns _current_return_columns;
@@ -422,8 +422,9 @@ private:
     // first, read predicate columns by various index
     // second, read non-predicate columns
     // so we need a field to stand for columns first time to read
-    std::vector<ColumnId> _predicate_column_ids;
-    std::vector<ColumnId> _non_predicate_column_ids;
+    std::vector<ColumnId> _cols_read_by_column_predicate;
+    std::vector<bool> _is_pred_column;
+    std::vector<ColumnId> _cols_read_by_common_expr;
     std::vector<ColumnId> _columns_to_filter;
     std::vector<ColumnId> _converted_column_ids;
     std::vector<int> _schema_block_id_map; // map from schema column id to column idx in Block

--- a/be/src/olap/rowset/segment_v2/virtual_column_iterator.h
+++ b/be/src/olap/rowset/segment_v2/virtual_column_iterator.h
@@ -38,9 +38,9 @@ public:
 
     Status init(const ColumnIteratorOptions& opts) override;
 
-    Status seek_to_first() override { return Status::OK(); }
+    Status seek_to_first() override;
 
-    Status seek_to_ordinal(ordinal_t ord_idx) override { return Status::OK(); }
+    Status seek_to_ordinal(ordinal_t ord_idx) override;
 
     Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override;
 
@@ -57,9 +57,10 @@ private:
     vectorized::IColumn::Ptr _materialized_column_ptr;
     // segment rowid to index in column.
     std::map<uint64_t, uint64_t> _row_id_to_idx;
-
     doris::vectorized::IColumn::Filter _filter;
     size_t _size = 0;
+
+    ordinal_t _current_ordinal = 0;
 };
 
 } // namespace doris::segment_v2

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -569,11 +569,13 @@ Status OlapScanLocalState::init(RuntimeState* state, LocalStateInfo& info) {
         // order by 的表达式需要是一个 slot_ref，并且类型需要是虚拟列
         DCHECK(ordering_expr.nodes[0].__isset.slot_ref);
         DCHECK(ordering_expr.nodes[0].slot_ref.is_virtual_slot);
-        size_t limit = olap_scan_node.ann_sort_limit;
+        DCHECK(olap_scan_node.ann_sort_info.is_asc_order.size() == 1);
+        const bool asc = olap_scan_node.ann_sort_info.is_asc_order[0];
+        const size_t limit = olap_scan_node.ann_sort_limit;
         std::shared_ptr<vectorized::VExprContext> ordering_expr_ctx;
         RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(ordering_expr, ordering_expr_ctx));
         _ann_topn_descriptor =
-                vectorized::AnnTopNDescriptor::create_shared(limit, ordering_expr_ctx);
+                vectorized::AnnTopNDescriptor::create_shared(asc, limit, ordering_expr_ctx);
     }
 
     return ScanLocalState<OlapScanLocalState>::init(state, info);

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -198,15 +198,15 @@ Status OperatorXBase::init(const TPlanNode& tnode, RuntimeState* /*state*/) {
     if (tnode.__isset.vconjunct) {
         vectorized::VExprContextSPtr context;
         RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(tnode.vconjunct, context));
-        LOG_INFO("Conjunct of {} is\n{}", _op_name,
-                 apache::thrift::ThriftDebugString(tnode.vconjunct));
+        // LOG_INFO("Conjunct of {} is\n{}", _op_name,
+        //          apache::thrift::ThriftDebugString(tnode.vconjunct));
         _conjuncts.emplace_back(context);
     } else if (tnode.__isset.conjuncts) {
         for (auto& conjunct : tnode.conjuncts) {
             vectorized::VExprContextSPtr context;
             RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(conjunct, context));
-            LOG_INFO("Conjunct of {} is\n{}", _op_name,
-                     apache::thrift::ThriftDebugString(conjunct));
+            // LOG_INFO("Conjunct of {} is\n{}", _op_name,
+            //          apache::thrift::ThriftDebugString(conjunct));
             // // Write the conjunct to a file for debugging
             // doris::vectorized::write_to_json(
             //         "/mnt/disk4/hezhiqiang/workspace/doris/cmaster/RELEASE/be1", "conjunct.json",

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -49,7 +49,7 @@
 #include "runtime/workload_group/workload_group.h"
 #include "util/debug_util.h"
 #include "util/runtime_profile.h"
-#include "vec/columns/columns_number.h"
+#include "vec/runtime/vector_search_user_params.h"
 
 namespace doris {
 class RuntimeFilter;
@@ -656,6 +656,12 @@ public:
     int task_num() const { return _task_num; }
 
     int profile_level() const { return _profile_level; }
+
+    VectorSearchUserParams get_vector_search_params() const {
+        return VectorSearchUserParams(_query_options.hnsw_ef_search,
+                                      _query_options.hnsw_check_relative_distance,
+                                      _query_options.hnsw_bounded_queue);
+    }
 
 private:
     Status create_error_log_file();

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -777,6 +777,7 @@ void Block::update_hash(SipHash& hash) const {
     }
 }
 
+// columns_to_filter 实际上是需要进行过滤的 col 的 position
 void Block::filter_block_internal(Block* block, const std::vector<uint32_t>& columns_to_filter,
                                   const IColumn::Filter& filter) {
     size_t count = filter.size() - simd::count_zero_num((int8_t*)filter.data(), filter.size());

--- a/be/src/vec/exec/scan/olap_scanner.h
+++ b/be/src/vec/exec/scan/olap_scanner.h
@@ -36,6 +36,7 @@
 #include "olap/tablet.h"
 #include "olap/tablet_reader.h"
 #include "olap/tablet_schema.h"
+#include "runtime/runtime_state.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exec/scan/scanner.h"
 
@@ -118,6 +119,8 @@ public:
     std::map<size_t, vectorized::DataTypePtr> _vir_col_idx_to_type;
 
     std::shared_ptr<vectorized::AnnTopNDescriptor> _ann_topn_descriptor;
+
+    VectorSearchUserParams _vector_search_params;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exprs/ann_range_search_params.h
+++ b/be/src/vec/exprs/ann_range_search_params.h
@@ -22,18 +22,21 @@
 #include <string>
 
 #include "olap/rowset/segment_v2/ann_index_iterator.h"
+#include "runtime/runtime_state.h"
+#include "vector/vector_index.h"
 
 namespace doris::vectorized {
-struct AnnRangeSearchParams {
+struct RangeSearchRuntimeInfo {
     bool is_ann_range_search = false;
     bool is_le_or_lt = true;
     size_t src_col_idx = 0;
     int64_t dst_col_idx = -1;
     double radius = 0.0;
-    int ef_search = 0;
+    segment_v2::VectorIndex::Metric metric_type;
+    doris::VectorSearchUserParams user_params;
     std::unique_ptr<float[]> query_value;
 
-    segment_v2::RangeSearchParams toRangeSearchParams() {
+    segment_v2::RangeSearchParams to_range_search_params() {
         segment_v2::RangeSearchParams params;
         params.query_value = query_value.get();
         params.radius = static_cast<float>(radius);
@@ -42,17 +45,13 @@ struct AnnRangeSearchParams {
         return params;
     }
 
-    segment_v2::CustomSearchParams toCustomSearchParams() {
-        segment_v2::CustomSearchParams params;
-        params.ef_search = ef_search;
-        return params;
-    }
-
     std::string to_string() const {
         return fmt::format(
                 "is_ann_range_search: {}, is_le_or_lt: {}, src_col_idx: {}, "
-                "dst_col_idx: {}, radius: {}, ef_search: {}",
-                is_ann_range_search, is_le_or_lt, src_col_idx, dst_col_idx, radius, ef_search);
+                "dst_col_idx: {}, metric_type {}, radius: {}, user params: {}",
+                is_ann_range_search, is_le_or_lt, src_col_idx, dst_col_idx,
+                segment_v2::VectorIndex::metric_to_string(metric_type), radius,
+                user_params.to_string());
     }
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "runtime/runtime_state.h"
 #include "udf/udf.h"
 #include "vec/core/column_numbers.h"
 #include "vec/exprs/ann_range_search_params.h"
@@ -60,6 +61,7 @@ public:
                 FunctionContext::FunctionStateScope scope) override;
     void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     const std::string& expr_name() const override;
+    std::string function_name() const;
     std::string debug_string() const override;
     bool is_constant() const override {
         if (!_function->is_use_default_implementation_for_constants() ||
@@ -82,13 +84,13 @@ public:
             const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
             roaring::Roaring& row_bitmap) override;
 
-    Status prepare_ann_range_search() override;
+    Status prepare_ann_range_search(const doris::VectorSearchUserParams& params) override;
 
 protected:
     FunctionBasePtr _function;
     std::string _expr_name;
     std::string _function_name;
-    AnnRangeSearchParams _ann_range_search_params;
+    RangeSearchRuntimeInfo _ann_range_search_params;
 
 private:
     Status _do_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -807,9 +807,9 @@ Status VExpr::evaluate_ann_range_search(
     return Status::OK();
 }
 
-Status VExpr::prepare_ann_range_search() {
+Status VExpr::prepare_ann_range_search(const doris::VectorSearchUserParams& params) {
     for (auto& child : _children) {
-        RETURN_IF_ERROR(child->prepare_ann_range_search());
+        RETURN_IF_ERROR(child->prepare_ann_range_search(params));
     }
     return Status::OK();
 }

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -283,7 +283,7 @@ public:
             const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
             roaring::Roaring& row_bitmap);
 
-    virtual Status prepare_ann_range_search();
+    virtual Status prepare_ann_range_search(const doris::VectorSearchUserParams& params);
 
     bool has_been_executed();
 

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -432,11 +432,11 @@ void VExprContext::_reset_memory_usage(const VExprContextSPtrs& contexts) {
                   [](auto&& context) { context->_memory_usage = 0; });
 }
 
-Status VExprContext::prepare_ann_range_search() {
+Status VExprContext::prepare_ann_range_search(const doris::VectorSearchUserParams& params) {
     if (_root == nullptr) {
         return Status::OK();
     }
-    return _root->prepare_ann_range_search();
+    return _root->prepare_ann_range_search(params);
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -28,6 +28,7 @@
 #include "common/factory_creator.h"
 #include "common/status.h"
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
+#include "runtime/runtime_state.h"
 #include "runtime/types.h"
 #include "udf/udf.h"
 #include "vec/core/block.h"
@@ -279,7 +280,7 @@ public:
 
     [[nodiscard]] size_t get_memory_usage() const { return _memory_usage; }
 
-    Status prepare_ann_range_search();
+    Status prepare_ann_range_search(const doris::VectorSearchUserParams& params);
 
 private:
     // Close method is called in vexpr context dector, not need call expicility

--- a/be/src/vec/exprs/virtual_slot_ref.cpp
+++ b/be/src/vec/exprs/virtual_slot_ref.cpp
@@ -91,7 +91,7 @@ Status VirtualSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescr
                 state->desc_tbl().debug_string());
     }
     const TExpr& expr = *slot_desc->get_virtual_column_expr();
-    LOG_INFO("Virtual column expr is {}", apache::thrift::ThriftDebugString(expr));
+    // LOG_INFO("Virtual column expr is {}", apache::thrift::ThriftDebugString(expr));
     // Create a temp_ctx only for create_expr_tree.
     VExprContextSPtr temp_ctx;
     RETURN_IF_ERROR(VExpr::create_expr_tree(expr, temp_ctx));

--- a/be/src/vec/functions/array/function_array_distance.h
+++ b/be/src/vec/functions/array/function_array_distance.h
@@ -96,6 +96,9 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
+        LOG_INFO("Function {} is executed with {} rows, stack {}", get_name(), input_rows_count,
+                 doris::get_stack_trace());
+
         const auto& arg1 = block.get_by_position(arguments[0]);
         const auto& arg2 = block.get_by_position(arguments[1]);
         if (!_check_input_type(arg1.type) || !_check_input_type(arg2.type)) {

--- a/be/src/vec/runtime/vector_search_user_params.cpp
+++ b/be/src/vec/runtime/vector_search_user_params.cpp
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/runtime/vector_search_user_params.h"
+
+#include <fmt/format.h>
+
+namespace doris {
+bool VectorSearchUserParams::operator==(const VectorSearchUserParams& other) const {
+    return hnsw_ef_search == other.hnsw_ef_search &&
+           hnsw_check_relative_distance == other.hnsw_check_relative_distance &&
+           hnsw_bounded_queue == other.hnsw_bounded_queue;
+}
+
+std::string VectorSearchUserParams::to_string() const {
+    return fmt::format(
+            "hnsw_ef_search: {}, hnsw_check_relative_distance: {}, "
+            "hnsw_bounded_queue: {}",
+            hnsw_ef_search, hnsw_check_relative_distance, hnsw_bounded_queue);
+}
+} // namespace doris

--- a/be/src/vec/runtime/vector_search_user_params.h
+++ b/be/src/vec/runtime/vector_search_user_params.h
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <string>
+
+namespace doris {
+// Constructed from session variables.
+struct VectorSearchUserParams {
+    int hnsw_ef_search = 16;
+    bool hnsw_check_relative_distance = true;
+    bool hnsw_bounded_queue = true;
+
+    bool operator==(const VectorSearchUserParams& other) const;
+
+    std::string to_string() const;
+};
+} // namespace doris

--- a/be/src/vector/faiss_vector_index.h
+++ b/be/src/vector/faiss_vector_index.h
@@ -26,13 +26,20 @@
 #include <string>
 
 #include "common/status.h"
+#include "util/metrics.h"
 #include "vector_index.h"
 
 namespace doris::segment_v2 {
 struct FaissBuildParameter {
     enum class IndexType { BruteForce, IVF, HNSW };
 
-    enum class Quantilizer { FLAT, SQ, PQ };
+    enum class Quantilizer { FLAT, PQ };
+
+    enum class MetricType {
+        L2,    // Euclidean distance
+        IP,    // Inner product
+        COSINE // Cosine similarity
+    };
 
     static IndexType string_to_index_type(const std::string& type) {
         if (type == "brute_force") {
@@ -48,19 +55,30 @@ struct FaissBuildParameter {
     static Quantilizer string_to_quantilizer(const std::string& type) {
         if (type == "flat") {
             return Quantilizer::FLAT;
-        } else if (type == "sq") {
-            return Quantilizer::SQ;
         } else if (type == "pq") {
             return Quantilizer::PQ;
         }
         return Quantilizer::FLAT; // default
     }
 
+    static MetricType string_to_metric_type(const std::string& type) {
+        if (type == "l2") {
+            return MetricType::L2;
+        } else if (type == "ip") {
+            return MetricType::IP;
+        } else if (type == "cosine") {
+            return MetricType::COSINE;
+        }
+        return MetricType::L2; // default
+    }
+
     // HNSW
     int d = 0;
     int m = 0;
+    int pq_m = -1; // Only used for PQ quantilizer
     IndexType index_type;
     Quantilizer quantilizer;
+    MetricType metric_type = MetricType::L2;
 };
 
 class FaissVectorIndex : public VectorIndex {

--- a/be/test/olap/vector_search/ann_index_reader_test.cpp
+++ b/be/test/olap/vector_search/ann_index_reader_test.cpp
@@ -33,7 +33,7 @@ using namespace doris::vector_search_utils;
 namespace doris::vectorized {
 
 TEST_F(VectorSearchTest, AnnIndexReaderRangeSearch) {
-    size_t iterato = 50;
+    size_t iterato = 25;
     for (size_t i = 0; i < iterato; ++i) {
         std::map<std::string, std::string> index_properties;
         index_properties["index_type"] = "hnsw";

--- a/be/test/olap/vector_search/ann_index_reader_test.cpp
+++ b/be/test/olap/vector_search/ann_index_reader_test.cpp
@@ -15,33 +15,93 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "olap/rowset/segment_v2/ann_index_reader.h"
-
+#include <gen_cpp/olap_file.pb.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <memory>
+#include <string>
 
+#include "faiss_vector_index.h"
+#include "olap/rowset/segment_v2/ann_index_iterator.h"
+#include "olap/tablet_schema.h"
+#include "runtime/runtime_state.h"
 #include "vector_search_utils.h"
+using namespace doris::vector_search_utils;
 
-namespace doris::segment_v2 {
+namespace doris::vectorized {
 
-using namespace vector_search_utils;
-class AnnIndexReaderTest : public testing::Test {};
+TEST_F(VectorSearchTest, AnnIndexReaderRangeSearch) {
+    size_t iterato = 50;
+    for (size_t i = 0; i < iterato; ++i) {
+        std::map<std::string, std::string> index_properties;
+        index_properties["index_type"] = "hnsw";
+        index_properties["metric_type"] = "l2";
+        std::unique_ptr<doris::TabletIndex> index_meta = std::make_unique<doris::TabletIndex>();
+        index_meta->_properties = index_properties;
+        auto mock_index_file_reader = std::make_shared<MockIndexFileReader>();
+        auto ann_index_reader = std::make_unique<segment_v2::AnnIndexReader>(
+                index_meta.get(), mock_index_file_reader);
+        doris::vector_search_utils::IndexType index_type =
+                doris::vector_search_utils::IndexType::HNSW;
+        const size_t dim = 128;
+        const size_t m = 16;
+        auto doris_faiss_index = doris::vector_search_utils::create_doris_index(index_type, dim, m);
+        auto native_faiss_index =
+                doris::vector_search_utils::create_native_index(index_type, dim, m);
+        const size_t num_vectors = 1000;
+        auto vectors = doris::vector_search_utils::generate_test_vectors_matrix(num_vectors, dim);
+        doris::vector_search_utils::add_vectors_to_indexes_serial_mode(
+                doris_faiss_index.get(), native_faiss_index.get(), vectors);
+        std::ignore = doris_faiss_index->save(this->_ram_dir.get());
+        std::vector<float> query_value = vectors[0];
+        const float radius = doris::vector_search_utils::get_radius_from_matrix(query_value.data(),
+                                                                                dim, vectors, 0.3);
 
-TEST_F(AnnIndexReaderTest, TestLoadIndex) {
-    MockTabletSchema tablet_schema;
-    std::shared_ptr<MockIndexFileReader> index_file_reader =
-            std::make_shared<MockIndexFileReader>();
-    auto ann_index_reader = std::make_unique<AnnIndexReader>(&tablet_schema, index_file_reader);
+        // Make sure all rows are in the roaring
+        auto roaring = std::make_unique<roaring::Roaring>();
+        for (size_t i = 0; i < num_vectors; ++i) {
+            roaring->add(i);
+        }
 
-    EXPECT_TRUE(ann_index_reader->load_index(nullptr).ok());
-}
+        doris::segment_v2::RangeSearchParams params;
+        params.radius = radius;
+        params.query_value = query_value.data();
+        params.roaring = roaring.get();
+        doris::VectorSearchUserParams custom_params;
+        custom_params.hnsw_ef_search = 16;
+        doris::segment_v2::RangeSearchResult result;
+        auto doris_faiss_vector_index = std::make_unique<doris::segment_v2::FaissVectorIndex>();
+        std::ignore = doris_faiss_vector_index->load(this->_ram_dir.get());
+        ann_index_reader->_vector_index = std::move(doris_faiss_vector_index);
+        std::ignore = ann_index_reader->range_search(params, custom_params, &result, nullptr);
 
-TEST_F(AnnIndexReaderTest, TestQuery) {
-    MockTabletSchema tablet_schema;
-    std::shared_ptr<MockIndexFileReader> index_file_reader =
-            std::make_shared<MockIndexFileReader>();
-    auto ann_index_reader = std::make_unique<AnnIndexReader>(&tablet_schema, index_file_reader);
-}
-} // namespace doris::segment_v2
+        ASSERT_TRUE(result.roaring != nullptr);
+        ASSERT_TRUE(result.distance != nullptr);
+        ASSERT_TRUE(result.row_ids != nullptr);
+        std::vector<std::pair<int, float>> doris_search_result_order_by_lables;
+        for (size_t i = 0; i < result.roaring->cardinality(); ++i) {
+            doris_search_result_order_by_lables.push_back(
+                    {result.row_ids->at(i), result.distance[i]});
+        }
+
+        std::sort(doris_search_result_order_by_lables.begin(),
+                  doris_search_result_order_by_lables.end(),
+                  [](const auto& a, const auto& b) { return a.first < b.first; });
+
+        std::vector<std::pair<int, float>> native_search_result_order_by_lables =
+                doris::vector_search_utils::perform_native_index_range_search(
+                        native_faiss_index.get(), query_value.data(), radius);
+
+        ASSERT_EQ(result.roaring->cardinality(), native_search_result_order_by_lables.size());
+
+        for (size_t i = 0; i < native_search_result_order_by_lables.size(); ++i) {
+            ASSERT_EQ(doris_search_result_order_by_lables[i].first,
+                      native_search_result_order_by_lables[i].first);
+            ASSERT_FLOAT_EQ(doris_search_result_order_by_lables[i].second,
+                            native_search_result_order_by_lables[i].second);
+        }
+    }
+};
+} // namespace doris::vectorized

--- a/be/test/olap/vector_search/ann_topn_descriptor_test.cpp
+++ b/be/test/olap/vector_search/ann_topn_descriptor_test.cpp
@@ -65,8 +65,8 @@ TEST_F(VectorSearchTest, AnnTopNDescriptorConstructor) {
     v->set_virtual_column_expr(distanc_calcu_fn_call_ctx->root());
 
     std::shared_ptr<AnnTopNDescriptor> predicate;
-    predicate = AnnTopNDescriptor::create_shared(limit, virtual_slot_expr_ctx);
-    ASSERT_TRUE(predicate != nullptr) << "AnnTopNDescriptor::create_shared() failed";
+    predicate = AnnTopNDescriptor::create_shared(true, limit, virtual_slot_expr_ctx);
+    ASSERT_TRUE(predicate != nullptr) << "AnnTopNDescriptor::create_shared(true,) failed";
 }
 
 TEST_F(VectorSearchTest, AnnTopNDescriptorPrepare) {
@@ -86,7 +86,7 @@ TEST_F(VectorSearchTest, AnnTopNDescriptorPrepare) {
 
     v->set_virtual_column_expr(distanc_calcu_fn_call_ctx->root());
     std::shared_ptr<AnnTopNDescriptor> predicate;
-    predicate = AnnTopNDescriptor::create_shared(limit, virtual_slot_expr_ctx);
+    predicate = AnnTopNDescriptor::create_shared(true, limit, virtual_slot_expr_ctx);
     st = predicate->prepare(&_runtime_state, _row_desc);
     ASSERT_TRUE(st.ok()) << fmt::format("st: {}, expr {}", st.to_string(),
                                         predicate->get_order_by_expr_ctx()->root()->debug_string());
@@ -111,7 +111,7 @@ TEST_F(VectorSearchTest, AnnTopNDescriptorEvaluateTopN) {
 
     v->set_virtual_column_expr(distanc_calcu_fn_call_ctx->root());
     std::shared_ptr<AnnTopNDescriptor> predicate;
-    predicate = AnnTopNDescriptor::create_shared(limit, virtual_slot_expr_ctx);
+    predicate = AnnTopNDescriptor::create_shared(true, limit, virtual_slot_expr_ctx);
     st = predicate->prepare(&_runtime_state, _row_desc);
     ASSERT_TRUE(st.ok()) << fmt::format("st: {}, expr {}", st.to_string(),
                                         predicate->get_order_by_expr_ctx()->root()->debug_string());

--- a/be/test/olap/vector_search/vector_search_utils.cpp
+++ b/be/test/olap/vector_search/vector_search_utils.cpp
@@ -29,6 +29,7 @@ namespace doris::vector_search_utils {
 static void accumulate(double x, double y, double& sum) {
     sum += (x - y) * (x - y);
 }
+
 static double finalize(double sum) {
     return sqrt(sum);
 }

--- a/be/test/olap/vector_search/vector_search_utils.cpp
+++ b/be/test/olap/vector_search/vector_search_utils.cpp
@@ -247,4 +247,14 @@ float get_radius_from_matrix(const float* vector, int dim,
 
     return radius;
 }
+
+std::pair<std::unique_ptr<MockTabletIndex>, std::shared_ptr<segment_v2::AnnIndexReader>>
+create_tmp_ann_index_reader(std::map<std::string, std::string> properties) {
+    auto mock_tablet_index = std::make_unique<MockTabletIndex>();
+    mock_tablet_index->_properties = properties;
+    auto mock_index_file_reader = std::make_shared<MockIndexFileReader>();
+    auto ann_reader = std::make_shared<segment_v2::AnnIndexReader>(mock_tablet_index.get(),
+                                                                   mock_index_file_reader);
+    return std::make_pair(std::move(mock_tablet_index), ann_reader);
+}
 } // namespace doris::vector_search_utils

--- a/be/test/olap/vector_search/vector_search_utils.h
+++ b/be/test/olap/vector_search/vector_search_utils.h
@@ -27,8 +27,9 @@
 #include <thrift/protocol/TDebugProtocol.h>
 #include <thrift/protocol/TJSONProtocol.h>
 
-#include <iostream>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "common/object_pool.h"
 #include "olap/rowset/segment_v2/ann_index_iterator.h"
@@ -157,35 +158,15 @@ public:
 private:
     io::IOContext _io_ctx_mock;
 };
+
+class MockAnnIndexReader : public doris::segment_v2::AnnIndexReader {};
+
+std::pair<std::unique_ptr<MockTabletIndex>, std::shared_ptr<segment_v2::AnnIndexReader>>
+create_tmp_ann_index_reader(std::map<std::string, std::string> properties);
+
 } // namespace doris::vector_search_utils
 
 namespace doris::vectorized {
-template <typename T>
-T read_from_json(const std::string& json_str) {
-    auto memBufferIn = std::make_shared<apache::thrift::transport::TMemoryBuffer>(
-            reinterpret_cast<uint8_t*>(const_cast<char*>(json_str.data())),
-            static_cast<uint32_t>(json_str.size()));
-    auto jsonProtocolIn = std::make_shared<apache::thrift::protocol::TJSONProtocol>(memBufferIn);
-    T params;
-    params.read(jsonProtocolIn.get());
-    return params;
-}
-
-template <typename T>
-void write_to_json(const std::string& path, std::string name, const T& expr) {
-    auto memBuffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
-    auto jsonProtocol = std::make_shared<apache::thrift::protocol::TJSONProtocol>(memBuffer);
-
-    expr.write(jsonProtocol.get());
-    uint8_t* buf;
-    uint32_t size;
-    memBuffer->getBuffer(&buf, &size);
-    std::string file_path = fmt::format("{}/{}.json", path, name);
-    std::ofstream ofs(file_path, std::ios::binary);
-    ofs.write(reinterpret_cast<const char*>(buf), size);
-    ofs.close();
-    std::cout << fmt::format("Serialized JSON written to {}\n", file_path);
-}
 
 class VectorSearchTest : public ::testing::Test {
 public:

--- a/be/test/olap/vector_search/vector_search_utils.h
+++ b/be/test/olap/vector_search/vector_search_utils.h
@@ -150,7 +150,7 @@ public:
     MOCK_METHOD(Status, read_from_index, (const doris::segment_v2::IndexParam& param), (override));
     MOCK_METHOD(Status, range_search,
                 (const segment_v2::RangeSearchParams& params,
-                 const segment_v2::CustomSearchParams& custom_params,
+                 const VectorSearchUserParams& custom_params,
                  segment_v2::RangeSearchResult* result),
                 (override));
 

--- a/be/test/olap/vector_search/virtual_column_iterator_test.cpp
+++ b/be/test/olap/vector_search/virtual_column_iterator_test.cpp
@@ -336,17 +336,11 @@ TEST_F(VectorSearchTest, NextBatchTest1) {
         }
     }
 
-    // 4. seek到越界位置（如100），next_batch应该返回0行
+    // 4. seek到越界位置（如100），应该报错
     {
         vectorized::MutableColumnPtr dst = vectorized::ColumnVector<int32_t>::create();
         Status st = iterator.seek_to_ordinal(100);
-        ASSERT_TRUE(st.ok());
-        size_t rows_read = 10;
-        bool has_null = false;
-        st = iterator.next_batch(&rows_read, dst, &has_null);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(rows_read, 0);
-        ASSERT_EQ(dst->size(), 0);
+        ASSERT_EQ(st.ok(), false);
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -739,6 +739,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SQL_CONVERTOR_CONFIG = "sql_convertor_config";
 
+    public static final String HNSW_EF_SEARCH = "hnsw_ef_search";
+    public static final String HNSW_CHECK_RELATIVE_DISTANCE = "hnsw_check_relative_distance";
+    public static final String HNSW_BOUNDED_QUEUE = "hnsw_bounded_queue";
+
     /**
      * If set false, user couldn't submit analyze SQL and FE won't allocate any related resources.
      */
@@ -2611,6 +2615,22 @@ public class SessionVariable implements Serializable, Writable {
         return enableESParallelScroll;
     }
 
+    @VariableMgr.VarAttr(name = HNSW_EF_SEARCH, needForward = true,
+            description = {"HNSW索引的EF搜索参数，控制搜索的精度和速度",
+                    "HNSW index EF search parameter, controls the precision and speed of the search"})  
+    public int hnswEFSearch = 16;
+
+    @VariableMgr.VarAttr(name = HNSW_CHECK_RELATIVE_DISTANCE, needForward = true,
+            description = {"是否启用相对距离检查机制，以提升HNSW搜索的准确性",
+                       "Enable relative distance checking to improve HNSW search accuracy"})
+    public boolean hnswCheckRelativeDistance = true;
+
+    @VariableMgr.VarAttr(name = HNSW_BOUNDED_QUEUE, needForward = true,
+            description = {"是否使用有界优先队列来优化HNSW的搜索性能",
+                       "Whether to use a bounded priority queue to optimize HNSW search performance"})
+    public boolean hnswBoundedQueue = true;
+
+
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
     @SuppressWarnings("checkstyle:Indentation")
@@ -4218,6 +4238,11 @@ public class SessionVariable implements Serializable, Writable {
 
         tResult.setMinimumOperatorMemoryRequiredKb(minimumOperatorMemoryRequiredKB);
         tResult.setExchangeMultiBlocksByteSize(exchangeMultiBlocksByteSize);
+
+        tResult.setHnswEfSearch(hnswEFSearch);
+        tResult.setHnswCheckRelativeDistance(hnswCheckRelativeDistance);
+        tResult.setHnswBoundedQueue(hnswBoundedQueue);
+
         return tResult;
     }
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -395,6 +395,10 @@ struct TQueryOptions {
   164: optional bool check_orc_init_sargs_success = false
   165: optional i32 exchange_multi_blocks_byte_size = 262144 
 
+  166: optional i32 hnsw_ef_search = 16;
+  167: optional bool hnsw_check_relative_distance = true;
+  168: optional bool hnsw_bounded_queue = true; 
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
A huge step forward on stability and functionality.

### Functionality
1. Search parameters like `ef_search`, can be passed to index as session variables. This behavior is same with pg-vector and duckdb vector search plug-in.
2. Correct processing for order by desc. Fallback to brute force search when it is necessary.
3. Support using inner product as index metric and order by inner_product.
4. When metrics of sql dismatches with index, fallback to brute force.

### Stability
1. More unit test
2. Virtual column iterator.
3. According to custom script, result of range search, topn search & compound search is almost same with native faiss. The overlap rate of result is more than 90%. The 10% difference is introduced by batch insert mode of native faiss.
