### PR TITLE
[opt](auditlog) Use varchar(1024) for column frontend_ip of audit log table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -135,7 +135,7 @@ public class InternalSchema {
         AUDIT_SCHEMA.add(new ColumnDef("user",
                 TypeDef.createVarchar(128), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA.add(new ColumnDef("frontend_ip",
-                TypeDef.createVarchar(128), ColumnNullableType.NULLABLE));
+                TypeDef.createVarchar(1024), ColumnNullableType.NULLABLE));
         // default ctl and db
         AUDIT_SCHEMA.add(new ColumnDef("catalog",
                 TypeDef.createVarchar(128), ColumnNullableType.NULLABLE));

--- a/regression-test/suites/manager/test_manager_interface_1.groovy
+++ b/regression-test/suites/manager/test_manager_interface_1.groovy
@@ -562,7 +562,7 @@ suite('test_manager_interface_1',"p0") {
         assertTrue(result[0][1].contains("`return_rows` bigint NULL,")) 
         assertTrue(result[0][1].contains("`stmt_id` bigint NULL,"))
         assertTrue(result[0][1].contains("`is_query` tinyint NULL,"))
-        assertTrue(result[0][1].contains("`frontend_ip` varchar(128) NULL,"))
+        assertTrue(result[0][1].contains("`frontend_ip` varchar(1024) NULL,"))
         assertTrue(result[0][1].contains("`cpu_time_ms` bigint NULL,"))
         assertTrue(result[0][1].contains("`sql_hash` varchar(128) NULL,"))
         assertTrue(result[0][1].contains("`sql_digest` varchar(128) NULL,"))


### PR DESCRIPTION
length 128 of column frontend_ip of audit log table may be not large enough for k8s env.
```
Reason:column_name ［frontend_ip］, the length of input is too long than schema.
first 32 bytes of input str:  ［ abcedf-xxxxxx-yyyyyyy］ schema length: 128; 
actual length:159; . src line ［］;
```