### PR TITLE
[fix](nereids)scalar subquery should not show error message when there are multiple agg functions in top-level agg node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SubqueryToApply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SubqueryToApply.java
@@ -60,6 +60,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.Utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -137,7 +138,7 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                                     .collect(ImmutableList.toImmutableList()), tmpPlan,
                                 context.getSubqueryToMarkJoinSlot(),
                                 ctx.cascadesContext,
-                                Optional.of(conjunct), false, isMarkSlotNotNull);
+                                Optional.of(conjunct), isMarkSlotNotNull);
                         applyPlan = result.first;
                         tmpPlan = applyPlan;
                         newConjuncts.add(result.second.isPresent() ? result.second.get() : conjunct);
@@ -179,7 +180,7 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                     Pair<LogicalPlan, Optional<Expression>> result =
                             subqueryToApply(Utils.fastToImmutableList(subqueryExprs), childPlan,
                                     context.getSubqueryToMarkJoinSlot(), ctx.cascadesContext,
-                                    Optional.of(newProject), true, false);
+                                    Optional.of(newProject), false);
                     applyPlan = result.first;
                     childPlan = applyPlan;
                     newProjects.add(
@@ -263,7 +264,7 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                                 subqueryExprs.stream().collect(ImmutableList.toImmutableList()),
                                 relatedInfoList.get(i) == RelatedInfo.RelatedToLeft ? leftChildPlan : rightChildPlan,
                                 context.getSubqueryToMarkJoinSlot(),
-                                ctx.cascadesContext, Optional.of(conjunct), false, isMarkSlotNotNull);
+                                ctx.cascadesContext, Optional.of(conjunct), isMarkSlotNotNull);
                         applyPlan = result.first;
                         if (relatedInfoList.get(i) == RelatedInfo.RelatedToLeft) {
                             leftChildPlan = applyPlan;
@@ -360,22 +361,20 @@ public class SubqueryToApply implements AnalysisRuleFactory {
     private Pair<LogicalPlan, Optional<Expression>> subqueryToApply(
             List<SubqueryExpr> subqueryExprs, LogicalPlan childPlan,
             Map<SubqueryExpr, Optional<MarkJoinSlotReference>> subqueryToMarkJoinSlot,
-            CascadesContext ctx, Optional<Expression> conjunct, boolean isProject,
-            boolean isMarkJoinSlotNotNull) {
-        Pair<LogicalPlan, Optional<Expression>> tmpPlan = Pair.of(childPlan, conjunct);
+            CascadesContext ctx, Optional<Expression> correlatedOuterExpr, boolean isMarkJoinSlotNotNull) {
+        Pair<LogicalPlan, Optional<Expression>> tmpPlan = Pair.of(childPlan, correlatedOuterExpr);
         for (int i = 0; i < subqueryExprs.size(); ++i) {
             SubqueryExpr subqueryExpr = subqueryExprs.get(i);
             if (subqueryExpr instanceof Exists && hasTopLevelScalarAgg(subqueryExpr.getQueryPlan())) {
                 // because top level scalar agg always returns a value or null(for empty input)
-                // so Exists and Not Exists conjunct are always evaluated to True and false literals respectively
-                // we don't create apply node for it
+                // so Exists and Not Exists correlatedOuterExpr are always evaluated to
+                // True and false literals respectively, we don't create apply node for it
                 continue;
             }
 
             if (!ctx.subqueryIsAnalyzed(subqueryExpr)) {
                 tmpPlan = addApply(subqueryExpr, tmpPlan.first,
-                    subqueryToMarkJoinSlot, ctx, tmpPlan.second,
-                    isProject, subqueryExprs.size() == 1, isMarkJoinSlotNotNull);
+                    subqueryToMarkJoinSlot, ctx, tmpPlan.second, isMarkJoinSlotNotNull);
             }
         }
         return tmpPlan;
@@ -390,30 +389,27 @@ public class SubqueryToApply implements AnalysisRuleFactory {
         return false;
     }
 
-    private Pair<LogicalPlan, Optional<Expression>> addApply(SubqueryExpr subquery,
-            LogicalPlan childPlan,
+    private Pair<LogicalPlan, Optional<Expression>> addApply(SubqueryExpr subquery, LogicalPlan childPlan,
             Map<SubqueryExpr, Optional<MarkJoinSlotReference>> subqueryToMarkJoinSlot,
-            CascadesContext ctx, Optional<Expression> conjunct, boolean isProject,
-            boolean singleSubquery, boolean isMarkJoinSlotNotNull) {
+            CascadesContext ctx, Optional<Expression> correlatedOuterExpr, boolean isMarkJoinSlotNotNull) {
         ctx.setSubqueryExprIsAnalyzed(subquery, true);
         Optional<MarkJoinSlotReference> markJoinSlot = subqueryToMarkJoinSlot.get(subquery);
-        boolean needAddScalarSubqueryOutputToProjects = isConjunctContainsScalarSubqueryOutput(
-                subquery, conjunct, isProject, singleSubquery);
+        boolean needAddScalarSubqueryOutputToProjects = isScalarSubqueryOutputUsedInOuterScope(
+                subquery, correlatedOuterExpr);
         // for scalar subquery, we need ensure it output at most 1 row
         // by doing that, we add an aggregate function any_value() to the project list
         // we use needRuntimeAnyValue to indicate if any_value() is needed
         // if needRuntimeAnyValue is true, we will add it to the project list
         boolean needRuntimeAnyValue = false;
-        NamedExpression oldSubqueryOutput = subquery.getQueryPlan().getOutput().get(0);
+        NamedExpression subqueryOutput = subquery.getQueryPlan().getOutput().get(0);
         if (subquery instanceof ScalarSubquery) {
             // scalar sub query may adjust output slot's nullable.
-            oldSubqueryOutput = ((ScalarSubquery) subquery).getOutputSlotAdjustNullable();
+            subqueryOutput = ((ScalarSubquery) subquery).getOutputSlotAdjustNullable();
         }
         Slot countSlot = null;
         Slot anyValueSlot = null;
-        Optional<Expression> newConjunct = conjunct;
-        if (needAddScalarSubqueryOutputToProjects && subquery instanceof ScalarSubquery
-                && !subquery.getCorrelateSlots().isEmpty()) {
+        Optional<Expression> newCorrelatedOuterExpr = correlatedOuterExpr;
+        if (needAddScalarSubqueryOutputToProjects && !subquery.getCorrelateSlots().isEmpty()) {
             if (((ScalarSubquery) subquery).hasTopLevelScalarAgg()) {
                 // consider sql: SELECT * FROM t1 WHERE t1.a <= (SELECT COUNT(t2.a) FROM t2 WHERE (t1.b = t2.b));
                 // when unnest correlated subquery, we create a left join node.
@@ -421,49 +417,21 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                 // if there is no match, the row from right table is filled with nulls
                 // but COUNT function is always not nullable.
                 // so wrap COUNT with Nvl to ensure its result is 0 instead of null to get the correct result
-                if (conjunct.isPresent()) {
+                if (correlatedOuterExpr.isPresent()) {
                     List<NamedExpression> aggFunctions = ScalarSubquery.getTopLevelScalarAggFunctions(
                             subquery.getQueryPlan(), subquery.getCorrelateSlots());
-                    Map<Expression, Expression> replaceMapForSubqueryProject = new HashMap<>();
-                    Map<Expression, Expression> replaceMapForSubqueryOutput = new HashMap<>();
-                    for (NamedExpression agg : aggFunctions) {
-                        if (agg instanceof Alias && ((Alias) agg).child() instanceof NotNullableAggregateFunction) {
-                            NotNullableAggregateFunction notNullableAggFunc =
-                                    (NotNullableAggregateFunction) ((Alias) agg).child();
-                            if (subquery.getQueryPlan() instanceof LogicalProject) {
-                                Slot aggSlot = agg.toSlot();
-                                replaceMapForSubqueryProject.put(aggSlot, new Alias(new Nvl(aggSlot,
-                                        notNullableAggFunc.resultForEmptyInput())));
-                            } else {
-                                replaceMapForSubqueryOutput.put(oldSubqueryOutput, new Nvl(oldSubqueryOutput,
-                                        notNullableAggFunc.resultForEmptyInput()));
-                            }
-                        }
-                    }
-                    if (!replaceMapForSubqueryProject.isEmpty()) {
-                        Preconditions.checkState(subquery.getQueryPlan() instanceof LogicalProject,
-                                "Scalar subquery's top plan node should be LogicalProject");
-                        LogicalProject logicalProject =
-                                (LogicalProject) subquery.getQueryPlan();
-                        Preconditions.checkState(logicalProject.getOutputs().size() == 1,
-                                "Scalar subuqery's should only output 1 column");
-                        NamedExpression newOutput = (NamedExpression) ExpressionUtils
-                                .replace((NamedExpression) logicalProject.getProjects().get(0),
-                                        replaceMapForSubqueryProject);
-                        replaceMapForSubqueryOutput.put(oldSubqueryOutput, newOutput.toSlot());
-                        oldSubqueryOutput = newOutput;
-                        subquery = subquery.withSubquery((LogicalPlan) logicalProject.child());
-                    }
-                    if (!replaceMapForSubqueryOutput.isEmpty()) {
-                        newConjunct = Optional.of(ExpressionUtils.replace(conjunct.get(), replaceMapForSubqueryOutput));
-                    }
+                    SubQueryRewriteResult result = addNvlForScalarSubqueryOutput(aggFunctions, subqueryOutput,
+                            subquery, correlatedOuterExpr);
+                    subqueryOutput = result.subqueryOutput;
+                    subquery = result.subquery;
+                    newCorrelatedOuterExpr = result.correlatedOuterExpr;
                 }
             } else {
                 // if scalar subquery doesn't have top level scalar agg we will create one, for example
                 // select (select t2.c1 from t2 where t2.c2 = t1.c2) from t1;
                 // the original output of the correlate subquery is t2.c1, after adding a scalar agg, it will be
                 // select (select count(*), any_value(t2.c1) from t2 where t2.c2 = t1.c2) from t1;
-                Alias anyValueAlias = new Alias(new AnyValue(oldSubqueryOutput));
+                Alias anyValueAlias = new Alias(new AnyValue(subqueryOutput));
                 LogicalAggregate<Plan> aggregate;
                 if (((ScalarSubquery) subquery).limitOneIsEliminated()) {
                     aggregate = new LogicalAggregate<>(ImmutableList.of(),
@@ -476,10 +444,11 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                 }
                 anyValueSlot = anyValueAlias.toSlot();
                 subquery = subquery.withSubquery(aggregate);
-                if (conjunct.isPresent()) {
+                if (correlatedOuterExpr.isPresent()) {
                     Map<Expression, Expression> replaceMap = new HashMap<>();
-                    replaceMap.put(oldSubqueryOutput, anyValueSlot);
-                    newConjunct = Optional.of(ExpressionUtils.replace(conjunct.get(), replaceMap));
+                    replaceMap.put(subqueryOutput, anyValueSlot);
+                    newCorrelatedOuterExpr = Optional.of(ExpressionUtils.replace(correlatedOuterExpr.get(),
+                            replaceMap));
                 }
                 needRuntimeAnyValue = true;
             }
@@ -503,7 +472,7 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                 subquery.getCorrelateSlots(),
                 subQueryType, isNot, compareExpr, subquery.getTypeCoercionExpr(), Optional.empty(),
                 markJoinSlot,
-                needAddScalarSubqueryOutputToProjects, isProject, isMarkJoinSlotNotNull,
+                needAddScalarSubqueryOutputToProjects, isMarkJoinSlotNotNull,
                 childPlan, subquery.getQueryPlan());
 
         ImmutableList.Builder<NamedExpression> projects =
@@ -530,22 +499,104 @@ public class SubqueryToApply implements AnalysisRuleFactory {
                     logicalProject = new LogicalProject(projects.build(), newApply);
                 }
             } else {
-                projects.add(oldSubqueryOutput);
+                projects.add(subqueryOutput);
                 logicalProject = new LogicalProject(projects.build(), newApply);
             }
         } else {
             logicalProject = new LogicalProject(projects.build(), newApply);
         }
 
-        return Pair.of(logicalProject, newConjunct);
+        return Pair.of(logicalProject, newCorrelatedOuterExpr);
     }
 
-    private boolean isConjunctContainsScalarSubqueryOutput(
-            SubqueryExpr subqueryExpr, Optional<Expression> conjunct, boolean isProject, boolean singleSubquery) {
+    /**
+     * SubQueryRewriteResult
+     */
+    @VisibleForTesting
+    protected class SubQueryRewriteResult {
+        public SubqueryExpr subquery;
+        public NamedExpression subqueryOutput;
+        public Optional<Expression> correlatedOuterExpr;
+
+        public SubQueryRewriteResult(SubqueryExpr subquery, NamedExpression subqueryOutput,
+                                     Optional<Expression> correlatedOuterExpr) {
+            this.subquery = subquery;
+            this.subqueryOutput = subqueryOutput;
+            this.correlatedOuterExpr = correlatedOuterExpr;
+        }
+    }
+
+    /**
+     * for correlated scalar subquery like select c1, (select count(c1) from t2 where t1.c2 = t2.c2) as c from t1
+     * if we don't add extra nvl for not nullable agg functions, the plan will be like bellow:
+     * +--LogicalProject(projects=[c1#0, count(c1)#4 AS `c`#5])
+     *    +--LogicalJoin(type=LEFT_OUTER_JOIN, hashJoinConjuncts=[(c2#1 = c2#3)])
+     *       |--LogicalOlapScan (t1)
+     *       +--LogicalAggregate[108] (groupByExpr=[c2#3], outputExpr=[c2#3, count(c1#2) AS `count(c1)`#4])
+     *          +--LogicalOlapScan (t2)
+     *
+     * the count(c1)#4 may be null because of unmatched row of left outer join, but count is not nullable agg function,
+     * it should never be null, we need use nvl to wrap it and change the plan like bellow:
+     * +--LogicalProject(projects=[c1#0, ifnull(count(c1)#4, 0) AS `c`#5])
+     *    +--LogicalJoin(type=LEFT_OUTER_JOIN, hashJoinConjuncts=[(c2#1 = c2#3)])
+     *       |--LogicalOlapScan (t1)
+     *       +--LogicalAggregate[108] (groupByExpr=[c2#3], outputExpr=[c2#3, count(c1#2) AS `count(c1)`#4])
+     *          +--LogicalOlapScan (t2)
+     *
+     * in order to do that, we need change subquery's output and replace the correlated outer expr
+     */
+    @VisibleForTesting
+    protected SubQueryRewriteResult addNvlForScalarSubqueryOutput(List<NamedExpression> aggFunctions,
+                                                                NamedExpression subqueryOutput,
+                                                                SubqueryExpr subquery,
+                                                                Optional<Expression> correlatedOuterExpr) {
+        SubQueryRewriteResult result = new SubQueryRewriteResult(subquery, subqueryOutput, correlatedOuterExpr);
+        Map<Expression, Expression> replaceMapForSubqueryProject = new HashMap<>();
+        Map<Expression, Expression> replaceMapForCorrelatedOuterExpr = new HashMap<>();
+        for (NamedExpression agg : aggFunctions) {
+            if (agg instanceof Alias && ((Alias) agg).child() instanceof NotNullableAggregateFunction) {
+                NotNullableAggregateFunction notNullableAggFunc =
+                        (NotNullableAggregateFunction) ((Alias) agg).child();
+                if (subquery.getQueryPlan() instanceof LogicalProject) {
+                    // if the top node of subquery is LogicalProject, we need replace the agg slot in
+                    // project list by nvl(agg), and this project will be placed above LogicalApply node
+                    Slot aggSlot = agg.toSlot();
+                    replaceMapForSubqueryProject.put(aggSlot, new Alias(new Nvl(aggSlot,
+                            notNullableAggFunc.resultForEmptyInput())));
+                } else {
+                    replaceMapForCorrelatedOuterExpr.put(subqueryOutput, new Nvl(subqueryOutput,
+                            notNullableAggFunc.resultForEmptyInput()));
+                }
+            }
+        }
+        if (!replaceMapForSubqueryProject.isEmpty()) {
+            Preconditions.checkState(subquery.getQueryPlan() instanceof LogicalProject,
+                    "Scalar subquery's top plan node should be LogicalProject");
+            LogicalProject logicalProject =
+                    (LogicalProject) subquery.getQueryPlan();
+            Preconditions.checkState(logicalProject.getOutputs().size() == 1,
+                    "Scalar subuqery's should only output 1 column");
+            NamedExpression newOutput = (NamedExpression) ExpressionUtils
+                    .replace((NamedExpression) logicalProject.getProjects().get(0),
+                            replaceMapForSubqueryProject);
+            replaceMapForCorrelatedOuterExpr.put(subqueryOutput, newOutput.toSlot());
+            result.subqueryOutput = newOutput;
+            // logicalProject will be placed above LogicalApply later, so we remove it from subquery
+            result.subquery = subquery.withSubquery((LogicalPlan) logicalProject.child());
+        }
+        if (!replaceMapForCorrelatedOuterExpr.isEmpty()) {
+            result.correlatedOuterExpr = Optional.of(ExpressionUtils.replace(correlatedOuterExpr.get(),
+                    replaceMapForCorrelatedOuterExpr));
+        }
+        return result;
+    }
+
+    private boolean isScalarSubqueryOutputUsedInOuterScope(
+            SubqueryExpr subqueryExpr, Optional<Expression> correlatedOuterExpr) {
         return subqueryExpr instanceof ScalarSubquery
-            && ((conjunct.isPresent() && ((ImmutableSet) conjunct.get().collect(SlotReference.class::isInstance))
-                    .contains(subqueryExpr.getQueryPlan().getOutput().get(0)))
-                || isProject);
+            && ((correlatedOuterExpr.isPresent()
+                && ((ImmutableSet) correlatedOuterExpr.get().collect(SlotReference.class::isInstance))
+                    .contains(subqueryExpr.getQueryPlan().getOutput().get(0))));
     }
 
     /**
@@ -676,12 +727,6 @@ public class SubqueryToApply implements AnalysisRuleFactory {
             subqueryToMarkJoinSlot.put(subquery, markJoinSlotReference);
         }
 
-    }
-
-    private enum SearchState {
-        SearchNot,
-        SearchAnd,
-        SearchExistsOrInSubquery
     }
 
     private List<Boolean> shouldOutputMarkJoinSlot(Collection<Expression> conjuncts) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyAggregateFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyAggregateFilter.java
@@ -118,8 +118,7 @@ public class UnCorrelatedApplyAggregateFilter implements RewriteRuleFactory {
         return new LogicalApply<>(apply.getCorrelationSlot(), apply.getSubqueryType(), apply.isNot(),
                 apply.getCompareExpr(), apply.getTypeCoercionExpr(),
                 ExpressionUtils.optionalAnd(correlatedPredicate), apply.getMarkJoinSlotReference(),
-                apply.isNeedAddSubOutputToProjects(), apply.isInProject(),
-                apply.isMarkJoinSlotNotNull(), apply.left(),
+                apply.isNeedAddSubOutputToProjects(), apply.isMarkJoinSlotNotNull(), apply.left(),
                 isRightChildAgg ? newAgg : apply.right().withChildren(newAgg));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyFilter.java
@@ -70,7 +70,7 @@ public class UnCorrelatedApplyFilter extends OneRewriteRuleFactory {
                     apply.getCompareExpr(), apply.getTypeCoercionExpr(),
                     ExpressionUtils.optionalAnd(correlatedPredicate), apply.getMarkJoinSlotReference(),
                     apply.isNeedAddSubOutputToProjects(),
-                    apply.isInProject(), apply.isMarkJoinSlotNotNull(), apply.left(), child);
+                    apply.isMarkJoinSlotNotNull(), apply.left(), child);
         }).toRule(RuleType.UN_CORRELATED_APPLY_FILTER);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
@@ -91,7 +91,7 @@ public class UnCorrelatedApplyProjectFilter extends OneRewriteRuleFactory {
                             apply.getCompareExpr(), apply.getTypeCoercionExpr(),
                             ExpressionUtils.optionalAnd(correlatedPredicate), apply.getMarkJoinSlotReference(),
                             apply.isNeedAddSubOutputToProjects(),
-                            apply.isInProject(), apply.isMarkJoinSlotNotNull(), apply.left(), newProject);
+                            apply.isMarkJoinSlotNotNull(), apply.left(), newProject);
                 }).toRule(RuleType.UN_CORRELATED_APPLY_PROJECT_FILTER);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -152,7 +152,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
                 .map(m -> (MarkJoinSlotReference) ExpressionDeepCopier.INSTANCE.deepCopy(m, context));
         return new LogicalApply<>(correlationSlot, apply.getSubqueryType(), apply.isNot(),
                 compareExpr, typeCoercionExpr, correlationFilter,
-                markJoinSlotReference, apply.isNeedAddSubOutputToProjects(), apply.isInProject(),
+                markJoinSlotReference, apply.isNeedAddSubOutputToProjects(),
                 apply.isMarkJoinSlotNotNull(), left, right);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
@@ -68,9 +68,6 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
     // The slot replaced by the subquery in MarkJoin
     private final Optional<MarkJoinSlotReference> markJoinSlotReference;
 
-    // Whether the subquery is in logicalProject
-    private final boolean inProject;
-
     // Whether adding the subquery's output to projects
     private final boolean needAddSubOutputToProjects;
 
@@ -89,7 +86,6 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
             Optional<Expression> correlationFilter,
             Optional<MarkJoinSlotReference> markJoinSlotReference,
             boolean needAddSubOutputToProjects,
-            boolean inProject,
             boolean isMarkJoinSlotNotNull,
             LEFT_CHILD_TYPE leftChild, RIGHT_CHILD_TYPE rightChild) {
         super(PlanType.LOGICAL_APPLY, groupExpression, logicalProperties, leftChild, rightChild);
@@ -104,17 +100,16 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
         this.correlationFilter = correlationFilter;
         this.markJoinSlotReference = markJoinSlotReference;
         this.needAddSubOutputToProjects = needAddSubOutputToProjects;
-        this.inProject = inProject;
         this.isMarkJoinSlotNotNull = isMarkJoinSlotNotNull;
     }
 
     public LogicalApply(List<Slot> correlationSlot, SubQueryType subqueryType, boolean isNot,
             Optional<Expression> compareExpr, Optional<Expression> typeCoercionExpr,
             Optional<Expression> correlationFilter, Optional<MarkJoinSlotReference> markJoinSlotReference,
-            boolean needAddSubOutputToProjects, boolean inProject, boolean isMarkJoinSlotNotNull,
+            boolean needAddSubOutputToProjects, boolean isMarkJoinSlotNotNull,
             LEFT_CHILD_TYPE input, RIGHT_CHILD_TYPE subquery) {
         this(Optional.empty(), Optional.empty(), correlationSlot, subqueryType, isNot, compareExpr, typeCoercionExpr,
-                correlationFilter, markJoinSlotReference, needAddSubOutputToProjects, inProject, isMarkJoinSlotNotNull,
+                correlationFilter, markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull,
                 input, subquery);
     }
 
@@ -178,10 +173,6 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
         return needAddSubOutputToProjects;
     }
 
-    public boolean isInProject() {
-        return inProject;
-    }
-
     public boolean isMarkJoinSlotNotNull() {
         return isMarkJoinSlotNotNull;
     }
@@ -229,7 +220,6 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
                 && Objects.equals(correlationFilter, that.getCorrelationFilter())
                 && Objects.equals(markJoinSlotReference, that.getMarkJoinSlotReference())
                 && needAddSubOutputToProjects == that.needAddSubOutputToProjects
-                && inProject == that.inProject
                 && isMarkJoinSlotNotNull == that.isMarkJoinSlotNotNull
                 && isNot == that.isNot;
     }
@@ -238,7 +228,7 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
     public int hashCode() {
         return Objects.hash(
                 correlationSlot, subqueryType, compareExpr, typeCoercionExpr, correlationFilter,
-                markJoinSlotReference, needAddSubOutputToProjects, inProject, isMarkJoinSlotNotNull, isNot);
+                markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull, isNot);
     }
 
     @Override
@@ -264,7 +254,7 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
     public LogicalApply<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new LogicalApply<>(correlationSlot, subqueryType, isNot, compareExpr, typeCoercionExpr,
-                correlationFilter, markJoinSlotReference, needAddSubOutputToProjects, inProject, isMarkJoinSlotNotNull,
+                correlationFilter, markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull,
                 children.get(0), children.get(1));
     }
 
@@ -272,7 +262,7 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalApply<>(groupExpression, Optional.of(getLogicalProperties()),
                 correlationSlot, subqueryType, isNot, compareExpr, typeCoercionExpr, correlationFilter,
-                markJoinSlotReference, needAddSubOutputToProjects, inProject, isMarkJoinSlotNotNull, left(), right());
+                markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull, left(), right());
     }
 
     @Override
@@ -281,7 +271,7 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
         Preconditions.checkArgument(children.size() == 2);
         return new LogicalApply<>(groupExpression, logicalProperties, correlationSlot, subqueryType, isNot,
                 compareExpr, typeCoercionExpr, correlationFilter, markJoinSlotReference,
-                needAddSubOutputToProjects, inProject, isMarkJoinSlotNotNull, children.get(0), children.get(1));
+                needAddSubOutputToProjects, isMarkJoinSlotNotNull, children.get(0), children.get(1));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/SubqueryToApplyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/SubqueryToApplyTest.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.util.LogicalPlanBuilder;
+import org.apache.doris.nereids.util.PlanConstructor;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class SubqueryToApplyTest {
+
+    @Test
+    void testAddNvlAggregate() {
+        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE);
+        NamedExpression aggregateFunction = new Alias(new ExprId(12345), new Count(slotReference), "count");
+        LogicalOlapScan logicalOlapScan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+        LogicalAggregate<Plan> logicalAggregate = new LogicalAggregate<>(
+                ImmutableList.of(), ImmutableList.of(aggregateFunction), logicalOlapScan);
+        LogicalPlanBuilder planBuilder = new LogicalPlanBuilder(logicalAggregate);
+        LogicalPlan plan = planBuilder.projectAll().build();
+        Optional<Expression> correlatedOuterExpr = Optional
+                .of(new EqualTo(plan.getOutput().get(0), new BigIntLiteral(1)));
+        ScalarSubquery subquery = new ScalarSubquery(plan);
+        SubqueryToApply subqueryToApply = new SubqueryToApply();
+        SubqueryToApply.SubQueryRewriteResult rewriteResult = subqueryToApply.addNvlForScalarSubqueryOutput(
+                ImmutableList.of(aggregateFunction), plan.getOutput().get(0), subquery, correlatedOuterExpr);
+        Assertions.assertInstanceOf(EqualTo.class, rewriteResult.correlatedOuterExpr.get());
+        Assertions.assertInstanceOf(Alias.class, rewriteResult.subqueryOutput);
+        Assertions.assertInstanceOf(Nvl.class, rewriteResult.subqueryOutput.child(0));
+        Assertions.assertEquals(rewriteResult.subqueryOutput.toSlot(),
+                rewriteResult.correlatedOuterExpr.get().child(0));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ExistsApplyToJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ExistsApplyToJoinTest.java
@@ -47,7 +47,7 @@ class ExistsApplyToJoinTest implements MemoPatternMatchSupported {
                 new LogicalApply<>(ImmutableList.of(leftSlots.get(0), rightSlots.get(0)),
                         LogicalApply.SubQueryType.EXITS_SUBQUERY, false, Optional.empty(), Optional.empty(),
                         Optional.of(equalTo), Optional.empty(),
-                        false, false, false, left, right);
+                        false, false, left, right);
         PlanChecker.from(MemoTestUtils.createConnectContext(), apply)
                 .applyTopDown(new ExistsApplyToJoin())
                 .matchesFromRoot(logicalJoin(
@@ -67,7 +67,7 @@ class ExistsApplyToJoinTest implements MemoPatternMatchSupported {
                 new LogicalApply<>(Collections.emptyList(),
                         LogicalApply.SubQueryType.EXITS_SUBQUERY, false, Optional.empty(), Optional.empty(),
                         Optional.of(equalTo), Optional.empty(),
-                        false, false, false, left, right);
+                        false, false, left, right);
         PlanChecker.from(MemoTestUtils.createConnectContext(), apply)
                 .applyTopDown(new ExistsApplyToJoin())
                 .matchesFromRoot(logicalJoin(
@@ -87,7 +87,7 @@ class ExistsApplyToJoinTest implements MemoPatternMatchSupported {
                 new LogicalApply<>(Collections.emptyList(),
                         LogicalApply.SubQueryType.EXITS_SUBQUERY, true, Optional.empty(), Optional.empty(),
                         Optional.of(equalTo), Optional.empty(),
-                        false, false, false, left, right);
+                        false, false, left, right);
         PlanChecker.from(MemoTestUtils.createConnectContext(), apply)
                 .applyTopDown(new ExistsApplyToJoin())
                 .matchesFromRoot(logicalFilter(logicalJoin(
@@ -108,7 +108,7 @@ class ExistsApplyToJoinTest implements MemoPatternMatchSupported {
                 new LogicalApply<>(ImmutableList.of(leftSlots.get(0), rightSlots.get(0)),
                         LogicalApply.SubQueryType.EXITS_SUBQUERY, true, Optional.empty(), Optional.empty(),
                         Optional.of(equalTo), Optional.empty(),
-                        false, false, false, left, right);
+                        false, false, left, right);
         PlanChecker.from(MemoTestUtils.createConnectContext(), apply)
                 .applyTopDown(new ExistsApplyToJoin())
                 .matchesFromRoot(logicalJoin(

--- a/regression-test/data/nereids_p0/subquery/correlated_scalar_subquery.out
+++ b/regression-test/data/nereids_p0/subquery/correlated_scalar_subquery.out
@@ -115,3 +115,26 @@
 1
 1
 
+-- !select_agg_project1 --
+3
+4
+
+-- !select_agg_project2 --
+2
+2
+
+-- !select_2_aggs --
+3
+3
+4
+4
+5
+
+-- !select_3_aggs --
+1
+2
+2
+3
+4
+5
+

--- a/regression-test/suites/nereids_p0/subquery/correlated_scalar_subquery.groovy
+++ b/regression-test/suites/nereids_p0/subquery/correlated_scalar_subquery.groovy
@@ -243,4 +243,9 @@ suite("correlated_scalar_subquery") {
         """
         exception "access outer query column"
     }
+
+    qt_select_agg_project1 """select c2 from correlated_scalar_t1 where correlated_scalar_t1.c2 > (select if(count(c1) = 0, 2, 100) from correlated_scalar_t2 where correlated_scalar_t1.c1 = correlated_scalar_t2.c1) order by c2;"""
+    qt_select_agg_project2 """select c2 from correlated_scalar_t1 where correlated_scalar_t1.c2 = (select if(sum(c1) is null, 2, 100) from correlated_scalar_t2 where correlated_scalar_t1.c1 = correlated_scalar_t2.c1) order by c2;"""
+    qt_select_2_aggs """select c2 from correlated_scalar_t1 where correlated_scalar_t1.c2 > (select count(c1) - min(c1) from correlated_scalar_t2 where correlated_scalar_t1.c1 = correlated_scalar_t2.c1) order by c2;"""
+    qt_select_3_aggs """select c2 from correlated_scalar_t1 where correlated_scalar_t1.c2 > (select if(sum(c1) is null, count(c1), max(c2)) from correlated_scalar_t2 where correlated_scalar_t1.c1 = correlated_scalar_t2.c1) order by c2;"""
 }


### PR DESCRIPTION
support subquery like bellow:
`select * from t1 where t1.c1 = (select count(*) + sum(c2) from t2  where t1.c1=t2.c2);`
before this pr, doris will report an error when there are more than 1 agg functions in subquery, like count(*) and sum(c2). This pr fix this issue.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

