### PR TITLE
[fix](load) resolve UBSan error when printing unique IDs

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -72,7 +72,7 @@ TabletStream::TabletStream(PUniqueId load_id, int64_t id, int64_t txn_id,
 }
 
 inline std::ostream& operator<<(std::ostream& ostr, const TabletStream& tablet_stream) {
-    ostr << "load_id=" << tablet_stream._load_id << ", txn_id=" << tablet_stream._txn_id
+    ostr << "load_id=" << print_id(tablet_stream._load_id) << ", txn_id=" << tablet_stream._txn_id
          << ", tablet_id=" << tablet_stream._id << ", status=" << tablet_stream._status.status();
     return ostr;
 }

--- a/be/src/util/uid_util.cpp
+++ b/be/src/util/uid_util.cpp
@@ -44,6 +44,10 @@ std::ostream& operator<<(std::ostream& os, const UniqueId& uid) {
     return os;
 }
 
+std::string print_id(const UniqueId& id) {
+    return id.to_string();
+}
+
 std::string print_id(const TUniqueId& id) {
     return fmt::format(FMT_COMPILE("{:x}-{:x}"), static_cast<uint64_t>(id.hi),
                        static_cast<uint64_t>(id.lo));

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -168,6 +168,7 @@ inline TUniqueId generate_uuid() {
 
 std::ostream& operator<<(std::ostream& os, const UniqueId& uid);
 
+std::string print_id(const UniqueId& id);
 std::string print_id(const TUniqueId& id);
 std::string print_id(const PUniqueId& id);
 


### PR DESCRIPTION
### What problem does this PR solve?

This commit fixes an Undefined Behavior Sanitizer error triggered when printing `PUniqueId` directly to an ostream.
Among the three types of unique IDs, `UniqueId`, `PUniqueId` (protobuf), and `TUniqueId` (thrift),
only `UniqueId` has an overloaded `operator<<()`.
Attempting to stream the other two types leads to undefined behavior, making the current approach error-prone.

Introduces a unified `print_id()` function for safely printing all unique ID types (`UniqueId`, `PUniqueId`, `TUniqueId`).
It is recommended to use `print_id()` instead of streaming directly.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

