### PR TITLE
[regression-test](fix) fix StreamLoadAction bug

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
@@ -216,7 +216,9 @@ class StreamLoadAction implements SuiteAction {
             throw new IllegalStateException("Get http stream failed, status code is ${code}, body:\n${streamBody}")
         }
 
-        return resp.getEntity().getContent()
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        resp.getEntity().writeTo(buffer); // 完整读取数据
+        return new ByteArrayInputStream(buffer.toByteArray());
     }
 
     private RequestBuilder prepareRequestHeader(RequestBuilder requestBuilder) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
@@ -218,6 +218,7 @@ class StreamLoadAction implements SuiteAction {
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         resp.getEntity().writeTo(buffer); // 完整读取数据
+        log.info("entity new size is ${buffer.size()}")
         return new ByteArrayInputStream(buffer.toByteArray());
     }
 


### PR DESCRIPTION
### What problem does this PR solve?
fix:
When running stream load on same remote file, sometimes load meets 
`Caused by: org.apache.http.client.NonRepeatableRequestException: Cannot retry request with a non-repeatable request entity
            		 	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:108)
            		 	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
            		 	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
            		 	... 100 common frames omitted
            		 Caused by: org.apache.http.ConnectionClosedException: Premature end of Content-Length delimited message body (expected: 129,961,387; received: 120,217,793)`

This pr try to solve this problem by put resp body into different buffer.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

