### PR TITLE
[fix](iceberg) Fix transaction issues

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
@@ -151,6 +151,7 @@ public class IcebergTransaction implements Transaction {
                     "Should have no referenced data files for append.");
             Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
         }
+        appendFiles.commit();
     }
 
 
@@ -168,6 +169,7 @@ public class IcebergTransaction implements Transaction {
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
+                overwriteFiles.commit();
             }
             return;
         }
@@ -181,6 +183,7 @@ public class IcebergTransaction implements Transaction {
                     "Should have no referenced data files.");
             Arrays.stream(result.dataFiles()).forEach(appendPartitionOp::addFile);
         }
+        appendPartitionOp.commit();
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
@@ -108,8 +108,8 @@ public class IcebergTransaction implements Transaction {
     }
 
     private void updateManifestAfterInsert(TUpdateMode updateMode) {
-        PartitionSpec spec = table.spec();
-        FileFormat fileFormat = IcebergUtils.getFileFormat(table);
+        PartitionSpec spec = transaction.table().spec();
+        FileFormat fileFormat = IcebergUtils.getFileFormat(transaction.table());
 
         List<WriteResult> pendingResults;
         if (commitDataList.isEmpty()) {
@@ -122,9 +122,9 @@ public class IcebergTransaction implements Transaction {
         }
 
         if (updateMode == TUpdateMode.APPEND) {
-            commitAppendTxn(table, pendingResults);
+            commitAppendTxn(pendingResults);
         } else {
-            commitReplaceTxn(table, pendingResults);
+            commitReplaceTxn(pendingResults);
         }
     }
 
@@ -143,43 +143,44 @@ public class IcebergTransaction implements Transaction {
         return commitDataList.stream().mapToLong(TIcebergCommitData::getRowCount).sum();
     }
 
-    private void commitAppendTxn(Table table, List<WriteResult> pendingResults) {
+    private void commitAppendTxn(List<WriteResult> pendingResults) {
         // commit append files.
-        AppendFiles appendFiles = table.newAppend().scanManifestsWith(ops.getThreadPoolWithPreAuth());
+        AppendFiles appendFiles = transaction.newAppend().scanManifestsWith(ops.getThreadPoolWithPreAuth());
         for (WriteResult result : pendingResults) {
             Preconditions.checkState(result.referencedDataFiles().length == 0,
                     "Should have no referenced data files for append.");
             Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
         }
-        appendFiles.commit();
     }
 
 
-    private void commitReplaceTxn(Table table, List<WriteResult> pendingResults) {
+    private void commitReplaceTxn(List<WriteResult> pendingResults) {
         if (pendingResults.isEmpty()) {
             // such as : insert overwrite table `dst_tb` select * from `empty_tb`
             // 1. if dst_tb is a partitioned table, it will return directly.
             // 2. if dst_tb is an unpartitioned table, the `dst_tb` table will be emptied.
-            if (!table.spec().isPartitioned()) {
-                OverwriteFiles overwriteFiles = table.newOverwrite().scanManifestsWith(ops.getThreadPoolWithPreAuth());
+            if (!transaction.table().spec().isPartitioned()) {
+                OverwriteFiles overwriteFiles = transaction
+                        .newOverwrite()
+                        .scanManifestsWith(ops.getThreadPoolWithPreAuth());
                 try (CloseableIterable<FileScanTask> fileScanTasks = table.newScan().planFiles()) {
                     fileScanTasks.forEach(f -> overwriteFiles.deleteFile(f.file()));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-                overwriteFiles.commit();
             }
             return;
         }
 
         // commit replace partitions
-        ReplacePartitions appendPartitionOp = table.newReplacePartitions();
+        ReplacePartitions appendPartitionOp = transaction
+                .newReplacePartitions()
+                .scanManifestsWith(ops.getThreadPoolWithPreAuth());
         for (WriteResult result : pendingResults) {
             Preconditions.checkState(result.referencedDataFiles().length == 0,
                     "Should have no referenced data files.");
             Arrays.stream(result.dataFiles()).forEach(appendPartitionOp::addFile);
         }
-        appendPartitionOp.commit();
     }
 
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. In a transaction, the transaction API should be used, and commits should not be made when finishInsert is called.
2. The ExecutorService for ReplacePartitions was omitted.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

