### PR TITLE
[improvment](regression) sleep after waitForSchemaChangeDone

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/WaitForAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/WaitForAction.groovy
@@ -73,5 +73,10 @@ class WaitForAction implements SuiteAction {
             }
             return false;
         });
+        // In the current implementation, Doris's ALTER TABLE operation 
+        // cannot ensure the table status is transitioned to NORMAL state atomically 
+        // upon job completion. As a workaround, we introduce a sleep interval to await 
+        // the table's state normalization, thereby avoiding failures in follow-up operations.
+        sleep(300)
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Do schema change after waitForSchemaChangeDone of another schema change sometimes failed.
The reason is:
In the current implementation, Doris's ALTER TABLE operation cannot ensure the table status is transitioned to NORMAL state atomically upon job completion. 

As a workaround, this PR introduce a sleep interval to await the table's state normalization, thereby avoiding failures in follow-up operations.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

