### PR TITLE
[fix](be-jni-env) Fix java.lang.StackOverflowError thrown from the UncaughtExceptionHandler in thread "process reaper".

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1210,6 +1210,9 @@ DEFINE_mString(kerberos_krb5_conf_path, "/etc/krb5.conf");
 // Deprecated
 DEFINE_mInt32(kerberos_refresh_interval_second, "43200");
 
+// JDK-8153057: avoid StackOverflowError thrown from the UncaughtExceptionHandler in thread "process reaper"
+DEFINE_mBool(jdk_process_reaper_use_default_stack_size, "true");
+
 DEFINE_mString(get_stack_trace_tool, "libunwind");
 DEFINE_mString(dwarf_location_info_mode, "FAST");
 DEFINE_mBool(enable_address_sanitizers_with_stack_trace, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1258,6 +1258,9 @@ DECLARE_mString(kerberos_krb5_conf_path);
 // the interval for renew kerberos ticket cache
 DECLARE_mInt32(kerberos_refresh_interval_second);
 
+// JDK-8153057: avoid StackOverflowError thrown from the UncaughtExceptionHandler in thread "process reaper"
+DECLARE_mBool(jdk_process_reaper_use_default_stack_size);
+
 // Values include `none`, `glog`, `boost`, `glibc`, `libunwind`
 DECLARE_mString(get_stack_trace_tool);
 DECLARE_mBool(enable_address_sanitizers_with_stack_trace);

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -101,6 +101,8 @@ const std::string GetKerb5ConfPath() {
     std::string libhdfs_opts = getenv("LIBHDFS_OPTS") ? getenv("LIBHDFS_OPTS") : "";
     CHECK(libhdfs_opts != "") << "LIBHDFS_OPTS is not set";
     libhdfs_opts += fmt::format(" {} ", GetKerb5ConfPath());
+    libhdfs_opts += fmt::format(" -Djdk.lang.processReaperUseDefaultStackSize{}",
+                                config::jdk_process_reaper_use_default_stack_size);
     setenv("LIBHDFS_OPTS", libhdfs_opts.c_str(), 1);
     LOG(INFO) << "set final LIBHDFS_OPTS: " << libhdfs_opts;
 }
@@ -118,6 +120,8 @@ const std::string GetKerb5ConfPath() {
                     GetDorisJNIClasspathOption(), fmt::format("-Xmx{}", "1g"),
                     fmt::format("-DlogPath={}/log/jni.log", getenv("DORIS_HOME")),
                     fmt::format("-Dsun.java.command={}", "DorisBE"), "-XX:-CriticalJNINatives",
+                    fmt::format("-Djdk.lang.processReaperUseDefaultStackSize{}",
+                                config::jdk_process_reaper_use_default_stack_size),
 #ifdef __APPLE__
                     // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
                     // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In some env, jni will throw
``` 
Exception: java.lang.StackOverflowError thrown from the UncaughtExceptionHandler in thread "process reaper".
```

### Release note

Fix java.lang.StackOverflowError thrown from the UncaughtExceptionHandler in thread "process reaper" by set `-Djdk.lang.processReaperUseDefaultStackSize`. Similar with https://bugs.openjdk.org/browse/JDK-8153057, because we use jni with other c/c++ lib which use thread-local.
We don't know if turning this on has any side effects at this time, so provide an option 'jdk_process_reaper_use_default_stack_size' to control it, defaults is true.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

