### PR TITLE
[Bug](topn) variant column read in topn may coredump

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1960,6 +1960,8 @@ Status set_fuzzy_configs() {
     // if have set enable_fuzzy_mode=true in be.conf, will fuzzy those field and values
     fuzzy_field_and_value["disable_storage_page_cache"] =
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
+    fuzzy_field_and_value["disable_segment_cache"] =
+            ((distribution(*generator) % 2) == 0) ? "true" : "false";
     fuzzy_field_and_value["enable_system_metrics"] =
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
     fuzzy_field_and_value["enable_set_in_bitmap_value"] =

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -1142,11 +1142,16 @@ Status Segment::seek_and_read_by_rowid(const TabletSchema& schema, SlotDescripto
             .io_ctx = io::IOContext {.reader_type = ReaderType::READER_QUERY,
                                      .file_cache_stats = &stats.file_cache_stats},
     };
+
     std::vector<segment_v2::rowid_t> single_row_loc {row_id};
     if (!slot->column_paths().empty()) {
         vectorized::PathInDataPtr path = std::make_shared<vectorized::PathInData>(
                 schema.column_by_uid(slot->col_unique_id()).name_lower_case(),
                 slot->column_paths());
+
+        // here need create column readers to make sure column reader is created before seek_and_read_by_rowid
+        // if segment cache miss, column reader will be created to make sure the variant column result not coredump
+        RETURN_IF_ERROR(_create_column_readers_once(&stats));
         auto storage_type = get_data_type_of(ColumnIdentifier {.unique_id = slot->col_unique_id(),
                                                                .path = path,
                                                                .is_nullable = slot->is_nullable()},


### PR DESCRIPTION
### What problem does this PR solve?

some Regression test coredump when segment cache miss：

```
thrift error, reason=No more data to read.thrift error, reason=No more data to read.thrift error, reason=No more data to read.terminate called after throwing an instance of 'doris::Exception'
  what():  [E3] Method insert_many_dict_data is not supported for variant
*** Query id: 0-0 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1749816938 (unix time) try "date -d @1749816938" if you are using GNU date ***
*** Current BE git commitID: a8f84d2feb ***
*** SIGABRT unknown detail explain (@0x3e9003b76c0) received by PID 3897024 (TID 3898413 OR 0x7c0e01b00700) from PID 3897024; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/tengjianping/doris-master/be/src/common/signal_handler.h:421
 1# 0x00007F013A4705B0 in /lib64/libc.so.6
 2# __GI_raise in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] in /mnt/disk2/tengjianping/doris-master/output/be/lib/doris_be
 5# __cxxabiv1::__terminate(void (*)()) in /mnt/disk2/tengjianping/doris-master/output/be/lib/doris_be
 6# 0x00005640CA3EFC71 in /mnt/disk2/tengjianping/doris-master/output/be/lib/doris_be
 7# 0x00005640CA3EFDC4 in /mnt/disk2/tengjianping/doris-master/output/be/lib/doris_be
 8# doris::vectorized::IColumn::insert_many_dict_data(int const*, unsigned long, doris::StringRef const*, unsigned long, unsigned int) at /mnt/disk2/tengjianping/doris-master/be/src/vec/columns/column.h:247
 9# doris::vectorized::ColumnNullable::insert_many_dict_data(int const*, unsigned long, doris::StringRef const*, unsigned long, unsigned int) at /mnt/disk2/tengjianping/doris-master/be/src/vec/columns/column_nullable.h:242
10# doris::segment_v2::BinaryDictPageDecoder::read_by_rowids(unsigned int const*, unsigned long, unsigned long*, doris::COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&) at /mnt/disk2/tengjianping/doris-master/be/src/olap/rowset/segment_v2/binary_dict_page.cpp:325
11# doris::segment_v2::FileColumnIterator::read_by_rowids(unsigned int const*, unsigned long, doris::COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&) at /mnt/disk2/tengjianping/doris-master/be/src/olap/rowset/segment_v2/column_reader.cpp:1368
12# doris::segment_v2::Segment::seek_and_read_by_rowid(doris::TabletSchema const&, doris::SlotDescriptor*, unsigned int, doris::COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&, doris::OlapReaderStatistics&, std::unique_ptr<doris::segment_v2::ColumnIterator, std::default_delete<doris::segment_v2::ColumnIterator> >&) at /mnt/disk2/tengjianping/doris-master/be/src/olap/rowset/segment_v2/segment.cpp:1163
13# doris::RowIdStorageReader::read_doris_format_row(std::shared_ptr<doris::IdFileMap> const&, std::shared_ptr<doris::FileMapping> const&, long, std::vector<doris::SlotDescriptor, std::allocator<doris::SlotDescriptor> >&, doris::TabletSchema const&, doris::RowStoreReadStruct&, doris::OlapReaderStatistics&, long*, long*, long*, long*, std::unordered_map<doris::IteratorKey, doris::IteratorItem, doris::HashOfIteratorKey, std::equal_to<doris::IteratorKey>, std::allocator<std::pair<doris::IteratorKey const, doris::IteratorItem> > >&, doris::vectorized::Block&) at /mnt/disk2/tengjianping/doris-master/be/src/exec/rowid_fetcher.cpp:816
14# doris::RowIdStorageReader::read_batch_doris_format_row(doris::PRequestBlockDesc const&, std::shared_ptr<doris::IdFileMap>, std::vector<doris::SlotDescriptor, std::allocator<doris::SlotDescriptor> >&, doris::TUniqueId const&, doris::vectorized::Block&, doris::OlapReaderStatistics&, long*, long*, long*, long*) at /mnt/disk2/tengjianping/doris-master/be/src/exec/rowid_fetcher.cpp:624
15# doris::RowIdStorageReader::read_by_rowids(doris::PMultiGetRequestV2 const&, doris::PMultiGetResponseV2*) at /mnt/disk2/tengjianping/doris-master/be/src/exec/rowid_fetcher.cpp:538
16# doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0::operator()() const at /mnt/disk2/tengjianping/doris-master/be/src/service/internal_service.cpp:2124
17# void std::__invoke_impl<void, doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0&>(std::__invoke_other, doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61
18# std::enable_if<is_invocable_r_v<void, doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0&>, void>::type std::__invoke_r<void, doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0&>(doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:117
19# std::_Function_handler<void (), doris::PInternalService::multiget_data_v2(google::protobuf::RpcController*, doris::PMultiGetRequestV2 const*, doris::PMultiGetResponseV2*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
20# std::function<void ()>::operator()() const at /mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591
21# doris::vectorized::SimplifiedScanScheduler::submit_scan_task(doris::vectorized::SimplifiedScanTask)::{lambda()#1}::operator()() const at /mnt/disk2/tengjianping/doris-master/be/src/vec/exec/scan/scanner_scheduler.h:134
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

