### PR TITLE
[fix](nereids) update shape plan in order_push_down.out

### DIFF
--- a/regression-test/data/nereids_rules_p0/limit_push_down/order_push_down.out
+++ b/regression-test/data/nereids_rules_p0/limit_push_down/order_push_down.out
@@ -74,12 +74,13 @@ PhysicalResultSink
 
 -- !cross_join_order --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----NestedLoopJoin[CROSS_JOIN]
-------PhysicalTopN[MERGE_SORT]
---------PhysicalTopN[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
-------PhysicalStorageLayerAggregate[t2]
+--PhysicalLazyMaterialize[materializedSlots:(t1.msg) lazySlots:(t1.id)]
+----PhysicalTopN[GATHER_SORT]
+------NestedLoopJoin[CROSS_JOIN]
+--------PhysicalTopN[MERGE_SORT]
+----------PhysicalTopN[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.id)]
+--------PhysicalStorageLayerAggregate[t2]
 
 -- !limit_offset_sort_join --
 PhysicalResultSink
@@ -170,11 +171,12 @@ PhysicalResultSink
 
 -- !limit_sort_window --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----PhysicalWindow
-------PhysicalQuickSort[MERGE_SORT]
---------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
+--PhysicalLazyMaterialize[materializedSlots:(t1.id,row_num) lazySlots:(t1.msg)]
+----PhysicalTopN[GATHER_SORT]
+------PhysicalWindow
+--------PhysicalQuickSort[MERGE_SORT]
+----------PhysicalQuickSort[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.msg)]
 
 -- !limit_offset_window --
 PhysicalResultSink
@@ -188,11 +190,12 @@ PhysicalResultSink
 
 -- !limit_offset_sort_window --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----PhysicalWindow
-------PhysicalQuickSort[MERGE_SORT]
---------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
+--PhysicalLazyMaterialize[materializedSlots:(t1.id,row_num) lazySlots:(t1.msg)]
+----PhysicalTopN[GATHER_SORT]
+------PhysicalWindow
+--------PhysicalQuickSort[MERGE_SORT]
+----------PhysicalQuickSort[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.msg)]
 
 -- !limit_sort_filter --
 PhysicalResultSink
@@ -260,19 +263,21 @@ PhysicalResultSink
 
 -- !limit_window --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----PhysicalWindow
-------PhysicalQuickSort[MERGE_SORT]
---------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
+--PhysicalLazyMaterialize[materializedSlots:(t1.id,row_num) lazySlots:(t1.msg)]
+----PhysicalTopN[GATHER_SORT]
+------PhysicalWindow
+--------PhysicalQuickSort[MERGE_SORT]
+----------PhysicalQuickSort[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.msg)]
 
 -- !limit_offset_window --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----PhysicalWindow
-------PhysicalQuickSort[MERGE_SORT]
---------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
+--PhysicalLazyMaterialize[materializedSlots:(t1.id,row_num) lazySlots:(t1.msg)]
+----PhysicalTopN[GATHER_SORT]
+------PhysicalWindow
+--------PhysicalQuickSort[MERGE_SORT]
+----------PhysicalQuickSort[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.msg)]
 
 -- !limit_filter --
 PhysicalResultSink
@@ -328,11 +333,12 @@ PhysicalResultSink
 
 -- !limit_subquery_window --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----PhysicalWindow
-------PhysicalQuickSort[MERGE_SORT]
---------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
+--PhysicalLazyMaterialize[materializedSlots:(t1.id,row_num) lazySlots:(t1.msg)]
+----PhysicalTopN[GATHER_SORT]
+------PhysicalWindow
+--------PhysicalQuickSort[MERGE_SORT]
+----------PhysicalQuickSort[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.msg)]
 
 -- !limit_nested_subquery --
 PhysicalResultSink
@@ -399,13 +405,14 @@ PhysicalResultSink
 
 -- !limit_subqueryjoin_window --
 PhysicalResultSink
---PhysicalTopN[MERGE_SORT]
-----PhysicalTopN[LOCAL_SORT]
-------PhysicalWindow
---------PhysicalQuickSort[LOCAL_SORT]
-----------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
-------------PhysicalOlapScan[t1]
-------------PhysicalOlapScan[t2]
+--PhysicalLazyMaterialize[materializedSlots:(subq.id,row_num) lazySlots:(subq.msg)]
+----PhysicalTopN[MERGE_SORT]
+------PhysicalTopN[LOCAL_SORT]
+--------PhysicalWindow
+----------PhysicalQuickSort[LOCAL_SORT]
+------------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=()
+--------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(subq.msg)]
+--------------PhysicalOlapScan[t2]
 
 -- !limit_subquery_union_filter --
 PhysicalResultSink
@@ -556,11 +563,12 @@ PhysicalResultSink
 
 -- !limit_subquery_window --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----PhysicalWindow
-------PhysicalQuickSort[MERGE_SORT]
---------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
+--PhysicalLazyMaterialize[materializedSlots:(id,row_num) lazySlots:(subq.msg)]
+----PhysicalTopN[GATHER_SORT]
+------PhysicalWindow
+--------PhysicalQuickSort[MERGE_SORT]
+----------PhysicalQuickSort[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(subq.msg)]
 
 -- !limit_nested_subquery --
 PhysicalResultSink
@@ -577,12 +585,13 @@ PhysicalResultSink
 
 -- !limit_cross_join --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----NestedLoopJoin[CROSS_JOIN]
-------PhysicalTopN[MERGE_SORT]
---------PhysicalTopN[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
-------PhysicalStorageLayerAggregate[t2]
+--PhysicalLazyMaterialize[materializedSlots:(t1.msg) lazySlots:(t1.id)]
+----PhysicalTopN[GATHER_SORT]
+------NestedLoopJoin[CROSS_JOIN]
+--------PhysicalTopN[MERGE_SORT]
+----------PhysicalTopN[LOCAL_SORT]
+------------PhysicalLazyMaterializeOlapScan[t1 lazySlots:(t1.id)]
+--------PhysicalStorageLayerAggregate[t2]
 
 -- !limit_multiple_left_outer_join --
 PhysicalResultSink
@@ -618,32 +627,35 @@ PhysicalResultSink
 
 -- !limit_subquery_cross_join --
 PhysicalResultSink
---PhysicalTopN[GATHER_SORT]
-----NestedLoopJoin[CROSS_JOIN]
-------PhysicalTopN[MERGE_SORT]
---------PhysicalTopN[LOCAL_SORT]
-----------PhysicalOlapScan[t1]
-------PhysicalOlapScan[t2]
+--PhysicalLazyMaterialize[materializedSlots:(subq.id) lazySlots:(t2.id,t2.msg)]
+----PhysicalTopN[GATHER_SORT]
+------NestedLoopJoin[CROSS_JOIN]
+--------PhysicalTopN[MERGE_SORT]
+----------PhysicalTopN[LOCAL_SORT]
+------------PhysicalOlapScan[t1]
+--------PhysicalLazyMaterializeOlapScan[t2 lazySlots:(t2.id,t2.msg)]
 
 -- !limit_subquery_multiple_join --
 PhysicalResultSink
---PhysicalTopN[MERGE_SORT]
-----PhysicalTopN[LOCAL_SORT]
-------hashJoin[INNER_JOIN] hashCondition=((subq.id = t3.id)) otherCondition=()
---------hashJoin[INNER_JOIN] hashCondition=((subq.id = t2.id)) otherCondition=()
-----------PhysicalOlapScan[t1]
-----------PhysicalOlapScan[t2]
---------PhysicalOlapScan[t3]
+--PhysicalLazyMaterialize[materializedSlots:(subq.id,t2.id,t3.id) lazySlots:(t2.msg,t3.msg)]
+----PhysicalTopN[MERGE_SORT]
+------PhysicalTopN[LOCAL_SORT]
+--------hashJoin[INNER_JOIN] hashCondition=((subq.id = t3.id)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((subq.id = t2.id)) otherCondition=()
+------------PhysicalOlapScan[t1]
+------------PhysicalLazyMaterializeOlapScan[t2 lazySlots:(t2.msg)]
+----------PhysicalLazyMaterializeOlapScan[t3 lazySlots:(t3.msg)]
 
 -- !limit_subquery_multiple_join_nested_subquery --
 PhysicalResultSink
---PhysicalTopN[MERGE_SORT]
-----PhysicalTopN[LOCAL_SORT]
-------hashJoin[INNER_JOIN] hashCondition=((subq2.id = t3.id)) otherCondition=()
---------hashJoin[INNER_JOIN] hashCondition=((subq2.id = t2.id)) otherCondition=()
-----------PhysicalOlapScan[t1]
-----------PhysicalOlapScan[t2]
---------PhysicalOlapScan[t3]
+--PhysicalLazyMaterialize[materializedSlots:(subq2.id,t2.id,t3.id) lazySlots:(t2.msg,t3.msg)]
+----PhysicalTopN[MERGE_SORT]
+------PhysicalTopN[LOCAL_SORT]
+--------hashJoin[INNER_JOIN] hashCondition=((subq2.id = t3.id)) otherCondition=()
+----------hashJoin[INNER_JOIN] hashCondition=((subq2.id = t2.id)) otherCondition=()
+------------PhysicalOlapScan[t1]
+------------PhysicalLazyMaterializeOlapScan[t2 lazySlots:(t2.msg)]
+----------PhysicalLazyMaterializeOlapScan[t3 lazySlots:(t3.msg)]
 
 -- !limit_subquery_multiple_join_nested_subquery_distinct --
 PhysicalResultSink


### PR DESCRIPTION
### What problem does this PR solve?
after topn lazy materialization enabled, one shape plan in order_push_down.out should be updated.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

