### PR TITLE
[fix](hudi) check requiredFields exists in splitHudiColumnNames in HudiJniScanner

### DIFF
--- a/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
+++ b/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
@@ -207,7 +207,7 @@ public class HadoopHudiJniScanner extends JniScanner {
                 IntStream.range(0, splitHudiColumnNames.length)
                         .boxed()
                         .collect(Collectors.toMap(i -> splitHudiColumnNames[i], i -> hudiColumnTypes[i]));
-        
+
         requiredTypes = new ColumnType[requiredFields.length];
         for (int i = 0; i < requiredFields.length; i++) {
             String requiredField = requiredFields[i];

--- a/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
+++ b/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
@@ -170,9 +170,6 @@ public class HadoopHudiJniScanner extends JniScanner {
                     for (int i = 0; i < fields.length; i++) {
                         Object fieldData = rowInspector.getStructFieldData(rowData, structFields[i]);
                         columnValue.setRow(fieldData);
-                        // LOG.info("rows: {}, column: {}, col name: {}, col type: {}, inspector: {}",
-                        //        numRows, i, types[i].getName(), types[i].getType().name(),
-                        //        fieldInspectors[i].getTypeName());
                         columnValue.setField(types[i], fieldInspectors[i]);
                         appendData(i, columnValue);
                     }
@@ -210,10 +207,16 @@ public class HadoopHudiJniScanner extends JniScanner {
                 IntStream.range(0, splitHudiColumnNames.length)
                         .boxed()
                         .collect(Collectors.toMap(i -> splitHudiColumnNames[i], i -> hudiColumnTypes[i]));
-
-        requiredTypes = Arrays.stream(requiredFields)
-                .map(field -> ColumnType.parseType(field, hudiColNameToType.get(field)))
-                .toArray(ColumnType[]::new);
+        
+        requiredTypes = new ColumnType[requiredFields.length];
+        for (int i = 0; i < requiredFields.length; i++) {
+            String requiredField = requiredFields[i];
+            if (!hudiColNameToType.containsKey(requiredField)) {
+                throw new IllegalArgumentException(
+                        "Required field " + requiredField + " not found in Hudi column names: " + splitHudiColumnNames);
+            }
+            requiredTypes[i] = ColumnType.parseType(requiredField, hudiColNameToType.get(requiredField));
+        }
 
         requiredColumnIds = Arrays.stream(requiredFields)
                 .mapToInt(hudiColNameToIdx::get)


### PR DESCRIPTION
### What problem does this PR solve?

### Release note
Check requiredFields exists in splitHudiColumnNames to avoid meaningless NullPointerException error messages.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

