### PR TITLE
[opt](memory) Optimize PODArray memory tracking performance

### DIFF
--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -27,6 +27,7 @@
 #include "util/memcpy_inlined.h"
 #include "util/slice.h"
 #include "vec/common/allocator.h"
+#include "vec/common/allocator_fwd.h"
 
 namespace doris {
 

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "vec/common/allocator.h"
+#include "vec/common/allocator_fwd.h"
 
 namespace doris {
 

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -45,20 +45,22 @@ namespace doris {
 std::unordered_map<void*, size_t> RecordSizeMemoryAllocator::_allocated_sizes;
 std::mutex RecordSizeMemoryAllocator::_mutex;
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_memory_exceed(
-        size_t size, std::string* err_msg) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::sys_memory_exceed(size_t size,
+                                                             std::string* err_msg) const {
 #ifdef BE_TEST
     if (!doris::pthread_context_ptr_init) {
         return false;
     }
 #endif
-    auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
-    if (thread_mem_ctx->skip_memory_check != 0) {
+    if (UNLIKELY(doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0)) {
         return false;
     }
 
     if (doris::GlobalMemoryArbitrator::is_exceed_hard_mem_limit(size)) {
+        auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
         // Only thread attach task, and has not completely waited for thread_wait_gc_max_milliseconds,
         // will wait for gc. otherwise, if the outside will catch the exception, throwing an exception.
         *err_msg += fmt::format(
@@ -84,16 +86,16 @@ bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
     return false;
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc_fault_probability()
-        const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::alloc_fault_probability() const {
 #ifdef BE_TEST
     if (!doris::pthread_context_ptr_init) {
         return;
     }
 #endif
-    auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
-    if (thread_mem_ctx->skip_memory_check != 0) {
+    if (doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0) {
         return;
     }
 
@@ -105,7 +107,9 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc_f
             const std::string injection_err_msg = fmt::format(
                     "[MemAllocInjectFault] Task {} alloc memory failed due to fault "
                     "injection.",
-                    thread_mem_ctx->limiter_mem_tracker()->label());
+                    doris::thread_context()
+                            ->thread_mem_tracker_mgr->limiter_mem_tracker()
+                            ->label());
             // Print stack trace for debug.
             [[maybe_unused]] auto stack_trace_st =
                     doris::Status::Error<doris::ErrorCode::MEM_ALLOC_FAILED, true>(
@@ -120,9 +124,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc_f
     }
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_memory_check(
-        size_t size) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::sys_memory_check(size_t size) const {
     std::string err_msg;
     if (sys_memory_exceed(size, &err_msg)) {
         auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
@@ -189,31 +194,35 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::sys_mem
     }
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_tracker_exceed(
-        size_t size, std::string* err_msg) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+bool Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::memory_tracker_exceed(size_t size,
+                                                                 std::string* err_msg) const {
 #ifdef BE_TEST
     if (!doris::pthread_context_ptr_init) {
         return false;
     }
 #endif
-    auto* thread_mem_ctx = doris::thread_context()->thread_mem_tracker_mgr.get();
-    if (thread_mem_ctx->skip_memory_check != 0) {
+    if (UNLIKELY(doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0)) {
         return false;
     }
 
-    auto st = thread_mem_ctx->limiter_mem_tracker()->check_limit(size);
+    auto st = doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->check_limit(
+            size);
     if (!st) {
         *err_msg += fmt::format("Allocator mem tracker check failed, {}", st.to_string());
-        thread_mem_ctx->limiter_mem_tracker()->print_log_usage(*err_msg);
+        doris::thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker()->print_log_usage(
+                *err_msg);
         return true;
     }
     return false;
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_tracker_check(
-        size_t size) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::memory_tracker_check(size_t size) const {
     std::string err_msg;
     if (memory_tracker_exceed(size, &err_msg)) {
         doris::thread_context()->thread_mem_tracker_mgr->disable_wait_gc();
@@ -228,35 +237,39 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_
     }
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::memory_check(
-        size_t size) const {
-    if (MemoryAllocator::need_check_and_tracking_memory()) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::memory_check(size_t size) const {
+    if (check_and_tracking_memory) {
         alloc_fault_probability();
         sys_memory_check(size);
         memory_tracker_check(size);
     }
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::consume_memory(
-        size_t size) const {
-    if (MemoryAllocator::need_check_and_tracking_memory()) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::consume_memory(size_t size) const {
+    if (check_and_tracking_memory) {
         CONSUME_THREAD_MEM_TRACKER(size);
     }
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::release_memory(
-        size_t size) const {
-    if (MemoryAllocator::need_check_and_tracking_memory()) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::release_memory(size_t size) const {
+    if (check_and_tracking_memory) {
         RELEASE_THREAD_MEM_TRACKER(size);
     }
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::throw_bad_alloc(
-        const std::string& err) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::throw_bad_alloc(const std::string& err) const {
     LOG(WARNING) << err
                  << fmt::format("{}, Stacktrace: {}",
                                 doris::GlobalMemoryArbitrator::process_mem_log_str(),
@@ -265,9 +278,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::throw_b
     throw doris::Exception(doris::ErrorCode::MEM_ALLOC_FAILED, err);
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_address_sanitizers(
-        void* buf, size_t size) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::add_address_sanitizers(void* buf, size_t size) const {
     if (!doris::config::crash_in_memory_tracker_inaccurate) {
         return;
     }
@@ -275,9 +289,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::add_add
             buf, size);
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_address_sanitizers(
-        void* buf, size_t size) const {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::remove_address_sanitizers(void* buf, size_t size) const {
     if (!doris::config::crash_in_memory_tracker_inaccurate) {
         return;
     }
@@ -286,9 +301,10 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::remove_
             ->remove_address_sanitizers(buf, size);
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc(size_t size,
-                                                                                size_t alignment) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+                check_and_tracking_memory>::alloc(size_t size, size_t alignment) {
     memory_check(size);
     // consume memory in tracker before alloc, similar to early declaration.
     consume_memory(size);
@@ -354,9 +370,10 @@ void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::alloc(
     return buf;
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::free(void* buf,
-                                                                              size_t size) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+               check_and_tracking_memory>::free(void* buf, size_t size) {
     if (use_mmap && size >= doris::config::mmap_threshold) {
         if (0 != munmap(buf, size)) {
             throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
@@ -368,9 +385,11 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::free(vo
     release_memory(size);
 }
 
-template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator>
-void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::realloc(
-        void* buf, size_t old_size, size_t new_size, size_t alignment) {
+template <bool clear_memory_, bool mmap_populate, bool use_mmap, typename MemoryAllocator,
+          bool check_and_tracking_memory>
+void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
+                check_and_tracking_memory>::realloc(void* buf, size_t old_size, size_t new_size,
+                                                    size_t alignment) {
     if (old_size == new_size) {
         /// nothing to do.
         /// BTW, it's not possible to change alignment while doing realloc.
@@ -441,42 +460,58 @@ void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator>::reallo
     return buf;
 }
 
-template class Allocator<true, true, true, DefaultMemoryAllocator>;
-template class Allocator<true, true, false, DefaultMemoryAllocator>;
-template class Allocator<true, false, true, DefaultMemoryAllocator>;
-template class Allocator<true, false, false, DefaultMemoryAllocator>;
-template class Allocator<false, true, true, DefaultMemoryAllocator>;
-template class Allocator<false, true, false, DefaultMemoryAllocator>;
-template class Allocator<false, false, true, DefaultMemoryAllocator>;
-template class Allocator<false, false, false, DefaultMemoryAllocator>;
-
-template class Allocator<true, true, true, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<true, true, false, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<true, false, true, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<true, false, false, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<false, true, true, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<false, true, false, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<false, false, true, NoTrackingDefaultMemoryAllocator>;
-template class Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>;
+template class Allocator<true, true, true, DefaultMemoryAllocator, true>;
+template class Allocator<true, true, false, DefaultMemoryAllocator, true>;
+template class Allocator<true, false, true, DefaultMemoryAllocator, true>;
+template class Allocator<true, false, false, DefaultMemoryAllocator, true>;
+template class Allocator<false, true, true, DefaultMemoryAllocator, true>;
+template class Allocator<false, true, false, DefaultMemoryAllocator, true>;
+template class Allocator<false, false, true, DefaultMemoryAllocator, true>;
+template class Allocator<false, false, false, DefaultMemoryAllocator, true>;
+template class Allocator<true, true, true, DefaultMemoryAllocator, false>;
+template class Allocator<true, true, false, DefaultMemoryAllocator, false>;
+template class Allocator<true, false, true, DefaultMemoryAllocator, false>;
+template class Allocator<true, false, false, DefaultMemoryAllocator, false>;
+template class Allocator<false, true, true, DefaultMemoryAllocator, false>;
+template class Allocator<false, true, false, DefaultMemoryAllocator, false>;
+template class Allocator<false, false, true, DefaultMemoryAllocator, false>;
+template class Allocator<false, false, false, DefaultMemoryAllocator, false>;
 
 /** It would be better to put these Memory Allocators where they are used, such as in the orc memory pool and arrow memory pool.
   * But currently allocators use templates in .cpp instead of all in .h, so they can only be placed here.
   */
-template class Allocator<true, true, false, ORCMemoryAllocator>;
-template class Allocator<true, false, true, ORCMemoryAllocator>;
-template class Allocator<true, false, false, ORCMemoryAllocator>;
-template class Allocator<false, true, true, ORCMemoryAllocator>;
-template class Allocator<false, true, false, ORCMemoryAllocator>;
-template class Allocator<false, false, true, ORCMemoryAllocator>;
-template class Allocator<false, false, false, ORCMemoryAllocator>;
+template class Allocator<true, true, true, ORCMemoryAllocator, true>;
+template class Allocator<true, true, false, ORCMemoryAllocator, true>;
+template class Allocator<true, false, true, ORCMemoryAllocator, true>;
+template class Allocator<true, false, false, ORCMemoryAllocator, true>;
+template class Allocator<false, true, true, ORCMemoryAllocator, true>;
+template class Allocator<false, true, false, ORCMemoryAllocator, true>;
+template class Allocator<false, false, true, ORCMemoryAllocator, true>;
+template class Allocator<false, false, false, ORCMemoryAllocator, true>;
+template class Allocator<true, true, true, ORCMemoryAllocator, false>;
+template class Allocator<true, true, false, ORCMemoryAllocator, false>;
+template class Allocator<true, false, true, ORCMemoryAllocator, false>;
+template class Allocator<true, false, false, ORCMemoryAllocator, false>;
+template class Allocator<false, true, true, ORCMemoryAllocator, false>;
+template class Allocator<false, true, false, ORCMemoryAllocator, false>;
+template class Allocator<false, false, true, ORCMemoryAllocator, false>;
+template class Allocator<false, false, false, ORCMemoryAllocator, false>;
 
-template class Allocator<true, true, true, RecordSizeMemoryAllocator>;
-template class Allocator<true, true, false, RecordSizeMemoryAllocator>;
-template class Allocator<true, false, true, RecordSizeMemoryAllocator>;
-template class Allocator<true, false, false, RecordSizeMemoryAllocator>;
-template class Allocator<false, true, true, RecordSizeMemoryAllocator>;
-template class Allocator<false, true, false, RecordSizeMemoryAllocator>;
-template class Allocator<false, false, true, RecordSizeMemoryAllocator>;
-template class Allocator<false, false, false, RecordSizeMemoryAllocator>;
+template class Allocator<true, true, true, RecordSizeMemoryAllocator, true>;
+template class Allocator<true, true, false, RecordSizeMemoryAllocator, true>;
+template class Allocator<true, false, true, RecordSizeMemoryAllocator, true>;
+template class Allocator<true, false, false, RecordSizeMemoryAllocator, true>;
+template class Allocator<false, true, true, RecordSizeMemoryAllocator, true>;
+template class Allocator<false, true, false, RecordSizeMemoryAllocator, true>;
+template class Allocator<false, false, true, RecordSizeMemoryAllocator, true>;
+template class Allocator<false, false, false, RecordSizeMemoryAllocator, true>;
+template class Allocator<true, true, true, RecordSizeMemoryAllocator, false>;
+template class Allocator<true, true, false, RecordSizeMemoryAllocator, false>;
+template class Allocator<true, false, true, RecordSizeMemoryAllocator, false>;
+template class Allocator<true, false, false, RecordSizeMemoryAllocator, false>;
+template class Allocator<false, true, true, RecordSizeMemoryAllocator, false>;
+template class Allocator<false, true, false, RecordSizeMemoryAllocator, false>;
+template class Allocator<false, false, true, RecordSizeMemoryAllocator, false>;
+template class Allocator<false, false, false, RecordSizeMemoryAllocator, false>;
 
 } // namespace doris

--- a/be/src/vec/common/allocator.cpp
+++ b/be/src/vec/common/allocator.cpp
@@ -95,7 +95,7 @@ void Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
         return;
     }
 #endif
-    if (doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0) {
+    if (UNLIKELY(doris::thread_context()->thread_mem_tracker_mgr->skip_memory_check != 0)) {
         return;
     }
 

--- a/be/src/vec/common/allocator_fwd.h
+++ b/be/src/vec/common/allocator_fwd.h
@@ -26,10 +26,9 @@
 #include <cstddef>
 namespace doris {
 class DefaultMemoryAllocator;
-class NoTrackingDefaultMemoryAllocator;
 
 template <bool clear_memory_, bool mmap_populate = false, bool use_mmap = false,
-          typename MemoryAllocator = DefaultMemoryAllocator>
+          typename MemoryAllocator = DefaultMemoryAllocator, bool check_and_tracking_memory = true>
 class Allocator;
 
 template <typename Base, size_t N = 64, size_t Alignment = 1>

--- a/be/src/vec/common/hash_table/phmap_fwd_decl.h
+++ b/be/src/vec/common/hash_table/phmap_fwd_decl.h
@@ -20,6 +20,7 @@
 #include <parallel_hashmap/phmap.h> // IWYU pragma: export
 
 #include "vec/common/allocator.h"
+#include "vec/common/allocator_fwd.h"
 
 namespace doris::vectorized {
 

--- a/be/src/vec/common/pod_array_fwd.h
+++ b/be/src/vec/common/pod_array_fwd.h
@@ -33,7 +33,7 @@ inline constexpr size_t integerRoundUp(size_t value, size_t dividend) {
 }
 
 template <typename T, size_t initial_bytes = 4096,
-          typename TAllocator = Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
+          typename TAllocator = Allocator<false, false, false, DefaultMemoryAllocator, false>,
           size_t pad_right_ = 0, size_t pad_left_ = 0>
 class PODArray;
 
@@ -42,7 +42,7 @@ class PODArray;
   *       Padding in internal data structures increased to 64 bytes., support AVX-512 simd.
   */
 template <typename T, size_t initial_bytes = 4096,
-          typename TAllocator = Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>>
+          typename TAllocator = Allocator<false, false, false, DefaultMemoryAllocator, false>>
 using PaddedPODArray = PODArray<T, initial_bytes, TAllocator, 16, 15>;
 
 /** A helper for declaring PODArray that uses inline memory.
@@ -53,7 +53,7 @@ template <typename T, size_t inline_bytes,
           size_t rounded_bytes = integerRoundUp(inline_bytes, sizeof(T))>
 using PODArrayWithStackMemory = PODArray<
         T, rounded_bytes,
-        AllocatorWithStackMemory<Allocator<false, false, false, NoTrackingDefaultMemoryAllocator>,
+        AllocatorWithStackMemory<Allocator<false, false, false, DefaultMemoryAllocator, false>,
                                  rounded_bytes, alignof(T)>>;
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/orc/orc_memory_pool.h
+++ b/be/src/vec/exec/format/orc/orc_memory_pool.h
@@ -19,6 +19,7 @@
 
 #include "orc/MemoryPool.hh"
 #include "vec/common/allocator.h"
+#include "vec/common/allocator_fwd.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"


### PR DESCRIPTION
### What problem does this PR solve?

#50549 may cause performance loss

 If capacity_bytes <= 256K, res_mem_growth = c_end_of_storage - c_res_mem.

If capacity >= 512K:
      - If `c_end_of_storage - c_res_mem < TrackingGrowthMinSize`, then tracking to c_end_of_storage.
      - `c_end_new - c_res_mem` is the size of the physical memory growth,
        which is also the minimum tracking size of this time,
        `(((c_end_new - c_res_mem) >> 16) << 16)` is aligned down to 64K,
        assuming `capacity_bytes >= 512K`, so `(capacity_bytes >> 3)` is at least 64K,
        so `(((c_end_new - c_res_mem) >> 16) << 16) + (capacity_bytes() >> 3)`
        must be greater than `c_end_new - c_res_mem`.

        For example:
         - 256K < capacity <= 512K,
           it will only tracking twice,
           the second time `c_end_of_storage - c_res_mem < TrackingGrowthMinSize` is true,
           so it will tracking to c_end_of_storage.
         - capacity > 32M, `(((c_end_new - c_res_mem) >> 16) << 16)` align the increased
           physical memory size down to 64k, then add `(capacity_bytes() >> 3)` equals 2M,
           so `reset_resident_memory` is tracking an additional 2M,
           after that, physical memory growth within 2M does not need to reset_resident_memory again.

 so, when PODArray is expanded by power of 2,
 the memory is checked and tracked up to 8 times between each expansion,
 because each time additional tracking `(capacity_bytes() >> 3)`.
 after each reset_resident_memory, tracking_res_memory >= used_bytes;

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

