### PR TITLE
[fix](array) disable ALTER TABLE add ARRAY column into AGG table

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1386,15 +1386,13 @@ public class Config extends ConfigBase {
     /**
      * Set the maximum number of rows that can be cached
      */
-    @ConfField(mutable = true, masterOnly = false, description = {"SQL/Partition Cache可以缓存的最大行数。",
-        "Maximum number of rows that can be cached in SQL/Partition Cache, is 3000 by default."})
+    @ConfField(mutable = true, masterOnly = false)
     public static int cache_result_max_row_count = 3000;
 
     /**
      * Set the maximum data size that can be cached
      */
-    @ConfField(mutable = true, masterOnly = false, description = {"SQL/Partition Cache可以缓存的最大数据大小。",
-        "Maximum data size of rows that can be cached in SQL/Partition Cache, is 3000 by default."})
+    @ConfField(mutable = true, masterOnly = false)
     public static int cache_result_max_data_size = 31457280; // 30M
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

While create AGG table with ARRAY column, we return an error:
```
> CREATE TABLE `test_v3` (
    ->   `id` varchar(16),
    ->   `v_array` array<string> REPLACE_IF_NOT_NULL NULL
    -> ) ENGINE=OLAP
    -> AGGREGATE KEY(`id`)
    -> DISTRIBUTED BY HASH(`id`) BUCKETS 16
    -> PROPERTIES (
    -> "replication_allocation" = "tag.location.default: 1"
    -> );
ERROR 1105 (HY000): errCode = 2, detailMessage = Array column can't be used in aggregate table
```

But we can use ALTER command to add an ARRAY Column, this pr disable this case:
```
ALTER TABLE test_v2 ADD COLUMN v2 ARRAY<string> REPLACE_IF_NOT_NULL;
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

