### PR TITLE
[fix](Nereids) not generate duplicate exprid after convert outer to anti rule 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -52,6 +52,7 @@ import org.apache.doris.nereids.rules.rewrite.CollectFilterAboveConsumer;
 import org.apache.doris.nereids.rules.rewrite.CollectPredicateOnScan;
 import org.apache.doris.nereids.rules.rewrite.ColumnPruning;
 import org.apache.doris.nereids.rules.rewrite.ConvertInnerOrCrossJoin;
+import org.apache.doris.nereids.rules.rewrite.ConvertOuterJoinToAntiJoin;
 import org.apache.doris.nereids.rules.rewrite.CountDistinctRewrite;
 import org.apache.doris.nereids.rules.rewrite.CountLiteralRewrite;
 import org.apache.doris.nereids.rules.rewrite.CreatePartitionTopNFromWindow;
@@ -512,8 +513,7 @@ public class Rewriter extends AbstractBatchJobExecutor {
                                 new CollectCteConsumerOutput()
                         )
                 ),
-                topic("Collect used column", custom(RuleType.COLLECT_COLUMNS, QueryColumnCollector::new)
-            )
+                topic("Collect used column", custom(RuleType.COLLECT_COLUMNS, QueryColumnCollector::new))
         )
     );
 
@@ -521,6 +521,7 @@ public class Rewriter extends AbstractBatchJobExecutor {
             ImmutableSet.of(LogicalCTEAnchor.class),
             () -> jobs(
                 // after variant sub path pruning, we need do column pruning again
+                bottomUp(RuleSet.PUSH_DOWN_FILTERS),
                 custom(RuleType.COLUMN_PRUNING, ColumnPruning::new),
                 bottomUp(ImmutableList.of(
                         new PushDownFilterThroughProject(),
@@ -630,6 +631,8 @@ public class Rewriter extends AbstractBatchJobExecutor {
                                         () -> new RewriteCteChildren(beforePushDownJobs, runCboRules)
                                 )
                         )));
+                rewriteJobs.addAll(jobs(topic("convert outer join to anti",
+                        custom(RuleType.CONVERT_OUTER_JOIN_TO_ANTI, ConvertOuterJoinToAntiJoin::new))));
                 if (needOrExpansion) {
                     rewriteJobs.addAll(jobs(topic("or expansion",
                             custom(RuleType.OR_EXPANSION, () -> OrExpansion.INSTANCE))));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -87,7 +87,6 @@ import org.apache.doris.nereids.rules.implementation.LogicalTVFRelationToPhysica
 import org.apache.doris.nereids.rules.implementation.LogicalTopNToPhysicalTopN;
 import org.apache.doris.nereids.rules.implementation.LogicalUnionToPhysicalUnion;
 import org.apache.doris.nereids.rules.implementation.LogicalWindowToPhysicalWindow;
-import org.apache.doris.nereids.rules.rewrite.ConvertOuterJoinToAntiJoin;
 import org.apache.doris.nereids.rules.rewrite.CreatePartitionTopNFromWindow;
 import org.apache.doris.nereids.rules.rewrite.EliminateFilter;
 import org.apache.doris.nereids.rules.rewrite.EliminateOuterJoin;
@@ -164,7 +163,6 @@ public class RuleSet {
             new PushDownFilterThroughGenerate(),
             new PushDownProjectThroughLimit(),
             new EliminateOuterJoin(),
-            new ConvertOuterJoinToAntiJoin(),
             new MergeProjectable(),
             new MergeFilters(),
             new MergeGenerates(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.expression;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.pattern.ExpressionPatternRules;
 import org.apache.doris.nereids.pattern.ExpressionPatternTraverseListeners;
+import org.apache.doris.nereids.pattern.MatchingContext;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
@@ -29,25 +30,37 @@ import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.EqualPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.OrderExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalCTEConsumer;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalGenerate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapTableSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSetOperation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
+import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
+import org.apache.doris.nereids.trees.plans.logical.LogicalWindow;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -85,7 +98,20 @@ public class ExpressionRewrite implements RewriteRuleFactory {
                 new SortExpressionRewrite().build(),
                 new LogicalRepeatRewrite().build(),
                 new HavingExpressionRewrite().build(),
-                new OlapTableSinkExpressionRewrite().build());
+                new LogicalPartitionTopNExpressionRewrite().build(),
+                new LogicalTopNExpressionRewrite().build(),
+                new LogicalSetOperationRewrite().build(),
+                new LogicalWindowRewrite().build(),
+                new LogicalCteConsumerRewrite().build(),
+                new LogicalResultSinkRewrite().build(),
+                new LogicalFileSinkRewrite().build(),
+                new LogicalHiveTableSinkRewrite().build(),
+                new LogicalIcebergTableSinkRewrite().build(),
+                new LogicalJdbcTableSinkRewrite().build(),
+                new LogicalOlapTableSinkRewrite().build(),
+                new LogicalDictionarySinkRewrite().build(),
+                new LogicalDeferMaterializeResultSinkRewrite().build(),
+                new LogicalOlapTableSinkExpressionRewrite().build());
     }
 
     /** GenerateExpressionRewrite */
@@ -174,7 +200,7 @@ public class ExpressionRewrite implements RewriteRuleFactory {
     }
 
     /** OlapTableSinkExpressionRewrite */
-    public class OlapTableSinkExpressionRewrite extends OneRewriteRuleFactory {
+    public class LogicalOlapTableSinkExpressionRewrite extends OneRewriteRuleFactory {
         @Override
         public Rule build() {
             return logicalOlapTableSink().thenApply(ctx -> {
@@ -309,6 +335,190 @@ public class ExpressionRewrite implements RewriteRuleFactory {
                 return having.withConjuncts(newConjuncts);
             }).toRule(RuleType.REWRITE_HAVING_EXPRESSION);
         }
+    }
+
+    private class LogicalWindowRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalWindow().thenApply(ctx -> {
+                LogicalWindow<Plan> window = ctx.root;
+                List<NamedExpression> windowExpressions = window.getWindowExpressions();
+                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
+                RewriteResult<NamedExpression> result = rewriteAll(windowExpressions, rewriter, context);
+                if (!result.changed) {
+                    return window;
+                }
+                return window.withExpressionsAndChild(result.result, window.child());
+            })
+            .toRule(RuleType.REWRITE_WINDOW_EXPRESSION);
+        }
+    }
+
+    private class LogicalSetOperationRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalSetOperation().thenApply(ctx -> {
+                LogicalSetOperation setOperation = ctx.root;
+                List<List<SlotReference>> slotsList = setOperation.getRegularChildrenOutputs();
+                List<List<SlotReference>> newSlotsList = new ArrayList<>();
+                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
+                boolean changed = false;
+                for (List<SlotReference> slots : slotsList) {
+                    RewriteResult<SlotReference> result = rewriteAll(slots, rewriter, context);
+                    changed |= result.changed;
+                    newSlotsList.add(result.result);
+                }
+                if (!changed) {
+                    return setOperation;
+                }
+                return setOperation.withChildrenAndTheirOutputs(setOperation.children(), newSlotsList);
+            })
+            .toRule(RuleType.REWRITE_SET_OPERATION_EXPRESSION);
+        }
+    }
+
+    private class LogicalTopNExpressionRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalTopN().thenApply(ctx -> {
+                LogicalTopN<Plan> topN = ctx.root;
+                List<OrderKey> orderKeys = topN.getOrderKeys();
+                ImmutableList.Builder<OrderKey> rewrittenOrderKeys
+                        = ImmutableList.builderWithExpectedSize(orderKeys.size());
+                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
+                boolean changed = false;
+                for (OrderKey k : orderKeys) {
+                    Expression expression = rewriter.rewrite(k.getExpr(), context);
+                    changed |= expression != k.getExpr();
+                    rewrittenOrderKeys.add(new OrderKey(expression, k.isAsc(), k.isNullFirst()));
+                }
+                return changed ? topN.withOrderKeys(rewrittenOrderKeys.build()) : topN;
+            }).toRule(RuleType.REWRITE_TOPN_EXPRESSION);
+        }
+    }
+
+    private class LogicalPartitionTopNExpressionRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalPartitionTopN().thenApply(ctx -> {
+                LogicalPartitionTopN<Plan> partitionTopN = ctx.root;
+                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
+                List<OrderExpression> newOrderExpressions = new ArrayList<>();
+                boolean changed = false;
+                for (OrderExpression orderExpression : partitionTopN.getOrderKeys()) {
+                    OrderKey orderKey = orderExpression.getOrderKey();
+                    Expression expr = rewriter.rewrite(orderKey.getExpr(), context);
+                    changed |= expr != orderKey.getExpr();
+                    OrderKey newOrderKey = new OrderKey(expr, orderKey.isAsc(), orderKey.isNullFirst());
+                    newOrderExpressions.add(new OrderExpression(newOrderKey));
+                }
+                RewriteResult<Expression> result = rewriteAll(partitionTopN.getPartitionKeys(),
+                        rewriter, context);
+                changed |= result.changed;
+                if (!changed) {
+                    return partitionTopN;
+                }
+                return partitionTopN.withPartitionKeysAndOrderKeys(result.result, newOrderExpressions);
+            }).toRule(RuleType.REWRITE_PARTITION_TOPN_EXPRESSION);
+        }
+    }
+
+    private class LogicalCteConsumerRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalCTEConsumer().thenApply(ctx -> {
+                LogicalCTEConsumer consumer = ctx.root;
+                boolean changed = false;
+                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
+                ImmutableMap.Builder<Slot, Slot> cToPBuilder = ImmutableMap.builder();
+                ImmutableMultimap.Builder<Slot, Slot> pToCBuilder = ImmutableMultimap.builder();
+                for (Map.Entry<Slot, Slot> entry : consumer.getConsumerToProducerOutputMap().entrySet()) {
+                    Slot key = (Slot) rewriter.rewrite(entry.getKey(), context);
+                    Slot value = (Slot) rewriter.rewrite(entry.getValue(), context);
+                    cToPBuilder.put(key, value);
+                    pToCBuilder.put(value, key);
+                    if (!key.equals(entry.getKey()) || !value.equals(entry.getValue())) {
+                        changed = true;
+                    }
+                }
+                return changed ? consumer.withTwoMaps(cToPBuilder.build(), pToCBuilder.build()) : consumer;
+            }).toRule(RuleType.REWRITE_TOPN_EXPRESSION);
+        }
+    }
+
+    private class LogicalResultSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalResultSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalFileSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalFileSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalHiveTableSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalHiveTableSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalIcebergTableSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalIcebergTableSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalJdbcTableSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalJdbcTableSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalOlapTableSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalOlapTableSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalDictionarySinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalDictionarySink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private class LogicalDeferMaterializeResultSinkRewrite extends OneRewriteRuleFactory {
+        @Override
+        public Rule build() {
+            return logicalDeferMaterializeResultSink().thenApply(ExpressionRewrite.this::applyRewriteToSink)
+                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
+        }
+    }
+
+    private LogicalSink<Plan> applyRewriteToSink(MatchingContext<? extends LogicalSink<Plan>> ctx) {
+        LogicalSink<Plan> sink = ctx.root;
+        ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
+        List<NamedExpression> outputExprs = sink.getOutputExprs();
+        RewriteResult<NamedExpression> result = rewriteAll(outputExprs, rewriter, context);
+        if (!result.changed) {
+            return sink;
+        }
+        return sink.withOutputExprs(result.result);
     }
 
     /** LogicalRepeatRewrite */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExprIdRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExprIdRewriter.java
@@ -18,33 +18,21 @@
 package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.jobs.JobContext;
-import org.apache.doris.nereids.pattern.MatchingContext;
 import org.apache.doris.nereids.pattern.Pattern;
-import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.rules.Rule;
-import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternMatcher;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
 import org.apache.doris.nereids.rules.expression.ExpressionRewrite;
-import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleExecutor;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.NamedExpression;
-import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
-import org.apache.doris.nereids.trees.plans.logical.LogicalSetOperation;
-import org.apache.doris.nereids.trees.plans.logical.LogicalSink;
-import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
-import org.apache.doris.nereids.trees.plans.logical.LogicalWindow;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -57,27 +45,6 @@ public class ExprIdRewriter extends ExpressionRewrite {
         super(new ExpressionRuleExecutor(ImmutableList.of(bottomUp(replaceRule))));
         rules = buildRules();
         this.jobContext = jobContext;
-    }
-
-    @Override
-    public List<Rule> buildRules() {
-        ImmutableList.Builder<Rule> builder = ImmutableList.builder();
-        builder.addAll(super.buildRules());
-        builder.addAll(ImmutableList.of(
-                new LogicalPartitionTopNExpressionRewrite().build(),
-                new LogicalTopNExpressionRewrite().build(),
-                new LogicalSetOperationRewrite().build(),
-                new LogicalWindowRewrite().build(),
-                new LogicalResultSinkRewrite().build(),
-                new LogicalFileSinkRewrite().build(),
-                new LogicalHiveTableSinkRewrite().build(),
-                new LogicalIcebergTableSinkRewrite().build(),
-                new LogicalJdbcTableSinkRewrite().build(),
-                new LogicalOlapTableSinkRewrite().build(),
-                new LogicalDictionarySinkRewrite().build(),
-                new LogicalDeferMaterializeResultSinkRewrite().build()
-                ));
-        return builder.build();
     }
 
     /**rewriteExpr*/
@@ -136,166 +103,5 @@ public class ExprIdRewriter extends ExpressionRewrite {
                     }).toRule(ExpressionRuleType.EXPR_ID_REWRITE_REPLACE)
             );
         }
-    }
-
-    private class LogicalResultSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalResultSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalFileSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalFileSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalHiveTableSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalHiveTableSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalIcebergTableSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalIcebergTableSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalJdbcTableSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalJdbcTableSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalOlapTableSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalOlapTableSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalDictionarySinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalDictionarySink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalDeferMaterializeResultSinkRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalDeferMaterializeResultSink().thenApply(ExprIdRewriter.this::applyRewrite)
-                    .toRule(RuleType.REWRITE_SINK_EXPRESSION);
-        }
-    }
-
-    private class LogicalSetOperationRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalSetOperation().thenApply(ctx -> {
-                LogicalSetOperation setOperation = ctx.root;
-                List<List<SlotReference>> slotsList = setOperation.getRegularChildrenOutputs();
-                List<List<SlotReference>> newSlotsList = new ArrayList<>();
-                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
-                boolean changed = false;
-                for (List<SlotReference> slots : slotsList) {
-                    RewriteResult<SlotReference> result = rewriteAll(slots, rewriter, context);
-                    changed |= result.changed;
-                    newSlotsList.add(result.result);
-                }
-                if (!changed) {
-                    return setOperation;
-                }
-                return setOperation.withChildrenAndTheirOutputs(setOperation.children(), newSlotsList);
-            })
-            .toRule(RuleType.REWRITE_SET_OPERATION_EXPRESSION);
-        }
-    }
-
-    private class LogicalWindowRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalWindow().thenApply(ctx -> {
-                LogicalWindow<Plan> window = ctx.root;
-                List<NamedExpression> windowExpressions = window.getWindowExpressions();
-                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
-                RewriteResult<NamedExpression> result = rewriteAll(windowExpressions, rewriter, context);
-                if (!result.changed) {
-                    return window;
-                }
-                return window.withExpressionsAndChild(result.result, window.child());
-            })
-            .toRule(RuleType.REWRITE_WINDOW_EXPRESSION);
-        }
-    }
-
-    private class LogicalTopNExpressionRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalTopN().thenApply(ctx -> {
-                LogicalTopN<Plan> topN = ctx.root;
-                List<OrderKey> orderKeys = topN.getOrderKeys();
-                ImmutableList.Builder<OrderKey> rewrittenOrderKeys
-                        = ImmutableList.builderWithExpectedSize(orderKeys.size());
-                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
-                boolean changed = false;
-                for (OrderKey k : orderKeys) {
-                    Expression expression = rewriter.rewrite(k.getExpr(), context);
-                    changed |= expression != k.getExpr();
-                    rewrittenOrderKeys.add(new OrderKey(expression, k.isAsc(), k.isNullFirst()));
-                }
-                return changed ? topN.withOrderKeys(rewrittenOrderKeys.build()) : topN;
-            }).toRule(RuleType.REWRITE_TOPN_EXPRESSION);
-        }
-    }
-
-    private class LogicalPartitionTopNExpressionRewrite extends OneRewriteRuleFactory {
-        @Override
-        public Rule build() {
-            return logicalPartitionTopN().thenApply(ctx -> {
-                LogicalPartitionTopN<Plan> partitionTopN = ctx.root;
-                ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
-                List<OrderExpression> newOrderExpressions = new ArrayList<>();
-                boolean changed = false;
-                for (OrderExpression orderExpression : partitionTopN.getOrderKeys()) {
-                    OrderKey orderKey = orderExpression.getOrderKey();
-                    Expression expr = rewriter.rewrite(orderKey.getExpr(), context);
-                    changed |= expr != orderKey.getExpr();
-                    OrderKey newOrderKey = new OrderKey(expr, orderKey.isAsc(), orderKey.isNullFirst());
-                    newOrderExpressions.add(new OrderExpression(newOrderKey));
-                }
-                RewriteResult<Expression> result = rewriteAll(partitionTopN.getPartitionKeys(),
-                        rewriter, context);
-                changed |= result.changed;
-                if (!changed) {
-                    return partitionTopN;
-                }
-                return partitionTopN.withPartitionKeysAndOrderKeys(result.result, newOrderExpressions);
-            }).toRule(RuleType.REWRITE_PARTITION_TOPN_EXPRESSION);
-        }
-    }
-
-    private LogicalSink<Plan> applyRewrite(MatchingContext<? extends LogicalSink<Plan>> ctx) {
-        LogicalSink<Plan> sink = ctx.root;
-        ExpressionRewriteContext context = new ExpressionRewriteContext(ctx.cascadesContext);
-        List<NamedExpression> outputExprs = sink.getOutputExprs();
-        RewriteResult<NamedExpression> result = rewriteAll(outputExprs, rewriter, context);
-        if (!result.changed) {
-            return sink;
-        }
-        return sink.withOutputExprs(result.result);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/StatementScopeIdGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/StatementScopeIdGenerator.java
@@ -67,7 +67,7 @@ public class StatementScopeIdGenerator {
         if (ConnectContext.get() != null) {
             ConnectContext.get().setStatementContext(new StatementContext());
         }
-        statementContext = new StatementContext();
+        statementContext = new StatementContext(10000);
     }
 
     /** getStatementContext */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
@@ -200,4 +200,21 @@ public class LogicalCTEConsumer extends LogicalRelation implements BlockFuncDeps
                 "name", name,
                 "stats", statistics);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        LogicalCTEConsumer that = (LogicalCTEConsumer) o;
+        return Objects.equals(consumerToProducerOutputMap, that.consumerToProducerOutputMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ConvertOuterJoinToAntiJoinTest.java
@@ -31,17 +31,21 @@ import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
-    private final LogicalOlapScan scan1;
-    private final LogicalOlapScan scan2;
+    private LogicalOlapScan scan1;
+    private LogicalOlapScan scan2;
 
-    public ConvertOuterJoinToAntiJoinTest() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         // clear id so that slot id keep consistent every running
+        ConnectContext.remove();
         StatementScopeIdGenerator.clear();
         scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
@@ -57,7 +61,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new InferFilterNotNull())
-                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .applyCustom(new ConvertOuterJoinToAntiJoin())
                 .printlnTree()
                 .matches(logicalJoin().when(join -> join.getJoinType().isLeftAntiJoin()));
     }
@@ -72,7 +76,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new InferFilterNotNull())
-                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .applyCustom(new ConvertOuterJoinToAntiJoin())
                 .printlnTree()
                 .matches(logicalJoin().when(join -> join.getJoinType().isRightAntiJoin()));
     }
@@ -90,7 +94,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new InferFilterNotNull())
-                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .applyCustom(new ConvertOuterJoinToAntiJoin())
                 .printlnTree()
                 .matches(logicalJoin().when(join -> join.getJoinType().isLeftAntiJoin()));
     }
@@ -108,7 +112,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new InferFilterNotNull())
-                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .applyCustom(new ConvertOuterJoinToAntiJoin())
                 .printlnTree()
                 .matches(logicalJoin().when(join -> join.getJoinType().isLeftAntiJoin()));
     }
@@ -126,7 +130,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new InferFilterNotNull())
-                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .applyCustom(new ConvertOuterJoinToAntiJoin())
                 .printlnTree()
                 .matches(logicalJoin().when(join -> join.getJoinType().isLeftOuterJoin()));
     }
@@ -145,7 +149,7 @@ class ConvertOuterJoinToAntiJoinTest implements MemoPatternMatchSupported {
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
                 .applyTopDown(new InferFilterNotNull())
-                .applyTopDown(new ConvertOuterJoinToAntiJoin())
+                .applyCustom(new ConvertOuterJoinToAntiJoin())
                 .printlnTree()
                 .matches(logicalJoin().when(join -> join.getJoinType().isLeftOuterJoin()));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateOuterJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateOuterJoinTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
@@ -69,7 +70,7 @@ class EliminateOuterJoinTest implements MemoPatternMatchSupported {
     void testEliminateRight() {
         LogicalPlan plan = new LogicalPlanBuilder(scan1)
                 .join(scan2, JoinType.RIGHT_OUTER_JOIN, Pair.of(0, 0))  // t1.id = t2.id
-                .filter(new GreaterThan(scan1.getOutput().get(0), Literal.of(1)))
+                .filter(new GreaterThan(scan1.getOutput().get(0), new IntegerLiteral(1)))
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
@@ -81,7 +82,7 @@ class EliminateOuterJoinTest implements MemoPatternMatchSupported {
                         logicalFilter(
                                 logicalJoin().when(join -> join.getJoinType().isInnerJoin())
                         ).when(filter -> filter.getConjuncts().size() == 1)
-                                .when(filter -> Objects.equals(filter.getConjuncts().toString(), "[(id#0 > 1)]"))
+                                .when(filter -> Objects.equals(filter.getConjuncts().iterator().next(), new GreaterThan(scan1.getOutput().get(0), new IntegerLiteral(1))))
                 );
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/SplitMultiDistinctTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/SplitMultiDistinctTest.java
@@ -46,23 +46,25 @@ public class SplitMultiDistinctTest extends TestWithFeService implements MemoPat
                     physicalCTEAnchor(
                             physicalCTEProducer(any()),
                             physicalResultSink(
-                                    physicalProject(
+
                                             physicalNestedLoopJoin(
+                                                    physicalProject(
                                                     physicalHashAggregate(
                                                             physicalDistribute(
                                                                     physicalHashAggregate(
                                                                             physicalHashAggregate(
                                                                                     physicalDistribute(
-                                                                                            physicalHashAggregate(any())))))),
+                                                                                            physicalHashAggregate(any()))))))),
                                                     physicalDistribute(
+                                                            physicalProject(
                                                             physicalHashAggregate(
                                                                     physicalDistribute(
                                                                             physicalHashAggregate(
                                                                                     physicalHashAggregate(
                                                                                             physicalDistribute(
-                                                                                                    physicalHashAggregate(any())))))))
+                                                                                                    physicalHashAggregate(any()))))))))
                                             )
-                                    )
+
                             )
                     )
             );
@@ -78,23 +80,25 @@ public class SplitMultiDistinctTest extends TestWithFeService implements MemoPat
                     physicalCTEAnchor(
                             physicalCTEProducer(any()),
                             physicalResultSink(
-                                    physicalProject(
+
                                             physicalNestedLoopJoin(
+                                                    physicalProject(
                                                     physicalHashAggregate(
                                                             physicalDistribute(
                                                                     physicalHashAggregate(
                                                                             physicalHashAggregate(
                                                                                     physicalDistribute(
-                                                                                            physicalHashAggregate(any())))))),
+                                                                                            physicalHashAggregate(any()))))))),
                                                     physicalDistribute(
+                                                            physicalProject(
                                                             physicalHashAggregate(
                                                                     physicalDistribute(
                                                                             physicalHashAggregate(
                                                                                     physicalHashAggregate(
                                                                                             physicalDistribute(
-                                                                                                    physicalHashAggregate(any())))))))
+                                                                                                    physicalHashAggregate(any()))))))))
                                             )
-                                    )
+
                             )
                     )
             );
@@ -108,26 +112,26 @@ public class SplitMultiDistinctTest extends TestWithFeService implements MemoPat
             Plan plan = planner.getOptimizedPlan();
             MatchingUtils.assertMatches(plan,
                     physicalCTEAnchor(
-                            physicalCTEProducer(any()),
-                            physicalResultSink(
-                                    physicalProject(
-                                            physicalNestedLoopJoin(
-                                                    physicalHashAggregate(
-                                                            physicalDistribute(
-                                                                    physicalHashAggregate(
-                                                                            physicalHashAggregate(
-                                                                                    physicalDistribute(
-                                                                                            physicalHashAggregate(any())))))),
-                                                    physicalDistribute(
-                                                            physicalHashAggregate(
-                                                                    physicalDistribute(
-                                                                            physicalHashAggregate(
-                                                                                    physicalHashAggregate(
-                                                                                            physicalDistribute(
-                                                                                                    physicalHashAggregate(any())))))))
-                                            )
-                                    )
-                            )
+                        physicalCTEProducer(any()),
+                        physicalResultSink(
+                             physicalNestedLoopJoin(
+                                 physicalProject(
+                                     physicalHashAggregate(
+                                         physicalDistribute(
+                                             physicalHashAggregate(
+                                                 physicalHashAggregate(
+                                                     physicalDistribute(
+                                                         physicalHashAggregate(any()))))))),
+                                     physicalDistribute(
+                                         physicalProject(
+                                             physicalHashAggregate(
+                                                 physicalDistribute(
+                                                     physicalHashAggregate(
+                                                         physicalHashAggregate(
+                                                             physicalDistribute(
+                                                                physicalHashAggregate(any()))))))))
+                                )
+                        )
                     )
             );
         });
@@ -142,19 +146,21 @@ public class SplitMultiDistinctTest extends TestWithFeService implements MemoPat
                     physicalCTEAnchor(
                             physicalCTEProducer(any()),
                             physicalResultSink(
-                                    physicalProject(
+
                                             physicalNestedLoopJoin(
+                                                    physicalProject(
                                                     physicalHashAggregate(
                                                             physicalHashAggregate(
                                                                     physicalDistribute(
-                                                                            physicalHashAggregate(any())))),
+                                                                            physicalHashAggregate(any()))))),
                                                     physicalDistribute(
+                                                            physicalProject(
                                                             physicalHashAggregate(
                                                                     physicalHashAggregate(
                                                                             physicalDistribute(
-                                                                                    physicalHashAggregate(any())))))
+                                                                                    physicalHashAggregate(any()))))))
                                             )
-                                    )
+
                             )
                     )
             );
@@ -174,14 +180,16 @@ public class SplitMultiDistinctTest extends TestWithFeService implements MemoPat
                                     physicalDistribute(
                                             physicalProject(
                                                     physicalHashJoin(
+                                                            physicalProject(
                                                             physicalHashAggregate(
                                                                     physicalHashAggregate(
                                                                             physicalDistribute(
-                                                                                    physicalHashAggregate(any())))),
+                                                                                    physicalHashAggregate(any()))))),
+                                                            physicalProject(
                                                             physicalHashAggregate(
                                                                     physicalHashAggregate(
                                                                             physicalDistribute(
-                                                                                    physicalHashAggregate(any()))))
+                                                                                    physicalHashAggregate(any())))))
                                                     ).when(join ->
                                                         join.getJoinType() == JoinType.INNER_JOIN && join.getHashJoinConjuncts().get(0) instanceof NullSafeEqual
                                                     )

--- a/regression-test/data/nereids_rules_p0/distinct_split/disitinct_split.out
+++ b/regression-test/data/nereids_rules_p0/distinct_split/disitinct_split.out
@@ -380,7 +380,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalOlapScan[test_distinct_multi]
 --PhysicalResultSink
-----hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
+----hashJoin[INNER_JOIN] hashCondition=((d <=> .d)) otherCondition=()
 ------hashAgg[DISTINCT_LOCAL]
 --------hashAgg[GLOBAL]
 ----------hashAgg[LOCAL]
@@ -415,9 +415,9 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
 ----PhysicalOlapScan[test_distinct_multi]
 --PhysicalResultSink
-----hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
-------hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
---------hashJoin[INNER_JOIN] hashCondition=((.d <=> .d)) otherCondition=()
+----hashJoin[INNER_JOIN] hashCondition=((d <=> .d)) otherCondition=()
+------hashJoin[INNER_JOIN] hashCondition=((d <=> .d)) otherCondition=()
+--------hashJoin[INNER_JOIN] hashCondition=((d <=> .d)) otherCondition=()
 ----------hashAgg[DISTINCT_LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]
@@ -463,7 +463,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalResultSink
 ----hashAgg[GLOBAL]
 ------hashAgg[LOCAL]
---------hashJoin[INNER_JOIN] hashCondition=((.c <=> .c)) otherCondition=()
+--------hashJoin[INNER_JOIN] hashCondition=((c <=> .c)) otherCondition=()
 ----------hashAgg[DISTINCT_LOCAL]
 ------------hashAgg[GLOBAL]
 --------------hashAgg[LOCAL]

--- a/regression-test/suites/nereids_syntax_p0/transform_outer_join_to_anti.groovy
+++ b/regression-test/suites/nereids_syntax_p0/transform_outer_join_to_anti.groovy
@@ -84,4 +84,12 @@ suite("transform_outer_join_to_anti") {
         sql("select * from eliminate_outer_join_A right outer join eliminate_outer_join_B on eliminate_outer_join_B.b = eliminate_outer_join_A.a where eliminate_outer_join_A.a is null and eliminate_outer_join_B.null_b is null and eliminate_outer_join_A.null_a is null")
         contains "ANTI JOIN"
     }
+
+    explain {
+        sql """with temp as (
+                   select * from eliminate_outer_join_A left outer join eliminate_outer_join_B on eliminate_outer_join_B.b = eliminate_outer_join_A.a where eliminate_outer_join_B.b is null
+               )
+               select * from temp t1 join temp t2"""
+        contains "ANTI JOIN"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

this rule could generate duplicate ExprID.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

