### PR TITLE
[test](mtmv) Fix regression test not stable and fail

### DIFF
--- a/regression-test/suites/nereids_rules_p0/mv/availability/grace_period.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/availability/grace_period.groovy
@@ -240,7 +240,7 @@ suite("grace_period") {
             o_orderdate,
             l_partkey,
             l_suppkey""",
-            15,
+            150000,
             "l_shipdate")
 
     sql """
@@ -308,7 +308,9 @@ suite("grace_period") {
         l_suppkey;
         """, mv_partition_allow_staleness_name)
     sql "SET enable_materialized_view_rewrite=true"
-    Thread.sleep(15000);
+
+    sql """ALTER MATERIALIZED VIEW ${mv_partition_allow_staleness_name} set('grace_period'='0');"""
+
     // after 10s when partition table, and query use the partition changed, should fail
     mv_not_part_in(
         """

--- a/regression-test/suites/nereids_rules_p0/mv/external_table/part_partition_invalid.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/external_table/part_partition_invalid.groovy
@@ -152,10 +152,11 @@ suite("part_partition_invalid", "p0,external,external_docker") {
     // refresh catalog cache
     sql """ REFRESH CATALOG ${hive_catalog_name} PROPERTIES("invalid_cache" = "true"); """
     mv_rewrite_success(query_sql, mv_name)
+    // in 2.1 and 3.0 should not compensate union all, in 3.1 and master should compensate union all
     order_qt_after_modify_data_and_refresh_catalog """ ${query_sql}"""
 
-    // query invalid partition data, should hit mv, because not check now.
-    mv_rewrite_fail("""
+    // query invalid partition data, should not part in mv rewrite
+    mv_not_part_in("""
             ${query_sql} where o_orderdate = '2023-10-19';
         """, mv_name)
     order_qt_after_modify_and_refresh_catalog_19 """ ${query_sql} where o_orderdate = '2023-10-19';"""
@@ -179,6 +180,7 @@ suite("part_partition_invalid", "p0,external,external_docker") {
     // refresh catalog cache
     sql """ REFRESH CATALOG ${hive_catalog_name} PROPERTIES("invalid_cache" = "true"); """
     mv_rewrite_success(query_sql, mv_name)
+    // in 2.1 and 3.0 should not compensate union all, in 3.1 and master should compensate union all
     order_qt_after_add_data_with_refresh_catalog """ ${query_sql}"""
 
     // query invalid partition data, should hit mv, because not check now.
@@ -188,8 +190,8 @@ suite("part_partition_invalid", "p0,external,external_docker") {
 
     order_qt_after_add_and_refresh_catalog_19 """ ${query_sql} where o_orderdate = '2023-10-19';"""
 
-    // query valid partition data, should hit mv
-    mv_rewrite_fail("""
+    // query valid partition data, mv should not part in mv rewrite
+    mv_not_part_in("""
             ${query_sql} where o_orderdate = '2023-10-20';
         """, mv_name)
     order_qt_after_add_and_refresh_catalog_20 """ ${query_sql} where o_orderdate = '2023-10-20';"""


### PR DESCRIPTION
### What problem does this PR solve?
grace_period.groovy(line 264) should not use sleep method, this would cause unstable
part_partition_invalid(line 158) mv should not part in, not fail


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

