### PR TITLE
[chore](Be)Optimize the binary size of be by reducing template instantiations for Min/Max/Any

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -37,55 +37,97 @@ AggregateFunctionPtr create_aggregate_function_single_value(const String& name,
                                                             const bool result_is_nullable,
                                                             const AggregateFunctionAttr& attr) {
     assert_unary(name, argument_types);
-
-    AggregateFunctionPtr res(creator_with_numeric_type::create<AggregateFunctionsSingleValue, Data,
-                                                               SingleValueDataFixed>(
-            argument_types, result_is_nullable));
-    if (res) {
-        return res;
-    }
-    res = creator_with_decimal_type::create<AggregateFunctionsSingleValue, Data,
-                                            SingleValueDataDecimal>(argument_types,
-                                                                    result_is_nullable);
-    if (res) {
-        return res;
-    }
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_STRING:
     case PrimitiveType::TYPE_CHAR:
     case PrimitiveType::TYPE_VARCHAR:
     case PrimitiveType::TYPE_JSONB:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataString>>>(argument_types,
                                                                             result_is_nullable);
     case PrimitiveType::TYPE_DATE:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATE>>>>(
                 argument_types, result_is_nullable);
     case PrimitiveType::TYPE_DATETIME:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATETIME>>>>(
                 argument_types, result_is_nullable);
     case PrimitiveType::TYPE_DATEV2:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATEV2>>>>(
                 argument_types, result_is_nullable);
     case PrimitiveType::TYPE_DATETIMEV2:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATETIMEV2>>>>(
                 argument_types, result_is_nullable);
     case PrimitiveType::TYPE_TIME:
     case PrimitiveType::TYPE_TIMEV2:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_TIMEV2>>>>(
                 argument_types, result_is_nullable);
     case PrimitiveType::TYPE_IPV4:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_IPV4>>>>(
                 argument_types, result_is_nullable);
     case PrimitiveType::TYPE_IPV6:
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_IPV6>>>>(
+                argument_types, result_is_nullable);
+    // For boolean, tinyint, smallint, int, bigint, largeint
+    case PrimitiveType::TYPE_BOOLEAN:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_BOOLEAN>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_TINYINT:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_TINYINT>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_SMALLINT:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_SMALLINT>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_INT:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_INT>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_BIGINT:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_BIGINT>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_LARGEINT:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_LARGEINT>>>>(
+                argument_types, result_is_nullable);
+    // For float, double
+    case PrimitiveType::TYPE_FLOAT:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_FLOAT>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DOUBLE:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DOUBLE>>>>(
+                argument_types, result_is_nullable);
+    // For decimal
+    case PrimitiveType::TYPE_DECIMAL32:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL32>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL64:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL64>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DECIMALV2:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMALV2>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL128I:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL128I>>>>(
+                argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL256:
+        return creator_without_type::create_unary_arguments<
+                AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL256>>>>(
                 argument_types, result_is_nullable);
     default:
         return nullptr;
@@ -110,7 +152,7 @@ AggregateFunctionPtr create_aggregate_function_single_value_any_value_function(
         argument_type->get_primitive_type() == PrimitiveType::TYPE_BITMAP ||
         argument_type->get_primitive_type() == PrimitiveType::TYPE_HLL ||
         argument_type->get_primitive_type() == PrimitiveType::TYPE_QUANTILE_STATE) {
-        return creator_without_type::create<
+        return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<SingleValueDataComplexType>>(argument_types,
                                                                            result_is_nullable);
     }

--- a/be/src/vec/aggregate_functions/helpers.h
+++ b/be/src/vec/aggregate_functions/helpers.h
@@ -130,6 +130,25 @@ struct creator_without_type {
         return AggregateFunctionPtr(result.release());
     }
 
+    template <typename AggregateFunctionTemplate, typename... TArgs>
+    static AggregateFunctionPtr create_unary_arguments(const DataTypes& argument_types_,
+                                                       const bool result_is_nullable,
+                                                       TArgs&&... args) {
+        std::unique_ptr<IAggregateFunction> result(std::make_unique<AggregateFunctionTemplate>(
+                std::forward<TArgs>(args)..., remove_nullable(argument_types_)));
+        if (have_nullable(argument_types_)) {
+            if (result_is_nullable) {
+                result.reset(new NullableT<false, true, AggregateFunctionTemplate>(
+                        result.release(), argument_types_));
+            } else {
+                result.reset(new NullableT<false, false, AggregateFunctionTemplate>(
+                        result.release(), argument_types_));
+            }
+        }
+        CHECK_AGG_FUNCTION_SERIALIZED_TYPE(AggregateFunctionTemplate);
+        return AggregateFunctionPtr(result.release());
+    }
+
     /// AggregateFunctionTemplate will handle the nullable arguments, no need to use
     /// AggregateFunctionNullVariadicInline/AggregateFunctionNullUnaryInline
     template <typename AggregateFunctionTemplate, typename... TArgs>


### PR DESCRIPTION
### What problem does this PR solve?

before
108.73 MB       ./vec/CMakeFiles/Vec.dir/aggregate_functions/aggregate_function_min_max.cpp.o
now
68.65 MB        ./vec/CMakeFiles/Vec.dir/aggregate_functions/aggregate_function_min_max.cpp.o


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

