### PR TITLE
[bugfix](show)fix show partitions error when offset is bigger than partitions' number

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -305,6 +305,11 @@ public class PartitionsProcDir implements ProcDirInterface {
             if (endIndex > filterPartitionInfos.size()) {
                 endIndex = filterPartitionInfos.size();
             }
+
+            // means that beginIndex is bigger than filterPartitionInfos.size(), just return empty
+            if (beginIndex > endIndex) {
+                beginIndex = endIndex;
+            }
             filterPartitionInfos = filterPartitionInfos.subList(beginIndex, endIndex);
         }
 
@@ -354,6 +359,11 @@ public class PartitionsProcDir implements ProcDirInterface {
             int endIndex = (int) (beginIndex + limitElement.getLimit());
             if (endIndex > filterPartitionInfos.size()) {
                 endIndex = filterPartitionInfos.size();
+            }
+
+            // means that beginIndex is bigger than filterPartitionInfos.size(), just return empty
+            if (beginIndex > endIndex) {
+                beginIndex = endIndex;
             }
             filterPartitionInfos = filterPartitionInfos.subList(beginIndex, endIndex);
         }

--- a/regression-test/suites/nereids_p0/show/test_nereids_show_partitions.groovy
+++ b/regression-test/suites/nereids_p0/show/test_nereids_show_partitions.groovy
@@ -63,6 +63,8 @@ suite("test_nereids_show_partitions") {
             "where PartitionId != 1748353297225 order by PartitionId limit 1")
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
             "where PartitionId != 1748353297225 limit 1,1")
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
+            "where PartitionId != 1748353297225 limit 100,1")
 
     // PartitionName
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
@@ -75,6 +77,8 @@ suite("test_nereids_show_partitions") {
             "where PartitionName = 'p_dongbei' limit 1")
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
             "where PartitionName = 'p_dongbei' limit 1,1")
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
+            "where PartitionName = 'p_dongbei' limit 100,1")
 
     // like
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
@@ -87,6 +91,8 @@ suite("test_nereids_show_partitions") {
             "where PartitionName like 'p_dongbei' limit 1")
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
             "where PartitionName like 'p_dongbei' limit 1,1")
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
+            "where PartitionName like 'p_dongbei' limit 100,1")
 
     // Buckets
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
@@ -107,6 +113,8 @@ suite("test_nereids_show_partitions") {
             "where Buckets >= 16 order by PartitionName limit 1")
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
             "where Buckets <= 16 limit 1")
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
+            "where Buckets <= 16 limit 100,1")
 
     // complex where
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
@@ -129,6 +137,8 @@ suite("test_nereids_show_partitions") {
             "where Buckets = 16 and PartitionName = 'p_dongbei' and PartitionId != 1748353297225 limit 1")
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
             "where Buckets = 16 and PartitionName = 'p_dongbei' and PartitionId != 1748353297225 limit 1,1")
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
+            "where Buckets = 16 and PartitionName = 'p_dongbei' and PartitionId != 1748353297225 limit 100,1")
 
    def res1 = sql """show partitions from test_show_partitions.test_show_partitions_tbl"""
    assertEquals(3, res1.size())
@@ -175,6 +185,10 @@ suite("test_nereids_show_partitions") {
    assertEquals("p_huabei", res21.get(0).get(1))
    def res22 = sql """show partitions from test_show_partitions.test_show_partitions_tbl where Buckets >= 16 and PartitionName = 'p_huabei' and PartitionId = 1"""
    assertEquals(0, res22.size())
+
+   // test for offset value is bigger than partitions' number
+   def res23 = sql """show partitions from test_show_partitions.test_show_partitions_tbl where Buckets = 16 limit 100,1"""
+   assertEquals(0, res23.size())
 
    assertThrows(Exception.class, {
       sql """show partitions from test_show_partitions.test_show_partitions_tbl where VisibleVersion = 1"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #51328

Problem Summary:

SQL : `show partitions from table_name where PartitionId = 123 limit 100,1`
if the row number of 'show partitions from table_name where PartitionId = 123' is less than the offset value, the SQL may get an error. 
So just return empty set when we encounter that situation. (The behaviors of old optimizer and nereids are the same.)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

