### PR TITLE
[improvement](cloud) enable s3 load from volcano engine object storag…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/RemoteBase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/RemoteBase.java
@@ -153,6 +153,8 @@ public abstract class RemoteBase {
                 return new BosRemote(obj);
             case AZURE:
                 return new AzureRemote(obj);
+            case TOS:
+                return new TosRemote(obj);
             default:
                 throw new Exception("current not support obj : " + obj.toString());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/TosRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/TosRemote.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.storage;
+
+import org.apache.doris.common.DdlException;
+
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class TosRemote extends DefaultRemote {
+    private static final Logger LOG = LogManager.getLogger(TosRemote.class);
+
+    public TosRemote(ObjectInfo obj) {
+        super(obj);
+    }
+
+    public String getPresignedUrl(String fileName) {
+        throw new UnsupportedOperationException("not unsupported for tos yet");
+    }
+
+    @Override
+    public Triple<String, String, String> getStsToken() throws DdlException {
+        throw new DdlException("Get sts token for tos is unsupported");
+    }
+}


### PR DESCRIPTION
### Proposed changes
```
LOAD LABEL s3_load_2025_05_30
(
    DATA INFILE("s3://doristest/s3load_example.csv")
    INTO TABLE example_tbl_duplicate
    COLUMNS TERMINATED BY ","
    FORMAT AS "CSV"
    (log_time,log_type,error_code,error_msg,op_id,op_time)
)
WITH S3
(
    "provider" = "TOS", 
    "s3.endpoint" = "tos-s3-xxx.volces.com",  
    "s3.region" = "region",
    "s3.access_key" = "xxx",
    "s3.secret_key" = "yyyy=="
)
PROPERTIES
(
    "timeout" = "3600"
);
```
enable specify tos as provider