### PR TITLE
[Fix](Load) fix load hang when the instance cancel with memory tracker before exe…

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -394,7 +394,9 @@ Status PlanFragmentExecutor::execute() {
     }
 #ifndef BE_TEST
     if (_runtime_state->is_cancelled()) {
-        return Status::Cancelled("cancelled before execution");
+        _status = Status::Cancelled("cancelled before execution, msg:" + _cancel_msg);
+        send_report(true);
+        return _status;
     }
 #endif
     int64_t duration_ns = 0;


### PR DESCRIPTION
…cution

when the load task cancelled before execution as memory limitation,  the load task will hang as  the coordinator is waiting the report from BE.

solution:
Let BE report the task status when task cancelled before execution .


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

