### PR TITLE
[fix](mtmv)Fix issue that refreshState turns to init when replaying alterStatus editLog 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -110,7 +110,6 @@ public class MTMV extends OlapTable {
         this.querySql = params.querySql;
         this.refreshInfo = params.refreshInfo;
         this.status = new MTMVStatus();
-        this.status.init();
         this.jobInfo = new MTMVJobInfo(MTMVJobManager.MTMV_JOB_PREFIX + params.tableId);
         this.mvProperties = params.mvProperties;
         this.mvPartitionInfo = params.mvPartitionInfo;
@@ -185,7 +184,8 @@ public class MTMV extends OlapTable {
     public MTMVStatus alterStatus(MTMVStatus newStatus) {
         writeMvLock();
         try {
-            return this.status.updateNotNull(newStatus);
+            // only can update state, refresh state will be change by add task
+            return this.status.updateStateAndDetail(newStatus);
         } finally {
             writeMvUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -110,6 +110,7 @@ public class MTMV extends OlapTable {
         this.querySql = params.querySql;
         this.refreshInfo = params.refreshInfo;
         this.status = new MTMVStatus();
+        this.status.init();
         this.jobInfo = new MTMVJobInfo(MTMVJobManager.MTMV_JOB_PREFIX + params.tableId);
         this.mvProperties = params.mvProperties;
         this.mvPartitionInfo = params.mvPartitionInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVStatus.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVStatus.java
@@ -33,13 +33,16 @@ public class MTMVStatus {
     private MTMVRefreshState refreshState;
 
     public MTMVStatus() {
-        this.state = MTMVState.INIT;
-        this.refreshState = MTMVRefreshState.INIT;
     }
 
     public MTMVStatus(MTMVState state, String schemaChangeDetail) {
         this.state = state;
         this.schemaChangeDetail = schemaChangeDetail;
+    }
+
+    public void init() {
+        this.state = MTMVState.INIT;
+        this.refreshState = MTMVRefreshState.INIT;
     }
 
     public MTMVStatus(MTMVRefreshState refreshState) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVStatus.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVStatus.java
@@ -33,16 +33,13 @@ public class MTMVStatus {
     private MTMVRefreshState refreshState;
 
     public MTMVStatus() {
+        this.state = MTMVState.INIT;
+        this.refreshState = MTMVRefreshState.INIT;
     }
 
     public MTMVStatus(MTMVState state, String schemaChangeDetail) {
         this.state = state;
         this.schemaChangeDetail = schemaChangeDetail;
-    }
-
-    public void init() {
-        this.state = MTMVState.INIT;
-        this.refreshState = MTMVRefreshState.INIT;
     }
 
     public MTMVStatus(MTMVRefreshState refreshState) {
@@ -73,18 +70,14 @@ public class MTMVStatus {
         this.refreshState = refreshState;
     }
 
-    public MTMVStatus updateNotNull(MTMVStatus status) {
-        Objects.requireNonNull(status);
-        if (status.getState() != null) {
-            this.state = status.getState();
-            if (this.state == MTMVState.SCHEMA_CHANGE) {
-                this.schemaChangeDetail = status.getSchemaChangeDetail();
-            } else {
-                this.schemaChangeDetail = null;
-            }
-        }
-        if (status.getRefreshState() != null) {
-            this.refreshState = status.getRefreshState();
+    public MTMVStatus updateStateAndDetail(MTMVStatus status) {
+        Objects.requireNonNull(status, "status can not be null");
+        Objects.requireNonNull(status.getState(), "status.state can not be null");
+        this.state = status.getState();
+        if (this.state == MTMVState.SCHEMA_CHANGE) {
+            this.schemaChangeDetail = status.getSchemaChangeDetail();
+        } else {
+            this.schemaChangeDetail = null;
         }
         return this;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
@@ -73,7 +73,6 @@ public class MTMVTest {
         mtmv.setRefreshInfo(buildMTMVRefreshInfo(mtmv));
         mtmv.setQuerySql("select * from xxx;");
         MTMVStatus mtmvStatus = new MTMVStatus();
-        mtmvStatus.init();
         mtmv.setStatus(mtmvStatus);
         mtmv.setJobInfo(buildMTMVJobInfo(mtmv));
         mtmv.setMvProperties(new HashMap<>());
@@ -183,7 +182,6 @@ public class MTMVTest {
         MTMV mtmv = new MTMV();
         MTMVStatus status = new MTMVStatus();
         mtmv.setStatus(status);
-        status.init();
         // test init
         Assert.assertEquals(MTMVState.INIT, status.getState());
         Assert.assertEquals(MTMVRefreshState.INIT, status.getRefreshState());

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
@@ -32,6 +32,8 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.job.common.IntervalUnit;
 import org.apache.doris.job.extensions.mtmv.MTMVTask;
 import org.apache.doris.mtmv.MTMVRefreshEnum.BuildMode;
+import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
+import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
 import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshMethod;
 import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshTrigger;
 
@@ -70,7 +72,9 @@ public class MTMVTest {
         mtmv.setQualifiedDbName("db1");
         mtmv.setRefreshInfo(buildMTMVRefreshInfo(mtmv));
         mtmv.setQuerySql("select * from xxx;");
-        mtmv.setStatus(new MTMVStatus());
+        MTMVStatus mtmvStatus = new MTMVStatus();
+        mtmvStatus.init();
+        mtmv.setStatus(mtmvStatus);
         mtmv.setJobInfo(buildMTMVJobInfo(mtmv));
         mtmv.setMvProperties(new HashMap<>());
         mtmv.setRelation(new MTMVRelation(Sets.newHashSet(), Sets.newHashSet(), Sets.newHashSet()));
@@ -172,5 +176,28 @@ public class MTMVTest {
         Assert.assertTrue(excludedTriggerTables.contains(new TableName("ctl1", "db1", "t1")));
         Assert.assertTrue(excludedTriggerTables.contains(new TableName(null, "db2", "t2")));
         Assert.assertTrue(excludedTriggerTables.contains(new TableName(null, null, "t3")));
+    }
+
+    @Test
+    public void testAlterStatus() {
+        MTMV mtmv = new MTMV();
+        MTMVStatus status = new MTMVStatus();
+        mtmv.setStatus(status);
+        status.init();
+        // test init
+        Assert.assertEquals(MTMVState.INIT, status.getState());
+        Assert.assertEquals(MTMVRefreshState.INIT, status.getRefreshState());
+        // test schema change
+        status.setRefreshState(MTMVRefreshState.SUCCESS);
+        mtmv.alterStatus(new MTMVStatus(MTMVState.SCHEMA_CHANGE, "base table"));
+        Assert.assertEquals(MTMVState.SCHEMA_CHANGE, status.getState());
+        Assert.assertEquals(MTMVRefreshState.SUCCESS, status.getRefreshState());
+
+        MTMVStatus alterStatus = new MTMVStatus();
+        alterStatus.setState(MTMVState.SCHEMA_CHANGE);
+        alterStatus.setSchemaChangeDetail("base table");
+        mtmv.alterStatus(new MTMVStatus(MTMVState.SCHEMA_CHANGE, "base table"));
+        Assert.assertEquals(MTMVState.SCHEMA_CHANGE, status.getState());
+        Assert.assertEquals(MTMVRefreshState.SUCCESS, status.getRefreshState());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTest.java
@@ -72,8 +72,7 @@ public class MTMVTest {
         mtmv.setQualifiedDbName("db1");
         mtmv.setRefreshInfo(buildMTMVRefreshInfo(mtmv));
         mtmv.setQuerySql("select * from xxx;");
-        MTMVStatus mtmvStatus = new MTMVStatus();
-        mtmv.setStatus(mtmvStatus);
+        mtmv.setStatus(new MTMVStatus());
         mtmv.setJobInfo(buildMTMVJobInfo(mtmv));
         mtmv.setMvProperties(new HashMap<>());
         mtmv.setRelation(new MTMVRelation(Sets.newHashSet(), Sets.newHashSet(), Sets.newHashSet()));


### PR DESCRIPTION
### What problem does this PR solve?

During Gson deserialization, the no-arg constructor of MTMVStatus is invoked, which sets refreshState to "init". However, the org.apache.doris.mtmv.MTMVStatus#updateNotNull method determines which properties to modify by checking whether each parameter is null. The unintended side effect is that refreshState, which should remain null, gets initialized as "init", leading to unexpected behavior

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fix issue that refreshState turns to init when replaying alterStatus editLog 
### Release note

Fix issue that refreshState turns to init when replaying alterStatus editLog 

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

