### PR TITLE
[fix](inverted index) fix error when writing empty index file

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_file_writer.cpp
@@ -266,6 +266,10 @@ void InvertedIndexFileWriter::copyFile(const char* fileName, lucene::store::Dire
         err.set(CL_ERR_IO, "debug point: copyFile_openInput_error");
     });
     if (!open) {
+        if (err.number() == CL_ERR_EmptyIndexSegment) {
+            LOG(WARNING) << "InvertedIndexFileWriter::copyFile: " << fileName << " is empty";
+            return;
+        }
         throw err;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
@@ -1525,4 +1525,60 @@ TEST_F(InvertedIndexFileWriterTest, MultipleIndicesCreateOutputStreamException) 
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
 
+TEST_F(InvertedIndexFileWriterTest, CopyFileEmptyFileTest) {
+    // This test uses the existing MockDorisFSDirectoryOpenInput class
+    auto mock_dir = std::make_shared<MockDorisFSDirectoryOpenInput>();
+    std::string local_fs_index_path = InvertedIndexDescriptor::get_temporary_index_path(
+            ExecEnv::GetInstance()->get_tmp_file_dirs()->get_tmp_file_dir().native(), _rowset_id,
+            _seg_id, 1, "suffix1");
+    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(local_fs_index_path).ok());
+    EXPECT_TRUE(io::global_local_filesystem()->create_directory(local_fs_index_path).ok());
+    mock_dir->init(_fs, local_fs_index_path.c_str());
+
+    // Create test files
+    std::vector<std::string> files = {"_0.fnm", "_0.frq", "_0.tii"};
+    for (const auto& file : files) {
+        auto out_file =
+                std::unique_ptr<lucene::store::IndexOutput>(mock_dir->createOutput(file.c_str()));
+        out_file->writeString("test content");
+        out_file->close();
+    }
+
+    InvertedIndexFileWriter writer(_fs, _index_path_prefix, _rowset_id, _seg_id,
+                                   InvertedIndexStorageFormatPB::V2);
+
+    // Setup mock to simulate CL_ERR_EmptyIndexSegment error for _0.frq file
+    EXPECT_CALL(*mock_dir,
+                openInput(::testing::StrEq("_0.frq"), ::testing::_, ::testing::_, ::testing::_))
+            .WillOnce(::testing::Invoke([&](const char* name, lucene::store::IndexInput*& ret,
+                                            CLuceneError& err_ref, int32_t bufferSize) {
+                err_ref.set(CL_ERR_EmptyIndexSegment,
+                            std::string("Empty index segment for file: ").append(name).c_str());
+                return false;
+            }));
+
+    // Test copyFile with the mock directory
+    uint8_t buffer[16384];
+
+    // Create a temporary output stream to test copyFile
+    auto* ram_dir = new lucene::store::RAMDirectory();
+    auto* output = ram_dir->createOutput("test_output");
+
+    // Before the fix, this would throw an exception
+    // After the fix, this should log a warning and return gracefully
+    EXPECT_NO_THROW({ writer.copyFile("_0.frq", mock_dir.get(), output, buffer, sizeof(buffer)); });
+
+    // The output should remain valid (not corrupted by the exception)
+    EXPECT_NE(output, nullptr);
+
+    // Clean up
+    output->close();
+    _CLLDELETE(output);
+    ram_dir->close();
+    _CLLDELETE(ram_dir);
+
+    // Clean up the test directory
+    EXPECT_TRUE(io::global_local_filesystem()->delete_directory(local_fs_index_path).ok());
+}
+
 } // namespace doris::segment_v2


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #51393

Problem Summary:
This PR ensures that copying an empty inverted index segment no longer throws an exception.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

