### PR TITLE
[check](cast) add nullable check after cast expr execute

### DIFF
--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -124,6 +124,14 @@ doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block
     } catch (const Exception& e) {
         state = e.to_status();
     }
+    if (state.ok()) {
+        auto result_column = block->get_by_position(num_columns_without_result).column;
+        if (result_column->is_nullable() != _data_type->is_nullable()) {
+            return Status::InternalError(
+                    fmt::format("CastExpr result column type mismatch, expect {}, got {}",
+                                _data_type->get_name(), result_column->get_name()));
+        }
+    }
     return state;
 }
 

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -125,11 +125,14 @@ doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block
         state = e.to_status();
     }
     if (state.ok()) {
-        auto result_column = block->get_by_position(num_columns_without_result).column;
+        auto [result_column, is_const] =
+                unpack_if_const(block->get_by_position(num_columns_without_result).column);
+
         if (result_column->is_nullable() != _data_type->is_nullable()) {
             return Status::InternalError(
-                    fmt::format("CastExpr result column type mismatch, expect {}, got {}",
-                                _data_type->get_name(), result_column->get_name()));
+                    fmt::format("CastExpr result column type mismatch, expect {}, got {} , return "
+                                "column is const {}",
+                                _data_type->get_name(), result_column->get_name(), is_const));
         }
     }
     return state;


### PR DESCRIPTION
### What problem does this PR solve?

Add nullable check for return columns in cast operations. 

Although there is a check for return type inside the function, the function's return value is not strictly bound by the return type. 

Since cast will be refactored in the future, and the nullable property of cast's return value might change under different modes, we need to add this check.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

