### PR TITLE
[fix](cache) Add conf `segment_cache_enable_prune`

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1178,7 +1178,7 @@ DEFINE_Int32(segment_cache_capacity, "-1");
 DEFINE_Int32(segment_cache_fd_percentage, "20");
 DEFINE_mInt32(estimated_mem_per_column_reader, "512");
 DEFINE_Int32(segment_cache_memory_percentage, "5");
-DEFINE_Bool(segment_cache_enable_prune, "true");
+DEFINE_Bool(enable_segment_cache_prune, "true");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1178,6 +1178,7 @@ DEFINE_Int32(segment_cache_capacity, "-1");
 DEFINE_Int32(segment_cache_fd_percentage, "20");
 DEFINE_mInt32(estimated_mem_per_column_reader, "512");
 DEFINE_Int32(segment_cache_memory_percentage, "5");
+DEFINE_Bool(segment_cache_enable_prune, "true");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1217,7 +1217,7 @@ DECLARE_mInt32(schema_cache_sweep_time_sec);
 DECLARE_Int32(segment_cache_capacity);
 DECLARE_Int32(segment_cache_fd_percentage);
 DECLARE_Int32(segment_cache_memory_percentage);
-DECLARE_Bool(segment_cache_enable_prune);
+DECLARE_Bool(enable_segment_cache_prune);
 
 DECLARE_mInt32(estimated_mem_per_column_reader);
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1217,6 +1217,8 @@ DECLARE_mInt32(schema_cache_sweep_time_sec);
 DECLARE_Int32(segment_cache_capacity);
 DECLARE_Int32(segment_cache_fd_percentage);
 DECLARE_Int32(segment_cache_memory_percentage);
+DECLARE_Bool(segment_cache_enable_prune);
+
 DECLARE_mInt32(estimated_mem_per_column_reader);
 
 // enable binlog

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -83,7 +83,8 @@ public:
     SegmentCache(size_t memory_bytes_limit, size_t segment_num_limit)
             : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, memory_bytes_limit,
                              LRUCacheType::SIZE, config::tablet_rowset_stale_sweep_time_sec,
-                             DEFAULT_LRU_CACHE_NUM_SHARDS * 2, segment_num_limit) {}
+                             DEFAULT_LRU_CACHE_NUM_SHARDS * 2, segment_num_limit,
+                             config::segment_cache_enable_prune) {}
 
     // Lookup the given segment in the cache.
     // If the segment is found, the cache entry will be written into handle.

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -84,7 +84,7 @@ public:
             : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, memory_bytes_limit,
                              LRUCacheType::SIZE, config::tablet_rowset_stale_sweep_time_sec,
                              DEFAULT_LRU_CACHE_NUM_SHARDS * 2, segment_num_limit,
-                             config::segment_cache_enable_prune) {}
+                             config::enable_segment_cache_prune) {}
 
     // Lookup the given segment in the cache.
     // If the segment is found, the cache entry will be written into handle.


### PR DESCRIPTION
In the storage and computing separation scenario, prune Segment Cache will cause performance jitter. This PR allows to disable Segment Cache prune and reset capacity.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

