### PR TITLE
[fix](move-memtable) gracefully shutdown flush token in TabletStream::pre_close

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -296,6 +296,8 @@ Status TabletStream::_run_in_heavy_work_pool(std::function<Status()> fn) {
 
 void TabletStream::pre_close() {
     if (!_status.ok()) {
+        // cancel all pending tasks, wait all running tasks to finish
+        _flush_token->shutdown();
         return;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-20881
Problem Summary:

If TabletStream exits with an abnormal status, we should cancel all pending 
flush tasks and wait for any running ones to finish by shutting down the 
flush token in `pre_close()`.
Without this, pending tasks may continue running after TabletStream has
been destructed, leading to undefined behavior or potential crashes.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

