### PR TITLE
[feat] add hot spot table feature:

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -200,7 +200,6 @@ public class ColumnDef {
     private Optional<GeneratedColumnInfo> generatedColumnInfo = Optional.empty();
     private Set<String> generatedColumnsThatReferToThis = new HashSet<>();
 
-
     public ColumnDef(String name, TypeDef typeDef) {
         this(name, typeDef, false, null, ColumnNullableType.NOT_NULLABLE, DefaultValue.NOT_SET, "");
     }
@@ -321,6 +320,10 @@ public class ColumnDef {
 
     public String getDefaultValue() {
         return defaultValue.value;
+    }
+
+    public DefaultValue getInitDefaultValue() {
+        return defaultValue;
     }
 
     public String getName() {
@@ -491,7 +494,6 @@ public class ColumnDef {
                 throw new AnalysisException("Struct type column default value just support null");
             }
         }
-
 
         if (aggregateType == AggregateType.REPLACE_IF_NOT_NULL) {
             if (!isAllowNull) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.ColumnDef;
 import org.apache.doris.analysis.ColumnNullableType;
 import org.apache.doris.analysis.TypeDef;
 import org.apache.doris.common.UserException;
+import org.apache.doris.plugin.audit.AuditHotSpotLoader;
 import org.apache.doris.plugin.audit.AuditLoader;
 import org.apache.doris.statistics.StatisticConstants;
 
@@ -36,6 +37,7 @@ public class InternalSchema {
     public static final List<ColumnDef> PARTITION_STATS_SCHEMA;
     public static final List<ColumnDef> HISTO_STATS_SCHEMA;
     public static final List<ColumnDef> AUDIT_SCHEMA;
+    public static final List<ColumnDef> HOT_SPOT_SCHEMA;
 
     static {
         // table statistics table
@@ -169,6 +171,22 @@ public class InternalSchema {
                 new ColumnDef("compute_group", TypeDef.create(PrimitiveType.STRING), ColumnNullableType.NULLABLE));
         // Keep stmt as last column. So that in fe.audit.log, it will be easier to get sql string
         AUDIT_SCHEMA.add(new ColumnDef("stmt", TypeDef.create(PrimitiveType.STRING), ColumnNullableType.NULLABLE));
+        //hot spot schema
+        HOT_SPOT_SCHEMA = new ArrayList<>();
+        HOT_SPOT_SCHEMA.add(new ColumnDef("catalog", TypeDef.createVarchar(128), ColumnNullableType.NULLABLE));
+        HOT_SPOT_SCHEMA.add(new ColumnDef("db", TypeDef.createVarchar(128), ColumnNullableType.NULLABLE));
+        HOT_SPOT_SCHEMA.add(new ColumnDef("tbl", TypeDef.createVarchar(256), ColumnNullableType.NULLABLE));
+        HOT_SPOT_SCHEMA.add(new ColumnDef("time", TypeDef.createDatetimeV2(0), ColumnNullableType.NULLABLE));
+        HOT_SPOT_SCHEMA.add(new ColumnDef("query_count", TypeDef.create(PrimitiveType.BIGINT),
+                false, AggregateType.SUM, ColumnNullableType.NOT_NULLABLE,
+                new ColumnDef.DefaultValue(true, "0"), "query count"));
+        HOT_SPOT_SCHEMA.add(new ColumnDef("write_count", TypeDef.create(PrimitiveType.BIGINT),
+                false, AggregateType.SUM, ColumnNullableType.NOT_NULLABLE,
+                new ColumnDef.DefaultValue(true, "0"), "write count"));
+        HOT_SPOT_SCHEMA.add(new ColumnDef("last_visit_date", TypeDef.create(PrimitiveType.DATETIME),
+                false, AggregateType.REPLACE_IF_NOT_NULL, ColumnNullableType.NOT_NULLABLE,
+                ColumnDef.DefaultValue.CURRENT_TIMESTAMP_DEFAULT_VALUE, "last visit date"));
+
     }
 
     // Get copied schema for statistic table
@@ -188,12 +206,18 @@ public class InternalSchema {
             case AuditLoader.AUDIT_LOG_TABLE:
                 schema = AUDIT_SCHEMA;
                 break;
+            case AuditHotSpotLoader.HOT_SPOT_TABLE:
+                schema = HOT_SPOT_SCHEMA;
+                break;
+
             default:
                 throw new UserException("Unknown internal table name: " + tblName);
         }
         List<ColumnDef> copiedSchema = Lists.newArrayList();
         for (ColumnDef columnDef : schema) {
-            copiedSchema.add(new ColumnDef(columnDef.getName(), columnDef.getTypeDef(), columnDef.isAllowNull()));
+            copiedSchema.add(new ColumnDef(columnDef.getName(), columnDef.getTypeDef(), columnDef.isKey(),
+                    columnDef.getAggregateType(),
+                    columnDef.isAllowNull(), columnDef.getInitDefaultValue(), columnDef.getComment()));
         }
         return copiedSchema;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -77,6 +77,7 @@ public class TimeUtils {
             "yyyy-MM-dd HH:mm:ss.SSSSSSSSS");
     private static final DateTimeFormatter DATETIME_FORMAT_WITH_HYPHEN = DateTimeFormatter.ofPattern(
             "yyyy-MM-dd-HH-mm-ss");
+    private static final DateTimeFormatter DATETIME_HOUR_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:00:00");
 
     public static DateTimeFormatter getDateFormatWithTimeZone() {
         return DATE_FORMAT.withZone(getDorisZoneId());
@@ -96,6 +97,10 @@ public class TimeUtils {
 
     public static DateTimeFormatter getDatetimeMsFormatWithTimeZone() {
         return DATETIME_MS_FORMAT.withZone(getDorisZoneId());
+    }
+
+    public static DateTimeFormatter getDatetimeHourFormatWithTimeZone() {
+        return DATETIME_HOUR_FORMAT.withZone(getDorisZoneId());
     }
 
     public static DateTimeFormatter getDatetimeNsFormatWithTimeZone() {
@@ -192,6 +197,10 @@ public class TimeUtils {
 
     public static String longToTimeStringWithms(Long timeStamp) {
         return longToTimeStringWithFormat(timeStamp, getDatetimeMsFormatWithTimeZone());
+    }
+
+    public static String longToTimeStringWithHour(Long timeStamp) {
+        return longToTimeStringWithFormat(timeStamp, getDatetimeHourFormatWithTimeZone());
     }
 
     public static Date getHourAsDate(String hour) {
@@ -363,7 +372,6 @@ public class TimeUtils {
                 parts.length > 3 ? String.format(" %02d:%02d:%02d", Integer.parseInt(parts[3]),
                         Integer.parseInt(parts[4]), Integer.parseInt(parts[5])) : "");
     }
-
 
     // Refer to be/src/vec/runtime/vdatetime_value.h
     public static long convertToDateTimeV2(

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -17,9 +17,10 @@
 
 package org.apache.doris.plugin;
 
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
 
 /*
  * AuditEvent contains all information about audit log info.
@@ -119,6 +120,8 @@ public class AuditEvent {
     public long spillReadBytesFromLocalStorage = -1;
 
     public long pushToAuditLogQueueTime;
+    //note : for hotspot use
+    public List<String> tableFullQualifiers = new ArrayList<String>();
 
     public static class AuditEventBuilder {
 
@@ -288,6 +291,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setSpillReadBytesFromLocalStorage(long bytes) {
             auditEvent.spillReadBytesFromLocalStorage = bytes;
+            return this;
+        }
+
+        public AuditEventBuilder setTableFullQualifiers(List<String> tableFullQualifiers) {
+            auditEvent.tableFullQualifiers = tableFullQualifiers;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/PluginMgr.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.nereids.parser.Dialect;
 import org.apache.doris.plugin.PluginInfo.PluginType;
 import org.apache.doris.plugin.PluginLoader.PluginStatus;
+import org.apache.doris.plugin.audit.AuditHotSpotLoader;
 import org.apache.doris.plugin.audit.AuditLoader;
 import org.apache.doris.plugin.audit.AuditLogBuilder;
 import org.apache.doris.plugin.dialect.HttpDialectConverterPlugin;
@@ -63,6 +64,8 @@ public class PluginMgr implements Writable {
 
     // Save this handler for external call
     private AuditLoader auditLoader = null;
+
+    private AuditHotSpotLoader auditHotSpotLoader = null;
 
     public PluginMgr() {
         plugins = new Map[PluginType.MAX_PLUGIN_TYPE_SIZE];
@@ -121,6 +124,11 @@ public class PluginMgr implements Writable {
             LOG.warn("failed to register audit log builder");
         }
 
+        this.auditHotSpotLoader = new AuditHotSpotLoader();
+        if (!registerBuiltinPlugin(auditHotSpotLoader.getPluginInfo(), auditHotSpotLoader)) {
+            LOG.warn("failed to register audit hot spot log builder");
+        }
+
         // sql dialect converter
         HttpDialectConverterPlugin httpDialectConverterPlugin = new HttpDialectConverterPlugin();
         if (!registerBuiltinPlugin(httpDialectConverterPlugin.getPluginInfo(), httpDialectConverterPlugin)) {
@@ -168,7 +176,6 @@ public class PluginMgr implements Writable {
             throw e;
         }
     }
-
 
     // install a plugin from user's command.
     // install should be successfully, or nothing should be left if failed to install.

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditStreamLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditStreamLoader.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.plugin.audit;
 
+import org.apache.doris.analysis.ColumnDef;
 import org.apache.doris.catalog.InternalSchema;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
@@ -32,6 +33,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Calendar;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class AuditStreamLoader {
@@ -42,6 +44,8 @@ public class AuditStreamLoader {
     private String auditLogTbl;
     private String auditLogLoadUrlStr;
     private String feIdentity;
+    private String schema;
+    private String labelPrefix;
 
     public AuditStreamLoader() {
         this.hostPort = "127.0.0.1:" + Config.http_port;
@@ -50,6 +54,20 @@ public class AuditStreamLoader {
         this.auditLogLoadUrlStr = String.format(loadUrlPattern, hostPort, db, auditLogTbl);
         // currently, FE identity is FE's IP, so we replace the "." in IP to make it suitable for label
         this.feIdentity = hostPort.replaceAll("\\.", "_").replaceAll(":", "_");
+        this.schema = InternalSchema.AUDIT_SCHEMA.stream().map(c -> c.getName()).collect(
+            Collectors.joining(","));
+        this.labelPrefix = "audit";
+    }
+
+    public AuditStreamLoader(String labelPrefix, String db, String table, List<ColumnDef> columnDefs) {
+        this.hostPort = "127.0.0.1:" + Config.http_port;
+        this.db = db;
+        this.auditLogTbl = table;
+        this.auditLogLoadUrlStr = String.format(loadUrlPattern, hostPort, db, auditLogTbl);
+        this.feIdentity = hostPort.replaceAll("\\.", "_").replaceAll(":", "_");
+        this.schema = columnDefs.stream().map(c -> c.getName()).collect(
+            Collectors.joining(","));
+        this.labelPrefix = labelPrefix;
     }
 
     private HttpURLConnection getConnection(String urlStr, String label, String clusterToken) throws IOException {
@@ -64,9 +82,7 @@ public class AuditStreamLoader {
         conn.addRequestProperty("label", label);
         conn.setRequestProperty("timeout", String.valueOf(GlobalVariable.auditPluginLoadTimeoutS));
         conn.addRequestProperty("max_filter_ratio", "1.0");
-        conn.addRequestProperty("columns",
-                InternalSchema.AUDIT_SCHEMA.stream().map(c -> c.getName()).collect(
-                        Collectors.joining(",")));
+        conn.addRequestProperty("columns", schema);
         conn.addRequestProperty("redirect-policy", "random-be");
         conn.setDoOutput(true);
         conn.setDoInput(true);
@@ -81,9 +97,7 @@ public class AuditStreamLoader {
         sb.append("-H \"").append("Content-Type\":").append("\"text/plain; charset=UTF-8\" \\\n  ");
         sb.append("-H \"").append("max_filter_ratio\":").append("\"1.0\" \\\n  ");
         sb.append("-H \"").append("columns\":")
-                .append("\"" + InternalSchema.AUDIT_SCHEMA.stream().map(c -> c.getName()).collect(
-                        Collectors.joining(",")) + "\" \\\n  ");
-        sb.append("-H \"").append("redirect-policy\":").append("\"random-be").append("\" \\\n  ");
+                .append("\"" + schema + "\" \\\n  ");
         sb.append("\"").append(conn.getURL()).append("\"");
         return sb.toString();
     }
@@ -115,7 +129,7 @@ public class AuditStreamLoader {
         HttpURLConnection beConn = null;
         try {
             // build request and send to fe
-            label = "audit" + label;
+            label = labelPrefix + label;
             feConn = getConnection(auditLogLoadUrlStr, label, clusterToken);
             int status = feConn.getResponseCode();
             // fe send back http response code TEMPORARY_REDIRECT 307 and new be location

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.StmtType;
 import org.apache.doris.analysis.ValueList;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.Config;
@@ -58,7 +59,9 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class AuditLogHelper {
 
@@ -263,6 +266,14 @@ public class AuditLogHelper {
                             statistics == null ? 0 : statistics.getScanBytesFromLocalStorage())
                     .setScanBytesFromRemoteStorage(
                             statistics == null ? 0 : statistics.getScanBytesFromRemoteStorage());
+            Map<List<String>, TableIf> tableMap = ctx.getStatementContext().getTables();
+            if (null != tableMap && !tableMap.isEmpty()) {
+                List<String> tableFullQualifiers = new ArrayList<String>(tableMap.size());
+                for (TableIf table : tableMap.values()) {
+                    tableFullQualifiers.add(table.getNameWithFullQualifiers());
+                }
+                auditEventBuilder.setTableFullQualifiers(tableFullQualifiers);
+            }
         } else {
             auditEventBuilder.setIsQuery(false);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -61,6 +61,7 @@ public final class GlobalVariable {
 
     public static final String SQL_CONVERTER_SERVICE_URL = "sql_converter_service_url";
     public static final String ENABLE_AUDIT_PLUGIN = "enable_audit_plugin";
+    public static final String ENABLE_HOT_SPOT = "enable_hotspot_plugin";
     public static final String AUDIT_PLUGIN_MAX_BATCH_BYTES = "audit_plugin_max_batch_bytes";
     public static final String AUDIT_PLUGIN_MAX_BATCH_INTERVAL_SEC = "audit_plugin_max_batch_interval_sec";
     public static final String AUDIT_PLUGIN_MAX_SQL_LENGTH = "audit_plugin_max_sql_length";
@@ -145,6 +146,9 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = ENABLE_AUDIT_PLUGIN, flag = VariableMgr.GLOBAL)
     public static boolean enableAuditLoader = false;
 
+    @VariableMgr.VarAttr(name = ENABLE_HOT_SPOT, flag = VariableMgr.GLOBAL)
+    public static boolean enableHotSpot = false;
+
     @VariableMgr.VarAttr(name = AUDIT_PLUGIN_MAX_BATCH_BYTES, flag = VariableMgr.GLOBAL)
     public static long auditPluginMaxBatchBytes = 50 * 1024 * 1024;
 
@@ -194,7 +198,6 @@ public final class GlobalVariable {
                 "当HMS catalog中的Iceberg表没有统计信息时，是否通过Iceberg Api获取统计信息",
                 "Enable fetch stats for HMS Iceberg table when it's not analyzed."})
     public static boolean enableFetchIcebergStats = false;
-
 
     @VariableMgr.VarAttr(name = ENABLE_ANSI_QUERY_ORGANIZATION_BEHAVIOR, flag = VariableMgr.GLOBAL,
             description = {


### PR DESCRIPTION
- After executed sql command: 
`_set global enable_hotspot_plugin = true;_`
- user can get all table query hot spot using: 
`_Secondly: select * from __internal_schema.hot_spot_`

1. add enable_hotspot_plugin to GlobalVariable.
2. add table: hot_spot to InternalSchemaInitializer during FE startup.
3. add hotspot plugin to PluginMgr during FE startup.
4. add tableFullQualifiers property to AuditEventBuilder.
5. when enable_hotspot_plugin is set to true AuditHotSpotLoader will split tableFullQualifiers and load into hot_spot.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

