### PR TITLE
[Refactor]get workload group from compute group

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterWorkloadGroupCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterWorkloadGroupCommand.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -30,6 +29,7 @@ import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
 
 import org.apache.commons.lang3.StringUtils;
@@ -78,20 +78,24 @@ public class AlterWorkloadGroupCommand extends AlterCommand {
             throw new AnalysisException(WorkloadGroup.COMPUTE_GROUP + " can not be set in property.");
         }
 
-        if (StringUtils.isEmpty(computeGroup)) {
-            computeGroup = Config.isCloudMode() ? Tag.VALUE_DEFAULT_COMPUTE_GROUP_NAME : Tag.DEFAULT_BACKEND_TAG.value;
-        }
-
+        ComputeGroup cg = null;
         if (Config.isCloudMode()) {
-            String originStr = computeGroup;
-            computeGroup = ((CloudSystemInfoService) Env.getCurrentEnv().getClusterInfo()).getCloudClusterIdByName(
-                    computeGroup);
             if (StringUtils.isEmpty(computeGroup)) {
-                throw new UserException("Can not find compute group " + originStr + ".");
+                computeGroup = Tag.VALUE_DEFAULT_COMPUTE_GROUP_NAME;
             }
+            String cgName = computeGroup;
+            cg = Env.getCurrentEnv().getComputeGroupMgr().getComputeGroupByName(cgName);
+            if (cg == null) {
+                throw new UserException("Can not find compute group:" + cgName);
+            }
+        } else {
+            if (StringUtils.isEmpty(computeGroup)) {
+                computeGroup = Tag.DEFAULT_BACKEND_TAG.value;
+            }
+            cg = Env.getCurrentEnv().getComputeGroupMgr().getComputeGroupByName(computeGroup);
         }
 
-        Env.getCurrentEnv().getWorkloadGroupMgr().alterWorkloadGroup(computeGroup, workloadGroupName, properties);
+        Env.getCurrentEnv().getWorkloadGroupMgr().alterWorkloadGroup(cg, workloadGroupName, properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/AllBackendComputeGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/AllBackendComputeGroup.java
@@ -18,13 +18,18 @@
 package org.apache.doris.resource.computegroup;
 
 import org.apache.doris.common.Config;
+import org.apache.doris.common.UserException;
+import org.apache.doris.resource.workloadgroup.WorkloadGroup;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupKey;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 
 public class AllBackendComputeGroup extends ComputeGroup {
 
@@ -59,14 +64,31 @@ public class AllBackendComputeGroup extends ComputeGroup {
     }
 
     @Override
-    public Set<String> getNames() {
-        // in cloud mode, name is cluster id.
-        // in no-cloud mode, name is resource tag's name
-        Set<String> ret = Sets.newHashSet();
-        for (Backend backend : systemInfoService.getAllClusterBackendsNoException().values()) {
-            ret.add(backend.getComputeGroup());
+    public List<WorkloadGroup> getWorkloadGroup(String wgName, WorkloadGroupMgr wgMgr) throws UserException {
+        List<WorkloadGroup> wgList = Lists.newArrayList();
+        Collection<Backend> beList = systemInfoService.getAllClusterBackendsNoException().values();
+        if (beList.size() == 0) {
+            throw new RuntimeException("No backend available for Workload Group " + wgName);
         }
-        return ret;
+        for (Backend backend : beList) {
+            // in cloud mode, name is cluster id.
+            // in no-cloud mode, name is resource tag's name
+            String computeGroup = backend.getComputeGroup();
+            WorkloadGroup wg = wgMgr.getWorkloadGroupByComputeGroup(
+                    WorkloadGroupKey.get(computeGroup, wgName));
+            if (wg == null) {
+                if (Config.isCloudMode()) {
+                    throw new UserException(
+                            "Can not find workload group " + wgName + " in compute croup "
+                                    + backend.getCloudClusterName());
+                } else {
+                    throw new UserException(
+                            "Can not find workload group " + wgName + " in compute group " + computeGroup);
+                }
+            }
+            wgList.add(wg);
+        }
+        return wgList;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/CloudComputeGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/CloudComputeGroup.java
@@ -20,10 +20,7 @@ package org.apache.doris.resource.computegroup;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.system.Backend;
 
-import com.google.common.collect.Sets;
-
 import java.util.List;
-import java.util.Set;
 
 public class CloudComputeGroup extends ComputeGroup {
 
@@ -34,11 +31,6 @@ public class CloudComputeGroup extends ComputeGroup {
     @Override
     public List<Backend> getBackendList() {
         return ((CloudSystemInfoService) (super.systemInfoService)).getBackendsByClusterName(name);
-    }
-
-    @Override
-    public Set<String> getNames() {
-        return Sets.newHashSet(id);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/ComputeGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/ComputeGroup.java
@@ -17,10 +17,14 @@
 
 package org.apache.doris.resource.computegroup;
 
+import org.apache.doris.common.UserException;
+import org.apache.doris.resource.workloadgroup.WorkloadGroup;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupKey;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -92,9 +96,16 @@ public class ComputeGroup {
         return (this == obj);
     }
 
-    // todo(wb) remove getNames, and get workload group from ComputeGroup
-    public Set<String> getNames() {
-        return Sets.newHashSet(name);
+    // use wgMgr as args is just for FE UT, otherwise get wgMgr from env is hard to mock
+    public List<WorkloadGroup> getWorkloadGroup(String wgName, WorkloadGroupMgr wgMgr) throws UserException {
+        List<WorkloadGroup> wgList = Lists.newArrayList();
+        WorkloadGroup wg = wgMgr
+                .getWorkloadGroupByComputeGroup(WorkloadGroupKey.get(id, wgName));
+        if (wg == null) {
+            throw new UserException("Can not find workload group " + wgName + " in compute croup " + name);
+        }
+        wgList.add(wg);
+        return wgList;
     }
 
     private void checkInvalidComputeGroup() {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/MergedComputeGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/computegroup/MergedComputeGroup.java
@@ -17,11 +17,17 @@
 
 package org.apache.doris.resource.computegroup;
 
+import org.apache.doris.common.UserException;
+import org.apache.doris.resource.workloadgroup.WorkloadGroup;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupKey;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
+import java.util.List;
 import java.util.Set;
 
 public class MergedComputeGroup extends ComputeGroup {
@@ -43,9 +49,17 @@ public class MergedComputeGroup extends ComputeGroup {
         return systemInfoService.getBackendListByComputeGroup(computeGroupSet);
     }
 
-    @Override
-    public Set<String> getNames() {
-        return computeGroupSet;
+    public List<WorkloadGroup> getWorkloadGroup(String wgName, WorkloadGroupMgr wgMgr) throws UserException {
+        List<WorkloadGroup> wgList = Lists.newArrayList();
+
+        for (String cgName : computeGroupSet) {
+            WorkloadGroup wg = wgMgr.getWorkloadGroupByComputeGroup(WorkloadGroupKey.get(cgName, wgName));
+            if (wg == null) {
+                throw new UserException("Can not find workload group " + wgName + " in compute group " + cgName);
+            }
+            wgList.add(wg);
+        }
+        return wgList;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -41,6 +41,7 @@ import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.resource.computegroup.ComputeGroupMgr;
 import org.apache.doris.thrift.TPipelineWorkloadGroup;
 import org.apache.doris.thrift.TUserIdentity;
@@ -176,17 +177,20 @@ public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPost
         return wg;
     }
 
+    public WorkloadGroup getWorkloadGroupByComputeGroup(WorkloadGroupKey wgKey) {
+        return keyToWorkloadGroup.get(wgKey);
+    }
+
     public List<TPipelineWorkloadGroup> getWorkloadGroup(ConnectContext context) throws UserException {
         String wgName = getWorkloadGroupNameAndCheckPriv(context);
-        Set<String> cgNames = context.getComputeGroup().getNames();
+        ComputeGroup cg = context.getComputeGroup();
 
         List<TPipelineWorkloadGroup> workloadGroups = Lists.newArrayList();
         readLock();
         try {
-            for (String cgName : cgNames) {
-                WorkloadGroup workloadGroup = getWorkloadGroupByComputeGroupUnlock(
-                        WorkloadGroupKey.get(cgName, wgName));
-                workloadGroups.add(workloadGroup.toThrift());
+            List<WorkloadGroup> wgList = cg.getWorkloadGroup(wgName, this);
+            for (WorkloadGroup wg : wgList) {
+                workloadGroups.add(wg.toThrift());
             }
             context.setWorkloadGroupName(wgName);
         } finally {
@@ -370,17 +374,26 @@ public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPost
         throw new DdlException("Unsupported alter statement");
     }
 
-    public void alterWorkloadGroup(String computeGroup, String workloadGroupName, Map<String, String> properties)
-            throws DdlException {
+    public void alterWorkloadGroup(ComputeGroup cg, String workloadGroupName, Map<String, String> properties)
+            throws UserException {
         if (properties.size() == 0) {
             throw new DdlException("Alter workload group should contain at least one property");
         }
 
+        String cgName = cg.getName();
         WorkloadGroup newWorkloadGroup;
-        WorkloadGroupKey wgKey = WorkloadGroupKey.get(computeGroup, workloadGroupName);
+        WorkloadGroupKey wgKey = WorkloadGroupKey.get(cgName, workloadGroupName);
         writeLock();
         try {
-            WorkloadGroup currentWorkloadGroup = getWorkloadGroupByComputeGroupUnlock(wgKey);
+            // get 0 idx here because there can only be one wg in cg with specify wg name.
+            List<WorkloadGroup> ret = cg.getWorkloadGroup(workloadGroupName, this);
+            if (ret.size() != 1) {
+                throw new RuntimeException(
+                        "Unexpected error: find " + ret.size() + " workload group " + workloadGroupName
+                                + " in compute group "
+                                + cgName);
+            }
+            WorkloadGroup currentWorkloadGroup = ret.get(0);
             newWorkloadGroup = WorkloadGroup.copyAndUpdate(currentWorkloadGroup, properties);
             checkGlobalUnlock(newWorkloadGroup, currentWorkloadGroup);
             keyToWorkloadGroup.put(wgKey, newWorkloadGroup);
@@ -389,7 +402,7 @@ public class WorkloadGroupMgr extends MasterDaemon implements Writable, GsonPost
         } finally {
             writeUnlock();
         }
-        LOG.info("Alter workload group {} for compute group {} success: {}", newWorkloadGroup, computeGroup);
+        LOG.info("Alter workload group {} for compute group {} success: {}", newWorkloadGroup, cgName);
     }
 
     public void dropWorkloadGroup(DropWorkloadGroupStmt stmt) throws DdlException {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ResourceTagQueryTest.java
@@ -63,7 +63,6 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.UUID;
 
 public class ResourceTagQueryTest {
@@ -207,9 +206,8 @@ public class ResourceTagQueryTest {
         ComputeGroup cg2 = Env.getCurrentEnv().getAuth().getComputeGroup(Auth.ROOT_USER);
         Assert.assertTrue(cg2 instanceof MergedComputeGroup);
         MergedComputeGroup cg3 = (MergedComputeGroup) cg2;
-        Set<String> cgNameSet1 = cg3.getNames();
-        Assert.assertTrue(cgNameSet1.size() == 1);
-        Assert.assertTrue(cgNameSet1.contains("default"));
+        String cg3Name = cg3.getName();
+        Assert.assertTrue(cg3Name.contains("default"));
 
         // update connection context and query
         connectContext.setComputeGroup(cg2);
@@ -224,8 +222,7 @@ public class ResourceTagQueryTest {
         ComputeGroup cg4 = Env.getCurrentEnv().getAuth().getComputeGroup(Auth.ROOT_USER);
         Assert.assertTrue(cg4 instanceof MergedComputeGroup);
         MergedComputeGroup cg5 = (MergedComputeGroup) cg4;
-        Assert.assertTrue(cg5.getNames().size() == 1);
-        Assert.assertTrue(cg5.getNames().contains("zone1"));
+        Assert.assertTrue(cg5.getName().contains("zone1"));
 
         // update connection context and query, it will failed because no zone1 backend
         connectContext.setComputeGroup(cg4);

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/ComputeGroupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/ComputeGroupTest.java
@@ -159,14 +159,14 @@ public class ComputeGroupTest {
                 auth.createUser(createNonAdminUser);
                 ComputeGroup cg = auth.getComputeGroup(nonAdminUserStr);
                 Assert.assertTrue(cg instanceof MergedComputeGroup);
-                Assert.assertTrue(((MergedComputeGroup) cg).getNames().contains(Tag.VALUE_DEFAULT_TAG));
+                Assert.assertTrue(((MergedComputeGroup) cg).getName().contains(Tag.VALUE_DEFAULT_TAG));
 
                 // 2.1 get a non-admin user with resource tag
                 String setPropStr = "set property for '" + nonAdminUserStr + "' 'resource_tags.location' = 'test_rg1';";
                 ExceptionChecker.expectThrowsNoException(() -> setProperty(setPropStr));
                 ComputeGroup cg2 = auth.getComputeGroup(nonAdminUserStr);
                 Assert.assertTrue(cg2 instanceof MergedComputeGroup);
-                Assert.assertTrue(((MergedComputeGroup) cg2).getNames().contains("test_rg1"));
+                Assert.assertTrue(((MergedComputeGroup) cg2).getName().contains("test_rg1"));
 
                 // 2.2 get a non-admin user with multi-resource tag
                 String setPropStr2 = "set property for '" + nonAdminUserStr
@@ -174,10 +174,9 @@ public class ComputeGroupTest {
                 ExceptionChecker.expectThrowsNoException(() -> setProperty(setPropStr2));
                 ComputeGroup cg3 = auth.getComputeGroup(nonAdminUserStr);
                 Assert.assertTrue(cg3 instanceof MergedComputeGroup);
-                Set<String> cgNameSet = ((MergedComputeGroup) cg3).getNames();
-                Assert.assertTrue(cgNameSet.contains("test_rg1"));
-                Assert.assertTrue(cgNameSet.contains("test_rg2"));
-                Assert.assertTrue(cgNameSet.size() == 2);
+                String cgName3 = ((MergedComputeGroup) cg3).getName();
+                Assert.assertTrue(cgName3.contains("test_rg1"));
+                Assert.assertTrue(cgName3.contains("test_rg2"));
 
                 // 2.3 get a non-admin user with empty tag
                 String setPropStr3 = "set property for '" + nonAdminUserStr
@@ -185,9 +184,8 @@ public class ComputeGroupTest {
                 ExceptionChecker.expectThrowsNoException(() -> setProperty(setPropStr3));
                 ComputeGroup cg4 = auth.getComputeGroup(nonAdminUserStr);
                 Assert.assertTrue(cg4 instanceof MergedComputeGroup);
-                Set<String> cgNameSets = ((MergedComputeGroup) cg4).getNames();
-                Assert.assertTrue(cgNameSets.size() == 1);
-                Assert.assertTrue(cgNameSets.contains("default"));
+                String cgName4 = ((MergedComputeGroup) cg4).getName();
+                Assert.assertTrue(cgName4.contains("default"));
             }
 
             // 4 get an admin user without resource tag
@@ -200,7 +198,7 @@ public class ComputeGroupTest {
                 ExceptionChecker.expectThrowsNoException(() -> setProperty(setPropStr));
                 ComputeGroup cg2 = auth.getComputeGroup("root");
                 Assert.assertTrue(cg2 instanceof MergedComputeGroup);
-                Assert.assertTrue(((MergedComputeGroup) cg2).getNames().contains("test_rg2"));
+                Assert.assertTrue(((MergedComputeGroup) cg2).getName().contains("test_rg2"));
 
 
                 // 4.2 get an admin user with an empty resource tag
@@ -562,7 +560,7 @@ public class ComputeGroupTest {
                 brokerLoadJob.setComputeGroup();
                 ComputeGroup cg = ConnectContext.get().getComputeGroupSafely();
                 Assert.assertTrue(cg instanceof MergedComputeGroup);
-                Assert.assertTrue(((MergedComputeGroup) cg).getNames().contains(tagName));
+                Assert.assertTrue(((MergedComputeGroup) cg).getName().contains(tagName));
 
             }
     }
@@ -610,7 +608,7 @@ public class ComputeGroupTest {
                 job.setComputeGroup();
                 ComputeGroup cg = ConnectContext.get().getComputeGroupSafely();
                 Assert.assertTrue(cg instanceof MergedComputeGroup);
-                Assert.assertTrue(((MergedComputeGroup) cg).getNames().contains("tag_rg_1"));
+                Assert.assertTrue(((MergedComputeGroup) cg).getName().contains("tag_rg_1"));
             }
 
             // 4 get a null job

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
@@ -221,11 +221,11 @@ public class WorkloadGroupMgrTest {
         // 1 test get workload group by ConnectContext
         ConnectContext ctx = new ConnectContext();
         // 1.1 not set wg, get normal
-        ctx.setComputeGroup(new ComputeGroup("1", cgName1, null));
+        ctx.setComputeGroup(new ComputeGroup(cgName1, cgName1, null));
         List<TPipelineWorkloadGroup> ret = workloadGroupMgr.getWorkloadGroup(ctx);
         Assert.assertTrue(ret.get(0).getId() == 100);
 
-        ctx.setComputeGroup(new ComputeGroup("2", cgName2, null));
+        ctx.setComputeGroup(new ComputeGroup(cgName2, cgName2, null));
         Assert.assertTrue(workloadGroupMgr.getWorkloadGroup(ctx).get(0).getId() == 101);
 
 
@@ -262,7 +262,7 @@ public class WorkloadGroupMgrTest {
         try {
             workloadGroupMgr.getWorkloadGroup(ctx);
             Assert.fail();
-        } catch (DdlException e) {
+        } catch (UserException e) {
             Assert.assertTrue(e.getMessage().contains("Can not find workload group"));
         }
     }
@@ -276,15 +276,15 @@ public class WorkloadGroupMgrTest {
 
         Map<String, String> p0 = Maps.newHashMap();
         try {
-            workloadGroupMgr.alterWorkloadGroup("", "", p0);
+            workloadGroupMgr.alterWorkloadGroup(new ComputeGroup("", "", null), "", p0);
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("should contain at least one property"));
         }
 
         p0.put(WorkloadGroup.CPU_SHARE, "10");
         try {
-            workloadGroupMgr.alterWorkloadGroup("", "abc", p0);
-        } catch (DdlException e) {
+            workloadGroupMgr.alterWorkloadGroup(new ComputeGroup("", "", null), "abc", p0);
+        } catch (UserException e) {
             Assert.assertTrue(e.getMessage().contains("Can not find workload group"));
         }
 
@@ -305,14 +305,14 @@ public class WorkloadGroupMgrTest {
         Map<String, String> prop2 = Maps.newHashMap();
         prop2.put(WorkloadGroup.CPU_SHARE, "20");
         try {
-            workloadGroupMgr.alterWorkloadGroup(cgName2, wgName2, prop2);
+            workloadGroupMgr.alterWorkloadGroup(new ComputeGroup(cgName2, cgName2, null), wgName2, prop2);
             Assert.fail();
-        } catch (DdlException e) {
+        } catch (UserException e) {
             Assert.assertTrue(e.getMessage().contains("Can not find workload group"));
         }
 
         // test alter success
-        workloadGroupMgr.alterWorkloadGroup(cgName1, wgName1, prop2);
+        workloadGroupMgr.alterWorkloadGroup(new ComputeGroup(cgName1, cgName1, null), wgName1, prop2);
         WorkloadGroup wg = workloadGroupMgr.getNameToWorkloadGroup().get(WorkloadGroupKey.get(cgName1, wgName1));
         Assert.assertTrue(Long.valueOf(wg.getProperties().get(WorkloadGroup.CPU_SHARE)) == 20);
     }
@@ -546,7 +546,7 @@ public class WorkloadGroupMgrTest {
                     Map<String, String> properties = Maps.newHashMap();
                     properties.put(prop, "90%");
                     try {
-                        workloadGroupMgr.alterWorkloadGroup(cg1, "wg1", properties);
+                        workloadGroupMgr.alterWorkloadGroup(new ComputeGroup(cg1, cg1, null), "wg1", properties);
                     } catch (DdlException e) {
                         Assert.assertTrue(e.getMessage().contains("current sum val:110"));
                         Assert.assertTrue(e.getMessage().contains("cg1"));
@@ -558,7 +558,7 @@ public class WorkloadGroupMgrTest {
                 {
                     Map<String, String> properties = Maps.newHashMap();
                     properties.put(prop, "20%");
-                    workloadGroupMgr.alterWorkloadGroup(cg1, "wg1", properties);
+                    workloadGroupMgr.alterWorkloadGroup(new ComputeGroup(cg1, cg1, null), "wg1", properties);
                 }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?
Get workload group from compute group to show compute group name when workload group can not be found.
Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

