### PR TITLE
[draft] [improvement](load) try to locate why csv load causing high cpu usage

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -87,9 +87,10 @@ void PlainCsvTextFieldSplitter::_split_field_single_char(const Slice& line,
                                                          std::vector<Slice>* splitted_values) {
     const char* data = line.data;
     const size_t size = line.size;
+    char seq = _value_seq[0];
     size_t value_start = 0;
     for (size_t i = 0; i < size; ++i) {
-        if (data[i] == _value_sep[0]) {
+        if (data[i] == seq) {
             process_value_func(data, value_start, i - value_start, _trimming_char, splitted_values);
             value_start = i + _value_sep_len;
         }


### PR DESCRIPTION
### What problem does this PR solve?
we've found when running load_p0 regression cases, cpu reaches 100%, and causing many load timeout, like 
http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/690628?buildTab=perfmon&focusLine=NaN
and flame grash shows that https://justtmp-1308700295.cos.ap-hongkong.myqcloud.com/flamegraph_20250528_152033.svg split single char costs a lot time.

Though compiled with -o1 ( not o3 ), string[] operator not optimized, but it is so strange that it costs so much cpu time.
try to move _value_seq[0] out to find more information.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

