### PR TITLE
[test](json) fix cases in TestJsonFunctions.sql

### DIFF
--- a/regression-test/suites/external_table_p0/dialect_compatible/sql/presto/scalar/TestJsonFunctions.sql
+++ b/regression-test/suites/external_table_p0/dialect_compatible/sql/presto/scalar/TestJsonFunctions.sql
@@ -175,8 +175,8 @@ SELECT json_array_get('[{\, :null}]', 0);
 SELECT json_array_get('[{\, :null}]', -1);
 -- SELECT json_parse('INVALID'); # error: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]json parse error: Exception throwed for value: INVALID
 -- SELECT json_parse('\, : 1'); # error: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]json parse error: Exception throwed for value: \, : 1
-SELECT json_parse('{}{');
-SELECT json_parse('{}{abc');
+SELECT json_parse('{}');
+SELECT json_parse('{}');
 -- SELECT json_parse(''); # error: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]json parse error: Empty document for value: 
 -- SELECT json_format(JSON '[\, , \, ]'); # error: errCode = 2, detailMessage = Can not found function 'JSON_FORMAT'
 SELECT json_size('{\, : {\,  : 1, \,  : 2} }', '$');
@@ -369,8 +369,8 @@ SELECT json_array_get('[{\, :null}]', 0);
 SELECT json_array_get('[{\, :null}]', -1);
 -- SELECT json_parse('INVALID'); # error: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]json parse error: Exception throwed for value: INVALID
 -- SELECT json_parse('\, : 1'); # error: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]json parse error: Exception throwed for value: \, : 1
-SELECT json_parse('{}{');
-SELECT json_parse('{}{abc');
+SELECT json_parse('{}');
+SELECT json_parse('{}');
 -- SELECT json_parse(''); # error: errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]json parse error: Empty document for value: 
 -- SELECT json_format(JSON '[\, , \, ]'); # error: errCode = 2, detailMessage = Can not found function 'JSON_FORMAT'
 SELECT json_size('{\, : {\,  : 1, \,  : 2} }', '$');


### PR DESCRIPTION
### What problem does this PR solve?

After upgrading the simdjson library to version 3.11.6, JSON string validation has become more strict. Previously, malformed JSON strings such as '{}{' might have been treated as valid. With this update, such strings are now correctly rejected as invalid JSON, ensuring stricter compliance with JSON parsing standards.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

