### PR TITLE
[fix](build) Replace legacy endian macros for macOS compatibility

### DIFF
--- a/be/src/glibc-compatibility/musl/libm.h
+++ b/be/src/glibc-compatibility/musl/libm.h
@@ -8,7 +8,7 @@
 #include "musl_features.h"
 
 #if LDBL_MANT_DIG == 53 && LDBL_MAX_EXP == 1024
-#elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER == __LITTLE_ENDIAN
+#elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 union ldshape {
 	long double f;
 	struct {
@@ -16,7 +16,7 @@ union ldshape {
 		uint16_t se;
 	} i;
 };
-#elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER == __BIG_ENDIAN
+#elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 /* This is the m68k variant of 80-bit long double, and this definition only works
  * on archs where the alignment requirement of uint64_t is <= 4. */
 union ldshape {
@@ -27,7 +27,7 @@ union ldshape {
 		uint64_t m;
 	} i;
 };
-#elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER == __LITTLE_ENDIAN
+#elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 union ldshape {
 	long double f;
 	struct {
@@ -41,7 +41,7 @@ union ldshape {
 		uint64_t hi;
 	} i2;
 };
-#elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER == __BIG_ENDIAN
+#elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384 && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 union ldshape {
 	long double f;
 	struct {

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -192,7 +192,7 @@ public:
     // Returns the rounded up to 32 multiple. Used for conversions of bits to i32.
     constexpr static inline uint32_t round_up_numi32(uint32_t bits) { return (bits + 31) >> 5; }
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     // Converts to big endian format (if not already in big endian).
     static inline int64_t big_endian(int64_t value) { return byte_swap(value); }
     static inline uint64_t big_endian(uint64_t value) { return byte_swap(value); }

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -4328,7 +4328,7 @@ private:
             return;
         }
         const char* bytes = (const char*)(num);
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
         int k = 3;
         for (; k >= 0; --k) {
             if (bytes[k]) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #51889

Problem Summary:

Fixes macOS compilation errors by replacing legacy endian macros (`__BYTE_ORDER`, `__LITTLE_ENDIAN`) with modern standard macros (`__BYTE_ORDER__`, `__ORDER_LITTLE_ENDIAN__`).

The issue was introduced in commit 2d513dfe71 which removed `gutil/port.h`. This file previously provided legacy macro definitions for macOS, but after removal, only Linux retained these macros through system `<endian.h>`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

