### PR TITLE
[chore](compile) Split aggregate_function_collect.cpp into multiple files for compilation

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_collect.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.cpp
@@ -21,30 +21,11 @@
 
 #include "common/exception.h"
 #include "common/status.h"
+#include "vec/aggregate_functions/aggregate_function_collect_creator.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
-#include "vec/aggregate_functions/helpers.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
-
-template <PrimitiveType T, typename HasLimit>
-AggregateFunctionPtr do_create_agg_function_collect(bool distinct, const DataTypes& argument_types,
-                                                    const bool result_is_nullable) {
-    if (distinct) {
-        if constexpr (T == INVALID_TYPE) {
-            throw Exception(ErrorCode::INTERNAL_ERROR,
-                            "unexpected type for collect, please check the input");
-        } else {
-            return creator_without_type::create<AggregateFunctionCollect<
-                    AggregateFunctionCollectSetData<T, HasLimit>, HasLimit>>(argument_types,
-                                                                             result_is_nullable);
-        }
-    } else {
-        return creator_without_type::create<
-                AggregateFunctionCollect<AggregateFunctionCollectListData<T, HasLimit>, HasLimit>>(
-                argument_types, result_is_nullable);
-    }
-}
 
 template <typename HasLimit>
 AggregateFunctionPtr create_aggregate_function_collect_impl(const std::string& name,
@@ -54,75 +35,75 @@ AggregateFunctionPtr create_aggregate_function_collect_impl(const std::string& n
 
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
-        return do_create_agg_function_collect<TYPE_BOOLEAN, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+        return AggregateFunctionCollectCreator<TYPE_BOOLEAN, HasLimit>()(distinct, argument_types,
+                                                                         result_is_nullable);
     case PrimitiveType::TYPE_TINYINT:
-        return do_create_agg_function_collect<TYPE_TINYINT, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+        return AggregateFunctionCollectCreator<TYPE_TINYINT, HasLimit>()(distinct, argument_types,
+                                                                         result_is_nullable);
     case PrimitiveType::TYPE_SMALLINT:
-        return do_create_agg_function_collect<TYPE_SMALLINT, HasLimit>(distinct, argument_types,
-                                                                       result_is_nullable);
-    case PrimitiveType::TYPE_INT:
-        return do_create_agg_function_collect<TYPE_INT, HasLimit>(distinct, argument_types,
-                                                                  result_is_nullable);
-    case PrimitiveType::TYPE_BIGINT:
-        return do_create_agg_function_collect<TYPE_BIGINT, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
-    case PrimitiveType::TYPE_LARGEINT:
-        return do_create_agg_function_collect<TYPE_LARGEINT, HasLimit>(distinct, argument_types,
-                                                                       result_is_nullable);
-    case PrimitiveType::TYPE_FLOAT:
-        return do_create_agg_function_collect<TYPE_FLOAT, HasLimit>(distinct, argument_types,
-                                                                    result_is_nullable);
-    case PrimitiveType::TYPE_DOUBLE:
-        return do_create_agg_function_collect<TYPE_DOUBLE, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
-    case PrimitiveType::TYPE_DECIMAL32:
-        return do_create_agg_function_collect<TYPE_DECIMAL32, HasLimit>(distinct, argument_types,
-                                                                        result_is_nullable);
-    case PrimitiveType::TYPE_DECIMAL64:
-        return do_create_agg_function_collect<TYPE_DECIMAL64, HasLimit>(distinct, argument_types,
-                                                                        result_is_nullable);
-    case PrimitiveType::TYPE_DECIMALV2:
-        return do_create_agg_function_collect<TYPE_DECIMALV2, HasLimit>(distinct, argument_types,
-                                                                        result_is_nullable);
-    case PrimitiveType::TYPE_DECIMAL128I:
-        return do_create_agg_function_collect<TYPE_DECIMAL128I, HasLimit>(distinct, argument_types,
+        return AggregateFunctionCollectCreator<TYPE_SMALLINT, HasLimit>()(distinct, argument_types,
                                                                           result_is_nullable);
-    case PrimitiveType::TYPE_DECIMAL256:
-        return do_create_agg_function_collect<TYPE_DECIMAL256, HasLimit>(distinct, argument_types,
-                                                                         result_is_nullable);
-    case PrimitiveType::TYPE_DATE:
-        return do_create_agg_function_collect<TYPE_DATE, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
-    case PrimitiveType::TYPE_DATETIME:
-        return do_create_agg_function_collect<TYPE_DATETIME, HasLimit>(distinct, argument_types,
+    case PrimitiveType::TYPE_INT:
+        return AggregateFunctionCollectCreator<TYPE_INT, HasLimit>()(distinct, argument_types,
+                                                                     result_is_nullable);
+    case PrimitiveType::TYPE_BIGINT:
+        return AggregateFunctionCollectCreator<TYPE_BIGINT, HasLimit>()(distinct, argument_types,
+                                                                        result_is_nullable);
+    case PrimitiveType::TYPE_LARGEINT:
+        return AggregateFunctionCollectCreator<TYPE_LARGEINT, HasLimit>()(distinct, argument_types,
+                                                                          result_is_nullable);
+    case PrimitiveType::TYPE_FLOAT:
+        return AggregateFunctionCollectCreator<TYPE_FLOAT, HasLimit>()(distinct, argument_types,
                                                                        result_is_nullable);
-    case PrimitiveType::TYPE_DATEV2:
-        return do_create_agg_function_collect<TYPE_DATEV2, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
-    case PrimitiveType::TYPE_DATETIMEV2:
-        return do_create_agg_function_collect<TYPE_DATETIMEV2, HasLimit>(distinct, argument_types,
-                                                                         result_is_nullable);
-    case PrimitiveType::TYPE_IPV6:
-        return do_create_agg_function_collect<TYPE_IPV6, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
-    case PrimitiveType::TYPE_IPV4:
-        return do_create_agg_function_collect<TYPE_IPV4, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
-    case PrimitiveType::TYPE_STRING:
-        return do_create_agg_function_collect<TYPE_STRING, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
-    case PrimitiveType::TYPE_CHAR:
-        return do_create_agg_function_collect<TYPE_CHAR, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
-    case PrimitiveType::TYPE_VARCHAR:
-        return do_create_agg_function_collect<TYPE_VARCHAR, HasLimit>(distinct, argument_types,
+    case PrimitiveType::TYPE_DOUBLE:
+        return AggregateFunctionCollectCreator<TYPE_DOUBLE, HasLimit>()(distinct, argument_types,
+                                                                        result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL32:
+        return AggregateFunctionCollectCreator<TYPE_DECIMAL32, HasLimit>()(distinct, argument_types,
+                                                                           result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL64:
+        return AggregateFunctionCollectCreator<TYPE_DECIMAL64, HasLimit>()(distinct, argument_types,
+                                                                           result_is_nullable);
+    case PrimitiveType::TYPE_DECIMALV2:
+        return AggregateFunctionCollectCreator<TYPE_DECIMALV2, HasLimit>()(distinct, argument_types,
+                                                                           result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL128I:
+        return AggregateFunctionCollectCreator<TYPE_DECIMAL128I, HasLimit>()(
+                distinct, argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DECIMAL256:
+        return AggregateFunctionCollectCreator<TYPE_DECIMAL256, HasLimit>()(
+                distinct, argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_DATE:
+        return AggregateFunctionCollectCreator<TYPE_DATE, HasLimit>()(distinct, argument_types,
                                                                       result_is_nullable);
+    case PrimitiveType::TYPE_DATETIME:
+        return AggregateFunctionCollectCreator<TYPE_DATETIME, HasLimit>()(distinct, argument_types,
+                                                                          result_is_nullable);
+    case PrimitiveType::TYPE_DATEV2:
+        return AggregateFunctionCollectCreator<TYPE_DATEV2, HasLimit>()(distinct, argument_types,
+                                                                        result_is_nullable);
+    case PrimitiveType::TYPE_DATETIMEV2:
+        return AggregateFunctionCollectCreator<TYPE_DATETIMEV2, HasLimit>()(
+                distinct, argument_types, result_is_nullable);
+    case PrimitiveType::TYPE_IPV6:
+        return AggregateFunctionCollectCreator<TYPE_IPV6, HasLimit>()(distinct, argument_types,
+                                                                      result_is_nullable);
+    case PrimitiveType::TYPE_IPV4:
+        return AggregateFunctionCollectCreator<TYPE_IPV4, HasLimit>()(distinct, argument_types,
+                                                                      result_is_nullable);
+    case PrimitiveType::TYPE_STRING:
+        return AggregateFunctionCollectCreator<TYPE_STRING, HasLimit>()(distinct, argument_types,
+                                                                        result_is_nullable);
+    case PrimitiveType::TYPE_CHAR:
+        return AggregateFunctionCollectCreator<TYPE_CHAR, HasLimit>()(distinct, argument_types,
+                                                                      result_is_nullable);
+    case PrimitiveType::TYPE_VARCHAR:
+        return AggregateFunctionCollectCreator<TYPE_VARCHAR, HasLimit>()(distinct, argument_types,
+                                                                         result_is_nullable);
     default:
         // We do not care what the real type is.
-        return do_create_agg_function_collect<INVALID_TYPE, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+        return AggregateFunctionCollectCreator<INVALID_TYPE, HasLimit>()(distinct, argument_types,
+                                                                         result_is_nullable);
     }
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator.h
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/data_types/data_type.h"
+
+namespace doris::vectorized {
+template <PrimitiveType T, typename HasLimit>
+struct AggregateFunctionCollectCreator {
+    AggregateFunctionPtr operator()(bool distinct, const DataTypes& argument_types,
+                                    const bool result_is_nullable);
+};
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_datetime.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_datetime.cpp
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DATE)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DATETIME)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DATEV2)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DATETIMEV2)
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_decimal.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_decimal.cpp
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DECIMAL32)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DECIMAL64)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DECIMAL128I)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DECIMAL256)
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_decimalv2.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_decimalv2.cpp
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DECIMALV2)
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_float.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_float.cpp
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+#include "runtime/define_primitive_type.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_DOUBLE)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_FLOAT)
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_integer.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_integer.cpp
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_TINYINT)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_SMALLINT)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_INT)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_BIGINT)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_LARGEINT)
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_others.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_others.cpp
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_IPV6)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_IPV4)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(INVALID_TYPE)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_BOOLEAN)
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_collect_creator_string.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect_creator_string.cpp
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aggregate_function_collect_creator_impl.h"
+
+namespace doris::vectorized {
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_STRING)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_CHAR)
+INSTANTIATE_AGGREGATE_FUNCTION_COLLECT_CREATOR(TYPE_VARCHAR)
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

To avoid large aggregate_function_collect.o file and improve compile performance, this commit refactors the instantiation of AggregateFunctionCollectCreator by splitting template specializations into multiple units.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

