### PR TITLE
[opt](memory) dynamic adjustment of jemalloc's sampling rate during runtime

### DIFF
--- a/be/src/http/action/jeprofile_actions.h
+++ b/be/src/http/action/jeprofile_actions.h
@@ -32,6 +32,13 @@ public:
     void handle(HttpRequest* req) override;
 };
 
+class SetJeHeapProfileResetActions final : public HttpHandlerWithAuth {
+public:
+    SetJeHeapProfileResetActions(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+    ~SetJeHeapProfileResetActions() override = default;
+    void handle(HttpRequest* req) override;
+};
+
 class DumpJeHeapProfileToDotActions final : public HttpHandlerWithAuth {
 public:
     DumpJeHeapProfileToDotActions(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}

--- a/be/src/runtime/memory/heap_profiler.cpp
+++ b/be/src/runtime/memory/heap_profiler.cpp
@@ -147,7 +147,8 @@ bool HeapProfiler::heap_profiler_reset(size_t lg_sample) {
 #ifdef USE_JEMALLOC
     int ret = jemallctl("prof.reset", nullptr, nullptr, &lg_sample, sizeof(lg_sample));
     if (ret != 0) {
-        LOG(WARNING) << "jemallctl failed to set prof.reset:" << lg_sample << ".Check whether JEMALLOC_CONF is configured with prof:true.";
+        LOG(WARNING) << "jemallctl failed to set prof.reset:" << lg_sample
+                     << ".Check whether JEMALLOC_CONF is configured with prof:true.";
         return false;
     }
 #endif

--- a/be/src/runtime/memory/heap_profiler.cpp
+++ b/be/src/runtime/memory/heap_profiler.cpp
@@ -147,7 +147,7 @@ bool HeapProfiler::heap_profiler_reset(size_t lg_sample) {
 #ifdef USE_JEMALLOC
     int ret = jemallctl("prof.reset", nullptr, nullptr, &lg_sample, sizeof(lg_sample));
     if (ret != 0) {
-        LOG(WARNING) << "jemallctl set prof.reset:" << lg_sample << " err";
+        LOG(WARNING) << "jemallctl failed to set prof.reset:" << lg_sample << ".Check whether JEMALLOC_CONF is configured with prof:true.";
         return false;
     }
 #endif

--- a/be/src/runtime/memory/heap_profiler.cpp
+++ b/be/src/runtime/memory/heap_profiler.cpp
@@ -90,7 +90,7 @@ void HeapProfiler::heap_profiler_stop() {
     set_prof_active(false);
 }
 
-bool HeapProfiler::check_heap_profiler() {
+bool HeapProfiler::check_active_heap_profiler() {
 #ifdef USE_JEMALLOC
     size_t value = 0;
     size_t sz = sizeof(value);
@@ -98,6 +98,19 @@ bool HeapProfiler::check_heap_profiler() {
     // the real conf `prof` value cannot be checked.
     jemallctl("prof.active", &value, &sz, nullptr, 0);
     return value;
+#else
+    return false;
+#endif
+}
+
+bool HeapProfiler::check_enable_heap_profiler() {
+#ifdef USE_JEMALLOC
+    bool prof = false;
+    size_t sz = sizeof(prof);
+    if (jemallctl("opt.prof", &prof, &sz, nullptr, 0) != 0) {
+        LOG(WARNING) << "Failed to get option: opt.prof";
+    }
+    return prof;
 #else
     return false;
 #endif
@@ -128,6 +141,17 @@ std::string HeapProfiler::dump_heap_profile_to_dot() {
     } else {
         return "";
     }
+}
+
+bool HeapProfiler::heap_profiler_reset(size_t lg_sample) {
+#ifdef USE_JEMALLOC
+    int ret = jemallctl("prof.reset", nullptr, nullptr, &lg_sample, sizeof(lg_sample));
+    if (ret != 0) {
+        LOG(WARNING) << "jemallctl set prof.reset:" << lg_sample << " err";
+        return false;
+    }
+#endif
+    return true;
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/runtime/memory/heap_profiler.h
+++ b/be/src/runtime/memory/heap_profiler.h
@@ -30,7 +30,9 @@ public:
 
     void heap_profiler_start();
     void heap_profiler_stop();
-    bool check_heap_profiler();
+    bool heap_profiler_reset(size_t lg_sample);
+    bool check_active_heap_profiler();
+    bool check_enable_heap_profiler();
     std::string dump_heap_profile();
     std::string dump_heap_profile_to_dot();
 

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -211,6 +211,11 @@ Status HttpService::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/jeheap/active/{prof_value}",
                                       set_jeheap_profile_active_action);
 
+    SetJeHeapProfileResetActions* set_jeheap_profile_reset_action =
+            _pool.add(new SetJeHeapProfileResetActions(_env));
+    _ev_http_server->register_handler(HttpMethod::GET, "/jeheap/reset/{reset_value}",
+                                      set_jeheap_profile_reset_action);
+
     DumpJeHeapProfileToDotActions* dump_jeheap_profile_to_dot_action =
             _pool.add(new DumpJeHeapProfileToDotActions(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/jeheap/dump",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52000

Related PR: #xxx

Problem Summary:

A new HTTP API has been introduced: http://{be_ip}:{webserver_port}/jeheap/reset/{reset_value}, which allows resetting the jemalloc heap sampling rate during runtime.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [X] Regression test
    - [X] Unit Test
    - [X] Manual test (add detailed scripts or steps below)
            step 1 : `curl http://{be_ip}:{webserver_port}/jeheap/reset/17`
            step 2:   `open http://{be_ip}:{webserver_port}/profile` , Check if the Memory Option Settings have been updated.

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

