### PR TITLE
[fix](nereids) fix Cast cannot be cast to class org.apache.doris.nereids.trees.expressions.NamedExpression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
@@ -416,9 +416,6 @@ public class InsertUtils {
                             castValue = rewriteContext == null
                                     ? castValue
                                     : FoldConstantRuleOnFE.evaluate(castValue, rewriteContext);
-                            if (!(castValue instanceof NamedExpression)) {
-                                castValue = new Alias(castValue);
-                            }
                             addColumnValue(analyzer, optimizedRowConstructor, (NamedExpression) castValue);
                         }
                     }
@@ -442,9 +439,6 @@ public class InsertUtils {
                             castValue = rewriteContext == null
                                     ? castValue
                                     : FoldConstantRuleOnFE.evaluate(castValue, rewriteContext);
-                            if (!(castValue instanceof NamedExpression)) {
-                                castValue = new Alias(castValue);
-                            }
                             addColumnValue(analyzer, optimizedRowConstructor, (NamedExpression) castValue);
                         }
                     }
@@ -535,16 +529,16 @@ public class InsertUtils {
         optimizedRowConstructor.add(value);
     }
 
-    private static Expression castValue(Expression value, DataType targetType) {
+    private static Alias castValue(Expression value, DataType targetType) {
         if (value instanceof Alias) {
             Expression oldChild = value.child(0);
             Expression newChild = TypeCoercionUtils.castUnbound(oldChild, targetType);
-            return oldChild == newChild ? value : value.withChildren(newChild);
+            return (Alias) (oldChild == newChild ? value : value.withChildren(newChild));
         } else if (value instanceof UnboundAlias) {
             UnboundAlias unboundAlias = (UnboundAlias) value;
             return new Alias(TypeCoercionUtils.castUnbound(unboundAlias.child(), targetType));
         } else {
-            return TypeCoercionUtils.castUnbound(value, targetType);
+            return new Alias(TypeCoercionUtils.castUnbound(value, targetType));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
@@ -416,6 +416,9 @@ public class InsertUtils {
                             castValue = rewriteContext == null
                                     ? castValue
                                     : FoldConstantRuleOnFE.evaluate(castValue, rewriteContext);
+                            if (!(castValue instanceof NamedExpression)) {
+                                castValue = new Alias(castValue);
+                            }
                             addColumnValue(analyzer, optimizedRowConstructor, (NamedExpression) castValue);
                         }
                     }
@@ -439,6 +442,9 @@ public class InsertUtils {
                             castValue = rewriteContext == null
                                     ? castValue
                                     : FoldConstantRuleOnFE.evaluate(castValue, rewriteContext);
+                            if (!(castValue instanceof NamedExpression)) {
+                                castValue = new Alias(castValue);
+                            }
                             addColumnValue(analyzer, optimizedRowConstructor, (NamedExpression) castValue);
                         }
                     }

--- a/regression-test/suites/insert_p0/insert.groovy
+++ b/regression-test/suites/insert_p0/insert.groovy
@@ -149,4 +149,9 @@ suite("insert") {
     def rows1 = sql """select count() from source;"""
     def rows2 = sql """select count() from dest;"""
     assertTrue(rows1 == rows2);
+
+    test {
+        sql("insert into dest values(now(), 0xff, 0xaa)")
+        exception "Unknown column '0xff' in 'table list' in UNBOUND_OLAP_TABLE_SINK clause"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

fix error message `Cast cannot be cast to class org.apache.doris.nereids.trees.expressions.NamedExpression`, introduced by #40202

the right error message should be `Unknown column 'xxx' in 'table list' in UNBOUND_OLAP_TABLE_SINK clause`


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

