### PR TITLE
[fix](Nereids) not process must shuffle when regulate can not be banned agg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -111,7 +111,7 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<List<List<PhysicalP
             return ImmutableList.of();
         }
         if (!agg.getAggregateParam().canBeBanned) {
-            return ImmutableList.of(originChildrenProperties);
+            return visit(agg, context);
         }
         // forbid one phase agg on distribute
         if (agg.getAggMode() == AggMode.INPUT_TO_RESULT && children.get(0).getPlan() instanceof PhysicalDistribute) {
@@ -177,9 +177,7 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<List<List<PhysicalP
             }
         }
         // process must shuffle
-        visit(agg, context);
-        // process agg
-        return ImmutableList.of(originChildrenProperties);
+        return visit(agg, context);
     }
 
     @Override

--- a/regression-test/data/query_p0/group_concat/test_group_concat.out
+++ b/regression-test/data/query_p0/group_concat/test_group_concat.out
@@ -39,6 +39,10 @@ false
 1	2
 1	2
 
+-- !select_13 --
+1	2
+1	2
+
 -- !select_group_concat_order_by_all_data --
 1	1	1
 1	1	11

--- a/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
+++ b/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
@@ -79,6 +79,16 @@ suite("test_group_concat", "query,p0,arrow_flight_sql") {
                 b2;
               """
 
+    // test SPLIT_MULTI_DISTINCT could work right with can not be banned aggregation
+    qt_select_13 """
+                select
+                group_concat( distinct b1, cast(b2 as varchar)), group_concat( distinct b3, '?')
+                from
+                table_group_concat
+                group by 
+                b2;
+              """
+
     sql """ drop table table_group_concat """
     sql """create table table_group_concat ( b1 varchar(10) not null, b2 int not null, b3 varchar(10) not null )
             ENGINE=OLAP


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #21565

Problem Summary:

when a aggregation node with can not be banned property, we forgot to process DistributionSpecMustShuffle require property. So, we pushed aggregation node through MultiCastDataSinks by mistake. 
The wrong plan is like below
```
+--PhysicalHashAggregate
   +--PhysicalDistribute
      +--PhysicalHashAggregate
         +--PhysicalCTEConsumer
```
the right plan is like below
```
PhysicalHashAggregate
+--PhysicalDistribute
   +--PhysicalHashAggregate
      +--PhysicalDistribute
         +--PhysicalCTEConsumer
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

