### PR TITLE
[fix](be) fix macos report wrong cpu cores

### DIFF
--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -160,6 +160,11 @@ void CpuInfo::init() {
         }
     }
 
+#ifdef __APPLE__
+    size_t len = sizeof(max_num_cores_);
+    sysctlbyname("hw.physicalcpu", &physical_num_cores, &len, nullptr, 0);
+#endif
+
     int num_cores = CGroupUtil::get_cgroup_limited_cpu_number(physical_num_cores);
     if (max_mhz != 0) {
         cycles_per_ms_ = int64_t(max_mhz) * 1000;
@@ -178,7 +183,6 @@ void CpuInfo::init() {
     }
 
 #ifdef __APPLE__
-    size_t len = sizeof(max_num_cores_);
     sysctlbyname("hw.logicalcpu", &max_num_cores_, &len, nullptr, 0);
 #else
     max_num_cores_ = get_nprocs_conf();


### PR DESCRIPTION
### What problem does this PR solve?

Fix Mac always report 1 cpu core, this issue can lead to inconsistent behavior between Linux and Mac, e.g. Linux maybe throw exception of local shuffle, but Mac can not reproduce

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

