### PR TITLE
[fix](doris compose) be disable java support

### DIFF
--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -588,6 +588,9 @@ class BE(Node):
 
     def get_add_init_config(self):
         cfg = super().get_add_init_config()
+        cfg += [
+            'enable_java_support = false',
+        ]
         if self.cluster.be_config:
             cfg += self.cluster.be_config
         if self.cluster.is_cloud:


### PR DESCRIPTION
### What problem does this PR solve?

be sometimes hang at libjvm when it start,  we don't known why.

so disable be java support. only after we fix the be hang at libjvm, we enable java support again.

```
Thread 1 (LWP 867 "doris_be"):
#0  0x00007fc6b09087b2 in __pthread_cond_signal_2_0 (cond=0x0) at old_pthread_cond_signal.c:40
#1  0x00007fffab25a2f0 in ?? ()
#2  0x00000000ab25a2f0 in ?? ()
#3  0x00007fc6b1a9436e in WeakHandle::WeakHandle(OopStorage*, oopDesc*) () from /usr/local/openjdk-17/lib/server/libjvm.so
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
[Inferior 1 (process 867) detached]
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

