### PR TITLE
[chore](storage vault) Make CacheHotspotManager exception msg more distinct

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
@@ -125,12 +125,16 @@ public class CacheHotspotManager extends MasterDaemon {
             jobDaemon.start();
             startJobDaemon = true;
         }
+
         if (!tableCreated) {
             try {
                 CacheHotspotManagerUtils.execCreateCacheTable();
                 tableCreated = true;
+                this.intervalMs = Config.fetch_cluster_cache_hotspot_interval_ms;
             } catch (Exception e) {
-                LOG.warn("Create cache hot spot table failed", e);
+                // sleep 60s wait for syncing storage vault info from ms and retry
+                this.intervalMs = 60000;
+                LOG.warn("Create cache hot spot table failed, sleep 60s and retry", e);
                 return;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManagerUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManagerUtils.java
@@ -216,11 +216,15 @@ public class CacheHotspotManagerUtils {
         Database db = Env.getCurrentInternalCatalog().getDbNullable(FeConstants.INTERNAL_DB_NAME);
         if (db == null) {
             LOG.warn("{} database doesn't exist", FeConstants.INTERNAL_DB_NAME);
+            throw new Exception(
+                    String.format("Database %s doesn't exist", FeConstants.INTERNAL_DB_NAME));
         }
 
         Table t = db.getTableNullable(FeConstants.INTERNAL_FILE_CACHE_HOTSPOT_TABLE_NAME);
         if (t == null) {
             LOG.warn("{} table doesn't exist", FeConstants.INTERNAL_FILE_CACHE_HOTSPOT_TABLE_NAME);
+            throw new Exception(
+                    String.format("Table %s doesn't exist", FeConstants.INTERNAL_FILE_CACHE_HOTSPOT_TABLE_NAME));
         }
         INTERNAL_TABLE_ID = String.valueOf(t.getId());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -1242,7 +1242,7 @@ public class PropertyAnalyzer {
             } else {
                 // continue to check default vault
                 Pair<String, String> info = Env.getCurrentEnv().getStorageVaultMgr().getDefaultStorageVault();
-                if (info == null) {
+                if (info == null || Strings.isNullOrEmpty(info.first) || Strings.isNullOrEmpty(info.second)) {
                     throw new AnalysisException("No default storage vault."
                             + " You can use `SHOW STORAGE VAULT` to get all available vaults,"
                             + " and pick one set default vault with `SET <vault_name> AS DEFAULT STORAGE VAULT`");

--- a/regression-test/suites/vault_p0/alter/test_alter_s3_vault.groovy
+++ b/regression-test/suites/vault_p0/alter/test_alter_s3_vault.groovy
@@ -203,8 +203,11 @@ suite("test_alter_s3_vault", "nonConcurrent") {
     for (int i = 0; i < vaultInfos.size(); i++) {
         logger.info("vault info: ${vaultInfos[i]}")
         if (vaultInfos[i][0].equals(s3VaultName)) {
+            // [s3_9f2c2f80a45c4fb48ad901f70675ffdf, 8, ctime: 1750217403 mtime: 1750217404 ak: "*******" sk: "xxxxxxx" bucket: "xxx" ...]
             def newProperties = vaultInfos[i][2]
-            assertTrue(properties.equals(newProperties), "Properties are not the same")
+            def oldAkSkStr = properties.substring(properties.indexOf("ak:") + 3, properties.indexOf("bucket:") - 1)
+            def newAkSkStr = newProperties.substring(newProperties.indexOf("ak:") + 3, newProperties.indexOf("bucket:") - 1)
+            assertTrue(oldAkSkStr.equals(newAkSkStr), "Ak and Sk string are not the same")
         }
     }
 

--- a/regression-test/suites/vault_p0/concurent/test_create_vault_concurrently.groovy
+++ b/regression-test/suites/vault_p0/concurent/test_create_vault_concurrently.groovy
@@ -35,7 +35,7 @@ suite("test_create_vault_concurrently", "nonConcurrent") {
 
     def future1 = thread("threadName1") {
         for (int i = 0; i < 100; i++) {
-            sql """
+            try_sql """
                 CREATE STORAGE VAULT IF NOT EXISTS ${s3VaultName}
                 PROPERTIES (
                     "type"="S3",
@@ -55,7 +55,7 @@ suite("test_create_vault_concurrently", "nonConcurrent") {
 
     def future2 = thread("threadName2") {
         for (int i = 0; i < 100; i++) {
-            sql """
+            try_sql """
                 CREATE STORAGE VAULT IF NOT EXISTS ${s3VaultName}
                 PROPERTIES (
                     "type"="S3",
@@ -75,7 +75,7 @@ suite("test_create_vault_concurrently", "nonConcurrent") {
 
     def future3 = thread("threadName3") {
         for (int i = 0; i < 100; i++) {
-            sql """
+            try_sql """
                 CREATE STORAGE VAULT IF NOT EXISTS ${s3VaultName}
                 PROPERTIES (
                     "type"="S3",
@@ -95,7 +95,7 @@ suite("test_create_vault_concurrently", "nonConcurrent") {
 
     def future4 = thread("threadName4") {
         for (int i = 0; i < 100; i++) {
-            sql """
+            try_sql """
                 CREATE STORAGE VAULT IF NOT EXISTS ${s3VaultName}
                 PROPERTIES (
                     "type"="S3",


### PR DESCRIPTION
* When first boot fe cluster and not set default storage vault, creating `CacheHotspotManager` internal table will fail it will retry later, just make the exception msg more distinct

* Fix two storage vault case not stable

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

