### PR TITLE
[fix](case) Remove bitmap_to_base64 cases when bitmap type is set

### DIFF
--- a/be/test/vec/function/function_bitmap_test.cpp
+++ b/be/test/vec/function/function_bitmap_test.cpp
@@ -175,26 +175,13 @@ TEST(function_bitmap_test, function_bitmap_to_base64) {
     {
         DataSet data_set = {
                 {{&bitmap32_1}, std::string("AQEAAAA=")},
-                {{&bitmap32_2}, std::string("BQIBAAAAAAAAAH+WmAAAAAAA")},
                 {{&bitmap32_3}, std::string("AjswAAABAAAgAAEAAAAgAA==")},
                 {{&bitmap64_1}, std::string("AwAAAAABAAAA")},
-                {{&bitmap64_2}, std::string("BQIAAAAAAQAAAAEAAAAAAAAA")},
                 {{&bitmap64_3},
                  std::string("BAIAAAAAOzAAAAEAAB8AAQAAAB8AAQAAADowAAABAAAAAAAAABAAAAAAAA==")},
                 {{&empty_bitmap}, std::string("AA==")},
                 {{Null()}, Null()}};
 
-        static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
-    }
-
-    {
-        std::string base64("BQQAAAAAAAAAAAEAAAAAAAAAAgAAAAAAAAADAAAAAAAAAA==");
-        BitmapValue bitmap;
-        bitmap.add(0);
-        bitmap.add(1);
-        bitmap.add(2);
-        bitmap.add(3);
-        DataSet data_set = {{{&bitmap}, base64}};
         static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #42157 

Problem Summary: Due to the non-guaranteed order of elements in a bitmap, the generated Base64 string may not always be the same for the same content

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

