### PR TITLE
[fix](doris-compose) fix docker file create directory

### DIFF
--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -74,7 +74,8 @@ RUN sed -i -e s@/deb.debian.org/@/mirrors.aliyun.com/@g -e s@/security.debian.or
     && dpkg-reconfigure -f noninteractive tzdata \
     && apt-get clean
 
-RUN mkdir -p /opt/apache-doris/{fdb,coverage}
+RUN mkdir -p /opt/apache-doris/fdb \
+    && mkdir -p /opt/apache-doris/coverage
 
 RUN curl -f https://repo1.maven.org/maven2/org/jacoco/jacoco/${JACOCO_VERSION}/jacoco-${JACOCO_VERSION}.zip -o jacoco.zip \
     && mkdir /jacoco \


### PR DESCRIPTION
### What problem does this PR solve?

For Docker file command `RUN mkdir -p /opt/apache-doris/{fdb,coverage}`,   it wouldn't create two directories 'fdb' and 'coverage',    it only create one direcotry '{fdb,coverage}',    because expand the '{}' is the bash function,  and the Dockerfile command `RUN` wouldn't invoke bash call. Need to remove the '{}' in Dockerfile.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

