### PR TITLE
[Enhancement](s3) Support reading directory bucket

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/S3URI.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/S3URI.java
@@ -76,6 +76,9 @@ public class S3URI {
     private static final Set<String> OS_SCHEMES = ImmutableSet.of("s3", "s3a", "s3n",
             "bos", "oss", "cos", "cosn", "obs", "azure");
 
+    /** Suffix of S3Express storage bucket names. */
+    private static final String S3_DIRECTORY_BUCKET_SUFFIX = "--x-s3";
+
     private URI uri;
 
     private String bucket;
@@ -331,5 +334,70 @@ public class S3URI {
         sb.append(", queryParams=").append(queryParams);
         sb.append('}');
         return sb.toString();
+    }
+
+    /**
+     * Check if this S3URI uses a directory bucket.
+     *
+     * @return true if the bucket is a directory bucket
+     */
+    public boolean useS3DirectoryBucket() {
+        return isS3DirectoryBucket(this.bucket);
+    }
+
+    /**
+     * Check if the bucket name indicates the bucket is a directory bucket. This method does not check
+     * against the S3 service.
+     *
+     * <p>Directory bucket names follow the format: bucket-name--azid--x-s3
+     * where azid is an availability zone identifier like "usw2-az1", "use1-az4", etc.
+     *
+     * @param bucketName bucket to probe.
+     * @return true if the bucket name indicates the bucket is a directory bucket
+     */
+    public static boolean isS3DirectoryBucket(final String bucketName) {
+        if (bucketName == null || !bucketName.endsWith(S3_DIRECTORY_BUCKET_SUFFIX)) {
+            return false;
+        }
+        // Check if the bucket name has the correct format: bucket-name--azid--x-s3
+        // The bucket name should have at least 3 segments separated by "--"
+        String[] segments = bucketName.split("--");
+        if (segments.length < 3) {
+            return false;
+        }
+        // The last segment should be "x-s3"
+        if (!"x-s3".equals(segments[segments.length - 1])) {
+            return false;
+        }
+        // The second-to-last segment should be the availability zone identifier
+        // It should have a format like "usw2-az1", "use1-az4", etc.
+        String azid = segments[segments.length - 2];
+        if (azid == null || azid.isEmpty()) {
+            return false;
+        }
+        // Basic validation: azid should contain at least one hyphen and not be empty
+        // More sophisticated validation could be added here if needed
+        return azid.contains("-") && azid.length() > 3;
+    }
+
+    /**
+     * Adjusts a glob prefix for S3 Directory Bucket listing.
+     * <p>
+     * For Directory Buckets, listing with a prefix like "path/to/files" will not return any results
+     * if the objects are "path/to/files1.csv", "path/to/files2.csv", etc. The prefix needs to be
+     * adjusted to the containing "directory", which is "path/to/".
+     *
+     * @param globPrefix The prefix derived from a glob pattern (e.g., "path/to/files" from "path/to/files*.csv").
+     * @return The adjusted prefix ending with a "/" (e.g., "path/to/"), or an empty string if no "/" is present.
+     */
+    public static String getDirectoryPrefixForGlob(final String globPrefix) {
+        if (globPrefix == null || globPrefix.isEmpty() || globPrefix.endsWith("/")) {
+            return globPrefix;
+        }
+        int lastSlashIndex = globPrefix.lastIndexOf('/');
+        if (lastSlashIndex >= 0) {
+            return globPrefix.substring(0, lastSlashIndex + 1);
+        }
+        return "";
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
@@ -194,7 +194,15 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
         }
         Matcher matcher = endpointPattern().matcher(endpoint.toLowerCase());
         if (matcher.find()) {
-            String region = matcher.group(1);
+            // Check all possible groups for region (group 1, 2, or 3)
+            String region = null;
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                String group = matcher.group(i);
+                if (StringUtils.isNotBlank(group)) {
+                    region = group;
+                    break;
+                }
+            }
             if (StringUtils.isBlank(region)) {
                 throw new IllegalArgumentException("Invalid endpoint format: " + endpoint);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
@@ -122,11 +122,18 @@ public class S3Properties extends AbstractS3CompatibleProperties {
      * - s3.dualstack.us-east-1.amazonaws.com      => region = us-east-1
      * - s3-fips.us-east-2.amazonaws.com           => region = us-east-2
      * - s3-fips.dualstack.us-east-2.amazonaws.com => region = us-east-2
+     * - s3express-control.us-west-2.amazonaws.com => region = us-west-2 (S3 Directory Bucket Regional)
+     * - s3express-usw2-az1.us-west-2.amazonaws.com => region = us-west-2 (S3 Directory Bucket Zonal)
      * <p>
-     * Group(1) in the pattern captures the region part if available.
+     * Group(1), Group(2), or Group(3) in the pattern captures the region part if available.
      */
     private static final Pattern ENDPOINT_PATTERN = Pattern.compile(
-            "^(?:https?://)?s3(?:[-.]fips)?(?:[-.]dualstack)?(?:[-.]([a-z0-9-]+))?\\.amazonaws\\.com$"
+            "^(?:https?://)?(?:"
+                    + "s3(?:[-.]fips)?(?:[-.]dualstack)?[-.]([a-z0-9-]+)|" // Standard S3 endpoints
+                    + "s3express-control\\.([a-z0-9-]+)|"                  // Directory bucket regional
+                    + "s3express-[a-z0-9-]+\\.([a-z0-9-]+)"                // Directory bucket zonal
+                    + ")\\.amazonaws\\.com(?:/.*)?$",
+            Pattern.CASE_INSENSITIVE
     );
 
     public S3Properties(Map<String, String> origProps) {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/S3URITest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/S3URITest.java
@@ -215,4 +215,49 @@ public class S3URITest {
         Assert.assertEquals("foo", uri1.getQueryParams().get().get("query").get(0));
 
     }
+
+    @Test
+    public void testS3DirectoryBucket() throws UserException {
+        // Valid directory bucket
+        String validDirBucket = "my-bucket--usw2-az1--x-s3";
+        Assert.assertTrue(S3URI.isS3DirectoryBucket(validDirBucket));
+        S3URI uriWithDirBucket = S3URI.create("s3://" + validDirBucket + "/some/file.csv");
+        Assert.assertTrue(uriWithDirBucket.useS3DirectoryBucket());
+        Assert.assertEquals(validDirBucket, uriWithDirBucket.getBucket());
+
+        // Another valid one
+        String validDirBucket2 = "another-bucket--use1-az4--x-s3";
+        Assert.assertTrue(S3URI.isS3DirectoryBucket(validDirBucket2));
+
+        // Invalid directory buckets
+        Assert.assertFalse(S3URI.isS3DirectoryBucket("my-bucket")); // regular bucket
+        Assert.assertFalse(S3URI.isS3DirectoryBucket("my-bucket--x-s3")); // missing azid
+        Assert.assertFalse(S3URI.isS3DirectoryBucket("my-bucket--usw2-az1--x-s4")); // wrong suffix
+        Assert.assertFalse(S3URI.isS3DirectoryBucket("my-bucket-usw2-az1--x-s3")); // incorrect format
+        Assert.assertFalse(S3URI.isS3DirectoryBucket("my-bucket--usw2az1--x-s3")); // azid without hyphen
+        Assert.assertFalse(S3URI.isS3DirectoryBucket("my-bucket---x-s3")); // empty azid
+        Assert.assertFalse(S3URI.isS3DirectoryBucket(null));
+        Assert.assertFalse(S3URI.isS3DirectoryBucket(""));
+
+        S3URI uriWithRegularBucket = S3URI.create("s3://my-bucket/some/file.csv");
+        Assert.assertFalse(uriWithRegularBucket.useS3DirectoryBucket());
+    }
+
+    @Test
+    public void testGetDirectoryPrefixForGlob() {
+        // Case 1: Standard glob prefix
+        Assert.assertEquals("path/to/", S3URI.getDirectoryPrefixForGlob("path/to/file.csv"));
+        // Case 2: Prefix already ends with a slash
+        Assert.assertEquals("path/to/", S3URI.getDirectoryPrefixForGlob("path/to/"));
+        // Case 3: No slashes in prefix
+        Assert.assertEquals("", S3URI.getDirectoryPrefixForGlob("file.csv"));
+        // Case 4: Empty prefix
+        Assert.assertEquals("", S3URI.getDirectoryPrefixForGlob(""));
+        // Case 5: Null prefix
+        Assert.assertNull(S3URI.getDirectoryPrefixForGlob(null));
+        // Case 6: Prefix is just a slash
+        Assert.assertEquals("/", S3URI.getDirectoryPrefixForGlob("/"));
+        // Case 7: Starts with slash
+        Assert.assertEquals("/path/to/", S3URI.getDirectoryPrefixForGlob("/path/to/file.csv"));
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

#### S3 TVF

```sql
Doris > SELECT *
    -> FROM s3(
    ->     "uri"              = "s3://xxx--usw2-az1--x-s3/test1.csv",
    ->     "s3.access_key"    = "xxx",
    ->     "s3.secret_key"    = "xxx",
    ->     "s3.region"        = "us-west-2",
    ->     "s3.endpoint"      = "https://s3express-usw2-az1.us-west-2.amazonaws.com",
    ->     "format"           = "csv"
    -> );
+---------+
| c1      |
+---------+
| test1.1 |
| test1.2 |
+---------+
2 rows in set (1.75 sec)

Doris > SELECT *
    -> FROM s3(
    ->     "uri"              = "s3://xxx--usw2-az1--x-s3/test2.csv",
    ->     "s3.access_key"    = "xxx",
    ->     "s3.secret_key"    = "xxx",
    ->     "s3.region"        = "us-west-2",
    ->     "s3.endpoint"      = "https://s3express-usw2-az1.us-west-2.amazonaws.com",
    ->     "format"           = "csv"
    -> );
+---------+
| c1      |
+---------+
| test2.1 |
| test2.2 |
+---------+
2 rows in set (2.43 sec)

Doris > SELECT *
    -> FROM s3(
    ->     "uri"              = "s3://xxx--usw2-az1--x-s3/*",
    ->     "s3.access_key"    = "xxx",
    ->     "s3.secret_key"    = "xxx",
    ->     "s3.region"        = "us-west-2",
    ->     "s3.endpoint"      = "https://s3express-usw2-az1.us-west-2.amazonaws.com",
    ->     "format"           = "csv"
    -> );
+---------+
| c1      |
+---------+
| test1.1 |
| test1.2 |
| test2.1 |
| test2.2 |
+---------+
4 rows in set (2.20 sec)
```

#### nessie iceberg rest catalog on directory bucket

**Need to set `nessie.catalog.service.s3.default-options.request-signing-enabled=false` in nessie**

```sql
Doris > CREATE CATALOG `nessie_catalog` PROPERTIES (
    ->   'type'                   = 'iceberg',
    ->   'iceberg.catalog.type'   = 'rest',
    ->   'uri'                    = 'http://localhost:19120/iceberg',
    ->   'warehouse'              = 'warehouse',
    ->   's3.access_key'          = 'xxx',
    ->   's3.secret_key'          = 'xxx',
    ->   's3.endpoint'            = 'https://s3express-usw2-az1.us-west-2.amazonaws.com',
    ->   's3.region'              = 'us-west-2'
    -> );
Query OK, 0 rows affected (0.02 sec)

Doris > 
Doris > use nessie_catalog.test;

Database changed
Doris > select * from test;
+------+------+
| id   | name |
+------+------+
|    1 | aa   |
+------+------+

```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

