### PR TITLE
[fix](restore) Analyze idx meta in Olap Table after restore commit

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -2537,6 +2537,9 @@ public class RestoreJob extends AbstractJob {
                 if (committed && isBeingSynced) {
                     olapTbl.setBeingSyncedProperties();
                 }
+                if (committed) {
+                    olapTbl.analyze(db.getName());
+                }
             } finally {
                 tbl.writeUnlock();
             }

--- a/regression-test/suites/backup_restore/test_backup_restore_mv_write.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_mv_write.groovy
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_backup_restore_mv_write", "backup_restore") {
+    String suiteName = "test_backup_restore_mv_write"
+    String dbName = context.dbName
+    String repoName = "${suiteName}_repo_" + UUID.randomUUID().toString().replace("-", "")
+    String snapshotName = "snapshot_${suiteName}"
+    String tableNamePrefix = "tbl_${suiteName}"
+    String viewName = "mv_${tableNamePrefix}"
+
+    def syncer = getSyncer()
+    syncer.createS3Repository(repoName)
+
+    sql "CREATE DATABASE IF NOT EXISTS ${dbName}"
+
+    sql "DROP TABLE IF EXISTS ${tableNamePrefix}"
+    sql "DROP materialized VIEW IF EXISTS ${viewName}"
+
+    sql """
+        CREATE TABLE `${tableNamePrefix}` (
+        `k` int NOT NULL,
+        `k1` datetime NOT NULL,
+        `k2` datetime NOT NULL,
+        `vin` varchar(128) NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`k`, `k1`, `k2`, `vin`)
+        DISTRIBUTED BY HASH(`k`) BUCKETS 5
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+
+    sql """
+            CREATE materialized VIEW ${viewName} AS SELECT
+            DATE_FORMAT( date_add( k2, INTERVAL 1 HOUR ), '%Y-%m-%d %H:00:00' ) AS k2,
+            vin,
+            count( 1 ) AS val 
+            FROM
+            ${tableNamePrefix} 
+            WHERE
+            k1 > '2025-06-12 00:00:00' 
+            GROUP BY
+            DATE_FORMAT( date_add( k2, INTERVAL 1 HOUR ), '%Y-%m-%d %H:00:00' ),
+            vin
+    """
+
+    sql """
+        BACKUP SNAPSHOT ${snapshotName}
+        TO `${repoName}`
+        ON (`${tableNamePrefix}`)
+        PROPERTIES ("type" = "full")
+    """
+
+    syncer.waitSnapshotFinish(dbName)
+
+    def snapshot = syncer.getSnapshotTimestamp(repoName, snapshotName)
+    assertTrue(snapshot != null)
+
+    def res0 = sql "desc ${tableNamePrefix} all"
+
+    sql "DROP TABLE IF EXISTS ${tableNamePrefix}"
+
+    sql """
+        RESTORE SNAPSHOT ${snapshotName}
+        FROM `${repoName}`
+        ON ( `${tableNamePrefix}` )
+        PROPERTIES
+        (
+            "backup_timestamp"="${snapshot}",
+            "replication_num" = "1"
+        );
+    """
+
+    syncer.waitAllRestoreFinish(dbName)
+
+    def res = sql "desc ${tableNamePrefix} all"
+
+    // DefineExpr and WhereClause should not be null after restore
+    // desc table all:
+    // IndexName: mv_t
+    // IndexKeysType: AGG_KEYS
+    // Field: mv_date_format(hours_add(k2, 1), '%Y-%m-%d %H:00:00')
+    // Type: varchar(65533)
+    // InternalType: varchar(65533)
+    // Null: Yes
+    // Key: true
+    // Default: NULL
+    // Extra: 
+    // Visible: true
+    // DefineExpr: date_format(hours_add(`k2`, 1), '%Y-%m-%d %H:00:00')
+    // WhereClause: (`k1` > '2025-06-12 00:00:00')
+
+    assertTrue(res0.toString() == res.toString())
+
+    sql "insert into ${tableNamePrefix} values (1, '2025-06-12 01:00:00', '2025-06-12 02:00:00', 'test_vin_0')"
+    sql "insert into ${tableNamePrefix} values (2, '2025-06-13 02:00:00', '2025-06-13 03:00:00', 'test_vin_1')"
+    sql "insert into ${tableNamePrefix} values (3, '2025-06-14 03:00:00', '2025-06-14 04:00:00', 'test_vin_2')"
+
+    def select_res = sql "select * from ${tableNamePrefix}"
+    assertTrue(select_res.size() == 3)
+
+    sql "DROP REPOSITORY `${repoName}`"
+}


### PR DESCRIPTION
reproduce: backup and restore Table or restart fe, then insert


before:
```
desc tbl all
*************************** 26. row ***************************
    IndexName: idx
IndexKeysType: AGG_KEYS
        Field: mv_date_format(hours_add(happen_time, 1), '%Y-%m-%d %H:00:00')
         Type: varchar(65533)
 InternalType: varchar(65533)
         Null: Yes
          Key: true
      Default: NULL
        Extra: 
      Visible: true
   DefineExpr:
  WhereClause:

insert into wrong
[ANALYSIS_ERROR]TStatus: errCode = 2, detailMessage = column has no source field, column=mva_SUM__CASE WHEN 1 IS NULL THEN 0 ELSE 1 END
```

now
```
desc tbl all
*************************** 26. row ***************************
    IndexName: idx
IndexKeysType: AGG_KEYS
        Field: mv_date_format(hours_add(happen_time, 1), '%Y-%m-%d %H:00:00')
         Type: varchar(65533)
 InternalType: varchar(65533)
         Null: Yes
          Key: true
      Default: NULL
        Extra: 
      Visible: true
   DefineExpr: date_format(hours_add(`happen_time`, 1), '%Y-%m-%d %H:00:00')
  WhereClause: (`k1` > '2025-06-12 00:00:00')

insert into ok
```
