### PR TITLE
[fix](regress) fix test_simplify_comparison_predicate

### DIFF
--- a/regression-test/suites/nereids_rules_p0/expression/test_simplify_comparison_predicate.groovy
+++ b/regression-test/suites/nereids_rules_p0/expression/test_simplify_comparison_predicate.groovy
@@ -20,28 +20,18 @@
 suite('test_simplify_comparison_predicate', 'nonConcurrent') {
     def tbl = 'test_simplify_comparison_predicate_tbl'
     def checkExplain = { expression, resExpression ->
-        def checker = { explainString, exception, startTime, endTime ->
-            assertNull(exception)
-            def foundOutputExprs = false
-            def succ = false
-            for (def line : explainString.split('\n')) {
-                if (foundOutputExprs) {
-                    assertTrue(line.contains(resExpression), "'${line}' no contains '${resExpression}'")
-                    succ = true
-                    break
-                }
-                if (line.contains('OUTPUT EXPRS:')) {
-                    foundOutputExprs = true
-                }
+        def shapePlan = sql("EXPLAIN SHAPE PLAN SELECT ${expression} FROM ${tbl}")
+        // logger.info("shape plan:  ${shapePlan}")
+        def foundOutputExprs = false
+        for (def node : shapePlan) {
+            def line = node.get(0)
+            if (line.contains('PhysicalProject')) {
+                def expectSubStr = "PhysicalProject[${resExpression}"
+                assertTrue(line.contains(expectSubStr), "'${line}' no contains '${expectSubStr}'")
+                foundOutputExprs = true
             }
-            assertTrue(foundOutputExprs)
-            assertTrue(succ)
         }
-
-        explain {
-            sql "SELECT ${expression} FROM ${tbl}"
-            check checker
-        }
+        assertTrue(foundOutputExprs)
     }
     def testSimplify = { checkNullColumn, checkNotNullColumn, expression, resExpression ->
         def types = ['']
@@ -75,6 +65,8 @@ suite('test_simplify_comparison_predicate', 'nonConcurrent') {
 
     setFeConfigTemporary([disable_datev1:false, disable_decimalv2:false]) {
         sql """
+            SET detail_shape_nodes='PhysicalProject';
+
             DROP TABLE IF EXISTS ${tbl} FORCE;
 
             CREATE TABLE ${tbl} (
@@ -137,10 +129,10 @@ suite('test_simplify_comparison_predicate', 'nonConcurrent') {
         testSimplify false, false, 'c_decimal_5_2_null = CAST(1.12 as DECIMAL(10, 5))',  '(c_decimal_5_2_null = 1.12)'
         testSimplify false, false, 'c_decimal_5_2_null = CAST(1.123 as DECIMAL(10, 5))',  'AND[c_decimal_5_2_null IS NULL,NULL]'
         testSimplify false, false, 'c_decimal_5_2 = CAST(1.123 as DECIMAL(10, 5))',  'FALSE'
-        testSimplify false, false, 'c_decimal_5_2_null > CAST(1.123 as DECIMAL(10, 5))',  'c_decimal_5_2_null > 1.12'
-        testSimplify false, false, 'c_decimal_5_2_null >= CAST(1.123 as DECIMAL(10, 5))',  'c_decimal_5_2_null >= 1.13'
-        testSimplify false, false, 'c_decimal_5_2_null <= CAST(1.123 as DECIMAL(10, 5))',  'c_decimal_5_2_null <= 1.12'
-        testSimplify false, false, 'c_decimal_5_2_null < CAST(1.123 as DECIMAL(10, 5))',  'c_decimal_5_2_null < 1.13'
+        testSimplify false, false, 'c_decimal_5_2_null > CAST(1.123 as DECIMAL(10, 5))',  '(c_decimal_5_2_null > 1.12)'
+        testSimplify false, false, 'c_decimal_5_2_null >= CAST(1.123 as DECIMAL(10, 5))',  '(c_decimal_5_2_null >= 1.13)'
+        testSimplify false, false, 'c_decimal_5_2_null <= CAST(1.123 as DECIMAL(10, 5))',  '(c_decimal_5_2_null <= 1.12)'
+        testSimplify false, false, 'c_decimal_5_2_null < CAST(1.123 as DECIMAL(10, 5))',  '(c_decimal_5_2_null < 1.13)'
         testSimplify false, false, "CAST(c_datetime_0 AS DATETIME(5)) = '2000-01-01'", "(c_datetime_0 = '2000-01-01 00:00:00')"
         testSimplify false, false, "CAST(c_datetime_0 AS DATETIME(5)) = '2000-01-01 00:00:00.1'", 'FALSE'
         testSimplify false, false, "CAST(c_datetime_0_null AS DATETIME(5)) = '2000-01-01 00:00:00.1'", 'AND[c_datetime_0_null IS NULL,NULL]'
@@ -160,10 +152,10 @@ suite('test_simplify_comparison_predicate', 'nonConcurrent') {
         testSimplify false, false, "c_date = '2000-01-01 00:00:01'", 'FALSE'
         testSimplify false, false, "CAST(c_date_null AS DATETIME(5)) = '2000-01-01 00:00:01'", 'AND[c_date_null IS NULL,NULL]'
         testSimplify false, false, "CAST(c_date_null AS DATETIME(5)) <=> '2000-01-01 00:00:01'", 'FALSE'
-        testSimplify false, false, "CAST(c_date AS DATETIME(5)) > '2000-01-01 00:00:01'", "c_date > '2000-01-01'"
-        testSimplify false, false, "CAST(c_date AS DATETIME(5)) >= '2000-01-01 00:00:01'", "c_date >= '2000-01-02'"
-        testSimplify false, false, "CAST(c_date AS DATETIME(5)) <= '2000-01-01 00:00:01'", "c_date <= '2000-01-01'"
-        testSimplify false, false, "CAST(c_date AS DATETIME(5)) < '2000-01-01 00:00:01'", "c_date < '2000-01-02'"
+        testSimplify false, false, "CAST(c_date AS DATETIME(5)) > '2000-01-01 00:00:01'", "(c_date > '2000-01-01')"
+        testSimplify false, false, "CAST(c_date AS DATETIME(5)) >= '2000-01-01 00:00:01'", "(c_date >= '2000-01-02')"
+        testSimplify false, false, "CAST(c_date AS DATETIME(5)) <= '2000-01-01 00:00:01'", "(c_date <= '2000-01-01')"
+        testSimplify false, false, "CAST(c_date AS DATETIME(5)) < '2000-01-01 00:00:01'", "(c_date < '2000-01-02')"
 
         sql "DROP TABLE IF EXISTS ${tbl} FORCE"
     }


### PR DESCRIPTION
### What problem does this PR solve?

fix test_simplify_comparison_predicate due to the project change to  `the-rewritten-expression AS the-origin-expression`.

No use `explain`, but use `explain shape plan` to get the rewritten expression.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

