### PR TITLE
[Fix](arm) fix arm compile failure in clang-16

### DIFF
--- a/be/src/util/byte_stream_split.cpp
+++ b/be/src/util/byte_stream_split.cpp
@@ -20,6 +20,7 @@
 #include <glog/logging.h>
 
 #include <array>
+#include <bit> // IWYU pragma: keep
 #include <cstring>
 #include <vector>
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

fix bug like 
```
 /home/zcp/repo_center/doris_master/doris/be/src/util/byte_stream_split.cpp:41:36: error: no member named 'endian' in namespace 'std'
```
because of lost of a header file.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

