### PR TITLE
branch-2.1: [fix](nereids) exceed expr limit error not fallback to legacy planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.analyzer.PlaceholderExpression;
 import org.apache.doris.nereids.analyzer.Unbound;
 import org.apache.doris.nereids.analyzer.UnboundVariable;
 import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.exceptions.DoNotFallbackException;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.AbstractTreeNode;
 import org.apache.doris.nereids.trees.expressions.ArrayItemReference.ArrayItemSlot;
@@ -182,11 +183,11 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
 
     private void checkLimit() {
         if (depth > Config.expr_depth_limit) {
-            throw new AnalysisException(String.format("Exceeded the maximum depth of an "
+            throw new DoNotFallbackException(String.format("Exceeded the maximum depth of an "
                     + "expression tree (%s).", Config.expr_depth_limit));
         }
         if (width > Config.expr_children_limit) {
-            throw new AnalysisException(String.format("Exceeded the maximum children of an "
+            throw new DoNotFallbackException(String.format("Exceeded the maximum children of an "
                     + "expression tree (%s).", Config.expr_children_limit));
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -183,12 +183,12 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
 
     private void checkLimit() {
         if (depth > Config.expr_depth_limit) {
-            throw new DoNotFallbackException(String.format("Exceeded the maximum depth of an "
-                    + "expression tree (%s).", Config.expr_depth_limit));
+            throw new DoNotFallbackException(String.format("Expression %s with depth %s, Exceeded the maximum depth "
+                    + "of an expression tree (%s).", getClass().getSimpleName(), depth, Config.expr_depth_limit));
         }
         if (width > Config.expr_children_limit) {
-            throw new DoNotFallbackException(String.format("Exceeded the maximum children of an "
-                    + "expression tree (%s).", Config.expr_children_limit));
+            throw new DoNotFallbackException(String.format("Expression %s with width %s, Exceeded the maximum children "
+                    + "of an expression tree (%s).", getClass().getSimpleName(), width, Config.expr_children_limit));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -35,6 +35,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ConnectionException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.NotImplementedException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
@@ -53,6 +54,7 @@ import org.apache.doris.mysql.MysqlServerStatusFlag;
 import org.apache.doris.nereids.SqlCacheContext;
 import org.apache.doris.nereids.SqlCacheContext.CacheKeyType;
 import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.exceptions.DoNotFallbackException;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.nereids.exceptions.ParseException;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -278,6 +280,11 @@ public abstract class ConnectProcessor {
                     // Because ParseException means the sql is not supported by Nereids.
                     // It should be parsed by old parser, so not setting nereidsParseException to avoid
                     // suppressing the exception thrown by old parser.
+                } catch (DoNotFallbackException e) {
+                    LOG.warn("nereids parse met not fallback error, ", e);
+                    handleQueryException(new UserException(InternalErrorCode.INTERNAL_ERR, e.getMessage()),
+                            convertedStmt, null, null);
+                    return;
                 } catch (Exception e) {
                     // TODO: We should catch all exception here until we support all query syntax.
                     if (LOG.isDebugEnabled()) {

--- a/regression-test/suites/nereids_p0/expression/check_expr_limit.groovy
+++ b/regression-test/suites/nereids_p0/expression/check_expr_limit.groovy
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('check_expr_limit', 'nonConcurrent') {
+    setFeConfigTemporary([expr_children_limit : 20]) {
+        test {
+            sql 'select 1 in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)'
+            exception 'Expression InPredicate with width 26, Exceeded the maximum children of an expression tree (20).'
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Legacy planner check expr limit is not reliable. When planner expr change,  it need explict call expr.analyse to check the limit.

Nereids planner check expr limit at expr's construct function,  it's reliable.

So nereids don't fallback to legacy planner when met exceed expr limit error,  this can avoid legacy planner forget to check the expr limit and use a lot of memory. 


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

