### PR TITLE
[fix](mtmv) Fix compensate union all wrongly when partition mv use partition external table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionCompensator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PartitionCompensator.java
@@ -85,8 +85,10 @@ public class PartitionCompensator {
         }
         MTMVPartitionInfo mvCustomPartitionInfo = mtmv.getMvPartitionInfo();
         BaseTableInfo relatedPartitionTable = mvCustomPartitionInfo.getRelatedTableInfo();
-        if (relatedPartitionTable == null || queryUsedBaseTablePartitionNameSet.isEmpty()) {
+        if (relatedPartitionTable == null || queryUsedBaseTablePartitionNameSet.isEmpty()
+                || !relatedPartitionTable.isInternalTable()) {
             // if mv is not partitioned or query not query any partition, doesn't compensate
+            // in 2.1, external table should not compensate union all
             return Pair.of(ImmutableMap.of(), ImmutableMap.of());
         }
         Collection<Partition> mvValidPartitions = cascadesContext.getStatementContext()


### PR DESCRIPTION
Fix compensate union all wrongly when partition mv use partition external table

in test mv/external_table/part_partition_invalid.groovy
order_qt_after_modify_data_and_refresh_catalog data should be as following:
```
1	2	1	2023-10-17	2023-10-17
2	2	2	2023-10-18	2023-10-18
3	2	3	2023-10-19	2023-10-19
```


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #49514 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

