### PR TITLE
[Fix](Iceberg-hadoop-catalog)Fix Kerberos-authenticated HadoopCatalog insert failures due to missing kerberos credentials

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
@@ -73,10 +73,18 @@ public class IcebergTransaction implements Transaction {
         }
     }
 
-    public void beginInsert(SimpleTableInfo tableInfo) {
-        this.tableInfo = tableInfo;
-        this.table = getNativeTable(tableInfo);
-        this.transaction = table.newTransaction();
+    public void beginInsert(SimpleTableInfo tableInfo) throws UserException {
+        try {
+            ops.getPreExecutionAuthenticator().execute(() -> {
+                // create and start the iceberg transaction
+                this.tableInfo = tableInfo;
+                this.table = getNativeTable(tableInfo);
+                this.transaction = table.newTransaction();
+            });
+        } catch (Exception e) {
+            throw new UserException("Failed to begin insert for iceberg table " + tableInfo, e);
+        }
+
     }
 
     public void finishInsert(SimpleTableInfo tableInfo, Optional<InsertCommandContext> insertCtx) {

--- a/regression-test/suites/external_table_p0/kerberos/test_iceberg_hadoop_catalog_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_iceberg_hadoop_catalog_kerberos.groovy
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_iceberg_hadoop_catalog_kerberos", "p0,external,kerberos,external_docker,external_docker_kerberos") {
+    String enabled = context.config.otherConfigs.get("enableKerberosTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        return
+    }
+    def String catalog_name = "iceberg_hadoop_catalog_kerberos_test"
+    def database_name = "test_iceberg_hadoop_db"
+    def String test_tbl_name="iceberg_test_table"
+    def keytab_root_dir = "/keytabs"
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    sql """
+            drop catalog if exists ${catalog_name}
+        """
+    sql """
+            CREATE CATALOG IF NOT EXISTS ${catalog_name}
+            PROPERTIES ( 
+            'type'='iceberg',
+            'iceberg.catalog.type' = 'hadoop',
+            'warehouse' = 'hdfs://${externalEnvIp}:8520/tmp/iceberg/catalog',
+            "hadoop.security.authentication" = "kerberos",
+            "hadoop.security.auth_to_local" = "RULE:[2:\$1@\$0](.*@LABS.TERADATA.COM)s/@.*//
+                                               RULE:[2:\$1@\$0](.*@OTHERLABS.TERADATA.COM)s/@.*//
+                                               RULE:[2:\$1@\$0](.*@OTHERREALM.COM)s/@.*//
+                                               DEFAULT",
+            "hadoop.kerberos.principal" = "hive/presto-master.docker.cluster@LABS.TERADATA.COM",
+            "hadoop.kerberos.min.seconds.before.relogin" = "5",
+            "hadoop.kerberos.keytab.login.autorenewal.enabled" = "false",
+              "hadoop.kerberos.keytab" = "${keytab_root_dir}/hive-presto-master.keytab",
+            "fs.defaultFS" = "hdfs://${externalEnvIp}:8520"
+            ); 
+        """
+
+    sql """ switch ${catalog_name} """
+    sql """ drop database if exists ${database_name} """
+    sql """ create database if not exists ${database_name} """
+    def database = sql """ show databases like '%${database_name}' """
+    assert database.size() == 1
+    sql """ use ${database_name} """
+    sql """ drop table  if exists ${test_tbl_name}"""
+    sql """
+       CREATE TABLE ${test_tbl_name} (                   
+            `ts` DATETIME COMMENT 'ts',       
+            `col1` BOOLEAN COMMENT 'col1',             
+            `col2` INT COMMENT 'col2',       
+            `col3` BIGINT COMMENT 'col3',           
+            `col4` FLOAT COMMENT 'col4',          
+            `col5` DOUBLE COMMENT 'col5',              
+            `col6` DECIMAL(9,4) COMMENT 'col6',
+            `col7` STRING COMMENT 'col7',                
+            `col8` DATE COMMENT 'col8',             
+            `col9` DATETIME COMMENT 'col9',               
+            `pt1` STRING COMMENT 'pt1',                   
+            `pt2` STRING COMMENT 'pt2'                
+             )  ENGINE=iceberg              
+                PARTITION BY LIST (DAY(ts), pt1, pt2) ()                
+                 PROPERTIES (                   
+                 'write-format'='orc',                
+                  'compression-codec'='zlib'     
+                 );
+    """
+    def table = sql """ show tables like '%${test_tbl_name}' """
+    assert table.size() == 1
+    sql """
+        insert into ${test_tbl_name} values (
+          '2024-05-26 12:34:56',
+          true,
+          123,
+          1234567890123,
+          12.34,
+          56.789,
+          12345.6789,
+          'example text',
+          '2024-05-26',
+          '2024-05-26 14:00:00',
+          'partition_val1',
+          'partition_val2'
+        );
+    """
+    def dataResult = sql """select count(1) from ${test_tbl_name} """
+    assert dataResult.get(0).get(0) == 1
+}


### PR DESCRIPTION

### What problem does this PR solve?

When using HadoopCatalog with Kerberos authentication, write operations fail during doCommit because the underlying FileSystem is accessed without proper credentials.

This patch ensures that the Kerberos credentials are available during commit-time FS operations, allowing data writes to succeed under kerberos environments.

```
Caused by: org.apache.iceberg.exceptions.RuntimeIOException: Failed to refresh the table    at org.apache.iceberg.hadoop.HadoopTableOperations.refresh(HadoopTableOperations.java:128) ~[iceberg-core-1.6.1.jar:?]    at org.apache.iceberg.Transactions.newTransaction(Transactions.java:63) ~[iceberg-core-1.6.1.jar:?]    at org.apache.iceberg.BaseTable.newTransaction(BaseTable.java:240) ~[iceberg-core-1.6.1.jar:?]    at org.apache.doris.datasource.iceberg.IcebergTransaction.beginInsert(IcebergTransaction.java:79) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.IcebergInsertExecutor.beforeExec(IcebergInsertExecutor.java:55) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.AbstractInsertExecutor.executeSingleInsert(AbstractInsertExecutor.java:198) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.runInternal(InsertIntoTableCommand.java:472) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.run(InsertIntoTableCommand.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:771) ~[doris-fe.jar:1.2-SNAPSHOT]    ... 17 moreCaused by: java.io.IOException: DestHost:destPort hadoop-master:8520 , LocalHost:localPort vm-204/172.20.57.204:0. Failed on local exception: java.io.IOException: org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]    at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]    at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]    at org.apache.hadoop.net.NetUtils.wrapWithMessage(NetUtils.java:930) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:905) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.ipc.Client.getRpcResponse(Client.java:1571) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.ipc.Client.call(Client.java:1513) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.ipc.Client.call(Client.java:1410) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:258) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:139) ~[hadoop-common-3.3.6.jar:?]    at jdk.proxy3.$Proxy162.getFileInfo(Unknown Source) ~[?:?]    at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:966) ~[hadoop-hdfs-client-3.3.6.jar:?]    at jdk.internal.reflect.GeneratedMethodAccessor53.invoke(Unknown Source) ~[?:?]    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]    at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]    at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:433) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:166) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:158) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:96) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:362) ~[hadoop-common-3.3.6.jar:?]    at jdk.proxy3.$Proxy163.getFileInfo(Unknown Source) ~[?:?]    at org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:1739) ~[hadoop-hdfs-client-3.3.6.jar:?]    at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1829) ~[hadoop-hdfs-client-3.3.6.jar:?]    at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1826) ~[hadoop-hdfs-client-3.3.6.jar:?]    at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81) ~[hadoop-common-3.3.6.jar:?]    at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1841) ~[hadoop-hdfs-client-3.3.6.jar:?]    at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1862) ~[hadoop-common-3.3.6.jar:?]    at org.apache.iceberg.hadoop.HadoopTableOperations.getMetadataFile(HadoopTableOperations.java:243) ~[iceberg-core-1.6.1.jar:?]    at org.apache.iceberg.hadoop.HadoopTableOperations.refresh(HadoopTableOperations.java:108) ~[iceberg-core-1.6.1.jar:?]    at org.apache.iceberg.Transactions.newTransaction(Transactions.java:63) ~[iceberg-core-1.6.1.jar:?]    at org.apache.iceberg.BaseTable.newTransaction(BaseTable.java:240) ~[iceberg-core-1.6.1.jar:?]    at org.apache.doris.datasource.iceberg.IcebergTransaction.beginInsert(IcebergTransaction.java:79) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.IcebergInsertExecutor.beforeExec(IcebergInsertExecutor.java:55) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.AbstractInsertExecutor.executeSingleInsert(AbstractInsertExecutor.java:198) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.runInternal(InsertIntoTableCommand.java:472) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.run(InsertIntoTableCommand.java:166) ~[doris-fe.jar:1.2-SNAPSHOT]    at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:771) ~[doris-fe.jar:1.2-SNAPSHOT]    ... 17 more 
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

