### PR TITLE
[Bug](runtime-filter) init finish_dependency on SetSinkLocalState

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -248,7 +248,8 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
                 "blocked_by_shared_hash_table_signal: "
                 "{}",
                 e.to_string(), _terminated, _should_build_hash_table,
-                _finish_dependency->debug_string(), blocked_by_shared_hash_table_signal);
+                _finish_dependency ? _finish_dependency->debug_string() : "null",
+                blocked_by_shared_hash_table_signal);
     }
     if (_runtime_filter_producer_helper) {
         _runtime_filter_producer_helper->collect_realtime_profile(profile());

--- a/be/src/pipeline/exec/set_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_sink_operator.cpp
@@ -49,7 +49,8 @@ Status SetSinkLocalState<is_intersect>::close(RuntimeState* state, Status exec_s
         } catch (Exception& e) {
             return Status::InternalError(
                     "rf process meet error: {}, _terminated: {}, _finish_dependency: {}",
-                    e.to_string(), _terminated, _finish_dependency->debug_string());
+                    e.to_string(), _terminated,
+                    _finish_dependency ? _finish_dependency->debug_string() : "null");
         }
     }
 

--- a/be/src/pipeline/exec/set_sink_operator.h
+++ b/be/src/pipeline/exec/set_sink_operator.h
@@ -40,7 +40,11 @@ public:
     using Base = PipelineXSinkLocalState<SetSharedState>;
     using Parent = SetSinkOperatorX<is_intersect>;
 
-    SetSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state) : Base(parent, state) {}
+    SetSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state) : Base(parent, state) {
+        _finish_dependency = std::make_shared<CountedFinishDependency>(
+                parent->operator_id(), parent->node_id(),
+                parent->get_name() + "_FINISH_DEPENDENCY");
+    }
 
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
     Status open(RuntimeState* state) override;


### PR DESCRIPTION
### What problem does this PR solve?
init finish_dependency on SetSinkLocalState
related with https://github.com/apache/doris/pull/49947

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

