### PR TITLE
[enhancement](inverted index) ensure consistent ordering of properties for inverted index show

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Index.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Index.java
@@ -145,7 +145,8 @@ public class Index implements Writable {
             return "";
         }
 
-        return "(" + new PrintableMap(properties, "=", true, false, ",").toString() + ")";
+        // Use TreeMap to ensure consistent ordering of properties
+        return "(" + new PrintableMap(new java.util.TreeMap<>(properties), "=", true, false, ",").toString() + ")";
     }
 
     public String getInvertedIndexParser() {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/IndexPropertiesOrderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/IndexPropertiesOrderTest.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.analysis.IndexDef;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.*;
+
+public class IndexPropertiesOrderTest {
+
+    @Test
+    public void testIndexPropertiesConsistentOrder() {
+        // Create properties with multiple key-value pairs to test ordering
+        Map<String, String> properties = new HashMap<>();
+        properties.put("parser", "english");
+        properties.put("lower_case", "true");
+        properties.put("support_phrase", "true");
+
+        List<String> columns = Arrays.asList("description");
+
+        // Create multiple Index objects with the same properties
+        Index index1 = new Index(1L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+                                 new HashMap<>(properties), "test comment");
+        Index index2 = new Index(2L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+                                 new HashMap<>(properties), "test comment");
+        Index index3 = new Index(3L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+                                 new HashMap<>(properties), "test comment");
+
+        // The properties part should be consistent across all instances
+        String props1 = index1.getPropertiesString();
+        String props2 = index2.getPropertiesString();
+        String props3 = index3.getPropertiesString();
+
+        // Assert that all properties strings are identical
+        Assertions.assertEquals(props1, props2, "Properties order should be consistent between index1 and index2");
+        Assertions.assertEquals(props2, props3, "Properties order should be consistent between index2 and index3");
+        Assertions.assertEquals(props1, props3, "Properties order should be consistent between index1 and index3");
+
+        // Verify the properties are in alphabetical order
+        Assertions.assertTrue(props1.contains("lower_case"), "Properties should contain lower_case");
+        Assertions.assertTrue(props1.contains("parser"), "Properties should contain parser");
+        Assertions.assertTrue(props1.contains("support_phrase"), "Properties should contain support_phrase");
+
+        // Test with different orderings of the same properties
+        Map<String, String> properties2 = new LinkedHashMap<>();
+        properties2.put("support_phrase", "true");
+        properties2.put("parser", "english");
+        properties2.put("lower_case", "true");
+        Index index4 = new Index(4L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+                                 properties2, "test comment");
+        String props4 = index4.getPropertiesString();
+
+        // Should still be the same as the others due to TreeMap sorting
+        Assertions.assertEquals(props1, props4, "Properties order should be consistent regardless of input order");
+    }
+} 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/IndexPropertiesOrderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/IndexPropertiesOrderTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class IndexPropertiesOrderTest {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/IndexPropertiesOrderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/IndexPropertiesOrderTest.java
@@ -19,10 +19,14 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.IndexDef;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class IndexPropertiesOrderTest {
 
@@ -37,11 +41,11 @@ public class IndexPropertiesOrderTest {
         List<String> columns = Arrays.asList("description");
 
         // Create multiple Index objects with the same properties
-        Index index1 = new Index(1L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+        Index index1 = new Index(1L, "test_idx", columns, IndexDef.IndexType.INVERTED,
                                  new HashMap<>(properties), "test comment");
-        Index index2 = new Index(2L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+        Index index2 = new Index(2L, "test_idx", columns, IndexDef.IndexType.INVERTED,
                                  new HashMap<>(properties), "test comment");
-        Index index3 = new Index(3L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+        Index index3 = new Index(3L, "test_idx", columns, IndexDef.IndexType.INVERTED,
                                  new HashMap<>(properties), "test comment");
 
         // The properties part should be consistent across all instances
@@ -64,11 +68,11 @@ public class IndexPropertiesOrderTest {
         properties2.put("support_phrase", "true");
         properties2.put("parser", "english");
         properties2.put("lower_case", "true");
-        Index index4 = new Index(4L, "test_idx", columns, IndexDef.IndexType.INVERTED, 
+        Index index4 = new Index(4L, "test_idx", columns, IndexDef.IndexType.INVERTED,
                                  properties2, "test comment");
         String props4 = index4.getPropertiesString();
 
         // Should still be the same as the others due to TreeMap sorting
         Assertions.assertEquals(props1, props4, "Properties order should be consistent regardless of input order");
     }
-} 
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexesProcNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/IndexesProcNodeTest.java
@@ -80,7 +80,7 @@ public class IndexesProcNodeTest {
         Assert.assertEquals(procResult.getRows().get(1).get(5), "col_2");
         Assert.assertEquals(procResult.getRows().get(1).get(11), "INVERTED");
         Assert.assertEquals(procResult.getRows().get(1).get(12), "inverted index on col_2");
-        Assert.assertEquals(procResult.getRows().get(1).get(13), "(\"parser\" = \"unicode\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")");
+        Assert.assertEquals(procResult.getRows().get(1).get(13), "(\"lower_case\" = \"true\", \"parser\" = \"unicode\", \"support_phrase\" = \"true\")");
 
         Assert.assertEquals(procResult.getRows().get(2).get(0), "tbl_test_indexes_proc");
         Assert.assertEquals(procResult.getRows().get(2).get(1), "3");

--- a/regression-test/suites/backup_restore/test_backup_restore_inverted_index.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_inverted_index.groovy
@@ -75,7 +75,7 @@ suite("test_backup_restore_inverted_index", "backup_restore") {
 
     def restore_index_comment = sql "SHOW CREATE TABLE ${dbName}.${tableName}"
 
-    assertTrue(restore_index_comment[0][1].contains("USING INVERTED PROPERTIES(\"parser\" = \"english\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")"))
+    assertTrue(restore_index_comment[0][1].contains("USING INVERTED PROPERTIES(\"lower_case\" = \"true\", \"parser\" = \"english\", \"support_phrase\" = \"true\")"))
 
     result = sql "SELECT id, TOKENIZE(comment,'\"parser\"=\"english\"') as token FROM ${dbName}.${tableName}"
     assertEquals(result.size(), 2)

--- a/regression-test/suites/index_p0/test_index_meta.groovy
+++ b/regression-test/suites/index_p0/test_index_meta.groovy
@@ -71,7 +71,7 @@ suite("index_meta", "p0") {
     assertEquals(show_result[1][4], "name")
     assertEquals(show_result[1][10], "INVERTED")
     assertEquals(show_result[1][11], "index for name")
-    assertEquals(show_result[1][12], "(\"parser\" = \"none\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")")
+    assertEquals(show_result[1][12], "(\"lower_case\" = \"true\", \"parser\" = \"none\", \"support_phrase\" = \"true\")")
 
     // add index on column description
     sql "create index idx_desc on ${tableName}(description) USING INVERTED PROPERTIES(\"parser\"=\"standard\") COMMENT 'index for description';"
@@ -90,12 +90,12 @@ suite("index_meta", "p0") {
     assertEquals(show_result[1][4], "name")
     assertEquals(show_result[1][10], "INVERTED")
     assertEquals(show_result[1][11], "index for name")
-    assertEquals(show_result[1][12], "(\"parser\" = \"none\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")")
+    assertEquals(show_result[1][12], "(\"lower_case\" = \"true\", \"parser\" = \"none\", \"support_phrase\" = \"true\")")
     assertEquals(show_result[2][2], "idx_desc")
     assertEquals(show_result[2][4], "description")
     assertEquals(show_result[2][10], "INVERTED")
     assertEquals(show_result[2][11], "index for description")
-    assertEquals(show_result[2][12], "(\"parser\" = \"standard\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")")
+    assertEquals(show_result[2][12], "(\"lower_case\" = \"true\", \"parser\" = \"standard\", \"support_phrase\" = \"true\")")
 
     // drop index
     // add index on column description
@@ -114,7 +114,7 @@ suite("index_meta", "p0") {
     assertEquals(show_result[1][4], "description")
     assertEquals(show_result[1][10], "INVERTED")
     assertEquals(show_result[1][11], "index for description")
-    assertEquals(show_result[1][12], "(\"parser\" = \"standard\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")")
+    assertEquals(show_result[1][12], "(\"lower_case\" = \"true\", \"parser\" = \"standard\", \"support_phrase\" = \"true\")")
 
     // add index on column description
     sql "create index idx_name on ${tableName}(name) USING INVERTED COMMENT 'new index for name';"
@@ -133,7 +133,7 @@ suite("index_meta", "p0") {
     assertEquals(show_result[1][4], "description")
     assertEquals(show_result[1][10], "INVERTED")
     assertEquals(show_result[1][11], "index for description")
-    assertEquals(show_result[1][12], "(\"parser\" = \"standard\", \"lower_case\" = \"true\", \"support_phrase\" = \"true\")")
+    assertEquals(show_result[1][12], "(\"lower_case\" = \"true\", \"parser\" = \"standard\", \"support_phrase\" = \"true\")")
     assertEquals(show_result[2][2], "idx_name")
     assertEquals(show_result[2][4], "name")
     assertEquals(show_result[2][10], "INVERTED")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
This PR enhances the inverted index implementation to always output its properties in a consistent, alphabetical order and adds tests to verify this behavior.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

