### PR TITLE
[improvment](show)support jobid in show load warnings

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommand.java
@@ -79,7 +79,7 @@ public class ShowLoadWarningsCommand extends ShowCommand {
                 .build();
     private static final String LABEL = "label";
     private static final String LOAD_JOB_ID = "load_job_id";
-    private static final String JOB_ID = "job_id";
+    private static final String JOB_ID = "JobId";
     private String dbName;
     private URL url;
     private String label;
@@ -152,7 +152,7 @@ public class ShowLoadWarningsCommand extends ShowCommand {
 
         if (hasLoadJobId) {
             if (!(subExpr.child(1) instanceof IntegerLikeLiteral)) {
-                LOG.warn("load_job_id/job_id is not IntLiteral. value: {}", subExpr.toSql());
+                LOG.warn("load_job_id/jobid is not IntLiteral. value: {}", subExpr.toSql());
                 return false;
             }
             jobId = ((IntegerLikeLiteral) subExpr.child(1)).getLongValue();
@@ -161,7 +161,7 @@ public class ShowLoadWarningsCommand extends ShowCommand {
         return true;
     }
 
-    private void validate(ConnectContext ctx) throws AnalysisException {
+    protected void validate(ConnectContext ctx) throws AnalysisException {
         if (rawUrl != null) {
             // get load error from url
             if (rawUrl.isEmpty()) {
@@ -191,7 +191,7 @@ public class ShowLoadWarningsCommand extends ShowCommand {
             // analyze where clause if not null
             if (wildWhere == null) {
                 throw new AnalysisException("should supply condition like: LABEL = \"your_load_label\","
-                    + " or LOAD_JOB_ID/JOB_ID = $job_id");
+                    + " or LOAD_JOB_ID/JOBID = $job_id");
             }
             boolean valid = true;
             if (wildWhere instanceof CompoundPredicate) {
@@ -206,7 +206,7 @@ public class ShowLoadWarningsCommand extends ShowCommand {
             }
             if (!valid) {
                 throw new AnalysisException("Where clause should looks like: LABEL = \"your_load_label\","
-                    + " or LOAD_JOB_ID/JOB_ID = $job_id");
+                    + " or LOAD_JOB_ID/JOBID = $job_id");
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommand.java
@@ -79,6 +79,7 @@ public class ShowLoadWarningsCommand extends ShowCommand {
                 .build();
     private static final String LABEL = "label";
     private static final String LOAD_JOB_ID = "load_job_id";
+    private static final String JOB_ID = "job_id";
     private String dbName;
     private URL url;
     private String label;
@@ -108,72 +109,56 @@ public class ShowLoadWarningsCommand extends ShowCommand {
         }
     }
 
-    private void analyzeSubPredicate(Expression subExpr) throws AnalysisException {
-        boolean valid = false;
+    private boolean analyzeSubPredicate(Expression subExpr) throws AnalysisException {
         boolean hasLabel = false;
         boolean hasLoadJobId = false;
-        do {
-            if (subExpr == null) {
-                valid = false;
-                break;
-            }
-
-            if (subExpr instanceof ComparisonPredicate) {
-                if (!(subExpr instanceof EqualTo)) {
-                    valid = false;
-                    break;
-                }
-            } else {
-                valid = false;
-                break;
-            }
-
-            // left child
-            if (!(subExpr.child(0) instanceof UnboundSlot)) {
-                valid = false;
-                break;
-            }
-            String leftKey = ((UnboundSlot) subExpr.child(0)).getName();
-            if (leftKey.equalsIgnoreCase(LABEL)) {
-                hasLabel = true;
-            } else if (leftKey.equalsIgnoreCase(LOAD_JOB_ID)) {
-                hasLoadJobId = true;
-            } else {
-                valid = false;
-                break;
-            }
-
-            if (hasLabel) {
-                if (!(subExpr.child(1) instanceof StringLikeLiteral)) {
-                    valid = false;
-                    break;
-                }
-
-                String value = ((StringLikeLiteral) subExpr.child(1)).getStringValue();
-                if (Strings.isNullOrEmpty(value)) {
-                    valid = false;
-                    break;
-                }
-
-                label = value;
-            }
-
-            if (hasLoadJobId) {
-                if (!(subExpr.child(1) instanceof IntegerLikeLiteral)) {
-                    LOG.warn("load_job_id is not IntLiteral. value: {}", subExpr.toSql());
-                    valid = false;
-                    break;
-                }
-                jobId = ((IntegerLikeLiteral) subExpr.child(1)).getLongValue();
-            }
-
-            valid = true;
-        } while (false);
-
-        if (!valid) {
-            throw new AnalysisException("Where clause should looks like: LABEL = \"your_load_label\","
-                + " or LOAD_JOB_ID = $job_id");
+        if (subExpr == null) {
+            return false;
         }
+
+        if (subExpr instanceof ComparisonPredicate) {
+            if (!(subExpr instanceof EqualTo)) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        // left child
+        if (!(subExpr.child(0) instanceof UnboundSlot)) {
+            return false;
+        }
+        String leftKey = ((UnboundSlot) subExpr.child(0)).getName();
+        if (leftKey.equalsIgnoreCase(LABEL)) {
+            hasLabel = true;
+        } else if (leftKey.equalsIgnoreCase(LOAD_JOB_ID) || leftKey.equalsIgnoreCase(JOB_ID)) {
+            hasLoadJobId = true;
+        } else {
+            return false;
+        }
+
+        if (hasLabel) {
+            if (!(subExpr.child(1) instanceof StringLikeLiteral)) {
+                return false;
+            }
+
+            String value = ((StringLikeLiteral) subExpr.child(1)).getStringValue();
+            if (Strings.isNullOrEmpty(value)) {
+                return false;
+            }
+
+            label = value;
+        }
+
+        if (hasLoadJobId) {
+            if (!(subExpr.child(1) instanceof IntegerLikeLiteral)) {
+                LOG.warn("load_job_id/job_id is not IntLiteral. value: {}", subExpr.toSql());
+                return false;
+            }
+            jobId = ((IntegerLikeLiteral) subExpr.child(1)).getLongValue();
+        }
+
+        return true;
     }
 
     private void validate(ConnectContext ctx) throws AnalysisException {
@@ -206,20 +191,22 @@ public class ShowLoadWarningsCommand extends ShowCommand {
             // analyze where clause if not null
             if (wildWhere == null) {
                 throw new AnalysisException("should supply condition like: LABEL = \"your_load_label\","
-                    + " or LOAD_JOB_ID = $job_id");
+                    + " or LOAD_JOB_ID/JOB_ID = $job_id");
             }
-
-            if (wildWhere != null) {
-                if (wildWhere instanceof CompoundPredicate) {
-                    if (!(wildWhere instanceof And)) {
-                        throw new AnalysisException("Only allow compound predicate with operator AND");
-                    }
-                    for (Expression child : wildWhere.children()) {
-                        analyzeSubPredicate(child);
-                    }
-                } else {
-                    analyzeSubPredicate(wildWhere);
+            boolean valid = true;
+            if (wildWhere instanceof CompoundPredicate) {
+                if (!(wildWhere instanceof And)) {
+                    throw new AnalysisException("Only allow compound predicate with operator AND");
                 }
+                for (Expression child : wildWhere.children()) {
+                    valid &= analyzeSubPredicate(child);
+                }
+            } else {
+                valid = analyzeSubPredicate(wildWhere);
+            }
+            if (!valid) {
+                throw new AnalysisException("Where clause should looks like: LABEL = \"your_load_label\","
+                    + " or LOAD_JOB_ID/JOB_ID = $job_id");
             }
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadWarningsCommandTest.java
@@ -59,5 +59,24 @@ public class ShowLoadWarningsCommandTest extends TestWithFeService {
         sl = new ShowLoadWarningsCommand("test", where4, -1, 0, null);
         ShowLoadWarningsCommand finalSl4 = sl;
         Assertions.assertThrows(AnalysisException.class, () -> finalSl4.handleShowLoadWarnings(connectContext, null));
+
+        Expression where5 = new EqualTo(new UnboundSlot(Lists.newArrayList("jobid")),
+                new BigIntLiteral(1748399001963L));
+        sl = new ShowLoadWarningsCommand("test", where5, -1, 0, null);
+        ShowLoadWarningsCommand finalSl5 = sl;
+        Assertions.assertThrows(AnalysisException.class, () -> finalSl5.handleShowLoadWarnings(connectContext, null));
+    }
+
+    @Test
+    void testValidate() throws Exception {
+        Expression where = new EqualTo(new UnboundSlot(Lists.newArrayList("jobid")),
+                new BigIntLiteral(1748399001963L));
+        ShowLoadWarningsCommand sl = new ShowLoadWarningsCommand("test", where, -1, 0, null);
+        sl.validate(connectContext);
+
+        Expression where1 = new EqualTo(new UnboundSlot(Lists.newArrayList("load_job_id")),
+                new BigIntLiteral(1748399001963L));
+        sl = new ShowLoadWarningsCommand("test", where1, -1, 0, null);
+        sl.validate(connectContext);
     }
 }

--- a/regression-test/suites/nereids_p0/show/test_nereids_show_load_warnings.groovy
+++ b/regression-test/suites/nereids_p0/show/test_nereids_show_load_warnings.groovy
@@ -64,12 +64,20 @@ suite("test_nereids_show_load_warnings") {
         checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where LOAD_JOB_ID = 123 limit 1")
         checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where LOAD_JOB_ID = 123 and label = '${load_label}'")
         checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where LOAD_JOB_ID = 123 and label = '${load_label}' limit 1")
+        checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where JobId = 123")
+        checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where JobId = 123 limit 1")
+        checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where JobId = 123 and label = '${load_label}'")
+        checkNereidsExecute("SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where JobId = 123 and label = '${load_label}' limit 1")
 
         def res1 = sql """SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db limit 1"""
         assertEquals("${load_label}", res1.get(0).get(1))
 
         def res2 = sql """SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where label = '${load_label}'"""
         assertEquals("${load_label}", res2.get(0).get(1))
+
+        def jobid = res2.get(0).get(0)
+        def res3 = sql """SHOW LOAD WARNINGS FROM test_nereids_show_load_warnnings_db where JobId = ${jobid}"""
+        assertEquals(1, res3.size())
     }
     sql "DROP TABLE IF EXISTS test_nereids_show_load_warningns_tbl "
     sql "drop database if exists  test_nereids_show_load_warnnings_db"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #51736

Problem Summary:
when you execute `show load warnings where label = 'label1';` , you can get the result like this :
| JobId | Label | ErrorMsgDetail |
| --- | --- | --- |
| 1750232588639 | label1 | CANCELLED | 

but you can't use JobId as your where clause, if you execute `show load warnings where jobid = 1750232588639`, 
then you will get a error like `ERROR 1105 (HY000): errCode = 2, detailMessage = Where clause should looks like: LABEL = "your_load_label", or LOAD_JOB_ID = $job_id`, it's not acceptable.

So this PR support `show load warnings where jobid = 1750232588639`, you can get the same result.

BTW, I have made some changes to the code format.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

