### PR TITLE
[improve](cloud) make meta_service_endpoint configurable

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -182,15 +182,12 @@ public:
 
         long deadline = now;
         // connection age only works without list endpoint.
-        if (!is_meta_service_endpoint_list() &&
-            config::meta_service_connection_age_base_seconds > 0) {
+        if (config::meta_service_connection_age_base_seconds > 0) {
             std::default_random_engine rng(static_cast<uint32_t>(now));
             std::uniform_int_distribution<> uni(
                     config::meta_service_connection_age_base_seconds,
                     config::meta_service_connection_age_base_seconds * 2);
             deadline = now + duration_cast<milliseconds>(seconds(uni(rng))).count();
-        } else {
-            deadline = LONG_MAX;
         }
 
         // Last one WIN

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3147,7 +3147,7 @@ public class Config extends ConfigBase {
      * If you want to access a group of meta services, separated the endpoints by comma,
      * like "host-1:port,host-2:port".
      */
-    @ConfField
+    @ConfField(mutable = true, callback = CommaSeparatedIntersectConfHandler.class)
     public static String meta_service_endpoint = "";
 
     @ConfField(mutable = true)
@@ -3168,8 +3168,6 @@ public class Config extends ConfigBase {
 
     // A connection will expire after a random time during [base, 2*base), so that the FE
     // has a chance to connect to a new RS. Set zero to disable it.
-    //
-    // It only works if the meta_service_endpoint is not point to a group of meta services.
     @ConfField(mutable = true)
     public static int meta_service_connection_age_base_minutes = 5;
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -20,6 +20,7 @@ package org.apache.doris.common;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -76,6 +78,20 @@ public class ConfigBase {
         @Override
         public void handle(Field field, String confVal) throws Exception {
             setConfigField(field, confVal);
+        }
+    }
+
+    static class CommaSeparatedIntersectConfHandler implements ConfHandler {
+        @Override
+        public void handle(Field field, String newVal) throws Exception {
+            String oldVal = String.valueOf(field.get(null));
+            Set<String> oldSets = Sets.newHashSet(oldVal.split(","));
+            Set<String> newSets = Sets.newHashSet(newVal.split(","));
+            if (!oldSets.removeAll(newSets)) {
+                throw new ConfigException("Config '" + field.getName()
+                    + "' must have intersection between the configs");
+            }
+            setConfigField(field, newVal);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
@@ -48,7 +48,6 @@ public class MetaServiceClient {
     private final MetaServiceGrpc.MetaServiceBlockingStub blockingStub;
     private final ManagedChannel channel;
     private final long expiredAt;
-    private final boolean isMetaServiceEndpointList;
     private Random random = new Random();
 
     static {
@@ -64,10 +63,8 @@ public class MetaServiceClient {
     public MetaServiceClient(String address) {
         this.address = address;
 
-        isMetaServiceEndpointList = address.contains(",");
-
         String target = address;
-        if (isMetaServiceEndpointList) {
+        if (address.contains(",")) {
             target = MetaServiceListResolverProvider.MS_LIST_SCHEME_PREFIX + address;
         }
 
@@ -87,8 +84,7 @@ public class MetaServiceClient {
 
     private long connectionAgeExpiredAt() {
         long connectionAgeBase = Config.meta_service_connection_age_base_minutes;
-        // Disable connection age if the endpoint is a list.
-        if (!isMetaServiceEndpointList && connectionAgeBase > 1) {
+        if (connectionAgeBase >= 1) {
             long base = TimeUnit.MINUTES.toMillis(connectionAgeBase);
             long now = System.currentTimeMillis();
             long rand = random.nextLong() % base;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceClient.java
@@ -84,7 +84,7 @@ public class MetaServiceClient {
 
     private long connectionAgeExpiredAt() {
         long connectionAgeBase = Config.meta_service_connection_age_base_minutes;
-        if (connectionAgeBase >= 1) {
+        if (connectionAgeBase > 0) {
             long base = TimeUnit.MINUTES.toMillis(connectionAgeBase);
             long now = System.currentTimeMillis();
             long rand = random.nextLong() % base;

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -109,6 +109,9 @@ public class HeartbeatMgr extends MasterDaemon {
      */
     @Override
     protected void runAfterCatalogReady() {
+        if (Config.isCloudMode() && masterInfo.get() != null) {
+            masterInfo.get().setMetaServiceEndpoint(Config.meta_service_endpoint);
+        }
         // Get feInfos of previous iteration.
         List<TFrontendInfo> feInfos = Env.getCurrentEnv().getFrontendInfos();
         List<Future<HeartbeatResponse>> hbResponses = Lists.newArrayList();


### PR DESCRIPTION
### Proposed changes
When scale out the meta service, we need to change the `meta_service_endpoint` conf item  in both fe and be, and restart all the service. This is not the best practice in a cloud environment. Using admin set all frontends config to change the config and without restarting it is good practice. 

In order to prevent setting a wrong meta_service_endpoint config,  it has a constraint: new config and old config should have endpoint intersect to indicate they belong to the same cluster