### PR TITLE
[Opt](performance) Support column like use dict to speed up query

### DIFF
--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -101,6 +101,7 @@ private:
             if (nested_col.is_column_dictionary()) {
                 auto* nested_col_ptr =
                         vectorized::check_and_get_column<vectorized::ColumnDictI32>(nested_col);
+                const auto& dict_res = _find_code_from_dictionary_column(*nested_col_ptr);
                 auto& data_array = nested_col_ptr->get_data();
                 for (uint16_t i = 0; i < size; i++) {
                     if (null_map_data[i]) {
@@ -112,18 +113,10 @@ private:
                         continue;
                     }
 
-                    StringRef cell_value = nested_col_ptr->get_shrink_value(data_array[i]);
+                    unsigned char flag = dict_res[data_array[i]];
                     if constexpr (is_and) {
-                        unsigned char flag = 0;
-                        THROW_IF_ERROR((_state->scalar_function)(
-                                const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                StringRef(cell_value.data, cell_value.size), pattern, &flag));
                         flags[i] &= _opposite ^ flag;
                     } else {
-                        unsigned char flag = 0;
-                        THROW_IF_ERROR((_state->scalar_function)(
-                                const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                StringRef(cell_value.data, cell_value.size), pattern, &flag));
                         flags[i] = _opposite ^ flag;
                     }
                 }
@@ -136,19 +129,12 @@ private:
                 auto* nested_col_ptr =
                         vectorized::check_and_get_column<vectorized::ColumnDictI32>(column);
                 auto& data_array = nested_col_ptr->get_data();
+                const auto& dict_res = _find_code_from_dictionary_column(*nested_col_ptr);
                 for (uint16_t i = 0; i < size; i++) {
-                    StringRef cell_value = nested_col_ptr->get_shrink_value(data_array[i]);
+                    unsigned char flag = dict_res[data_array[i]];
                     if constexpr (is_and) {
-                        unsigned char flag = 0;
-                        THROW_IF_ERROR((_state->scalar_function)(
-                                const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                StringRef(cell_value.data, cell_value.size), pattern, &flag));
                         flags[i] &= _opposite ^ flag;
                     } else {
-                        unsigned char flag = 0;
-                        THROW_IF_ERROR((_state->scalar_function)(
-                                const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                StringRef(cell_value.data, cell_value.size), pattern, &flag));
                         flags[i] = _opposite ^ flag;
                     }
                 }
@@ -158,6 +144,47 @@ private:
             }
         }
     }
+
+    __attribute__((flatten)) std::vector<bool> _find_code_from_dictionary_column(
+            const vectorized::ColumnDictI32& column) const {
+        std::vector<bool> res;
+        if (_segment_id_to_cached_res_flags.if_contains(
+                    column.get_rowset_segment_id(),
+                    [&res](const auto& pair) { res = pair.second; })) {
+            return res;
+        }
+
+        std::vector<bool> tmp_res(column.dict_size(), false);
+        for (int i = 0; i < column.dict_size(); i++) {
+            StringRef cell_value = column.get_shrink_value(i);
+            unsigned char flag = 0;
+            THROW_IF_ERROR((_state->scalar_function)(
+                    const_cast<vectorized::LikeSearchState*>(&_like_state),
+                    StringRef(cell_value.data, cell_value.size), pattern, &flag));
+            tmp_res[i] = flag;
+        }
+        // Sometimes the dict is not initialized when run comparison predicate here, for example,
+        // the full page is null, then the reader will skip read, so that the dictionary is not
+        // inited. The cached code is wrong during this case, because the following page maybe not
+        // null, and the dict should have items in the future.
+        //
+        // Cached code may have problems, so that add a config here, if not opened, then
+        // we will return the code and not cache it.
+        if (!column.is_dict_empty() && config::enable_low_cardinality_cache_code) {
+            _segment_id_to_cached_res_flags.emplace(
+                    std::pair {column.get_rowset_segment_id(), tmp_res});
+        }
+
+        return tmp_res;
+    }
+
+    mutable phmap::parallel_flat_hash_map<
+            std::pair<RowsetId, uint32_t>, std::vector<bool>,
+            phmap::priv::hash_default_hash<std::pair<RowsetId, uint32_t>>,
+            phmap::priv::hash_default_eq<std::pair<RowsetId, uint32_t>>,
+            std::allocator<std::pair<const std::pair<RowsetId, uint32_t>, int32_t>>, 4,
+            std::shared_mutex>
+            _segment_id_to_cached_res_flags;
 
     std::string _debug_string() const override {
         std::string info = "LikeColumnPredicate";


### PR DESCRIPTION
### What problem does this PR solve?

before:
```
SELECT count(1) AS n FROM t WHERE query LIKE '%xll%'

4sec 
```

after:
```
SELECT count(1) AS n FROM t WHERE query LIKE '%xll%'

2sec 
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

