### PR TITLE
[fix](s3client) Fix `aws_config.maxConnections` set incorrectly

### DIFF
--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -307,14 +307,8 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_s3_client(
     if (s3_conf.max_connections > 0) {
         aws_config.maxConnections = s3_conf.max_connections;
     } else {
-#ifdef BE_TEST
-        // the S3Client may shared by many threads.
-        // So need to set the number of connections large enough.
-        aws_config.maxConnections = config::doris_scanner_thread_pool_thread_num;
-#else
-        aws_config.maxConnections =
-                ExecEnv::GetInstance()->scanner_scheduler()->remote_thread_pool_max_thread_num();
-#endif
+        // AWS SDK max concurrent tcp connections for a single http client to use. Default 25.
+        aws_config.maxConnections = std::max(config::doris_scanner_thread_pool_thread_num, 25);
     }
 
     aws_config.requestTimeoutMs = 30000;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

the pr  #50817 introduced a bug which `aws_config.maxConnections` will be set to 0

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

