### PR TITLE
branch-3.1: [fix](iceberg)Table operations are not supported for catalogs of the dlf type. #50696

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergDLFExternalCatalog.java
@@ -17,10 +17,18 @@
 
 package org.apache.doris.datasource.iceberg;
 
+import org.apache.doris.analysis.CreateDbStmt;
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.analysis.DropDbStmt;
+import org.apache.doris.analysis.DropTableStmt;
+import org.apache.doris.analysis.TruncateTableStmt;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.iceberg.dlf.DLFCatalog;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.HMSProperties;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
 
 import java.util.Map;
 
@@ -44,5 +52,30 @@ public class IcebergDLFExternalCatalog extends IcebergExternalCatalog {
         String catalogName = getName();
         dlfCatalog.initialize(catalogName, catalogProperties);
         catalog = dlfCatalog;
+    }
+
+    @Override
+    public void createDb(CreateDbStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'create database'");
+    }
+
+    @Override
+    public void dropDb(DropDbStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'drop database'");
+    }
+
+    @Override
+    public boolean createTable(CreateTableStmt stmt) throws UserException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'create table'");
+    }
+
+    @Override
+    public void dropTable(DropTableStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'drop table'");
+    }
+
+    @Override
+    public void truncateTable(TruncateTableStmt stmt) throws DdlException {
+        throw new NotSupportedException("iceberg catalog with dlf type not supports 'truncate table'");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/dlf/client/IcebergDLFExternalCatalogTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.datasource.iceberg.dlf.client;
 
+import org.apache.doris.datasource.iceberg.IcebergDLFExternalCatalog;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,5 +40,16 @@ public class IcebergDLFExternalCatalogTest {
         // so the object addresses of clients in different pools must be different
         Assert.assertNotSame(dlfClientPool1, dlfClientPool2);
 
+    }
+
+    @Test
+    public void testNotSupportOperation() {
+        HashMap<String, String> props = new HashMap<>();
+        IcebergDLFExternalCatalog catalog = new IcebergDLFExternalCatalog(1, "test", "test", props, "test");
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.createDb(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.dropDb(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.createTable(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.dropTable(null));
+        Assert.assertThrows(NotSupportedException.class, () -> catalog.truncateTable(null));
     }
 }


### PR DESCRIPTION
bp #50696