### PR TITLE
[Fix](Oss-Hdfs)ensure single URI and correct OSS-HDFS type detection

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/ConnectionProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/ConnectionProperties.java
@@ -85,10 +85,7 @@ public abstract class ConnectionProperties {
         if (Strings.isNullOrEmpty(resourceConfig)) {
             return new HashMap<>();
         }
-        if (Strings.isNullOrEmpty(origProps.get(resourceConfig))) {
-            return Maps.newHashMap();
-        }
-        Configuration conf = CatalogConfigFileUtils.loadConfigurationFromHadoopConfDir(origProps.get(resourceConfig));
+        Configuration conf = CatalogConfigFileUtils.loadConfigurationFromHadoopConfDir(resourceConfig);
         Map<String, String> confMap = Maps.newHashMap();
         for (Map.Entry<String, String> entry : conf) {
             confMap.put(entry.getKey(), entry.getValue());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/HMSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/HMSProperties.java
@@ -96,7 +96,7 @@ public class HMSProperties extends MetastoreProperties {
     @Override
     protected void initNormalizeAndCheckProps() {
         super.initNormalizeAndCheckProps();
-        hiveConfParams = loadConfigFromFile(getResourceConfigPropName());
+        hiveConfParams = loadConfigFromFile(hiveConfResourcesConfig);
         initHmsConnectionProperties();
     }
 
@@ -113,7 +113,7 @@ public class HMSProperties extends MetastoreProperties {
     }
 
     private void checkHiveConfResourcesConfig() {
-        loadConfigFromFile(getResourceConfigPropName());
+        loadConfigFromFile(hiveConfResourcesConfig);
     }
 
     public void toPaimonOptionsAndConf(Options options) {
@@ -125,10 +125,10 @@ public class HMSProperties extends MetastoreProperties {
     }
 
     protected Map<String, String> loadConfigFromFile(String resourceConfig) {
-        if (Strings.isNullOrEmpty(origProps.get(resourceConfig))) {
+        if (Strings.isNullOrEmpty(resourceConfig)) {
             return Maps.newHashMap();
         }
-        HiveConf conf = CatalogConfigFileUtils.loadHiveConfFromHiveConfDir(origProps.get(resourceConfig));
+        HiveConf conf = CatalogConfigFileUtils.loadHiveConfFromHiveConfDir(resourceConfig);
         Map<String, String> confMap = Maps.newHashMap();
         for (Map.Entry<String, String> entry : conf) {
             confMap.put(entry.getKey(), entry.getValue());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsCompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsCompatibleProperties.java
@@ -17,59 +17,27 @@
 
 package org.apache.doris.datasource.property.storage;
 
-import org.apache.doris.datasource.property.ConnectorProperty;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public abstract class HdfsCompatibleProperties extends StorageProperties {
 
 
-    @ConnectorProperty(names = {"fs.defaultFS"}, required = false, description = "")
-    protected String fsDefaultFS = "";
-
-    @ConnectorProperty(names = {"hadoop.config.resources"},
-            required = false,
-            description = "The xml files of Hadoop configuration.")
-    protected String hadoopConfigResources = "";
-
-    protected static final List<String> HDFS_COMPATIBLE_PROPERTIES_KEYS = Arrays.asList("fs.defaultFS",
-            "hadoop.config.resources");
-
-    protected Configuration configuration;
-
     public static final String HDFS_DEFAULT_FS_NAME = "fs.defaultFS";
-
-    abstract Set<String> getSupportedSchemas();
-
-    @Override
-    protected void initNormalizeAndCheckProps() {
-        super.initNormalizeAndCheckProps();
-        // If fsDefaultFS is not explicitly provided, we attempt to infer it from the 'uri' field.
-        // However, the 'uri' is not a dedicated HDFS-specific property and may be present
-        // even when the user is configuring multiple storage backends.
-        // Additionally, since we are not using FileSystem.get(Configuration conf),
-        // fsDefaultFS is not strictly required here.
-        // This is a best-effort fallback to populate fsDefaultFS when possible.
-        if (StringUtils.isBlank(fsDefaultFS)) {
-            this.fsDefaultFS = HdfsPropertiesUtils.extractDefaultFsFromUri(origProps, getSupportedSchemas());
-        }
-    }
 
     protected HdfsCompatibleProperties(Type type, Map<String, String> origProps) {
         super(type, origProps);
     }
 
-    public abstract Configuration getHadoopConfiguration();
-
+    protected Configuration configuration;
 
     @Override
     protected String getResourceConfigPropName() {
         return "hadoop.config.resources";
+    }
+
+    public Configuration getHadoopConfiguration() {
+        return configuration;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtils.java
@@ -22,7 +22,6 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.URI;
 import org.apache.doris.datasource.property.storage.exception.StoragePropertiesException;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
@@ -30,9 +29,8 @@ import java.util.Set;
 
 public class HdfsPropertiesUtils {
     private static final String URI_KEY = "uri";
-    private static final Set<String> supportSchema = ImmutableSet.of("hdfs", "viewfs");
 
-    public static String validateAndGetUri(Map<String, String> props) throws UserException {
+    public static String validateAndGetUri(Map<String, String> props, Set<String> supportSchemas) throws UserException {
         if (props.isEmpty()) {
             throw new UserException("props is empty");
         }
@@ -40,10 +38,11 @@ public class HdfsPropertiesUtils {
         if (StringUtils.isBlank(uriStr)) {
             throw new StoragePropertiesException("props must contain uri");
         }
-        return validateAndNormalizeUri(uriStr);
+        return validateAndNormalizeUri(uriStr, supportSchemas);
     }
 
-    public static boolean validateUriIsHdfsUri(Map<String, String> props) {
+    public static boolean validateUriIsHdfsUri(Map<String, String> props,
+                                               Set<String> supportSchemas) {
         String uriStr = getUri(props);
         if (StringUtils.isBlank(uriStr)) {
             return false;
@@ -54,7 +53,7 @@ public class HdfsPropertiesUtils {
             if (StringUtils.isBlank(schema)) {
                 throw new IllegalArgumentException("Invalid uri: " + uriStr + ", extract schema is null");
             }
-            return isSupportedSchema(schema);
+            return isSupportedSchema(schema, supportSchemas);
         } catch (AnalysisException e) {
             throw new IllegalArgumentException("Invalid uri: " + uriStr, e);
         }
@@ -72,14 +71,14 @@ public class HdfsPropertiesUtils {
         }
     }
 
-    public static String extractDefaultFsFromUri(Map<String, String> props) {
+    public static String extractDefaultFsFromUri(Map<String, String> props, Set<String> supportSchemas) {
         String uriStr = getUri(props);
         if (StringUtils.isBlank(uriStr)) {
             return null;
         }
         try {
             URI uri = URI.create(uriStr);
-            if (!isSupportedSchema(uri.getScheme())) {
+            if (!isSupportedSchema(uri.getScheme(), supportSchemas)) {
                 return null;
             }
             return uri.getScheme() + "://" + uri.getAuthority();
@@ -88,8 +87,8 @@ public class HdfsPropertiesUtils {
         }
     }
 
-    public static String convertUrlToFilePath(String uriStr) throws UserException {
-        return validateAndNormalizeUri(uriStr);
+    public static String convertUrlToFilePath(String uriStr, Set<String> supportSchemas) throws UserException {
+        return validateAndNormalizeUri(uriStr, supportSchemas);
     }
 
     /*
@@ -116,11 +115,11 @@ public class HdfsPropertiesUtils {
         return uriValue;
     }
 
-    private static boolean isSupportedSchema(String schema) {
+    private static boolean isSupportedSchema(String schema, Set<String> supportSchema) {
         return schema != null && supportSchema.contains(schema.toLowerCase());
     }
 
-    private static String validateAndNormalizeUri(String uriStr) throws AnalysisException {
+    private static String validateAndNormalizeUri(String uriStr, Set<String> supportSchema) throws AnalysisException {
         if (StringUtils.isBlank(uriStr)) {
             throw new IllegalArgumentException("Properties 'uri' is required");
         }
@@ -129,7 +128,7 @@ public class HdfsPropertiesUtils {
         if (StringUtils.isBlank(schema)) {
             throw new IllegalArgumentException("Invalid uri: " + uriStr + ", extract schema is null");
         }
-        if (!isSupportedSchema(schema)) {
+        if (!isSupportedSchema(schema, supportSchema)) {
             throw new IllegalArgumentException("Invalid export path:"
                     + schema + " , please use valid 'hdfs://' or 'viewfs://' path.");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtils.java
@@ -92,13 +92,28 @@ public class HdfsPropertiesUtils {
         return validateAndNormalizeUri(uriStr);
     }
 
+    /*
+     * Extracts the URI value from the given properties.
+     * If multiple URIs are specified (separated by commas), this method returns null.
+     * Note: Some storage systems may support multiple URIs (e.g., for load balancing or multi-host),
+     * but in the HDFS scenario, fs.defaultFS only supports a single URI.
+     * Therefore, such a format is considered invalid for HDFS. so, just return null.
+     */
     private static String getUri(Map<String, String> props) {
-        return props.entrySet().stream()
+        String uriValue = props.entrySet().stream()
                 .filter(e -> e.getKey().equalsIgnoreCase(URI_KEY))
                 .map(Map.Entry::getValue)
                 .filter(StringUtils::isNotBlank)
                 .findFirst()
                 .orElse(null);
+        if (uriValue == null) {
+            return null;
+        }
+        String[] uris = uriValue.split(",");
+        if (uris.length > 1) {
+            return null;
+        }
+        return uriValue;
     }
 
     private static boolean isSupportedSchema(String schema) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
@@ -65,7 +65,7 @@ public class OSSHdfsProperties extends HdfsCompatibleProperties {
     private Map<String, String> backendConfigProperties;
 
     private static final Pattern ENDPOINT_PATTERN = Pattern
-            .compile("(?:https?://)?(cn-[a-z0-9-]+)\\.oss-dls\\.aliyuncs\\.com");
+            .compile("(?:https?://)?([a-z]{2}-[a-z0-9-]+)\\.oss-dls\\.aliyuncs\\.com");
 
     private static final String ENABLE_KEY = "oss.hdfs.enabled";
 
@@ -100,7 +100,7 @@ public class OSSHdfsProperties extends HdfsCompatibleProperties {
         Matcher matcher = ENDPOINT_PATTERN.matcher(endpoint.toLowerCase());
         if (!matcher.matches()) {
             throw new IllegalArgumentException("The endpoint is not a valid OSS HDFS endpoint: " + endpoint
-                    + ". It should match the pattern: cn-<region>.oss-dls.aliyuncs.com");
+                    + ". It should match the pattern: <region>.oss-dls.aliyuncs.com");
         }
         // Extract region from the endpoint, e.g., "cn-shanghai.oss-dls.aliyuncs.com" -> "cn-shanghai"
         if (StringUtils.isBlank(this.region)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
@@ -20,12 +20,14 @@ package org.apache.doris.datasource.property.storage;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.ConnectorProperty;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -69,6 +71,8 @@ public class OSSHdfsProperties extends HdfsCompatibleProperties {
 
     private static final String ENABLE_KEY = "oss.hdfs.enabled";
 
+    private static final Set<String> supportSchema = ImmutableSet.of("oss");
+
     protected OSSHdfsProperties(Map<String, String> origProps) {
         super(Type.HDFS, origProps);
     }
@@ -92,6 +96,11 @@ public class OSSHdfsProperties extends HdfsCompatibleProperties {
         if (!endpointIsValid(endpoint)) {
             throw new IllegalArgumentException("Property oss.endpoint is required and must be a valid OSS endpoint.");
         }
+    }
+
+    @Override
+    Set<String> getSupportedSchemas() {
+        return supportSchema;
     }
 
     @Override
@@ -138,6 +147,9 @@ public class OSSHdfsProperties extends HdfsCompatibleProperties {
         config.put("fs.oss.region", region);
         config.put("fs.oss.impl", "com.aliyun.jindodata.oss.JindoOssFileSystem");
         config.put("fs.AbstractFileSystem.oss.impl", "com.aliyun.jindodata.oss.JindoOSS");
+        if (StringUtils.isNotBlank(fsDefaultFS)) {
+            config.put(HDFS_DEFAULT_FS_NAME, fsDefaultFS);
+        }
         config.forEach(conf::set);
         this.backendConfigProperties = config;
         this.configuration = conf;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -57,7 +57,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     /**
      * Pattern to extract the region from an Alibaba Cloud OSS endpoint.
      * <p>
-     * Supported formats:
+     * Supported formats: <a href="https://help.aliyun.com/zh/oss/user-guide/regions-and-endpoints">aliyun oss</a>?
      * - oss-cn-hangzhou.aliyuncs.com              => region = cn-hangzhou
      * - <a href="https://oss-cn-shanghai.aliyuncs.com">...</a>      => region = cn-shanghai
      * - oss-cn-beijing-internal.aliyuncs.com      => region = cn-beijing (internal endpoint)

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -79,7 +79,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
                 .findFirst()
                 .orElse(null);
         if (!Strings.isNullOrEmpty(value)) {
-            return value.contains("aliyuncs.com");
+            return (value.contains("aliyuncs.com") && !value.contains("oss-dls.aliyuncs.com"));
         }
         Optional<String> uriValue = origProps.entrySet().stream()
                 .filter(e -> e.getKey().equalsIgnoreCase("uri"))

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/HMSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/HMSPropertiesTest.java
@@ -50,7 +50,7 @@ public class HMSPropertiesTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> MetastoreProperties.create(params));
         params.put("hive.metastore.uris", "thrift://default:9083");
         hmsProperties = (HMSProperties) MetastoreProperties.create(params);
-        Map<String, String> hiveConf = hmsProperties.loadConfigFromFile("hive.conf.resources");
+        Map<String, String> hiveConf = hmsProperties.loadConfigFromFile("/hive-conf/hive1/hive-site.xml");
         Assertions.assertNotNull(hiveConf);
         Assertions.assertEquals("/user/hive/default", hiveConf.get("hive.metastore.warehouse.dir"));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtilsTest.java
@@ -20,20 +20,24 @@ package org.apache.doris.datasource.property.storage;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.exception.StoragePropertiesException;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class HdfsPropertiesUtilsTest {
+
+    private static final Set<String> supportSchema = ImmutableSet.of("hdfs", "viewfs");
 
     @Test
     public void testCheckLoadPropsAndReturnUri_success() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("uri", "hdfs://localhost:9000/data/file.txt");
 
-        String result = HdfsPropertiesUtils.validateAndGetUri(props);
+        String result = HdfsPropertiesUtils.validateAndGetUri(props, supportSchema);
         Assertions.assertEquals("hdfs://localhost:9000/data/file.txt", result);
     }
 
@@ -42,7 +46,7 @@ public class HdfsPropertiesUtilsTest {
         Map<String, String> props = new HashMap<>();
 
         Exception exception = Assertions.assertThrows(UserException.class, () -> {
-            HdfsPropertiesUtils.validateAndGetUri(props);
+            HdfsPropertiesUtils.validateAndGetUri(props, supportSchema);
         });
         Assertions.assertEquals("errCode = 2, detailMessage = props is empty", exception.getMessage());
     }
@@ -53,7 +57,7 @@ public class HdfsPropertiesUtilsTest {
         props.put("path", "xxx");
 
         Exception exception = Assertions.assertThrows(StoragePropertiesException.class, () -> {
-            HdfsPropertiesUtils.validateAndGetUri(props);
+            HdfsPropertiesUtils.validateAndGetUri(props, supportSchema);
         });
         Assertions.assertEquals("props must contain uri", exception.getMessage());
     }
@@ -61,7 +65,7 @@ public class HdfsPropertiesUtilsTest {
     @Test
     public void testConvertUrlToFilePath_valid() throws Exception {
         String uri = "viewfs://cluster/user/test";
-        String result = HdfsPropertiesUtils.convertUrlToFilePath(uri);
+        String result = HdfsPropertiesUtils.convertUrlToFilePath(uri, supportSchema);
         Assertions.assertEquals("viewfs://cluster/user/test", result);
     }
 
@@ -70,7 +74,7 @@ public class HdfsPropertiesUtilsTest {
         String uri = "s3://bucket/file.txt";
 
         Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            HdfsPropertiesUtils.convertUrlToFilePath(uri);
+            HdfsPropertiesUtils.convertUrlToFilePath(uri, supportSchema);
         });
         Assertions.assertTrue(exception.getMessage().contains("Invalid export path"));
     }
@@ -80,7 +84,7 @@ public class HdfsPropertiesUtilsTest {
         String uri = "   ";
 
         Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            HdfsPropertiesUtils.convertUrlToFilePath(uri);
+            HdfsPropertiesUtils.convertUrlToFilePath(uri, supportSchema);
         });
         Assertions.assertTrue(exception.getMessage().contains("Properties 'uri' is required"));
     }
@@ -90,7 +94,7 @@ public class HdfsPropertiesUtilsTest {
         Map<String, String> props = new HashMap<>();
         props.put("uri", "hdfs://localhost:8020/data");
 
-        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props);
+        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props, supportSchema);
         Assertions.assertEquals("hdfs://localhost:8020", result);
     }
 
@@ -99,7 +103,7 @@ public class HdfsPropertiesUtilsTest {
         Map<String, String> props = new HashMap<>();
         props.put("uri", "viewfs://cluster/path");
 
-        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props);
+        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props, supportSchema);
         Assertions.assertEquals("viewfs://cluster", result);
     }
 
@@ -107,13 +111,13 @@ public class HdfsPropertiesUtilsTest {
     public void testConstructDefaultFsFromUri_invalidSchema() {
         Map<String, String> props = new HashMap<>();
         props.put("uri", "obs://bucket/test");
-        Assertions.assertNull(HdfsPropertiesUtils.extractDefaultFsFromUri(props));
+        Assertions.assertNull(HdfsPropertiesUtils.extractDefaultFsFromUri(props, supportSchema));
     }
 
     @Test
     public void testConstructDefaultFsFromUri_emptyProps() {
         Map<String, String> props = new HashMap<>();
-        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props);
+        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props, supportSchema);
         Assertions.assertNull(result);
     }
 
@@ -122,7 +126,7 @@ public class HdfsPropertiesUtilsTest {
         Map<String, String> props = new HashMap<>();
         props.put("x", "y");
 
-        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props);
+        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props, supportSchema);
         Assertions.assertNull(result);
     }
 
@@ -131,14 +135,14 @@ public class HdfsPropertiesUtilsTest {
         Map<String, String> props = new HashMap<>();
         props.put("uri", "  ");
 
-        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props);
+        String result = HdfsPropertiesUtils.extractDefaultFsFromUri(props, supportSchema);
         Assertions.assertNull(result);
     }
 
     @Test
     public void testConvertUrlToFilePath_uppercaseSchema() throws Exception {
         String uri = "HDFS://localhost:9000/test";
-        String result = HdfsPropertiesUtils.convertUrlToFilePath(uri);
+        String result = HdfsPropertiesUtils.convertUrlToFilePath(uri, supportSchema);
         Assertions.assertEquals("HDFS://localhost:9000/test", result);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
@@ -106,6 +106,12 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.endpoint", "http://cn-hangzhou.oss-dls.aliyuncs.com");
         OSSHdfsProperties props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("cn-hangzhou", props.getBackendConfigProperties().get("fs.oss.region"));
+        origProps.put("oss.endpoint", "ap-northeast-1.oss-dls.aliyuncs.com");
+        props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("ap-northeast-1", props.getBackendConfigProperties().get("fs.oss.region"));
+        origProps.put("oss.endpoint", "cn-north-2-gov-1.oss-dls.aliyuncs.com");
+        props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("cn-north-2-gov-1", props.getBackendConfigProperties().get("fs.oss.region"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
@@ -32,6 +32,9 @@ public class OSSHdfsPropertiesTest {
     @Test
     public void testValidOSSConfiguration() throws UserException {
         Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.hdfs.enabled", "true");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StorageProperties.createPrimary(origProps),
+                "Property oss.endpoint is required.");
         origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
         origProps.put("oss.access_key", "testAccessKey");
         origProps.put("oss.secret_key", "testSecretKey");
@@ -56,7 +59,7 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.access_key", "testAccessKey");
         origProps.put("oss.secret_key", "testSecretKey");
         origProps.put("oss.region", "cn-shanghai");
-        origProps.put("uri", "oss://my-bucket/path");
+        origProps.put("uri", "thrit://my-bucket/path,thrift://my-bucket/path");
         origProps.put("hadoop.config.resources", "hdfs-site.xml,core-site.xml");
         URL hdfsFileUrl = OSSHdfsPropertiesTest.class.getClassLoader().getResource("plugins");
         Config.hadoop_config_dir = hdfsFileUrl.getPath().toString() + "/hadoop_conf/";
@@ -85,7 +88,6 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.endpoint", "invalid.aliyuncs.com");
         origProps.put("oss.access_key", "testAccessKey");
         origProps.put("oss.secret_key", "testSecretKey");
-        origProps.put("oss.region", "cn-shanghai");
         Assertions.assertThrows(RuntimeException.class, () -> {
             StorageProperties.createPrimary(origProps);
         });
@@ -93,6 +95,17 @@ public class OSSHdfsPropertiesTest {
         Assertions.assertDoesNotThrow(() -> {
             StorageProperties.createPrimary(origProps);
         });
+        origProps.put("oss.endpoint", "https://cn-shanghai.oss-dls.aliyuncs.com");
+        Assertions.assertDoesNotThrow(() -> {
+            StorageProperties.createPrimary(origProps);
+        });
+        origProps.put("oss.endpoint", "http://cn-shanghai.oss-dls.aliyuncs.com");
+        Assertions.assertDoesNotThrow(() -> {
+            StorageProperties.createPrimary(origProps);
+        });
+        origProps.put("oss.endpoint", "http://cn-hangzhou.oss-dls.aliyuncs.com");
+        OSSHdfsProperties props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("cn-hangzhou", props.getBackendConfigProperties().get("fs.oss.region"));
     }
 
     @Test
@@ -115,7 +128,6 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.access_key", "testAccessKey");
         origProps.put("oss.secret_key", "testSecretKey");
         origProps.put("oss.region", "cn-shanghai");
-
         OSSHdfsProperties props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("HDFS", props.getStorageName());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
@@ -138,4 +138,21 @@ public class OSSHdfsPropertiesTest {
         Assertions.assertEquals("HDFS", props.getStorageName());
     }
 
+    @Test
+    public void testDefaultFS() {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        origProps.put("fs.defaultFS", "oss://my-bucket");
+        OSSHdfsProperties props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("oss://my-bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
+        origProps.put("uri", "oss://bucket/");
+        props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("oss://my-bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
+        origProps.remove("fs.defaultFS");
+        props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("oss://bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
+    }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
@@ -60,10 +60,10 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.secret_key", "testSecretKey");
         origProps.put("oss.region", "cn-shanghai");
         origProps.put("uri", "thrit://my-bucket/path,thrift://my-bucket/path");
-        origProps.put("hadoop.config.resources", "hdfs-site.xml,core-site.xml");
+        origProps.put("oss.hdfs.hadoop.config.resources", "hdfs-site.xml,core-site.xml");
         URL hdfsFileUrl = OSSHdfsPropertiesTest.class.getClassLoader().getResource("plugins");
         Config.hadoop_config_dir = hdfsFileUrl.getPath().toString() + "/hadoop_conf/";
-        origProps.put("hadoop.config.resources", "osshdfs1/core-site.xml");
+        origProps.put("oss.hdfs.hadoop.config.resources", "osshdfs1/core-site.xml");
         StorageProperties props = StorageProperties.createPrimary(origProps);
         Assertions.assertInstanceOf(OSSHdfsProperties.class, props);
         Configuration conf = ((OSSHdfsProperties) props).getHadoopConfiguration();
@@ -144,13 +144,13 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
         origProps.put("oss.access_key", "testAccessKey");
         origProps.put("oss.secret_key", "testSecretKey");
-        origProps.put("fs.defaultFS", "oss://my-bucket");
+        origProps.put("oss.hdfs.fs.defaultFS", "oss://my-bucket");
         OSSHdfsProperties props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("oss://my-bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
         origProps.put("uri", "oss://bucket/");
         props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("oss://my-bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
-        origProps.remove("fs.defaultFS");
+        origProps.remove("oss.hdfs.fs.defaultFS");
         props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("oss://bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -41,8 +41,11 @@ public class OSSPropertiesTest {
         origProps.put(StorageProperties.FS_OSS_SUPPORT, "true");
         Map<String, String> finalOrigProps = origProps;
         Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> StorageProperties.createPrimary(finalOrigProps), "Property oss.endpoint is required.");
-        origProps.put("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com");
+        origProps.put("oss.endpoint", "oss-cn-shenzhen-finance-1-internal.aliyuncs.com");
         Map<String, String> finalOrigProps1 = origProps;
+        OSSProperties ossProperties = (OSSProperties) StorageProperties.createPrimary(finalOrigProps1);
+        Assertions.assertEquals("oss-cn-shenzhen-finance-1-internal.aliyuncs.com", ossProperties.getEndpoint());
+        Assertions.assertEquals("cn-shenzhen-finance-1", ossProperties.getRegion());
         Assertions.assertDoesNotThrow(() -> StorageProperties.createPrimary(finalOrigProps1));
         origProps = new HashMap<>();
         origProps.put("oss.endpoint", "https://oss.aliyuncs.com");


### PR DESCRIPTION
#50238 
### What problem does this PR solve?

This PR enhances the URI parsing logic for OSS and HDFS storage types to resolve the following issues:↳

Only a single URI is supported for HDFS/OSS storage types to prevent parsing failures caused by multiple comma-separated addresses.

OSSHDFS now supports extracting the region from the endpoint, using an improved regular expression that accurately captures the full region (e.g., cn-shanghai instead of shanghai).

OSS type detection logic is strengthened to prevent incorrect recognition of non-OSS storage as OSS-HDFS.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

