### PR TITLE
[opt](nereids) avoid printing duplicated table stats in profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -66,6 +66,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -132,7 +133,7 @@ public class Profile {
 
     private PhysicalPlan physicalPlan;
     public Map<String, Long> rowsProducedMap = new HashMap<>();
-    private List<PhysicalRelation> physicalRelations = new ArrayList<>();
+    private Set<PhysicalRelation> physicalRelations = new LinkedHashSet<>();
 
     private String changedSessionVarCache = "";
 


### PR DESCRIPTION
### What problem does this PR solve?
Query related tables are collected by function org.apache.doris.common.profile.Profile#updateSummary().
This function is invoked multiple times during a query execution. And hence,  tables are added to Profile.physicalRelations multiple times.
In this pr, Profile.physicalRelations is defined as Set instead of List to remove duplications.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

