### PR TITLE
[fix](txnkv) avoid skip keys during reverse full range iteration

### DIFF
--- a/cloud/src/meta-store/mem_txn_kv.h
+++ b/cloud/src/meta-store/mem_txn_kv.h
@@ -56,7 +56,8 @@ public:
 
     TxnErrorCode get_kv(const std::string& key, std::string* val, int64_t version);
     TxnErrorCode get_kv(const std::string& begin, const std::string& end, int64_t version,
-                        int limit, bool* more, std::map<std::string, std::string>* kv_list);
+                        const RangeGetOptions& opts, bool* more,
+                        std::vector<std::pair<std::string, std::string>>* kv_list);
 
     size_t total_kvs() const {
         std::lock_guard<std::mutex> l(lock_);
@@ -286,19 +287,9 @@ public:
         return k;
     }
 
-    std::string prev_end_key() const override {
+    std::string_view last_key() const override {
         if (!more()) return {};
-        std::string k(kvs_[kvs_size_ - 1].first);
-        if (k.empty()) {
-            // The minimum key, return an empty string
-        } else if (k.back() == '\x00') {
-            // If the last byte is a null byte, we should remove it
-            k.pop_back();
-        } else {
-            // Otherwise, we should decrement the last byte
-            k.back() -= 1;
-        }
-        return k;
+        return kvs_[kvs_size_ - 1].first;
     }
 
 private:

--- a/cloud/src/meta-store/txn_kv.cpp
+++ b/cloud/src/meta-store/txn_kv.cpp
@@ -850,9 +850,16 @@ void FullRangeGetIterator::async_inner_get(std::string_view begin, std::string_v
 
 void FullRangeGetIterator::async_get_next_batch() {
     if (opts_.reverse) {
-        async_inner_get(begin_, inner_iter_->prev_end_key());
+        // Change the end key to the previous last key. The key selector will be
+        // FIRST_GREATER_OR_EQUAL, so we need to use the last key of the inner iterator as the
+        // end key, since the end key is exclusive.
+        opts_.end_key_selector = RangeKeySelector::FIRST_GREATER_OR_EQUAL;
+        std::string_view end_key = inner_iter_->last_key();
+        async_inner_get(begin_, end_key);
     } else {
-        async_inner_get(inner_iter_->next_begin_key(), end_);
+        opts_.begin_key_selector = RangeKeySelector::FIRST_GREATER_OR_EQUAL;
+        std::string begin_key = inner_iter_->next_begin_key();
+        async_inner_get(begin_key, end_);
     }
 }
 

--- a/cloud/src/meta-store/txn_kv.h
+++ b/cloud/src/meta-store/txn_kv.h
@@ -382,10 +382,12 @@ public:
     virtual std::string next_begin_key() const = 0;
 
     /**
-     * Get the end key of the next iterator if `more()` is true, otherwise returns empty string.
-     * This is used for reverse range get.
+     * Get the last key of the iterator, it can be used as the end key of the next iterator when
+     * the key selector is FIRST_GREATER_OR_EQUAL.
+     *
+     * ATTN: This is ONLY used for reverse range get.
      */
-    virtual std::string prev_end_key() const = 0;
+    virtual std::string_view last_key() const = 0;
 
     RangeGetIterator(const RangeGetIterator&) = delete;
     RangeGetIterator& operator=(const RangeGetIterator&) = delete;
@@ -559,20 +561,10 @@ public:
         return k;
     }
 
-    std::string prev_end_key() const override {
-        if (!more()) return {};
+    std::string_view last_key() const override {
+        if (kvs_size_ <= 0) return {};
         const auto& kv = kvs_[kvs_size_ - 1];
-        std::string k((char*)kv.key, (size_t)kv.key_length);
-        if (k.empty()) {
-            // The minimum key, return an empty string
-        } else if (k.back() == '\x00') {
-            // If the last byte is a null byte, we should remove it
-            k.pop_back();
-        } else {
-            // Otherwise, we should decrement the last byte
-            k.back() -= 1;
-        }
-        return k;
+        return {(char*)kv.key, (size_t)kv.key_length};
     }
 
     RangeGetIterator(const RangeGetIterator&) = delete;

--- a/cloud/test/mem_txn_kv_test.cpp
+++ b/cloud/test/mem_txn_kv_test.cpp
@@ -25,6 +25,7 @@
 #include "common/config.h"
 #include "common/util.h"
 #include "meta-service/doris_txn.h"
+#include "meta-store/codec.h"
 #include "meta-store/txn_kv.h"
 #include "meta-store/txn_kv_error.h"
 
@@ -936,5 +937,362 @@ TEST(TxnMemKvTest, MaybeUnusedFunctionTest) {
             std::cout << "version: " << ver << std::endl;
             ASSERT_EQ(ver, 1);
         }
+    }
+}
+
+TEST(TxnMemKvTest, RangeGetKeySelector) {
+    using namespace doris::cloud;
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    constexpr std::string_view prefix = "range_get_key_selector_";
+
+    {
+        // Remove the existing keys and insert some new keys.
+        std::unique_ptr<Transaction> txn;
+        TxnErrorCode err = txn_kv->create_txn(&txn);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        std::string last_key = fmt::format("{}{}", prefix, 9);
+        encode_int64(INT64_MAX, &last_key);
+        txn->remove(prefix, last_key);
+        for (int i = 0; i < 5; ++i) {
+            std::string key = fmt::format("{}{}", prefix, i);
+            txn->put(key, std::to_string(i));
+        }
+        err = txn->commit();
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+    }
+
+    struct TestCase {
+        RangeKeySelector begin_key_selector, end_key_selector;
+        std::vector<std::string> expected_keys;
+    };
+
+    std::string range_begin = fmt::format("{}{}", prefix, 1);
+    std::string range_end = fmt::format("{}{}", prefix, 3);
+    std::vector<TestCase> test_case {
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 1), fmt::format("{}{}", prefix, 2)},
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    {
+                            fmt::format("{}{}", prefix, 1),
+                            fmt::format("{}{}", prefix, 2),
+                            fmt::format("{}{}", prefix, 3),
+                    },
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 1), fmt::format("{}{}", prefix, 2)},
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::LAST_LESS_THAN,
+                    {fmt::format("{}{}", prefix, 1)},
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 2)},
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    {fmt::format("{}{}", prefix, 2), fmt::format("{}{}", prefix, 3)},
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 2)},
+            },
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::LAST_LESS_THAN,
+                    {},
+            },
+            {
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 1), fmt::format("{}{}", prefix, 2)},
+            },
+            {
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    {
+                            fmt::format("{}{}", prefix, 1),
+                            fmt::format("{}{}", prefix, 2),
+                            fmt::format("{}{}", prefix, 3),
+                    },
+            },
+            {
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 1), fmt::format("{}{}", prefix, 2)},
+            },
+            {
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    RangeKeySelector::LAST_LESS_THAN,
+                    {fmt::format("{}{}", prefix, 1)},
+            },
+            {
+                    RangeKeySelector::LAST_LESS_THAN,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    {
+                            fmt::format("{}{}", prefix, 0),
+                            fmt::format("{}{}", prefix, 1),
+                            fmt::format("{}{}", prefix, 2),
+                    },
+            },
+            {
+                    RangeKeySelector::LAST_LESS_THAN,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    {
+                            fmt::format("{}{}", prefix, 0),
+                            fmt::format("{}{}", prefix, 1),
+                            fmt::format("{}{}", prefix, 2),
+                            fmt::format("{}{}", prefix, 3),
+                    },
+            },
+            {
+                    RangeKeySelector::LAST_LESS_THAN,
+                    RangeKeySelector::LAST_LESS_OR_EQUAL,
+                    {
+                            fmt::format("{}{}", prefix, 0),
+                            fmt::format("{}{}", prefix, 1),
+                            fmt::format("{}{}", prefix, 2),
+                    },
+            },
+            {
+                    RangeKeySelector::LAST_LESS_THAN,
+                    RangeKeySelector::LAST_LESS_THAN,
+                    {fmt::format("{}{}", prefix, 0), fmt::format("{}{}", prefix, 1)},
+            },
+    };
+
+    // Scan range with different key selectors
+    for (const auto& tc : test_case) {
+        std::unique_ptr<Transaction> txn;
+        TxnErrorCode err = txn_kv->create_txn(&txn);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        RangeGetOptions options;
+        options.batch_limit = 1000;
+        options.begin_key_selector = tc.begin_key_selector;
+        options.end_key_selector = tc.end_key_selector;
+        std::unique_ptr<RangeGetIterator> it;
+        err = txn->get(range_begin, range_end, &it, options);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        std::vector<std::string> actual_keys;
+        while (it->has_next()) {
+            auto [k, v] = it->next();
+            actual_keys.emplace_back(k);
+        }
+        EXPECT_EQ(actual_keys, tc.expected_keys)
+                << "Failed for begin_key_selector=" << static_cast<int>(tc.begin_key_selector)
+                << ", end_key_selector=" << static_cast<int>(tc.end_key_selector);
+    }
+}
+
+TEST(TxnMemKvTest, ReverseRangeGet) {
+    using namespace doris::cloud;
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    constexpr std::string_view prefix = "reverse_range_get_";
+
+    {
+        // Remove the existing keys and insert some new keys.
+        std::unique_ptr<Transaction> txn;
+        TxnErrorCode err = txn_kv->create_txn(&txn);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        std::string last_key = fmt::format("{}{}", prefix, 9);
+        encode_int64(INT64_MAX, &last_key);
+        txn->remove(prefix, last_key);
+        for (int i = 0; i < 5; ++i) {
+            std::string key = fmt::format("{}{}", prefix, i);
+            txn->put(key, std::to_string(i));
+        }
+        err = txn->commit();
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+    }
+
+    std::string range_begin = fmt::format("{}{}", prefix, 1);
+    std::string range_end = fmt::format("{}{}", prefix, 3);
+
+    struct TestCase {
+        RangeKeySelector begin_key_selector, end_key_selector;
+        std::vector<std::string> expected_keys;
+    };
+
+    std::vector<TestCase> test_case {
+            // 1. [begin, end)
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 2), fmt::format("{}{}", prefix, 1)},
+            },
+            // 2. [begin, end]
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    {
+                            fmt::format("{}{}", prefix, 3),
+                            fmt::format("{}{}", prefix, 2),
+                            fmt::format("{}{}", prefix, 1),
+                    },
+            },
+            // 3. (begin, end)
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    {fmt::format("{}{}", prefix, 2)},
+            },
+            // 4. (begin, end]
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    {fmt::format("{}{}", prefix, 3), fmt::format("{}{}", prefix, 2)},
+            },
+    };
+    for (const auto& tc : test_case) {
+        std::unique_ptr<Transaction> txn;
+        TxnErrorCode err = txn_kv->create_txn(&txn);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        RangeGetOptions options;
+        options.batch_limit = 1000;
+        options.begin_key_selector = tc.begin_key_selector;
+        options.end_key_selector = tc.end_key_selector;
+        options.reverse = true; // Reserve range get
+        std::unique_ptr<RangeGetIterator> it;
+        err = txn->get(range_begin, range_end, &it, options);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        std::vector<std::string> actual_keys;
+        while (it->has_next()) {
+            auto [k, v] = it->next();
+            actual_keys.emplace_back(k);
+        }
+        EXPECT_EQ(actual_keys, tc.expected_keys)
+                << "Failed for begin_key_selector=" << static_cast<int>(tc.begin_key_selector)
+                << ", end_key_selector=" << static_cast<int>(tc.end_key_selector);
+    }
+}
+
+TEST(TxnMemKvTest, ReverseFullRangeGet) {
+    using namespace doris::cloud;
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    constexpr std::string_view prefix = "reverse_full_range_get_";
+
+    {
+        // Remove the existing keys and insert some new keys.
+        std::unique_ptr<Transaction> txn;
+        TxnErrorCode err = txn_kv->create_txn(&txn);
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+        std::string last_key = fmt::format("{}{:03}", prefix, 99);
+        encode_int64(INT64_MAX, &last_key);
+        txn->remove(prefix, last_key);
+        for (int i = 0; i < 100; ++i) {
+            std::string key = fmt::format("{}{:03}", prefix, i);
+            txn->put(key, std::to_string(i));
+        }
+        err = txn->commit();
+        ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+    }
+
+    std::string range_begin = fmt::format("{}{:03}", prefix, 1);
+    std::string range_end = fmt::format("{}{:03}", prefix, 98);
+
+    struct TestCase {
+        RangeKeySelector begin_key_selector, end_key_selector;
+    };
+
+    std::vector<TestCase> test_case {
+            // 1. [begin, end)
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+            },
+            // 2. [begin, end]
+            {
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+            },
+            // 3. (begin, end)
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::FIRST_GREATER_OR_EQUAL,
+            },
+            // 4. (begin, end]
+            {
+                    RangeKeySelector::FIRST_GREATER_THAN,
+                    RangeKeySelector::FIRST_GREATER_THAN,
+            },
+    };
+
+    for (const auto& tc : test_case) {
+        std::vector<std::string> expected_keys;
+        {
+            // Read the expected keys via range_get
+            std::unique_ptr<Transaction> txn;
+            TxnErrorCode err = txn_kv->create_txn(&txn);
+            ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+            RangeGetOptions options;
+            options.batch_limit = 11;
+            options.begin_key_selector = tc.begin_key_selector;
+            options.end_key_selector = tc.end_key_selector;
+            options.reverse = true; // Reserve range get
+            std::string begin = range_begin, end = range_end;
+
+            std::unique_ptr<RangeGetIterator> it;
+            do {
+                err = txn->get(begin, end, &it, options);
+                ASSERT_EQ(err, TxnErrorCode::TXN_OK);
+
+                while (it->has_next()) {
+                    auto [k, v] = it->next();
+                    expected_keys.emplace_back(k);
+                }
+                // Get next begin key for reverse range get
+                end = it->last_key();
+                options.end_key_selector = RangeKeySelector::FIRST_GREATER_OR_EQUAL;
+            } while (it->more());
+        }
+
+        std::vector<std::string> actual_keys;
+        {
+            // Read the actual keys via full_range_get
+            FullRangeGetOptions opts(txn_kv);
+            opts.batch_limit = 11;
+            opts.begin_key_selector = tc.begin_key_selector;
+            opts.end_key_selector = tc.end_key_selector;
+            opts.reverse = true; // Reserve full range get
+
+            auto it = txn_kv->full_range_get(range_begin, range_end, opts);
+            ASSERT_TRUE(it->is_valid());
+
+            while (it->has_next()) {
+                auto kvp = it->next();
+                ASSERT_TRUE(kvp.has_value());
+                auto [k, v] = *kvp;
+                actual_keys.emplace_back(k);
+            }
+        }
+
+        EXPECT_EQ(actual_keys, expected_keys)
+                << "Failed for begin_key_selector=" << static_cast<int>(tc.begin_key_selector)
+                << ", end_key_selector=" << static_cast<int>(tc.end_key_selector);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

It was introduced by #52730. When switching to the next batch, FullRangeGetIterator should not continue to use the RangeKeySelector provided by the user; otherwise, it will lead to inaccurate key bounds.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

