### PR TITLE
[fix](inverted index) fix error when open empty index file

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_reader.cpp
@@ -67,6 +67,9 @@ Status InvertedIndexFileReader::_init_from(int32_t read_buffer_size, const io::I
             if (err.number() == CL_ERR_FileNotFound) {
                 return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
                         "inverted index file {} is not found.", index_file_full_path);
+            } else if (err.number() == CL_ERR_EmptyIndexSegment) {
+                return Status::Error<ErrorCode::INVERTED_INDEX_BYPASS>(
+                        "inverted index file {} is empty.", index_file_full_path);
             }
             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                     "CLuceneError occur when open idx file {}, error msg: {}", index_file_full_path,

--- a/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
@@ -116,6 +116,10 @@ bool DorisFSDirectory::FSIndexInput::open(const io::FileSystemSPtr& fs, const ch
         if (h->_reader->size() == 0) {
             // may be an empty file
             LOG(INFO) << "Opened inverted index file is empty, file is " << path;
+            // need to return false to avoid the error of CLucene
+            error.set(CL_ERR_EmptyIndexSegment,
+                      fmt::format("File is empty, file is {}", path).data());
+            return false;
         }
         //Store the file length
         h->_length = h->_reader->size();

--- a/regression-test/suites/inverted_index_p0/test_variant_empty_index_file.groovy
+++ b/regression-test/suites/inverted_index_p0/test_variant_empty_index_file.groovy
@@ -50,8 +50,14 @@ suite("test_variant_empty_index_file", "p0") {
     if (!isCloudMode()) {
         def (code, out, err) = http_client("GET", String.format("http://%s:%s/api/show_nested_index_file?tablet_id=%s", ip, port, tablet_id))
         logger.info("Run show_nested_index_file_on_tablet: code=" + code + ", out=" + out + ", err=" + err)
-        assertEquals("E-6002", parseJson(out.trim()).status)
+        assertEquals("E-6004", parseJson(out.trim()).status)
+        assertTrue(out.contains(" is empty"))
     }
 
-    qt_sql """ select * from ${tableName} where v match 'abcd'"""
+    try {
+        sql """ select /*+ SET_VAR(enable_match_without_inverted_index = 0) */  * from ${tableName} where v match 'abcd';  """
+    } catch (Exception e) {
+        log.info(e.getMessage());
+        assertTrue(e.getMessage().contains("match_any not support execute_match"))
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #50937 

Problem Summary:
This PR fixes the error that occurs when attempting to open an empty inverted index file by adding a proper empty file check and error reporting.

Added a condition to verify if the file size is zero.
Sets an error message and returns false to prevent CLucene errors.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

