### PR TITLE
[opt](nereids) opt eliminate empty relation with union

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateEmptyRelation.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.UnaryNode;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
@@ -33,6 +34,7 @@ import org.apache.doris.nereids.trees.plans.algebra.SetOperation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.qe.ConnectContext;
 
@@ -102,6 +104,22 @@ public class EliminateEmptyRelation implements RewriteRuleFactory {
                         return new LogicalEmptyRelation(
                                 ConnectContext.get().getStatementContext().getNextRelationId(),
                                 union.getOutput());
+                    } else if (union.getConstantExprsList().size() == 1) {
+                        List<NamedExpression> constantExprs = union.getConstantExprsList().get(0);
+                        ImmutableList.Builder<NamedExpression> newOneRowRelationOutput
+                                = ImmutableList.builderWithExpectedSize(constantExprs.size());
+                        for (int i = 0; i < constantExprs.size(); i++) {
+                            NamedExpression setOutput = union.getOutput().get(i);
+                            NamedExpression constantExpr = constantExprs.get(i);
+                            Expression realConstantExpr = constantExpr instanceof Alias
+                                    ? ((Alias) constantExpr).child() : constantExpr;
+                            Alias oneRowRelationOutput = new Alias(
+                                    setOutput.getExprId(), realConstantExpr, setOutput.getName());
+                            newOneRowRelationOutput.add(oneRowRelationOutput);
+                        }
+                        return new LogicalOneRowRelation(
+                                ConnectContext.get().getStatementContext().getNextRelationId(),
+                                newOneRowRelationOutput.build());
                     } else {
                         return union.withChildrenAndTheirOutputs(ImmutableList.of(), ImmutableList.of());
                     }

--- a/regression-test/data/empty_relation/eliminate_empty.out
+++ b/regression-test/data/empty_relation/eliminate_empty.out
@@ -137,6 +137,28 @@ PhysicalResultSink
 
 -- !null_except_empty_data --
 
+-- !union_to_onerow_1 --
+1	2
+
+-- !union_to_onerow_1_shape --
+PhysicalResultSink
+--PhysicalDistribute[DistributionSpecGather]
+----hashAgg[GLOBAL]
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[LOCAL]
+----------PhysicalOneRowRelation
+
+-- !union_to_onerow_2 --
+1	2
+
+-- !union_to_onerow_2_shape --
+PhysicalResultSink
+--PhysicalDistribute[DistributionSpecGather]
+----hashAgg[GLOBAL]
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[LOCAL]
+----------PhysicalOneRowRelation
+
 -- !prune_partition1 --
 PhysicalResultSink
 --PhysicalEmptyRelation


### PR DESCRIPTION
### What problem does this PR solve?

for rule  EliminateEmptyRelation,  when processing union, if all its children are EmptyRelations and it had only 1 constant expr,  then the union can rewrite to one row relation.

for example:   `EmptyRelation union select 1, 2`,   then this UNION will convert to LogicalOneRowRelation(1, 2)

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

