### PR TITLE
[refactor](date) Simplify template args for date functions

### DIFF
--- a/be/src/vec/functions/function_date_or_datetime_computation.cpp
+++ b/be/src/vec/functions/function_date_or_datetime_computation.cpp
@@ -55,24 +55,15 @@ using FunctionSubMonthsDate = FunctionDateOrDateTimeComputation<SubtractMonthsIm
 using FunctionSubQuartersDate = FunctionDateOrDateTimeComputation<SubtractQuartersImpl<TYPE_DATE>>;
 using FunctionSubYearsDate = FunctionDateOrDateTimeComputation<SubtractYearsImpl<TYPE_DATE>>;
 
-using FunctionDateDiff =
-        FunctionDateOrDateTimeComputation<DateDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionTimeDiff =
-        FunctionDateOrDateTimeComputation<TimeDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionYearsDiff =
-        FunctionDateOrDateTimeComputation<YearsDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionMonthsDiff =
-        FunctionDateOrDateTimeComputation<MonthsDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionDaysDiff =
-        FunctionDateOrDateTimeComputation<DaysDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionWeeksDiff =
-        FunctionDateOrDateTimeComputation<WeeksDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionHoursDiff =
-        FunctionDateOrDateTimeComputation<HoursDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionMinutesDiff =
-        FunctionDateOrDateTimeComputation<MintuesDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
-using FunctionSecondsDiff =
-        FunctionDateOrDateTimeComputation<SecondsDiffImpl<TYPE_DATETIME, TYPE_DATETIME>>;
+using FunctionDateDiff = FunctionTimeDiff<DateDiffImpl<TYPE_DATETIME>>;
+using FunctionTimeDiffImpl = FunctionTimeDiff<TimeDiffImpl<TYPE_DATETIME>>;
+using FunctionYearsDiff = FunctionTimeDiff<YearsDiffImpl<TYPE_DATETIME>>;
+using FunctionMonthsDiff = FunctionTimeDiff<MonthsDiffImpl<TYPE_DATETIME>>;
+using FunctionDaysDiff = FunctionTimeDiff<DaysDiffImpl<TYPE_DATETIME>>;
+using FunctionWeeksDiff = FunctionTimeDiff<WeeksDiffImpl<TYPE_DATETIME>>;
+using FunctionHoursDiff = FunctionTimeDiff<HoursDiffImpl<TYPE_DATETIME>>;
+using FunctionMinutesDiff = FunctionTimeDiff<MintuesDiffImpl<TYPE_DATETIME>>;
+using FunctionSecondsDiff = FunctionTimeDiff<SecondsDiffImpl<TYPE_DATETIME>>;
 
 using FunctionToYearWeekTwoArgs =
         FunctionDateOrDateTimeComputation<ToYearWeekTwoArgsImpl<TYPE_DATETIME>>;
@@ -144,7 +135,7 @@ void register_function_date_time_computation(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionSubHoursDate>();
 
     factory.register_function<FunctionDateDiff>();
-    factory.register_function<FunctionTimeDiff>();
+    factory.register_function<FunctionTimeDiffImpl>();
     factory.register_function<FunctionYearsDiff>();
     factory.register_function<FunctionMonthsDiff>();
     factory.register_function<FunctionWeeksDiff>();

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -103,6 +103,7 @@ typename PrimitiveTypeTraits<ReturnType>::DataType::FieldType date_time_add(
                                                                    : TYPE_DATETIMEV2)               \
                                    : (is_date_or_datetime(ArgType) ? TYPE_DATE : TYPE_DATEV2))      \
                         : (is_date_or_datetime(ArgType) ? TYPE_DATETIME : TYPE_DATETIMEV2);         \
+        static constexpr PrimitiveType ArgPType = ArgType;                                          \
         using ReturnNativeType = typename PrimitiveTypeTraits<ReturnType>::DataType::FieldType;     \
         using InputNativeType = typename PrimitiveTypeTraits<ArgType>::DataType::FieldType;         \
         static constexpr auto name = #NAME;                                                         \
@@ -130,6 +131,7 @@ ADD_TIME_FUNCTION_IMPL(AddYearsImpl, years_add, YEAR);
 
 template <PrimitiveType ArgType>
 struct AddQuartersImpl {
+    static constexpr PrimitiveType ArgPType = ArgType;
     static constexpr PrimitiveType ReturnType = ArgType;
     using InputNativeType = typename PrimitiveTypeTraits<ArgType>::DataType::FieldType;
     using ReturnNativeType = typename PrimitiveTypeTraits<ReturnType>::DataType::FieldType;
@@ -147,6 +149,7 @@ struct AddQuartersImpl {
 
 template <typename Transform>
 struct SubtractIntervalImpl {
+    static constexpr PrimitiveType ArgPType = Transform::ArgPType;
     static constexpr PrimitiveType ReturnType = Transform::ReturnType;
     using InputNativeType = typename Transform::InputNativeType;
     using ReturnNativeType = typename Transform::ReturnNativeType;
@@ -211,50 +214,47 @@ struct SubtractYearsImpl : SubtractIntervalImpl<AddYearsImpl<DateType>> {
 };
 
 #define DECLARE_DATE_FUNCTIONS(NAME, FN_NAME, RETURN_TYPE, STMT)                              \
-    template <PrimitiveType DateType1, PrimitiveType DateType2>                               \
+    template <PrimitiveType DateType>                                                         \
     struct NAME {                                                                             \
-        using NativeType1 = typename PrimitiveTypeTraits<DateType1>::DataType::FieldType;     \
-        using NativeType2 = typename PrimitiveTypeTraits<DateType2>::DataType::FieldType;     \
-        using DateValueType1 = typename PrimitiveTypeTraits<DateType1>::CppType;              \
-        using DateValueType2 = typename PrimitiveTypeTraits<DateType2>::CppType;              \
+        using NativeType = typename PrimitiveTypeTraits<DateType>::DataType::FieldType;       \
+        using DateValueType = typename PrimitiveTypeTraits<DateType>::CppType;                \
+        static constexpr PrimitiveType ArgPType = DateType;                                   \
         static constexpr PrimitiveType ReturnType = PrimitiveType::RETURN_TYPE;               \
                                                                                               \
         static constexpr auto name = #FN_NAME;                                                \
         static constexpr auto is_nullable = false;                                            \
         static inline typename PrimitiveTypeTraits<RETURN_TYPE>::DataType::FieldType execute( \
-                const NativeType1& t0, const NativeType2& t1, bool& is_null) {                \
-            const auto& ts0 = reinterpret_cast<const DateValueType1&>(t0);                    \
-            const auto& ts1 = reinterpret_cast<const DateValueType2&>(t1);                    \
+                const NativeType& t0, const NativeType& t1, bool& is_null) {                  \
+            const auto& ts0 = reinterpret_cast<const DateValueType&>(t0);                     \
+            const auto& ts1 = reinterpret_cast<const DateValueType&>(t1);                     \
             is_null = !ts0.is_valid_date() || !ts1.is_valid_date();                           \
             return (STMT);                                                                    \
         }                                                                                     \
         static DataTypes get_variadic_argument_types() {                                      \
-            return {std::make_shared<typename PrimitiveTypeTraits<DateType1>::DataType>(),    \
-                    std::make_shared<typename PrimitiveTypeTraits<DateType2>::DataType>()};   \
+            return {std::make_shared<typename PrimitiveTypeTraits<DateType>::DataType>(),     \
+                    std::make_shared<typename PrimitiveTypeTraits<DateType>::DataType>()};    \
         }                                                                                     \
     };
 
 DECLARE_DATE_FUNCTIONS(DateDiffImpl, datediff, TYPE_INT, (ts0.daynr() - ts1.daynr()));
 // DECLARE_DATE_FUNCTIONS(TimeDiffImpl, timediff, DataTypeTime, ts0.datetime_diff_in_seconds(ts1));
 // Expands to below here because it use Time type which need some special deal.
-template <PrimitiveType DateType1, PrimitiveType DateType2>
+template <PrimitiveType DateType>
 struct TimeDiffImpl {
-    using NativeType1 = typename PrimitiveTypeTraits<DateType1>::CppType;
-    using NativeType2 = typename PrimitiveTypeTraits<DateType2>::CppType;
-    using ArgType1 = typename PrimitiveTypeTraits<DateType1>::DataType::FieldType;
-    using ArgType2 = typename PrimitiveTypeTraits<DateType2>::DataType::FieldType;
-    static constexpr bool UsingTimev2 =
-            is_date_v2_or_datetime_v2(DateType1) || is_date_v2_or_datetime_v2(DateType2);
+    static constexpr PrimitiveType ArgPType = DateType;
+    using NativeType = typename PrimitiveTypeTraits<DateType>::CppType;
+    using ArgType = typename PrimitiveTypeTraits<DateType>::DataType::FieldType;
+    static constexpr bool UsingTimev2 = is_date_v2_or_datetime_v2(DateType);
 
     static constexpr PrimitiveType ReturnType =
             TYPE_TIMEV2; // TimeV1Type also use double as native type. same as v2.
 
     static constexpr auto name = "timediff";
     static constexpr int64_t limit_value = 3020399000000; // 838:59:59 convert to microsecond
-    static inline DataTypeTimeV2::FieldType execute(const ArgType1& t0, const ArgType2& t1,
+    static inline DataTypeTimeV2::FieldType execute(const ArgType& t0, const ArgType& t1,
                                                     bool& is_null) {
-        const auto& ts0 = reinterpret_cast<const NativeType1&>(t0);
-        const auto& ts1 = reinterpret_cast<const NativeType2&>(t1);
+        const auto& ts0 = reinterpret_cast<const NativeType&>(t0);
+        const auto& ts1 = reinterpret_cast<const NativeType&>(t1);
         is_null = !ts0.is_valid_date() || !ts1.is_valid_date();
         if constexpr (UsingTimev2) {
             // refer to https://dev.mysql.com/doc/refman/5.7/en/time.html
@@ -272,8 +272,8 @@ struct TimeDiffImpl {
         }
     }
     static DataTypes get_variadic_argument_types() {
-        return {std ::make_shared<typename PrimitiveTypeTraits<DateType1>::DataType>(),
-                std ::make_shared<typename PrimitiveTypeTraits<DateType2>::DataType>()};
+        return {std ::make_shared<typename PrimitiveTypeTraits<DateType>::DataType>(),
+                std ::make_shared<typename PrimitiveTypeTraits<DateType>::DataType>()};
     }
 };
 #define TIME_DIFF_FUNCTION_IMPL(CLASS, NAME, UNIT) \
@@ -293,6 +293,7 @@ TIME_DIFF_FUNCTION_IMPL(MicroSecondsDiffImpl, microseconds_diff, MICROSECOND);
 #define TIME_FUNCTION_TWO_ARGS_IMPL(CLASS, NAME, FUNCTION, RETURN_TYPE)                       \
     template <PrimitiveType DateType>                                                         \
     struct CLASS {                                                                            \
+        static constexpr PrimitiveType ArgPType = DateType;                                   \
         using ArgType = typename PrimitiveTypeTraits<DateType>::DataType::FieldType;          \
         using DateValueType = typename PrimitiveTypeTraits<DateType>::CppType;                \
         static constexpr PrimitiveType ReturnType = RETURN_TYPE;                              \
@@ -409,6 +410,138 @@ struct DateTimeOp {
     }
 };
 
+template <typename Transform>
+class FunctionTimeDiff : public IFunction {
+public:
+    static constexpr auto name = Transform::name;
+    static constexpr bool has_variadic_argument =
+            !std::is_void_v<decltype(has_variadic_argument_types(std::declval<Transform>()))>;
+
+    static FunctionPtr create() { return std::make_shared<FunctionTimeDiff>(); }
+
+    String get_name() const override { return name; }
+
+    bool is_variadic() const override { return true; }
+    size_t get_number_of_arguments() const override { return 0; }
+
+    DataTypes get_variadic_argument_types_impl() const override {
+        if constexpr (has_variadic_argument) {
+            return Transform::get_variadic_argument_types();
+        }
+        return {};
+    }
+    bool use_default_implementation_for_nulls() const override { return false; }
+
+    DataTypePtr get_return_type_impl(const ColumnsWithTypeAndName& arguments) const override {
+        RETURN_REAL_TYPE_FOR_DATEV2_FUNCTION(Transform::ReturnType);
+    }
+
+    Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                        uint32_t result, size_t input_rows_count) const override {
+        using ResFieldType =
+                typename PrimitiveTypeTraits<Transform::ReturnType>::DataType::FieldType;
+        using Op = DateTimeOp<Transform::ArgPType, Transform::ArgPType, ResFieldType, Transform>;
+
+        auto get_null_map = [](const ColumnPtr& col) -> const NullMap* {
+            if (col->is_nullable()) {
+                return &static_cast<const ColumnNullable&>(*col).get_null_map_data();
+            }
+            // Const(Nullable)
+            if (const auto* const_col = check_and_get_column<ColumnConst>(col.get());
+                const_col != nullptr && const_col->is_concrete_nullable()) {
+                return &static_cast<const ColumnNullable&>(const_col->get_data_column())
+                                .get_null_map_data();
+            }
+            return nullptr;
+        };
+
+        //ATTN: those null maps may be nullmap of ColumnConst(only 1 row)
+        // src column is always datelike type.
+        ColumnPtr& col0 = block.get_by_position(arguments[0]).column;
+        const NullMap* nullmap0 = get_null_map(col0);
+        // the second column may be delta column(xx_add/sub) or datelike column(xxx_diff)
+        ColumnPtr& col1 = block.get_by_position(arguments[1]).column;
+        const NullMap* nullmap1 = get_null_map(col1);
+
+        // if null wrapped, extract nested column as src_nested_col
+        const ColumnPtr src_nested_col = remove_nullable(col0);
+        const auto result_nullable = block.get_by_position(result).type->is_nullable();
+        auto res_col = ColumnVector<Transform::ReturnType>::create();
+
+        // vector-const or vector-vector
+        if (const auto* sources =
+                    check_and_get_column<ColumnVector<Transform::ArgPType>>(src_nested_col.get())) {
+            const ColumnPtr nest_col1 = remove_nullable(col1);
+            bool rconst = false;
+            // vector-const
+            if (const auto* nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
+                rconst = true;
+                const auto col1_inside_const =
+                        assert_cast<const ColumnVector<Transform::ArgPType>&>(
+                                nest_col1_const->get_data_column());
+                Op::vector_constant(sources->get_data(), res_col->get_data(),
+                                    col1_inside_const.get_data()[0], nullmap0, nullmap1);
+            } else { // vector-vector
+                const auto concrete_col1 =
+                        assert_cast<const ColumnVector<Transform::ArgPType>&>(*nest_col1);
+                Op::vector_vector(sources->get_data(), concrete_col1.get_data(),
+                                  res_col->get_data(), nullmap0, nullmap1);
+            }
+
+            // update result nullmap with inputs
+            if (result_nullable) {
+                auto null_map = ColumnBool::create(input_rows_count, 0);
+                NullMap& result_null_map = assert_cast<ColumnBool&>(*null_map).get_data();
+                if (nullmap0) {
+                    VectorizedUtils::update_null_map(result_null_map, *nullmap0);
+                }
+                if (nullmap1) {
+                    VectorizedUtils::update_null_map(result_null_map, *nullmap1, rconst);
+                }
+                block.get_by_position(result).column =
+                        ColumnNullable::create(std::move(res_col), std::move(null_map));
+            } else {
+                block.replace_by_position(result, std::move(res_col));
+            }
+        } else if (const auto* sources_const =
+                           check_and_get_column_const<ColumnVector<Transform::ArgPType>>(
+                                   src_nested_col.get())) {
+            // const-vector
+            const auto col0_inside_const = assert_cast<const ColumnVector<Transform::ArgPType>&>(
+                    sources_const->get_data_column());
+            const ColumnPtr nested_col1 = remove_nullable(col1);
+            const auto concrete_col1 =
+                    assert_cast<const ColumnVector<Transform::ArgPType>&>(*nested_col1);
+            Op::constant_vector(col0_inside_const.get_data()[0], res_col->get_data(),
+                                concrete_col1.get_data(), nullmap0, nullmap1);
+
+            // update result nullmap with inputs
+            if (result_nullable) {
+                auto null_map = ColumnBool::create(input_rows_count, 0);
+                NullMap& result_null_map = assert_cast<ColumnBool&>(*null_map).get_data();
+                if (nullmap0) {
+                    VectorizedUtils::update_null_map(result_null_map, *nullmap0, true);
+                }
+                if (nullmap1) { // no const-const here. default impl deal it.
+                    VectorizedUtils::update_null_map(result_null_map, *nullmap1);
+                }
+                block.get_by_position(result).column =
+                        ColumnNullable::create(std::move(res_col), std::move(null_map));
+            } else {
+                block.replace_by_position(result, std::move(res_col));
+            }
+        } else { // no const-const here. default impl deal it.
+            return Status::InternalError(
+                    "Illegel columns for function {}:\n1: {} with type {}\n2: {} with type {}",
+                    Transform::name, block.get_by_position(arguments[0]).name,
+                    block.get_by_position(arguments[0]).type->get_name(),
+                    block.get_by_position(arguments[1]).name,
+                    block.get_by_position(arguments[1]).type->get_name());
+        }
+        return Status::OK();
+    }
+};
+
 // Used for date(time) add/sub date(time)/integer. the input types are variadic and dispatch in execute. the return type is
 //  decided by Transform
 template <typename Transform>
@@ -439,76 +572,9 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
-        const auto& first_arg_type = block.get_by_position(arguments[0]).type;
-        const auto& second_arg_type = block.get_by_position(arguments[1]).type;
-        /// now dispatch with the two arguments' type. no need to consider return type because the same arguments decide a
-        /// unique return type which could be extracted from Transform.
-
-        // for all `xxx_add/sub`, the second arg is int32.
-        // for `week/yearweek`, if it has the second arg, it's int32.
-        // in these situations, the first would be any datelike type.
-        //TODO: now we use switch and if to do check in runtime.
-        // it leads to generation of a lot of useless template. try to use if constexpr to avoid this.
-        if (second_arg_type->get_primitive_type() == PrimitiveType::TYPE_INT) {
-            switch (first_arg_type->get_primitive_type()) {
-            case PrimitiveType::TYPE_DATE:
-                return execute_inner<TYPE_DATE, TYPE_INT>(block, arguments, result,
-                                                          input_rows_count);
-                break;
-            case PrimitiveType::TYPE_DATETIME:
-                return execute_inner<TYPE_DATETIME, TYPE_INT>(block, arguments, result,
-                                                              input_rows_count);
-                break;
-            case PrimitiveType::TYPE_DATEV2:
-                return execute_inner<TYPE_DATEV2, TYPE_INT>(block, arguments, result,
-                                                            input_rows_count);
-                break;
-            case PrimitiveType::TYPE_DATETIMEV2:
-                return execute_inner<TYPE_DATETIMEV2, TYPE_INT>(block, arguments, result,
-                                                                input_rows_count);
-                break;
-            default:
-                return Status::InternalError("Illegal argument {} and {} of function {}",
-                                             block.get_by_position(arguments[0]).type->get_name(),
-                                             block.get_by_position(arguments[1]).type->get_name(),
-                                             get_name());
-            }
-        }
-        // then consider datelike - datelike. everything is possible here as well.
-        // for `xxx_diff`, every combination of V2 is possible. but for V1 we only support Datetime - Datetime
-        if (first_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATEV2 &&
-            second_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATEV2) {
-            return execute_inner<TYPE_DATEV2, TYPE_DATEV2>(block, arguments, result,
-                                                           input_rows_count);
-        } else if (first_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATETIMEV2 &&
-                   second_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATETIMEV2) {
-            return execute_inner<TYPE_DATETIMEV2, TYPE_DATETIMEV2>(block, arguments, result,
-                                                                   input_rows_count);
-        } else if (first_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATEV2 &&
-                   second_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATETIMEV2) {
-            return execute_inner<TYPE_DATEV2, TYPE_DATETIMEV2>(block, arguments, result,
-                                                               input_rows_count);
-        } else if (first_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATETIMEV2 &&
-                   second_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATEV2) {
-            return execute_inner<TYPE_DATETIMEV2, TYPE_DATEV2>(block, arguments, result,
-                                                               input_rows_count);
-        } else if (first_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATETIME &&
-                   second_arg_type->get_primitive_type() == PrimitiveType::TYPE_DATETIME) {
-            return execute_inner<TYPE_DATETIME, TYPE_DATETIME>(block, arguments, result,
-                                                               input_rows_count);
-        }
-        return Status::InternalError("Illegal argument {} and {} of function {}",
-                                     block.get_by_position(arguments[0]).type->get_name(),
-                                     block.get_by_position(arguments[1]).type->get_name(),
-                                     get_name());
-    }
-
-    template <PrimitiveType DataType0, PrimitiveType DataType1>
-    static Status execute_inner(Block& block, const ColumnNumbers& arguments, uint32_t result,
-                                size_t input_rows_count) {
         using ResFieldType =
                 typename PrimitiveTypeTraits<Transform::ReturnType>::DataType::FieldType;
-        using Op = DateTimeOp<DataType0, DataType1, ResFieldType, Transform>;
+        using Op = DateTimeOp<Transform::ArgPType, TYPE_INT, ResFieldType, Transform>;
 
         auto get_null_map = [](const ColumnPtr& col) -> const NullMap* {
             if (col->is_nullable()) {
@@ -538,18 +604,18 @@ public:
 
         // vector-const or vector-vector
         if (const auto* sources =
-                    check_and_get_column<ColumnVector<DataType0>>(src_nested_col.get())) {
+                    check_and_get_column<ColumnVector<Transform::ArgPType>>(src_nested_col.get())) {
             const ColumnPtr nest_col1 = remove_nullable(col1);
             bool rconst = false;
             // vector-const
             if (const auto* nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
                 rconst = true;
-                const auto col1_inside_const = assert_cast<const ColumnVector<DataType1>&>(
-                        nest_col1_const->get_data_column());
+                const auto col1_inside_const =
+                        assert_cast<const ColumnInt32&>(nest_col1_const->get_data_column());
                 Op::vector_constant(sources->get_data(), res_col->get_data(),
                                     col1_inside_const.get_data()[0], nullmap0, nullmap1);
             } else { // vector-vector
-                const auto concrete_col1 = assert_cast<const ColumnVector<DataType1>&>(*nest_col1);
+                const auto concrete_col1 = assert_cast<const ColumnInt32&>(*nest_col1);
                 Op::vector_vector(sources->get_data(), concrete_col1.get_data(),
                                   res_col->get_data(), nullmap0, nullmap1);
             }
@@ -569,13 +635,14 @@ public:
             } else {
                 block.replace_by_position(result, std::move(res_col));
             }
-        } else if (const auto* sources_const = check_and_get_column_const<ColumnVector<DataType0>>(
-                           src_nested_col.get())) {
+        } else if (const auto* sources_const =
+                           check_and_get_column_const<ColumnVector<Transform::ArgPType>>(
+                                   src_nested_col.get())) {
             // const-vector
-            const auto col0_inside_const =
-                    assert_cast<const ColumnVector<DataType0>&>(sources_const->get_data_column());
+            const auto col0_inside_const = assert_cast<const ColumnVector<Transform::ArgPType>&>(
+                    sources_const->get_data_column());
             const ColumnPtr nested_col1 = remove_nullable(col1);
-            const auto concrete_col1 = assert_cast<const ColumnVector<DataType1>&>(*nested_col1);
+            const auto concrete_col1 = assert_cast<const ColumnInt32&>(*nested_col1);
             Op::constant_vector(col0_inside_const.get_data()[0], res_col->get_data(),
                                 concrete_col1.get_data(), nullmap0, nullmap1);
 

--- a/be/src/vec/functions/function_date_or_datetime_computation_v2.cpp
+++ b/be/src/vec/functions/function_date_or_datetime_computation_v2.cpp
@@ -81,26 +81,23 @@ using FunctionDatetimeV2SubQuarters =
 using FunctionDatetimeV2SubYears =
         FunctionDateOrDateTimeComputation<SubtractYearsImpl<TYPE_DATETIMEV2>>;
 
-#define FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, TYPE1, TYPE2) \
-    using NAME##_##TYPE1##_##TYPE2 = FunctionDateOrDateTimeComputation<IMPL<TYPE1, TYPE2>>;
+#define FUNCTION_TIME_DIFF_V2(NAME, IMPL, TYPE) using NAME##_##TYPE = FunctionTimeDiff<IMPL<TYPE>>;
 
-#define ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL)                           \
-    FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, TYPE_DATETIMEV2, TYPE_DATETIMEV2) \
-    FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, TYPE_DATETIMEV2, TYPE_DATEV2)     \
-    FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, TYPE_DATEV2, TYPE_DATETIMEV2)     \
-    FUNCTION_DATEV2_WITH_TWO_ARGS(NAME, IMPL, TYPE_DATEV2, TYPE_DATEV2)
+#define ALL_FUNCTION_TIME_DIFF_V2(NAME, IMPL)          \
+    FUNCTION_TIME_DIFF_V2(NAME, IMPL, TYPE_DATETIMEV2) \
+    FUNCTION_TIME_DIFF_V2(NAME, IMPL, TYPE_DATEV2)
 // these diff functions accept all v2 types. but for v1 only datetime.
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2DateDiff, DateDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2TimeDiff, TimeDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2YearsDiff, YearsDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MonthsDiff, MonthsDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2WeeksDiff, WeeksDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2HoursDiff, HoursDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MinutesDiff, MintuesDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2SecondsDiff, SecondsDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2DaysDiff, DaysDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MilliSecondsDiff, MilliSecondsDiffImpl)
-ALL_FUNCTION_DATEV2_WITH_TWO_ARGS(FunctionDatetimeV2MicroSecondsDiff, MicroSecondsDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2DateDiff, DateDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2TimeDiff, TimeDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2YearsDiff, YearsDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2MonthsDiff, MonthsDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2WeeksDiff, WeeksDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2HoursDiff, HoursDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2MinutesDiff, MintuesDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2SecondsDiff, SecondsDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2DaysDiff, DaysDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2MilliSecondsDiff, MilliSecondsDiffImpl)
+ALL_FUNCTION_TIME_DIFF_V2(FunctionDatetimeV2MicroSecondsDiff, MicroSecondsDiffImpl)
 
 using FunctionDatetimeV2ToYearWeekTwoArgs =
         FunctionDateOrDateTimeComputation<ToYearWeekTwoArgsImpl<TYPE_DATETIMEV2>>;
@@ -148,26 +145,23 @@ void register_function_date_time_computation_v2(SimpleFunctionFactory& factory) 
     factory.register_function<FunctionDatetimeV2SubQuarters>();
     factory.register_function<FunctionDatetimeV2SubWeeks>();
 
-#define REGISTER_DATEV2_FUNCTIONS_WITH_TWO_ARGS(NAME, TYPE1, TYPE2) \
-    factory.register_function<NAME##_##TYPE1##_##TYPE2>();
+#define REGISTER_DATEV2_FUNCTIONS_DIFF(NAME, TYPE) factory.register_function<NAME##_##TYPE>();
 
-#define REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(NAME)                           \
-    REGISTER_DATEV2_FUNCTIONS_WITH_TWO_ARGS(NAME, TYPE_DATETIMEV2, TYPE_DATETIMEV2) \
-    REGISTER_DATEV2_FUNCTIONS_WITH_TWO_ARGS(NAME, TYPE_DATETIMEV2, TYPE_DATEV2)     \
-    REGISTER_DATEV2_FUNCTIONS_WITH_TWO_ARGS(NAME, TYPE_DATEV2, TYPE_DATETIMEV2)     \
-    REGISTER_DATEV2_FUNCTIONS_WITH_TWO_ARGS(NAME, TYPE_DATEV2, TYPE_DATEV2)
+#define REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(NAME)          \
+    REGISTER_DATEV2_FUNCTIONS_DIFF(NAME, TYPE_DATETIMEV2) \
+    REGISTER_DATEV2_FUNCTIONS_DIFF(NAME, TYPE_DATEV2)
 
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2DateDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2TimeDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2YearsDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2MonthsDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2WeeksDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2HoursDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2MinutesDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2SecondsDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2DaysDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2MilliSecondsDiff)
-    REGISTER_ALL_DATEV2_FUNCTIONS_WITH_TWO_ARGS(FunctionDatetimeV2MicroSecondsDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2DateDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2TimeDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2YearsDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2MonthsDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2WeeksDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2HoursDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2MinutesDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2SecondsDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2DaysDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2MilliSecondsDiff)
+    REGISTER_ALL_DATEV2_FUNCTIONS_DIFF(FunctionDatetimeV2MicroSecondsDiff)
 
     factory.register_function<FunctionToYearWeekTwoArgsV2>();
     factory.register_function<FunctionToWeekTwoArgsV2>();

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -955,18 +955,6 @@ TEST(VTimestampFunctionsTest, datediff_v2_test) {
 
         static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
     }
-
-    {
-        InputTypeSet input_types = {PrimitiveType::TYPE_DATETIMEV2, PrimitiveType::TYPE_DATEV2};
-
-        DataSet data_set = {
-                {{std::string("2019-07-18 00:00:00.123"), std::string("2019-07-19")}, -1},
-                {{std::string("2019-07-18 00:00:00.123"), std::string("2019-07-17")}, 1},
-                {{std::string("2019-00-18 00:00:00.123"), std::string("2019-07-18")}, Null()},
-                {{std::string("2019-07-18 00:00:00.123"), std::string("2019-07-00")}, Null()}};
-
-        static_cast<void>(check_function<DataTypeInt32, true>(func_name, input_types, data_set));
-    }
 }
 
 TEST(VTimestampFunctionsTest, date_format_v2_test) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DateDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DateDiff.java
@@ -43,8 +43,6 @@ public class DateDiff extends ScalarFunction
             FunctionSignature.ret(IntegerType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(IntegerType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
-            FunctionSignature.ret(IntegerType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(IntegerType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(IntegerType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)
     );
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DaysDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DaysDiff.java
@@ -45,8 +45,6 @@ public class DaysDiff extends ScalarFunction implements BinaryExpression, Explic
             FunctionSignature.ret(BigIntType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)
     );
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/HoursDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/HoursDiff.java
@@ -44,8 +44,6 @@ public class HoursDiff extends ScalarFunction implements BinaryExpression, Expli
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)
     );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MinutesDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MinutesDiff.java
@@ -44,8 +44,6 @@ public class MinutesDiff extends ScalarFunction implements BinaryExpression, Exp
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE)
     );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MonthsDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MonthsDiff.java
@@ -43,8 +43,6 @@ public class MonthsDiff extends ScalarFunction implements BinaryExpression, Expl
 
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SecondsDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SecondsDiff.java
@@ -44,8 +44,6 @@ public class SecondsDiff extends ScalarFunction implements BinaryExpression, Exp
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)
             );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/TimeDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/TimeDiff.java
@@ -41,8 +41,6 @@ public class TimeDiff extends ScalarFunction
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(TimeV2Type.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(TimeV2Type.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
-            FunctionSignature.ret(TimeV2Type.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(TimeV2Type.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE));
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/WeeksDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/WeeksDiff.java
@@ -43,8 +43,6 @@ public class WeeksDiff extends ScalarFunction implements BinaryExpression, Expli
 
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE)
             .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/YearsDiff.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/YearsDiff.java
@@ -43,8 +43,6 @@ public class YearsDiff extends ScalarFunction implements BinaryExpression, Expli
 
     private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateV2Type.INSTANCE),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateV2Type.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeV2Type.SYSTEM_DEFAULT, DateV2Type.INSTANCE),
             FunctionSignature.ret(BigIntType.INSTANCE)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(BigIntType.INSTANCE).args(DateTimeType.INSTANCE, DateTimeType.INSTANCE)


### PR DESCRIPTION
### What problem does this PR solve?

Simplify template args to reduce binary size.
Before:
41.97 MB	./vec/CMakeFiles/Vec.dir/functions/function_date_or_datetime_computation.cpp.o
68.24 MB	./vec/CMakeFiles/Vec.dir/functions/function_date_or_datetime_computation_v2.cpp.o

After:
18.90 MB	./vec/CMakeFiles/Vec.dir/functions/function_date_or_datetime_computation.cpp.o
18.63 MB	./vec/CMakeFiles/Vec.dir/functions/function_date_or_datetime_computation_v2.cpp.o

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

