### PR TITLE
[feature](fe) add arthas tool in fe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -767,6 +767,15 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     mkdir -p "${DORIS_OUTPUT}/fe/plugins/connectors/"
     mkdir -p "${DORIS_OUTPUT}/fe/plugins/hadoop_conf/"
     mkdir -p "${DORIS_OUTPUT}/fe/plugins/java_extensions/"
+
+    if [ "${TARGET_SYSTEM}" = "Darwin" ] || [ "${TARGET_SYSTEM}" = "Linux" ]; then
+      mkdir -p "${DORIS_OUTPUT}/fe/arthas"
+      rm -rf "${DORIS_OUTPUT}/fe/arthas/*"
+      unzip -o "${DORIS_OUTPUT}/fe/lib/arthas-packaging-*.jar" arthas-bin.zip -d "${DORIS_OUTPUT}/fe/arthas/"
+      unzip -o "${DORIS_OUTPUT}/fe/arthas/arthas-bin.zip" -d "${DORIS_OUTPUT}/fe/arthas/"
+      rm "${DORIS_OUTPUT}/fe/arthas/math-game.jar"
+      rm "${DORIS_OUTPUT}/fe/arthas/arthas-bin.zip"
+    fi
 fi
 
 if [[ "${OUTPUT_BE_BINARY}" -eq 1 ]]; then

--- a/dist/LICENSE-dist.txt
+++ b/dist/LICENSE-dist.txt
@@ -1235,6 +1235,8 @@ The Apache Software License, Version 2.0
         - oro:oro:2.0.8 (no url defined)
     * je:
         - com.sleepycat:je:18.3.12 (no url defined)
+    * arthas-packaging:
+        - com.taobao.arthas:arthas-packaging:4.0.5 (https://github.com/alibaba/arthas)
     ### The following components use multiple licenses and we choose APLv2
     * JAX-RS provider for JSON content type:
         - org.codehaus.jackson:jackson-jaxrs:1.8.3 (http://jackson.codehaus.org)

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -899,7 +899,11 @@ under the License.
             <artifactId>sdk-core</artifactId>
             <version>${awssdk.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.taobao.arthas</groupId>
+            <artifactId>arthas-packaging</artifactId>
+            <version>4.0.5</version>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
### What problem does this PR solve?

add Arthas in fe's deploy path: `output/fe/arthas`.


Arthas helps developers in trouble-shooting issues in production environment for Java based applications without modifying code or restarting servers.

see the document of arthas: https://arthas.aliyun.com/en/doc/

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

