### PR TITLE
[file cache]add some stats for file_cache_statistics

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1789,6 +1789,7 @@ void BlockFileCache::run_background_monitor() {
             check_need_evict_cache_in_advance();
         } else {
             _need_evict_cache_in_advance = false;
+            _need_evict_cache_in_advance_metrics->set_value(0);
         }
 
         {
@@ -2173,6 +2174,12 @@ std::map<std::string, double> BlockFileCache::get_stats() {
     stats["disposable_queue_max_elements"] = (double)_disposable_queue.get_max_element_size();
     stats["disposable_queue_curr_elements"] =
             (double)_cur_disposable_queue_element_count_metrics->get_value();
+
+    stats["total_removed_counts"] = (double)_num_removed_blocks->get_value();
+    stats["total_hit_counts"] = (double)_num_hit_blocks->get_value();
+    stats["total_read_counts"] = (double)_num_read_blocks->get_value();
+    stats["need_evict_cache_in_advance"] = (double)_need_evict_cache_in_advance;
+    stats["disk_resource_limit_mode"] = (double)_disk_resource_limit_mode;
 
     return stats;
 }


### PR DESCRIPTION
…t_cache_in_advance stat/metrics when false

### What problem does this PR solve?

Currently, file_cache_statistics only exposes the overall hit rate, as well as the 5-minute and 1-hour hit rates, which makes it impossible to flexibly and accurately calculate the hit rate for any arbitrary time period. Therefore, this PR exposes metrics such as the number of cache reads and hits, enabling precise calculation of cache hit rates at the query level.

Additionally, this PR also exposes the current states of need_evict_cache_in_advance and disk_resource_limit_mode, as they significantly impact cache performance and query hit rates. By making them available in file_cache_statistics, users can easily retrieve these metrics via SQL.

If the parameter enable_evict_file_cache_in_advance is set to false, then the _need_evict_cache_in_advance_metrics should be set to 0.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

