### PR TITLE
[Fix](dictionary) Fix concurrency conflict when collect dictionary status

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/Dictionary.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/Dictionary.java
@@ -108,7 +108,7 @@ public class Dictionary extends Table {
     // if srcVersion same with this, we could skip automatically update.
     private long latestInvalidVersion = 0;
 
-    private List<DictionaryDistribution> dataDistributions; // every time update, reset with a new list
+    private volatile List<DictionaryDistribution> dataDistributions; // every time update, reset with a new list
     private String lastUpdateResult;
 
     // we need this to call Table's constructor with no args which construct new rwLock and more.
@@ -387,6 +387,10 @@ public class Dictionary extends Table {
         return "{" + StringUtils.join(dataDistributions, ", ") + "}";
     }
 
+    public void setDataDistributions(List<DictionaryDistribution> dataDistributions) {
+        this.dataDistributions = dataDistributions;
+    }
+
     public List<DictionaryDistribution> getDataDistributions() {
         return dataDistributions;
     }
@@ -423,7 +427,8 @@ public class Dictionary extends Table {
         if (dataDistributions == null || dataDistributions.isEmpty()) {
             // only called when do partial load. it bases on collection of data distributions.
             // so dataDistributions should not be null.
-            LOG.warn("dataDistributions of " + getName() + " is null or empty. should not happen");
+            LOG.warn("dataDistributions of " + getName() + " is " + (dataDistributions == null ? "null" : "empty")
+                    + ". should not happen");
             return backends;
         }
         Set<Long> validBEs = Sets.newHashSet();

--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -472,6 +472,9 @@ public class DictionaryManager extends MasterDaemon implements Writable {
             if (!ctx.getStatementContext().isPartialLoadDictionary()) {
                 dictionary.increaseVersion();
                 Env.getCurrentEnv().getEditLog().logDictionaryIncVersion(dictionary);
+            } else {
+                LOG.info("Dictionary {} is partial load, not increase version, keep {}", dictionary.getName(),
+                        dictionary.getVersion());
             }
         } finally {
             if (!unlocked) {
@@ -667,11 +670,13 @@ public class DictionaryManager extends MasterDaemon implements Writable {
      */
     public Map<Long, List<Long>> collectDictionaryStatus(List<Long> queryDicts) throws RuntimeException {
         Map<Long, List<Long>> unknownDictionaries = Maps.newHashMap();
-        // make the old stats of query dicts expired
+        // if dict is loading, may query dataDistribution. so we should do atomic replace at the end. otherwise may
+        // lead to wrong dataDistribution. when planning to load.
+        Map<Long, List<DictionaryDistribution>> newDataDistributions = Maps.newHashMap();
         if (queryDicts == null) {
             queryDicts = ImmutableList.of(); // query all dictionaries
             for (Dictionary dictionary : idToDictionary.values()) {
-                dictionary.resetDataDistributions();
+                newDataDistributions.put(dictionary.getId(), Lists.newArrayList());
             }
         } else {
             for (Long dictId : queryDicts) {
@@ -679,7 +684,7 @@ public class DictionaryManager extends MasterDaemon implements Writable {
                 if (dictionary == null) {
                     throw new RuntimeException("Dictionary " + dictId + " does not exist");
                 }
-                dictionary.resetDataDistributions();
+                newDataDistributions.put(dictionary.getId(), Lists.newArrayList());
             }
         }
 
@@ -730,7 +735,25 @@ public class DictionaryManager extends MasterDaemon implements Writable {
                         status.getDictionaryMemorySize());
 
                 // add new distribution to list
-                dictionary.getDataDistributions().add(newDistribution);
+                if (newDataDistributions.containsKey(dictionaryId)) {
+                    newDataDistributions.get(dictionaryId).add(newDistribution);
+                } else {
+                    // maybe new dictionary added when collecting status. just skip them.
+                    LOG.warn("Dictionary {}-{} not found in FE when collecting status", dictionaryId,
+                            dictionary.getName());
+                }
+            }
+        }
+        // replace results
+        for (Map.Entry<Long, List<DictionaryDistribution>> entry : newDataDistributions.entrySet()) {
+            Long dictId = entry.getKey();
+            List<DictionaryDistribution> distributions = entry.getValue();
+            Dictionary dictionary = idToDictionary.get(dictId);
+            if (dictionary != null) {
+                // replace dataDistributions with new one
+                dictionary.setDataDistributions(distributions);
+            } else {
+                LOG.warn("Dictionary {} not found when collecting status", dictId);
             }
         }
         LOG.info("Collect all dictionaries status succeed");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Fix bugs like:
```
2025-06-26 21:20:21,353 WARN (dictionary-task-execute-1-thread-3|211) [Dictionary.filterOutdatedBEs():426] dataDistributions of advertiser_dict is null or empty. should not happen
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

