### PR TITLE
[fix](vectorized): Fix heap-use-after-free in VCompoundPred null map handling

### DIFF
--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -231,7 +231,9 @@ public:
         auto create_null_map_column = [&](ColumnPtr& null_map_column,
                                           uint8_t* __restrict null_map_data) {
             if (null_map_data == nullptr) {
-                null_map_column = ColumnUInt8::create(size, 0);
+                if (null_map_column == nullptr) {
+                    null_map_column = ColumnUInt8::create(size, 0);
+                }
                 null_map_data = assert_cast<ColumnUInt8*>(null_map_column->assume_mutable().get())
                                         ->get_data()
                                         .data();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This PR fixes a critical heap-use-after-free bug in `VCompoundPred::execute` method that occurs when processing compound predicates (AND/OR operations) with mixed boolean values.

**Root Cause:**
The bug was in the `create_null_map_column` lambda function within the `vector_vector_null` execution path. The lambda used a single shared `temp_null_map` variable to store temporary columns for both left-hand-side (lhs) and right-hand-side (rhs) null maps. When called twice:

1. First call creates a column and stores raw pointer to its data
2. Second call overwrites `temp_null_map`, destroying the first column
3. The raw pointer from the first call now points to freed memory
4. Subsequent access to this pointer causes heap-use-after-free

**When it occurs:**
- Only triggered when both child expressions return `is_compound_predicate() = false`
- Only affects compound predicates with mixed boolean values (not all-true or all-false)
- Optimization paths for uniform values (all-true/all-false) avoid this code path entirely

**Impact:**
- Crashes with AddressSanitizer heap-use-after-free error
- Affects real-world queries with complex boolean expressions
- Previously undetected due to most tests hitting optimization paths

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

