### PR TITLE
[fix](nereids) fix ConvertAggStateCast is not used when sql has order by 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionNormalization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionNormalization.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.rules.expression;
 
-import org.apache.doris.nereids.rules.expression.check.CheckCast;
 import org.apache.doris.nereids.rules.expression.rules.ConvertAggStateCast;
 import org.apache.doris.nereids.rules.expression.rules.DigitalMaskingConvert;
 import org.apache.doris.nereids.rules.expression.rules.FoldConstantRule;
@@ -58,8 +57,7 @@ public class ExpressionNormalization extends ExpressionRewrite {
                 MedianConvert.INSTANCE,
                 SimplifyArithmeticComparisonRule.INSTANCE,
                 ConvertAggStateCast.INSTANCE,
-                MergeDateTrunc.INSTANCE,
-                CheckCast.INSTANCE
+                MergeDateTrunc.INSTANCE
             )
     );
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/check/CheckCast.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/check/CheckCast.java
@@ -18,8 +18,10 @@
 package org.apache.doris.nereids.rules.expression.check;
 
 import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.rules.expression.AbstractExpressionRewriteRule;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternMatcher;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
+import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -40,8 +42,14 @@ import java.util.List;
 /**
  * check cast valid
  */
-public class CheckCast implements ExpressionPatternRuleFactory {
+public class CheckCast extends AbstractExpressionRewriteRule implements ExpressionPatternRuleFactory {
     public static CheckCast INSTANCE = new CheckCast();
+
+    @Override
+    public Expression visitCast(Cast cast, ExpressionRewriteContext ctx) {
+        Expression expr = check(cast);
+        return visit(expr, ctx);
+    }
 
     @Override
     public List<ExpressionPatternMatcher<? extends Expression>> buildRules() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx
Problem Summary:
insert into t select use aggState in select may lead to this error with order by key:
```sql
Caused by: org.apache.doris.nereids.exceptions.AnalysisException: cannot cast agg_state<group_concat(varchar(65533) null)> to agg_state<group_concat(text null)>
        at org.apache.doris.nereids.rules.expression.check.CheckCast.check(CheckCast.java:57) ~[classes/:?]
        at org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory$ExpressionPatternDescriptor.lambda$then$3(ExpressionPatternRuleFactory.java:80) ~[classes/:?]      
        at org.apache.doris.nereids.rules.expression.ExpressionPatternMatchRule.apply(ExpressionPatternMatchRule.java:58) ~[classes/:?]
        at org.apache.doris.nereids.pattern.ExpressionPatternRules.matchesAndApply(ExpressionPatternRules.java:88) ~[classes/:?]
        at org.apache.doris.nereids.rules.expression.ExpressionBottomUpRewriter.rewriteBottomUp(ExpressionBottomUpRewriter.java:79) ~[classes/:?]
        at org.apache.doris.nereids.rules.expression.ExpressionBottomUpRewriter.rewriteChildren(ExpressionBottomUpRewriter.java:110) ~[classes/:?]
        at org.apache.doris.nereids.rules.expression.ExpressionBottomUpRewriter.rewriteBottomUp(ExpressionBottomUpRewriter.java:71) ~[classes/:?]
        at
```

This is because the LogicalSort separates the two LogicalProjects, preventing mergeProjects, which in turn prevents the application of ConvertAggStateCast—because ConvertAggStateCast requires that the child of the cast must be a StateCombinator for the conversion to take place. This PR moves the EliminateSort rule earlier, after which mergeProjects and ExpressionNormalization in PUSH_DOWN_FILTERS will handle the mergeProjects and ConvertAggStateCast operations.

Additionally, this PR relocates CheckCast to the final validation step in the rewriter to avoid intermediate errors, even though the final rewritten result is actually correct.

```sql
LogicalOlapTableSink[33] ( outputExprs=[market_place_id#21, na_exposure#22], database=maldb, targetTable=a_table_300, cols=[`market_place_id` tinyint NOT NULL COMMENT "ID", `na_exposure` agg_state<group_concat(text null)> GENERIC NOT NULL], partitionIds=[], isPartialUpdate=false, dmlCommandType=INSERT )
+--LogicalProject[30] ( distinct=false, projects=[market_place_id#0 AS `market_place_id`#21, cast(na_exposure#20 as agg_state<group_concat(text null)>) AS `na_exposure`#22] )
   +--LogicalSort[21] ( orderKeys=[sync_time#1 asc null first] )
      +--LogicalProject[20] ( distinct=false, projects=[market_place_id#0, group_concat_state(date_format(sync_time#1, '%y')) AS `na_exposure`#20, sync_time#1] )
         +--LogicalOlapScan ( qualified=internal.maldb.amz_asin_info_day, indexName=<index_not_selected>, selectedIndexId=1750337869693, preAgg=UNSET, operativeCol=[] )
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

