### PR TITLE
[fix](case) Fix case BlockFileCacheTest.ttl_gc

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1851,7 +1851,7 @@ void BlockFileCache::run_background_ttl_gc() {
             SCOPED_RAW_TIMER(&duration_ns);
             while (!_time_to_key.empty()) {
                 auto begin = _time_to_key.begin();
-                if (cur_time < begin->first || count > batch_size) {
+                if (cur_time < begin->first || count >= batch_size) {
                     break;
                 }
                 remove_if_ttl_file_blocks(begin->second, false, cache_lock, false);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -2960,10 +2960,10 @@ TEST_F(BlockFileCacheTest, ttl_gc) {
     }
     ASSERT_EQ(cache._time_to_key.size(), 12);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
-    ASSERT_GT(cache._time_to_key.size(), 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(3100));
+    ASSERT_EQ(cache._time_to_key.size(), 6);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(3100));
     ASSERT_EQ(cache._time_to_key.size(), 0);
 
     if (fs::exists(cache_base_path)) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52670 

Problem Summary: Because the gc time interval is exactly the same as the sleep time defined in code, sometimes the background gc thread runs after assertion, cause assert failure. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [x] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

