### PR TITLE
[feat](query) Add session_id to audit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -141,6 +141,8 @@ public class InternalSchema {
                 ScalarType.createVarchar(Config.label_regex_length), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA.add(new ColumnDef("time",
                 ScalarType.createDatetimeV2Type(3), ColumnNullableType.NULLABLE));
+        AUDIT_SCHEMA.add(new ColumnDef("session_id",
+                ScalarType.createVarchar(36), ColumnNullableType.NULLABLE));
         // cs info
         AUDIT_SCHEMA.add(new ColumnDef("client_ip",
                 ScalarType.createVarchar(128), ColumnNullableType.NULLABLE));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -343,6 +343,7 @@ public class InternalSchemaInitializer extends Thread {
          *CREATE TABLE IF NOT EXISTS `internal`.`__internal_schema`.`audit_log` (
          *   `query_id` varchar(48) NULL COMMENT "",
          *   `time` datetimev2(3) NULL COMMENT "",
+         *   `session_id` varchar(36) NULL COMMENT "",
          *   `client_ip` varchar(128) NULL COMMENT "",
          *   `user` varchar(128) NULL COMMENT "",
          *   `frontend_ip` varchar(1024) NULL COMMENT "",
@@ -384,7 +385,7 @@ public class InternalSchemaInitializer extends Thread {
          *   `compute_group` text NULL COMMENT "",
          *   `stmt` text NULL COMMENT ""
          * ) ENGINE = olap
-         * DUPLICATE KEY(`query_id`, `time`, `client_ip`)
+         * DUPLICATE KEY(`query_id`, `time`, `session_id`)
          * COMMENT "Doris internal audit table, DO NOT MODIFY IT"
          * PARTITION BY RANGE(`time`)
          * (
@@ -467,7 +468,7 @@ public class InternalSchemaInitializer extends Thread {
                 "CREATE TABLE IF NOT EXISTS `%s`.`%s`.`%s` (\n"
                         + "%s\n"
                         + ") ENGINE = olap\n"
-                        + "DUPLICATE KEY(`query_id`, `time`, `client_ip`)\n"
+                        + "DUPLICATE KEY(`query_id`, `time`, `session_id`)\n"
                         + "COMMENT \"Doris internal audit table, DO NOT MODIFY IT\"\n"
                         + "PARTITION BY RANGE(`time`)\n"
                         + "(\n"

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -58,6 +58,8 @@ public class AuditEvent {
     public String queryId = "";
     @AuditField(value = "Timestamp", colName = "time")
     public long timestamp = -1;
+    @AuditField(value = "SessionId")
+    public String sessionId = "";
 
     // cs info
     @AuditField(value = "Client", colName = "client_ip")
@@ -183,6 +185,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setTimestamp(long timestamp) {
             auditEvent.timestamp = timestamp;
+            return this;
+        }
+
+        public AuditEventBuilder setSessionId(String sessionId) {
+            auditEvent.sessionId = sessionId;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
@@ -151,6 +151,7 @@ public class AuditLoader extends Plugin implements AuditPlugin {
         // uuid and time
         logBuffer.append(event.queryId).append(AUDIT_TABLE_COL_SEPARATOR);
         logBuffer.append(TimeUtils.longToTimeStringWithms(event.timestamp)).append(AUDIT_TABLE_COL_SEPARATOR);
+        logBuffer.append(event.sessionId).append(AUDIT_TABLE_COL_SEPARATOR);
 
         // cs info
         logBuffer.append(event.clientIp).append(AUDIT_TABLE_COL_SEPARATOR);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -243,6 +243,7 @@ public class AuditLogHelper {
                 .setQueryId(ctx.queryId() == null ? "NaN" : DebugUtil.printId(ctx.queryId()))
                 .setTimestamp(ctx.getStartTime())
                 .setClientIp(ctx.getClientIP())
+                .setSessionId(ctx.getSessionId())
                 .setUser(ClusterNamespace.getNameFromFullName(ctx.getQualifiedUser()))
                 .setFeIp(FrontendOptions.getLocalHostAddress())
                 .setCtl(catalog == null ? InternalCatalog.INTERNAL_CATALOG_NAME : catalog.getName())

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/AuditEventProcessorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/AuditEventProcessorTest.java
@@ -53,6 +53,7 @@ public class AuditEventProcessorTest {
     public void testAuditEvent() {
         AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                 .setTimestamp(System.currentTimeMillis())
+                .setSessionId("sessionId")
                 .setClientIp("127.0.0.1")
                 .setUser("user1")
                 .setDb("db1")
@@ -80,6 +81,7 @@ public class AuditEventProcessorTest {
             for (int i = 0; i < 10000; i++) {
                 AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                         .setTimestamp(System.currentTimeMillis())
+                        .setSessionId("sessionId")
                         .setClientIp("127.0.0.1")
                         .setUser("user1")
                         .setDb("db1")
@@ -106,6 +108,7 @@ public class AuditEventProcessorTest {
         for (int i = 0; i < 10000; i++) {
             AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                     .setTimestamp(System.currentTimeMillis())
+                    .setSessionId("sessionId")
                     .setClientIp("127.0.0.1")
                     .setUser("user1")
                     .setDb("db1")

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/custom/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/custom/AuditLoaderPlugin.java
@@ -161,6 +161,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
     private void fillLogBuffer(AuditEvent event, StringBuilder logBuffer) {
         logBuffer.append(event.queryId).append("\t");
         logBuffer.append(longToTimeString(event.timestamp)).append("\t");
+        logBuffer.append(event.sessionId).append("\t");
         logBuffer.append(event.clientIp).append("\t");
         logBuffer.append(event.user).append("\t");
         logBuffer.append(event.ctl).append("\t");

--- a/pytest/deploy/start.py
+++ b/pytest/deploy/start.py
@@ -179,6 +179,7 @@ def add_auditload_plugin():
           ( \
               query_id varchar(48) comment 'Unique query id', \
               \`time\` datetime not null comment 'Query start time', \
+              session_id varchar(36) comment 'Session id', \
               client_ip varchar(32) comment 'Client IP', \
               user varchar(64) comment 'User name', \
               db varchar(96) comment 'Database of this query', \
@@ -196,7 +197,7 @@ def add_auditload_plugin():
               peak_memory_bytes bigint comment 'Peak memory bytes used on all backends of this query', \
               stmt string comment 'The original statement, trimed if longer than 2G ' \
           ) engine=OLAP \
-          duplicate key(query_id, \`time\`, client_ip) \
+          duplicate key(query_id, \`time\`, session_id) \
           partition by range(\`time\`) () \
           distributed by hash(query_id) buckets 1 \
           properties( \

--- a/regression-test/data/audit/test_audit_log_behavior.out
+++ b/regression-test/data/audit/test_audit_log_behavior.out
@@ -2,7 +2,8 @@
 -- !audit_log_schema --
 query_id	varchar(48)	Yes	true	\N	
 time	datetime(3)	Yes	true	\N	
-client_ip	varchar(128)	Yes	true	\N	
+session_id	varchar(36)	Yes	true	\N	
+client_ip	varchar(128)	Yes	false	\N	NONE
 user	varchar(128)	Yes	false	\N	NONE
 frontend_ip	varchar(1024)	Yes	false	\N	NONE
 catalog	varchar(128)	Yes	false	\N	NONE

--- a/regression-test/suites/manager/test_manager_interface_1.groovy
+++ b/regression-test/suites/manager/test_manager_interface_1.groovy
@@ -527,6 +527,7 @@ suite('test_manager_interface_1',"p0") {
         assertTrue(result[0][1].contains("CREATE TABLE `audit_log`"))
         assertTrue(result[0][1].contains("`query_id` varchar(128) NULL,"))
         assertTrue(result[0][1].contains("`time` datetime(3) NULL,"))
+        assertTrue(result[0][1].contains("`session_id` varchar(36) NULL,"))
         assertTrue(result[0][1].contains("`client_ip` varchar(128) NULL,")) 
         assertTrue(result[0][1].contains("`user` varchar(128) NULL,")) 
         assertTrue(result[0][1].contains("`catalog` varchar(128) NULL")) 
@@ -550,7 +551,7 @@ suite('test_manager_interface_1',"p0") {
 
         assertTrue(result[0][1].contains("ENGINE=OLAP"))
 
-        assertTrue(result[0][1].contains("DUPLICATE KEY(`query_id`, `time`, `client_ip`)"))
+        assertTrue(result[0][1].contains("DUPLICATE KEY(`query_id`, `time`, `session_id`)"))
         assertTrue(result[0][1].contains("""PARTITION BY RANGE(`time`)"""))
         assertTrue(result[0][1].contains("""dynamic_partition.enable" = "true"""))
         assertTrue(result[0][1].contains("""dynamic_partition.time_unit" = "DAY"""))


### PR DESCRIPTION
### What problem does this PR solve?

Partially solves #49915

Problem Summary:
* Add `sessionId` field to `AuditEvent` class
* Update structure of internal `audit_log` table to include this column
* Update `AuditLogHelper` to populate this field using ConnectionContext info
* Add `session_id` column to `AuditLoaderPlugin` table
* Use `session_id` column as part of primary key instead of `client_ip` (could be reverted)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [X] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [X] Yes. Added new column to `audit_log` table & AuditLoaderPlugin

- Does this need documentation?
    - [ ] No.
    - [X] Yes. https://github.com/apache/doris-website/pull/2483

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

