### PR TITLE
[improvement](jdbc catalog) Optimize the acquisition of indentity type in SQLServer

### DIFF
--- a/docker/thirdparties/docker-compose/sqlserver/init/03-create-table.sql
+++ b/docker/thirdparties/docker-compose/sqlserver/init/03-create-table.sql
@@ -272,3 +272,8 @@ CREATE TABLE dbo.extreme_test_multi_block
     IPv6_Col         VARCHAR(39) NOT NULL,  -- e.g., 'FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF'
     IPv6_Nullable    VARCHAR(39) NULL
 );
+
+CREATE TABLE dbo.test_identity_decimal (
+	id decimal(18,0) IDENTITY(1,1),
+	col int
+);

--- a/docker/thirdparties/docker-compose/sqlserver/init/04-insert.sql
+++ b/docker/thirdparties/docker-compose/sqlserver/init/04-insert.sql
@@ -121,3 +121,5 @@ insert into dbo.extreme_test_multi_block select * from dbo.extreme_test_multi_bl
 insert into dbo.extreme_test_multi_block select * from dbo.extreme_test_multi_block;
 insert into dbo.extreme_test_multi_block select * from dbo.extreme_test_multi_block;
 insert into dbo.extreme_test_multi_block select * from dbo.extreme_test;
+
+INSERT INTO dbo.test_identity_decimal(col) select 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
@@ -32,7 +32,14 @@ public class JdbcSQLServerClient extends JdbcClient {
         String originSqlserverType = fieldSchema.getDataTypeName().orElse("unknown");
         // For sqlserver IDENTITY type, such as 'INT IDENTITY'
         // originSqlserverType is "int identity", so we only get "int".
+        // For types with parameters like 'decimal(18,0) IDENTITY(1,1)', we need to extract the base type
         String sqlserverType = originSqlserverType.split(" ")[0];
+
+        // Handle types with parentheses like decimal(18,0), varchar(50), etc.
+        if (sqlserverType.contains("(")) {
+            sqlserverType = sqlserverType.substring(0, sqlserverType.indexOf("("));
+        }
+
         switch (sqlserverType) {
             case "bit":
                 return Type.BOOLEAN;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
@@ -62,7 +62,7 @@ public class JdbcSQLServerClient extends JdbcClient {
             case "numeric": {
                 int precision = fieldSchema.getColumnSize().orElse(0);
                 int scale = fieldSchema.getDecimalDigits().orElse(0);
-                return ScalarType.createDecimalV3Type(precision, scale);
+                return createDecimalOrStringType(scale, precision);
             }
             case "date":
                 return ScalarType.createDateV2Type();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcSQLServerClient.java
@@ -62,7 +62,7 @@ public class JdbcSQLServerClient extends JdbcClient {
             case "numeric": {
                 int precision = fieldSchema.getColumnSize().orElse(0);
                 int scale = fieldSchema.getDecimalDigits().orElse(0);
-                return createDecimalOrStringType(scale, precision);
+                return createDecimalOrStringType(precision, scale);
             }
             case "date":
                 return ScalarType.createDateV2Type();

--- a/regression-test/data/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.out
@@ -130,6 +130,9 @@ timestamp_col	text	Yes	true	\N
 1	doris	18	0	1	1	123.123	123.123	123.123	12345678901234567890123456789012345678	12345678901234567890123456789012345678	1234567890123456789012345678.0123456789	1234567890123456789012345678.0123456789	Make Doris Great!   	Make Doris Great!	Make Doris Great!	Make Doris Great!   	Make Doris Great!	Make Doris Great!	2023-01-17	16:49:05.123	2023-01-17T16:49:05	2023-01-17T16:49:05.123456	2023-01-17T16:49	2023-01-17 16:49:05 +08:00	Make Doris Great!	Make Doris Great!	922337203685477.5807	214748.3647	false
 2	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
 
+-- !identity_decimal --
+1	1
+
 -- !sql --
 db_accessadmin
 db_backupoperator

--- a/regression-test/suites/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.groovy
@@ -83,6 +83,8 @@ suite("test_sqlserver_jdbc_catalog", "p0,external,sqlserver,external_docker,exte
 
         order_qt_all_types_tvf """ select * from query('catalog' = '${catalog_name}', 'query' = 'select * from all_type;') order by 1"""
 
+        order_qt_identity_decimal """ select * from test_identity_decimal order by id; """
+
         sql """ drop catalog if exists ${catalog_name} """
 
         sql """ create catalog if not exists ${catalog_name} properties(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

1、In SQLServer, if a type is indentity, then the display of its original type may be changed, such as decimal -> decima(), so we get the string from subscript 0 to ( before as typename
2、For decimal, we should use the unified createDecimalOrStringType method to build the type

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

