### PR TITLE
[fix](mow) fix potential mem leak for DeleteBitmap::AggCache

### DIFF
--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -588,7 +588,7 @@ public:
 
                 // release the sigleton instance at program exit
                 std::atexit([] {
-                    auto *ptr = AggCache::s_repr.exchange(nullptr, std::memory_order_acquire);
+                    auto* ptr = AggCache::s_repr.exchange(nullptr, std::memory_order_acquire);
                     delete ptr;
                 });
             });

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -585,6 +585,12 @@ public:
             std::call_once(once, [size_in_bytes] {
                 auto* tmp = new AggCachePolicy(size_in_bytes);
                 AggCache::s_repr.store(tmp, std::memory_order_release);
+
+                // release the sigleton instance at program exit
+                std::atexit([] {
+                    auto *ptr = AggCache::s_repr.exchange(nullptr, std::memory_order_acquire);
+                    delete ptr;
+                });
             });
 
             while (!s_repr.load(std::memory_order_acquire)) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

DeleteBitmap::AggCache use a singleton to manage the memory of LRUCache. It needs to release the cache memory at program exit.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

