### PR TITLE
[fix](audit) fix potential NPE when auditing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -121,8 +121,10 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
     @Override
     public LogicalPlan visitTableValuedFunction(DorisParser.TableValuedFunctionContext ctx) {
         DorisParser.PropertyItemListContext properties = ctx.properties;
-        encryptProperty(visitPropertyItemList(properties), properties.start.getStartIndex(),
-                properties.stop.getStopIndex());
+        if (properties != null) {
+            encryptProperty(visitPropertyItemList(properties), properties.start.getStartIndex(),
+                    properties.stop.getStopIndex());
+        }
         return super.visitTableValuedFunction(ctx);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
@@ -244,7 +244,8 @@ public class CreateTableCommand extends Command implements NeedAuditEncryption, 
 
     @Override
     public boolean needAuditEncryption() {
-        return !createTableInfo.getEngineName().equalsIgnoreCase(CreateTableInfo.ENGINE_OLAP);
+        // ATTN: createTableInfo.getEngineName() may be null
+        return !CreateTableInfo.ENGINE_OLAP.equalsIgnoreCase(createTableInfo.getEngineName());
     }
 }
 


### PR DESCRIPTION
Related #47595

### What problem does this PR solve?

```
2025-05-13 04:56:37,695 WARN (mysql-nio-pool-0|120) [AuditLogHelper.logAuditLog():77] Failed to write audit log.
java.lang.NullPointerException: Cannot invoke "String.equalsIgnoreCase(String)" because the return value of "org.apache.doris.nereids.trees.plans.commands.info.CreateTableInfo.getEngineName()" is null
at org.apache.doris.nereids.trees.plans.commands.CreateTableCommand.needAuditEncryption(CreateTableCommand.java:247) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.trees.plans.commands.NeedAuditEncryption.geneEncryptionSQL(NeedAuditEncryption.java:36) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.AuditLogHelper.logAuditLogImpl(AuditLogHelper.java:280) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.AuditLogHelper.logAuditLog(AuditLogHelper.java:75) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.ConnectProcessor.auditAfterExec(ConnectProcessor.java:230) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:377) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:249) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:233) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:261) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:444) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

```
java.lang.NullPointerException: Cannot read field "start" because "properties" is null
at org.apache.doris.nereids.parser.LogicalPlanBuilderForEncryption.visitTableValuedFunction(LogicalPlanBuilderForEncryption.java:124) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.parser.LogicalPlanBuilderForEncryption.visitTableValuedFunction(LogicalPlanBuilderForEncryption.java:36) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.DorisParser$TableValuedFunctionContext.accept(DorisParser.java:41762) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.parser.LogicalPlanBuilder.plan(LogicalPlanBuilder.java:3226) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitRelation(LogicalPlanBuilder.java:3142) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.parser.LogicalPlanBuilder.withRelations(LogicalPlanBuilder.java:3977) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.nereids.parser.LogicalPlanBuilder.lambda$visitRelations$39(LogicalPlanBuilder.java:3152) ~[doris-fe.jar:1.2-SNAPSHOT]
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

