### PR TITLE
branch-3.0 [fix](nerieds)removing tailing .0 from DoubleLiteral.getStringValue()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DoubleLiteral.java
@@ -49,4 +49,34 @@ public class DoubleLiteral extends FractionalLiteral {
     public LiteralExpr toLegacyLiteral() {
         return new FloatLiteral(value, Type.DOUBLE);
     }
+
+    @Override
+    public String getStringValue() {
+        Double num = getValue();
+        if (Double.isNaN(num)) {
+            return "nan";
+        } else if (Double.isInfinite(num)) {
+            return num > 0 ? "inf" : "-inf";
+        }
+
+        // Use %.17g to format the result，replace 'E' with 'e'
+        String formatted = String.format("%.17g", num).replace('E', 'e');
+
+        // Remove trailing .0 in scientific notation.
+        if (formatted.contains("e")) {
+            String[] parts = formatted.split("e");
+            String mantissa = parts[0];
+            String exponent = parts.length > 1 ? "e" + parts[1] : "";
+            mantissa = mantissa.replaceAll("\\.?0+$", "");
+            if (mantissa.isEmpty()) {
+                mantissa = "0";
+            }
+            formatted = mantissa + exponent;
+        } else if (formatted.contains(".")) {
+            // remove trailing .0 in fixed-point representation
+            formatted = formatted.replaceAll("\\.?0+$", "");
+        }
+
+        return formatted;
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?
in master, cast(106.0 as varchar) =>106
in 3.0.3, cast(106.0 as varchar) => 106.0
this diff makes some customers' script does not work

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

