### PR TITLE
[improvement](nereids)Support GROUP BY ... WITH ROLLUP syntax

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -1207,7 +1207,7 @@ groupingElement
     : ROLLUP LEFT_PAREN (expression (COMMA expression)*)? RIGHT_PAREN
     | CUBE LEFT_PAREN (expression (COMMA expression)*)? RIGHT_PAREN
     | GROUPING SETS LEFT_PAREN groupingSet (COMMA groupingSet)* RIGHT_PAREN
-    | expression (COMMA expression)*
+    | expression (COMMA expression)* (WITH ROLLUP)?
     ;
 
 groupingSet

--- a/regression-test/data/nereids_syntax_p0/grouping_sets.out
+++ b/regression-test/data/nereids_syntax_p0/grouping_sets.out
@@ -132,6 +132,35 @@
 13	0
 7	0
 
+-- !select_with_rollup1 --
+\N	\N	36
+2	\N	6
+2	0	\N
+2	1	6
+3	\N	12
+3	2	12
+4	\N	18
+4	0	\N
+4	3	18
+
+-- !select_with_rollup2 --
+\N	1
+2	0
+3	0
+4	0
+
+-- !select_with_rollup3 --
+3	0
+8	0
+9	0
+20	1
+
+-- !select_with_rollup4 --
+\N	1
+2	0
+3	0
+4	0
+
 -- !select --
 \N	\N	36
 \N	0	\N

--- a/regression-test/suites/nereids_syntax_p0/grouping_sets.groovy
+++ b/regression-test/suites/nereids_syntax_p0/grouping_sets.groovy
@@ -110,6 +110,15 @@ suite("test_nereids_grouping_sets") {
     order_qt_select "select sum(k2+1), grouping_id(k1+1) from groupingSetsTable group by grouping sets((k1+1)) having (k1+1) > 1;";
     order_qt_select "select sum(k2+1), grouping_id(k1+1) from groupingSetsTable group by grouping sets((k1+1), (k1)) having (k1+1) > 1;";
 
+    // with rollup
+    qt_select_with_rollup1 """
+                 select (k1 + 1) k1_, k2, sum(k3) from groupingSetsTable group by
+                 k1_, k2 with rollup order by k1_, k2
+               """
+    qt_select_with_rollup2 "select k1+1, grouping(k1+1) from groupingSetsTable group by (k1+1) with rollup order by k1+1;";
+    qt_select_with_rollup3 "select sum(k2), grouping(k1+1) from groupingSetsTable group by k1+1 with rollup order by sum(k2)"
+    qt_select_with_rollup4 "select k1+1, grouping_id(k1) from groupingSetsTable group by k1 with rollup order by k1+1;"
+
     // old grouping sets
     qt_select """
                 SELECT k1, k2, SUM(k3) FROM groupingSetsTable


### PR DESCRIPTION
### What problem does this PR solve?

Support GROUP BY ... WITH ROLLUP syntax

```
mysql> SELECT    year,   month,  SUM(amount) AS total_amount FROM sales GROUP BY year, month WITH ROLLUP order by year desc, month desc;
+------+-------+--------------+
| year | month | total_amount |
+------+-------+--------------+
| 2024 |     1 |      3400.00 |
| 2024 |  NULL |      3400.00 |
| 2023 |     2 |      4000.00 |
| 2023 |     1 |      3000.00 |
| 2023 |  NULL |      7000.00 |
| NULL |  NULL |     10400.00 |
+------+-------+--------------+
6 rows in set (0.02 sec)
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

