### PR TITLE
[fix](expr) avoid explode serialize in gson

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -103,8 +103,10 @@ public final class FeMetaVersion {
 
     public static final int VERSION_140 = 140;
 
+    public static final int VERSION_141 = 141;
+
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_140;
+    public static final int VERSION_CURRENT = VERSION_141;
 
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -643,6 +643,7 @@ public class GsonUtils {
             .registerTypeAdapter(ImmutableList.class, new ImmutableListDeserializer())
             .registerTypeAdapter(AtomicBoolean.class, new AtomicBooleanAdapter())
             .registerTypeAdapter(PartitionKey.class, new PartitionKey.PartitionKeySerializer())
+            .registerTypeAdapter(FunctionCallExpr.class, new FunctionCallExpr.FunctionCallExprSerializer())
             .registerTypeAdapter(Range.class, new RangeUtils.RangeSerializer()).setExclusionStrategies(
                     new ExclusionStrategy() {
                         @Override

--- a/regression-test/suites/ddl_p0/test_alias_function.groovy
+++ b/regression-test/suites/ddl_p0/test_alias_function.groovy
@@ -31,4 +31,132 @@ suite("test_alias_function") {
           sql """create GLOBAL ALIAS FUNCTION userlevel(bigint) with PARAMETER(level_score) as (CASE WHEN level_score < 0 THEN 0 WHEN level_score < 1000 THEN 1 WHEN level_score < 5000 THEN 2 WHEN level_score < 10000 THEN 3 WHEN level_score < 407160000 THEN 29 ELSE 30 END);"""
           exception "Not supported expr type"
     }
+
+
+    sql """DROP FUNCTION IF EXISTS userlevel(bigint)"""
+    test {
+          sql """CREATE GLOBAL ALIAS FUNCTION userlevel(bigint) WITH PARAMETER(level_score) AS
+            IF(level_score < 0, 0,
+
+                IF(level_score BETWEEN 0 AND 999, 1,
+
+                    IF(level_score BETWEEN 1000 AND 4999, 2,
+
+                        IF(level_score BETWEEN 5000 AND 9999, 3,
+
+                            IF(level_score BETWEEN 10000 AND 15999, 4,
+
+                                IF(level_score BETWEEN 16000 AND 23499, 5,
+
+                                    IF(level_score BETWEEN 23500 AND 33999, 6,
+
+                                        IF(level_score BETWEEN 34000 AND 47499, 7,
+
+                                            IF(level_score BETWEEN 47500 AND 63999, 8,
+
+                                                IF(level_score BETWEEN 64000 AND 83499, 9,
+
+                                                    IF(level_score BETWEEN 83500 AND 113499, 10,
+
+                                                        IF(level_score BETWEEN 113500 AND 155499, 11,
+
+                                                            IF(level_score BETWEEN 155500 AND 209499, 12,
+
+                                                                IF(level_score BETWEEN 209500 AND 275499, 13,
+
+                                                                    IF(level_score BETWEEN 275500 AND 353499, 14,
+
+                                                                        IF(level_score BETWEEN 353500 AND 533499, 15,
+
+                                                                            IF(level_score BETWEEN 533500 AND 785499, 16,
+
+                                                                                IF(level_score BETWEEN 785500 AND 1109499, 17,
+
+                                                                                    IF(level_score BETWEEN 1109500 AND 1505499, 18,
+
+                                                                                        IF(level_score BETWEEN 1505500 AND 1973499, 19,
+
+                                                                                            IF(level_score BETWEEN 1973500 AND 2333499, 20,
+
+                                                                                                IF(level_score BETWEEN 2333500 AND 2837499, 21,
+
+                                                                                                    IF(level_score BETWEEN 2837500 AND 3485499, 22,
+
+                                                                                                        IF(level_score BETWEEN 3485500 AND 4277499, 23,
+
+                                                                                                            IF(level_score BETWEEN 4277500 AND 5213499, 24,
+
+                                                                                                                IF(level_score BETWEEN 5213500 AND 25447499, 25,
+
+                                                                                                                    IF(level_score BETWEEN 25447500 AND 50894999, 26,
+
+                                                                                                                        IF(level_score BETWEEN 50895000 AND 101789999, 27,
+
+                                                                                                                            IF(level_score BETWEEN 101790000 AND 203579999, 28,
+
+                                                                                                                                IF(level_score BETWEEN 203580000 AND 407159999, 29,
+
+                                                                                                                                    IF(level_score >= 407160000, 30, 0)
+
+                                                                                                                                )
+
+                                                                                                                            )
+
+                                                                                                                        )
+
+                                                                                                                    )
+
+                                                                                                                )
+
+                                                                                                            )
+
+                                                                                                        )
+
+                                                                                                    )
+
+                                                                                                )
+
+                                                                                            )
+
+                                                                                        )
+
+                                                                                    )
+
+                                                                                )
+
+                                                                            )
+
+                                                                        )
+
+                                                                    )
+
+                                                                )
+
+                                                            )
+
+                                                        )
+
+                                                    )
+
+                                                )
+
+                                            )
+
+                                        )
+
+                                    )
+
+                                )
+
+                            )
+
+                        )
+
+                    )
+
+                )
+
+            )
+        """
+    }
 }


### PR DESCRIPTION
introduce by #34449.

Before #34449, expr is not serialized by FunctionCallExpr.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

