### PR TITLE
[chore](ci)Replace local setup-maven with setup-java for more stable and simplified Maven setup

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -51,11 +51,13 @@ jobs:
               - 'gensrc/proto/**'
               - 'gensrc/thrift/**'
 
-      - name: Setup Maven Action
+      - name: Set up JDK with Maven
         if: steps.filter.outputs.fe_changes == 'true'
-        uses: ./.github/actions/setup-maven
+        uses: actions/setup-java@v4
         with:
-          maven-version: 3.8.4
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'    
 
       - name: Run java checkstyle
         if: steps.filter.outputs.fe_changes == 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule ".github/actions/get-workflow-origin"]
 	path = .github/actions/get-workflow-origin
 	url = https://github.com/potiuk/get-workflow-origin.git
-[submodule ".github/actions/setup-maven"]
-	path = .github/actions/setup-maven
-	url = https://github.com/stCarolas/setup-maven.git
 [submodule ".github/actions/paths-filter"]
 	path = .github/actions/paths-filter
 	url = https://github.com/dorny/paths-filter

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
@@ -70,8 +70,6 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
     protected void beforeCreatingConnectContext() throws Exception {
         FeConstants.default_scheduler_interval_millisecond = 10;
         FeConstants.runningUnitTest = true;
-        
-        
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
@@ -70,6 +70,8 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
     protected void beforeCreatingConnectContext() throws Exception {
         FeConstants.default_scheduler_interval_millisecond = 10;
         FeConstants.runningUnitTest = true;
+        
+        
     }
 
     @Override


### PR DESCRIPTION
https://github.com/apache/doris/actions/runs/15847722025/job/44673659755?pr=52229


Maven setup is now handled via setup-java, which supports automatic Maven installation

Removed hard dependency on a specific Maven version, as our use case (Checkstyle) doesn't require it

External Maven download failures have been observed with the custom setup — switching to the official action improves 