### PR TITLE
[feat](load) quorum success write (part I)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1522,6 +1522,11 @@ DEFINE_mInt32(load_trigger_compaction_version_percent, "66");
 DEFINE_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
 DEFINE_mBool(enable_compaction_pause_on_high_memory, "true");
 
+DEFINE_mBool(enable_quorum_success_write, "true");
+DEFINE_mDouble(quorum_success_max_wait_multiplier, "0.2");
+DEFINE_mInt64(quorum_success_min_wait_seconds, "10");
+DEFINE_mInt32(quorum_success_remaining_timeout_seconds, "30");
+
 DEFINE_mBool(enable_calc_delete_bitmap_between_segments_concurrently, "false");
 
 DEFINE_mBool(enable_update_delete_bitmap_kv_check_core, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1593,6 +1593,11 @@ DECLARE_mInt32(load_trigger_compaction_version_percent);
 DECLARE_mInt64(base_compaction_interval_seconds_since_last_operation);
 DECLARE_mBool(enable_compaction_pause_on_high_memory);
 
+DECLARE_mBool(enable_quorum_success_write);
+DECLARE_mDouble(quorum_success_max_wait_multiplier);
+DECLARE_mInt64(quorum_success_min_wait_seconds);
+DECLARE_mInt32(quorum_success_remaining_timeout_seconds);
+
 DECLARE_mBool(enable_calc_delete_bitmap_between_segments_concurrently);
 
 DECLARE_mBool(enable_update_delete_bitmap_kv_check_core);

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -198,6 +198,15 @@ int IndexChannel::_max_failed_replicas(int64_t tablet_id) {
     return max_failed_replicas;
 }
 
+int IndexChannel::_load_required_replicas_num(int64_t tablet_id) {
+    auto [total_replicas_num, load_required_replicas_num] =
+            _parent->_tablet_replica_info[tablet_id];
+    if (total_replicas_num == 0) {
+        return (_parent->_num_replicas + 1) / 2;
+    }
+    return load_required_replicas_num;
+}
+
 Status IndexChannel::check_intolerable_failure() {
     std::lock_guard<std::mutex> l(_fail_lock);
     return _intolerable_failure_status;
@@ -302,23 +311,61 @@ static Status cancel_channel_and_check_intolerable_failure(Status status,
 Status IndexChannel::close_wait(
         RuntimeState* state, WriterStats* writer_stats,
         std::unordered_map<int64_t, AddBatchCounter>* node_add_batch_counter_map,
-        std::unordered_set<int64_t> unfinished_node_channel_ids) {
+        std::unordered_set<int64_t> unfinished_node_channel_ids,
+        bool need_wait_after_quorum_success) {
+    DBUG_EXECUTE_IF("IndexChannel.close_wait.timeout",
+                    { return Status::TimedOut("injected timeout"); });
     Status status = Status::OK();
+    // 1. wait quorum success
+    std::unordered_set<int64_t> write_tablets;
+    for (const auto& [node_id, node_channel] : _node_channels) {
+        auto node_channel_write_tablets = node_channel->write_tablets();
+        write_tablets.insert(node_channel_write_tablets.begin(), node_channel_write_tablets.end());
+    }
     while (true) {
-        status = check_each_node_channel_close(&unfinished_node_channel_ids,
-                                               node_add_batch_counter_map, writer_stats, status);
-        if (!status.ok() || unfinished_node_channel_ids.empty()) {
-            LOG(INFO) << ", is all unfinished: " << unfinished_node_channel_ids.empty()
-                      << ", status: " << status << ", txn_id: " << _parent->_txn_id
+        RETURN_IF_ERROR(check_each_node_channel_close(
+                &unfinished_node_channel_ids, node_add_batch_counter_map, writer_stats, status));
+        bool quorum_success = _quorum_success(unfinished_node_channel_ids, write_tablets);
+        if (unfinished_node_channel_ids.empty() || quorum_success) {
+            LOG(INFO) << "quorum_success: " << quorum_success
+                      << ", is all unfinished: " << unfinished_node_channel_ids.empty()
+                      << ", txn_id: " << _parent->_txn_id
                       << ", load_id: " << print_id(_parent->_load_id);
             break;
         }
         bthread_usleep(1000 * 10);
     }
 
-    DBUG_EXECUTE_IF("IndexChannel.close_wait.timeout",
-                    { status = Status::TimedOut("injected timeout"); });
-
+    // 2. wait for all node channel to complete as much as possible
+    if (!unfinished_node_channel_ids.empty() && need_wait_after_quorum_success) {
+        int64_t max_wait_time_ms = _calc_max_wait_time_ms(unfinished_node_channel_ids);
+        while (true) {
+            RETURN_IF_ERROR(check_each_node_channel_close(&unfinished_node_channel_ids,
+                                                          node_add_batch_counter_map, writer_stats,
+                                                          status));
+            if (unfinished_node_channel_ids.empty()) {
+                break;
+            }
+            int64_t elapsed_ms = UnixMillis() - _start_time;
+            if (elapsed_ms > max_wait_time_ms ||
+                _parent->_load_channel_timeout_s - elapsed_ms / 1000 <
+                        config::quorum_success_remaining_timeout_seconds) {
+                // cancel unfinished node channel
+                std::stringstream unfinished_node_channel_host_str;
+                for (auto& it : unfinished_node_channel_ids) {
+                    unfinished_node_channel_host_str << _node_channels[it]->host() << ",";
+                    _node_channels[it]->cancel("timeout");
+                }
+                LOG(WARNING) << "reach max wait time, max_wait_time_ms: " << max_wait_time_ms
+                             << ", cancel unfinished node channel and finish close"
+                             << ", load id: " << print_id(_parent->_load_id)
+                             << ", txn_id: " << _parent->_txn_id << ", unfinished node channel: "
+                             << unfinished_node_channel_host_str.str();
+                break;
+            }
+            bthread_usleep(1000 * 10);
+        }
+    }
     return status;
 }
 
@@ -341,6 +388,8 @@ Status IndexChannel::check_each_node_channel_close(
                                                          node_add_batch_counter_map);
             unfinished_node_channel_ids->erase(it.first);
         }
+        DBUG_EXECUTE_IF("IndexChannel.check_each_node_channel_close.close_status_not_ok",
+                        { close_status = Status::InternalError("injected close status not ok"); });
         if (!close_status.ok()) {
             final_status = cancel_channel_and_check_intolerable_failure(
                     std::move(final_status), close_status.to_string(), *this, *it.second);
@@ -348,6 +397,80 @@ Status IndexChannel::check_each_node_channel_close(
     }
 
     return final_status;
+}
+
+bool IndexChannel::_quorum_success(const std::unordered_set<int64_t>& unfinished_node_channel_ids,
+                                   const std::unordered_set<int64_t>& write_tablets) {
+    if (!config::enable_quorum_success_write) {
+        return false;
+    }
+    std::unordered_map<int64_t, int64_t> finished_tablets_replica;
+
+    // 1. collect all write tablets and finished tablets
+    for (const auto& [node_id, node_channel] : _node_channels) {
+        auto node_channel_write_tablets = node_channel->write_tablets();
+        if (unfinished_node_channel_ids.contains(node_id) || !node_channel->check_status().ok()) {
+            continue;
+        }
+        for (const auto& tablet_id : node_channel_write_tablets) {
+            finished_tablets_replica[tablet_id]++;
+        }
+    }
+
+    // 2. check if quorum success
+    if (write_tablets.empty()) {
+        return false;
+    }
+    for (const auto& tablet_id : write_tablets) {
+        if (finished_tablets_replica[tablet_id] < _load_required_replicas_num(tablet_id)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int64_t IndexChannel::_calc_max_wait_time_ms(
+        const std::unordered_set<int64_t>& unfinished_node_channel_ids) {
+    // 1. calculate avg speed of all unfinished node channel
+    int64_t elapsed_ms = UnixMillis() - _start_time;
+    int64_t total_bytes = 0;
+    int finished_count = 0;
+    for (const auto& [node_id, node_channel] : _node_channels) {
+        if (unfinished_node_channel_ids.contains(node_id)) {
+            continue;
+        }
+        total_bytes += node_channel->write_bytes();
+        finished_count++;
+    }
+    // no data loaded in index channel, return 0
+    if (total_bytes == 0 || finished_count == 0) {
+        return 0;
+    }
+    // if elapsed_ms is equal to 0, explain the loaded data is too small
+    if (elapsed_ms <= 0) {
+        return config::quorum_success_min_wait_seconds * 1000;
+    }
+    double avg_speed =
+            static_cast<double>(total_bytes) / (static_cast<double>(elapsed_ms) * finished_count);
+
+    // 2. calculate max wait time of each unfinished node channel and return the max value
+    int64_t max_wait_time_ms = 0;
+    for (int64_t id : unfinished_node_channel_ids) {
+        int64_t bytes = _node_channels[id]->write_bytes();
+        int64_t wait =
+                avg_speed > 0 ? static_cast<int64_t>(static_cast<double>(bytes) / avg_speed) : 0;
+        max_wait_time_ms = std::max(max_wait_time_ms, wait);
+    }
+
+    // 3. calculate max wait time
+    // introduce quorum_success_min_wait_seconds to avoid jitter of small load
+    max_wait_time_ms =
+            std::max(static_cast<int64_t>(static_cast<double>(max_wait_time_ms) *
+                                          (1.0 + config::quorum_success_max_wait_multiplier)),
+                     config::quorum_success_min_wait_seconds * 1000);
+
+    return max_wait_time_ms;
 }
 
 static Status none_of(std::initializer_list<bool> vars) {
@@ -633,6 +756,11 @@ Status VNodeChannel::add_block(vectorized::Block* block, const Payload* payload)
     for (auto tablet_id : payload->second) {
         _cur_add_block_request->add_tablet_ids(tablet_id);
     }
+    {
+        std::lock_guard<std::mutex> l(_write_tablets_lock);
+        _write_tablets.insert(payload->second.begin(), payload->second.end());
+    }
+    _write_bytes.fetch_add(_cur_mutable_block->bytes());
 
     if (_cur_mutable_block->rows() >= _batch_size ||
         _cur_mutable_block->bytes() > config::doris_scanner_row_bytes) {
@@ -1082,6 +1210,10 @@ Status VNodeChannel::after_close_handle(
     return st;
 }
 
+Status VNodeChannel::check_status() {
+    return none_of({_cancelled, !_eos_is_produced});
+}
+
 void VNodeChannel::_close_check() {
     std::lock_guard<std::mutex> lg(_pending_batches_lock);
     CHECK(_pending_blocks.empty()) << name();
@@ -1202,6 +1334,7 @@ Status VTabletWriter::open(doris::RuntimeState* state, doris::RuntimeProfile* pr
     VLOG_DEBUG << "list of open index id = " << fmt::to_string(buf);
 
     for (const auto& index_channel : _channels) {
+        index_channel->set_start_time(UnixMillis());
         index_channel->for_each_node_channel([&index_channel](
                                                      const std::shared_ptr<VNodeChannel>& ch) {
             auto st = ch->open_wait();
@@ -1581,9 +1714,11 @@ void VTabletWriter::_do_try_close(RuntimeState* state, const Status& exec_status
                 if (!status.ok()) {
                     break;
                 }
-
+                // Do not need to wait after quorum success,
+                // for first-stage close_wait only ensure incremental node channels load has been completed,
+                // unified waiting in the second-stage close_wait.
                 status = index_channel->close_wait(_state, nullptr, nullptr,
-                                                   index_channel->init_node_channel_ids());
+                                                   index_channel->init_node_channel_ids(), false);
                 if (!status.ok()) {
                     break;
                 }
@@ -1661,7 +1796,7 @@ Status VTabletWriter::close(Status exec_status) {
             int64_t add_batch_exec_time = 0;
             int64_t wait_exec_time = 0;
             status = index_channel->close_wait(_state, &writer_stats, &node_add_batch_counter_map,
-                                               index_channel->each_node_channel_ids());
+                                               index_channel->each_node_channel_ids(), true);
 
             // Due to the non-determinism of compaction, the rowsets of each replica may be different from each other on different
             // BE nodes. The number of rows filtered in SegmentWriter depends on the historical rowsets located in the correspoding

--- a/be/src/vec/sink/writer/vtablet_writer.h
+++ b/be/src/vec/sink/writer/vtablet_writer.h
@@ -292,6 +292,8 @@ public:
             RuntimeState* state, WriterStats* writer_stats,
             std::unordered_map<int64_t, AddBatchCounter>* node_add_batch_counter_map);
 
+    Status check_status();
+
     void cancel(const std::string& cancel_msg);
 
     void time_report(std::unordered_map<int64_t, AddBatchCounter>* add_batch_counter_map,
@@ -325,6 +327,12 @@ public:
     size_t get_pending_bytes() { return _pending_batches_bytes; }
 
     bool is_incremental() const { return _is_incremental; }
+
+    int64_t write_bytes() const { return _write_bytes.load(); }
+    std::unordered_set<int64_t> write_tablets() {
+        std::lock_guard<std::mutex> l(_write_tablets_lock);
+        return _write_tablets;
+    }
 
 protected:
     // make a real open request for relative BE's load channel.
@@ -428,6 +436,10 @@ protected:
     int64_t _wg_id = -1;
 
     bool _is_incremental;
+
+    std::mutex _write_tablets_lock;
+    std::atomic<int64_t> _write_bytes {0};
+    std::unordered_set<int64_t> _write_tablets;
 };
 
 // an IndexChannel is related to specific table and its rollup and mv
@@ -505,7 +517,8 @@ public:
 
     Status close_wait(RuntimeState* state, WriterStats* writer_stats,
                       std::unordered_map<int64_t, AddBatchCounter>* node_add_batch_counter_map,
-                      std::unordered_set<int64_t> unfinished_node_channel_ids);
+                      std::unordered_set<int64_t> unfinished_node_channel_ids,
+                      bool need_wait_after_quorum_success);
 
     Status check_each_node_channel_close(
             std::unordered_set<int64_t>* unfinished_node_channel_ids,
@@ -544,6 +557,8 @@ public:
     // check whether the rows num filtered by different replicas is consistent
     Status check_tablet_filtered_rows_consistency();
 
+    void set_start_time(const int64_t& start_time) { _start_time = start_time; }
+
     vectorized::VExprContextSPtr get_where_clause() { return _where_clause; }
 
 private:
@@ -552,6 +567,13 @@ private:
     friend class VRowDistribution;
 
     int _max_failed_replicas(int64_t tablet_id);
+
+    int _load_required_replicas_num(int64_t tablet_id);
+
+    bool _quorum_success(const std::unordered_set<int64_t>& unfinished_node_channel_ids,
+                         const std::unordered_set<int64_t>& write_tablets);
+
+    int64_t _calc_max_wait_time_ms(const std::unordered_set<int64_t>& unfinished_node_channel_ids);
 
     VTabletWriter* _parent = nullptr;
     int64_t _index_id;
@@ -586,6 +608,8 @@ private:
     // rows num filtered by DeltaWriter per tablet, tablet_id -> <node_Id, filtered_rows_num>
     // used to verify whether the rows num filtered by different replicas is consistent
     std::map<int64_t, std::vector<std::pair<int64_t, int64_t>>> _tablets_filtered_rows;
+
+    int64_t _start_time = 0;
 };
 } // namespace vectorized
 } // namespace doris

--- a/regression-test/suites/fault_injection_p0/test_writer_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_writer_fault_injection.groovy
@@ -94,6 +94,8 @@ suite("test_writer_fault_injection", "nonConcurrent") {
         load_with_injection("IndexChannel.close_wait.timeout")
         // Test VTabletWriter close with _close_status not ok
         load_with_injection("VTabletWriter.close.close_status_not_ok")
+        // Test IndexChannel check_each_node_channel_close with close_status not ok
+        load_with_injection("IndexChannel.check_each_node_channel_close.close_status_not_ok")
     } finally {
         sql """ set enable_memtable_on_sink_node=true """
     }


### PR DESCRIPTION
### What problem does this PR solve?

related issue: https://github.com/apache/doris/issues/51426

![image](https://github.com/user-attachments/assets/23b19e6e-5209-4f4e-936c-93563b3dcf64)

If there is a node with slow response (possibly due to high load or configuration issues), then global writes will respond slowly or even timeout. 

Introducing **quorum success write** to solve this problem:

1. maintain the completed target nodes at each sender's sink operator. After most `tablet replica` completion, the receiving end considers it complete and tries to wait for the remaining nodes as much as possible. 
2. The waiting strategy is: 
- calculate avg speed of all unfinished channel and calculate the time that unfinished nodes should complete based on the average time(max_wait_time_ms).
- `max_wait_time_ms = max_wait_time_ms * (1.0 + config::quorum_success_max_wait_time_multiplier)), config::quorum_success_min_wait_time_ms);`


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

