### PR TITLE
[Fix]quick fix for duplicate wg id

### DIFF
--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -124,7 +124,7 @@ WorkloadGroupPtr WorkloadGroupMgr::get_group(std::vector<uint64_t>& id_list) {
         }
         LOG(ERROR) << ss.str();
     }
-    DCHECK(wg_cout <= 1);
+    // DCHECK(wg_cout <= 1);
 
     if (ret_wg == nullptr) {
         std::shared_lock<std::shared_mutex> r_lock(_group_mutex);


### PR DESCRIPTION
### What problem does this PR solve?

introduced by https://github.com/apache/doris/pull/50817

A quick fix for duplicate workload group id.

reason:
```
 Unexpected error: find too much wg in BE; input id=1749790916566,1749790916566,
```
Duplicate wg id may cause DCHECK failed.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

