### PR TITLE
[fix](case) Fix case test_index_like_select

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_index_like_select.groovy
+++ b/regression-test/suites/inverted_index_p0/test_index_like_select.groovy
@@ -166,7 +166,7 @@ suite("test_index_like_select", "inverted_index_select"){
         } catch(Exception ex) {
             logger.info("int colume should not match succ, result: " + ex)
         }
-        assertEquals(int_colume_like_result, 'fail')
+        assertEquals(int_colume_like_result, 'success')
 
         // case6: mix select
         // case6.0 common colume and index mix select


### PR DESCRIPTION
1. Numeric types can use LIKE

