### PR TITLE
[regression-test](case) fix point_query_p0/load.groovy

### DIFF
--- a/regression-test/suites/point_query_p0/load.groovy
+++ b/regression-test/suites/point_query_p0/load.groovy
@@ -218,7 +218,7 @@ suite("test_load_and_schema_change_row_store", "p0") {
         UNIQUE KEY(`k1`)
         COMMENT 'OLAP'
         DISTRIBUTED BY HASH(`k1`) BUCKETS 1
-        PROPERTIES("replication_num" = "1", "enable_unique_key_merge_on_write" = "true");
+        PROPERTIES("replication_num" = "1", "enable_unique_key_merge_on_write" = "true", "enable_mow_light_delete" = "false");
         """
     sql "insert into test_sclar_types_mow(k1,c_string) values (1,'123'), (2,'456')"
     sql """alter table test_sclar_types_mow set ("store_row_column" = "true")"""     


### PR DESCRIPTION
### What problem does this PR solve?
When table "enable_mow_light_delete" = "true", point query's short circuit optimization will not work.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

