### PR TITLE
[improvement](iceberg) Support displaying the complete table structure of Iceberg tables via the show create table syntax in Doris.

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -355,6 +355,14 @@ under the License.
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-tags_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.alibaba.otter/canal.client -->
         <dependency>
             <groupId>com.alibaba.otter</groupId>
@@ -659,6 +667,12 @@ under the License.
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
             <version>${scala.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -85,6 +85,11 @@ under the License.
     </profiles>
     <dependencies>
         <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fe-common</artifactId>
             <version>${project.version}</version>

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -450,6 +450,10 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return false;
     }
 
+    public boolean isTable() {
+        return true;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/BucketPartitionerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/BucketPartitionerUtil.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.transforms.PartitionSpecVisitor;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+final class BucketPartitionerUtil {
+
+    private BucketPartitionerUtil() {}
+
+    public static List<Tuple2<Integer, Integer>> getBucketFields(PartitionSpec spec) {
+        return PartitionSpecVisitor.visit(spec, new BucketPartitionSpecVisitor()).stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+
+    private static class BucketPartitionSpecVisitor implements PartitionSpecVisitor<Tuple2<Integer, Integer>> {
+        @Override
+        public Tuple2<Integer, Integer> identity(int fieldId, String sourceName, int sourceId) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> bucket(
+                int fieldId, String sourceName, int sourceId, int numBuckets) {
+            return new Tuple2<>(fieldId, numBuckets);
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> truncate(
+                int fieldId, String sourceName, int sourceId, int width) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> year(int fieldId, String sourceName, int sourceId) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> month(int fieldId, String sourceName, int sourceId) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> day(int fieldId, String sourceName, int sourceId) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> hour(int fieldId, String sourceName, int sourceId) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> alwaysNull(int fieldId, String sourceName, int sourceId) {
+            return null;
+        }
+
+        @Override
+        public Tuple2<Integer, Integer> unknown(
+                int fieldId, String sourceName, int sourceId, String transform) {
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/BucketSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/BucketSpec.java
@@ -17,36 +17,27 @@
 
 package org.apache.doris.datasource.iceberg;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 class BucketSpec {
-    private final int numBuckets;
-    private final List<String> bucketColumnNames;
-    private final List<String> sortColumnNames;
 
-    public BucketSpec(int numBuckets, List<String> bucketColumnNames, List<String> sortColumnNames) {
+    private final int numBuckets;
+    private final int fieldId;
+    private final String bucketColumnName;
+
+    public BucketSpec(int numBuckets, int fieldId, String bucketColumnName) {
         this.numBuckets = numBuckets;
-        this.bucketColumnNames = Collections.unmodifiableList(new ArrayList<>(bucketColumnNames));
-        this.sortColumnNames = Collections.unmodifiableList(new ArrayList<>(sortColumnNames));
+        this.fieldId = fieldId;
+        this.bucketColumnName = bucketColumnName;
     }
 
-    public int numBuckets() {
+    public int getNumBuckets() {
         return numBuckets;
     }
 
-    public List<String> bucketColumnNames() {
-        return bucketColumnNames;
+    public int getFieldId() {
+        return fieldId;
     }
 
-    public List<String> sortColumnNames() {
-        return sortColumnNames;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("BucketSpec{numBuckets=%d, bucketColumnNames=%s, sortColumnNames=%s}",
-            numBuckets, bucketColumnNames, sortColumnNames);
+    public String getBucketColumnName() {
+        return bucketColumnName;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/BucketSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/BucketSpec.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class BucketSpec {
+    private final int numBuckets;
+    private final List<String> bucketColumnNames;
+    private final List<String> sortColumnNames;
+
+    public BucketSpec(int numBuckets, List<String> bucketColumnNames, List<String> sortColumnNames) {
+        this.numBuckets = numBuckets;
+        this.bucketColumnNames = Collections.unmodifiableList(new ArrayList<>(bucketColumnNames));
+        this.sortColumnNames = Collections.unmodifiableList(new ArrayList<>(sortColumnNames));
+    }
+
+    public int numBuckets() {
+        return numBuckets;
+    }
+
+    public List<String> bucketColumnNames() {
+        return bucketColumnNames;
+    }
+
+    public List<String> sortColumnNames() {
+        return sortColumnNames;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("BucketSpec{numBuckets=%d, bucketColumnNames=%s, sortColumnNames=%s}",
+            numBuckets, bucketColumnNames, sortColumnNames);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/DescribeSortOrderVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/DescribeSortOrderVisitor.java
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.transforms.SortOrderVisitor;
+
+class DescribeSortOrderVisitor implements SortOrderVisitor<String> {
+
+    public static final DescribeSortOrderVisitor INSTANCE = new DescribeSortOrderVisitor();
+
+    private DescribeSortOrderVisitor() {}
+
+    @Override
+    public String field(
+            String sourceName,
+            int sourceId,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("%s %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String bucket(
+            String sourceName,
+            int sourceId,
+            int numBuckets,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("bucket(%s, %s) %s %s", numBuckets, sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String truncate(
+            String sourceName,
+            int sourceId,
+            int width,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("truncate(%s, %s) %s %s", sourceName, width, direction, nullOrder);
+    }
+
+    @Override
+    public String year(
+            String sourceName,
+            int sourceId,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("years(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String month(
+            String sourceName,
+            int sourceId,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("months(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String day(
+            String sourceName,
+            int sourceId,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("days(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String hour(
+            String sourceName,
+            int sourceId,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("hours(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String unknown(
+            String sourceName,
+            int sourceId,
+            String transform,
+            org.apache.iceberg.SortDirection direction,
+            NullOrder nullOrder) {
+        return String.format("%s(%s) %s %s", transform, sourceName, direction, nullOrder);
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
@@ -64,6 +64,7 @@ public class IcebergExternalTable extends ExternalTable implements MTMVRelatedTa
     private Table table;
     private boolean isValidRelatedTableCached = false;
     private boolean isValidRelatedTable = false;
+    private boolean isTable;
 
     public IcebergExternalTable(long id, String name, String remoteName, IcebergExternalCatalog catalog,
             IcebergExternalDatabase db) {
@@ -77,6 +78,7 @@ public class IcebergExternalTable extends ExternalTable implements MTMVRelatedTa
     protected synchronized void makeSureInitialized() {
         super.makeSureInitialized();
         if (!objectCreated) {
+            isTable = catalog.tableExist(null, dbName, getRemoteName());
             objectCreated = true;
         }
     }
@@ -124,6 +126,12 @@ public class IcebergExternalTable extends ExternalTable implements MTMVRelatedTa
 
     public Table getIcebergTable() {
         return IcebergUtils.getIcebergTable(getCatalog(), getDbName(), getName());
+    }
+
+    @Override
+    public boolean isTable() {
+        makeSureInitialized();
+        return isTable;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/ProjectionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/ProjectionUtil.java
@@ -1,0 +1,382 @@
+package org.apache.doris.datasource.iceberg;
+
+import org.apache.iceberg.expressions.BoundLiteralPredicate;
+import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.BoundSetPredicate;
+import org.apache.iceberg.expressions.BoundTransform;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transform;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Set;
+import java.util.function.Function;
+
+class ProjectionUtil {
+
+    private ProjectionUtil() {
+    }
+
+    static <T> UnboundPredicate<T> truncateInteger(
+            String name, BoundLiteralPredicate<Integer> pred, Function<Integer, T> transform) {
+        int boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+                // adjust closed and then transform ltEq
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1));
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+            case GT:
+                // adjust closed and then transform gtEq
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1));
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+            case EQ:
+                return Expressions.predicate(pred.op(), name, transform.apply(boundary));
+            default:
+                return null;
+        }
+    }
+
+    static <T> UnboundPredicate<T> truncateIntegerStrict(
+            String name, BoundLiteralPredicate<Integer> pred, Function<Integer, T> transform) {
+        int boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(boundary));
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(boundary + 1));
+            case GT:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(boundary));
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(boundary - 1));
+            case NOT_EQ:
+                return Expressions.predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+            case EQ:
+                // there is no predicate that guarantees equality because adjacent ints transform to the
+                // same value
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    static <T> UnboundPredicate<T> truncateLongStrict(
+            String name, BoundLiteralPredicate<Long> pred, Function<Long, T> transform) {
+        long boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(boundary));
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(boundary + 1L));
+            case GT:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(boundary));
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(boundary - 1L));
+            case NOT_EQ:
+                return Expressions.predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+            case EQ:
+                // there is no predicate that guarantees equality because adjacent longs transform to the
+                // same value
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    static <T> UnboundPredicate<T> truncateLong(
+            String name, BoundLiteralPredicate<Long> pred, Function<Long, T> transform) {
+        long boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+                // adjust closed and then transform ltEq
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1L));
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+            case GT:
+                // adjust closed and then transform gtEq
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1L));
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+            case EQ:
+                return Expressions.predicate(pred.op(), name, transform.apply(boundary));
+            default:
+                return null;
+        }
+    }
+
+    static <T> UnboundPredicate<T> truncateDecimal(
+            String name, BoundLiteralPredicate<BigDecimal> pred, Function<BigDecimal, T> transform) {
+        BigDecimal boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+                // adjust closed and then transform ltEq
+                BigDecimal minusOne =
+                        new BigDecimal(boundary.unscaledValue().subtract(BigInteger.ONE), boundary.scale());
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(minusOne));
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+            case GT:
+                // adjust closed and then transform gtEq
+                BigDecimal plusOne =
+                        new BigDecimal(boundary.unscaledValue().add(BigInteger.ONE), boundary.scale());
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(plusOne));
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+            case EQ:
+                return Expressions.predicate(pred.op(), name, transform.apply(boundary));
+            default:
+                return null;
+        }
+    }
+
+    static <T> UnboundPredicate<T> truncateDecimalStrict(
+            String name, BoundLiteralPredicate<BigDecimal> pred, Function<BigDecimal, T> transform) {
+        BigDecimal boundary = pred.literal().value();
+
+        BigDecimal minusOne =
+                new BigDecimal(boundary.unscaledValue().subtract(BigInteger.ONE), boundary.scale());
+
+        BigDecimal plusOne =
+                new BigDecimal(boundary.unscaledValue().add(BigInteger.ONE), boundary.scale());
+
+        switch (pred.op()) {
+            case LT:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(boundary));
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(plusOne));
+            case GT:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(boundary));
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(minusOne));
+            case NOT_EQ:
+                return Expressions.predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+            case EQ:
+                // there is no predicate that guarantees equality because adjacent decimals transform to the
+                // same value
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    static <S, T> UnboundPredicate<T> truncateArray(
+            String name, BoundLiteralPredicate<S> pred, Function<S, T> transform) {
+        S boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+            case GT:
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+            case EQ:
+                return Expressions.predicate(Expression.Operation.EQ, name, transform.apply(boundary));
+            case STARTS_WITH:
+                return Expressions.predicate(Expression.Operation.STARTS_WITH, name, transform.apply(boundary));
+            default:
+                return null;
+        }
+    }
+
+    static <S, T> UnboundPredicate<T> truncateArrayStrict(
+            String name, BoundLiteralPredicate<S> pred, Function<S, T> transform) {
+        S boundary = pred.literal().value();
+        switch (pred.op()) {
+            case LT:
+            case LT_EQ:
+                return Expressions.predicate(Expression.Operation.LT, name, transform.apply(boundary));
+            case GT:
+            case GT_EQ:
+                return Expressions.predicate(Expression.Operation.GT, name, transform.apply(boundary));
+            case NOT_EQ:
+                return Expressions.predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+            case EQ:
+                // there is no predicate that guarantees equality because adjacent values transform to the
+                // same partition
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * If the predicate has a transformed child that matches the given transform, return a predicate.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> UnboundPredicate<T> projectTransformPredicate(
+            Transform<?, T> transform, String partitionName, BoundPredicate<?> pred) {
+        if (pred.term() instanceof BoundTransform
+                && transform.toString().equals(((BoundTransform<?, ?>) pred.term()).transform().toString())) {
+            // the bound value must be a T because the transform matches
+            return (UnboundPredicate<T>) removeTransform(partitionName, pred);
+        }
+        return null;
+    }
+
+    private static <T> UnboundPredicate<T> removeTransform(
+            String partitionName, BoundPredicate<T> pred) {
+        if (pred.isUnaryPredicate()) {
+            return Expressions.predicate(pred.op(), partitionName);
+        } else if (pred.isLiteralPredicate()) {
+            return Expressions.predicate(pred.op(), partitionName, pred.asLiteralPredicate().literal());
+        } else if (pred.isSetPredicate()) {
+            return Expressions.predicate(pred.op(), partitionName, pred.asSetPredicate().literalSet());
+        }
+        throw new UnsupportedOperationException(
+            "Cannot replace transform in unknown predicate: " + pred);
+    }
+
+    static <S, T> UnboundPredicate<T> transformSet(
+            String fieldName, BoundSetPredicate<S> predicate, Function<S, T> transform) {
+        return Expressions.predicate(
+            predicate.op(),
+            fieldName,
+            Iterables.transform(predicate.asSetPredicate().literalSet(), transform::apply));
+    }
+
+    /**
+     * Fixes an inclusive projection to account for incorrectly transformed values.
+     *
+     * <p>A bug in 0.10.0 and earlier caused negative values to be incorrectly transformed by date and
+     * timestamp transforms to 1 larger than the correct value. For example, day(1969-12-31 10:00:00)
+     * produced 0 instead of -1. To read data written by versions with this bug, this method adjusts
+     * the inclusive projection. The current inclusive projection is correct, so this modifies the
+     * "correct" projection when needed. For example, < day(1969-12-31 10:00:00) will produce <= -1 (=
+     * 1969-12-31) and is adjusted to <= 0 (= 1970-01-01) because the incorrect transformed value was
+     * 0.
+     */
+    static UnboundPredicate<Integer> fixInclusiveTimeProjection(UnboundPredicate<Integer> projected) {
+        if (projected == null) {
+            return projected;
+        }
+
+        // adjust the predicate for values that were 1 larger than the correct transformed value
+        switch (projected.op()) {
+            case LT:
+                if (projected.literal().value() < 0) {
+                    return Expressions.lessThan(projected.term(), projected.literal().value() + 1);
+                }
+                return projected;
+
+            case LT_EQ:
+                if (projected.literal().value() < 0) {
+                    return Expressions.lessThanOrEqual(projected.term(), projected.literal().value() + 1);
+                }
+                return projected;
+
+            case GT:
+            case GT_EQ:
+                // incorrect projected values are already greater than the bound for GT, GT_EQ
+                return projected;
+
+            case EQ:
+                if (projected.literal().value() < 0) {
+                    // match either the incorrect value (projectedValue + 1) or the correct value
+                    // (projectedValue)
+                    return Expressions.in(
+                        projected.term(), projected.literal().value(), projected.literal().value() + 1);
+                }
+                return projected;
+
+            case IN:
+                Set<Integer> fixedSet = Sets.newHashSet();
+                boolean hasNegativeValue = false;
+                for (Literal<Integer> lit : projected.literals()) {
+                    Integer value = lit.value();
+                    fixedSet.add(value);
+                    if (value < 0) {
+                        hasNegativeValue = true;
+                        fixedSet.add(value + 1);
+                    }
+                }
+
+                if (hasNegativeValue) {
+                    return Expressions.in(projected.term(), fixedSet);
+                }
+                return projected;
+
+            case NOT_IN:
+            case NOT_EQ:
+                // there is no inclusive projection for NOT_EQ and NOT_IN
+                return null;
+
+            default:
+                return projected;
+        }
+    }
+
+    /**
+     * Fixes a strict projection to account for incorrectly transformed values.
+     *
+     * <p>A bug in 0.10.0 and earlier caused negative values to be incorrectly transformed by date and
+     * timestamp transforms to 1 larger than the correct value. For example, day(1969-12-31 10:00:00)
+     * produced 0 instead of -1. To read data written by versions with this bug, this method adjusts
+     * the strict projection.
+     */
+    static UnboundPredicate<Integer> fixStrictTimeProjection(UnboundPredicate<Integer> projected) {
+        if (projected == null) {
+            return null;
+        }
+
+        switch (projected.op()) {
+            case LT:
+            case LT_EQ:
+                // the correct bound is a correct strict projection for the incorrectly transformed values.
+                return projected;
+
+            case GT:
+                // GT and GT_EQ need to be adjusted because values that do not match the predicate may have
+                // been transformed into partition values that match the projected predicate. For example, >=
+                // month(1969-11-31) is > -2, but 1969-10-31 was previously transformed to month -2 instead
+                // of -3. This must use the more strict value.
+                if (projected.literal().value() <= 0) {
+                    return Expressions.greaterThan(projected.term(), projected.literal().value() + 1);
+                }
+                return projected;
+
+            case GT_EQ:
+                if (projected.literal().value() <= 0) {
+                    return Expressions.greaterThanOrEqual(projected.term(), projected.literal().value() + 1);
+                }
+                return projected;
+
+            case EQ:
+            case IN:
+                // there is no strict projection for EQ and IN
+                return null;
+
+            case NOT_EQ:
+                if (projected.literal().value() < 0) {
+                    return Expressions.notIn(
+                        projected.term(), projected.literal().value(), projected.literal().value() + 1);
+                }
+                return projected;
+
+            case NOT_IN:
+                Set<Integer> fixedSet = Sets.newHashSet();
+                boolean hasNegativeValue = false;
+                for (Literal<Integer> lit : projected.literals()) {
+                    Integer value = lit.value();
+                    fixedSet.add(value);
+                    if (value < 0) {
+                        hasNegativeValue = true;
+                        fixedSet.add(value + 1);
+                    }
+                }
+
+                if (hasNegativeValue) {
+                    return Expressions.notIn(projected.term(), fixedSet);
+                }
+                return projected;
+
+            default:
+                return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/SpecTransformToSparkTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/SpecTransformToSparkTransform.java
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.transforms.PartitionSpecVisitor;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Transform;
+
+import java.util.Map;
+import java.util.function.Function;
+
+class SpecTransformToSparkTransform implements PartitionSpecVisitor<Transform> {
+    private final Map<Integer, String> quotedNameById;
+
+    SpecTransformToSparkTransform(Schema schema) {
+        this.quotedNameById = indexQuotedNameById(schema);
+    }
+
+    @Override
+    public Transform identity(String sourceName, int sourceId) {
+        return Expressions.identity(quotedName(sourceId));
+    }
+
+    @Override
+    public Transform bucket(String sourceName, int sourceId, int numBuckets) {
+        return Expressions.bucket(numBuckets, quotedName(sourceId));
+    }
+
+    @Override
+    public Transform truncate(String sourceName, int sourceId, int width) {
+        NamedReference column = Expressions.column(quotedName(sourceId));
+        return Expressions.apply("truncate", Expressions.literal(width), column);
+    }
+
+    @Override
+    public Transform year(String sourceName, int sourceId) {
+        return Expressions.years(quotedName(sourceId));
+    }
+
+    @Override
+    public Transform month(String sourceName, int sourceId) {
+        return Expressions.months(quotedName(sourceId));
+    }
+
+    @Override
+    public Transform day(String sourceName, int sourceId) {
+        return Expressions.days(quotedName(sourceId));
+    }
+
+    @Override
+    public Transform hour(String sourceName, int sourceId) {
+        return Expressions.hours(quotedName(sourceId));
+    }
+
+    @Override
+    public Transform alwaysNull(int fieldId, String sourceName, int sourceId) {
+        // do nothing for alwaysNull, it doesn't need to be converted to a transform
+        return null;
+    }
+
+    @Override
+    public Transform unknown(int fieldId, String sourceName, int sourceId, String transform) {
+        return Expressions.apply(transform, Expressions.column(quotedName(sourceId)));
+    }
+
+    private String quotedName(int id) {
+        return quotedNameById.get(id);
+    }
+
+    private Map<Integer, String> indexQuotedNameById(Schema schema) {
+        Function<String, String> quotingFunc = name -> String.format("`%s`", name.replace("`", "``"));
+        return TypeUtil.indexQuotedNameById(schema.asStruct(), quotingFunc);
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -194,6 +194,7 @@ import org.apache.doris.datasource.hive.HiveMetaStoreClientHelper;
 import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergExternalDatabase;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergUtils;
 import org.apache.doris.datasource.maxcompute.MaxComputeExternalCatalog;
 import org.apache.doris.job.manager.JobManager;
 import org.apache.doris.load.DeleteHandler;
@@ -1030,6 +1031,12 @@ public class ShowExecutor {
             if (table.getType() == TableType.HMS_EXTERNAL_TABLE) {
                 rows.add(Arrays.asList(table.getName(),
                         HiveMetaStoreClientHelper.showCreateTable((HMSExternalTable) table)));
+                resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
+                return;
+            }
+            if ((table.getType() == TableType.ICEBERG_EXTERNAL_TABLE) && (((IcebergExternalTable) table).isTable())) {
+                rows.add(Arrays.asList(table.getName(),
+                        IcebergUtils.showCreateTable((IcebergExternalTable) table)));
                 resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
                 return;
             }

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -319,7 +319,7 @@ under the License.
         <!-- ATTN: avro version must be consistent with Iceberg version -->
         <!-- Please modify iceberg.version and avro.version together,
          you can find avro version info in iceberg mvn repository -->
-        <iceberg.version>1.6.1</iceberg.version>
+        <iceberg.version>1.9.1</iceberg.version>
         <maxcompute.version>0.49.0-public</maxcompute.version>
         <!-- Arrow 19.0.1 will MacOS compile error and decimal type error when convert to Parquet
          https://github.com/apache/doris/pull/51217-->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1456,6 +1456,12 @@ under the License.
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-reflect</artifactId>
+                <version>${scala.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.esotericsoftware</groupId>
                 <artifactId>kryo-shaded</artifactId>
                 <version>${kryo.version}</version>


### PR DESCRIPTION

### What problem does this PR solve?

Support displaying the complete table structure of Iceberg tables via the show create table syntax in Doris.

Problem Summary:
Currently, when performing the show create table operation on Iceberg tables in Doris, the displayed table structure information is incomplete. It lacks the display of partition/bucket columns, and the table properties are also not fully shown.


### Check List (For Author)
    - [ ] Manual test (add detailed scripts or steps below)
[show_create_iceberg_table.docx](https://github.com/user-attachments/files/20745577/show_create_iceberg_table.docx)


- Behavior changed:
    - [ ] No.

- Does this need documentation?
    - [ ] No.


