### PR TITLE
[Bug](fix) try to fix double free materialization status

### DIFF
--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -830,7 +830,8 @@ public:
     void create_counter_dependency(int operator_id, int node_id, const std::string& name);
 
     bool rpc_struct_inited = false;
-    Status rpc_status = Status::OK();
+    AtomicStatus rpc_status;
+
     bool last_block = false;
     // empty materialization sink block not need to merge block
     bool need_merge_block = true;

--- a/be/src/pipeline/exec/materialization_sink_operator.cpp
+++ b/be/src/pipeline/exec/materialization_sink_operator.cpp
@@ -83,10 +83,10 @@ public:
                     ::doris::DummyBrpcCallback<Response>::cntl_->ErrorText(),
                     BackendOptions::get_localhost(),
                     ::doris::DummyBrpcCallback<Response>::cntl_->latency_us());
-            _shared_state->rpc_status = Status::InternalError(err);
+            _shared_state->rpc_status.update(Status::InternalError(err));
         } else {
-            _shared_state->rpc_status =
-                    Status::create(doris::DummyBrpcCallback<Response>::response_->status());
+            _shared_state->rpc_status.update(
+                    Status::create(doris::DummyBrpcCallback<Response>::response_->status()));
         }
         ((CountedFinishDependency*)_shared_state->source_deps.back().get())->sub();
     }

--- a/be/src/pipeline/exec/materialization_source_operator.cpp
+++ b/be/src/pipeline/exec/materialization_source_operator.cpp
@@ -29,7 +29,7 @@ Status MaterializationSourceOperatorX::get_block(RuntimeState* state, vectorized
     auto& local_state = get_local_state(state);
     SCOPED_TIMER(local_state.exec_time_counter());
     if (!local_state._shared_state->rpc_status.ok()) {
-        return local_state._shared_state->rpc_status;
+        return local_state._shared_state->rpc_status.status();
     }
 
     // clear origin block, do merge response to build a ret block


### PR DESCRIPTION
### What problem does this PR solve?
```
=================================================================
==8328==ERROR: AddressSanitizer: attempting double-free on 0x60600333cf80 in thread T1682:
    #0 0x5631ccdaed9d in operator delete(void*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3caa6d9d) (BuildId: dab4df3df11ecdce)
    #1 0x5631ccdde467 in std::__uniq_ptr_impl>::operator=(std::__uniq_ptr_impl>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:167:2
    #2 0x5631ccdc942d in std::__uniq_ptr_data, true, true>::operator=(std::__uniq_ptr_data, true, true>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:212:61
    #3 0x5631ccdc942d in std::unique_ptr>::operator=(std::unique_ptr>&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:371:51
    #4 0x5631ccdc942d in doris::Status::operator=(doris::Status&&) /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:400:22
    #5 0x56320bfc33ba in doris::pipeline::MaterializationCallback::call() /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/materialization_sink_operator.cpp:88:39
    #6 0x56320bfc5cdd in doris::AutoReleaseClosure>::Run() /home/zcp/repo_center/doris_master/doris/be/src/util/brpc_closure.h:98:18
    #7 0x5631d03b7b1b in doris::FailureDetectClosure::Run() /home/zcp/repo_center/doris_master/doris/be/src/util/brpc_client_cache.h:83:20
    #8 0x56320dce1943 in brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9d9943) (BuildId: dab4df3df11ecdce)
    #9 0x56320dd0cc4e in brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7da04c4e) (BuildId: dab4df3df11ecdce)
    #10 0x56320dd03f76 in brpc::ProcessInputMessage(void*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9fbf76) (BuildId: dab4df3df11ecdce)
    #11 0x56320dd04920 in brpc::InputMessenger::InputMessageClosure::~InputMessageClosure() (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9fc920) (BuildId: dab4df3df11ecdce)
    #12 0x56320dd052ab in brpc::InputMessenger::OnNewMessages(brpc::Socket*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9fd2ab) (BuildId: dab4df3df11ecdce)
    #13 0x56320de3437d in brpc::Socket::ProcessEvent(void*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7db2c37d) (BuildId: dab4df3df11ecdce)
    #14 0x56320dc970a6 in bthread::TaskGroup::task_runner(long) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d98f0a6) (BuildId: dab4df3df11ecdce)
    #15 0x56320dc83660 in bthread_make_fcontext (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d97b660) (BuildId: dab4df3df11ecdce)

0x60600333cf80 is located 0 bytes inside of 64-byte region [0x60600333cf80,0x60600333cfc0)
freed by thread T1791 here:
    #0 0x5631ccdaed9d in operator delete(void*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3caa6d9d) (BuildId: dab4df3df11ecdce)

previously allocated by thread T1623 here:
    #0 0x5631ccdae53d in operator new(unsigned long) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3caa653d) (BuildId: dab4df3df11ecdce)

Thread T1682 created by T0 here:
    #0 0x5631ccd5bcaa in pthread_create (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3ca53caa) (BuildId: dab4df3df11ecdce)
    #1 0x56320dc907be in bthread::TaskControl::add_workers(int) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9887be) (BuildId: dab4df3df11ecdce)
    #2 0x56320dc7f0ac in bthread_setconcurrency (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9770ac) (BuildId: dab4df3df11ecdce)
    #3 0x56320ddfcc79 in brpc::Server::StartInternal(butil::EndPoint const&, brpc::PortRange const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7daf4c79) (BuildId: dab4df3df11ecdce)
    #4 0x56320ddfecc9 in brpc::Server::Start(butil::EndPoint const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7daf6cc9) (BuildId: dab4df3df11ecdce)
    #5 0x5631d13708df in doris::BRpcService::start(int, int) /home/zcp/repo_center/doris_master/doris/be/src/service/brpc_service.cpp:94:18
    #6 0x5631ccdb73e2 in main /home/zcp/repo_center/doris_master/doris/be/src/service/doris_main.cpp:570:28
    #7 0x7faec2201d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

Thread T1791 created by T0 here:
    #0 0x5631ccd5bcaa in pthread_create (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3ca53caa) (BuildId: dab4df3df11ecdce)
    #1 0x56320dc907be in bthread::TaskControl::add_workers(int) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9887be) (BuildId: dab4df3df11ecdce)
    #2 0x56320dc7f0ac in bthread_setconcurrency (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9770ac) (BuildId: dab4df3df11ecdce)
    #3 0x56320ddfcc79 in brpc::Server::StartInternal(butil::EndPoint const&, brpc::PortRange const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7daf4c79) (BuildId: dab4df3df11ecdce)
    #4 0x56320ddfecc9 in brpc::Server::Start(butil::EndPoint const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7daf6cc9) (BuildId: dab4df3df11ecdce)
    #5 0x5631d13708df in doris::BRpcService::start(int, int) /home/zcp/repo_center/doris_master/doris/be/src/service/brpc_service.cpp:94:18
    #6 0x5631ccdb73e2 in main /home/zcp/repo_center/doris_master/doris/be/src/service/doris_main.cpp:570:28
    #7 0x7faec2201d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

Thread T1623 created by T0 here:
    #0 0x5631ccd5bcaa in pthread_create (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3ca53caa) (BuildId: dab4df3df11ecdce)
    #1 0x56320dc907be in bthread::TaskControl::add_workers(int) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9887be) (BuildId: dab4df3df11ecdce)
    #2 0x56320dc7f0ac in bthread_setconcurrency (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7d9770ac) (BuildId: dab4df3df11ecdce)
    #3 0x56320ddfcc79 in brpc::Server::StartInternal(butil::EndPoint const&, brpc::PortRange const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7daf4c79) (BuildId: dab4df3df11ecdce)
    #4 0x56320ddfecc9 in brpc::Server::Start(butil::EndPoint const&, brpc::ServerOptions const*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x7daf6cc9) (BuildId: dab4df3df11ecdce)
    #5 0x5631d13708df in doris::BRpcService::start(int, int) /home/zcp/repo_center/doris_master/doris/be/src/service/brpc_service.cpp:94:18
    #6 0x5631ccdb73e2 in main /home/zcp/repo_center/doris_master/doris/be/src/service/doris_main.cpp:570:28
    #7 0x7faec2201d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: double-free (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x3caa6d9d) (BuildId: dab4df3df11ecdce) in operator delete(void*)

```

Add a lock when need change the materialization status


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

