### PR TITLE
fix](load) fix S3 load cannot use HTTPS protocol

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -606,13 +606,8 @@ public class LoadStmt extends DdlStmt implements NotFallbackInParser {
     private void checkEndpoint(String endpoint) throws UserException {
         HttpURLConnection connection = null;
         try {
-            String urlStr = endpoint;
-            // Add default protocol if not specified
-            if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
-                urlStr = "http://" + endpoint;
-            }
-            SecurityChecker.getInstance().startSSRFChecking(urlStr);
-            URL url = new URL(urlStr);
+            SecurityChecker.getInstance().startSSRFChecking(endpoint);
+            URL url = new URL(endpoint);
             connection = (HttpURLConnection) url.openConnection();
             connection.setConnectTimeout(10000);
             connection.connect();
@@ -646,6 +641,11 @@ public class LoadStmt extends DdlStmt implements NotFallbackInParser {
                 && brokerDescProperties.containsKey(S3Properties.Env.REGION)) {
             String endpoint = brokerDescProperties.get(S3Properties.Env.ENDPOINT);
             checkWhiteList(endpoint);
+            // Add default protocol if not specified
+            if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
+                endpoint = "http://" + endpoint;
+            }
+            brokerDescProperties.put(S3Properties.Env.ENDPOINT, endpoint);
             if (AzureProperties.checkAzureProviderPropertyExist(brokerDescProperties)) {
                 return;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/DefaultRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/DefaultRemote.java
@@ -129,7 +129,11 @@ public class DefaultRemote extends RemoteBase {
                 credentials = AwsBasicCredentials.create(obj.getAk(), obj.getSk());
             }
             StaticCredentialsProvider scp = StaticCredentialsProvider.create(credentials);
-            URI endpointUri = URI.create("http://" + obj.getEndpoint());
+            String endpoint = obj.getEndpoint();
+            if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
+                endpoint = "http://" + endpoint;
+            }
+            URI endpointUri = URI.create(endpoint);
             s3Client = S3Client.builder().endpointOverride(endpointUri).credentialsProvider(scp)
                     .region(Region.of(obj.getRegion())).build();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #51246
#51246 did not completely fix the issue.

Problem Summary:

- DefaultRemote's S3Client is hardcoded to use HTTP protocol
- Protocol inconsistency between S3Client and S3AFileSystem:
    - S3AFileSystem defaults to HTTPS internally
    - S3Client forces HTTP
    - This can cause protocol mismatch issues

Solution
- Fix S3Client to support both HTTP and HTTPS protocols
- When users don't specify protocol in endpoint:
    - Add HTTP protocol prefix by default in LoadStmt
    - This maintains consistency with existing behavior
    - Prevents protocol mismatch between components

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

