### PR TITLE
[fix](catalog)Fixed the issue of missing data when querying external tables in multi-BE and batch mode.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -114,7 +114,7 @@ public class SplitAssignment {
                         assignment.computeIfAbsent(backend, be -> new LinkedBlockingQueue<>(10000));
                 try {
                     if (queue.offer(locations, 100, TimeUnit.MILLISECONDS)) {
-                        return;
+                        break;
                     }
                 } catch (InterruptedException e) {
                     addUserException(new UserException("Failed to offer batch split by interrupted", e));


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #51185

Problem Summary:
In pr #51185, in batch mode + multiple BE scenarios, when allocating splits, if a BE is successfully allocated, it will exit the current allocation, resulting in missing splits and missing data in query results.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->
          
- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

