### PR TITLE
[opt](multi-catalog) Optimize remote scan concurrency.

### DIFF
--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -39,9 +39,9 @@ Status FileScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
 
     auto& p = _parent->cast<FileScanOperatorX>();
     // There's only one scan range for each backend in batch split mode. Each backend only starts up one ScanNode instance.
-    uint32_t shard_num =
-            std::min(config::doris_scanner_thread_pool_thread_num / p.query_parallel_instance_num(),
-                     _max_scanners);
+    uint32_t shard_num = std::min(vectorized::ScannerScheduler::get_remote_scan_thread_num() /
+                                          p.query_parallel_instance_num(),
+                                  _max_scanners);
     shard_num = std::max(shard_num, 1U);
     _kv_cache.reset(new vectorized::ShardedKVCache(shard_num));
     for (int i = 0; i < _max_scanners; ++i) {
@@ -65,9 +65,8 @@ void FileScanLocalState::set_scan_ranges(RuntimeState* state,
     auto& p = _parent->cast<FileScanOperatorX>();
 
     auto calc_max_scanners = [&](int parallel_instance_num) -> int {
-        int max_scanners = config::doris_scanner_thread_pool_thread_num / parallel_instance_num;
-        max_scanners =
-                std::max(std::max(max_scanners, state->parallel_scan_max_scanners_count()), 1);
+        int max_scanners =
+                vectorized::ScannerScheduler::get_remote_scan_thread_num() / parallel_instance_num;
         if (should_run_serial()) {
             max_scanners = 1;
         }

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -402,11 +402,12 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
 }
 
 int ScannerScheduler::get_remote_scan_thread_num() {
-    int remote_max_thread_num = config::doris_max_remote_scanner_thread_pool_thread_num != -1
-                                        ? config::doris_max_remote_scanner_thread_pool_thread_num
-                                        : std::max(512, CpuInfo::num_cores() * 10);
-    remote_max_thread_num =
-            std::max(remote_max_thread_num, config::doris_scanner_thread_pool_thread_num);
+    static int remote_max_thread_num = []() {
+        int num = config::doris_max_remote_scanner_thread_pool_thread_num != -1
+                          ? config::doris_max_remote_scanner_thread_pool_thread_num
+                          : std::max(512, CpuInfo::num_cores() * 10);
+        return std::max(num, config::doris_scanner_thread_pool_thread_num);
+    }();
     return remote_max_thread_num;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### Release note

[opt] (multi-catalog) Optimize remote scan concurrency.
1. Use `ScannerScheduler::get_remote_scan_thread_num()` to replace `config::doris_scanner_thread_pool_thread_num` when calculate max scanners in the external table case.
2. Remove `parallel_scan_max_scanners_count` calculation logic.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    1. `set enable_profile=true; set profile_level=2;` 
    2. run sql and check profile `MaxScanConcurrency`.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

