### PR TITLE
[feat](param-refactor)Refactor RemoteFS: Decouple HDFS-Specific Logic and Align with Native Object Storage Protocols

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
@@ -68,6 +68,17 @@ public interface FileSystem {
 
     Status makeDir(String remotePath);
 
+    /*
+     * List files in remotePath
+     * @param remotePath remote path
+     * @param recursive whether to list files recursively
+     * <pre>
+     * If the path is a directory,
+     *   if recursive is false, returns files in the directory;
+     *   if recursive is true, return files in the subtree rooted at the path.
+     * If the path is a file, return the file's status and block locations.
+     * </pre>
+     * */
     Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result);
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -423,4 +423,10 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
         }
         return st;
     }
+
+    @Override
+    public void close() throws Exception {
+        // Create a BlobServiceClient instance (thread-safe and reusable).
+       // Note: BlobServiceClient does NOT implement Closeable and does not require explicit closing.
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
  * It is just used for reading remote object storage on cloud.
  * @param <C> cloud SDK Client
  */
-public interface ObjStorage<C> {
+public interface ObjStorage<C> extends AutoCloseable {
 
     // CHUNK_SIZE for multi part upload
     int CHUNK_SIZE = 5 * 1024 * 1024;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -27,6 +27,7 @@ import org.apache.doris.fs.remote.RemoteFile;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.fs.Path;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
@@ -52,6 +54,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
@@ -72,14 +75,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class S3ObjStorage implements ObjStorage<S3Client> {
     private static final Logger LOG = LogManager.getLogger(S3ObjStorage.class);
     private S3Client client;
-
-    protected Map<String, String> properties;
 
     protected AbstractS3CompatibleProperties s3Properties;
 
@@ -88,18 +89,10 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
     private boolean forceParsingByStandardUri = false;
 
     public S3ObjStorage(AbstractS3CompatibleProperties properties) {
-        this.properties = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        setProperties(properties);
-    }
-
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    protected void setProperties(AbstractS3CompatibleProperties properties) {
         this.s3Properties = properties;
         isUsePathStyle = Boolean.parseBoolean(properties.getUsePathStyle());
         forceParsingByStandardUri = Boolean.parseBoolean(s3Properties.getForceParsingByStandardUrl());
+
     }
 
     @Override
@@ -114,6 +107,116 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                     isUsePathStyle, s3Properties.getAwsCredentialsProvider());
         }
         return client;
+    }
+
+    /**
+     * Lists files from a given S3 path, optionally recursively, and populates the provided result list
+     * with metadata about each file.
+     *
+     * @param remotePath the full S3 path, e.g., "s3://my-bucket/path/to/dir/"
+     * @param recursive  whether to list files recursively
+     * @param result     the list to populate with file metadata
+     * @return Status.OK if successful, or an appropriate error status
+     */
+    public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
+        try {
+            S3URI s3Uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            String bucket = s3Uri.getBucket();
+            // prefix should end with '/' for directories
+            String prefix = s3Uri.getKey();
+            // obtain configured S3 client
+            S3Client s3 = getClient();
+            String continuationToken = null;
+            do {
+                ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+                        .bucket(bucket)
+                        .prefix(prefix);
+
+                if (!recursive) {
+                    requestBuilder.delimiter("/"); // group "directories" at current level
+                }
+
+                if (continuationToken != null) {
+                    requestBuilder.continuationToken(continuationToken);
+                }
+
+                ListObjectsV2Response response = s3.listObjectsV2(requestBuilder.build());
+                // Files
+                for (S3Object s3Object : response.contents()) {
+                    if (s3Object.key().equals(prefix)) {
+                        continue;
+                    }
+                    RemoteFile remoteFile = new RemoteFile(
+                            toPath(bucket, s3Object.key()),
+                            false,
+                            s3Object.size(),
+                            0L,
+                            s3Object.lastModified().toEpochMilli(),
+                            null
+                    );
+                    result.add(remoteFile);
+                }
+
+                // Simulated directories
+                if (!recursive) {
+                    for (CommonPrefix dir : response.commonPrefixes()) {
+                        RemoteFile remoteFile = new RemoteFile(
+                                toPath(bucket, dir.prefix()),
+                                true,
+                                0L,
+                                0L,
+                                0L,
+                                null
+                        );
+                        result.add(remoteFile);
+                    }
+                }
+
+                continuationToken = response.nextContinuationToken();
+
+            } while (continuationToken != null);
+
+        } catch (NoSuchKeyException e) {
+            return new Status(Status.ErrCode.NOT_FOUND, e.getMessage());
+        } catch (Exception e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        }
+
+        return Status.OK;
+    }
+
+    private Path toPath(String bucket, String key) {
+        return new Path("s3://" + bucket + "/" + key);
+    }
+
+    public Status listDirectories(String remotePath, Set<String> result) {
+        try {
+            S3URI s3Uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
+            String bucket = s3Uri.getBucket();
+            String prefix = s3Uri.getKey();
+            ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .prefix(prefix)
+                    .delimiter("/");
+
+            String continuationToken = null;
+            do {
+                if (continuationToken != null) {
+                    requestBuilder.continuationToken(continuationToken);
+                }
+
+                ListObjectsV2Response response = getClient().listObjectsV2(requestBuilder.build());
+
+                for (CommonPrefix dir : response.commonPrefixes()) {
+                    result.add("s3://" + bucket + "/" + dir.prefix());
+                }
+                continuationToken = response.nextContinuationToken();
+            } while (continuationToken != null);
+
+        } catch (Exception e) {
+            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
+        }
+        return Status.OK;
     }
 
 
@@ -488,6 +591,18 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                         elementCnt, remotePath, roundCnt, matchCnt,
                         duration / 1000 / 1000);
             }
+        }
+    }
+
+    @Override
+    public synchronized void close() throws Exception {
+        if (client != null) {
+            try {
+                client.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close S3 client: {}", e.getMessage(), e);
+            }
+            client = null;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
@@ -48,11 +48,6 @@ public class AzureFileSystem extends ObjFileSystem {
     }
 
     @Override
-    public Status globList(String remotePath, List<RemoteFile> result) {
-        return this.globList(remotePath, result, false);
-    }
-
-    @Override
     public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
         AzureObjStorage azureObjStorage = (AzureObjStorage) getObjStorage();
         return azureObjStorage.globList(remotePath, result, fileNameOnly);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/AzureFileSystem.java
@@ -19,14 +19,13 @@ package org.apache.doris.fs.remote;
 
 import org.apache.doris.analysis.StorageBackend.StorageType;
 import org.apache.doris.backup.Status;
-import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.AzureProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.fs.obj.AzureObjStorage;
 
-import org.apache.hadoop.fs.FileSystem;
-
+import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 public class AzureFileSystem extends ObjFileSystem {
 
@@ -39,8 +38,18 @@ public class AzureFileSystem extends ObjFileSystem {
     }
 
     @Override
-    protected FileSystem nativeFileSystem(String remotePath) throws UserException {
-        return null;
+    public Status renameDir(String origFilePath, String destFilePath) {
+        throw new UnsupportedOperationException("Renaming directories is not supported in Azure File System.");
+    }
+
+    @Override
+    public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
+        throw new UnsupportedOperationException("Listing files is not supported in Azure File System.");
+    }
+
+    @Override
+    public Status globList(String remotePath, List<RemoteFile> result) {
+        return this.globList(remotePath, result, false);
     }
 
     @Override
@@ -50,7 +59,23 @@ public class AzureFileSystem extends ObjFileSystem {
     }
 
     @Override
+    public Status listDirectories(String remotePath, Set<String> result) {
+        throw new UnsupportedOperationException("Listing directories is not supported in Azure File System.");
+    }
+
+    @Override
     public StorageProperties getStorageProperties() {
         return azureProperties;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                objStorage.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/BrokerFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/BrokerFileSystem.java
@@ -709,4 +709,9 @@ public class BrokerFileSystem extends RemoteFileSystem {
     public StorageProperties getStorageProperties() {
         return brokerProperties;
     }
+
+    @Override
+    public void close() throws IOException {
+        //  do nothing
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFileSystem.java
@@ -22,83 +22,21 @@ import org.apache.doris.backup.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.fs.PersistentFileSystem;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 
 import java.io.Closeable;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class RemoteFileSystem extends PersistentFileSystem implements Closeable {
-    // this field will be visited by multi-threads, better use volatile qualifier
-    protected volatile org.apache.hadoop.fs.FileSystem dfsFileSystem = null;
-    private final ReentrantLock fsLock = new ReentrantLock();
+
     protected AtomicBoolean closed = new AtomicBoolean(false);
 
     public RemoteFileSystem(String name, StorageBackend.StorageType type) {
         super(name, type);
-    }
-
-    /*
-     * todo In the previous design, RemoteFileSystem was modeled as an HDFS-style
-     * file system. However, this is no longer accurate — services like Azure
-     * and the refactored S3 do not follow the same semantics. We need to rethink
-     * the modeling of RemoteFileSystem. At the very least, this method should be
-     * deprecated and removed in the future, as keeping it may lead to functional inconsistencies.
-     */
-    protected org.apache.hadoop.fs.FileSystem nativeFileSystem(String remotePath) throws UserException {
-        throw new UserException("Not support to getFileSystem.");
-    }
-
-    @Override
-    public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
-        try {
-            org.apache.hadoop.fs.FileSystem fileSystem = nativeFileSystem(remotePath);
-            Path locatedPath = new Path(remotePath);
-            RemoteIterator<LocatedFileStatus> locatedFiles = getLocatedFiles(recursive, fileSystem, locatedPath);
-            while (locatedFiles.hasNext()) {
-                LocatedFileStatus fileStatus = locatedFiles.next();
-                RemoteFile location = new RemoteFile(
-                        fileStatus.getPath(), fileStatus.isDirectory(), fileStatus.getLen(),
-                        fileStatus.getBlockSize(), fileStatus.getModificationTime(), fileStatus.getBlockLocations());
-                result.add(location);
-            }
-        } catch (FileNotFoundException e) {
-            return new Status(Status.ErrCode.NOT_FOUND, e.getMessage());
-        } catch (Exception e) {
-            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
-        }
-        return Status.OK;
-    }
-
-    protected RemoteIterator<LocatedFileStatus> getLocatedFiles(boolean recursive,
-                FileSystem fileSystem, Path locatedPath) throws IOException {
-        return fileSystem.listFiles(locatedPath, recursive);
-    }
-
-    @Override
-    public Status listDirectories(String remotePath, Set<String> result) {
-        try {
-            FileSystem fileSystem = nativeFileSystem(remotePath);
-            FileStatus[] fileStatuses = getFileStatuses(remotePath, fileSystem);
-            result.addAll(
-                    Arrays.stream(fileStatuses)
-                            .filter(FileStatus::isDirectory)
-                            .map(file -> file.getPath().toString() + "/")
-                            .collect(ImmutableSet.toImmutableSet()));
-        } catch (Exception e) {
-            return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
-        }
-        return Status.OK;
     }
 
     protected FileStatus[] getFileStatuses(String remotePath, FileSystem fileSystem) throws IOException {
@@ -126,20 +64,6 @@ public abstract class RemoteFileSystem extends PersistentFileSystem implements C
         runWhenPathNotExist.run();
 
         return rename(origFilePath, destFilePath);
-    }
-
-    @Override
-    public void close() throws IOException {
-        fsLock.lock();
-        try {
-            if (!closed.getAndSet(true)) {
-                if (dfsFileSystem != null) {
-                    dfsFileSystem.close();
-                }
-            }
-        } finally {
-            fsLock.unlock();
-        }
     }
 
     public boolean connectivityTest(List<String> filePaths) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -55,21 +55,10 @@ public class S3FileSystem extends ObjFileSystem {
         this.properties.putAll(s3Properties.getOrigProps());
     }
 
-
-    @Override
-    public Status renameDir(String origFilePath, String destFilePath) {
-        return super.renameDir(origFilePath, destFilePath);
-    }
-
     @Override
     public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
         S3ObjStorage objStorage = (S3ObjStorage) this.objStorage;
         return objStorage.listFiles(remotePath, recursive, result);
-    }
-
-    @Override
-    public Status globList(String remotePath, List<RemoteFile> result) {
-        return this.globList(remotePath, result, false);
     }
 
     // broker file pattern glob is too complex, so we use hadoop directly

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -20,18 +20,16 @@ package org.apache.doris.fs.remote;
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.backup.Status;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.security.authentication.HadoopAuthenticator;
 import org.apache.doris.common.util.S3URI;
 import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.fs.obj.S3ObjStorage;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -39,12 +37,9 @@ import java.util.Set;
 public class S3FileSystem extends ObjFileSystem {
 
     private static final Logger LOG = LogManager.getLogger(S3FileSystem.class);
-    private HadoopAuthenticator authenticator = null;
     private final AbstractS3CompatibleProperties s3Properties;
 
-
     public S3FileSystem(AbstractS3CompatibleProperties s3Properties) {
-
         super(StorageBackend.StorageType.S3.name(), StorageBackend.StorageType.S3,
                 new S3ObjStorage(s3Properties));
         this.s3Properties = s3Properties;
@@ -62,14 +57,32 @@ public class S3FileSystem extends ObjFileSystem {
 
 
     @Override
-    protected FileSystem nativeFileSystem(String remotePath) throws UserException {
-        throw new UserException("S3 does not support native file system");
+    public Status renameDir(String origFilePath, String destFilePath) {
+        return super.renameDir(origFilePath, destFilePath);
     }
 
+    @Override
+    public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
+        S3ObjStorage objStorage = (S3ObjStorage) this.objStorage;
+        return objStorage.listFiles(remotePath, recursive, result);
+    }
+
+    @Override
+    public Status globList(String remotePath, List<RemoteFile> result) {
+        return this.globList(remotePath, result, false);
+    }
+
+    // broker file pattern glob is too complex, so we use hadoop directly
     @Override
     public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
         S3ObjStorage objStorage = (S3ObjStorage) this.objStorage;
         return objStorage.globList(remotePath, result, fileNameOnly);
+    }
+
+    @Override
+    public Status listDirectories(String remotePath, Set<String> result) {
+        S3ObjStorage objStorage = (S3ObjStorage) this.objStorage;
+        return objStorage.listDirectories(remotePath, result);
     }
 
     @Override
@@ -96,8 +109,14 @@ public class S3FileSystem extends ObjFileSystem {
         return false;
     }
 
-    @VisibleForTesting
-    public HadoopAuthenticator getAuthenticator() {
-        return authenticator;
+    @Override
+    public void close() throws IOException {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                objStorage.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -137,9 +137,6 @@ public class DFSFileSystem extends RemoteFileSystem {
                 }
                 if (dfsFileSystem == null) {
                     Configuration conf = hdfsProperties.getHadoopConfiguration();
-                    // TODO: Temporarily disable the HDFS file system cache to prevent instances from being closed by
-                    //  each other in V1. This line can be removed once V1 and V2 are unified.
-                    conf.set("fs.hdfs.impl.disable.cache", "true");
                     authenticator = HadoopAuthenticator.getHadoopAuthenticator(conf);
                     try {
                         dfsFileSystem = authenticator.doAs(() -> {
@@ -161,8 +158,7 @@ public class DFSFileSystem extends RemoteFileSystem {
     }
 
     protected RemoteIterator<LocatedFileStatus> getLocatedFiles(boolean recursive,
-                                                                FileSystem fileSystem, Path locatedPath)
-            throws IOException {
+                FileSystem fileSystem, Path locatedPath) throws IOException {
         return authenticator.doAs(() -> fileSystem.listFiles(locatedPath, recursive));
     }
 
@@ -272,7 +268,7 @@ public class DFSFileSystem extends RemoteFileSystem {
      * @throws IOException when read data error.
      */
     private static ByteBuffer readStreamBuffer(FSDataInputStream fsDataInputStream, long readOffset, long length)
-            throws IOException {
+                throws IOException {
         synchronized (fsDataInputStream) {
             long currentStreamOffset;
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystemPhantomReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystemPhantomReference.java
@@ -15,14 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.fs.remote;
+package org.apache.doris.fs.remote.dfs;
 
 import org.apache.hadoop.fs.FileSystem;
 
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 
-public class RemoteFileSystemPhantomReference extends PhantomReference<RemoteFileSystem> {
+public class DFSFileSystemPhantomReference extends PhantomReference<DFSFileSystem> {
 
     private FileSystem fs;
 
@@ -37,7 +37,7 @@ public class RemoteFileSystemPhantomReference extends PhantomReference<RemoteFil
      * @param q        the queue with which the reference is to be registered,
      *                 or {@code null} if registration is not required
      */
-    public RemoteFileSystemPhantomReference(RemoteFileSystem referent, ReferenceQueue<? super RemoteFileSystem> q) {
+    public DFSFileSystemPhantomReference(DFSFileSystem referent, ReferenceQueue<? super DFSFileSystem> q) {
         super(referent, q);
         this.fs = referent.dfsFileSystem;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.backup.Status;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
+import org.apache.doris.fs.remote.RemoteFile;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,16 +30,23 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.DeletedObject;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -48,6 +56,12 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class S3ObjStorageTest {
     private S3ObjStorage storage;
@@ -205,5 +219,305 @@ public class S3ObjStorageTest {
         InputStream content = new ByteArrayInputStream(new byte[10 * 1024 * 1024]); // 10 MB
         Status status = storage.multipartUpload("s3://bucket/key", content, 10 * 1024 * 1024);
         Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, status.getErrCode());
+    }
+
+    @Test
+    public void testListFiles_nonRecursive_filesOnly() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        ListObjectsV2Response response = ListObjectsV2Response.builder()
+                .contents(S3Object.builder()
+                        .key("folder/file.txt")
+                        .lastModified(Instant.now())
+                        .size(1024L)
+                        .build())
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(response);
+
+        Status status = storage.listFiles("s3://test-bucket/folder/", false, result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertFalse(result.get(0).isDirectory());
+    }
+
+    @Test
+    public void testListFiles_nonRecursive_withDirectory() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        ListObjectsV2Response response = ListObjectsV2Response.builder()
+                .commonPrefixes(CommonPrefix.builder().prefix("folder/subdir/").build())
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(response);
+
+        Status status = storage.listFiles("s3://test-bucket/folder/", false, result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).isDirectory());
+    }
+
+    @Test
+    public void testListFiles_recursive_filesAndSubdirs() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        ListObjectsV2Response response = ListObjectsV2Response.builder()
+                .contents(
+                        S3Object.builder().key("folder/a.txt").lastModified(Instant.now()).size(120L).build(),
+                        S3Object.builder().key("folder/sub/b.txt").lastModified(Instant.now()).size(20L).build()
+                ).build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(response);
+
+        Status status = storage.listFiles("s3://test-bucket/folder/", true, result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testListFiles_emptyDirectory() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        ListObjectsV2Response response = ListObjectsV2Response.builder().build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(response);
+
+        Status status = storage.listFiles("s3://test-bucket/empty/", false, result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testListFiles_keyEqualsPrefix_shouldBeSkipped() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        ListObjectsV2Response response = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("folder/").lastModified(Instant.now()).build())
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(response);
+
+        Status status = storage.listFiles("s3://test-bucket/folder/", true, result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testListFiles_withPagination() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        ListObjectsV2Response page1 = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("folder/file1.txt").lastModified(Instant.now()).size(1L).build())
+                .nextContinuationToken("next-token")
+                .build();
+
+        ListObjectsV2Response page2 = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("folder/file2.txt").size(2L).lastModified(Instant.now()).build())
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        Status status = storage.listFiles("s3://test-bucket/folder/", true, result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testListFiles_noSuchKeyException() {
+        List<RemoteFile> result = new ArrayList<>();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenThrow(NoSuchKeyException.builder().message("not found").build());
+
+        Status status = storage.listFiles("s3://test-bucket/folder/", false, result);
+
+        Assertions.assertEquals(Status.ErrCode.NOT_FOUND, status.getErrCode());
+    }
+
+    @Test
+    public void testListFiles_otherException() {
+        List<RemoteFile> result = new ArrayList<>();
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenThrow(new RuntimeException("something went wrong"));
+        Status status = storage.listFiles("s3://test-bucket/folder/", false, result);
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, status.getErrCode());
+    }
+
+    @Test
+    public void testCopyObject_success() {
+        CopyObjectResponse response = CopyObjectResponse.builder().build();
+        Mockito.when(mockClient.copyObject(Mockito.any(CopyObjectRequest.class))).thenReturn(response);
+        Status status = storage.copyObject("s3://bucket/source.txt", "s3://bucket/target.txt");
+        Assertions.assertEquals(Status.OK, status);
+    }
+
+    @Test
+    public void testCopyObject_s3Exception() {
+        Mockito.when(mockClient.copyObject(Mockito.any(CopyObjectRequest.class)))
+                .thenThrow(S3Exception.builder().message("Access denied").build());
+        Status status = storage.copyObject("s3://bucket/source.txt", "s3://bucket/target.txt");
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, status.getErrCode());
+        Assertions.assertTrue(status.getErrMsg().contains("copy file failed"));
+    }
+
+    @Test
+    public void testDeleteObjects_success_singlePage() throws DdlException {
+        DeleteObjectsResponse mockResp = DeleteObjectsResponse.builder().deleted(
+                DeletedObject.builder().key("folder/file1.txt").build(),
+                DeletedObject.builder().key("folder/file2.txt").build()
+        ).build();
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(
+                ListObjectsV2Response.builder().contents(
+                        S3Object.builder().key("folder/file1.txt").lastModified(Instant.now()).size(1L).build(),
+                        S3Object.builder().key("folder/file2.txt").lastModified(Instant.now()).size(1L).build()
+                ).isTruncated(false).build()
+        );
+        Mockito.when(mockClient.deleteObjects(Mockito.any(DeleteObjectsRequest.class))).thenReturn(mockResp);
+        Status status = storage.deleteObjects("s3://bucket/folder/");
+        Assertions.assertEquals(Status.OK, status);
+    }
+
+    @Test
+    public void testDeleteObjects_success_multiPage() throws DdlException {
+        ListObjectsV2Response page1 = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("folder/file1.txt").lastModified(Instant.now()).size(1L).build())
+                .nextContinuationToken("token-2")
+                .isTruncated(true)
+                .build();
+
+        ListObjectsV2Response page2 = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("folder/file2.txt").lastModified(Instant.now()).size(1L).build())
+                .isTruncated(false)
+                .build();
+
+        DeleteObjectsResponse deleteResp = DeleteObjectsResponse.builder()
+                .deleted(
+                        DeletedObject.builder().key("folder/file1.txt").build(),
+                        DeletedObject.builder().key("folder/file2.txt").build()
+                )
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(page1)
+                .thenReturn(page2);
+        Mockito.when(mockClient.deleteObjects(Mockito.any(DeleteObjectsRequest.class))).thenReturn(deleteResp);
+
+        Status status = storage.deleteObjects("s3://bucket/folder/");
+        Assertions.assertEquals(Status.OK, status);
+    }
+
+    @Test
+    public void testDeleteObjects_deleteThrowsRuntimeException() throws DdlException {
+        ListObjectsV2Response listResp = ListObjectsV2Response.builder().contents(
+                S3Object.builder().key("folder/file1.txt").lastModified(Instant.now()).size(1L).build()
+        ).isTruncated(false).build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(listResp);
+        Mockito.when(mockClient.deleteObjects(Mockito.any(DeleteObjectsRequest.class)))
+                .thenThrow(new RuntimeException("delete failed"));
+
+        Status status = storage.deleteObjects("s3://bucket/folder/");
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, status.getErrCode());
+        Assertions.assertTrue(status.getErrMsg().contains("delete objects failed"));
+    }
+
+    @Test
+    public void testDeleteObjects_emptyList() throws DdlException {
+        ListObjectsV2Response listResp = ListObjectsV2Response.builder()
+                .contents(Collections.emptyList())
+                .isTruncated(false)
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(listResp);
+
+        Status status = storage.deleteObjects("s3://bucket/empty/");
+        Assertions.assertEquals(Status.OK, status);
+    }
+
+    @Test
+    public void testListDirectories_success() {
+        ListObjectsV2Response response = ListObjectsV2Response.builder()
+                .commonPrefixes(
+                        CommonPrefix.builder().prefix("folder/a/").build(),
+                        CommonPrefix.builder().prefix("folder/b/").build()
+                )
+                .isTruncated(false)
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(response);
+
+        Set<String> result = new HashSet<>();
+        Status status = storage.listDirectories("s3://bucket/folder/", result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertTrue(result.contains("s3://bucket/folder/a/"));
+        Assertions.assertTrue(result.contains("s3://bucket/folder/b/"));
+    }
+
+    @Test
+    public void testListDirectories_empty() {
+        ListObjectsV2Response response = ListObjectsV2Response.builder()
+                .commonPrefixes(Collections.emptyList())
+                .isTruncated(false)
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(response);
+
+        Set<String> result = new HashSet<>();
+        Status status = storage.listDirectories("s3://bucket/folder/", result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testListDirectories_multiPage() {
+        ListObjectsV2Response page1 = ListObjectsV2Response.builder()
+                .commonPrefixes(CommonPrefix.builder().prefix("folder/a/").build())
+                .isTruncated(true)
+                .nextContinuationToken("token-2")
+                .build();
+
+        ListObjectsV2Response page2 = ListObjectsV2Response.builder()
+                .commonPrefixes(CommonPrefix.builder().prefix("folder/b/").build())
+                .isTruncated(false)
+                .build();
+
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        Set<String> result = new HashSet<>();
+        Status status = storage.listDirectories("s3://bucket/folder/", result);
+
+        Assertions.assertEquals(Status.OK, status);
+        Assertions.assertTrue(result.contains("s3://bucket/folder/a/"));
+        Assertions.assertTrue(result.contains("s3://bucket/folder/b/"));
+    }
+
+    @Test
+    public void testListDirectories_exception() {
+        Mockito.when(mockClient.listObjectsV2(Mockito.any(ListObjectsV2Request.class)))
+                .thenThrow(new RuntimeException("S3 error"));
+
+        Set<String> result = new HashSet<>();
+        Status status = storage.listDirectories("s3://bucket/folder/", result);
+
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, status.getErrCode());
+        Assertions.assertTrue(status.getErrMsg().contains("S3 error"));
+        Assertions.assertTrue(result.isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/remote/RemoteFileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/remote/RemoteFileSystemTest.java
@@ -21,158 +21,175 @@ import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.backup.Status;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.HashSet;
+import java.io.IOException;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RemoteFileSystemTest {
 
     private RemoteFileSystem remoteFileSystem;
     private FileSystem mockFileSystem;
 
-    @BeforeEach
-    void setUp() {
-        remoteFileSystem = Mockito.spy(new RemoteFileSystem("test", StorageBackend.StorageType.HDFS) {
-            @Override
-            public StorageProperties getStorageProperties() {
-                return null;
-            }
+    private static class DummyRemoteFileSystem extends RemoteFileSystem {
+        public DummyRemoteFileSystem() {
+            super("dummy", StorageBackend.StorageType.HDFS);
+        }
 
-            @Override
-            public Status exists(String remotePath) {
-                return null;
-            }
+        @Override
+        public Status exists(String path) {
+            return Status.OK;
+        }
 
-            @Override
-            public Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize) {
-                return null;
-            }
+        @Override
+        public Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize) {
+            return null;
+        }
 
-            @Override
-            public Status upload(String localPath, String remotePath) {
-                return null;
-            }
+        @Override
+        public Status upload(String localPath, String remotePath) {
+            return null;
+        }
 
-            @Override
-            public Status directUpload(String content, String remoteFile) {
-                return null;
-            }
+        @Override
+        public Status directUpload(String content, String remoteFile) {
+            return null;
+        }
 
-            @Override
-            public Status rename(String origFilePath, String destFilePath) {
-                return null;
-            }
+        @Override
+        public Status makeDir(String path) {
+            return Status.OK;
+        }
 
-            @Override
-            public Status delete(String remotePath) {
-                return null;
-            }
+        @Override
+        public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
+            return null;
+        }
 
-            @Override
-            public Status makeDir(String remotePath) {
-                return null;
-            }
+        @Override
+        public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
+            return null;
+        }
 
-            @Override
-            public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
-                return null;
-            }
-        });
-        mockFileSystem = Mockito.mock(FileSystem.class);
+        @Override
+        public Status rename(String src, String dst) {
+            return new Status(Status.ErrCode.OK, "Rename operation not implemented in DummyRemoteFileSystem");
+        }
+
+        @Override
+        public Status delete(String remotePath) {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+
+        @Override
+        public StorageProperties getStorageProperties() {
+            return null;
+        }
+
+        public Status rename(String path) {
+            return new Status(Status.ErrCode.OK, "Rename operation not implemented in DummyRemoteFileSystem");
+        }
     }
 
     @Test
-    @DisplayName("listFiles should return OK status and populate result list when files are found")
-    void listFilesReturnsOkWhenFilesFound() throws Exception {
-        String remotePath = "/test/path";
-        List<RemoteFile> result = new ArrayList<>();
-        RemoteIterator<LocatedFileStatus> mockIterator = Mockito.mock(RemoteIterator.class);
-        LocatedFileStatus mockFileStatus = Mockito.mock(LocatedFileStatus.class);
+    public void testRenameDir_destExists() {
+        RemoteFileSystem fs = new DummyRemoteFileSystem() {
+            @Override
+            public Status exists(String path) {
+                if (path.equals("s3://bucket/target")) {
+                    return Status.OK;
+                }
+                return new Status(Status.ErrCode.NOT_FOUND, "not found");
+            }
 
-        Mockito.doReturn(mockFileSystem).when(remoteFileSystem).nativeFileSystem(remotePath);
-        Mockito.when(mockFileSystem.listFiles(new Path(remotePath), true)).thenReturn(mockIterator);
-        Mockito.when(mockIterator.hasNext()).thenReturn(true, false);
-        Mockito.when(mockIterator.next()).thenReturn(mockFileStatus);
-        Mockito.when(mockFileStatus.getPath()).thenReturn(new Path("/test/path/file1"));
-        Mockito.when(mockFileStatus.isDirectory()).thenReturn(false);
-        Mockito.when(mockFileStatus.getLen()).thenReturn(100L);
-        Mockito.when(mockFileStatus.getBlockSize()).thenReturn(128L);
-        Mockito.when(mockFileStatus.getModificationTime()).thenReturn(123456789L);
-        Mockito.when(mockFileStatus.getBlockLocations()).thenReturn(null);
-
-        Status status = remoteFileSystem.listFiles(remotePath, true, result);
-
-        Assertions.assertEquals(Status.OK, status);
-        Assertions.assertEquals(1, result.size());
-        Assertions.assertEquals("/test/path/file1", result.get(0).getPath().toString());
-    }
-
-    @Test
-    @DisplayName("listFiles should return NOT_FOUND status when FileNotFoundException is thrown")
-    void listFilesReturnsNotFoundWhenFileNotFoundExceptionThrown() throws Exception {
-
-        mockFileSystem = Mockito.mock(FileSystem.class);
-        String remotePath = "/nonexistent/path";
-        List<RemoteFile> result = new ArrayList<>();
-        Mockito.doReturn(mockFileSystem).when(remoteFileSystem).nativeFileSystem(remotePath);
-        Mockito.doThrow(new FileNotFoundException("File not found"))
-                .when(mockFileSystem).listFiles(Mockito.any(Path.class), Mockito.anyBoolean());
-
-        Status status = remoteFileSystem.listFiles(remotePath, true, result);
-
-        Assertions.assertEquals(Status.ErrCode.NOT_FOUND, status.getErrCode());
-        Assertions.assertTrue(result.isEmpty());
-    }
-
-    @Test
-    @DisplayName("listDirectories should return OK status and populate result set with directories")
-    void listDirectoriesReturnsOkWhenDirectoriesFound() throws Exception {
-        String remotePath = "/test/path";
-        Set<String> result = new HashSet<>();
-        FileStatus[] mockFileStatuses = {
-                Mockito.mock(FileStatus.class),
-                Mockito.mock(FileStatus.class)
+            @Override
+            public Status rename(String path) {
+                return null;
+            }
         };
 
-        Mockito.doReturn(mockFileSystem).when(remoteFileSystem).nativeFileSystem(remotePath);
-        Mockito.when(mockFileSystem.listStatus(new Path(remotePath))).thenReturn(mockFileStatuses);
-        Mockito.when(mockFileStatuses[0].isDirectory()).thenReturn(true);
-        Mockito.when(mockFileStatuses[0].getPath()).thenReturn(new Path("/test/path/dir1"));
-        Mockito.when(mockFileStatuses[1].isDirectory()).thenReturn(false);
-
-        Status status = remoteFileSystem.listDirectories(remotePath, result);
-
-        Assertions.assertEquals(Status.OK, status);
-        Assertions.assertEquals(1, result.size());
-        Assertions.assertTrue(result.contains("/test/path/dir1/"));
+        Status result = fs.renameDir("s3://bucket/src", "s3://bucket/target", () -> {
+        });
+        Assertions.assertFalse(result.ok());
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, result.getErrCode());
     }
 
     @Test
-    @DisplayName("renameDir should return COMMON_ERROR when destination directory exists")
-    void renameDirReturnsErrorWhenDestinationExists() throws Exception {
-        String origFilePath = "/test/path/orig";
-        String destFilePath = "/test/path/dest";
+    public void testRenameDir_makeDirSuccess() {
+        AtomicBoolean runFlag = new AtomicBoolean(false);
 
-        Mockito.doReturn(new Status(Status.ErrCode.OK, ""))
-                .when(remoteFileSystem).exists(destFilePath);
+        RemoteFileSystem fs = new DummyRemoteFileSystem() {
+            @Override
+            public Status exists(String path) {
+                if (path.equals("s3://bucket/target")) {
+                    return new Status(Status.ErrCode.NOT_FOUND, "not found");
+                }
+                if (path.equals("s3://bucket")) {
+                    return new Status(Status.ErrCode.NOT_FOUND, "not found");
+                }
+                return Status.OK;
+            }
 
-        Status status = remoteFileSystem.renameDir(origFilePath, destFilePath, () -> {
+            @Override
+            public Status makeDir(String path) {
+                return Status.OK;
+            }
+
+            @Override
+            public Status rename(String src, String dst) {
+                return Status.OK;
+            }
+
+            @Override
+            public Status rename(String path) {
+                return null;
+            }
+        };
+
+        Status result = fs.renameDir("s3://bucket/src", "s3://bucket/target", () -> runFlag.set(true));
+        Assertions.assertTrue(result.ok());
+        Assertions.assertTrue(runFlag.get());
+    }
+
+    @Test
+    public void testRenameDir_makeDirFails() {
+        RemoteFileSystem fs = new DummyRemoteFileSystem() {
+            @Override
+            public Status exists(String path) {
+                if (path.equals("s3://bucket/target")) {
+                    return new Status(Status.ErrCode.NOT_FOUND, "not found");
+                }
+                if (path.equals("s3://bucket")) {
+                    return new Status(Status.ErrCode.NOT_FOUND, "not found");
+                }
+                return Status.OK;
+            }
+
+            @Override
+            public Status rename(String src, String dst) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "mkdir failed");
+            }
+
+            @Override
+            public Status rename(String path) {
+                return new Status(Status.ErrCode.COMMON_ERROR, "mkdir failed");
+            }
+
+        };
+
+        Status result = fs.renameDir("s3://bucket/src", "s3://bucket/target", () -> {
+            //no-op
         });
-
-        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, status.getErrCode());
-        Assertions.assertEquals("Destination directory already exists: /test/path/dest", status.getErrMsg());
+        Assertions.assertFalse(result.ok());
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, result.getErrCode());
+        Assertions.assertTrue(result.getErrMsg().contains("mkdir failed"));
     }
 }


### PR DESCRIPTION
### Background
#50238 

Historically, the `RemoteFS` abstraction was designed around the HDFS protocol and was also used to access object storage systems like S3 using Hadoop's HDFS-compatible APIs. However, this model no longer reflects the current state of our architecture:

- We have introduced native protocol support for AzureFS, bypassing Hadoop entirely.
- Recent enhancements have moved S3 access from the Hadoop HDFS layer to direct usage of the native S3 protocol.

These changes reflect a shift in the domain model of `RemoteFS`, which now spans native object storage systems beyond traditional HDFS.

### Changes

- **Decoupled HDFS-specific logic** from `RemoteFS` into a dedicated module/component.
- **Reorganized abstraction boundaries** to make `RemoteFS` neutral with respect to underlying protocols (HDFS, S3, Azure, etc).
- **Renamed or removed misleading HDFS-oriented configurations and references**.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

