### PR TITLE
[fix](iceberg)Ensure proper authentication context before accessing Iceberg Catalog 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
@@ -75,6 +75,18 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
         metadataOps = ops;
     }
 
+    /**
+     * Returns the underlying {@link Catalog} instance used by this external catalog.
+     *
+     * <p><strong>Warning:</strong> This method does not handle any authentication logic. If the
+     * returned catalog implementation relies on external systems
+     * that require authentication — especially in environments where Kerberos is enabled — the caller is
+     * fully responsible for ensuring the appropriate authentication has been performed <em>before</em>
+     * invoking this method.
+     * <p>Failing to authenticate beforehand may result in authorization errors or IO failures.
+     *
+     * @return the underlying catalog instance
+     */
     public Catalog getCatalog() {
         makeSureInitialized();
         return ((IcebergMetadataOps) metadataOps).getCatalog();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalDatabase.java
@@ -41,8 +41,14 @@ public class IcebergExternalDatabase extends ExternalDatabase<IcebergExternalTab
     }
 
     public String getLocation() {
-        Map<String, String> props = ((SupportsNamespaces) ((IcebergExternalCatalog) getCatalog()).getCatalog())
-                .loadNamespaceMetadata(Namespace.of(name));
-        return props.getOrDefault("location", "");
+        try {
+            return extCatalog.getPreExecutionAuthenticator().execute(() -> {
+                Map<String, String> props = ((SupportsNamespaces) ((IcebergExternalCatalog) getCatalog()).getCatalog())
+                        .loadNamespaceMetadata(Namespace.of(name));
+                return props.getOrDefault("location", "");
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get location for Iceberg database: " + name, e);
+        }
     }
 }


### PR DESCRIPTION
…

### What problem does this PR solve?
```
CREATE CATALOG `docker2_catalog3_iceberg` PROPERTIES (
"warehouse" = "hdfs://hadoop-master-2:8620/user/iceberg/hms/",
"uri" = "thrift://hadoop-master-2:9683",
"type" = "iceberg",
"list-all-tables" = "true",
"io-impl" = "org.apache.doris.datasource.iceberg.fileio.DelegateFileIO",
"iceberg.catalog.type" = "hms",
"hive.metastore.uris" = "thrift://hadoop-master-2:9683",
"hive.metastore.sasl.enabled" = "true",
"hive.metastore.kerberos.principal" = "hive/hadoop-master-2@OTHERREALM.COM",
"hadoop.security.authentication" = "kerberos",
"hadoop.kerberos.principal" = "hdfs/test4@OTHERREALM.COM",
"hadoop.kerberos.keytab" = "/kerberos/keytab/docker2/test4",
"fs.defaultFS" = "hdfs://hadoop-master-2:8620"
); 

show create create database icebergcatalog.db
```
```
Caused by: org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Failed to connect to Hive Metastore
        ... 13 more
Caused by: org.apache.iceberg.hive.RuntimeMetaException: Failed to connect to Hive Metastore
        at org.apache.iceberg.hive.HiveClientPool.newClient(HiveClientPool.java:85) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.hive.HiveClientPool.newClient(HiveClientPool.java:34) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.ClientPoolImpl.get(ClientPoolImpl.java:143) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.ClientPoolImpl.run(ClientPoolImpl.java:70) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.ClientPoolImpl.run(ClientPoolImpl.java:65) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.hive.CachedClientPool.run(CachedClientPool.java:122) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.hive.HiveCatalog.loadNamespaceMetadata(HiveCatalog.java:643) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.doris.datasource.iceberg.IcebergExternalDatabase.getLocation(IcebergExternalDatabase.java:45) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ShowCreateDatabaseCommand.doRun(ShowCreateDatabaseCommand.java:98) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ShowCommand.run(ShowCommand.java:54) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:769) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 12 more
Caused by: java.lang.RuntimeException: Unable to instantiate org.apache.hadoop.hive.metastore.HiveMetaStoreClient
        at org.apache.hadoop.hive.metastore.utils.JavaUtils.newInstance(JavaUtils.java:86) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.<init>(RetryingMetaStoreClient.java:95) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:148) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:119) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:112) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.apache.iceberg.common.DynMethods$UnboundMethod.invokeChecked(DynMethods.java:60) ~[iceberg-common-1.9.1.jar:?]
        at org.apache.iceberg.common.DynMethods$UnboundMethod.invoke(DynMethods.java:72) ~[iceberg-common-1.9.1.jar:?]
        at org.apache.iceberg.common.DynMethods$StaticMethod.invoke(DynMethods.java:189) ~[iceberg-common-1.9.1.jar:?]
        at org.apache.iceberg.hive.HiveClientPool.newClient(HiveClientPool.java:63) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.hive.HiveClientPool.newClient(HiveClientPool.java:34) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.ClientPoolImpl.get(ClientPoolImpl.java:143) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.ClientPoolImpl.run(ClientPoolImpl.java:70) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.ClientPoolImpl.run(ClientPoolImpl.java:65) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.hive.CachedClientPool.run(CachedClientPool.java:122) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.hive.HiveCatalog.loadNamespaceMetadata(HiveCatalog.java:643) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.doris.datasource.iceberg.IcebergExternalDatabase.getLocation(IcebergExternalDatabase.java:45) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ShowCreateDatabaseCommand.doRun(ShowCreateDatabaseCommand.java:98) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ShowCommand.run(ShowCommand.java:54) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:769) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 12 more
Caused by: java.lang.reflect.InvocationTargetException
        at jdk.internal.reflect.GeneratedConstructorAccessor114.newInstance(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at org.apache.hadoop.hive.metastore.utils.JavaUtils.newInstance(JavaUtils.java:84) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.<init>(RetryingMetaStoreClient.java:95) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:148) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:119) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:112) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.apache.iceberg.common.DynMethods$UnboundMethod.invokeChecked(DynMethods.java:60) ~[iceberg-common-1.9.1.jar:?]
        at org.apache.iceberg.common.DynMethods$UnboundMethod.invoke(DynMethods.java:72) ~[iceberg-common-1.9.1.jar:?]
        at org.apache.iceberg.common.DynMethods$StaticMethod.invoke(DynMethods.java:189) ~[iceberg-common-1.9.1.jar:?]
        at org.apache.iceberg.hive.HiveClientPool.newClient(HiveClientPool.java:63) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.hive.HiveClientPool.newClient(HiveClientPool.java:34) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.ClientPoolImpl.get(ClientPoolImpl.java:143) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.ClientPoolImpl.run(ClientPoolImpl.java:70) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.ClientPoolImpl.run(ClientPoolImpl.java:65) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.hive.CachedClientPool.run(CachedClientPool.java:122) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.iceberg.hive.HiveCatalog.loadNamespaceMetadata(HiveCatalog.java:643) ~[hive-catalog-shade-3.0.1.jar:3.0.1]
        at org.apache.doris.datasource.iceberg.IcebergExternalDatabase.getLocation(IcebergExternalDatabase.java:45) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ShowCreateDatabaseCommand.doRun(ShowCreateDatabaseCommand.java:98) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.ShowCommand.run(ShowCommand.java:54) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:769) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 12 more
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

