### PR TITLE
[fix](hudi) fix hudi scan problem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,7 @@ public class LogicalHudiScan extends LogicalFileScan {
             SelectedPartitions selectedPartitions, Optional<TableSample> tableSample,
             Optional<TableSnapshot> tableSnapshot,
             Optional<TableScanParams> scanParams, Optional<IncrementalRelation> incrementalRelation,
-            List<Slot> operativeSlots) {
+            Collection<Slot> operativeSlots) {
         super(id, table, qualifier, groupExpression, logicalProperties,
                 selectedPartitions, tableSample, tableSnapshot, operativeSlots);
         Objects.requireNonNull(scanParams, "scanParams should not null");
@@ -83,7 +84,7 @@ public class LogicalHudiScan extends LogicalFileScan {
     }
 
     public LogicalHudiScan(RelationId id, ExternalTable table, List<String> qualifier,
-            Optional<TableSample> tableSample, Optional<TableSnapshot> tableSnapshot, List<Slot> operativeSlots) {
+            Optional<TableSample> tableSample, Optional<TableSnapshot> tableSnapshot, Collection<Slot> operativeSlots) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 ((HMSExternalTable) table).initHudiSelectedPartitions(tableSnapshot), tableSample, tableSnapshot,
                 Optional.empty(), Optional.empty(),
@@ -165,6 +166,14 @@ public class LogicalHudiScan extends LogicalFileScan {
     @Override
     public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
         return visitor.visitLogicalHudiScan(this, context);
+    }
+
+    @Override
+    public LogicalFileScan withOperativeSlots(Collection<Slot> operativeSlots) {
+        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+                groupExpression, Optional.of(getLogicalProperties()),
+                selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
+                operativeSlots);
     }
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #51329 

Problem Summary:
The `LogicalHudiScan` class should overload the method `withOperativeSlots` and return the `LogicalHudiScan` type. Otherwise, the `LogicalFileScanToPhysicalFileScan` rule will be incorrectly applied when querying the hudi table, resulting in the generation of `PhysicalFileScan`.
Because `plan` is `LogicalFileScan`, `plan -> !(plan instanceof LogicalHudiScan)` will incorrectly return true.
```java
public class LogicalFileScanToPhysicalFileScan extends OneImplementationRuleFactory {
    @Override
    public Rule build() {
        return logicalFileScan().when(plan -> !(plan instanceof LogicalHudiScan)).then(fileScan ->
            new PhysicalFileScan(
                    fileScan.getRelationId(),
                    fileScan.getTable(),
                    fileScan.getQualifier(),
                    DistributionSpecAny.INSTANCE,
                    Optional.empty(),
                    fileScan.getLogicalProperties(),
                    fileScan.getSelectedPartitions(),
                    fileScan.getTableSample(),
                    fileScan.getTableSnapshot(),
                    fileScan.getOperativeSlots())
        ).toRule(RuleType.LOGICAL_FILE_SCAN_TO_PHYSICAL_FILE_SCAN_RULE);
    }
}
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

