### PR TITLE
[chore](cloud) rename cloud::put/get to blob_put/blob_get

### DIFF
--- a/cloud/src/common/util.cpp
+++ b/cloud/src/common/util.cpp
@@ -346,8 +346,8 @@ TxnErrorCode key_exists(Transaction* txn, std::string_view key, bool snapshot) {
     return it->has_next() ? TxnErrorCode::TXN_OK : TxnErrorCode::TXN_KEY_NOT_FOUND;
 }
 
-void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb, uint8_t ver,
-         size_t split_size) {
+void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb,
+              uint8_t ver, size_t split_size) {
     std::string value;
     bool ret = pb.SerializeToString(&value); // Always success
     DCHECK(ret) << hex(key) << ' ' << pb.ShortDebugString();
@@ -355,7 +355,7 @@ void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Me
 }
 
 void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
-         size_t split_size) {
+              size_t split_size) {
     auto split_vec = split_string(value, split_size);
     int64_t suffix_base = ver;
     suffix_base <<= 56;

--- a/cloud/src/common/util.cpp
+++ b/cloud/src/common/util.cpp
@@ -331,7 +331,7 @@ TxnErrorCode ValueBuf::get(Transaction* txn, std::string_view key, bool snapshot
     return TxnErrorCode::TXN_OK;
 }
 
-TxnErrorCode get(Transaction* txn, std::string_view key, ValueBuf* val, bool snapshot) {
+TxnErrorCode blob_get(Transaction* txn, std::string_view key, ValueBuf* val, bool snapshot) {
     return val->get(txn, key, snapshot);
 }
 
@@ -346,15 +346,15 @@ TxnErrorCode key_exists(Transaction* txn, std::string_view key, bool snapshot) {
     return it->has_next() ? TxnErrorCode::TXN_OK : TxnErrorCode::TXN_KEY_NOT_FOUND;
 }
 
-void put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb, uint8_t ver,
+void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb, uint8_t ver,
          size_t split_size) {
     std::string value;
     bool ret = pb.SerializeToString(&value); // Always success
     DCHECK(ret) << hex(key) << ' ' << pb.ShortDebugString();
-    put(txn, key, value, ver, split_size);
+    blob_put(txn, key, value, ver, split_size);
 }
 
-void put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
+void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
          size_t split_size) {
     auto split_vec = split_string(value, split_size);
     int64_t suffix_base = ver;

--- a/cloud/src/common/util.h
+++ b/cloud/src/common/util.h
@@ -39,7 +39,7 @@ std::string unhex(std::string_view str);
 
 /**
  * Prettifies the given key, the first byte must be key space tag, say 0x01, and
- * the remaining part must be the output of codec funtion family.
+ * the remaining part must be the output of codec function family.
  *
  * The result is like following:
  *
@@ -107,7 +107,7 @@ struct ValueBuf {
  * @param snapshot if true, `key` will not be included in txn conflict detection this time
  * @return return TXN_OK for success get a key, TXN_KEY_NOT_FOUND for key not found, otherwise for error.
  */
-TxnErrorCode get(Transaction* txn, std::string_view key, ValueBuf* val, bool snapshot = false);
+TxnErrorCode blob_get(Transaction* txn, std::string_view key, ValueBuf* val, bool snapshot = false);
 
 /**
  * Test whether key exists
@@ -127,8 +127,8 @@ TxnErrorCode key_exists(Transaction* txn, std::string_view key, bool snapshot = 
  * @param ver value version
  * @param split_size how many byte sized fragments are the value split into
  */
-void put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb, uint8_t ver,
-         size_t split_size = 90 * 1000);
+void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb,
+              uint8_t ver, size_t split_size = 90 * 1000);
 
 /**
  * Put a KV, it's value may be bigger than 100k
@@ -138,7 +138,7 @@ void put(Transaction* txn, std::string_view key, const google::protobuf::Message
  * @param ver value version
  * @param split_size how many byte sized fragments are the value split into
  */
-void put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
-         size_t split_size = 90 * 1000);
+void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
+              size_t split_size = 90 * 1000);
 
 } // namespace doris::cloud

--- a/cloud/src/meta-service/http_encode_key.cpp
+++ b/cloud/src/meta-service/http_encode_key.cpp
@@ -305,7 +305,7 @@ HttpResponse process_http_get_value(TxnKv* txn_kv, const brpc::URI& uri) {
             value.iters.push_back(std::move(it));
         } while (more);
     } else {
-        err = cloud::get(txn.get(), key, &value, true);
+        err = cloud::blob_get(txn.get(), key, &value, true);
     }
 
     if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
@@ -371,7 +371,7 @@ HttpResponse process_http_set_value(TxnKv* txn_kv, brpc::Controller* cntl) {
     // StatsTabletKey is special, it has a series of keys, we only handle the base stat key
     // MetaSchemaPBDictionaryKey, MetaSchemaKey, MetaDeleteBitmapKey are splited in to multiple KV
     ValueBuf value;
-    err = cloud::get(txn.get(), key, &value, true);
+    err = cloud::blob_get(txn.get(), key, &value, true);
 
     bool kv_found = true;
     if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
@@ -413,7 +413,7 @@ HttpResponse process_http_set_value(TxnKv* txn_kv, brpc::Controller* cntl) {
     // and the number of final keys may be less than the initial number of keys
     if (kv_found) value.remove(txn.get());
 
-    // TODO(gavin): use cloud::put() to deal with split-multi-kv and special keys
+    // TODO(gavin): use cloud::blob_put() to deal with split-multi-kv and special keys
     // StatsTabletKey is special, it has a series of keys, we only handle the base stat key
     // MetaSchemaPBDictionaryKey, MetaSchemaKey, MetaDeleteBitmapKey are splited in to multiple KV
     txn->put(key, serialized_value_to_save);

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -91,9 +91,7 @@ std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
 
     std::vector<NodeInfo> nodes;
     std::string err = rc_mgr->get_node(cloud_unique_id, &nodes);
-    {
-        TEST_SYNC_POINT_CALLBACK("get_instance_id_err", &err);
-    }
+    { TEST_SYNC_POINT_CALLBACK("get_instance_id_err", &err); }
     std::string instance_id;
     if (!err.empty()) {
         // cache can't find cloud_unique_id, so degraded by parse cloud_unique_id
@@ -290,9 +288,7 @@ void MetaServiceImpl::get_version(::google::protobuf::RpcController* controller,
             response->set_version(version_pb.version());
             response->add_version_update_time_ms(version_pb.update_time_ms());
         }
-        {
-            TEST_SYNC_POINT_CALLBACK("get_version_code", &code);
-        }
+        { TEST_SYNC_POINT_CALLBACK("get_version_code", &code); }
         return;
     } else if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
         msg = "not found";

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -91,7 +91,9 @@ std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
 
     std::vector<NodeInfo> nodes;
     std::string err = rc_mgr->get_node(cloud_unique_id, &nodes);
-    { TEST_SYNC_POINT_CALLBACK("get_instance_id_err", &err); }
+    {
+        TEST_SYNC_POINT_CALLBACK("get_instance_id_err", &err);
+    }
     std::string instance_id;
     if (!err.empty()) {
         // cache can't find cloud_unique_id, so degraded by parse cloud_unique_id
@@ -288,7 +290,9 @@ void MetaServiceImpl::get_version(::google::protobuf::RpcController* controller,
             response->set_version(version_pb.version());
             response->add_version_update_time_ms(version_pb.update_time_ms());
         }
-        { TEST_SYNC_POINT_CALLBACK("get_version_code", &code); }
+        {
+            TEST_SYNC_POINT_CALLBACK("get_version_code", &code);
+        }
         return;
     } else if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
         msg = "not found";
@@ -705,7 +709,7 @@ void internal_get_tablet(MetaServiceCode& code, std::string& msg, const std::str
         auto key = meta_schema_key(
                 {instance_id, tablet_meta->index_id(), tablet_meta->schema_version()});
         ValueBuf val_buf;
-        err = cloud::get(txn, key, &val_buf);
+        err = cloud::blob_get(txn, key, &val_buf);
         if (err != TxnErrorCode::TXN_OK) {
             code = cast_as<ErrCategory::READ>(err);
             msg = fmt::format("failed to get schema, err={}", err == TxnErrorCode::TXN_KEY_NOT_FOUND
@@ -779,7 +783,7 @@ void MetaServiceImpl::update_tablet(::google::protobuf::RpcController* controlle
                 auto key = meta_schema_key(
                         {instance_id, tablet_meta.index_id(), tablet_meta.schema_version()});
                 ValueBuf val_buf;
-                err = cloud::get(txn.get(), key, &val_buf);
+                err = cloud::blob_get(txn.get(), key, &val_buf);
                 if (err != TxnErrorCode::TXN_OK) {
                     code = cast_as<ErrCategory::READ>(err);
                     msg = fmt::format("failed to get schema, err={}",
@@ -951,7 +955,7 @@ static void set_schema_in_existed_rowset(MetaServiceCode& code, std::string& msg
         std::string schema_key = meta_schema_key({instance_id, existed_rowset_meta.index_id(),
                                                   existed_rowset_meta.schema_version()});
         ValueBuf val_buf;
-        TxnErrorCode err = cloud::get(txn, schema_key, &val_buf, true);
+        TxnErrorCode err = cloud::blob_get(txn, schema_key, &val_buf, true);
         if (err != TxnErrorCode::TXN_OK) {
             code = cast_as<ErrCategory::READ>(err);
             msg = fmt::format(
@@ -1665,7 +1669,7 @@ static bool try_fetch_and_parse_schema(Transaction* txn, RowsetMetaCloudPB& rows
                                        const std::string& key, MetaServiceCode& code,
                                        std::string& msg) {
     ValueBuf val_buf;
-    TxnErrorCode err = cloud::get(txn, key, &val_buf);
+    TxnErrorCode err = cloud::blob_get(txn, key, &val_buf);
     if (err != TxnErrorCode::TXN_OK) {
         code = cast_as<ErrCategory::READ>(err);
         msg = fmt::format("failed to get schema, schema_version={}, rowset_version=[{}-{}]: {}",
@@ -2442,7 +2446,7 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
                       << " initiator=" << request->initiator();
         }
         // splitting large values (>90*1000) into multiple KVs
-        cloud::put(txn.get(), key, val, 0);
+        cloud::blob_put(txn.get(), key, val, 0);
         current_key_count++;
         current_value_count += val.size();
         total_key_count++;
@@ -3646,7 +3650,7 @@ void MetaServiceImpl::get_schema_dict(::google::protobuf::RpcController* control
 
     std::string dict_key = meta_schema_pb_dictionary_key({instance_id, request->index_id()});
     ValueBuf dict_val;
-    err = cloud::get(txn.get(), dict_key, &dict_val);
+    err = cloud::blob_get(txn.get(), dict_key, &dict_val);
     LOG(INFO) << "Retrieved column pb dictionary, index_id=" << request->index_id()
               << " key=" << hex(dict_key) << " error=" << err;
     if (err != TxnErrorCode::TXN_KEY_NOT_FOUND && err != TxnErrorCode::TXN_OK) {

--- a/cloud/src/meta-service/meta_service_schema.cpp
+++ b/cloud/src/meta-service/meta_service_schema.cpp
@@ -56,7 +56,7 @@ void put_schema_kv(MetaServiceCode& code, std::string& msg, Transaction* txn,
                 return type;
             };
             ValueBuf buf;
-            auto err = cloud::get(txn, schema_key, &buf);
+            auto err = cloud::blob_get(txn, schema_key, &buf);
             if (err != TxnErrorCode::TXN_OK) {
                 LOG(WARNING) << "failed to get schema, err=" << err;
                 return false;
@@ -119,7 +119,7 @@ void put_schema_kv(MetaServiceCode& code, std::string& msg, Transaction* txn,
     LOG_INFO("put schema kv").tag("key", hex(schema_key));
     uint8_t ver = config::meta_schema_value_version;
     if (ver > 0) {
-        cloud::put(txn, schema_key, schema, ver);
+        cloud::blob_put(txn, schema_key, schema, ver);
     } else {
         auto schema_value = schema.SerializeAsString();
         txn->put(schema_key, schema_value);
@@ -221,7 +221,7 @@ void write_schema_dict(MetaServiceCode& code, std::string& msg, const std::strin
     SchemaCloudDictionary dict;
     std::string dict_key = meta_schema_pb_dictionary_key({instance_id, rowset_meta->index_id()});
     ValueBuf dict_val;
-    auto err = cloud::get(txn, dict_key, &dict_val);
+    auto err = cloud::blob_get(txn, dict_key, &dict_val);
     LOG(INFO) << "Retrieved column pb dictionary, index_id=" << rowset_meta->index_id()
               << " key=" << hex(dict_key) << " error=" << err;
     if (err != TxnErrorCode::TXN_KEY_NOT_FOUND && err != TxnErrorCode::TXN_OK) {
@@ -312,7 +312,7 @@ void write_schema_dict(MetaServiceCode& code, std::string& msg, const std::strin
             return;
         }
         // splitting large values (>90*1000) into multiple KVs
-        cloud::put(txn, dict_key, dict_val, 0);
+        cloud::blob_put(txn, dict_key, dict_val, 0);
         LOG(INFO) << "Dictionary saved, key=" << hex(dict_key)
                   << " txn_id=" << rowset_meta->txn_id() << " Dict size=" << dict.column_dict_size()
                   << ", index_id=" << rowset_meta->index_id()
@@ -331,7 +331,7 @@ void read_schema_dict(MetaServiceCode& code, std::string& msg, const std::string
     SchemaCloudDictionary dict;
     std::string column_dict_key = meta_schema_pb_dictionary_key({instance_id, index_id});
     ValueBuf dict_val;
-    auto err = cloud::get(txn, column_dict_key, &dict_val);
+    auto err = cloud::blob_get(txn, column_dict_key, &dict_val);
     if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
         code = cast_as<ErrCategory::READ>(err);
         ss << "internal error, failed to get dict, err=" << err;

--- a/cloud/src/recycler/meta_checker.cpp
+++ b/cloud/src/recycler/meta_checker.cpp
@@ -347,7 +347,7 @@ bool MetaChecker::check_fdb_by_fe_meta(MYSQL* conn) {
         meta_schema_key({instance_id_, tablet_info.index_id, tablet_info.schema_version},
                         &schema_key);
         ValueBuf val_buf;
-        err = cloud::get(txn.get(), schema_key, &val_buf);
+        err = cloud::blob_get(txn.get(), schema_key, &val_buf);
         if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
             LOG(WARNING) << "tablet schema not found: " << tablet_info.debug_string();
             return false;

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -423,7 +423,7 @@ public:
         }
         auto schema_key = meta_schema_key({instance_id_, index_id, schema_version});
         ValueBuf val_buf;
-        err = cloud::get(txn.get(), schema_key, &val_buf);
+        err = cloud::blob_get(txn.get(), schema_key, &val_buf);
         if (err != TxnErrorCode::TXN_OK) {
             LOG(WARNING) << "failed to get schema, err=" << err;
             return static_cast<int>(err);

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -343,7 +343,7 @@ static void create_delete_bitmaps(Transaction* txn, int64_t tablet_id, std::stri
                 txn->put(key, val);
             } else {
                 std::string val(1000, 'A');
-                cloud::put(txn, key, val, 0, 300);
+                cloud::blob_put(txn, key, val, 0, 300);
             }
         }
     }
@@ -2825,7 +2825,7 @@ TEST(CheckerTest, delete_bitmap_inverted_check_normal) {
                 auto delete_bitmap_key =
                         meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, ver, 0});
                 std::string delete_bitmap_val(1000, 'A');
-                cloud::put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0, 300);
+                cloud::blob_put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0, 300);
             }
         }
         if (is_last_tablet) {
@@ -2932,7 +2932,7 @@ TEST(CheckerTest, delete_bitmap_inverted_check_abnormal) {
                 auto delete_bitmap_key =
                         meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, ver, 0});
                 std::string delete_bitmap_val(1000, 'A');
-                cloud::put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0, 300);
+                cloud::blob_put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0, 300);
             }
         }
     }

--- a/cloud/test/txn_kv_test.cpp
+++ b/cloud/test/txn_kv_test.cpp
@@ -250,7 +250,7 @@ TEST(TxnKvTest, CompatibleGetTest) {
     ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
     ASSERT_EQ(doris::cloud::key_exists(txn.get(), key), TxnErrorCode::TXN_KEY_NOT_FOUND);
     ValueBuf val_buf;
-    ASSERT_EQ(doris::cloud::get(txn.get(), key, &val_buf), TxnErrorCode::TXN_KEY_NOT_FOUND);
+    ASSERT_EQ(doris::cloud::blob_get(txn.get(), key, &val_buf), TxnErrorCode::TXN_KEY_NOT_FOUND);
     txn->put(key, val);
     ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
 
@@ -259,7 +259,7 @@ TEST(TxnKvTest, CompatibleGetTest) {
     ASSERT_EQ(err, TxnErrorCode::TXN_OK);
     err = doris::cloud::key_exists(txn.get(), key);
     ASSERT_EQ(err, TxnErrorCode::TXN_OK);
-    err = doris::cloud::get(txn.get(), key, &val_buf);
+    err = doris::cloud::blob_get(txn.get(), key, &val_buf);
     ASSERT_EQ(err, TxnErrorCode::TXN_OK);
     EXPECT_EQ(val_buf.ver, 0);
     doris::TabletSchemaCloudPB saved_schema;
@@ -305,7 +305,7 @@ TEST(TxnKvTest, PutLargeValueTest) {
     auto key = meta_schema_key({instance_id, 10005, 1});
     std::unique_ptr<Transaction> txn;
     ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
-    doris::cloud::put(txn.get(), key, schema, 1, 100);
+    doris::cloud::blob_put(txn.get(), key, schema, 1, 100);
     ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
 
     // Check get

--- a/cloud/test/txn_kv_test.cpp
+++ b/cloud/test/txn_kv_test.cpp
@@ -277,7 +277,7 @@ TEST(TxnKvTest, CompatibleGetTest) {
     // Check remove
     ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
     ASSERT_EQ(doris::cloud::key_exists(txn.get(), key), TxnErrorCode::TXN_KEY_NOT_FOUND);
-    ASSERT_EQ(doris::cloud::get(txn.get(), key, &val_buf), TxnErrorCode::TXN_KEY_NOT_FOUND);
+    ASSERT_EQ(doris::cloud::blob_get(txn.get(), key, &val_buf), TxnErrorCode::TXN_KEY_NOT_FOUND);
 }
 
 TEST(TxnKvTest, PutLargeValueTest) {
@@ -313,7 +313,7 @@ TEST(TxnKvTest, PutLargeValueTest) {
     ValueBuf val_buf;
     doris::TabletSchemaCloudPB saved_schema;
     ASSERT_EQ(doris::cloud::key_exists(txn.get(), key), TxnErrorCode::TXN_OK);
-    TxnErrorCode err = doris::cloud::get(txn.get(), key, &val_buf);
+    TxnErrorCode err = doris::cloud::blob_get(txn.get(), key, &val_buf);
     ASSERT_EQ(err, TxnErrorCode::TXN_OK);
     std::cout << "num iterators=" << val_buf.iters.size() << std::endl;
     EXPECT_EQ(val_buf.ver, 1);
@@ -329,7 +329,7 @@ TEST(TxnKvTest, PutLargeValueTest) {
         auto* limit = doris::try_any_cast<int*>(args[0]);
         *limit = 100;
     });
-    err = doris::cloud::get(txn.get(), key, &val_buf);
+    err = doris::cloud::blob_get(txn.get(), key, &val_buf);
     ASSERT_EQ(err, TxnErrorCode::TXN_OK);
     std::cout << "num iterators=" << val_buf.iters.size() << std::endl;
     EXPECT_EQ(val_buf.ver, 1);
@@ -364,7 +364,7 @@ TEST(TxnKvTest, PutLargeValueTest) {
     // Check remove
     ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
     ASSERT_EQ(doris::cloud::key_exists(txn.get(), key), TxnErrorCode::TXN_KEY_NOT_FOUND);
-    ASSERT_EQ(doris::cloud::get(txn.get(), key, &val_buf), TxnErrorCode::TXN_KEY_NOT_FOUND);
+    ASSERT_EQ(doris::cloud::blob_get(txn.get(), key, &val_buf), TxnErrorCode::TXN_KEY_NOT_FOUND);
 }
 
 TEST(TxnKvTest, RangeGetIteratorContinue) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

The original names cloud::put/get are generic and don't show the utility. Since they split values into chunks by size, changing their names to blob_put/get is more accurate. Additionally, we will introduce more mechanisms to serialize large values into FDB.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

