### PR TITLE
[feat](iceberg) implement hdfs fileio for iceberg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
@@ -20,6 +20,9 @@ package org.apache.doris.datasource.iceberg;
 import org.apache.doris.catalog.HdfsResource;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.property.PropertyConverter;
+import org.apache.doris.datasource.property.storage.HdfsProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties.Type;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
@@ -62,14 +65,19 @@ public class IcebergHadoopExternalCatalog extends IcebergExternalCatalog {
         hadoopCatalog.setConf(conf);
         catalogProperties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouse);
 
-        // TODO: This is a temporary solution to support Iceberg with Kerberos authentication.
+        // TODO: This is a temporary solution to support Iceberg with HDFS Kerberos authentication.
         // Because currently, DelegateFileIO only support hdfs file operation,
         // and all we want to solve is to use the hdfs file operation in Iceberg to support Kerberos authentication.
         // Later, we should always set FILE_IO_IMPL to DelegateFileIO for all kinds of storages.
-        if (catalogProperties.getOrDefault("hdfs.authentication.type", "").equalsIgnoreCase("kerberos")
-                || catalogProperties.getOrDefault("hadoop.security.authentication", "").equalsIgnoreCase("kerberos")) {
-            catalogProperties.put(CatalogProperties.FILE_IO_IMPL,
-                    "org.apache.doris.datasource.iceberg.fileio.DelegateFileIO");
+        // So, here we strictly check the storage property, if only has one storage property and is kerberos hdfs,
+        // then we will use this file io impl.
+        Map<StorageProperties.Type, StorageProperties> storagePropertiesMap = catalogProperty.getStoragePropertiesMap();
+        if (storagePropertiesMap.size() == 1) {
+            HdfsProperties hdfsProperties = (HdfsProperties) storagePropertiesMap.get(Type.HDFS);
+            if (hdfsProperties != null && hdfsProperties.isKerberos()) {
+                catalogProperties.put(CatalogProperties.FILE_IO_IMPL,
+                        "org.apache.doris.datasource.iceberg.fileio.DelegateFileIO");
+            }
         }
 
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -754,7 +754,6 @@ public class IcebergUtils {
         }
         String metastoreUris = catalogProperties.getOrDefault(HMSProperties.HIVE_METASTORE_URIS, "");
         catalogProperties.put(CatalogProperties.URI, metastoreUris);
-
         hiveCatalog.initialize(name, catalogProperties);
         return hiveCatalog;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateFileIO.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateFileIO.java
@@ -1,0 +1,243 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.fileio;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.FileSystemFactory;
+import org.apache.doris.fs.io.ParsedPath;
+
+import com.google.common.collect.Iterables;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * DelegateFileIO is an implementation of the Iceberg SupportsBulkOperations interface.
+ * It delegates file operations (such as input, output, and deletion) to the underlying Doris FileSystem.
+ * This class is responsible for bridging Doris file system operations with Iceberg's file IO abstraction.
+ */
+public class DelegateFileIO implements SupportsBulkOperations {
+    private static final int DELETE_BATCH_SIZE = 1000;
+    /**
+     * Properties used to initialize the file system.
+     */
+    private Map<String, String> properties;
+    /**
+     * The underlying Doris file system used for file operations.
+     */
+    private FileSystem fileSystem;
+
+    /**
+     * Default constructor.
+     */
+    public DelegateFileIO() {
+
+    }
+
+    /**
+     * Constructor with a specified FileSystem.
+     *
+     * @param fileSystem the Doris file system to delegate operations to
+     */
+    public DelegateFileIO(FileSystem fileSystem) {
+        this.fileSystem = Objects.requireNonNull(fileSystem, "fileSystem is null");
+    }
+
+    // ===================== File Creation Methods =====================
+
+    /**
+     * Creates a new InputFile for the given path.
+     *
+     * @param path the file path
+     * @return an InputFile instance
+     */
+    @Override
+    public InputFile newInputFile(String path) {
+        return new DelegateInputFile(fileSystem.newInputFile(new ParsedPath(path)));
+    }
+
+    /**
+     * Creates a new InputFile for the given path and length.
+     *
+     * @param path the file path
+     * @param length the file length
+     * @return an InputFile instance
+     */
+    @Override
+    public InputFile newInputFile(String path, long length) {
+        return new DelegateInputFile(fileSystem.newInputFile(new ParsedPath(path), length));
+    }
+
+    /**
+     * Creates a new OutputFile for the given path.
+     *
+     * @param path the file path
+     * @return an OutputFile instance
+     */
+    @Override
+    public OutputFile newOutputFile(String path) {
+        return new DelegateOutputFile(fileSystem, new ParsedPath(path));
+    }
+
+    // ===================== File Deletion Methods =====================
+
+    /**
+     * Deletes a file at the specified path.
+     * Throws UncheckedIOException if deletion fails.
+     *
+     * @param path the file path to delete
+     */
+    @Override
+    public void deleteFile(String path) {
+        Status status = fileSystem.delete(path);
+        if (!status.ok()) {
+            throw new UncheckedIOException(
+                    new IOException("Failed to delete file: " + path + ", " + status.toString()));
+        }
+    }
+
+    /**
+     * Deletes a file represented by an InputFile.
+     * Delegates to the default implementation in SupportsBulkOperations.
+     *
+     * @param file the InputFile to delete
+     */
+    @Override
+    public void deleteFile(InputFile file) {
+        SupportsBulkOperations.super.deleteFile(file);
+    }
+
+    /**
+     * Deletes a file represented by an OutputFile.
+     * Delegates to the default implementation in SupportsBulkOperations.
+     *
+     * @param file the OutputFile to delete
+     */
+    @Override
+    public void deleteFile(OutputFile file) {
+        SupportsBulkOperations.super.deleteFile(file);
+    }
+
+    /**
+     * Deletes multiple files in batches.
+     * Throws BulkDeletionFailureException if any batch fails.
+     *
+     * @param pathsToDelete iterable of file paths to delete
+     * @throws BulkDeletionFailureException if deletion fails for any batch
+     */
+    @Override
+    public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
+        Iterable<List<String>> partitions = Iterables.partition(pathsToDelete, DELETE_BATCH_SIZE);
+        partitions.forEach(this::deleteBatch);
+    }
+
+    /**
+     * Helper method to delete a batch of files.
+     * Throws UncheckedIOException if deletion fails.
+     *
+     * @param filesToDelete list of file paths to delete
+     */
+    private void deleteBatch(List<String> filesToDelete) {
+        Status status = fileSystem.deleteAll(filesToDelete);
+        if (!status.ok()) {
+            throw new UncheckedIOException(new IOException("Failed to delete some or all files: " + status.toString()));
+        }
+    }
+
+    // ===================== Manifest/Data/Delete File Methods =====================
+
+    /**
+     * Creates a new InputFile from a ManifestFile.
+     * Delegates to the default implementation in SupportsBulkOperations.
+     *
+     * @param manifest the ManifestFile
+     * @return an InputFile instance
+     */
+    @Override
+    public InputFile newInputFile(ManifestFile manifest) {
+        return SupportsBulkOperations.super.newInputFile(manifest);
+    }
+
+    /**
+     * Creates a new InputFile from a DataFile.
+     * Delegates to the default implementation in SupportsBulkOperations.
+     *
+     * @param file the DataFile
+     * @return an InputFile instance
+     */
+    @Override
+    public InputFile newInputFile(DataFile file) {
+        return SupportsBulkOperations.super.newInputFile(file);
+    }
+
+    /**
+     * Creates a new InputFile from a DeleteFile.
+     * Delegates to the default implementation in SupportsBulkOperations.
+     *
+     * @param file the DeleteFile
+     * @return an InputFile instance
+     */
+    @Override
+    public InputFile newInputFile(DeleteFile file) {
+        return SupportsBulkOperations.super.newInputFile(file);
+    }
+
+    // ===================== Properties and Initialization =====================
+
+    /**
+     * Returns the properties used to initialize the file system.
+     *
+     * @return the properties map
+     */
+    @Override
+    public Map<String, String> properties() {
+        return properties;
+    }
+
+    /**
+     * Initializes the file system with the given properties.
+     *
+     * @param properties the properties map
+     */
+    @Override
+    public void initialize(Map<String, String> properties) {
+        StorageProperties storageProperties = StorageProperties.createPrimary(properties);
+        this.fileSystem = FileSystemFactory.get(storageProperties);
+        this.properties = properties;
+    }
+
+    /**
+     * Closes the file IO and releases any resources if necessary.
+     * No-op in this implementation.
+     */
+    @Override
+    public void close() {
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateInputFile.java
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.fileio;
+
+import org.apache.doris.fs.io.DorisInputFile;
+
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * DelegateInputFile is an implementation of the Iceberg InputFile interface.
+ * It wraps a DorisInputFile and delegates file input operations to it, providing
+ * integration between Doris file system and Iceberg's file IO abstraction.
+ */
+public class DelegateInputFile implements InputFile {
+    /**
+     * The underlying DorisInputFile used for file operations.
+     */
+    private final DorisInputFile inputFile;
+
+    /**
+     * Constructs a DelegateInputFile with the specified DorisInputFile.
+     * @param inputFile the DorisInputFile to delegate operations to
+     */
+    public DelegateInputFile(DorisInputFile inputFile) {
+        this.inputFile = Objects.requireNonNull(inputFile, "inputFile is null");
+    }
+
+    // ===================== File Information Methods =====================
+
+    /**
+     * Returns the length of the file in bytes.
+     * Throws UncheckedIOException if the file status cannot be retrieved.
+     * @return the file length in bytes
+     */
+    @Override
+    public long getLength() {
+        try {
+            return inputFile.length();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to get status for file: " + location(), e);
+        }
+    }
+
+    /**
+     * Returns the location (path) of the file as a string.
+     * @return the file location
+     */
+    @Override
+    public String location() {
+        return inputFile.path().toString();
+    }
+
+    /**
+     * Checks if the file exists.
+     * Throws UncheckedIOException if the existence check fails.
+     * @return true if the file exists, false otherwise
+     */
+    @Override
+    public boolean exists() {
+        try {
+            return inputFile.exists();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to check existence for file: " + location(), e);
+        }
+    }
+
+    // ===================== File Stream Methods =====================
+
+    /**
+     * Opens a new SeekableInputStream for reading the file.
+     * Throws NotFoundException if the file is not found, or UncheckedIOException for other IO errors.
+     * @return a SeekableInputStream for the file
+     */
+    @Override
+    public SeekableInputStream newStream() {
+        try {
+            return new DelegateSeekableInputStream(inputFile.newStream());
+        } catch (FileNotFoundException e) {
+            throw new NotFoundException(e, "Failed to open input stream for file: %s", location());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open input stream for file: " + location(), e);
+        }
+    }
+
+    // ===================== Object Methods =====================
+
+    /**
+     * Returns a string representation of this DelegateInputFile.
+     * @return string representation
+     */
+    @Override
+    public String toString() {
+        return inputFile.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateOutputFile.java
@@ -1,0 +1,197 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.fileio;
+
+import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.io.DorisOutputFile;
+import org.apache.doris.fs.io.ParsedPath;
+
+import com.google.common.io.CountingOutputStream;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * DelegateOutputFile is an implementation of the Iceberg OutputFile interface.
+ * It wraps a DorisOutputFile and delegates file output operations to it, providing
+ * integration between Doris file system and Iceberg's file IO abstraction.
+ */
+public class DelegateOutputFile implements OutputFile {
+    /**
+     * The underlying Doris file system used for file operations.
+     */
+    private final FileSystem fileSystem;
+    /**
+     * The DorisOutputFile instance representing the output file.
+     */
+    private final DorisOutputFile outputFile;
+
+    /**
+     * Constructs a DelegateOutputFile with the specified FileSystem and ParsedPath.
+     *
+     * @param fileSystem the Doris file system to delegate operations to
+     * @param path the ParsedPath representing the file location
+     */
+    public DelegateOutputFile(FileSystem fileSystem, ParsedPath path) {
+        this.fileSystem = Objects.requireNonNull(fileSystem, "fileSystem is null");
+        this.outputFile = fileSystem.newOutputFile(path);
+    }
+
+    // ===================== File Creation Methods =====================
+
+    /**
+     * Creates a new file for writing. Throws UncheckedIOException if creation fails.
+     *
+     * @return a PositionOutputStream for writing to the file
+     */
+    @Override
+    public PositionOutputStream create() {
+        try {
+            return new CountingPositionOutputStream(outputFile.create());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create file: " + location(), e);
+        }
+    }
+
+    /**
+     * Creates or overwrites a file for writing. Throws UncheckedIOException if creation fails.
+     *
+     * @return a PositionOutputStream for writing to the file
+     */
+    @Override
+    public PositionOutputStream createOrOverwrite() {
+        try {
+            return new CountingPositionOutputStream(outputFile.createOrOverwrite());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create file: " + location(), e);
+        }
+    }
+
+    // ===================== File Information Methods =====================
+
+    /**
+     * Returns the location (path) of the file as a string.
+     *
+     * @return the file location
+     */
+    @Override
+    public String location() {
+        return outputFile.path().toString();
+    }
+
+    /**
+     * Converts this output file to an InputFile for reading.
+     *
+     * @return an InputFile instance for the same file
+     */
+    @Override
+    public InputFile toInputFile() {
+        return new DelegateInputFile(fileSystem.newInputFile(outputFile.path()));
+    }
+
+    // ===================== Object Methods =====================
+
+    /**
+     * Returns a string representation of this DelegateOutputFile.
+     *
+     * @return string representation
+     */
+    @Override
+    public String toString() {
+        return outputFile.toString();
+    }
+
+    /**
+     * CountingPositionOutputStream is a wrapper around OutputStream that tracks the number of bytes written.
+     * It extends PositionOutputStream to provide position tracking for Iceberg.
+     */
+    private static class CountingPositionOutputStream extends PositionOutputStream {
+        /**
+         * The underlying CountingOutputStream that wraps the actual OutputStream.
+         */
+        private final CountingOutputStream stream;
+
+        /**
+         * Constructs a CountingPositionOutputStream with the specified OutputStream.
+         *
+         * @param stream the OutputStream to wrap
+         */
+        private CountingPositionOutputStream(OutputStream stream) {
+            this.stream = new CountingOutputStream(stream);
+        }
+
+        /**
+         * Returns the current position (number of bytes written).
+         *
+         * @return the number of bytes written
+         */
+        @Override
+        public long getPos() {
+            return stream.getCount();
+        }
+
+        /**
+         * Writes a single byte to the output stream.
+         *
+         * @param b the byte to write
+         * @throws IOException if an I/O error occurs
+         */
+        @Override
+        public void write(int b) throws IOException {
+            stream.write(b);
+        }
+
+        /**
+         * Writes a portion of a byte array to the output stream.
+         *
+         * @param b the byte array
+         * @param off the start offset
+         * @param len the number of bytes to write
+         * @throws IOException if an I/O error occurs
+         */
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            stream.write(b, off, len);
+        }
+
+        /**
+         * Flushes the output stream.
+         *
+         * @throws IOException if an I/O error occurs
+         */
+        @Override
+        public void flush() throws IOException {
+            stream.flush();
+        }
+
+        /**
+         * Closes the output stream.
+         *
+         * @throws IOException if an I/O error occurs
+         */
+        @Override
+        public void close() throws IOException {
+            stream.close();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateSeekableInputStream.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateSeekableInputStream.java
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.fileio;
+
+import org.apache.doris.fs.io.DorisInputStream;
+
+import org.apache.iceberg.io.SeekableInputStream;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * DelegateSeekableInputStream is an implementation of Iceberg's SeekableInputStream.
+ * It wraps a DorisInputStream and delegates all stream and seek operations to it,
+ * providing integration between Doris file system and Iceberg's seekable input abstraction.
+ */
+public class DelegateSeekableInputStream extends SeekableInputStream {
+    /**
+     * The underlying DorisInputStream used for all operations.
+     */
+    private final DorisInputStream stream;
+
+    /**
+     * Constructs a DelegateSeekableInputStream with the specified DorisInputStream.
+     * @param stream the DorisInputStream to delegate operations to
+     */
+    public DelegateSeekableInputStream(DorisInputStream stream) {
+        this.stream = Objects.requireNonNull(stream, "stream is null");
+    }
+
+    // ===================== Position and Seek Methods =====================
+
+    /**
+     * Returns the current position in the stream.
+     * @return the current byte position
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public long getPos() throws IOException {
+        return stream.getPosition();
+    }
+
+    /**
+     * Seeks to the specified position in the stream.
+     * @param pos the position to seek to
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void seek(long pos) throws IOException {
+        stream.seek(pos);
+    }
+
+    // ===================== Read Methods =====================
+
+    /**
+     * Reads a single byte from the stream.
+     * @return the byte read, or -1 if end of stream
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int read() throws IOException {
+        return stream.read();
+    }
+
+    /**
+     * Reads bytes into the specified array.
+     * @param b the buffer into which the data is read
+     * @return the number of bytes read, or -1 if end of stream
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int read(byte[] b) throws IOException {
+        return stream.read(b);
+    }
+
+    /**
+     * Reads up to len bytes of data from the stream into an array of bytes.
+     * @param b the buffer into which the data is read
+     * @param off the start offset in array b at which the data is written
+     * @param len the maximum number of bytes to read
+     * @return the number of bytes read, or -1 if end of stream
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return stream.read(b, off, len);
+    }
+
+    // ===================== Skip and Availability Methods =====================
+
+    /**
+     * Skips over and discards n bytes of data from the stream.
+     * @param n the number of bytes to skip
+     * @return the actual number of bytes skipped
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public long skip(long n) throws IOException {
+        return stream.skip(n);
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read from the stream.
+     * @return the number of bytes that can be read
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int available() throws IOException {
+        return stream.available();
+    }
+
+    // ===================== Mark, Reset, and Close Methods =====================
+
+    /**
+     * Closes the stream and releases any system resources associated with it.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        stream.close();
+    }
+
+    /**
+     * Marks the current position in the stream.
+     * @param readlimit the maximum limit of bytes that can be read before the mark position becomes invalid
+     */
+    @Override
+    public void mark(int readlimit) {
+        stream.mark(readlimit);
+    }
+
+    /**
+     * Resets the stream to the most recent mark.
+     * @throws IOException if the stream has not been marked or the mark has been invalidated
+     */
+    @Override
+    public void reset() throws IOException {
+        stream.reset();
+    }
+
+    /**
+     * Tests if this input stream supports the mark and reset methods.
+     * @return true if mark and reset are supported; false otherwise
+     */
+    @Override
+    public boolean markSupported() {
+        return stream.markSupported();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsProperties.java
@@ -189,6 +189,10 @@ public class HdfsProperties extends HdfsCompatibleProperties {
         return this.configuration;
     }
 
+    public boolean isKerberos() {
+        return "kerberos".equalsIgnoreCase(hdfsAuthenticationType);
+    }
+
     //fixme be should send use input params
     @Override
     public Map<String, String> getBackendConfigProperties() {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
@@ -18,6 +18,9 @@
 package org.apache.doris.fs;
 
 import org.apache.doris.backup.Status;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisOutputFile;
+import org.apache.doris.fs.io.ParsedPath;
 import org.apache.doris.fs.remote.RemoteFile;
 
 import java.util.List;
@@ -58,6 +61,16 @@ public interface FileSystem {
                              String destFilePath,
                              Runnable runWhenPathNotExist) {
         throw new UnsupportedOperationException("Unsupported operation rename dir on current file system.");
+    }
+
+    default Status deleteAll(List<String> remotePaths) {
+        for (String remotePath : remotePaths) {
+            Status deleteStatus = delete(remotePath);
+            if (!deleteStatus.ok()) {
+                return deleteStatus;
+            }
+        }
+        return Status.OK;
     }
 
     Status delete(String remotePath);
@@ -104,5 +117,17 @@ public interface FileSystem {
 
     default Status listDirectories(String remotePath, Set<String> result) {
         throw new UnsupportedOperationException("Unsupported operation list directories on current file system.");
+    }
+
+    default DorisOutputFile newOutputFile(ParsedPath path) {
+        throw new UnsupportedOperationException("Unsupported operation new output file on current file system.");
+    }
+
+    default DorisInputFile newInputFile(ParsedPath path) {
+        return newInputFile(path, -1);
+    }
+
+    default DorisInputFile newInputFile(ParsedPath path, long length) {
+        throw new UnsupportedOperationException("Unsupported operation new input file on current file system.");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInput.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInput.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * DorisInput provides an abstraction for random-access reading of file content in Doris filesystem layer.
+ * <p>
+ * This interface allows reading bytes from a specific position in a file into a buffer,
+ * supporting both custom and default read operations.
+ * It extends Closeable, so implementations must release resources when closed.
+ */
+public interface DorisInput extends Closeable {
+
+    /**
+     * Reads bytes from the file starting at the given position into the specified buffer.
+     *
+     * @param position the position in the file to start reading from
+     * @param buffer the buffer into which bytes are to be transferred
+     * @param bufferOffset the offset in the buffer at which bytes will be written
+     * @param bufferLength the number of bytes to read
+     * @throws IOException if an I/O error occurs
+     */
+    void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength) throws IOException;
+
+    /**
+     * Reads bytes from the file starting at the given position into the entire buffer.
+     * This is a convenience default method that delegates to the core readFully method.
+     *
+     * @param buffer    the buffer into which bytes are to be transferred
+     * @param position  the position in the file to start reading from
+     * @throws IOException if an I/O error occurs
+     */
+    default void readFully(byte[] buffer, long position) throws IOException {
+        readFully(position, buffer, 0, buffer.length);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInputFile.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io;
+
+import java.io.IOException;
+
+/**
+ * DorisInputFile represents an abstraction for a file input source in Doris filesystem layer.
+ * <p>
+ * This interface provides methods to access file content, retrieve file metadata, and check file existence.
+ * Implementations of this interface allow Doris to interact with various file systems in a unified way.
+ */
+public interface DorisInputFile {
+    /**
+     * Returns the path of this file as a ParsedPath object.
+     *
+     * @return the ParsedPath representing the file location
+     */
+    ParsedPath path();
+
+    /**
+     * Returns the length of the file in bytes.
+     *
+     * @return the size of the file in bytes
+     * @throws IOException if an I/O error occurs
+     */
+    long length() throws IOException;
+
+    /**
+     * Returns the last modified time of the file.
+     *
+     * @return the last modified timestamp in milliseconds since epoch
+     * @throws IOException if an I/O error occurs
+     */
+    long lastModifiedTime() throws IOException;
+
+    /**
+     * Checks whether the file exists.
+     *
+     * @return true if the file exists, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
+    boolean exists() throws IOException;
+
+    /**
+     * Creates a new DorisInput for reading the file content in a random-access manner.
+     *
+     * @return a new DorisInput instance for this file
+     * @throws IOException if an I/O error occurs
+     */
+    DorisInput newInput() throws IOException;
+
+    /**
+     * Creates a new DorisInputStream for reading the file content as a stream.
+     *
+     * @return a new DorisInputStream instance for this file
+     * @throws IOException if an I/O error occurs
+     */
+    DorisInputStream newStream() throws IOException;
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInputStream.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInputStream.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * DorisInputStream is an abstract base class for input streams in the Doris filesystem layer.
+ * <p>
+ * This class extends {@link InputStream} and provides additional methods for position-aware
+ * stream reading, such as retrieving the current position and seeking to a specific position.
+ * Implementations of this class enable Doris to interact with various storage backends in a unified way.
+ */
+public abstract class DorisInputStream extends InputStream {
+
+    /**
+     * Returns the current position in the input stream.
+     * <p>
+     * The position indicates the number of bytes read from the beginning of the stream.
+     *
+     * @return the current byte offset in the stream
+     * @throws IOException if an I/O error occurs while retrieving the position
+     */
+    public abstract long getPosition() throws IOException;
+
+    /**
+     * Seeks to the specified position in the input stream.
+     * <p>
+     * After calling this method, the next read will occur at the given byte offset.
+     *
+     * @param position the byte offset to seek to
+     * @throws IOException if an I/O error occurs or the position is invalid
+     */
+    public abstract void seek(long position) throws IOException;
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisOutputFile.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * DorisOutputFile represents an abstraction for a file output destination in the Doris filesystem layer.
+ * <p>
+ * This interface provides methods to create output streams for writing file content,
+ * either as a new file or by overwriting an existing file.
+ * It also provides a method to retrieve the file's path.
+ * Implementations of this interface allow Doris to interact with various file systems
+ * in a unified way for output operations.
+ */
+public interface DorisOutputFile {
+    /**
+     * Creates a new file and returns an OutputStream for writing to it.
+     * <p>
+     * If the file already exists, this method may fail depending on the implementation.
+     *
+     * @return an OutputStream for writing to the new file
+     * @throws IOException if an I/O error occurs or the file already exists
+     */
+    OutputStream create() throws IOException;
+
+    /**
+     * Creates a new file or overwrites the existing file and returns an OutputStream for writing to it.
+     * <p>
+     * If the file already exists, it will be overwritten.
+     *
+     * @return an OutputStream for writing to the file
+     * @throws IOException if an I/O error occurs
+     */
+    OutputStream createOrOverwrite() throws IOException;
+
+    /**
+     * Returns the path of this output file as a ParsedPath object.
+     *
+     * @return the ParsedPath representing the file location
+     */
+    ParsedPath path();
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/ParsedPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/ParsedPath.java
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io;
+
+import org.apache.hadoop.fs.Path;
+
+/**
+ * This is temporary class to isolate the path parsing logic from the rest of the codebase.
+ * Maybe refactored later
+ */
+public class ParsedPath {
+    private String origPath;
+
+    public ParsedPath(String path) {
+        this.origPath = path;
+    }
+
+    @Override
+    public String toString() {
+        return this.origPath;
+    }
+
+    public Path toHadoopPath() {
+        return new Path(origPath);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInput.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInput.java
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io.hdfs;
+
+import org.apache.doris.fs.io.DorisInput;
+import org.apache.doris.fs.io.DorisInputFile;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * HdfsInput provides an implementation of DorisInput for reading data from HDFS at a low level.
+ * It wraps an FSDataInputStream and a DorisInputFile, providing random access read functionality.
+ */
+public class HdfsInput implements DorisInput {
+    // The underlying Hadoop FSDataInputStream used for reading.
+    private final FSDataInputStream stream;
+    // The DorisInputFile representing the file.
+    private final DorisInputFile inputFile;
+    // Indicates whether the input has been closed.
+    private boolean closed;
+
+    /**
+     * Constructs a HdfsInput with the given FSDataInputStream and DorisInputFile.
+     *
+     * @param stream the underlying Hadoop FSDataInputStream
+     * @param inputFile the DorisInputFile representing the file
+     */
+    public HdfsInput(FSDataInputStream stream, DorisInputFile inputFile) {
+        this.stream = Objects.requireNonNull(stream, "stream is null");
+        this.inputFile = Objects.requireNonNull(inputFile, "inputFile is null");
+    }
+
+    /**
+     * Checks if the input is closed and throws an IOException if it is.
+     * Used internally before performing any operation.
+     *
+     * @throws IOException if the input is closed
+     */
+    private void checkClosed() throws IOException {
+        if (closed) {
+            throw new IOException("Input is closed: " + inputFile.toString());
+        }
+    }
+
+    /**
+     * Reads bytes from the file at the specified position into the buffer.
+     *
+     * @param position the position in the file to start reading
+     * @param buffer the buffer into which the data is read
+     * @param bufferOffset the start offset in the buffer
+     * @param bufferLength the number of bytes to read
+     * @throws IOException if an I/O error occurs or the input is closed
+     */
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength) throws IOException {
+        checkClosed();
+        try {
+            stream.readFully(position, buffer, bufferOffset, bufferLength);
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException(
+                    String.format("File %s not found: %s", inputFile.toString(), e.getMessage()));
+        } catch (IOException e) {
+            throw new IOException(String.format("Read %d bytes at position %d failed for file %s: %s",
+                    bufferLength, position, inputFile.toString(), e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Closes this input and releases any system resources associated with it.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        stream.close();
+    }
+
+    /**
+     * Returns the string representation of the input file.
+     *
+     * @return the file path as a string
+     */
+    @Override
+    public String toString() {
+        return inputFile.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInputFile.java
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io.hdfs;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.fs.io.DorisInput;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisInputStream;
+import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.remote.dfs.DFSFileSystem;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * HdfsInputFile provides an implementation of DorisInputFile for reading data from HDFS.
+ * It wraps a ParsedPath and DFSFileSystem to open files and retrieve file metadata from HDFS.
+ */
+public class HdfsInputFile implements DorisInputFile {
+    // The ParsedPath representing the file location in HDFS.
+    private final ParsedPath path;
+    // The Hadoop Path object corresponding to the file.
+    private final Path hadoopPath;
+    // The DFSFileSystem used to interact with HDFS.
+    private final DFSFileSystem dfs;
+
+    // The length of the file, lazily initialized.
+    private long length;
+    // The FileStatus object for the file, lazily initialized.
+    private FileStatus status;
+
+    /**
+     * Constructs a HdfsInputFile with the given ParsedPath, file length, and DFSFileSystem.
+     *
+     * @param path the ParsedPath representing the file location
+     * @param length the length of the file, or -1 if unknown
+     * @param dfs the DFSFileSystem used to interact with HDFS
+     */
+    public HdfsInputFile(ParsedPath path, long length, DFSFileSystem dfs) {
+        this.path = Objects.requireNonNull(path, "path is null");
+        this.dfs = Objects.requireNonNull(dfs, "hdfs file system is null");
+        this.hadoopPath = path.toHadoopPath();
+        this.length = length;
+    }
+
+    /**
+     * Returns a new DorisInput for reading from this file.
+     *
+     * @return a new DorisInput instance
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public DorisInput newInput() throws IOException {
+        return new HdfsInput(dfs.openFile(hadoopPath), this);
+    }
+
+    /**
+     * Returns a new DorisInputStream for streaming reads from this file.
+     *
+     * @return a new DorisInputStream instance
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public DorisInputStream newStream() throws IOException {
+        return new HdfsInputStream(path, dfs.openFile(hadoopPath));
+    }
+
+    /**
+     * Returns the length of the file, querying HDFS if necessary.
+     *
+     * @return the file length
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public long length() throws IOException {
+        if (length == -1) {
+            length = getFileStatus().getLen();
+        }
+        return length;
+    }
+
+    /**
+     * Returns the last modified time of the file.
+     *
+     * @return the last modified time in milliseconds
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public long lastModifiedTime() throws IOException {
+        return getFileStatus().getModificationTime();
+    }
+
+    /**
+     * Checks if the file exists in HDFS.
+     *
+     * @return true if the file exists, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public boolean exists() throws IOException {
+        Status status = dfs.exists(path.toString());
+        return status.ok();
+    }
+
+    /**
+     * Returns the ParsedPath associated with this input file.
+     *
+     * @return the ParsedPath
+     */
+    @Override
+    public ParsedPath path() {
+        return path;
+    }
+
+    /**
+     * Returns the string representation of the file path.
+     *
+     * @return the file path as a string
+     */
+    @Override
+    public String toString() {
+        return path().toString();
+    }
+
+    /**
+     * Lazily retrieves the FileStatus from HDFS for this file.
+     *
+     * @return the FileStatus object
+     * @throws IOException if an I/O error occurs
+     */
+    private FileStatus getFileStatus() throws IOException {
+        if (status == null) {
+            status = dfs.getFileStatus(hadoopPath);
+        }
+        return status;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInputStream.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInputStream.java
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io.hdfs;
+
+import org.apache.doris.fs.io.DorisInputStream;
+import org.apache.doris.fs.io.ParsedPath;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * HdfsInputStream provides an input stream implementation for reading data from HDFS
+ * using ParsedPath and FSDataInputStream.
+ * It extends DorisInputStream and wraps Hadoop's FSDataInputStream, providing additional checks and error handling.
+ */
+public class HdfsInputStream extends DorisInputStream {
+    // The ParsedPath representing the file location in HDFS.
+    private final ParsedPath path;
+    // The underlying Hadoop FSDataInputStream used for reading.
+    private final FSDataInputStream stream;
+    // Indicates whether the stream has been closed.
+    private boolean closed;
+
+    /**
+     * Constructs a HdfsInputStream with the given ParsedPath and FSDataInputStream.
+     *
+     * @param path the ParsedPath representing the file location
+     * @param stream the underlying Hadoop FSDataInputStream
+     */
+    HdfsInputStream(ParsedPath path, FSDataInputStream stream) {
+        this.path = Objects.requireNonNull(path, "path is null");
+        this.stream = Objects.requireNonNull(stream, "stream is null");
+    }
+
+    /**
+     * Checks if the stream is closed and throws an IOException if it is.
+     * Used internally before performing any operation.
+     *
+     * @throws IOException if the stream is closed
+     */
+    private void checkClosed() throws IOException {
+        if (closed) {
+            throw new IOException("Input stream is closed: " + path);
+        }
+    }
+
+    /**
+     * Returns the number of bytes that can be read from this input stream without blocking.
+     *
+     * @return the number of available bytes
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public int available() throws IOException {
+        checkClosed();
+        try {
+            return stream.available();
+        } catch (IOException e) {
+            throw new IOException(String.format("Failed to get available status for file %s.", path), e);
+        }
+    }
+
+    /**
+     * Returns the current position in the input stream.
+     *
+     * @return the current position
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public long getPosition() throws IOException {
+        checkClosed();
+        try {
+            return stream.getPos();
+        } catch (IOException e) {
+            throw new IOException(String.format("Failed to get position for file %s.", path), e);
+        }
+    }
+
+    /**
+     * Seeks to the specified position in the input stream.
+     *
+     * @param position the position to seek to
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public void seek(long position) throws IOException {
+        checkClosed();
+        try {
+            stream.seek(position);
+        } catch (IOException e) {
+            throw new IOException(
+                    String.format("Failed to seek to position %d for file %s: %s", position, path, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Reads the next byte of data from the input stream.
+     *
+     * @return the next byte of data, or -1 if the end of the stream is reached
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public int read() throws IOException {
+        checkClosed();
+        try {
+            return stream.read();
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException(String.format("File %s not found: %s", path, e.getMessage()));
+        } catch (IOException e) {
+            throw new IOException(String.format("Read of file %s failed: %s", path, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Reads up to len bytes of data from the input stream into an array of bytes.
+     *
+     * @param b the buffer into which the data is read
+     * @param off the start offset in array b at which the data is written
+     * @param len the maximum number of bytes to read
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        checkClosed();
+        try {
+            return stream.read(b, off, len);
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException(String.format("File %s not found: %s", path, e.getMessage()));
+        } catch (IOException e) {
+            throw new IOException(String.format("Read of file %s failed: %s", path, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Skips over and discards n bytes of data from this input stream.
+     *
+     * @param n the number of bytes to skip
+     * @return the actual number of bytes skipped
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public long skip(long n) throws IOException {
+        checkClosed();
+        try {
+            return stream.skip(n);
+        } catch (IOException e) {
+            throw new IOException(String.format("Skip in file %s failed: %s", path, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Closes this input stream and releases any system resources associated with it.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        stream.close();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsOutputFile.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io.hdfs;
+
+import org.apache.doris.fs.io.DorisOutputFile;
+import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.remote.dfs.DFSFileSystem;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+/**
+ * HdfsOutputFile provides an implementation of DorisOutputFile for writing data to HDFS.
+ * It wraps a ParsedPath and DFSFileSystem to create or overwrite files in HDFS.
+ */
+public class HdfsOutputFile implements DorisOutputFile {
+    // The ParsedPath representing the file location in HDFS.
+    private final ParsedPath path;
+    // The Hadoop Path object corresponding to the file.
+    private final Path hadoopPath;
+    // The DFSFileSystem used to interact with HDFS.
+    private final DFSFileSystem dfs;
+
+    /**
+     * Constructs a HdfsOutputFile with the given ParsedPath and DFSFileSystem.
+     *
+     * @param path the ParsedPath representing the file location
+     * @param dfs the DFSFileSystem used to interact with HDFS
+     */
+    public HdfsOutputFile(ParsedPath path, DFSFileSystem dfs) {
+        this.path = Objects.requireNonNull(path, "path is null");
+        this.hadoopPath = path.toHadoopPath();
+        this.dfs = Objects.requireNonNull(dfs, "dfs is null");
+    }
+
+    /**
+     * Creates a new file in HDFS. Fails if the file already exists.
+     *
+     * @return OutputStream for writing to the new file
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public OutputStream create() throws IOException {
+        return dfs.createFile(hadoopPath, false);
+    }
+
+    /**
+     * Creates a new file or overwrites the file if it already exists in HDFS.
+     *
+     * @return OutputStream for writing to the file
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public OutputStream createOrOverwrite() throws IOException {
+        return dfs.createFile(hadoopPath, true);
+    }
+
+    /**
+     * Returns the ParsedPath associated with this output file.
+     *
+     * @return the ParsedPath
+     */
+    @Override
+    public ParsedPath path() {
+        return path;
+    }
+
+    /**
+     * Returns the string representation of the file path.
+     *
+     * @return the file path as a string
+     */
+    @Override
+    public String toString() {
+        return path().toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsOutputStream.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsOutputStream.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs.io.hdfs;
+
+import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.remote.dfs.DFSFileSystem;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+/**
+ * HdfsOutputStream provides an output stream implementation for writing data to HDFS
+ * using ParsedPath and FSDataOutputStream.
+ * It extends FSDataOutputStream and adds additional checks and Kerberos authentication handling.
+ */
+public class HdfsOutputStream extends FSDataOutputStream {
+    // The ParsedPath representing the file location in HDFS.
+    private final ParsedPath path;
+    // The Hadoop Path object corresponding to the file.
+    private final Path hadoopPath;
+    // The DFSFileSystem used to interact with HDFS.
+    private final DFSFileSystem dfs;
+    // Indicates whether the stream has been closed.
+    private boolean closed;
+
+    /**
+     * Constructs a HdfsOutputStream with the given ParsedPath, FSDataOutputStream, and DFSFileSystem.
+     *
+     * @param path the ParsedPath representing the file location
+     * @param out the underlying Hadoop FSDataOutputStream
+     * @param dfs the DFSFileSystem used to interact with HDFS
+     */
+    public HdfsOutputStream(ParsedPath path, FSDataOutputStream out, DFSFileSystem dfs) {
+        super(out, null, out.getPos());
+        this.path = Objects.requireNonNull(path, "path is null");
+        this.hadoopPath = path.toHadoopPath();
+        this.dfs = dfs;
+    }
+
+    /**
+     * Checks if the stream is closed and throws an IOException if it is.
+     * Used internally before performing any operation.
+     *
+     * @throws IOException if the stream is closed
+     */
+    private void checkClosed() throws IOException {
+        if (closed) {
+            throw new IOException("Output stream is closed: " + path);
+        }
+    }
+
+    /**
+     * Returns the originally wrapped OutputStream, not the delegate.
+     *
+     * @return the wrapped OutputStream
+     */
+    @Override
+    public OutputStream getWrappedStream() {
+        return ((FSDataOutputStream) super.getWrappedStream()).getWrappedStream();
+    }
+
+    /**
+     * Writes the specified byte to this output stream, handling Kerberos ticket refresh if needed.
+     *
+     * @param b the byte to write
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public void write(int b) throws IOException {
+        checkClosed();
+        dfs.getAuthenticator().doAs(() -> {
+            super.write(b);
+            return null;
+        });
+    }
+
+    /**
+     * Writes len bytes from the specified byte array starting at offset off to this output stream,
+     * handling Kerberos ticket refresh if needed.
+     *
+     * @param b the data
+     * @param off the start offset in the data
+     * @param len the number of bytes to write
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        checkClosed();
+        dfs.getAuthenticator().doAs(() -> {
+            super.write(b, off, len);
+            return null;
+        });
+    }
+
+    /**
+     * Flushes this output stream and forces any buffered output bytes to be written out.
+     *
+     * @throws IOException if an I/O error occurs or the stream is closed
+     */
+    @Override
+    public void flush() throws IOException {
+        checkClosed();
+        super.flush();
+    }
+
+    /**
+     * Closes this output stream and releases any system resources associated with it.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        super.close();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 
 /**
  * It is just used for reading remote object storage on cloud.
+ *
  * @param <C> cloud SDK Client
  */
 public interface ObjStorage<C> extends AutoCloseable {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -92,11 +92,10 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         this.s3Properties = properties;
         isUsePathStyle = Boolean.parseBoolean(properties.getUsePathStyle());
         forceParsingByStandardUri = Boolean.parseBoolean(s3Properties.getForceParsingByStandardUrl());
-
     }
 
     @Override
-    public S3Client getClient() throws UserException {
+    public S3Client getClient() {
         if (client == null) {
             String endpointStr = s3Properties.getEndpoint();
             if (!endpointStr.contains("://")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -24,6 +24,11 @@ import org.apache.doris.common.security.authentication.HadoopAuthenticator;
 import org.apache.doris.common.util.URI;
 import org.apache.doris.datasource.property.storage.HdfsCompatibleProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisOutputFile;
+import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.io.hdfs.HdfsInputFile;
+import org.apache.doris.fs.io.hdfs.HdfsOutputFile;
 import org.apache.doris.fs.operations.HDFSFileOperations;
 import org.apache.doris.fs.operations.HDFSOpParams;
 import org.apache.doris.fs.operations.OpParams;
@@ -84,8 +89,8 @@ public class DFSFileSystem extends RemoteFileSystem {
     @Override
     public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
         try {
-            org.apache.hadoop.fs.FileSystem fileSystem = nativeFileSystem(remotePath);
             Path locatedPath = new Path(remotePath);
+            org.apache.hadoop.fs.FileSystem fileSystem = nativeFileSystem(locatedPath);
             RemoteIterator<LocatedFileStatus> locatedFiles = getLocatedFiles(recursive, fileSystem, locatedPath);
             while (locatedFiles.hasNext()) {
                 LocatedFileStatus fileStatus = locatedFiles.next();
@@ -106,8 +111,9 @@ public class DFSFileSystem extends RemoteFileSystem {
     @Override
     public Status listDirectories(String remotePath, Set<String> result) {
         try {
-            FileSystem fileSystem = nativeFileSystem(remotePath);
-            FileStatus[] fileStatuses = getFileStatuses(remotePath, fileSystem);
+            Path locatedPath = new Path(remotePath);
+            FileSystem fileSystem = nativeFileSystem(locatedPath);
+            FileStatus[] fileStatuses = getFileStatuses(locatedPath, fileSystem);
             result.addAll(
                     Arrays.stream(fileStatuses)
                             .filter(FileStatus::isDirectory)
@@ -126,14 +132,14 @@ public class DFSFileSystem extends RemoteFileSystem {
     }
 
     @VisibleForTesting
-    public FileSystem nativeFileSystem(String remotePath) throws UserException {
+    public FileSystem nativeFileSystem(Path remotePath) throws IOException {
         if (closed.get()) {
-            throw new UserException("FileSystem is closed.");
+            throw new IOException("FileSystem is closed.");
         }
         if (dfsFileSystem == null) {
             synchronized (this) {
                 if (closed.get()) {
-                    throw new UserException("FileSystem is closed.");
+                    throw new IOException("FileSystem is closed.");
                 }
                 if (dfsFileSystem == null) {
                     Configuration conf = hdfsProperties.getHadoopConfiguration();
@@ -141,7 +147,7 @@ public class DFSFileSystem extends RemoteFileSystem {
                     try {
                         dfsFileSystem = authenticator.doAs(() -> {
                             try {
-                                return FileSystem.get(new Path(remotePath).toUri(), conf);
+                                return FileSystem.get(remotePath.toUri(), conf);
                             } catch (IOException e) {
                                 throw new RuntimeException(e);
                             }
@@ -149,7 +155,7 @@ public class DFSFileSystem extends RemoteFileSystem {
                         operations = new HDFSFileOperations(dfsFileSystem);
                         RemoteFSPhantomManager.registerPhantomReference(this);
                     } catch (Exception e) {
-                        throw new UserException("Failed to get dfs FileSystem for " + e.getMessage(), e);
+                        throw new IOException("Failed to get dfs FileSystem for " + e.getMessage(), e);
                     }
                 }
             }
@@ -158,12 +164,12 @@ public class DFSFileSystem extends RemoteFileSystem {
     }
 
     protected RemoteIterator<LocatedFileStatus> getLocatedFiles(boolean recursive,
-                FileSystem fileSystem, Path locatedPath) throws IOException {
+            FileSystem fileSystem, Path locatedPath) throws IOException {
         return authenticator.doAs(() -> fileSystem.listFiles(locatedPath, recursive));
     }
 
-    protected FileStatus[] getFileStatuses(String remotePath, FileSystem fileSystem) throws IOException {
-        return authenticator.doAs(() -> fileSystem.listStatus(new Path(remotePath)));
+    protected FileStatus[] getFileStatuses(Path remotePath, FileSystem fileSystem) throws IOException {
+        return authenticator.doAs(() -> fileSystem.listStatus(remotePath));
     }
 
     public static Configuration getHdfsConf(boolean fallbackToSimpleAuth) {
@@ -262,13 +268,13 @@ public class DFSFileSystem extends RemoteFileSystem {
      * read data from fsDataInputStream.
      *
      * @param fsDataInputStream input stream for read.
-     * @param readOffset        read offset.
-     * @param length            read length.
+     * @param readOffset read offset.
+     * @param length read length.
      * @return ByteBuffer
      * @throws IOException when read data error.
      */
     private static ByteBuffer readStreamBuffer(FSDataInputStream fsDataInputStream, long readOffset, long length)
-                throws IOException {
+            throws IOException {
         synchronized (fsDataInputStream) {
             long currentStreamOffset;
             try {
@@ -335,8 +341,8 @@ public class DFSFileSystem extends RemoteFileSystem {
     public Status exists(String remotePath) {
         try {
             URI pathUri = URI.create(remotePath);
-            Path inputFilePath = new Path(pathUri.getPath());
-            FileSystem fileSystem = nativeFileSystem(remotePath);
+            Path inputFilePath = new Path(pathUri.getLocation());
+            FileSystem fileSystem = nativeFileSystem(inputFilePath);
             boolean isPathExist = authenticator.doAs(() -> fileSystem.exists(inputFilePath));
             if (!isPathExist) {
                 return new Status(Status.ErrCode.NOT_FOUND, "remote path does not exist: " + remotePath);
@@ -449,7 +455,7 @@ public class DFSFileSystem extends RemoteFileSystem {
             if (!srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
                 return new Status(Status.ErrCode.COMMON_ERROR, "only allow rename in same file system");
             }
-            FileSystem fileSystem = nativeFileSystem(destPath);
+            FileSystem fileSystem = nativeFileSystem(new Path(destPath));
             Path srcfilePath = new Path(srcPathUri.getPath());
             Path destfilePath = new Path(destPathUri.getPath());
             boolean isRenameSuccess = authenticator.doAs(() -> fileSystem.rename(srcfilePath, destfilePath));
@@ -471,8 +477,8 @@ public class DFSFileSystem extends RemoteFileSystem {
     public Status delete(String remotePath) {
         try {
             URI pathUri = URI.create(remotePath);
-            Path inputFilePath = new Path(pathUri.getPath());
-            FileSystem fileSystem = nativeFileSystem(remotePath);
+            Path inputFilePath = new Path(pathUri.getLocation());
+            FileSystem fileSystem = nativeFileSystem(inputFilePath);
             authenticator.doAs(() -> fileSystem.delete(inputFilePath, true));
         } catch (UserException e) {
             return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
@@ -488,8 +494,8 @@ public class DFSFileSystem extends RemoteFileSystem {
     /**
      * get files in remotePath of HDFS.
      *
-     * @param remotePath   hdfs://namenode:port/path.
-     * @param result       files in remotePath.
+     * @param remotePath hdfs://namenode:port/path.
+     * @param result files in remotePath.
      * @param fileNameOnly means get file only in remotePath if true.
      * @return Status.OK if success.
      */
@@ -497,8 +503,8 @@ public class DFSFileSystem extends RemoteFileSystem {
     public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
         try {
             URI pathUri = URI.create(remotePath);
-            FileSystem fileSystem = nativeFileSystem(remotePath);
-            Path pathPattern = new Path(pathUri.getPath());
+            Path pathPattern = new Path(pathUri.getLocation());
+            FileSystem fileSystem = nativeFileSystem(pathPattern);
             FileStatus[] files = authenticator.doAs(() -> fileSystem.globStatus(pathPattern));
             if (files == null) {
                 LOG.info("no files in path " + remotePath);
@@ -525,8 +531,9 @@ public class DFSFileSystem extends RemoteFileSystem {
     @Override
     public Status makeDir(String remotePath) {
         try {
-            FileSystem fileSystem = nativeFileSystem(remotePath);
-            if (!authenticator.doAs(() -> fileSystem.mkdirs(new Path(remotePath)))) {
+            Path locatedPath = new Path(remotePath);
+            FileSystem fileSystem = nativeFileSystem(locatedPath);
+            if (!authenticator.doAs(() -> fileSystem.mkdirs(locatedPath))) {
                 LOG.warn("failed to make dir for " + remotePath);
                 return new Status(Status.ErrCode.COMMON_ERROR, "failed to make dir for " + remotePath);
             }
@@ -553,5 +560,30 @@ public class DFSFileSystem extends RemoteFileSystem {
                 LOG.warn("Failed to close DFSFileSystem: {}", e.getMessage(), e);
             }
         }
+    }
+
+    public FileStatus getFileStatus(Path path) throws IOException {
+        FileSystem fileSystem = nativeFileSystem(path);
+        return authenticator.doAs(() -> fileSystem.getFileStatus(path));
+    }
+
+    public FSDataInputStream openFile(Path path) throws IOException {
+        FileSystem fileSystem = nativeFileSystem(path);
+        return authenticator.doAs(() -> fileSystem.open(path));
+    }
+
+    public FSDataOutputStream createFile(Path path, boolean overwrite) throws IOException {
+        FileSystem fileSystem = nativeFileSystem(path);
+        return authenticator.doAs(() -> fileSystem.create(path, overwrite));
+    }
+
+    @Override
+    public DorisOutputFile newOutputFile(ParsedPath path) {
+        return new HdfsOutputFile(path, this);
+    }
+
+    @Override
+    public DorisInputFile newInputFile(ParsedPath path, long length) {
+        return new HdfsInputFile(path, length, this);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/external/iceberg/IcebergHadoopCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/iceberg/IcebergHadoopCatalogTest.java
@@ -52,7 +52,7 @@ public class IcebergHadoopCatalogTest {
         Map<String, String> hadoopProps = PropertyConverter.convertToHadoopFSProperties(properties);
         String pathStr = "cosn://bucket1/namespace";
         DFSFileSystem fs = (DFSFileSystem) FileSystemFactory.get(StorageProperties.createPrimary(hadoopProps));
-        nativeFs = fs.nativeFileSystem(pathStr);
+        nativeFs = fs.nativeFileSystem(new Path(pathStr));
 
         RemoteIterator<FileStatus> it = nativeFs.listStatusIterator(new Path(pathStr));
         while (it.hasNext()) {


### PR DESCRIPTION
### What problem does this PR solve?

When using iceberg hadoop catalog, the FE need to access HDFS to get meta info of iceberg.
Previously, we use iceberg's default FileIO(HadoopFileIO) in Iceberg library to access HDFS.
But if the HDFS is kerberos enabled, it leads to some authentication issue, especially in multi kerberos env.

So this PR add a separate hdfs fileio impl, and for iceberg hadoop catalog, if there is only one storage
property and is kerberos hdfs, will use this new fileio.

This new hdfs fileio handles all kerberos authentication inside, to meet multi kerberos env need.

TODO:
This is just a beginning, we will implement other storage fileio later, to avoid using default FileIO, totally.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

