### PR TITLE
[chore](SerDe)remove mutable variables in DataTypeDecimalSerDe

### DIFF
--- a/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
@@ -53,6 +53,7 @@ Status DataTypeDecimalSerDe<T>::serialize_one_cell_to_json(const IColumn& column
         auto decimal_str = value.to_string(scale);
         bw.write(decimal_str.data(), decimal_str.size());
     } else {
+        char buf[FieldType::max_string_length()];
         auto length = col.get_element(row_num).to_string(buf, scale, scale_multiplier);
         bw.write(buf, length);
     }
@@ -255,6 +256,7 @@ Status DataTypeDecimalSerDe<T>::_write_column_to_mysql(const IColumn& column,
             return Status::InternalError("pack mysql buffer failed.");
         }
     } else {
+        char buf[FieldType::max_string_length()];
         auto length = data[col_index].to_string(buf, scale, scale_multiplier);
         if (UNLIKELY(0 != result.push_string(buf, length))) {
             return Status::InternalError("pack mysql buffer failed.");

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.h
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.h
@@ -114,7 +114,6 @@ private:
     int precision;
     int scale;
     const typename FieldType::NativeType scale_multiplier;
-    mutable char buf[FieldType::max_string_length()];
 };
 
 template <PrimitiveType T>


### PR DESCRIPTION
### What problem does this PR solve?

The datatype in Doris is often a shared_ptr that gets copied multiple times, and multiple threads might call serialize_one_cell_to_json simultaneously. Using mutable variables within const methods is not a good practice.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

