### PR TITLE
[opt](webui) support all kinds of statement in webui

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/StmtExecutionAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/StmtExecutionAction.java
@@ -119,7 +119,6 @@ public class StmtExecutionAction extends RestBaseController {
                             response, isStream);
     }
 
-
     /**
      * Get all create table stmt of a SQL
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
@@ -45,13 +45,13 @@ import javax.servlet.http.HttpServletResponse;
  * This is a simple stmt submitter for submitting a statement to the local FE.
  * It uses a fixed-size thread pool to receive query requests,
  * so it is only suitable for a small number of low-frequency request scenarios.
- * 
+ * <p>
  * This submitter can execute any SQL statement without pre-analysis or type checking.
  * It dynamically determines how to handle the results based on whether the statement
  * returns a ResultSet or not:
  *   - Statements with ResultSet (SELECT, SHOW, etc.): processed as query results
  *   - Statements without ResultSet (DDL, DML, etc.): processed as execution status
- * 
+ * <p>
  * Supported statement types include but are not limited to:
  *   - Query statements (SELECT, SHOW, DESCRIBE, etc.)
  *   - Data manipulation (INSERT, UPDATE, DELETE, COPY, etc.)
@@ -106,18 +106,18 @@ public class StatementSubmitter {
                 Class.forName(JDBC_DRIVER);
                 conn = DriverManager.getConnection(dbUrl, queryCtx.user, queryCtx.passwd);
                 long startTime = System.currentTimeMillis();
-                
+
                 if (!queryCtx.clusterName.isEmpty()) {
                     Statement useStmt = conn.createStatement();
                     useStmt.execute("use @" + queryCtx.clusterName);
                     useStmt.close();
                 }
-                
+
                 stmt = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 stmt.setFetchSize(1000);
-                
+
                 boolean hasResultSet = stmt.execute(queryCtx.stmt);
-                
+
                 if (hasResultSet) {
                     ResultSet rs = stmt.getResultSet();
                     if (queryCtx.isStream) {
@@ -160,21 +160,21 @@ public class StatementSubmitter {
             if (rs == null) {
                 return false;
             }
-            
+
             ResultSetMetaData metaData = rs.getMetaData();
             int colNum = metaData.getColumnCount();
-            
+
             if (colNum != copyResult.length) {
                 return false;
             }
-            
+
             for (int i = 1; i <= colNum; i++) {
                 String columnName = metaData.getColumnName(i);
                 if (!copyResult[i - 1].equalsIgnoreCase(columnName)) {
                     return false;
                 }
             }
-            
+
             return true;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
@@ -17,34 +17,19 @@
 
 package org.apache.doris.httpv2.util;
 
-// Remove unused imports for SQL statement analysis
-// import org.apache.doris.analysis.CopyStmt;
-// import org.apache.doris.analysis.DdlStmt;
-// import org.apache.doris.analysis.ExportStmt;
-// import org.apache.doris.analysis.QueryStmt;
-// import org.apache.doris.analysis.ShowStmt;
-// import org.apache.doris.analysis.SqlParser;
-// import org.apache.doris.analysis.SqlScanner;
-// import org.apache.doris.analysis.StatementBase;
-// import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
-// import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.httpv2.util.streamresponse.JsonStreamResponse;
 import org.apache.doris.httpv2.util.streamresponse.StreamResponseInf;
-// import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
-// import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-// import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StatementSubmitter.java
@@ -17,30 +17,31 @@
 
 package org.apache.doris.httpv2.util;
 
-import org.apache.doris.analysis.CopyStmt;
-import org.apache.doris.analysis.DdlStmt;
-import org.apache.doris.analysis.ExportStmt;
-import org.apache.doris.analysis.QueryStmt;
-import org.apache.doris.analysis.ShowStmt;
-import org.apache.doris.analysis.SqlParser;
-import org.apache.doris.analysis.SqlScanner;
-import org.apache.doris.analysis.StatementBase;
-import org.apache.doris.common.AnalysisException;
+// Remove unused imports for SQL statement analysis
+// import org.apache.doris.analysis.CopyStmt;
+// import org.apache.doris.analysis.DdlStmt;
+// import org.apache.doris.analysis.ExportStmt;
+// import org.apache.doris.analysis.QueryStmt;
+// import org.apache.doris.analysis.ShowStmt;
+// import org.apache.doris.analysis.SqlParser;
+// import org.apache.doris.analysis.SqlScanner;
+// import org.apache.doris.analysis.StatementBase;
+// import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
-import org.apache.doris.common.util.SqlParserUtils;
+// import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.httpv2.util.streamresponse.JsonStreamResponse;
 import org.apache.doris.httpv2.util.streamresponse.StreamResponseInf;
-import org.apache.doris.qe.AutoCloseConnectContext;
+// import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.statistics.util.StatisticsUtil;
+// import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.StringReader;
+// import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -59,12 +60,19 @@ import javax.servlet.http.HttpServletResponse;
  * This is a simple stmt submitter for submitting a statement to the local FE.
  * It uses a fixed-size thread pool to receive query requests,
  * so it is only suitable for a small number of low-frequency request scenarios.
- * Now it support submitting the following type of stmt:
- *      QueryStmt
- *      ShowStmt
- *      InsertStmt
- *      DdlStmt
- *      ExportStmt
+ * 
+ * This submitter can execute any SQL statement without pre-analysis or type checking.
+ * It dynamically determines how to handle the results based on whether the statement
+ * returns a ResultSet or not:
+ *   - Statements with ResultSet (SELECT, SHOW, etc.): processed as query results
+ *   - Statements without ResultSet (DDL, DML, etc.): processed as execution status
+ * 
+ * Supported statement types include but are not limited to:
+ *   - Query statements (SELECT, SHOW, DESCRIBE, etc.)
+ *   - Data manipulation (INSERT, UPDATE, DELETE, COPY, etc.)
+ *   - Data definition (CREATE, DROP, ALTER, etc.)
+ *   - Session management (SET, USE, etc.)
+ *   - Export statements
  */
 public class StatementSubmitter {
     private static final Logger LOG = LogManager.getLogger(StatementSubmitter.class);
@@ -106,8 +114,6 @@ public class StatementSubmitter {
 
         @Override
         public ExecutionResultSet call() throws Exception {
-            StatementBase stmtBase = analyzeStmt(queryCtx.stmt);
-
             Connection conn = null;
             Statement stmt = null;
             String dbUrl = String.format(DB_URL_PATTERN, Config.query_port, ctx.getDatabase());
@@ -115,36 +121,37 @@ public class StatementSubmitter {
                 Class.forName(JDBC_DRIVER);
                 conn = DriverManager.getConnection(dbUrl, queryCtx.user, queryCtx.passwd);
                 long startTime = System.currentTimeMillis();
-                if (stmtBase instanceof QueryStmt || stmtBase instanceof ShowStmt || stmtBase instanceof CopyStmt) {
-                    if (!queryCtx.clusterName.isEmpty()) {
-                        Statement useStmt = conn.createStatement();
-                        useStmt.execute("use @" + queryCtx.clusterName);
-                    }
-                    stmt = conn.prepareStatement(
-                            queryCtx.stmt, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-                    // set fetch size to 1 to enable streaming result set to avoid OOM.
-                    stmt.setFetchSize(1000);
-                    ResultSet rs = ((PreparedStatement) stmt).executeQuery();
+                
+                if (!queryCtx.clusterName.isEmpty()) {
+                    Statement useStmt = conn.createStatement();
+                    useStmt.execute("use @" + queryCtx.clusterName);
+                    useStmt.close();
+                }
+                
+                stmt = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+                stmt.setFetchSize(1000);
+                
+                boolean hasResultSet = stmt.execute(queryCtx.stmt);
+                
+                if (hasResultSet) {
+                    ResultSet rs = stmt.getResultSet();
                     if (queryCtx.isStream) {
                         StreamResponseInf streamResponse = new JsonStreamResponse(queryCtx.response);
                         streamResponse.handleQueryAndShow(rs, startTime);
                         rs.close();
                         return new ExecutionResultSet(null);
                     }
-                    ExecutionResultSet resultSet = generateResultSet(rs, startTime, stmtBase instanceof CopyStmt);
+                    boolean isCopyStmt = isCopyStatement(rs);
+                    ExecutionResultSet resultSet = generateResultSet(rs, startTime, isCopyStmt);
                     rs.close();
                     return resultSet;
-                } else if (stmtBase instanceof DdlStmt || stmtBase instanceof ExportStmt) {
-                    stmt = conn.createStatement();
-                    stmt.execute(queryCtx.stmt);
+                } else {
                     if (queryCtx.isStream) {
                         StreamResponseInf streamResponse = new JsonStreamResponse(queryCtx.response);
                         streamResponse.handleDdlAndExport(startTime);
                         return new ExecutionResultSet(null);
                     }
                     return generateExecStatus(startTime);
-                } else {
-                    throw new Exception("Unsupported statement type");
                 }
             } finally {
                 try {
@@ -162,6 +169,28 @@ public class StatementSubmitter {
                     LOG.warn("failed to close connection", se);
                 }
             }
+        }
+
+        private boolean isCopyStatement(ResultSet rs) throws SQLException {
+            if (rs == null) {
+                return false;
+            }
+            
+            ResultSetMetaData metaData = rs.getMetaData();
+            int colNum = metaData.getColumnCount();
+            
+            if (colNum != copyResult.length) {
+                return false;
+            }
+            
+            for (int i = 1; i <= colNum; i++) {
+                String columnName = metaData.getColumnName(i);
+                if (!copyResult[i - 1].equalsIgnoreCase(columnName)) {
+                    return false;
+                }
+            }
+            
+            return true;
         }
 
         /**
@@ -247,22 +276,6 @@ public class StatementSubmitter {
             result.put("status", Maps.newHashMap());
             result.put("time", (System.currentTimeMillis() - startTime));
             return new ExecutionResultSet(result);
-        }
-    }
-
-    public static StatementBase analyzeStmt(String stmtStr) throws Exception {
-        SqlParser parser = new SqlParser(new SqlScanner(new StringReader(stmtStr)));
-        try (AutoCloseConnectContext a = StatisticsUtil.buildConnectContext(false)) {
-            return SqlParserUtils.getFirstStmt(parser);
-        } catch (AnalysisException e) {
-            String errorMessage = parser.getErrorMsg(stmtStr);
-            if (errorMessage == null) {
-                throw e;
-            } else {
-                throw new AnalysisException(errorMessage, e);
-            }
-        } catch (Exception e) {
-            throw new Exception("error happens when parsing stmt: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Currently, only SELECT/CREATE/SHOW statement can be executed in FE webui.
Statement like `set query_time=10` is not support.
This PR fix it.

Also extends the rest api, support to list catalogs and get db/tbl in external catalogs.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

