### PR TITLE
[Topn](exec) Fix the materialization coredump

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -478,16 +478,7 @@ Status MaterializationSharedState::merge_multi_response(vectorized::Block* block
     for (int i = 0; i < block_order_results.size(); ++i) {
         for (auto& [backend_id, rpc_struct] : rpc_struct_map) {
             vectorized::Block partial_block;
-            if (rpc_struct.callback->response_->blocks_size() <= i) {
-                LOG(WARNING) << "backend id:" << backend_id << " response block size is not match"
-                             << " rpc_struct.callback->response_->blocks_size()="
-                             << rpc_struct.callback->response_->blocks_size()
-                             << " blocks=" << block_order_results.size()
-                             << " query_id=" << print_id(rpc_struct.request.query_id())
-                             << " status=" << rpc_status.status().to_string();
-                return Status::InternalError("backend id:" + std::to_string(backend_id) +
-                                             " response block size is not match");
-            }
+            DCHECK(rpc_struct.callback->response_->blocks_size() > i);
             RETURN_IF_ERROR(
                     partial_block.deserialize(rpc_struct.callback->response_->blocks(i).block()));
 

--- a/be/src/pipeline/exec/materialization_source_operator.cpp
+++ b/be/src/pipeline/exec/materialization_source_operator.cpp
@@ -41,10 +41,10 @@ Status MaterializationSourceOperatorX::get_block(RuntimeState* state, vectorized
     *eos = local_state._shared_state->last_block;
 
     if (!*eos) {
-        local_state._shared_state->sink_deps.back()->set_ready();
-
         ((CountedFinishDependency*)(local_state._shared_state->source_deps.back().get()))
                 ->add(local_state._shared_state->rpc_struct_map.size());
+
+        local_state._shared_state->sink_deps.back()->set_ready();
     } else {
         uint64_t max_rpc_time = 0;
         for (auto& [_, rpc_struct] : local_state._shared_state->rpc_struct_map) {


### PR DESCRIPTION
### What problem does this PR solve?

```
*** Check failure stack trace: ***
    @     0x55e606668bb6  google::LogMessage::SendToLog()
    @     0x55e606665600  google::LogMessage::Flush()
    @     0x55e6066693f9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55e608020e1a  (unknown)
    @     0x55e606d2a065  google::protobuf::internal::LogMessage::Finish()
    @     0x55e5cde86583  google::protobuf::internal::RepeatedPtrFieldBase::Get<>()
    @     0x55e603902442  doris::pipeline::MaterializationSharedState::merge_multi_response()
    @     0x55e6062dcf5a  doris::pipeline::MaterializationSourceOperatorX::get_block()
    @     0x55e603a0aab7  doris::pipeline::OperatorXBase::get_block_after_projects()
    @     0x55e60630823b  doris::pipeline::PipelineTask::execute()
    @     0x55e60635d59c  doris::pipeline::TaskScheduler::_do_work()
    @     0x55e5cbb65f4b  doris::ThreadPool::dispatch_thread()
    @     0x55e5cbb3ab8a  doris::Thread::supervise_thread()
    @     0x7fb9fd6c9ac3  (unknown)
    @     0x7fb9fd75b850  (unknown)
    @              (nil)  (unknown)
*** Query id: bbe1b26c676b4393-a6f1bddc32695405 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1749506623 (unix time) try "date -d @1749506623" if you are using GNU date ***
*** Current BE git commitID: fa1a5db678 ***
*** SIGABRT unknown detail explain (@0x1e86) received by PID 7814 (TID 9979 OR 0x7fb90d418640) from PID 7814; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:421
 1# 0x00007FB9FD677520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055E60667348D in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
 6# 0x000055E606665ACA in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
10# 0x000055E608020E1A in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
11# google::protobuf::internal::LogMessage::Finish() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
12# google::protobuf::RepeatedPtrField::TypeHandler::Type const& google::protobuf::internal::RepeatedPtrFieldBase::Get::TypeHandler>(int) const in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
13# doris::pipeline::MaterializationSharedState::merge_multi_response(doris::vectorized::Block*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/dependency.cpp:481
14# doris::pipeline::MaterializationSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/materialization_source_operator.cpp:39
15# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
16# doris::pipeline::PipelineTask::execute(bool*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
17# doris::pipeline::TaskScheduler::_do_work(int) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
18# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
19# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:469
20# start_thread at ./nptl/pthread_create.c:442
21# 0x00007FB9FD75B850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
172.20.56.194 last coredump sql: 
```

The problem is pipeline execute order cause the problem, we should block ourself operator and notify the up stream sink operator

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

