### PR TITLE
[fix](planner)fix routine load meta data failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1945,7 +1945,8 @@ public abstract class RoutineLoadJob
                 ctx.cleanup();
             }
         } catch (Exception e) {
-            throw new IOException("error happens when parsing create routine load stmt: " + origStmt.originStmt, e);
+            this.state = JobState.CANCELLED;
+            LOG.warn("error happens when parsing create routine load stmt: " + origStmt.originStmt, e);
         }
         if (userIdentity != null) {
             userIdentity.setIsAnalyzed();


### PR DESCRIPTION
### What problem does this PR solve?

 
```
  Caused by: org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Unknown table 'test_routine_load_with_user'
    at org.apache.doris.catalog.DatabaseIf.lambda$getTableOrAnalysisException$5(DatabaseIf.java:266) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.DatabaseIf.getTableOrException(DatabaseIf.java:139) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.DatabaseIf.getTableOrAnalysisException(DatabaseIf.java:265) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.trees.plans.commands.info.CreateRoutineLoadInfo.checkDBTable(CreateRoutineLoadInfo.java:253) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.nereids.trees.plans.commands.info.CreateRoutineLoadInfo.validate(CreateRoutineLoadInfo.java:209) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.load.routineload.RoutineLoadJob.gsonPostProcess(RoutineLoadJob.java:1942) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:949) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:926) ~[doris-fe.jar:1.2-SNAPSHOT]
    at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:299) ~[gson-2.10.1.jar:?]
    at org.apache.doris.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:330) ~[doris-fe.jar:1.2-SNAPSHOT]
    at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:204) ~[gson-2.10.1.jar:?]
    at com.google.gson.Gson.fromJson(Gson.java:1227) ~[gson-2.10.1.jar:?]
    at com.google.gson.Gson.fromJson(Gson.java:1137) ~[gson-2.10.1.jar:?]
    at com.google.gson.Gson.fromJson(Gson.java:1047) ~[gson-2.10.1.jar:?]
    at com.google.gson.Gson.fromJson(Gson.java:982) ~[gson-2.10.1.jar:?]
    at org.apache.doris.load.routineload.RoutineLoadJob.read(RoutineLoadJob.java:1908) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.load.routineload.RoutineLoadManager.readFields(RoutineLoadManager.java:955) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.catalog.Env.loadRoutineLoadJobs(Env.java:2411) ~[doris-fe.jar:1.2-SNAPSHOT]
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
    at java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
    at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:126) ~[doris-fe.jar:1.2-SNAPSHOT]
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

