### PR TITLE
[fix](case)Use relative cooldown time instead of absolute time in storage policy test case

### DIFF
--- a/regression-test/suites/cold_heat_separation/policy/drop.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/drop.groovy
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
 suite("drop_policy") {
     def storage_exist = { name ->
         def show_storage_policy = sql """
@@ -100,12 +104,13 @@ suite("drop_policy") {
         """
         // can drop, no table use
         assertEquals(drop_policy_ret.size(), 1)
-
+        def zonedDateTime = ZonedDateTime.now(ZoneId.of("UTC")).plusYears(1)
+        def futureTime = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
         def create_succ_2 = try_sql """
             CREATE STORAGE POLICY IF NOT EXISTS drop_policy_test_has_table_binded
             PROPERTIES(
             "storage_resource" = "${resource_table_use}",
-            "cooldown_datetime" = "2035-06-08 00:00:00"
+            "cooldown_datetime" = "${futureTime}"
             );
         """
         assertEquals(storage_exist.call("drop_policy_test_has_table_binded"), true)
@@ -114,7 +119,7 @@ suite("drop_policy") {
             CREATE STORAGE POLICY IF NOT EXISTS drop_policy_test_has_table_bind_1
             PROPERTIES(
             "storage_resource" = "${resource_table_use}",
-            "cooldown_datetime" = "2035-06-08 00:00:00"
+            "cooldown_datetime" = "${futureTime}"
             );
         """
         assertEquals(storage_exist.call("drop_policy_test_has_table_bind_1"), true)

--- a/regression-test/suites/cold_heat_separation/policy/drop_hdfs_reource.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/drop_hdfs_reource.groovy
@@ -14,6 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.ZoneId
 
 suite("drop_hdfs_policy") {
     def storage_exist = { name ->
@@ -74,13 +77,15 @@ suite("drop_hdfs_policy") {
             "dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
         );
         """
-
+        def zonedDateTime = ZonedDateTime.now(ZoneId.of("UTC")).plusYears(1)
+      
+        def futureTime = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
 
         def create_succ_1 = try_sql """
             CREATE STORAGE POLICY ${use_policy}
             PROPERTIES(
             "storage_resource" = "${resource_table_use}",
-            "cooldown_datetime" = "2035-06-08 00:00:00"
+            "cooldown_datetime" = "${futureTime}"
             );
         """
         assertEquals(storage_exist.call(use_policy), true)
@@ -96,12 +101,11 @@ suite("drop_hdfs_policy") {
         """
         // can drop, no table use
         assertEquals(drop_policy_ret.size(), 1)
-
         def create_succ_2 = try_sql """
             CREATE STORAGE POLICY IF NOT EXISTS drop_policy_test_has_table_binded_hdfs
             PROPERTIES(
             "storage_resource" = "${resource_table_use}",
-            "cooldown_datetime" = "2035-06-08 00:00:00"
+            "cooldown_datetime" = "${futureTime}"
             );
         """
         assertEquals(storage_exist.call("drop_policy_test_has_table_binded_hdfs"), true)


### PR DESCRIPTION
…



### What problem does this PR solve?

This PR updates the test case for creating a storage policy to use relative time (e.g., now() + interval) instead of an absolute UTC timestamp when setting the cooldown_datetime property.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

