### PR TITLE
[opt](nereids) optimize stats derive when using delta rows

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -110,7 +110,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                     if (conjunct instanceof ComparisonPredicate) {
                         Statistics partial = conjunct.accept(this, new EstimationContext(inputStats));
                         if (partial.getRowCount() == 0) {
-                            for (Slot slot: conjunct.getInputSlots()) {
+                            for (Slot slot : conjunct.getInputSlots()) {
                                 builder.putColumnStatistics(slot, ColumnStatistic.UNKNOWN);
                             }
                         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -45,6 +45,7 @@ import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.coercion.RangeScalable;
+import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
 import org.apache.doris.statistics.StatisticRange;
@@ -100,7 +101,24 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
             for (Expression expr : inputStats.columnStatistics().keySet()) {
                 deltaStats.putColumnStatistics(expr, ColumnStatistic.UNKNOWN);
             }
-            outputStats = expression.accept(this, new EstimationContext(deltaStats.build()));
+            Statistics deltaOutputStats = expression.accept(this, new EstimationContext(deltaStats.build()));
+            StatisticsBuilder builder = new StatisticsBuilder(inputStats).setDeltaRowCount(0)
+                    .setRowCount(deltaOutputStats.getRowCount());
+            if (expression instanceof And) {
+                List<Expression> conjuncts = ExpressionUtils.extractConjunction(expression);
+                for (Expression conjunct : conjuncts) {
+                    if (conjunct instanceof ComparisonPredicate) {
+                        Statistics partial = conjunct.accept(this, new EstimationContext(inputStats));
+                        if (partial.getRowCount() == 0) {
+                            for (Slot slot: conjunct.getInputSlots()) {
+                                builder.putColumnStatistics(slot, ColumnStatistic.UNKNOWN);
+                            }
+                        }
+                    }
+
+                }
+            }
+            outputStats = builder.build();
         }
         outputStats.normalizeColumnStatistics();
         return outputStats;


### PR DESCRIPTION
### What problem does this PR solve?
in previous version, when estimated rows of filter is zero, we set all column stats as unknown and delta row count to estimate again. And hence columns not involved in the filter lost their column stats.
in this pr, we only set unkonw column stats to those columns which is in comparison, and the comparison' selectivity is 0.

this change improves the estimation on plan nodes following the filter node.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

