### PR TITLE
[fix](column_string) remove inaccurate error message of string overflow

### DIFF
--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -64,12 +64,10 @@ public:
     void static check_chars_length(size_t total_length, size_t element_number, size_t rows = 0) {
         if constexpr (std::is_same_v<T, UInt32>) {
             if (UNLIKELY(total_length > MAX_STRING_SIZE)) {
-                throw Exception(
-                        ErrorCode::STRING_OVERFLOW_IN_VEC_ENGINE,
-                        "string column length is too large: total_length={}, element_number={}, "
-                        "you can set batch_size a number smaller than {} to avoid this error. "
-                        "rows:{}",
-                        total_length, element_number, element_number, rows);
+                throw Exception(ErrorCode::STRING_OVERFLOW_IN_VEC_ENGINE,
+                                "string column length is too large: total_length={}, "
+                                "element_number={}, rows={}",
+                                total_length, element_number, rows);
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The `batch_size` suggestion is not right sometimes, which may be misleading, remove it:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = ([192.xxx.xx.xx](http://92.xxx.xx.xx/))[E-3113]string column length is too large: total_length=4295994788, element_number=17404778, you can set batch_size a number smaller than 17404778 to avoid this error
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

