### PR TITLE
[feat](load) quorum success write (part II)

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -229,6 +229,7 @@ Status LoadStreamStub::append_data(int64_t partition_id, int64_t index_id, int64
     header.set_offset(offset);
     header.set_opcode(doris::PStreamHeader::APPEND_DATA);
     header.set_file_type(file_type);
+    add_write_tablets(tablet_id);
     return _encode_and_send(header, data);
 }
 
@@ -253,6 +254,7 @@ Status LoadStreamStub::add_segment(int64_t partition_id, int64_t index_id, int64
     if (flush_schema != nullptr) {
         flush_schema->to_schema_pb(header.mutable_flush_schema());
     }
+    add_write_tablets(tablet_id);
     return _encode_and_send(header);
 }
 
@@ -318,7 +320,7 @@ Status LoadStreamStub::wait_for_schema(int64_t partition_id, int64_t index_id, i
     watch.start();
     while (!_tablet_schema_for_index->contains(index_id) &&
            watch.elapsed_time() / 1000 / 1000 < timeout_ms) {
-        RETURN_IF_ERROR(_check_cancel());
+        RETURN_IF_ERROR(check_cancel());
         static_cast<void>(wait_for_new_schema(100));
     }
 
@@ -345,7 +347,7 @@ Status LoadStreamStub::close_finish_check(RuntimeState* state, bool* is_closed) 
         return _status;
     }
     if (_is_closed.load()) {
-        RETURN_IF_ERROR(_check_cancel());
+        RETURN_IF_ERROR(check_cancel());
         if (!_is_eos.load()) {
             return Status::InternalError("Stream closed without EOS, {}", to_string());
         }
@@ -381,6 +383,7 @@ Status LoadStreamStub::_encode_and_send(PStreamHeader& header, std::span<const S
     }
     bool eos = header.opcode() == doris::PStreamHeader::CLOSE_LOAD;
     bool get_schema = header.opcode() == doris::PStreamHeader::GET_SCHEMA;
+    add_bytes_written(buf.size());
     return _send_with_buffer(buf, eos || get_schema);
 }
 
@@ -469,7 +472,7 @@ void LoadStreamStub::_handle_failure(butil::IOBuf& buf, Status st) {
 
 Status LoadStreamStub::_send_with_retry(butil::IOBuf& buf) {
     for (;;) {
-        RETURN_IF_ERROR(_check_cancel());
+        RETURN_IF_ERROR(check_cancel());
         int ret;
         {
             DBUG_EXECUTE_IF("LoadStreamStub._send_with_retry.delay_before_send", {

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -501,6 +501,10 @@ Status VTabletWriterV2::write(RuntimeState* state, Block& input_block) {
     // For each tablet, send its input_rows from block to delta writer
     for (const auto& [tablet_id, rows] : rows_for_tablet) {
         RETURN_IF_ERROR(_write_memtable(block, tablet_id, rows));
+        {
+            std::lock_guard<std::mutex> l(_write_tablets_lock);
+            _write_tablets.insert(tablet_id);
+        }
     }
 
     COUNTER_SET(_input_rows_counter, _number_input_rows);
@@ -666,7 +670,10 @@ Status VTabletWriterV2::close(Status exec_status) {
         // close_wait on all non-incremental streams, even if this is not the last sink.
         // because some per-instance data structures are now shared among all sinks
         // due to sharing delta writers and load stream stubs.
-        RETURN_IF_ERROR(_close_wait(_non_incremental_streams()));
+        // Do not need to wait after quorum success,
+        // for first-stage close_wait only ensure incremental streams load has been completed,
+        // unified waiting in the second-stage close_wait.
+        RETURN_IF_ERROR(_close_wait(_non_incremental_streams(), false));
 
         // send CLOSE_LOAD on all incremental streams if this is the last sink.
         // this must happen after all non-incremental streams are closed,
@@ -676,7 +683,7 @@ Status VTabletWriterV2::close(Status exec_status) {
         }
 
         // close_wait on all incremental streams, even if this is not the last sink.
-        RETURN_IF_ERROR(_close_wait(_incremental_streams()));
+        RETURN_IF_ERROR(_close_wait(_all_streams(), true));
 
         // calculate and submit commit info
         if (is_last_sink) {
@@ -721,17 +728,15 @@ Status VTabletWriterV2::close(Status exec_status) {
     return status;
 }
 
-std::unordered_set<std::shared_ptr<LoadStreamStub>> VTabletWriterV2::_incremental_streams() {
-    std::unordered_set<std::shared_ptr<LoadStreamStub>> incremental_streams;
+std::unordered_set<std::shared_ptr<LoadStreamStub>> VTabletWriterV2::_all_streams() {
+    std::unordered_set<std::shared_ptr<LoadStreamStub>> all_streams;
     auto streams_for_node = _load_stream_map->get_streams_for_node();
     for (const auto& [dst_id, streams] : streams_for_node) {
         for (const auto& stream : streams->streams()) {
-            if (stream->is_incremental()) {
-                incremental_streams.insert(stream);
-            }
+            all_streams.insert(stream);
         }
     }
-    return incremental_streams;
+    return all_streams;
 }
 
 std::unordered_set<std::shared_ptr<LoadStreamStub>> VTabletWriterV2::_non_incremental_streams() {
@@ -748,25 +753,165 @@ std::unordered_set<std::shared_ptr<LoadStreamStub>> VTabletWriterV2::_non_increm
 }
 
 Status VTabletWriterV2::_close_wait(
-        std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams) {
+        std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams,
+        bool need_wait_after_quorum_success) {
     SCOPED_TIMER(_close_load_timer);
     Status status;
     auto streams_for_node = _load_stream_map->get_streams_for_node();
+    // 1. first wait for quorum success
     while (true) {
         RETURN_IF_ERROR(_check_timeout());
         RETURN_IF_ERROR(_check_streams_finish(unfinished_streams, status, streams_for_node));
-        if (!status.ok() || unfinished_streams.empty()) {
-            LOG(INFO) << "is all unfinished: " << unfinished_streams.empty()
-                      << ", status: " << status << ", txn_id: " << _txn_id
-                      << ", load_id: " << print_id(_load_id);
+        bool quorum_success = _quorum_success(unfinished_streams);
+        if (quorum_success || unfinished_streams.empty()) {
+            LOG(INFO) << "quorum_success: " << quorum_success
+                      << ", is all unfinished: " << unfinished_streams.empty()
+                      << ", txn_id: " << _txn_id << ", load_id: " << print_id(_load_id);
             break;
         }
         bthread_usleep(1000 * 10);
     }
+
+    // 2. then wait for remaining streams as much as possible
+    if (!unfinished_streams.empty() && need_wait_after_quorum_success) {
+        int64_t max_wait_time_ms = _calc_max_wait_time_ms(streams_for_node, unfinished_streams);
+        while (true) {
+            RETURN_IF_ERROR(_check_timeout());
+            RETURN_IF_ERROR(_check_streams_finish(unfinished_streams, status, streams_for_node));
+            if (unfinished_streams.empty()) {
+                break;
+            }
+            int64_t elapsed_ms = _timeout_watch.elapsed_time() / 1000 / 1000;
+            if (elapsed_ms > max_wait_time_ms ||
+                _state->execution_timeout() - elapsed_ms / 1000 <
+                        config::quorum_success_remaining_timeout_seconds) {
+                std::stringstream unfinished_streams_str;
+                for (const auto& stream : unfinished_streams) {
+                    unfinished_streams_str << stream->stream_id() << ",";
+                }
+                LOG(WARNING) << "reach max wait time, max_wait_time_ms: " << max_wait_time_ms
+                             << ", load_id=" << print_id(_load_id) << ", txn_id=" << _txn_id
+                             << ", unfinished streams: " << unfinished_streams_str.str();
+                break;
+            }
+            bthread_usleep(1000 * 10);
+        }
+    }
+
     if (!status.ok()) {
         LOG(WARNING) << "close_wait failed: " << status << ", load_id=" << print_id(_load_id);
     }
     return status;
+}
+
+bool VTabletWriterV2::_quorum_success(
+        const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams) {
+    if (!config::enable_quorum_success_write) {
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> l(_write_tablets_lock);
+        if (_write_tablets.empty()) {
+            return false;
+        }
+    }
+    std::unordered_map<int64_t, int64_t> finished_tablets_replica;
+    auto streams_for_node = _load_stream_map->get_streams_for_node();
+    std::unordered_set<int64_t> finished_dst_ids;
+
+    // 1. calculate finished tablets replica num
+    for (const auto& [dst_id, streams] : streams_for_node) {
+        bool finished = true;
+        for (const auto& stream : streams->streams()) {
+            if (unfinished_streams.contains(stream) || !stream->check_cancel().ok()) {
+                finished = false;
+                break;
+            }
+        }
+        if (finished) {
+            finished_dst_ids.insert(dst_id);
+        }
+    }
+    for (const auto& [dst_id, streams] : streams_for_node) {
+        if (!finished_dst_ids.contains(dst_id)) {
+            continue;
+        }
+        for (const auto& stream : streams->streams()) {
+            for (auto tablet_id : stream->write_tablets()) {
+                finished_tablets_replica[tablet_id]++;
+            }
+        }
+    }
+
+    // 2. check if quorum success
+    {
+        std::lock_guard<std::mutex> l(_write_tablets_lock);
+        for (const auto& tablet_id : _write_tablets) {
+            if (finished_tablets_replica[tablet_id] < _load_required_replicas_num(tablet_id)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+int VTabletWriterV2::_load_required_replicas_num(int64_t tablet_id) {
+    auto [total_replicas_num, load_required_replicas_num] = _tablet_replica_info[tablet_id];
+    if (total_replicas_num == 0) {
+        return (_num_replicas + 1) / 2;
+    }
+    return load_required_replicas_num;
+}
+
+int64_t VTabletWriterV2::_calc_max_wait_time_ms(
+        const std::unordered_map<int64_t, std::shared_ptr<LoadStreamStubs>>& streams_for_node,
+        const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams) {
+    // 1. calculate avg speed of all unfinished streams
+    int64_t elapsed_ms = _timeout_watch.elapsed_time() / 1000 / 1000;
+    int64_t total_bytes = 0;
+    int finished_count = 0;
+    for (const auto& [dst_id, streams] : streams_for_node) {
+        for (const auto& stream : streams->streams()) {
+            if (unfinished_streams.contains(stream) || !stream->check_cancel().ok()) {
+                continue;
+            }
+            total_bytes += stream->bytes_written();
+            finished_count++;
+        }
+    }
+    // no data loaded in index channel, return 0
+    if (total_bytes == 0 || finished_count == 0) {
+        return 0;
+    }
+    // if elapsed_ms is equal to 0, explain the loaded data is too small
+    if (elapsed_ms <= 0) {
+        return config::quorum_success_min_wait_seconds * 1000;
+    }
+    double avg_speed =
+            static_cast<double>(total_bytes) / (static_cast<double>(elapsed_ms) * finished_count);
+
+    // 2. calculate max wait time of each unfinished stream and return the max value
+    int64_t max_wait_time_ms = 0;
+    for (const auto& [dst_id, streams] : streams_for_node) {
+        for (const auto& stream : streams->streams()) {
+            if (unfinished_streams.contains(stream)) {
+                int64_t bytes = stream->bytes_written();
+                int64_t wait =
+                        avg_speed > 0 ? static_cast<int64_t>(static_cast<double>(bytes) / avg_speed)
+                                      : 0;
+                max_wait_time_ms = std::max(max_wait_time_ms, wait);
+            }
+        }
+    }
+
+    // 3. calculate max wait time
+    // introduce quorum_success_min_wait_time_ms to avoid jitter of small load
+    max_wait_time_ms =
+            std::max(static_cast<int64_t>(static_cast<double>(max_wait_time_ms) *
+                                          (1.0 + config::quorum_success_max_wait_multiplier)),
+                     config::quorum_success_min_wait_seconds * 1000);
+
+    return max_wait_time_ms;
 }
 
 Status VTabletWriterV2::_check_timeout() {
@@ -790,6 +935,8 @@ Status VTabletWriterV2::_check_streams_finish(
             }
             bool is_closed = false;
             auto stream_st = stream->close_finish_check(_state, &is_closed);
+            DBUG_EXECUTE_IF("VTabletWriterV2._check_streams_finish.close_stream_failed",
+                            { stream_st = Status::InternalError("close stream failed"); });
             if (!stream_st.ok()) {
                 status = stream_st;
                 unfinished_streams.erase(stream);

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -148,17 +148,27 @@ private:
 
     void _calc_tablets_to_commit();
 
-    std::unordered_set<std::shared_ptr<LoadStreamStub>> _incremental_streams();
-
     std::unordered_set<std::shared_ptr<LoadStreamStub>> _non_incremental_streams();
 
-    Status _close_wait(std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams);
+    std::unordered_set<std::shared_ptr<LoadStreamStub>> _all_streams();
+
+    Status _close_wait(std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams,
+                       bool need_wait_after_quorum_success);
+
+    bool _quorum_success(
+            const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams);
+
+    int _load_required_replicas_num(int64_t tablet_id);
 
     Status _check_timeout();
 
     Status _check_streams_finish(
             std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams, Status& status,
             const std::unordered_map<int64_t, std::shared_ptr<LoadStreamStubs>>& streams_for_node);
+
+    int64_t _calc_max_wait_time_ms(
+            const std::unordered_map<int64_t, std::shared_ptr<LoadStreamStubs>>& streams_for_node,
+            const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams);
 
     void _cancel(Status status);
 
@@ -244,6 +254,8 @@ private:
 
     // tablet_id -> <total replicas num, load required replicas num>
     std::unordered_map<int64_t, std::pair<int, int>> _tablet_replica_info;
+    std::mutex _write_tablets_lock;
+    std::unordered_set<int64_t> _write_tablets;
 };
 
 } // namespace vectorized

--- a/regression-test/suites/fault_injection_p0/test_writer_v2_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_writer_v2_fault_injection.groovy
@@ -123,6 +123,7 @@ suite("test_writer_v2_fault_injection", "nonConcurrent") {
         }
         // Test LoadStreamStub skip send segment
         load_with_injection("LoadStreamStub.skip_send_segment")
+        load_with_injection("VTabletWriterV2._check_streams_finish.close_stream_failed")
 
         sql """ set enable_memtable_on_sink_node=false """
     }


### PR DESCRIPTION
### What problem does this PR solve?

related issue: https://github.com/apache/doris/issues/51426

![image](https://github.com/user-attachments/assets/23b19e6e-5209-4f4e-936c-93563b3dcf64)

If there is a node with slow response (possibly due to high load or configuration issues), then global writes will respond slowly or even timeout. 

Introducing **quorum success write** to solve this problem:

1. maintain the completed target nodes at each sender's sink operator. After most `tablet replica` completion, the receiving end considers it complete and tries to wait for the remaining nodes as much as possible. 
2. The waiting strategy is: 
- calculate avg speed of all unfinished channel and calculate the time that unfinished nodes should complete based on the average time(max_wait_time_ms).
- `max_wait_time_ms = max_wait_time_ms * (1.0 + config::quorum_success_max_wait_time_multiplier)), config::quorum_success_min_wait_time_ms);`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

