### PR TITLE
[fix](hudi catalog) Fix the Kerberos authentication error when querying hudi table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -407,7 +407,14 @@ public class HudiScanNode extends HiveScanNode {
             partitionInit = true;
         }
         List<Split> splits = Collections.synchronizedList(new ArrayList<>());
-        getPartitionsSplits(prunedPartitions, splits);
+        try {
+            hmsTable.getCatalog().getPreExecutionAuthenticator().execute(() -> {
+                getPartitionsSplits(prunedPartitions, splits);
+                return null;
+            });
+        } catch (Exception e) {
+            throw new UserException(ExceptionUtils.getRootCauseMessage(e), e);
+        }
         return splits;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

This PR has resolved the Kerberos authentication error that occurs when Doris queries Hudi tables with Kerberos authentication enabled for the Hudi catalog.

Problem Summary:

When Kerberos authentication is enabled for the Hudi catalog, an error occurs when Doris queries a Hudi table.


### Check List (For Author)

    - [ ] Manual test (add detailed scripts or steps below)
    
[hudi外表查询测试.docx](https://github.com/user-attachments/files/20728247/hudi.docx)


- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.
