### PR TITLE
[opt](cache) Reset initial capacity of all caches after Cgroup memory limit changes

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -181,6 +181,10 @@ PrunedInfo LRUCache::set_capacity(size_t capacity) {
     LRUHandle* last_ref_list = nullptr;
     {
         std::lock_guard l(_mutex);
+        if (capacity > _capacity) {
+            _capacity = capacity;
+            return {0, 0};
+        }
         _capacity = capacity;
         _evict_from_lru(0, &last_ref_list);
     }

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -82,5 +82,12 @@ int64_t CacheManager::for_each_cache_refresh_capacity(double adjust_weighted,
     return freed_size;
 }
 
+void CacheManager::for_each_cache_reset_initial_capacity(double adjust_weighted) {
+    std::lock_guard<std::mutex> l(_caches_lock);
+    for (const auto& pair : _caches) {
+        pair.second->reset_initial_capacity(adjust_weighted);
+    }
+}
+
 #include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -86,6 +86,8 @@ public:
     int64_t for_each_cache_refresh_capacity(double adjust_weighted,
                                             RuntimeProfile* profile = nullptr);
 
+    void for_each_cache_reset_initial_capacity(double adjust_weighted);
+
 private:
     std::mutex _caches_lock;
     std::unordered_map<CachePolicy::CacheType, CachePolicy*> _caches;

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -157,6 +157,7 @@ public:
 
     CacheType type() { return _type; }
     size_t initial_capacity() const { return _initial_capacity; }
+    virtual int64_t reset_initial_capacity(double adjust_weighted) = 0;
     bool enable_prune() const { return _enable_prune; }
     RuntimeProfile* profile() { return _profile.get(); }
 

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -241,8 +241,7 @@ public:
         }
     }
 
-    int64_t adjust_capacity_weighted(double adjust_weighted) override {
-        std::lock_guard<std::mutex> l(_lock);
+    int64_t adjust_capacity_weighted_unlocked(double adjust_weighted) {
         auto capacity =
                 static_cast<size_t>(static_cast<double>(_initial_capacity) * adjust_weighted);
         COUNTER_SET(_freed_entrys_counter, (int64_t)0);
@@ -272,6 +271,25 @@ public:
                 _adjust_capacity_weighted_number_counter->value());
         return _freed_entrys_counter->value();
     }
+
+    int64_t adjust_capacity_weighted(double adjust_weighted) override {
+        std::lock_guard<std::mutex> l(_lock);
+        return adjust_capacity_weighted_unlocked(adjust_weighted);
+    }
+
+    int64_t reset_initial_capacity(double adjust_weighted) override {
+        DCHECK(adjust_weighted != 0.0); // otherwise initial_capacity will always to be 0.
+        std::lock_guard<std::mutex> l(_lock);
+        int64_t prune_num = adjust_capacity_weighted_unlocked(adjust_weighted);
+        size_t old_capacity = _initial_capacity;
+        _initial_capacity =
+                static_cast<size_t>(static_cast<double>(_initial_capacity) * adjust_weighted);
+        LOG(INFO) << fmt::format(
+                "[MemoryGC] {} reset initial capacity, new capacity {}, old capacity {}, prune num "
+                "{}",
+                type_string(_type), _initial_capacity, old_capacity, prune_num);
+        return prune_num;
+    };
 
 protected:
     void _init_mem_tracker(const std::string& type_name) {

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -20,6 +20,8 @@
 
 #include "mem_info.h"
 
+#include "runtime/memory/cache_manager.h"
+
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 #endif
@@ -159,6 +161,9 @@ void MemInfo::refresh_proc_meminfo() {
 
     // 2. if physical_mem changed, refresh mem limit and gc size.
     if (physical_mem > 0 && _s_physical_mem.load(std::memory_order_relaxed) != physical_mem) {
+        CacheManager::instance()->for_each_cache_reset_initial_capacity(physical_mem /
+                                                                        (_s_physical_mem * 1.0));
+
         _s_physical_mem.store(physical_mem);
 
         bool is_percent = true;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -161,8 +161,11 @@ void MemInfo::refresh_proc_meminfo() {
 
     // 2. if physical_mem changed, refresh mem limit and gc size.
     if (physical_mem > 0 && _s_physical_mem.load(std::memory_order_relaxed) != physical_mem) {
-        CacheManager::instance()->for_each_cache_reset_initial_capacity(physical_mem /
-                                                                        (_s_physical_mem * 1.0));
+        if (_s_physical_mem != std::numeric_limits<int64_t>::max()) {
+            // After MemInfo is initialized, if physical memory changed, reset initial capacity of all caches.
+            CacheManager::instance()->for_each_cache_reset_initial_capacity(
+                    physical_mem / (_s_physical_mem * 1.0));
+        }
 
         _s_physical_mem.store(physical_mem);
 

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -800,4 +800,61 @@ TEST_F(CacheTest, SetCapacity) {
     ASSERT_EQ(0, cache()->get_usage());
 }
 
+TEST_F(CacheTest, ResetInitialCapacity) {
+    init_number_cache();
+    for (int i = 0; i < kCacheSize; i++) {
+        Insert(i, 1000 + i, 1);
+        EXPECT_EQ(1000 + i, Lookup(i));
+    }
+    ASSERT_EQ(kCacheSize, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize, cache()->get_usage());
+
+    int64_t prune_num = cache()->adjust_capacity_weighted(0.5);
+    ASSERT_EQ(prune_num, kCacheSize / 2);
+    ASSERT_EQ(kCacheSize / 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+
+    prune_num = cache()->adjust_capacity_weighted(2);
+    ASSERT_EQ(prune_num, 0);
+    ASSERT_EQ(kCacheSize * 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+
+    prune_num = cache()->reset_initial_capacity(0.5);
+    ASSERT_EQ(prune_num, 0);
+    ASSERT_EQ(kCacheSize / 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+
+    prune_num = cache()->adjust_capacity_weighted(2);
+    ASSERT_EQ(prune_num, 0);
+    ASSERT_EQ(kCacheSize, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+
+    prune_num = cache()->adjust_capacity_weighted(1);
+    ASSERT_EQ(prune_num, 0);
+    ASSERT_EQ(kCacheSize / 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+
+    prune_num = cache()->reset_initial_capacity(4);
+    ASSERT_EQ(prune_num, 0);
+    ASSERT_EQ(kCacheSize * 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+
+    for (int i = kCacheSize; i < kCacheSize * 2; i++) {
+        Insert(i, 1000 + i, 1);
+        EXPECT_EQ(1000 + i, Lookup(i));
+    }
+    ASSERT_EQ(kCacheSize * 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize + kCacheSize / 2, cache()->get_usage());
+
+    prune_num = cache()->adjust_capacity_weighted(0.5);
+    ASSERT_EQ(prune_num, kCacheSize / 2);
+    ASSERT_EQ(kCacheSize, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize, cache()->get_usage());
+
+    prune_num = cache()->reset_initial_capacity(0.25);
+    ASSERT_EQ(prune_num, kCacheSize / 2);
+    ASSERT_EQ(kCacheSize / 2, cache()->get_capacity());
+    ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

After the VM on the cloud is scaled up or down, the cgroup memory limit will change, and the cache initial capacity needs to be scaled up or down accordingly.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

