### PR TITLE
[fix](iceberg) fix the iceberg eq-delete filter resize-fill bug.

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -460,6 +460,8 @@ public:
         this->c_end = this->c_start + new_size;
     }
 
+    /// reset the array capacity
+    /// fill the new additional elements using the value
     void resize_fill(size_t n, const T& value) {
         size_t old_size = this->size();
         const auto new_size = this->byte_size(n);
@@ -689,6 +691,8 @@ public:
         }
     }
 
+    /// reset the array capacity
+    /// replace the all elements using the value
     void assign(size_t n, const T& x) {
         this->resize(n);
         std::fill(begin(), end(), x);

--- a/be/src/vec/exec/format/table/equality_delete.cpp
+++ b/be/src/vec/exec/format/table/equality_delete.cpp
@@ -60,7 +60,8 @@ Status SimpleEqualityDelete::filter_data_block(Block* data_block) {
     if (_filter == nullptr) {
         _filter = std::make_unique<IColumn::Filter>(rows, 0);
     } else {
-        _filter->resize_fill(rows, 0);
+        // reset the array capacity and fill all elements using the 0
+        _filter->assign(rows, UInt8(0));
     }
 
     if (column_and_type->column->is_nullable()) {
@@ -132,7 +133,8 @@ Status MultiEqualityDelete::filter_data_block(Block* data_block) {
     if (_filter == nullptr) {
         _filter = std::make_unique<IColumn::Filter>(rows, 1);
     } else {
-        _filter->resize_fill(rows, 1);
+        //reset the array capacity and fill all elements using the 0
+        _filter->assign(rows, UInt8(1));
     }
     auto* filter_data = _filter->data();
     for (size_t i = 0; i < rows; ++i) {


### PR DESCRIPTION
solve the problem of inconsistent filter data in the doris eq-delete scenario

Problem Summary:
When Doris reads iceberg's data, if there is eq-deleted data, when filtering the data, the filter will have dirty data due to the incorrect use of the resize-fill function, which will eventually cause Doris's data to be filtered incorrectly.
[doris-iceberg-eq-delete-bug.pdf](https://github.com/user-attachments/files/20439214/doris-iceberg-eq-delete-bug.pdf)

- Behavior changed:
   yes
   added a reinit function to reset the size of a data and fill all the data with the new data area
- Does this need documentation?
    No.
 
