### PR TITLE
[be](gracefulexit) should stop async result writer when graceful exit

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -336,10 +336,10 @@ void FragmentMgr::stop() {
         _cancel_thread->join();
     }
 
+    _thread_pool->shutdown();
     // Only me can delete
     _query_ctx_map.clear();
     _pipeline_map.clear();
-    _thread_pool->shutdown();
 }
 
 std::string FragmentMgr::to_http_path(const std::string& file_name) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -171,6 +171,10 @@ public:
 
     ThreadPool* get_thread_pool() { return _thread_pool.get(); }
 
+    // When fragment mgr is going to stop, the _stop_background_threads_latch is set to 0
+    // and other module that use fragment mgr's thread pool should get this signal and exit.
+    bool shutting_down() { return _stop_background_threads_latch.count() == 0; }
+
     int32_t running_query_num() { return _query_ctx_map.num_items(); }
 
     std::string dump_pipeline_tasks(int64_t duration = 0);
@@ -215,7 +219,7 @@ private:
 
     CountDownLatch _stop_background_threads_latch;
     scoped_refptr<Thread> _cancel_thread;
-    // every job is a pool
+    // This pool is used as global async task pool
     std::unique_ptr<ThreadPool> _thread_pool;
 
     std::shared_ptr<MetricEntity> _entity;

--- a/be/src/vec/sink/writer/async_result_writer.cpp
+++ b/be/src/vec/sink/writer/async_result_writer.cpp
@@ -154,7 +154,7 @@ void AsyncResultWriter::process_block(RuntimeState* state, RuntimeProfile* profi
             }
             // If writer status is not ok, then we should not change its status to avoid lost the actual error status.
             if (ExecEnv::GetInstance()->fragment_mgr()->shutting_down() && _writer_status.ok()) {
-                _writer_status.update(Status::Error("FragmentMgr is shutting down"));
+                _writer_status.update(Status::InternalError<false>("FragmentMgr is shutting down"));
             }
 
             //check if eos or writer error

--- a/be/src/vec/sink/writer/async_result_writer.cpp
+++ b/be/src/vec/sink/writer/async_result_writer.cpp
@@ -144,9 +144,17 @@ void AsyncResultWriter::process_block(RuntimeState* state, RuntimeProfile* profi
         //1) wait scan operator write data
         {
             std::unique_lock l(_m);
-            while (!_eos && _data_queue.empty() && _writer_status.ok()) {
+            // When the query is cancelled, _writer_status may be set to error status in force_close method.
+            // When the BE process is exit gracefully, the fragment mgr's thread pool will be shutdown,
+            // and the async thread will be exit.
+            while (!_eos && _data_queue.empty() && _writer_status.ok() &&
+                   !ExecEnv::GetInstance()->fragment_mgr()->shutting_down()) {
                 // Add 1s to check to avoid lost signal
                 _cv.wait_for(l, std::chrono::seconds(1));
+            }
+            // If writer status is not ok, then we should not change its status to avoid lost the actual error status.
+            if (ExecEnv::GetInstance()->fragment_mgr()->shutting_down() && _writer_status.ok()) {
+                _writer_status.update(Status::Error("FragmentMgr is shutting down"));
             }
 
             //check if eos or writer error


### PR DESCRIPTION
During graceful exit, async result writer will not exit and hang because it will try to pull data block the queue endlessly.
AsyncResultWriter thread should exit when fragment mgr wants to exit.

Thread 652 (Thread 0x7fd20c1b0700 (LWP 434882) "FragmentMgrAsyn"):
#0  futex_abstimed_wait_cancelable (private=<optimized out>, abstime=0x7fca3442f560, clockid=<optimized out>, expected=0, futex_word=0x61b000c009f8) at ../sysdeps/nptl/futex-internal.h:320
#1  __pthread_cond_wait_common (abstime=0x7fca3442f560, clockid=<optimized out>, mutex=0x61b000c009a8, cond=0x61b000c009d0) at pthread_cond_wait.c:520
#2  __pthread_cond_timedwait (cond=0x61b000c009d0, mutex=0x61b000c009a8, abstime=0x7fca3442f560) at pthread_cond_wait.c:665
#3  0x00005566ce61f350 in __gthread_cond_timedwait (__cond=0x61b000c009d0, __mutex=0x61b000c009a8, __abs_timeout=0x7fca3442f560) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:872
#4  std::__condvar::wait_until (this=0x61b000c009d0, __m=..., __abs_time=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:162
#5  std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, 1000000000l> > > (this=<optimized out>, __lock=..., __atime=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/condition_variable:222
#6  0x00005566ce61f021 in std::condition_variable::wait_until<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > (this=<optimized out>, __lock=..., __atime=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/condition_variable:135
#7  0x000055670b59b0be in std::condition_variable::wait_for<long, std::ratio<1l, 1l> > (this=0x61b000c009d0, __lock=..., __rtime=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/condition_variable:163
#8  doris::vectorized::AsyncResultWriter::process_block (this=<optimized out>, state=0x61e001b3c080, profile=<optimized out>) at /root/doris/be/src/vec/sink/writer/async_result_writer.cpp:149
#9  0x000055670b59eb1f in doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0::operator()() const (this=0x60400146b110) at /root/doris/be/src/vec/sink/writer/async_result_writer.cpp:103
#10 std::__invoke_impl<void, doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0&>(std::__invoke_other, doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0&) (__f=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#11 std::__invoke_r<void, doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0&>(doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0&) (__fn=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#12 std::_Function_handler<void (), doris::vectorized::AsyncResultWriter::start_writer(doris::RuntimeState*, doris::RuntimeProfile*)::$_0>::_M_invoke(std::_Any_data const&) (__functor=...) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#13 0x00005566d2f2270b in doris::ThreadPool::dispatch_thread (this=0x616000415580) at /root/doris/be/src/util/threadpool.cpp:615
#14 0x00005566d2ef973a in doris::Thread::supervise_thread (arg=0x611005af0540) at /root/doris/be/src/util/thread.cpp:468
#15 0x00007fd5c2034609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#16 0x00007fd5c22e1133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

