### PR TITLE
branch-2.1: [chore](cataglog) Unlimit db data size quota (#51108)

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1445,7 +1445,7 @@ public class Config extends ConfigBase {
      * Used to set default db data quota bytes.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static long default_db_data_quota_bytes = 1024L * 1024 * 1024 * 1024 * 1024L; // 1PB
+    public static long default_db_data_quota_bytes = Long.MAX_VALUE; // 8192 PB
 
     /**
      * Used to set default db replica quota num.

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/DbsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/DbsProcDirTest.java
@@ -196,9 +196,9 @@ public class DbsProcDirTest {
                 "LastConsistencyCheckTime", "ReplicaCount", "ReplicaQuota", "TransactionQuota", "LastUpdateTime"),
                 result.getColumnNames());
         List<List<String>> rows = Lists.newArrayList();
-        rows.add(Arrays.asList(String.valueOf(db1.getId()), db1.getFullName(), "0", "0.000 ", "1024.000 TB",
+        rows.add(Arrays.asList(String.valueOf(db1.getId()), db1.getFullName(), "0", "0.000 ", "8388608.000 TB",
                 FeConstants.null_string, "0", "1073741824", "1000", FeConstants.null_string));
-        rows.add(Arrays.asList(String.valueOf(db2.getId()), db2.getFullName(), "0", "0.000 ", "1024.000 TB",
+        rows.add(Arrays.asList(String.valueOf(db2.getId()), db2.getFullName(), "0", "0.000 ", "8388608.000 TB",
                 FeConstants.null_string, "0", "1073741824", "1000", FeConstants.null_string));
         Assert.assertEquals(rows, result.getRows());
     }


### PR DESCRIPTION
we should not limit db data size for the db especially for the log scenarios
doc https://github.com/apache/doris-website/pull/2403

pick #51108 

