### PR TITLE
[fix](session variables) Limit query_timeout to within LoadTimeout

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -259,10 +259,11 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         switch (sourceType) {
             case BACKEND_STREAMING:
                 checkValidTimeoutSecond(timeoutSecond, Config.max_stream_load_timeout_second,
-                        Config.min_load_timeout_second);
+                        Config.min_load_timeout_second, sourceType);
                 break;
             default:
-                checkValidTimeoutSecond(timeoutSecond, Config.max_load_timeout_second, Config.min_load_timeout_second);
+                checkValidTimeoutSecond(timeoutSecond, Config.max_load_timeout_second,
+                        Config.min_load_timeout_second, sourceType);
         }
 
         BeginTxnResponse beginTxnResponse = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -164,16 +164,16 @@ public class GlobalTransactionMgr implements GlobalTransactionMgrIface {
             switch (sourceType) {
                 case BACKEND_STREAMING:
                     checkValidTimeoutSecond(timeoutSecond, Config.max_stream_load_timeout_second,
-                            Config.min_load_timeout_second);
+                            Config.min_load_timeout_second, sourceType);
                     break;
                 default:
                     checkValidTimeoutSecond(timeoutSecond, Config.max_load_timeout_second,
-                            Config.min_load_timeout_second);
+                            Config.min_load_timeout_second, sourceType);
             }
 
             DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
             return dbTransactionMgr.beginTransaction(tableIdList, label, requestId,
-                coordinator, sourceType, listenerId, timeoutSecond);
+                    coordinator, sourceType, listenerId, timeoutSecond);
         } catch (DuplicatedRequestException e) {
             throw e;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgrIface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgrIface.java
@@ -46,11 +46,23 @@ import java.util.concurrent.TimeoutException;
 
 public interface GlobalTransactionMgrIface extends Writable {
     default void checkValidTimeoutSecond(long timeoutSecond, int maxLoadTimeoutSecond,
-            int minLoadTimeOutSecond) throws AnalysisException {
-        if (timeoutSecond > maxLoadTimeoutSecond || timeoutSecond < minLoadTimeOutSecond) {
-            throw new AnalysisException("Invalid timeout: " + timeoutSecond + ". Timeout should between "
-                    + minLoadTimeOutSecond + " and " + maxLoadTimeoutSecond
-                    + " seconds");
+                                         int minLoadTimeOutSecond, LoadJobSourceType sourceType)
+            throws AnalysisException {
+        if (timeoutSecond < minLoadTimeOutSecond) {
+            throw new AnalysisException("Invalid timeout: " + timeoutSecond
+                    + ". Timeout should be higher than Config.min_load_timeout_second: "
+                    + minLoadTimeOutSecond);
+        } else if (timeoutSecond > maxLoadTimeoutSecond) {
+            switch (sourceType) {
+                case BACKEND_STREAMING:
+                    throw new AnalysisException("Invalid timeout: " + timeoutSecond
+                            + ". Timeout should be lower than Config.max_stream_load_timeout_second: "
+                            + maxLoadTimeoutSecond);
+                default:
+                    throw new AnalysisException("Invalid timeout: " + timeoutSecond
+                            + ". Timeout should be lower than Config.max_load_timeout_second: "
+                            + maxLoadTimeoutSecond);
+            }
         }
     }
 

--- a/regression-test/suites/insert_p0/test_insert_timeout.groovy
+++ b/regression-test/suites/insert_p0/test_insert_timeout.groovy
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// The cases is copied from https://github.com/trinodb/trino/tree/master
+// /testing/trino-product-tests/src/main/resources/sql-tests/testcases
+// and modified by Doris.
+
+suite("test_insert_timeout") {
+    def tableName = "test_insert_timeout_tbl"
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE ${tableName} (
+            `id` int(11) NOT NULL,
+            `name` varchar(50) NULL,
+            `score` int(11) NULL default "-1"
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`, `name`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        );
+    """
+
+    try {
+        def timeout = sql "SHOW FRONTEND CONFIG like '%max_load_timeout_second%';"
+
+        timeout = Integer.parseInt(timeout[0][1])
+
+        logger.info("${timeout}")
+
+        def invalid_timeout = timeout + 200
+
+        sql " set query_timeout = ${invalid_timeout} "
+
+        test {
+            sql " INSERT INTO ${tableName} VALUES (1, 'Alice', 90), (2, 'Bob', 85), (3, 'Charlie', 95) "
+            exception "begin transaction failed. errCode = 2, detailMessage = Invalid timeout: ${invalid_timeout}. Timeout should be lower than Config.max_load_timeout_second: ${timeout}"
+        }
+
+    } finally {
+        sql """
+        UNSET VARIABLE query_timeout;
+        """
+    }
+}


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/6a099009-0cb9-4b2e-a4b9-639eb2489968)
now:
```
mysql> CREATE TABLE t (
    ->     id int,
    ->     `k` int,
    ->     `k1` int,
    ->     `k2` int
    -> )
    -> DISTRIBUTED BY HASH(`id`) BUCKETS 5
    -> PROPERTIES (
    ->     "replication_num" = "1"
    -> );
Query OK, 0 rows affected (0.04 sec)

mysql> insert into t values (1,1,1,1);
Query OK, 1 row affected (0.17 sec)
{'label':'label_b75ddc8237654307_8d1d29f5e69b99d9', 'status':'VISIBLE', 'txnId':'2'}

mysql> set query_timeout = 1000000000;
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t values (1,1,1,1);
ERROR 1105 (HY000): errCode = 2, detailMessage = begin transaction failed. errCode = 2, detailMessage = Invalid timeout: 1000000000. Timeout should be lower than Config.max_load_timeout_second: 259200
```



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

