### PR TITLE
[fix](json) Got invalid path error when path column is ColumnConst with null value

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -326,6 +326,7 @@ public:
     String get_name() const override { return name; }
     bool is_variadic() const override { return true; }
     size_t get_number_of_arguments() const override { return 0; }
+    bool use_default_implementation_for_nulls() const override { return false; }
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
         return make_nullable(std::make_shared<typename Impl::ReturnType>());
     }
@@ -343,9 +344,15 @@ public:
 
         ColumnPtr jsonb_data_column;
         bool jsonb_data_const = false;
+        const NullMap* data_null_map = nullptr;
         // prepare jsonb data column
         std::tie(jsonb_data_column, jsonb_data_const) =
                 unpack_if_const(block.get_by_position(arguments[0]).column);
+        if (jsonb_data_column->is_nullable()) {
+            const auto& nullable_column = assert_cast<const ColumnNullable&>(*jsonb_data_column);
+            jsonb_data_column = nullable_column.get_nested_column_ptr();
+            data_null_map = &nullable_column.get_null_map_data();
+        }
         const auto& ldata = assert_cast<const ColumnString*>(jsonb_data_column.get())->get_chars();
         const auto& loffsets =
                 assert_cast<const ColumnString*>(jsonb_data_column.get())->get_offsets();
@@ -353,51 +360,68 @@ public:
         // prepare parse path column prepare
         std::vector<const ColumnString*> jsonb_path_columns;
         std::vector<bool> path_const(arguments.size() - 1);
+        std::vector<const NullMap*> path_null_maps(arguments.size() - 1, nullptr);
         for (int i = 0; i < arguments.size() - 1; ++i) {
             ColumnPtr path_column;
             bool is_const = false;
             std::tie(path_column, is_const) =
                     unpack_if_const(block.get_by_position(arguments[i + 1]).column);
             path_const[i] = is_const;
+            if (path_column->is_nullable()) {
+                const auto& nullable_column = assert_cast<const ColumnNullable&>(*path_column);
+                path_column = nullable_column.get_nested_column_ptr();
+                path_null_maps[i] = &nullable_column.get_null_map_data();
+            }
             jsonb_path_columns.push_back(assert_cast<const ColumnString*>(path_column.get()));
         }
 
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
         auto res = Impl::ColumnType::create();
 
-        bool is_invalid_json_path = false;
-
         // execute Impl
         if constexpr (std::is_same_v<typename Impl::ReturnType, DataTypeString> ||
                       std::is_same_v<typename Impl::ReturnType, DataTypeJsonb>) {
             auto& res_data = res->get_chars();
             auto& res_offsets = res->get_offsets();
-            Status st = Impl::vector_vector_v2(
-                    context, ldata, loffsets, jsonb_data_const, jsonb_path_columns, path_const,
-                    res_data, res_offsets, null_map->get_data(), is_invalid_json_path);
-            if (!st.ok()) {
-                return st;
-            }
+            RETURN_IF_ERROR(Impl::vector_vector_v2(
+                    context, ldata, loffsets, data_null_map, jsonb_data_const, jsonb_path_columns,
+                    path_null_maps, path_const, res_data, res_offsets, null_map->get_data()));
         } else {
             // not support other extract type for now (e.g. int, double, ...)
             DCHECK_EQ(jsonb_path_columns.size(), 1);
             const auto& rdata = jsonb_path_columns[0]->get_chars();
             const auto& roffsets = jsonb_path_columns[0]->get_offsets();
+
+            auto create_all_null_result = [&]() {
+                res = Impl::ColumnType::create();
+                res->insert_default();
+                auto nullable_column =
+                        ColumnNullable::create(std::move(res), ColumnUInt8::create(1, 1));
+                auto const_column =
+                        ColumnConst::create(std::move(nullable_column), input_rows_count);
+                block.get_by_position(result).column = std::move(const_column);
+                return Status::OK();
+            };
+
             if (jsonb_data_const) {
-                Impl::scalar_vector(context, jsonb_data_column->get_data_at(0), rdata, roffsets,
-                                    res->get_data(), null_map->get_data(), is_invalid_json_path);
+                if (data_null_map && (*data_null_map)[0]) {
+                    return create_all_null_result();
+                }
+
+                RETURN_IF_ERROR(Impl::scalar_vector(context, jsonb_data_column->get_data_at(0),
+                                                    rdata, roffsets, path_null_maps[0],
+                                                    res->get_data(), null_map->get_data()));
             } else if (path_const[0]) {
-                Impl::vector_scalar(context, ldata, loffsets, jsonb_path_columns[0]->get_data_at(0),
-                                    res->get_data(), null_map->get_data(), is_invalid_json_path);
+                if (path_null_maps[0] && (*path_null_maps[0])[0]) {
+                    return create_all_null_result();
+                }
+                RETURN_IF_ERROR(Impl::vector_scalar(context, ldata, loffsets, data_null_map,
+                                                    jsonb_path_columns[0]->get_data_at(0),
+                                                    res->get_data(), null_map->get_data()));
             } else {
-                Impl::vector_vector(context, ldata, loffsets, rdata, roffsets, res->get_data(),
-                                    null_map->get_data(), is_invalid_json_path);
-            }
-            if (is_invalid_json_path) {
-                return Status::InvalidArgument(
-                        "Json path error: Invalid Json Path for value: {}",
-                        std::string_view(reinterpret_cast<const char*>(rdata.data()),
-                                         rdata.size()));
+                RETURN_IF_ERROR(Impl::vector_vector(context, ldata, loffsets, data_null_map, rdata,
+                                                    roffsets, path_null_maps[0], res->get_data(),
+                                                    null_map->get_data()));
             }
         }
 
@@ -729,7 +753,6 @@ struct JsonbExtractStringImpl {
 private:
     static ALWAYS_INLINE void inner_loop_impl(size_t i, ColumnString::Chars& res_data,
                                               ColumnString::Offsets& res_offsets, NullMap& null_map,
-                                              const std::unique_ptr<JsonbWriter>& writer,
                                               std::unique_ptr<JsonbToJson>& formater,
                                               const char* l_raw, size_t l_size, JsonbPath& path) {
         if (null_map[i]) {
@@ -760,10 +783,10 @@ private:
         }
 
         if constexpr (std::is_same_v<DataTypeJsonb, ReturnType>) {
-            writer->reset();
-            writer->writeValue(find_result.value);
-            StringOP::push_value_string(std::string_view(writer->getOutput()->getBuffer(),
-                                                         writer->getOutput()->getSize()),
+            JsonbWriter writer;
+            writer.writeValue(find_result.value);
+            StringOP::push_value_string(std::string_view(writer.getOutput()->getBuffer(),
+                                                         writer.getOutput()->getSize()),
                                         i, res_data, res_offsets);
         } else {
             if (LIKELY(find_result.value->isString())) {
@@ -807,11 +830,12 @@ public:
     // for jsonb_extract_string
     static Status vector_vector_v2(
             FunctionContext* context, const ColumnString::Chars& ldata,
-            const ColumnString::Offsets& loffsets, const bool& json_data_const,
+            const ColumnString::Offsets& loffsets, const NullMap* l_null_map,
+            const bool& json_data_const,
             const std::vector<const ColumnString*>& rdata_columns, // here we can support more paths
-            const std::vector<bool>& path_const, ColumnString::Chars& res_data,
-            ColumnString::Offsets& res_offsets, NullMap& null_map, bool& is_invalid_json_path) {
-        size_t input_rows_count = json_data_const ? rdata_columns.size() : loffsets.size();
+            const std::vector<const NullMap*>& r_null_maps, const std::vector<bool>& path_const,
+            ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets, NullMap& null_map) {
+        const size_t input_rows_count = null_map.size();
         res_offsets.resize(input_rows_count);
 
         auto writer = std::make_unique<JsonbWriter>();
@@ -823,19 +847,19 @@ public:
 
         // lambda function to parse json path for row i and path pi
         auto parse_json_path = [&](size_t i, size_t pi) -> Status {
+            const auto index = index_check_const(i, path_const[pi]);
+
             const ColumnString* path_col = rdata_columns[pi];
             const ColumnString::Chars& rdata = path_col->get_chars();
             const ColumnString::Offsets& roffsets = path_col->get_offsets();
-            size_t r_off = roffsets[index_check_const(i, path_const[pi]) - 1];
-            size_t r_size = roffsets[index_check_const(i, path_const[pi])] - r_off;
+            size_t r_off = roffsets[index - 1];
+            size_t r_size = roffsets[index] - r_off;
             const char* r_raw = reinterpret_cast<const char*>(&rdata[r_off]);
 
             JsonbPath path;
             if (!path.seek(r_raw, r_size)) {
-                return Status::InvalidArgument(
-                        "Json path error: Invalid Json Path for value: {}",
-                        std::string_view(reinterpret_cast<const char*>(rdata.data()),
-                                         rdata.size()));
+                return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
+                                               std::string_view(r_raw, r_size));
             }
 
             json_path_list[pi] = std::move(path);
@@ -845,6 +869,9 @@ public:
 
         for (size_t pi = 0; pi < rdata_columns.size(); pi++) {
             if (path_const[pi]) {
+                if (r_null_maps[pi] && (*r_null_maps[pi])[0]) {
+                    continue;
+                }
                 RETURN_IF_ERROR(parse_json_path(0, pi));
             }
         }
@@ -854,14 +881,27 @@ public:
                 StringOP::push_null_string(i, res_data, res_offsets, null_map);
                 continue;
             }
-            size_t l_off = loffsets[index_check_const(i, json_data_const) - 1];
-            size_t l_size = loffsets[index_check_const(i, json_data_const)] - l_off;
+
+            const auto data_index = index_check_const(i, json_data_const);
+            if (l_null_map && (*l_null_map)[data_index]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
+            size_t l_off = loffsets[data_index - 1];
+            size_t l_size = loffsets[data_index] - l_off;
             const char* l_raw = reinterpret_cast<const char*>(&ldata[l_off]);
             if (rdata_columns.size() == 1) { // just return origin value
+                const auto path_index = index_check_const(i, path_const[0]);
+                if (r_null_maps[0] && (*r_null_maps[0])[path_index]) {
+                    StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                    continue;
+                }
+
                 if (!path_const[0]) {
                     RETURN_IF_ERROR(parse_json_path(i, 0));
                 }
-                inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
+                inner_loop_impl(i, res_data, res_offsets, null_map, formater, l_raw, l_size,
                                 json_path_list[0]);
             } else { // will make array string to user
                 writer->reset();
@@ -873,6 +913,11 @@ public:
 
                 for (size_t pi = 0; pi < rdata_columns.size(); ++pi) {
                     if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
+                        continue;
+                    }
+
+                    const auto path_index = index_check_const(i, path_const[pi]);
+                    if (r_null_maps[pi] && (*r_null_maps[pi])[path_index]) {
                         continue;
                     }
 
@@ -912,23 +957,28 @@ public:
         return Status::OK();
     }
 
-    static void vector_vector(FunctionContext* context, const ColumnString::Chars& ldata,
-                              const ColumnString::Offsets& loffsets,
-                              const ColumnString::Chars& rdata,
-                              const ColumnString::Offsets& roffsets, ColumnString::Chars& res_data,
-                              ColumnString::Offsets& res_offsets, NullMap& null_map,
-                              bool& is_invalid_json_path) {
+    static Status vector_vector(FunctionContext* context, const ColumnString::Chars& ldata,
+                                const ColumnString::Offsets& loffsets, const NullMap* l_null_map,
+                                const ColumnString::Chars& rdata,
+                                const ColumnString::Offsets& roffsets, const NullMap* r_null_map,
+                                ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                                NullMap& null_map) {
         size_t input_rows_count = loffsets.size();
         res_offsets.resize(input_rows_count);
-
-        std::unique_ptr<JsonbWriter> writer;
-        if constexpr (std::is_same_v<DataTypeJsonb, ReturnType>) {
-            writer.reset(new JsonbWriter());
-        }
 
         std::unique_ptr<JsonbToJson> formater;
 
         for (size_t i = 0; i < input_rows_count; ++i) {
+            if (l_null_map && (*l_null_map)[i]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
+            if (r_null_map && (*r_null_map)[i]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
             int l_size = loffsets[i] - loffsets[i - 1];
             const char* l_raw = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
 
@@ -937,73 +987,76 @@ public:
 
             JsonbPath path;
             if (!path.seek(r_raw, r_size)) {
-                is_invalid_json_path = true;
-                StringOP::push_null_string(i, res_data, res_offsets, null_map);
-                return;
+                return Status::InvalidArgument(
+                        "Json path error: Invalid Json Path for value: {} at row: {}",
+                        std::string_view(r_raw, r_size), i);
             }
 
-            inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
-                            path);
+            inner_loop_impl(i, res_data, res_offsets, null_map, formater, l_raw, l_size, path);
         } //for
-    }     //function
-    static void vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
-                              const ColumnString::Offsets& loffsets, const StringRef& rdata,
-                              ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
-                              NullMap& null_map, bool& is_invalid_json_path) {
+        return Status::OK();
+    } //function
+
+    static Status vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
+                                const ColumnString::Offsets& loffsets, const NullMap* l_null_map,
+                                const StringRef& rdata, ColumnString::Chars& res_data,
+                                ColumnString::Offsets& res_offsets, NullMap& null_map) {
         size_t input_rows_count = loffsets.size();
         res_offsets.resize(input_rows_count);
-
-        std::unique_ptr<JsonbWriter> writer;
-        if constexpr (std::is_same_v<DataTypeJsonb, ReturnType>) {
-            writer.reset(new JsonbWriter());
-        }
 
         std::unique_ptr<JsonbToJson> formater;
 
         JsonbPath path;
         if (!path.seek(rdata.data, rdata.size)) {
-            is_invalid_json_path = true;
-            return;
+            return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
+                                           std::string_view(rdata.data, rdata.size));
         }
 
         for (size_t i = 0; i < input_rows_count; ++i) {
+            if (l_null_map && (*l_null_map)[i]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
             int l_size = loffsets[i] - loffsets[i - 1];
             const char* l_raw = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
 
-            inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
-                            path);
+            inner_loop_impl(i, res_data, res_offsets, null_map, formater, l_raw, l_size, path);
         } //for
-    }     //function
-    static void scalar_vector(FunctionContext* context, const StringRef& ldata,
-                              const ColumnString::Chars& rdata,
-                              const ColumnString::Offsets& roffsets, ColumnString::Chars& res_data,
-                              ColumnString::Offsets& res_offsets, NullMap& null_map,
-                              bool& is_invalid_json_path) {
+        return Status::OK();
+    } //function
+
+    static Status scalar_vector(FunctionContext* context, const StringRef& ldata,
+                                const ColumnString::Chars& rdata,
+                                const ColumnString::Offsets& roffsets, const NullMap* r_null_map,
+                                ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                                NullMap& null_map) {
         size_t input_rows_count = roffsets.size();
         res_offsets.resize(input_rows_count);
-
-        std::unique_ptr<JsonbWriter> writer;
-        if constexpr (std::is_same_v<DataTypeJsonb, ReturnType>) {
-            writer.reset(new JsonbWriter());
-        }
 
         std::unique_ptr<JsonbToJson> formater;
 
         for (size_t i = 0; i < input_rows_count; ++i) {
+            if (r_null_map && (*r_null_map)[i]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
             int r_size = roffsets[i] - roffsets[i - 1];
             const char* r_raw = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
 
             JsonbPath path;
             if (!path.seek(r_raw, r_size)) {
-                is_invalid_json_path = true;
-                StringOP::push_null_string(i, res_data, res_offsets, null_map);
-                return;
+                return Status::InvalidArgument(
+                        "Json path error: Invalid Json Path for value: {} at row: {}",
+                        std::string_view(r_raw, r_size), i);
             }
 
-            inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, ldata.data,
-                            ldata.size, path);
+            inner_loop_impl(i, res_data, res_offsets, null_map, formater, ldata.data, ldata.size,
+                            path);
         } //for
-    }     //function
+        return Status::OK();
+    } //function
 };
 
 template <typename ValueType>
@@ -1105,17 +1158,23 @@ private:
 
 public:
     // for jsonb_extract_int/int64/double
-    static void vector_vector(FunctionContext* context, const ColumnString::Chars& ldata,
-                              const ColumnString::Offsets& loffsets,
-                              const ColumnString::Chars& rdata,
-                              const ColumnString::Offsets& roffsets, Container& res,
-                              NullMap& null_map, bool& is_invalid_json_path) {
+    static Status vector_vector(FunctionContext* context, const ColumnString::Chars& ldata,
+                                const ColumnString::Offsets& loffsets, const NullMap* l_null_map,
+                                const ColumnString::Chars& rdata,
+                                const ColumnString::Offsets& roffsets, const NullMap* r_null_map,
+                                Container& res, NullMap& null_map) {
         size_t size = loffsets.size();
         res.resize(size);
 
         for (size_t i = 0; i < loffsets.size(); i++) {
             if constexpr (only_check_exists) {
                 res[i] = 0;
+            }
+
+            if ((l_null_map && (*l_null_map)[i]) || (r_null_map && (*r_null_map)[i])) {
+                res[i] = 0;
+                null_map[i] = 1;
+                continue;
             }
 
             const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
@@ -1126,18 +1185,20 @@ public:
 
             JsonbPath path;
             if (!path.seek(r_raw_str, r_str_size)) {
-                is_invalid_json_path = true;
-                res[i] = 0;
-                return;
+                return Status::InvalidArgument(
+                        "Json path error: Invalid Json Path for value: {} at row: {}",
+                        std::string_view(r_raw_str, r_str_size), i);
             }
 
             inner_loop_impl(i, res, null_map, l_raw_str, l_str_size, path);
         } //for
-    }     //function
-    static void scalar_vector(FunctionContext* context, const StringRef& ldata,
-                              const ColumnString::Chars& rdata,
-                              const ColumnString::Offsets& roffsets, Container& res,
-                              NullMap& null_map, bool& is_invalid_json_path) {
+        return Status::OK();
+    } //function
+
+    static Status scalar_vector(FunctionContext* context, const StringRef& ldata,
+                                const ColumnString::Chars& rdata,
+                                const ColumnString::Offsets& roffsets, const NullMap* r_null_map,
+                                Container& res, NullMap& null_map) {
         size_t size = roffsets.size();
         res.resize(size);
 
@@ -1146,34 +1207,47 @@ public:
                 res[i] = 0;
             }
 
+            if (r_null_map && (*r_null_map)[i]) {
+                res[i] = 0;
+                null_map[i] = 1;
+                continue;
+            }
+
             const char* r_raw_str = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
             int r_str_size = roffsets[i] - roffsets[i - 1];
 
             JsonbPath path;
             if (!path.seek(r_raw_str, r_str_size)) {
-                is_invalid_json_path = true;
-                res[i] = 0;
-                return;
+                return Status::InvalidArgument(
+                        "Json path error: Invalid Json Path for value: {} at row: {}",
+                        std::string_view(r_raw_str, r_str_size), i);
             }
 
             inner_loop_impl(i, res, null_map, ldata.data, ldata.size, path);
         } //for
-    }     //function
-    static void vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
-                              const ColumnString::Offsets& loffsets, const StringRef& rdata,
-                              Container& res, NullMap& null_map, bool& is_invalid_json_path) {
+        return Status::OK();
+    } //function
+
+    static Status vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
+                                const ColumnString::Offsets& loffsets, const NullMap* l_null_map,
+                                const StringRef& rdata, Container& res, NullMap& null_map) {
         size_t size = loffsets.size();
         res.resize(size);
 
         JsonbPath path;
         if (!path.seek(rdata.data, rdata.size)) {
-            is_invalid_json_path = true;
-            return;
+            return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
+                                           std::string_view(rdata.data, rdata.size));
         }
 
         for (size_t i = 0; i < loffsets.size(); i++) {
             if constexpr (only_check_exists) {
                 res[i] = 0;
+            }
+            if (l_null_map && (*l_null_map)[i]) {
+                res[i] = 0;
+                null_map[i] = 1;
+                continue;
             }
 
             const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
@@ -1181,7 +1255,8 @@ public:
 
             inner_loop_impl(i, res, null_map, l_raw_str, l_str_size, path);
         } //for
-    }     //function
+        return Status::OK();
+    } //function
 };
 
 struct JsonbTypeExists {
@@ -1368,19 +1443,30 @@ struct JsonbLengthUtil {
         bool is_const = false;
         std::tie(path_column, is_const) =
                 unpack_if_const(block.get_by_position(arguments[1]).column);
-        JsonbPath path;
-        if (is_const) {
-            auto path_value = path_column->get_data_at(0);
-            if (!path.seek(path_value.data, path_value.size)) {
-                return Status::InvalidArgument(
-                        "Json path error: Invalid Json Path for value: {}",
-                        std::string_view(reinterpret_cast<const char*>(path_value.data),
-                                         path_value.size));
-            }
-        }
+
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
         auto return_type = block.get_data_type(result);
         MutableColumnPtr res = return_type->create_column();
+
+        JsonbPath path;
+        if (is_const) {
+            if (path_column->is_null_at(0)) {
+                for (size_t i = 0; i < input_rows_count; ++i) {
+                    null_map->get_data()[i] = 1;
+                    res->insert_data(nullptr, 0);
+                }
+
+                block.replace_by_position(
+                        result, ColumnNullable::create(std::move(res), std::move(null_map)));
+                return Status::OK();
+            }
+
+            auto path_value = path_column->get_data_at(0);
+            if (!path.seek(path_value.data, path_value.size)) {
+                return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
+                                               std::string_view(path_value.data, path_value.size));
+            }
+        }
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (jsonb_data_column->is_null_at(i) || path_column->is_null_at(i) ||
@@ -1494,19 +1580,29 @@ struct JsonbContainsUtil {
         std::tie(path_column, is_const) =
                 unpack_if_const(block.get_by_position(arguments[2]).column);
 
-        JsonbPath path;
-        if (is_const) {
-            auto path_value = path_column->get_data_at(0);
-            if (!path.seek(path_value.data, path_value.size)) {
-                return Status::InvalidArgument(
-                        "Json path error: Invalid Json Path for value: {}",
-                        std::string_view(reinterpret_cast<const char*>(path_value.data),
-                                         path_value.size));
-            }
-        }
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
         auto return_type = block.get_data_type(result);
         MutableColumnPtr res = return_type->create_column();
+
+        JsonbPath path;
+        if (is_const) {
+            if (path_column->is_null_at(0)) {
+                for (size_t i = 0; i < input_rows_count; ++i) {
+                    null_map->get_data()[i] = 1;
+                    res->insert_data(nullptr, 0);
+                }
+
+                block.replace_by_position(
+                        result, ColumnNullable::create(std::move(res), std::move(null_map)));
+                return Status::OK();
+            }
+
+            auto path_value = path_column->get_data_at(0);
+            if (!path.seek(path_value.data, path_value.size)) {
+                return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
+                                               std::string_view(path_value.data, path_value.size));
+            }
+        }
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (jsonb_data1_column->is_null_at(i) || jsonb_data2_column->is_null_at(i) ||
@@ -1522,8 +1618,7 @@ struct JsonbContainsUtil {
                 if (!path.seek(path_value.data, path_value.size)) {
                     return Status::InvalidArgument(
                             "Json path error: Invalid Json Path for value: {}",
-                            std::string_view(reinterpret_cast<const char*>(path_value.data),
-                                             path_value.size));
+                            std::string_view(path_value.data, path_value.size));
                 }
             }
 

--- a/regression-test/data/query_p0/sql_functions/json_functions/test_json_extract.out
+++ b/regression-test/data/query_p0/sql_functions/json_functions/test_json_extract.out
@@ -65,3 +65,59 @@ v31
 -- !array_last3 --
 4	4
 
+-- !test_col_vector_vector --
+"v31"
+1234.56
+null
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+
+-- !test_col_scalar_vector --
+"v1"
+\N
+2
+333
+\N
+\N
+\N
+\N
+"v1"
+\N
+2
+333
+
+-- !test_col_vector_scalar --
+"v31"
+"v31"
+"v31"
+"v31"
+"v31"
+"v31"
+"v31"
+"v31"
+\N
+\N
+\N
+\N
+
+-- !test_col_vector_scalar_2 --
+{"k1":"v31","k2":300}	["v31",300]
+{"k1":"v31","k2":{"sub_key":1234.56}}	["v31",{"sub_key":1234.56}]
+{"k1":"v31","k2":null}	["v31",null]
+{"k1":"v31","k2":300}	["v31",300]
+{"k1":"v31","k2":300}	["v31",300]
+{"k1":"v31","k2":{"sub_key":1234.56}}	["v31",{"sub_key":1234.56}]
+{"k1":"v31","k2":null}	["v31",null]
+{"k1":"v31","k2":300}	["v31",300]
+\N	\N
+\N	\N
+\N	\N
+\N	\N
+


### PR DESCRIPTION

### What problem does this PR solve?

The Path column may be a constant column(`ColumnConst`) containing NULL values, and such cases need to be handled in both the json_length and json_contains functions.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

