### PR TITLE
[fix]Close unclosed stream in MaxComputeScanNode.serializeSession

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -66,7 +66,10 @@ import com.google.common.collect.Maps;
 import jline.internal.Log;
 import lombok.Setter;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/source/MaxComputeScanNode.java
@@ -66,10 +66,7 @@ import com.google.common.collect.Maps;
 import jline.internal.Log;
 import lombok.Setter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import java.io.*;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -658,10 +655,11 @@ public class MaxComputeScanNode extends FileQueryScanNode {
     }
 
     private static String serializeSession(Serializable object) throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
-        objectOutputStream.writeObject(object);
-        byte[] serializedBytes = byteArrayOutputStream.toByteArray();
-        return Base64.getEncoder().encodeToString(serializedBytes);
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(object);
+            byte[] serializedBytes = byteArrayOutputStream.toByteArray();
+            return Base64.getEncoder().encodeToString(serializedBytes);
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
fix the bug MaxComputeScanNodefunction serializeSession objectOutputStream ObjectOutputStream resource unrelease



- Behavior changed:
    - [ ] No.


- Does this need documentation?
    - [ ] No.


### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

