### PR TITLE
[Opt](cloud-mow) Don't do lease for compaction job when commit compaction job

### DIFF
--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -112,7 +112,7 @@ protected:
     RowsetSharedPtr _output_rowset;
     std::unique_ptr<RowsetWriter> _output_rs_writer;
 
-    enum CompactionState : uint8_t { INITED = 0, SUCCESS = 1 };
+    enum CompactionState : uint8_t { INITED = 0, COMMITTING = 1, SUCCESS = 2 };
     CompactionState _state {CompactionState::INITED};
 
     bool _is_vertical;


### PR DESCRIPTION
### What problem does this PR solve?
When commit copmaction job on MS, it may encounter fdb txn conflict if a lease on the same compaction finished before compaction commit finishes. This may result in long compaction hold lock time due to long MS RPC backoff time.
This PR forbid do_lease on compaction if it's being commited.
```
I20250627 12:13:36.379174  5073 meta_service_helper.h:128] begin finish_tablet_job from 172.20.57.236:44202 request=cloud_unique_id: "1:5201314:cognNvoQ" action: COMMIT job { idx { table_id: 1750991434079 index_id: 1750991434080 partition_id: 1750991434078 tablet_id: 1750991434534 } compaction { initiator: "172.20.57.236:9050" type: CUMULATIVE input_cumulative_point: 36718 output_cumulative_point: 36718 num_input_rowsets: 17 num_input_segments: 7 num_output_rowsets: 1 num_output_segments: 1 size_input_rowsets: 33005 size_output_rowsets: 8082 num_input_rows: 101 num_output_rows: 101 input_versions: 36718 input_versions: 36953 output_versions: 36953 output_rowset_ids: "0200000000175cbbdb4b57836d7c69fb2cec40bb5d24ef8f" txn_id: 3444105666166667616 id: "dbc633ee-544b-4747-bedd-94c1f18522d3" delete_bitmap_lock_initiator: 8285608199103584638 index_size_input_rowsets: 0 segment_size_input_rowsets: 33005 index_size_output_rowsets: 0 segment_size_output_rowsets: 8082 } }
...
I20250627 12:13:36.383939  5089 meta_service_helper.h:128] begin finish_tablet_job from 172.20.57.236:46220 request=cloud_unique_id: "1:5201314:cognNvoQ" action: LEASE job { idx { table_id: 1750991434079 index_id: 1750991434080 partition_id: 1750991434078 tablet_id: 1750991434534 } compaction { id: "dbc633ee-544b-4747-bedd-94c1f18522d3" lease: 1750997696 } }
I20250627 12:13:36.393448  5071 meta_service_helper.h:183] finish finish_tablet_job from 172.20.57.236:46220 response=status { code: OK msg: "" }
...
I20250627 12:13:36.394833  5076 meta_service_helper.h:183] finish finish_tablet_job from 172.20.57.236:44202 response=status { code: KV_TXN_CONFLICT msg: "failed to commit job kv, err=Conflict" } stats { idx { table_id: 1750991434079 index_id: 1750991434080 partition_id: 1750991434078 tablet_id: 1750991434534 } data_size: 646770 num_rows: 15124 num_rowsets: 39 num_segments: 36 base_compaction_cnt: 1 cumulative_compaction_cnt: 1327 cumulative_point: 36718 last_base_compaction_time_ms: 1750992284000 last_cumu_compaction_time_ms: 1750997616000 index_size: 0 segment_size: 646770 } alter_version: -1
W20250627 12:13:36.394862  5076 meta_service.h:843] void doris::cloud::MetaServiceProxy::call_impl(MetaServiceMethod<Request, Response>, ::google::protobuf::RpcController *, const Request *, Response *, ::google::protobuf::Closure *) [Request = doris::cloud::FinishTabletJobRequest, Response = doris::cloud::FinishTabletJobResponse] sleep 981 ms before next round, retry times left: 3, code: KV_TXN_CONFLICT, msg: failed to commit job kv, err=Conflict
```

![image](https://github.com/user-attachments/assets/29219544-54d7-4080-94b5-61773e6694b3)


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

