### PR TITLE
fix scan_bytes_from_local/remote_storage issue in audit log, when enable file cache

### DIFF
--- a/be/src/runtime/workload_management/resource_context.cpp
+++ b/be/src/runtime/workload_management/resource_context.cpp
@@ -28,12 +28,19 @@ namespace doris {
 void ResourceContext::to_pb_query_statistics(PQueryStatistics* statistics) const {
     DCHECK(statistics != nullptr);
     statistics->set_scan_rows(io_context()->scan_rows());
-    statistics->set_scan_bytes(io_context()->scan_bytes());
+    int64_t scan_bytes_local = io_context()->scan_bytes_from_local_storage();
+    int64_t scan_bytes_remote = io_context()->scan_bytes_from_remote_storage();
+    //if enable file cache, total scan bytes should be sum of local and remote
+    if (scan_bytes_local + scan_bytes_remote > 0) {
+        statistics->set_scan_bytes(scan_bytes_local + scan_bytes_remote);
+    } else {
+        statistics->set_scan_bytes(io_context()->scan_bytes());
+    }
     statistics->set_cpu_ms(cpu_context()->cpu_cost_ms() / NANOS_PER_MILLIS);
     statistics->set_returned_rows(io_context()->returned_rows());
     statistics->set_max_peak_memory_bytes(memory_context()->max_peak_memory_bytes());
-    statistics->set_scan_bytes_from_remote_storage(io_context()->scan_bytes_from_remote_storage());
-    statistics->set_scan_bytes_from_local_storage(io_context()->scan_bytes_from_local_storage());
+    statistics->set_scan_bytes_from_remote_storage(scan_bytes_remote);
+    statistics->set_scan_bytes_from_local_storage(scan_bytes_local);
     statistics->set_spill_write_bytes_to_local_storage(
             io_context_->spill_write_bytes_to_local_storage());
     statistics->set_spill_read_bytes_from_local_storage(
@@ -43,16 +50,22 @@ void ResourceContext::to_pb_query_statistics(PQueryStatistics* statistics) const
 void ResourceContext::to_thrift_query_statistics(TQueryStatistics* statistics) const {
     DCHECK(statistics != nullptr);
     statistics->__set_scan_rows(io_context()->scan_rows());
-    statistics->__set_scan_bytes(io_context()->scan_bytes());
+    int64_t scan_bytes_local = io_context()->scan_bytes_from_local_storage();
+    int64_t scan_bytes_remote = io_context()->scan_bytes_from_remote_storage();
+    //if enable file cache, total scan bytes should be sum of local and remote
+    if (scan_bytes_local + scan_bytes_remote > 0) {
+        statistics->__set_scan_bytes(scan_bytes_local + scan_bytes_remote);
+    } else {
+        statistics->__set_scan_bytes(io_context()->scan_bytes());
+    }
     statistics->__set_cpu_ms(cpu_context()->cpu_cost_ms() / NANOS_PER_MILLIS);
     statistics->__set_returned_rows(io_context()->returned_rows());
     statistics->__set_max_peak_memory_bytes(memory_context()->max_peak_memory_bytes());
     statistics->__set_current_used_memory_bytes(memory_context()->current_memory_bytes());
     statistics->__set_shuffle_send_bytes(io_context()->shuffle_send_bytes());
     statistics->__set_shuffle_send_rows(io_context()->shuffle_send_rows());
-    statistics->__set_scan_bytes_from_remote_storage(
-            io_context()->scan_bytes_from_remote_storage());
-    statistics->__set_scan_bytes_from_local_storage(io_context()->scan_bytes_from_local_storage());
+    statistics->__set_scan_bytes_from_remote_storage(scan_bytes_remote);
+    statistics->__set_scan_bytes_from_local_storage(scan_bytes_local);
 
     if (workload_group() != nullptr) {
         statistics->__set_workload_group_id(workload_group()->id());

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -1541,6 +1541,13 @@ void FileScanner::_collect_profile_before_close() {
     if (_cur_reader != nullptr) {
         _cur_reader->collect_profile_before_close();
     }
+
+    if (_file_cache_statistics != nullptr) {
+        IOContext* io_ctx = _state->get_query_ctx()->resource_ctx()->io_context();
+        io_ctx->update_scan_bytes_from_local_storage(_file_cache_statistics->bytes_read_from_local);
+        io_ctx->update_scan_bytes_from_remote_storage(
+                _file_cache_statistics->bytes_read_from_remote);
+    }
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -707,10 +707,10 @@ void OlapScanner::_collect_profile_before_close() {
     tablet->query_scan_bytes->increment(local_state->_read_compressed_counter->value());
     tablet->query_scan_rows->increment(local_state->_scan_rows->value());
     tablet->query_scan_count->increment(1);
-    _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_local_storage(
-            stats.file_cache_stats.bytes_read_from_local);
-    _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_remote_storage(
-            stats.file_cache_stats.bytes_read_from_remote);
+
+    IOContext* io_ctx = _state->get_query_ctx()->resource_ctx()->io_context();
+    io_ctx->update_scan_bytes_from_local_storage(stats.file_cache_stats.bytes_read_from_local);
+    io_ctx->update_scan_bytes_from_remote_storage(stats.file_cache_stats.bytes_read_from_remote);
 }
 
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -504,7 +504,7 @@ public class DorisFE {
             releaseFileLockAndCloseFileChannel();
             throw new RuntimeException("Try to lock process failed", e);
         }
-        throw new RuntimeException("FE process has been started，please do not start multiple FE processes at the "
+        throw new RuntimeException("FE process has been started, please do not start multiple FE processes at the "
                 + "same time");
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

when enable file cache, the scan_bytes_from_local_storage and scan_bytes_from_remote_storage shoud not be zero, and scan_bytes should be scan_bytes_from_local_storage + scan_bytes_from_remote_storage


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

