### PR TITLE
[feat](restore): enhanced ccr storage_medium sync

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -229,6 +229,8 @@ DEFINE_Int32(alter_index_worker_count, "3");
 DEFINE_Int32(clone_worker_count, "3");
 // the count of thread to clone
 DEFINE_Int32(storage_medium_migrate_count, "1");
+// Enable storage medium fallback when specified medium is not available
+DEFINE_mBool(enable_storage_medium_fallback, "false");
 // the count of thread to check consistency
 DEFINE_Int32(check_consistency_worker_count, "1");
 // the count of thread to upload

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -274,6 +274,8 @@ DECLARE_Int32(alter_index_worker_count);
 DECLARE_Int32(clone_worker_count);
 // the count of thread to clone
 DECLARE_Int32(storage_medium_migrate_count);
+// Enable storage medium fallback when specified medium is not available
+DECLARE_mBool(enable_storage_medium_fallback);
 // the count of thread to check consistency
 DECLARE_Int32(check_consistency_worker_count);
 // the count of thread to upload

--- a/be/test/olap/storage_medium_fallback_test.cpp
+++ b/be/test/olap/storage_medium_fallback_test.cpp
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+
+#include "common/config.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/local_file_system.h"
+#include "olap/data_dir.h"
+#include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
+#include "util/threadpool.h"
+
+namespace doris {
+
+class StorageMediumFallbackTest : public testing::Test {
+public:
+    void SetUp() override {
+        // Create test directories
+        _test_path = "./be/test/olap/test_data/storage_medium_fallback_test";
+        _hdd_path = _test_path + "/hdd";
+        _ssd_path = _test_path + "/ssd";
+
+        // Clean up existing test directories
+        auto st = io::global_local_filesystem()->delete_directory(_test_path);
+        st = io::global_local_filesystem()->create_directory(_test_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(_hdd_path);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(_ssd_path);
+        ASSERT_TRUE(st.ok()) << st;
+
+        // Create meta directories
+        EXPECT_TRUE(io::global_local_filesystem()->create_directory(_hdd_path + "/meta").ok());
+        EXPECT_TRUE(io::global_local_filesystem()->create_directory(_ssd_path + "/meta").ok());
+
+        // Setup storage engine
+        EngineOptions options;
+        options.backend_uid = UniqueId::gen_uid();
+        _storage_engine = std::make_unique<StorageEngine>(options);
+
+        // Store original config values
+        _original_fallback_config = config::enable_storage_medium_fallback;
+    }
+
+    void TearDown() override {
+        // Restore original config
+        config::enable_storage_medium_fallback = _original_fallback_config;
+
+        // Clean up test directories
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_test_path).ok());
+        ExecEnv::GetInstance()->set_storage_engine(nullptr);
+    }
+
+protected:
+    // Helper method to setup storage engine with specific configuration
+    void setupStorageEngine(bool include_hdd = true, bool include_ssd = true) {
+        _storage_engine->_store_map.clear();
+        _storage_engine->_available_storage_medium_type_count = 0;
+
+        if (include_hdd) {
+            auto hdd_dir = std::make_unique<DataDir>(*_storage_engine, _hdd_path, 100000000,
+                                                     TStorageMedium::HDD);
+            auto init_status = hdd_dir->init();
+            EXPECT_TRUE(init_status.ok()) << "HDD DataDir init failed: " << init_status;
+            _storage_engine->_store_map[_hdd_path] = std::move(hdd_dir);
+        }
+
+        if (include_ssd) {
+            auto ssd_dir = std::make_unique<DataDir>(*_storage_engine, _ssd_path, 100000000,
+                                                     TStorageMedium::SSD);
+            auto init_status = ssd_dir->init();
+            EXPECT_TRUE(init_status.ok()) << "SSD DataDir init failed: " << init_status;
+            _storage_engine->_store_map[_ssd_path] = std::move(ssd_dir);
+        }
+
+        // Count unique storage medium types
+        std::set<TStorageMedium::type> medium_types;
+        for (const auto& store : _storage_engine->_store_map) {
+            medium_types.insert(store.second->storage_medium());
+        }
+        _storage_engine->_available_storage_medium_type_count = medium_types.size();
+    }
+
+    std::unique_ptr<StorageEngine> _storage_engine;
+    std::string _test_path;
+    std::string _hdd_path;
+    std::string _ssd_path;
+    bool _original_fallback_config;
+};
+
+TEST_F(StorageMediumFallbackTest, NormalCase_SingleMedium_HDD) {
+    setupStorageEngine(true, false); // only HDD
+    config::enable_storage_medium_fallback = true;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+}
+
+TEST_F(StorageMediumFallbackTest, NormalCase_MixedMedium_RequestHDD) {
+    setupStorageEngine(true, true); // both HDD and SSD
+    config::enable_storage_medium_fallback = true;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+}
+
+TEST_F(StorageMediumFallbackTest, NormalCase_MixedMedium_RequestSSD) {
+    setupStorageEngine(true, true); // both HDD and SSD
+    config::enable_storage_medium_fallback = true;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::SSD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::SSD);
+}
+
+TEST_F(StorageMediumFallbackTest, FallbackEnabled_SingleMediumInconsistent) {
+    setupStorageEngine(true, false); // only HDD
+    config::enable_storage_medium_fallback = true;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::SSD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD); // fallback to HDD
+}
+
+TEST_F(StorageMediumFallbackTest, FallbackEnabled_MixedMediumUnavailable) {
+    setupStorageEngine(false, true); // only SSD available
+    config::enable_storage_medium_fallback = true;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::SSD); // fallback to SSD
+}
+
+TEST_F(StorageMediumFallbackTest, FallbackDisabled_SingleMediumInconsistent) {
+    // Single medium type always forces fallback regardless of config
+    setupStorageEngine(true, false); // only HDD
+    config::enable_storage_medium_fallback = false;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::SSD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1); // forced fallback
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+}
+
+TEST_F(StorageMediumFallbackTest, FallbackDisabled_MixedMediumUnavailable) {
+    // Mixed environment: fallback disabled should be respected
+    setupStorageEngine(true, true); // both HDD and SSD
+    config::enable_storage_medium_fallback = false;
+
+    // Verify normal operation first
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+
+    // Simulate HDD becoming unavailable but maintain mixed environment count
+    _storage_engine->_store_map.erase(_hdd_path);
+    _storage_engine->_available_storage_medium_type_count = 2;
+
+    // Request unavailable HDD - should fail without fallback
+    dir_infos.clear();
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 0); // no fallback when disabled
+}
+
+TEST_F(StorageMediumFallbackTest, EmptyStoreMap) {
+    _storage_engine->_store_map.clear();
+    _storage_engine->_available_storage_medium_type_count = 0;
+    config::enable_storage_medium_fallback = true;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 0);
+}
+
+TEST_F(StorageMediumFallbackTest, SingleMediumType_AlwaysFallback) {
+    setupStorageEngine(true, false); // only HDD
+    _storage_engine->_available_storage_medium_type_count = 1;
+    config::enable_storage_medium_fallback = false;
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::SSD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1); // forced fallback
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+}
+
+TEST_F(StorageMediumFallbackTest, Config_DefaultValue) {
+    config::enable_storage_medium_fallback = false; // default
+    setupStorageEngine(true, true);                 // both HDD and SSD
+
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::SSD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::SSD);
+
+    // Single medium type forces fallback even with default config
+    setupStorageEngine(true, false); // only HDD
+    dir_infos.clear();
+    _storage_engine->_get_candidate_stores(TStorageMedium::SSD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1); // forced fallback
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+}
+
+TEST_F(StorageMediumFallbackTest, Config_MultiMediumFallbackControl) {
+    setupStorageEngine(true, true); // both HDD and SSD
+    config::enable_storage_medium_fallback = false;
+
+    // Normal operation works fine
+    std::vector<DirInfo> dir_infos;
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+    EXPECT_EQ(dir_infos.size(), 1);
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::HDD);
+
+    // Simulate HDD unavailable but maintain multi-medium count
+    _storage_engine->_store_map.erase(_hdd_path);
+    _storage_engine->_available_storage_medium_type_count = 2;
+
+    dir_infos.clear();
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+    EXPECT_EQ(dir_infos.size(), 0); // no fallback when disabled
+
+    // Enable fallback and test again
+    config::enable_storage_medium_fallback = true;
+    dir_infos.clear();
+    _storage_engine->_get_candidate_stores(TStorageMedium::HDD, dir_infos);
+
+    EXPECT_EQ(dir_infos.size(), 1); // fallback to SSD
+    EXPECT_EQ(dir_infos[0].data_dir->storage_medium(), TStorageMedium::SSD);
+}
+
+} // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RestoreStmt.java
@@ -29,11 +29,15 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Set;
 
 public class RestoreStmt extends AbstractBackupStmt implements NotFallbackInParser {
+    private static final Logger LOG = LogManager.getLogger(RestoreStmt.class);
+
     private static final String PROP_ALLOW_LOAD = "allow_load";
     private static final String PROP_BACKUP_TIMESTAMP = "backup_timestamp";
     private static final String PROP_META_VERSION = "meta_version";
@@ -46,6 +50,11 @@ public class RestoreStmt extends AbstractBackupStmt implements NotFallbackInPars
     public static final String PROP_CLEAN_PARTITIONS = "clean_partitions";
     public static final String PROP_ATOMIC_RESTORE = "atomic_restore";
     public static final String PROP_FORCE_REPLACE = "force_replace";
+    public static final String PROP_MEDIUM_SYNC_POLICY = "medium_sync_policy";
+    
+    // Medium sync policy values
+    public static final String MEDIUM_SYNC_POLICY_HDD = "hdd";
+    public static final String MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM = "same_with_upstream";
 
     private boolean allowLoad = false;
     private ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
@@ -60,6 +69,7 @@ public class RestoreStmt extends AbstractBackupStmt implements NotFallbackInPars
     private boolean isCleanPartitions = false;
     private boolean isAtomicRestore = false;
     private boolean isForceReplace = false;
+    private String mediumSyncPolicy = "hdd";
     private byte[] meta = null;
     private byte[] jobInfo = null;
 
@@ -137,6 +147,10 @@ public class RestoreStmt extends AbstractBackupStmt implements NotFallbackInPars
 
     public boolean isForceReplace() {
         return isForceReplace;
+    }
+
+    public String getMediumSyncPolicy() {
+        return mediumSyncPolicy;
     }
 
     @Override
@@ -227,6 +241,25 @@ public class RestoreStmt extends AbstractBackupStmt implements NotFallbackInPars
 
         // is force replace
         isForceReplace = eatBooleanProperty(copiedProperties, PROP_FORCE_REPLACE, isForceReplace);
+
+        // medium sync policy
+        if (copiedProperties.containsKey(PROP_MEDIUM_SYNC_POLICY)) {
+            String value = copiedProperties.get(PROP_MEDIUM_SYNC_POLICY);
+            LOG.info("RestoreStmt.analyzeProperties: found medium_sync_policy property with value: {}", value);
+            if (MEDIUM_SYNC_POLICY_HDD.equalsIgnoreCase(value) 
+                    || MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM.equalsIgnoreCase(value)) {
+                mediumSyncPolicy = value.toLowerCase();
+                LOG.info("RestoreStmt.analyzeProperties: set mediumSyncPolicy to: {}", mediumSyncPolicy);
+            } else {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid medium sync policy value: " + value + ". Valid values are: " 
+                        + MEDIUM_SYNC_POLICY_HDD + ", " + MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM);
+            }
+            copiedProperties.remove(PROP_MEDIUM_SYNC_POLICY);
+        } else {
+            LOG.info("RestoreStmt.analyzeProperties: no medium_sync_policy property found, using default: {}", 
+                     mediumSyncPolicy);
+        }
 
         if (!copiedProperties.isEmpty()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -675,14 +675,14 @@ public class BackupHandler extends MasterDaemon implements Writable {
                     stmt.getTimeoutMs(), metaVersion, stmt.reserveReplica(), stmt.reserveColocate(),
                     stmt.reserveDynamicPartitionEnable(), stmt.isBeingSynced(),
                     stmt.isCleanTables(), stmt.isCleanPartitions(), stmt.isAtomicRestore(), stmt.isForceReplace(),
-                    env, Repository.KEEP_ON_LOCAL_REPO_ID, backupMeta);
+                    stmt.getMediumSyncPolicy(), env, Repository.KEEP_ON_LOCAL_REPO_ID, backupMeta);
         } else {
-            restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
-                db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicaAlloc(),
-                stmt.getTimeoutMs(), stmt.getMetaVersion(), stmt.reserveReplica(), stmt.reserveColocate(),
-                stmt.reserveDynamicPartitionEnable(), stmt.isBeingSynced(), stmt.isCleanTables(),
-                stmt.isCleanPartitions(), stmt.isAtomicRestore(), stmt.isForceReplace(),
-                env, repository.getId());
+        restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
+            db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicaAlloc(),
+            stmt.getTimeoutMs(), stmt.getMetaVersion(), stmt.reserveReplica(), stmt.reserveColocate(),
+            stmt.reserveDynamicPartitionEnable(), stmt.isBeingSynced(), stmt.isCleanTables(),
+            stmt.isCleanPartitions(), stmt.isAtomicRestore(), stmt.isForceReplace(),
+            stmt.getMediumSyncPolicy(), env, repository.getId());
         }
 
         env.getEditLog().logRestoreJob(restoreJob);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/RestoreStmtMediumSyncSimpleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/RestoreStmtMediumSyncSimpleTest.java
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.analysis.AbstractBackupTableRefClause;
+import org.apache.doris.analysis.LabelName;
+import org.apache.doris.analysis.RestoreStmt;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.analysis.TableRef;
+import org.apache.doris.common.AnalysisException;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class RestoreStmtMediumSyncSimpleTest {
+
+    private LabelName labelName;
+    private String repoName = "test_repo";
+    private AbstractBackupTableRefClause tableRefClause;
+
+    @Before
+    public void setUp() {
+        labelName = new LabelName("test_db", "test_snapshot");
+        
+        List<TableRef> tableRefs = Lists.newArrayList();
+        tableRefs.add(new TableRef(new TableName(null, null, "test_table"), null));
+        tableRefClause = new AbstractBackupTableRefClause(false, tableRefs);
+    }
+
+    @Test
+    public void testMediumSyncPolicyHDD() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, RestoreStmt.MEDIUM_SYNC_POLICY_HDD);
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties to process medium_sync_policy
+
+        Assert.assertEquals("Medium sync policy should be hdd", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_HDD, stmt.getMediumSyncPolicy());
+    }
+
+    @Test
+    public void testMediumSyncPolicySameWithUpstream() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM);
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties to process medium_sync_policy
+
+        Assert.assertEquals("Medium sync policy should be same_with_upstream", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM, stmt.getMediumSyncPolicy());
+    }
+
+    @Test
+    public void testMediumSyncPolicyDefault() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        // No medium_sync_policy specified
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties
+
+        Assert.assertEquals("Default medium sync policy should be hdd", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_HDD, stmt.getMediumSyncPolicy());
+    }
+
+    @Test
+    public void testMediumSyncPolicyCaseInsensitive() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, "HDD"); // uppercase
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties
+
+        Assert.assertEquals("Medium sync policy should be normalized to lowercase", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_HDD, stmt.getMediumSyncPolicy());
+
+        // Test mixed case
+        properties.remove(RestoreStmt.PROP_MEDIUM_SYNC_POLICY);
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, "Same_With_Upstream");
+        stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties
+
+        Assert.assertEquals("Medium sync policy should be normalized to lowercase", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM, stmt.getMediumSyncPolicy());
+    }
+
+    @Test
+    public void testInvalidMediumSyncPolicy() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, "invalid_policy");
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        
+        try {
+            // Trigger validation by calling analyzeProperties
+            stmt.analyzeProperties();
+            Assert.fail("Should throw AnalysisException for invalid medium sync policy");
+        } catch (AnalysisException e) {
+            Assert.assertTrue("Error message should mention invalid medium sync policy", 
+                            e.getMessage().contains("Invalid medium sync policy value"));
+            Assert.assertTrue("Error message should list valid values", 
+                            e.getMessage().contains("hdd") && e.getMessage().contains("same_with_upstream"));
+        }
+    }
+
+    @Test
+    public void testMediumSyncPolicyWithOtherProperties() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put("reserve_replica", "true");
+        properties.put("atomic_restore", "true");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM);
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties
+
+        Assert.assertEquals("Medium sync policy should be preserved with other properties", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM, stmt.getMediumSyncPolicy());
+        
+        // Verify other properties don't interfere
+        Assert.assertTrue("Reserve replica should be true", stmt.reserveReplica());
+        Assert.assertTrue("Atomic restore should be true", stmt.isAtomicRestore());
+    }
+
+    @Test
+    public void testEmptyMediumSyncPolicy() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, "");
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        
+        try {
+            stmt.analyzeProperties();
+            Assert.fail("Should throw AnalysisException for empty medium sync policy");
+        } catch (AnalysisException e) {
+            Assert.assertTrue("Error message should mention invalid medium sync policy", 
+                            e.getMessage().contains("Invalid medium sync policy value"));
+        }
+    }
+
+    @Test 
+    public void testWhitespaceMediumSyncPolicy() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, "   ");
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+
+        try {
+            stmt.analyzeProperties();
+            Assert.fail("Should throw AnalysisException for whitespace medium sync policy");
+        } catch (AnalysisException e) {
+            Assert.assertTrue("Error message should mention invalid medium sync policy", 
+                            e.getMessage().contains("Invalid medium sync policy value"));
+        }
+    }
+
+    @Test
+    public void testMediumSyncPolicyToSql() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2023-12-01-10-00-00");
+        properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM);
+
+        RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+        stmt.analyzeProperties(); // Need to analyze properties
+        String sql = stmt.toSql();
+
+        Assert.assertTrue("SQL should contain medium sync policy", 
+                         sql.toLowerCase().contains("medium_sync_policy"));
+        Assert.assertTrue("SQL should contain same_with_upstream", 
+                         sql.toLowerCase().contains("same_with_upstream"));
+    }
+
+    @Test
+    public void testMediumSyncPolicyValidValues() throws Exception {
+        // Test all valid values
+        String[] validValues = {
+            RestoreStmt.MEDIUM_SYNC_POLICY_HDD,
+            RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM,
+            "HDD",
+            "SAME_WITH_UPSTREAM",
+            "hdd",
+            "same_with_upstream"
+        };
+
+        for (String value : validValues) {
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put("backup_timestamp", "2023-12-01-10-00-00");
+            properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, value);
+
+            RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+            stmt.analyzeProperties(); // Need to analyze properties
+            
+            // Should not throw exception
+            String normalizedValue = stmt.getMediumSyncPolicy();
+            Assert.assertTrue("Should be one of the valid normalized values", 
+                            normalizedValue.equals(RestoreStmt.MEDIUM_SYNC_POLICY_HDD) || 
+                            normalizedValue.equals(RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM));
+        }
+    }
+
+    @Test
+    public void testMediumSyncPolicyInvalidValues() throws Exception {
+        String[] invalidValues = {
+            "ssd", "invalid", "null", "auto", "mixed", "123", "same_upstream"
+        };
+
+        for (String value : invalidValues) {
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put("backup_timestamp", "2023-12-01-10-00-00");
+            properties.put(RestoreStmt.PROP_MEDIUM_SYNC_POLICY, value);
+
+            RestoreStmt stmt = new RestoreStmt(labelName, repoName, tableRefClause, properties);
+            
+            try {
+                stmt.analyzeProperties();
+                Assert.fail("Should throw AnalysisException for invalid value: " + value);
+            } catch (AnalysisException e) {
+                Assert.assertTrue("Error message should mention invalid value", 
+                                e.getMessage().contains("Invalid medium sync policy value"));
+            }
+        }
+    }
+} 

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupMetaTest.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.backup;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.DataProperty;
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.util.UnitTestUtil;
+import org.apache.doris.thrift.TStorageMedium;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.After;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class BackupMetaTest {
+
+    private long dbId = 1;
+    private long tblId = 2;
+    private long partId = 3;
+    private long idxId = 4;
+    private long tabletId = 5;
+    private long backendId = 10000;
+    private long version = 6;
+
+    private Database db;
+    private OlapTable originalTable;
+
+    @Before
+    public void setUp() {
+        // Create test database and table
+        db = UnitTestUtil.createDb(dbId, tblId, partId, idxId, tabletId, backendId, version);
+        originalTable = (OlapTable) db.getTableNullable(tblId);
+        Assert.assertNotNull(originalTable);
+    }
+
+    @Test
+    public void testBackupMetaPreservesOriginalStorageMedium() {
+        // Test case 1: Backup operation should always preserve original SSD medium
+        // Set partition to SSD storage medium
+        Partition partition = originalTable.getPartition(partId);
+        Assert.assertNotNull(partition);
+        
+        DataProperty ssdProperty = new DataProperty(TStorageMedium.SSD);
+        originalTable.getPartitionInfo().setDataProperty(partId, ssdProperty);
+        
+        // Verify original table has SSD storage medium
+        TStorageMedium originalMedium = originalTable.getPartitionInfo().getDataProperty(partId).getStorageMedium();
+        Assert.assertEquals(TStorageMedium.SSD, originalMedium);
+        
+        // Create selective copy for backup (isForBackup=true)
+        OlapTable copiedTable = originalTable.selectiveCopy(null, IndexExtState.VISIBLE, true);
+        Assert.assertNotNull(copiedTable);
+        
+        // Verify that the copied table preserves the original SSD medium
+        TStorageMedium copiedMedium = copiedTable.getPartitionInfo().getDataProperty(partId).getStorageMedium();
+        Assert.assertEquals("Backup operation should always preserve original storage medium", 
+                          TStorageMedium.SSD, copiedMedium);
+        
+        // Test case 2: Verify non-backup operations also preserve medium
+        OlapTable copiedTableNonBackup = originalTable.selectiveCopy(null, IndexExtState.VISIBLE, false);
+        Assert.assertNotNull(copiedTableNonBackup);
+        
+        // For non-backup operations, the original medium should be preserved
+        TStorageMedium nonBackupMedium = copiedTableNonBackup.getPartitionInfo().getDataProperty(partId).getStorageMedium();
+        Assert.assertEquals("Non-backup operations should preserve original medium", 
+                          TStorageMedium.SSD, nonBackupMedium);
+    }
+
+    @Test
+    public void testBackupMetaWithHDDPartition() {
+        // Test the default HDD case - backup should always preserve original medium
+        // Verify original table has HDD storage medium (default from UnitTestUtil.createDb)
+        TStorageMedium originalMedium = originalTable.getPartitionInfo().getDataProperty(partId).getStorageMedium();
+        Assert.assertEquals(TStorageMedium.HDD, originalMedium);
+        
+        // Create selective copy for backup
+        OlapTable copiedTable = originalTable.selectiveCopy(null, IndexExtState.VISIBLE, true);
+        Assert.assertNotNull(copiedTable);
+        
+        // Verify that HDD medium is preserved
+        TStorageMedium copiedMedium = copiedTable.getPartitionInfo().getDataProperty(partId).getStorageMedium();
+        Assert.assertEquals("HDD medium should be preserved during backup", 
+                          TStorageMedium.HDD, copiedMedium);
+    }
+} 

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobMediumSyncTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobMediumSyncTest.java
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.backup;
+
+import org.apache.doris.analysis.RestoreStmt;
+import org.apache.doris.catalog.ReplicaAllocation;
+import org.apache.doris.catalog.Env;
+
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RestoreJobMediumSyncTest {
+
+    @Mocked
+    private Env env;
+
+    @Test
+    public void testMediumSyncPolicyHDD() {
+        // Test case 1: medium_sync_policy = "hdd" should not preserve upstream storage medium
+        RestoreJob restoreJob = createRestoreJobWithMediumSyncPolicy(RestoreStmt.MEDIUM_SYNC_POLICY_HDD);
+        
+        // Verify that preserveStorageMedium() returns false for HDD policy
+        Assert.assertFalse("HDD policy should not preserve upstream storage medium", 
+                          restoreJob.preserveStorageMedium());
+        
+        // Verify medium sync policy is correctly set
+        Assert.assertEquals("Medium sync policy should be HDD", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_HDD, restoreJob.getMediumSyncPolicy());
+    }
+
+    @Test
+    public void testMediumSyncPolicySameWithUpstream() {
+        // Test case 2: medium_sync_policy = "same_with_upstream" should preserve upstream storage medium
+        RestoreJob restoreJob = createRestoreJobWithMediumSyncPolicy(RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM);
+        
+        // Verify that preserveStorageMedium() returns true for same_with_upstream policy
+        Assert.assertTrue("Same with upstream policy should preserve upstream storage medium", 
+                         restoreJob.preserveStorageMedium());
+        
+        // Verify medium sync policy is correctly set
+        Assert.assertEquals("Medium sync policy should be same_with_upstream", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM, restoreJob.getMediumSyncPolicy());
+    }
+
+    @Test
+    public void testDefaultMediumSyncPolicy() {
+        // Test case 3: Test default behavior when no medium sync policy is specified
+        RestoreJob restoreJob = createRestoreJobWithMediumSyncPolicy(null);
+        
+        // Verify default behavior (should be same as HDD policy)
+        Assert.assertFalse("Default policy should not preserve upstream storage medium", 
+                          restoreJob.preserveStorageMedium());
+        
+        // Verify medium sync policy is null
+        Assert.assertNull("Medium sync policy should be null when not specified", 
+                         restoreJob.getMediumSyncPolicy());
+    }
+    
+    @Test 
+    public void testMediumPolicyArchitectureImprovement() {
+        // Test that the new architecture passes policy instead of pre-determined medium
+        RestoreJob sameWithUpstreamJob = createRestoreJobWithMediumSyncPolicy(RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM);
+        RestoreJob hddJob = createRestoreJobWithMediumSyncPolicy(RestoreStmt.MEDIUM_SYNC_POLICY_HDD);
+        
+        // Verify that resetIdsForRestore will receive the policy, not a pre-computed medium
+        // This allows per-partition medium decision making inside resetIdsForRestore
+        Assert.assertEquals("Should preserve policy for downstream processing", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_SAME_WITH_UPSTREAM, sameWithUpstreamJob.getMediumSyncPolicy());
+        Assert.assertEquals("Should preserve policy for downstream processing", 
+                          RestoreStmt.MEDIUM_SYNC_POLICY_HDD, hddJob.getMediumSyncPolicy());
+        
+        // The decision logic should be delegated to OlapTable.resetIdsForRestore method
+        // which can handle per-partition medium selection based on the policy
+        Assert.assertTrue("Same with upstream should trigger preserve logic", sameWithUpstreamJob.preserveStorageMedium());
+        Assert.assertFalse("HDD policy should not trigger preserve logic", hddJob.preserveStorageMedium());
+    }
+
+    @Test
+    public void testInvalidMediumSyncPolicy() {
+        // Test case 4: Test behavior with invalid medium sync policy
+        RestoreJob restoreJob = createRestoreJobWithMediumSyncPolicy("invalid_policy");
+        
+        // Verify that invalid policy is treated as default (like HDD policy)
+        Assert.assertFalse("Invalid policy should not preserve upstream storage medium", 
+                          restoreJob.preserveStorageMedium());
+        
+        // Verify medium sync policy is set to the invalid value
+        Assert.assertEquals("Medium sync policy should be the invalid value", 
+                          "invalid_policy", restoreJob.getMediumSyncPolicy());
+    }
+
+    private RestoreJob createRestoreJobWithMediumSyncPolicy(String mediumSyncPolicy) {
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        jobInfo.dbName = "test_db";
+        
+        return new RestoreJob("test_restore", "20231201000000", 1, "test_db", 
+                            jobInfo, false, ReplicaAllocation.DEFAULT_ALLOCATION, 
+                            3600000, -1, false, false, false, false, 
+                            false, false, false, false, mediumSyncPolicy, env, 1);
+    }
+} 

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -260,7 +260,7 @@ public class RestoreJobTest {
 
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), jobInfo, false,
                 new ReplicaAllocation((short) 3), 100000, -1, false, false, false, false, false, false, false, false,
-                env, repo.getId());
+                "hdd", env, repo.getId());
 
         List<Table> tbls = Lists.newArrayList();
         List<Resource> resources = Lists.newArrayList();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1221,6 +1221,7 @@ struct TRestoreSnapshotRequest {
     15: optional bool atomic_restore
     16: optional bool compressed;
     17: optional bool force_replace
+    18: optional string medium_sync_policy
 }
 
 struct TRestoreSnapshotResult {


### PR DESCRIPTION
### What problem does this PR solve?
## **Overview**

This PR enhances CCR (Cross-Cluster Replication) synchronization capabilities with two distinct sync strategies. The enhancement addresses medium compatibility issues between upstream and downstream clusters while maintaining data availability through intelligent fallback mechanisms.
![sync](https://github.com/user-attachments/assets/43430f86-f7ef-4927-ac43-cf28848bad06)

## **Background & Problem**

In CCR scenarios, upstream and downstream clusters often have different storage configurations, but current implementation uses a rigid approach:

- **Upstream cluster**: May have diverse medium configurations (SSD/HDD/Mixed)
- **Downstream cluster**: May have different medium availability (SSD-only/HDD-only/Mixed)
- **Current approach**: Force all data to use HDD medium in downstream cluster
- **Limitations**: 
  - Under special circumstances, the performance of SSD cannot be utilized.

## **Solution: Two-Strategy Approach**

There are two `medium_sync_policy` strategies:

### **Strategy 1: `hdd` (Try HDD)**

- **FE shows**: HDD for all tables
- **BE shows**: Any available BE(HDD medium first)
- **Use case**: Standardize all data to HDD storage

### **Strategy 2: `same_with_upstream` (Try Preserve Original)**  

- **FE shows**: Original medium from backup
- **Be shows**: Any available BE(Original medium first)
- **Use case**: Maintain original medium when possible

## **Technical Implementation**
> The following examples are scenarios where the table/partition does not exist in the downstream cluster.
### **Backup Enhancement**

- **Before**: Fixed HDD metadata storage
- **After**: Save actual original medium information (SSD/HDD/Mixed)

### **Two-Layer Fallback Mechanism**

1. **FE Layer**: BE ids selection with fallback capability
2. **BE Layer**: Storage-level fallback controlled by `enable_storage_medium_fallback`

## **Strategy Comparison**

| Aspect                | `hdd` Strategy             | `same_with_upstream` Strategy         |
| --------------------- | -------------------------- | ------------------------------------- |
| **FE Display**        | Always shows HDD           | Shows original medium (SSD/HDD/Mixed) |
| **Target Medium**     | Force HDD for all tables   | Preserve original medium per table    |
| **Fallback Behavior** | HDD → Any available medium | Original → Any available medium       |

## **Examples**

### **Scenario 1: Upstream SSD → Downstream HDD-only**

```sql
-- hdd strategy
RESTORE SNAPSHOT [db_name].{snapshot_name} FROM `repository_name` PROPERTIES('medium_sync_policy' = 'hdd');
```

- **FE**: Shows HDD medium for all tables
- **BE**: Naturally uses HDD storage (perfect match)

```sql
-- same_with_upstream strategy  
RESTORE SNAPSHOT [db_name].{snapshot_name} FROM `repository_name` PROPERTIES('medium_sync_policy' = 'same_with_upstream');
```

- **FE**: Shows SSD medium (original)
- **BE**: Tries SSD, falls back to HDD (`enable_storage_medium_fallback=true`)

### **Scenario 2: Upstream Mixed → Downstream Mixed**

| Table     | Original Medium | `hdd` Strategy | `same_with_upstream` Strategy |
| --------- | --------------- | -------------- | ----------------------------- |
| orders    | SSD             | HDD (forced)   | SSD (preserved)               |
| logs      | HDD             | HDD (natural)  | HDD (preserved)               |
| analytics | SSD             | HDD (forced)   | SSD (preserved)               |

## **Configuration Options**

### **BE Configuration: `enable_storage_medium_fallback`**

- `true`: Allow medium switching when target unavailable
- `false`: Strict mode (fail if unavailable)
- **Single medium environment**: Always allow fallback (availability over strictness)


##ssue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

