### PR TITLE
[fix](arrow) Rollback Arrow version 19.0.1 -> 17.0.0, Fix MacOS compile error and decimal type error when convert to Parquet

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -321,7 +321,9 @@ under the License.
          you can find avro version info in iceberg mvn repository -->
         <iceberg.version>1.6.1</iceberg.version>
         <maxcompute.version>0.49.0-public</maxcompute.version>
-        <arrow.version>18.2.0</arrow.version>
+        <!-- Arrow 19.0.1 will MacOS compile error and decimal type error when convert to Parquet
+         https://github.com/apache/doris/pull/51217-->
+        <arrow.version>17.0.0</arrow.version>
         <presto.hadoop.version>2.7.4-11</presto.hadoop.version>
         <presto.hive.version>3.0.0-8</presto.hive.version>
         <!-- lakesoul -->

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -253,10 +253,12 @@ GRPC_SOURCE=grpc-1.54.3
 GRPC_MD5SUM="af00a2edeae0f02bb25917cc3473b7de"
 
 # arrow
-ARROW_DOWNLOAD="https://github.com/apache/arrow/archive/refs/tags/apache-arrow-19.0.1.tar.gz"
-ARROW_NAME="apache-arrow-19.0.1.tar.gz"
-ARROW_SOURCE="arrow-apache-arrow-19.0.1"
-ARROW_MD5SUM="8c5091da0f8fb41a47d7f4dad7b712df"
+# Arrow 19.0.1 will MacOS compile error and decimal type error when convert to Parquet.
+# https://github.com/apache/doris/pull/51217
+ARROW_DOWNLOAD="https://github.com/apache/arrow/archive/refs/tags/apache-arrow-17.0.0.tar.gz"
+ARROW_NAME="apache-arrow-17.0.0.tar.gz"
+ARROW_SOURCE="arrow-apache-arrow-17.0.0"
+ARROW_MD5SUM="ba18bf83e2164abd34b9ac4cb164f0f0"
 
 # Abseil
 ABSEIL_DOWNLOAD="https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz"


### PR DESCRIPTION
### What problem does this PR solve?

Introduced: #50939

In Arrow 19.0.1, 

1. some scenarios will force the use of `arrow::smallest_decimal` instead of `arrow::decimal`, but when `arrow::smallest_decimal` is converted to Parquet, an error will occur: `NotImplemented: Unhandled type for Arrow to Parquet schema conversion: decimal32(5, 2)`

2. when compile Doris BE on MacOS M1, an error `arithmetic on a pointer to an incomplete type 'arrow::flight::FlightEndpoint'` will occur. This is because there is a circular dependency in `arrow/flight/types.h`, `std::vector<FlightEndpoint>` is used in `476: struct Data`, but `809: struct FlightEndpoint` is defined later.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

