### PR TITLE
[Fix](Compaction) Fix delete rowset sleeping when compaction

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -53,7 +53,6 @@ Status CloudCumulativeCompaction::prepare_compact() {
     Defer defer_set_st([&] {
         if (!st.ok()) {
             cloud_tablet()->set_last_cumu_compaction_status(st.to_string());
-            cloud_tablet()->set_last_cumu_compaction_failure_time(UnixMillis());
         }
     });
     if (_tablet->tablet_state() != TABLET_RUNNING &&

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -85,7 +85,6 @@ Status CumulativeCompaction::prepare_compact() {
     Defer defer_set_st([&] {
         if (!st.ok()) {
             tablet()->set_last_cumu_compaction_status(st.to_string());
-            tablet()->set_last_cumu_compaction_failure_time(UnixMillis());
         }
     });
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1796,7 +1796,8 @@ Status Tablet::prepare_compaction_and_calculate_permits(
                 config::enable_sleep_between_delete_cumu_compaction) {
                 tablet->set_last_cumu_compaction_failure_time(UnixMillis());
             }
-            if (!res.is<CUMULATIVE_NO_SUITABLE_VERSION>()) {
+            if (!res.is<CUMULATIVE_NO_SUITABLE_VERSION>() &&
+                !res.is<ErrorCode::CUMULATIVE_MEET_DELETE_VERSION>()) {
                 DorisMetrics::instance()->cumulative_compaction_request_failed->increment(1);
                 return Status::InternalError("prepare cumulative compaction with err: {}",
                                              res.to_string());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

In #50950, we enhanced the observability of compaction, but in some places, the last_cumu_compaction_failure_time was incorrectly set, causing it to be set when encountering a delete rowset. As a result, when compaction encountered a delete rowset, it would consider it a failure and sleep for 5 seconds. This PR fixes the issue.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

