### PR TITLE
[fix](load) print real reason if fetching Kafka meta fail

### DIFF
--- a/regression-test/suites/load_p0/routine_load/test_routine_load_error.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_error.groovy
@@ -285,6 +285,7 @@ suite("test_routine_load_error","p0") {
                 }
                 log.info("reason of state changed: ${res[0][17].toString()}".toString())
                 assertTrue(res[0][17].toString().contains("may be Kafka properties set in job is error or no partition in this topic that should check Kafka"))
+                assertTrue(res[0][17].toString().contains("Unknown topic or partition"))
                 break;
             }
         } finally {


### PR DESCRIPTION
### What problem does this PR solve?

Print real reason if fetching Kafka meta fail, if set unknown topic：
before msg
```
Failed to get all partitions of kafka topic: invalid_topic error: errCode = 2, detailMessage = Failed to get info. No alive backends.
```

fix msg:
```
failed to get info: [(172.16.0.232)[INTERNAL_ERROR]error: Broker: Unknown topic or partition], may be Kafka properties set in job is error or no partition in this topic that should check Kafka
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

