### PR TITLE
[fix](be) Fix `check_storage_vault` deadlock

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -190,7 +190,7 @@ struct RefreshFSVaultVisitor {
 };
 
 Status CloudStorageEngine::open() {
-    sync_storage_vault(config::enable_check_storage_vault);
+    sync_storage_vault();
 
     // TODO(plat1ko): DeleteBitmapTxnManager
 
@@ -336,30 +336,28 @@ Status CloudStorageEngine::start_bg_threads(std::shared_ptr<WorkloadGroup> wg_sp
     return Status::OK();
 }
 
-void CloudStorageEngine::sync_storage_vault(bool check_storage_vault) {
+void CloudStorageEngine::sync_storage_vault() {
     cloud::StorageVaultInfos vault_infos;
     bool enable_storage_vault = false;
-    auto st = Status::OK();
-    while (true) {
-        st = _meta_mgr->get_storage_vault_info(&vault_infos, &enable_storage_vault);
-        if (st.ok()) {
-            break;
-        }
 
-        if (!check_storage_vault) {
-            LOG(WARNING) << "failed to get storage vault info. err=" << st;
-            return;
-        }
-
-        LOG(WARNING) << "failed to get storage vault info from ms, err=" << st
-                     << " sleep 200ms retry or add enable_check_storage_vault=false to be.conf"
-                     << " to skip the check.";
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    auto st = _meta_mgr->get_storage_vault_info(&vault_infos, &enable_storage_vault);
+    if (!st.ok()) {
+        LOG(WARNING) << "failed to get storage vault info. err=" << st;
+        return;
     }
 
     if (vault_infos.empty()) {
         LOG(WARNING) << "empty storage vault info";
         return;
+    }
+
+    bool check_storage_vault = false;
+    bool expected = false;
+    if (first_sync_storage_vault.compare_exchange_strong(expected, true)) {
+        check_storage_vault = config::enable_check_storage_vault;
+        LOG(INFO) << "first sync storage vault info, BE try to check iam role connectivity, "
+                     "check_storage_vault="
+                  << check_storage_vault;
     }
 
     for (auto& [id, vault_info, path_format] : vault_infos) {

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -137,7 +137,7 @@ public:
     std::shared_ptr<CloudCumulativeCompactionPolicy> cumu_compaction_policy(
             std::string_view compaction_policy);
 
-    void sync_storage_vault(bool check = false);
+    void sync_storage_vault();
 
     io::FileCacheBlockDownloader& file_cache_block_downloader() const {
         return *_file_cache_block_downloader;
@@ -219,6 +219,8 @@ private:
     using CumuPolices =
             std::unordered_map<std::string_view, std::shared_ptr<CloudCumulativeCompactionPolicy>>;
     CumuPolices _cumulative_compaction_policies;
+
+    std::atomic_bool first_sync_storage_vault {true};
 };
 
 } // namespace doris


### PR DESCRIPTION
* https://github.com/apache/doris/pull/51175 introduced a deadlock problem:
  1. the `sync_storage_vault()` func wait for heartbeat thread to set config::meta_service_endpoint

  2. the heartbeat thread wait for the `sync_storage_vault()` func success to start

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

