### PR TITLE
[Bug](aggregate) fix bitmap_union return error result in query sql

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -50,6 +50,7 @@ struct AggregateFunctionBitmapUnionOp {
     template <typename T>
     static void add(BitmapValue& res, const T& data, bool& is_first) {
         res.add(data);
+        is_first = false;
     }
 
     static void add(BitmapValue& res, const BitmapValue& data, bool& is_first) {
@@ -63,6 +64,9 @@ struct AggregateFunctionBitmapUnionOp {
 
     static void add_batch(BitmapValue& res, std::vector<const BitmapValue*>& data, bool& is_first) {
         res.fastunion(data);
+        // after fastunion, res myabe have many datas, so is_first should be false
+        // then call add function will not reset res
+        is_first = false;
     }
 
     static void merge(BitmapValue& res, const BitmapValue& data, bool& is_first) {

--- a/be/test/pipeline/operator/streaming_agg_operator_test.cpp
+++ b/be/test/pipeline/operator/streaming_agg_operator_test.cpp
@@ -29,7 +29,9 @@
 #include "testutil/mock/mock_agg_fn_evaluator.h"
 #include "testutil/mock/mock_runtime_state.h"
 #include "testutil/mock/mock_slot_ref.h"
+#include "util/bitmap_value.h"
 #include "util/jsonb_document.h"
+#include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_number.h"
 
 namespace doris::pipeline {
@@ -310,6 +312,95 @@ TEST_F(StreamingAggOperatorTest, test3) {
         EXPECT_TRUE(st.ok()) << st.msg();
         EXPECT_TRUE(eos);
         EXPECT_EQ(block.rows(), 3);
+    }
+
+    { EXPECT_TRUE(local_state->close(state.get()).ok()); }
+}
+
+TEST_F(StreamingAggOperatorTest, test4) {
+    op->_aggregate_evaluators.push_back(vectorized::create_agg_fn(
+            pool, "bitmap_union", {std::make_shared<DataTypeBitMap>()}, false));
+    op->_pool = &pool;
+    op->_needs_finalize = false;
+    op->_is_merge = false;
+
+    EXPECT_TRUE(op->set_child(child_op));
+
+    EXPECT_TRUE(op->prepare(state.get()).ok());
+    op->_probe_expr_ctxs = MockSlotRef::create_mock_contexts(
+            1, std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>()));
+
+    {
+        auto local_state = std::make_unique<MockStreamingAggLocalState>(state.get(), op.get());
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+
+        EXPECT_TRUE(local_state->init(state.get(), info).ok());
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state));
+    }
+
+    {
+        local_state =
+                static_cast<MockStreamingAggLocalState*>(state->get_local_state(op->operator_id()));
+        EXPECT_TRUE(local_state->open(state.get()).ok());
+    }
+
+    {
+        std::vector<BitmapValue> bitmaps = {BitmapValue(1), BitmapValue(2), BitmapValue(3),
+                                            BitmapValue(4), BitmapValue(5), BitmapValue(6)};
+
+        vectorized::Block block {
+                ColumnHelper::create_column_with_name<DataTypeBitMap>(bitmaps),
+                ColumnHelper::create_nullable_column_with_name<DataTypeInt64>(
+                        {1, 1, 2, 2, 2, 3}, {false, false, false, false, false, true})};
+        local_state->should_not_do_pre_agg = false;
+        local_state->_should_expand_hash_table = true;
+        std::cout << block.dump_data() << std::endl;
+        auto st = op->push(state.get(), &block, true);
+        EXPECT_TRUE(st.ok()) << st.msg();
+
+        EXPECT_EQ(local_state->_get_hash_table_size(), 3);
+        EXPECT_TRUE(op->need_more_input_data(state.get()));
+    }
+
+    {
+        local_state->should_not_do_pre_agg = false;
+        local_state->_should_expand_hash_table = false;
+        std::vector<BitmapValue> bitmaps2 = {BitmapValue(6), BitmapValue(7),  BitmapValue(8),
+                                             BitmapValue(9), BitmapValue(10), BitmapValue(11)};
+        vectorized::Block block {
+                ColumnHelper::create_column_with_name<DataTypeBitMap>(bitmaps2),
+                ColumnHelper::create_nullable_column_with_name<DataTypeInt64>(
+                        {2, 2, 2, 2, 4, 4}, {false, false, false, false, false, false})};
+        std::cout << block.dump_data() << std::endl;
+        auto st = op->push(state.get(), &block, true);
+        EXPECT_TRUE(st.ok()) << st.msg();
+
+        EXPECT_EQ(local_state->_get_hash_table_size(), 4);
+        EXPECT_TRUE(op->need_more_input_data(state.get()));
+    }
+
+    {
+        bool eos = false;
+        vectorized::Block block;
+        auto st = op->pull(state.get(), &block, &eos);
+        std::cout << block.dump_data() << std::endl;
+        EXPECT_TRUE(st.ok()) << st.msg();
+        EXPECT_TRUE(eos);
+        EXPECT_EQ(block.rows(), 4);
+        std::vector<BitmapValue> bitmaps_res = {BitmapValue({1, 2}),
+                                                BitmapValue({3, 4, 5, 6, 7, 8, 9}),
+                                                BitmapValue({10, 11}), BitmapValue(6)};
+        vectorized::Block res_block {
+                ColumnHelper::create_nullable_column_with_name<DataTypeInt64>(
+                        {1, 2, 4, 5}, {false, false, false, true}),
+                ColumnHelper::create_column_with_name<DataTypeBitMap>(bitmaps_res)};
+        EXPECT_TRUE(ColumnHelper::block_equal_with_sort(block, res_block))
+                << "Expected: " << res_block.dump_data() << ", but got: " << block.dump_data();
     }
 
     { EXPECT_TRUE(local_state->close(state.get()).ok()); }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
the bitmap union maybe could call add_batch firstly, and the call add function,
so if add_batch function not update is_first variable, it's will be loss data in union.
```
    static void add(BitmapValue& res, const BitmapValue& data, bool& is_first) {
        if (UNLIKELY(is_first)) {
            res = data;
            is_first = false;
        } else {
            res |= data;
        }
    }

    static void add_batch(BitmapValue& res, std::vector<const BitmapValue*>& data, bool& is_first) {
        res.fastunion(data);
        is_first = false;  // before not set this
    }
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

