### PR TITLE
[opt](query) accelerate query information_schema.tables from follower node in cloud mode (#51240)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -94,14 +94,26 @@ public class SchemaScanNode extends ScanNode {
         schemaCatalog = analyzer.getSchemaCatalog();
         schemaDb = analyzer.getSchemaDb();
         schemaTable = analyzer.getSchemaTable();
-        frontendIP = FrontendOptions.getLocalHostAddress();
-        frontendPort = Config.rpc_port;
+        if (ConnectContext.get().getSessionVariable().enableSchemaScanFromMasterFe
+                && tableName.equalsIgnoreCase("tables")) {
+            frontendIP = Env.getCurrentEnv().getMasterHost();
+            frontendPort = Env.getCurrentEnv().getMasterRpcPort();
+        } else {
+            frontendIP = FrontendOptions.getLocalHostAddress();
+            frontendPort = Config.rpc_port;
+        }
     }
 
     @Override
     public void finalizeForNereids() throws UserException {
-        frontendIP = FrontendOptions.getLocalHostAddress();
-        frontendPort = Config.rpc_port;
+        if (ConnectContext.get().getSessionVariable().enableSchemaScanFromMasterFe
+                && tableName.equalsIgnoreCase("tables")) {
+            frontendIP = Env.getCurrentEnv().getMasterHost();
+            frontendPort = Env.getCurrentEnv().getMasterRpcPort();
+        } else {
+            frontendIP = FrontendOptions.getLocalHostAddress();
+            frontendPort = Config.rpc_port;
+        }
     }
 
     private void setFeAddrList(TPlanNode msg) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -712,6 +712,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_SQL_CONVERTOR_FEATURES = "enable_sql_convertor_features";
 
+    public static final String ENABLE_SCHEMA_SCAN_FROM_MASTER_FE = "enable_schema_scan_from_master_fe";
+
     public static final String SQL_CONVERTOR_CONFIG = "sql_convertor_config";
 
     /**
@@ -2430,6 +2432,16 @@ public class SessionVariable implements Serializable, Writable {
                     "enable SQL convertor features. Multiple features are separated by commas"
             })
     public String enableSqlConvertorFeatures = "";
+
+    // The default value is true,
+    // which throughs reducing rpc call from follower node to meta service to improve query performance
+    // for getting version is memory operation in master node,
+    // but it will slightly increase the pressure on the FE master.
+    @VariableMgr.VarAttr(name = ENABLE_SCHEMA_SCAN_FROM_MASTER_FE, description = {
+            "在follower节点查询时, 是否允许从master节点扫描information_schema.tables的结果",
+            "Whether to allow scanning information_schema.tables from the master node"
+    })
+    public boolean enableSchemaScanFromMasterFe = true;
 
     @VariableMgr.VarAttr(name = SQL_CONVERTOR_CONFIG, needForward = true,
             description = {


### PR DESCRIPTION
pick #51240

Accelerate query information_schema.tables by scanning table information from FE master when sending query request from follower node. It can reduces rpc call from follower to meta service to improve query performance for master getting version is memory operation, but it will slightly increase the pressure on the FE master.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

