### PR TITLE
[improve](statistics)Add hot values to column statistics to string.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -263,8 +263,9 @@ public class ColumnStatistic {
     @Override
     public String toString() {
         return isUnKnown ? "unknown(" + count + ")"
-                : String.format("ndv=%.4f, min=%f(%s), max=%f(%s), count=%.4f, numNulls=%.4f, avgSizeByte=%f",
-                ndv, minValue, minExpr, maxValue, maxExpr, count, numNulls, avgSizeByte);
+                : String.format("ndv=%.4f, min=%f(%s), max=%f(%s), count=%.4f, numNulls=%.4f, "
+                                + "avgSizeByte=%f, hotValues=(%s)",
+                ndv, minValue, minExpr, maxValue, maxExpr, count, numNulls, avgSizeByte, getStringHotValues());
     }
 
     public JSONObject toJson() {

--- a/regression-test/suites/statistics/test_hot_value.groovy
+++ b/regression-test/suites/statistics/test_hot_value.groovy
@@ -80,6 +80,10 @@ suite("test_hot_value") {
     wait_row_count_reported("test_hot_value", "test1", 0, 4, "10000")
     wait_row_count_reported("test_hot_value", "test2", 0, 4, "10000")
     sql """analyze table test1 with sync"""
+    explain {
+        sql("memo plan select * from test1")
+        contains "hotValues=(null)"
+    }
     def result = sql """show column stats test1(key1)"""
     assertEquals(1, result.size())
     assertEquals("10000.0", result[0][2])
@@ -152,6 +156,10 @@ suite("test_hot_value") {
     assertEquals(1, result.size())
     assertEquals("5.0", result[0][2])
     assertEquals("aaa:22.33", result[0][17])
+    explain {
+        sql("memo plan select * from test1")
+        contains "hotValues=(aaa:22.33)"
+    }
 
     sql """alter table test1 modify column value1 set stats ('row_count'='5.0', 'ndv'='5.0', 'num_nulls'='0.0', 'data_size'='34.0', 'min_value'='AFRICA', 'max_value'='MIDDLE EAST', 'hot_values'='a \\\\;a \\\\:a :22.33');"""
     result = sql """show column stats test1(value1)"""
@@ -162,6 +170,10 @@ suite("test_hot_value") {
     assertEquals(1, result.size())
     assertEquals("5.0", result[0][2])
     assertEquals("a ;a :a:22.33", result[0][17])
+    explain {
+        sql("memo plan select * from test1")
+        contains "hotValues=(a ;a :a:22.33)"
+    }
 
     sql """analyze table test2 with sample rows 100 with sync"""
     result = sql """show column stats test2(value1)"""


### PR DESCRIPTION
### What problem does this PR solve?

Add hot values to column statistics to string, so that the hot values could be printed in memo plan.
related pr: https://github.com/apache/doris/pull/52048

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

