### PR TITLE
[fix](runtime filter) Fix light brpc thread pool being occupied by runtime filter merge operation

### DIFF
--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -444,10 +444,6 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
             // 1. All BE has been upgraded (e.g. _opt_remote_rf)
             // 2. FE has been upgraded (e.g. cnt_val->targetv2_info.size() > 0)
             // 3. This filter is bloom filter (only bloom filter should be used for merging)
-            using PPublishFilterRpcContext =
-                    AsyncRPCContext<PPublishFilterRequestV2, PPublishFilterResponse>;
-            std::vector<std::unique_ptr<PPublishFilterRpcContext>> rpc_contexts;
-            rpc_contexts.reserve(cnt_val->targetv2_info.size());
 
             butil::IOBuf request_attachment;
 
@@ -473,61 +469,48 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
             }
 
             std::vector<TRuntimeFilterTargetParamsV2>& targets = cnt_val->targetv2_info;
-            for (size_t i = 0; i < targets.size(); i++) {
-                rpc_contexts.emplace_back(new PPublishFilterRpcContext);
-                size_t cur = rpc_contexts.size() - 1;
-                rpc_contexts[cur]->request = apply_request;
-                rpc_contexts[cur]->request.set_filter_id(request->filter_id());
-                rpc_contexts[cur]->request.set_is_pipeline(request->has_is_pipeline() &&
-                                                           request->is_pipeline());
-                rpc_contexts[cur]->request.set_merge_time(merge_time);
-                *rpc_contexts[cur]->request.mutable_query_id() = request->query_id();
+            for (auto& target : targets) {
+                auto closure = AutoReleaseClosure<PPublishFilterRequestV2,
+                                                  DummyBrpcCallback<PPublishFilterResponse>>::
+                        create_unique(std::make_shared<PPublishFilterRequestV2>(apply_request),
+                                      DummyBrpcCallback<PPublishFilterResponse>::create_shared());
+
+                closure->request_->set_filter_id(request->filter_id());
+                closure->request_->set_is_pipeline(request->has_is_pipeline() &&
+                                                   request->is_pipeline());
+                closure->request_->set_merge_time(merge_time);
+                *closure->request_->mutable_query_id() = request->query_id();
                 if (has_attachment) {
-                    rpc_contexts[cur]->cntl.request_attachment().append(request_attachment);
+                    closure->cntl_->request_attachment().append(request_attachment);
                 }
-                rpc_contexts[cur]->cntl.set_timeout_ms(std::min(3600, _state->execution_timeout) *
-                                                       1000);
-                rpc_contexts[cur]->cid = rpc_contexts[cur]->cntl.call_id();
+                closure->cntl_->set_timeout_ms(std::min(3600, _state->execution_timeout) * 1000);
                 // set fragment-id
-                for (size_t fid = 0; fid < targets[cur].target_fragment_instance_ids.size();
-                     fid++) {
-                    PUniqueId* cur_id = rpc_contexts[cur]->request.add_fragment_instance_ids();
-                    cur_id->set_hi(targets[cur].target_fragment_instance_ids[fid].hi);
-                    cur_id->set_lo(targets[cur].target_fragment_instance_ids[fid].lo);
+                for (size_t fid = 0; fid < target.target_fragment_instance_ids.size(); fid++) {
+                    PUniqueId* cur_id = closure->request_->add_fragment_instance_ids();
+                    cur_id->set_hi(target.target_fragment_instance_ids[fid].hi);
+                    cur_id->set_lo(target.target_fragment_instance_ids[fid].lo);
                 }
 
                 std::shared_ptr<PBackendService_Stub> stub(
                         ExecEnv::GetInstance()->brpc_internal_client_cache()->get_client(
-                                targets[i].target_fragment_instance_addr));
-                VLOG_NOTICE << "send filter " << rpc_contexts[cur]->request.filter_id()
-                            << " to:" << targets[i].target_fragment_instance_addr.hostname << ":"
-                            << targets[i].target_fragment_instance_addr.port
-                            << rpc_contexts[cur]->request.ShortDebugString();
+                                target.target_fragment_instance_addr));
+                VLOG_NOTICE << "send filter " << closure->request_->filter_id()
+                            << " to:" << target.target_fragment_instance_addr.hostname << ":"
+                            << target.target_fragment_instance_addr.port
+                            << closure->request_->ShortDebugString();
                 if (stub == nullptr) {
-                    rpc_contexts.pop_back();
+                    LOG(WARNING) << "Failed to init rpc to "
+                                 << target.target_fragment_instance_addr.hostname << ":"
+                                 << target.target_fragment_instance_addr.port
+                                 << " when apply_filterv2";
                     continue;
                 }
-                stub->apply_filterv2(&rpc_contexts[cur]->cntl, &rpc_contexts[cur]->request,
-                                     &rpc_contexts[cur]->response, brpc::DoNothing());
-            }
-            for (auto& rpc_context : rpc_contexts) {
-                brpc::Join(rpc_context->cid);
-                if (auto status = Status::create(rpc_context->response.status()); !status) {
-                    return status;
-                }
-                if (rpc_context->cntl.Failed()) {
-                    LOG(WARNING) << "runtimefilter rpc err:" << rpc_context->cntl.ErrorText();
-                    ExecEnv::GetInstance()->brpc_internal_client_cache()->erase(
-                            rpc_context->cntl.remote_side());
-                }
+
+                stub->apply_filterv2(closure->cntl_.get(), closure->request_.get(),
+                                     closure->response_.get(), closure.get());
+                closure.release();
             }
         } else {
-            // prepare rpc context
-            using PPublishFilterRpcContext =
-                    AsyncRPCContext<PPublishFilterRequest, PPublishFilterResponse>;
-            std::vector<std::unique_ptr<PPublishFilterRpcContext>> rpc_contexts;
-            rpc_contexts.reserve(cnt_val->target_info.size());
-
             butil::IOBuf request_attachment;
 
             PPublishFilterRequest apply_request;
@@ -552,48 +535,43 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
             }
 
             std::vector<TRuntimeFilterTargetParams>& targets = cnt_val->target_info;
-            for (size_t i = 0; i < targets.size(); i++) {
-                rpc_contexts.emplace_back(new PPublishFilterRpcContext);
-                size_t cur = rpc_contexts.size() - 1;
-                rpc_contexts[cur]->request = apply_request;
-                rpc_contexts[cur]->request.set_filter_id(request->filter_id());
-                rpc_contexts[cur]->request.set_is_pipeline(request->has_is_pipeline() &&
-                                                           request->is_pipeline());
-                rpc_contexts[cur]->request.set_merge_time(merge_time);
-                *rpc_contexts[cur]->request.mutable_query_id() = request->query_id();
+            for (auto& target : targets) {
+                auto closure = AutoReleaseClosure<PPublishFilterRequest,
+                                                  DummyBrpcCallback<PPublishFilterResponse>>::
+                        create_unique(std::make_shared<PPublishFilterRequest>(apply_request),
+                                      DummyBrpcCallback<PPublishFilterResponse>::create_shared());
+                closure->request_->set_filter_id(request->filter_id());
+                closure->request_->set_is_pipeline(request->has_is_pipeline() &&
+                                                   request->is_pipeline());
+                closure->request_->set_merge_time(merge_time);
+                *closure->request_->mutable_query_id() = request->query_id();
                 if (has_attachment) {
-                    rpc_contexts[cur]->cntl.request_attachment().append(request_attachment);
+                    closure->cntl_->request_attachment().append(request_attachment);
                 }
-                rpc_contexts[cur]->cntl.set_timeout_ms(std::min(3600, _state->execution_timeout) *
-                                                       1000);
-                rpc_contexts[cur]->cid = rpc_contexts[cur]->cntl.call_id();
+                closure->cntl_->set_timeout_ms(std::min(3600, _state->execution_timeout) * 1000);
                 // set fragment_instance_id
                 auto request_fragment_instance_id =
-                        rpc_contexts[cur]->request.mutable_fragment_instance_id();
-                request_fragment_instance_id->set_hi(targets[cur].target_fragment_instance_id.hi);
-                request_fragment_instance_id->set_lo(targets[cur].target_fragment_instance_id.lo);
+                        closure->request_->mutable_fragment_instance_id();
+                request_fragment_instance_id->set_hi(target.target_fragment_instance_id.hi);
+                request_fragment_instance_id->set_lo(target.target_fragment_instance_id.lo);
 
                 std::shared_ptr<PBackendService_Stub> stub(
                         ExecEnv::GetInstance()->brpc_internal_client_cache()->get_client(
-                                targets[i].target_fragment_instance_addr));
-                VLOG_NOTICE << "send filter " << rpc_contexts[cur]->request.filter_id()
-                            << " to:" << targets[i].target_fragment_instance_addr.hostname << ":"
-                            << targets[i].target_fragment_instance_addr.port
-                            << rpc_contexts[cur]->request.ShortDebugString();
+                                target.target_fragment_instance_addr));
+                VLOG_NOTICE << "send filter " << closure->request_->filter_id()
+                            << " to:" << target.target_fragment_instance_addr.hostname << ":"
+                            << target.target_fragment_instance_addr.port
+                            << closure->request_->ShortDebugString();
                 if (stub == nullptr) {
-                    rpc_contexts.pop_back();
+                    LOG(WARNING) << "Failed to init rpc to "
+                                 << target.target_fragment_instance_addr.hostname << ":"
+                                 << target.target_fragment_instance_addr.port
+                                 << " when apply_filter";
                     continue;
                 }
-                stub->apply_filter(&rpc_contexts[cur]->cntl, &rpc_contexts[cur]->request,
-                                   &rpc_contexts[cur]->response, brpc::DoNothing());
-            }
-            for (auto& rpc_context : rpc_contexts) {
-                brpc::Join(rpc_context->cid);
-                if (rpc_context->cntl.Failed()) {
-                    LOG(WARNING) << "runtimefilter rpc err:" << rpc_context->cntl.ErrorText();
-                    ExecEnv::GetInstance()->brpc_internal_client_cache()->erase(
-                            rpc_context->cntl.remote_side());
-                }
+                stub->apply_filter(closure->cntl_.get(), closure->request_.get(),
+                                   closure->response_.get(), closure.get());
+                closure.release();
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?
Runtime filter join operation may cause BE light brpc thead pool hang. The timeout of join operation is query's timeout. So, **this bug may cause entire Doris cluster hang for few minutes**. In our cluster, the default query timeout is 15 minutes. That means our cluster can not read and write data for 15 minutes.
light brpc thread pool is being occupied by runtime filter merge operation.
The stack is as follows:
```
Thread 1012 (Thread 0x7fc628f726c0 (LWP 13362) "brpc_light"):
#0  0x00007fc89d5fba7d in syscall () from /lib64/libc.so.6
#1  0x0000558aa0409a7e in bthread::wait_pthread(bthread::ButexPthreadWaiter&, timespec*) ()
#2  0x0000558aa040a834 in bthread::butex_wait(void*, int, timespec const*) ()
#3  0x0000558aa044fa7e in bthread_id_join ()
#4  0x0000558a94d67aec in doris::RuntimeFilterMergeControllerEntity::merge(doris::PMergeFilterRequest const*, butil::IOBufAsZeroCopyInputStream*, bool) ()
#5  0x0000558a94c57330 in doris::FragmentMgr::merge_filter(doris::PMergeFilterRequest const*, butil::IOBufAsZeroCopyInputStream*) ()
#6  0x0000558a94e3ef32 in std::_Function_handler<void (), doris::PInternalServiceImpl::merge_filter(google::protobuf::RpcController*, doris::PMergeFilterRequest const*, doris::PMergeFilterResponse*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) ()
#7  0x0000558a94e51beb in doris::WorkThreadPool<false>::work_thread(int) ()
#8  0x0000558aa184d8d0 in execute_native_thread_routine ()
#9  0x00007fc89d57b215 in start_thread () from /lib64/libc.so.6
#10 0x00007fc89d5fdbdc in clone3 () from /lib64/libc.so.6
```
The deadlock may be as shown in the following figure:
<img width="627" alt="Clipboard_Screenshot_1750766684" src="https://github.com/user-attachments/assets/d59a5134-41ce-44d9-bb55-11fa8b2ecd60" />

Reproduce:
```
create table l (k int, v int) DISTRIBUTED BY HASH(`k`) BUCKETS 256 PROPERTIES ("replication_allocation" = "tag.location.default: 1");
create table r (k int, v int) DISTRIBUTED BY HASH(`k`) BUCKETS 256 PROPERTIES ("replication_allocation" = "tag.location.default: 1");
insert into l select 1,1;
insert into r select 1,1;
```
Execute the following SQL multiple times to insert some test data to table l and table r:
```
insert into l select k + 101, v + 101 from l;
insert into r select k + 101, v + 101 from r;
```
Set BE's config `brpc_light_work_pool_threads` to 1.

Execute SQL: 
```
set enable_bucket_shuffle_join =false;
select count(l.k) from l join [shuffle] r on l.k = r.v where r.k > 100;

```
Now, The merge BE's light brpc thread pool will hang.

use AutoReleaseClosure when merge runtime filter.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

