### PR TITLE
Branch 3.1: [memleak](be) fix memleak of TabletColumnObjectPool

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -854,9 +854,10 @@ Status ColumnReader::new_struct_iterator(ColumnIterator** iterator,
     // create default_iterator for schema-change behavior which increase column
     for (size_t i = child_size; i < tablet_column_size; i++) {
         TabletColumn column = tablet_column->get_sub_column(i);
-        std::unique_ptr<ColumnIterator>* it = new std::unique_ptr<ColumnIterator>();
-        RETURN_IF_ERROR(Segment::new_default_iterator(column, it));
-        sub_column_iterators.push_back(it->get());
+        std::unique_ptr<ColumnIterator> it;
+        RETURN_IF_ERROR(Segment::new_default_iterator(column, &it));
+        sub_column_iterators.push_back(it.get());
+        it.release();
     }
 
     ColumnIterator* null_iterator = nullptr;

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -1075,7 +1075,7 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema, bool ignore_extrac
             auto pair = TabletColumnObjectPool::instance()->insert_index(
                     deterministic_string_serialize(index_pb));
             index = pair.second;
-            _index_cache_handlers.push_back(pair.first);
+            TabletColumnObjectPool::instance()->release(pair.first);
         } else {
             index = std::make_shared<TabletIndex>();
             index->init_from_pb(index_pb);

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -634,7 +634,6 @@ private:
     std::vector<TabletColumnPtr> _cols;
 
     std::vector<TabletIndexPtr> _indexes;
-    std::vector<Cache::Handle*> _index_cache_handlers;
     std::unordered_map<StringRef, int32_t, StringRefHash> _field_name_to_index;
     std::unordered_map<int32_t, int32_t> _field_id_to_index;
     std::unordered_map<vectorized::PathInDataRef, int32_t, vectorized::PathInDataRef::Hash>


### PR DESCRIPTION
### What problem does this PR solve?

pick #51771 [[memleak](be) fix memleak of TabletColumnObjectPool](https://github.com/apache/doris/commit/fdc7a041e268698823f21e40f2be75f0db8c6aff)


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

