### PR TITLE
[optimize](util) Faster bit_pack

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -834,6 +834,7 @@ endforeach()
 
 if (BUILD_BENCHMARK)
     add_executable(benchmark_test ${BASE_DIR}/benchmark/benchmark_main.cpp)
+    set_target_properties(benchmark_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
     target_link_libraries(benchmark_test ${DORIS_LINK_LIBS})
     message(STATUS "Add benchmark to build")
     install(TARGETS benchmark_test DESTINATION ${OUTPUT_DIR}/lib)

--- a/be/benchmark/benchmark_bit_pack.cpp
+++ b/be/benchmark/benchmark_bit_pack.cpp
@@ -16,87 +16,88 @@
 // under the License.
 
 #include <benchmark/benchmark.h>
-#include <vector>
+
 #include <random>
+#include <vector>
 
 #include "util/frame_of_reference_coding.h"
 
 namespace doris {
 
-    // original bit_pack function
-    template <typename T>
-    void bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output) {
-        if (in_num == 0 || bit_width == 0) {
-            return;
-        }
+// original bit_pack function
+template <typename T>
+void bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output) {
+    if (in_num == 0 || bit_width == 0) {
+        return;
+    }
 
-        T in_mask = 0;
-        int bit_index = 0;
-        *output = 0;
-        for (int i = 0; i < in_num; i++) {
-            in_mask = ((T)1) << (bit_width - 1);
-            for (int k = 0; k < bit_width; k++) {
-                if (bit_index > 7) {
-                    bit_index = 0;
-                    output++;
-                    *output = 0;
-                }
-                *output |= (((input[i] & in_mask) >> (bit_width - k - 1)) << (7 - bit_index));
-                in_mask >>= 1;
-                bit_index++;
+    T in_mask = 0;
+    int bit_index = 0;
+    *output = 0;
+    for (int i = 0; i < in_num; i++) {
+        in_mask = ((T)1) << (bit_width - 1);
+        for (int k = 0; k < bit_width; k++) {
+            if (bit_index > 7) {
+                bit_index = 0;
+                output++;
+                *output = 0;
             }
+            *output |= (((input[i] & in_mask) >> (bit_width - k - 1)) << (7 - bit_index));
+            in_mask >>= 1;
+            bit_index++;
         }
     }
+}
 
-    static void BM_BitPack(benchmark::State& state) {
-        int w = state.range(0);
-        int n = 255;
+static void BM_BitPack(benchmark::State& state) {
+    int w = state.range(0);
+    int n = 255;
 
-        std::default_random_engine e;
-        std::uniform_int_distribution<int64_t> u;
-        std::vector<__int128_t> test_data(n);
-        __int128_t in_mask = ((__int128_t(1)) << w) - 1;
-        for (int i = 0; i < n; i++) {
-            test_data[i] = u(e) & in_mask;
-        }
-
-        int size = (n * w + 7) / 8;
-        std::vector<uint8_t> output(size);
-
-        for (auto _ : state) {
-            benchmark::DoNotOptimize(test_data.data());
-            benchmark::DoNotOptimize(output.data());
-            bit_pack(test_data.data(), n, w, output.data());
-            benchmark::ClobberMemory();
-        }
-
-        state.SetBytesProcessed(int64_t(state.iterations()) * size);
+    std::default_random_engine e;
+    std::uniform_int_distribution<int64_t> u;
+    std::vector<__int128_t> test_data(n);
+    __int128_t in_mask = ((__int128_t(1)) << w) - 1;
+    for (int i = 0; i < n; i++) {
+        test_data[i] = u(e) & in_mask;
     }
 
-    static void BM_BitPackOptimized(benchmark::State& state) {
-        int w = state.range(0);
-        int n = 255;
+    int size = (n * w + 7) / 8;
+    std::vector<uint8_t> output(size);
 
-        std::default_random_engine e;
-        std::uniform_int_distribution<int64_t> u;
-        std::vector<__int128_t> test_data(n);
-        __int128_t in_mask = ((__int128_t(1)) << w) - 1;
-        for (int i = 0; i < n; i++) {
-            test_data[i] = u(e) & in_mask;
-        }
-
-        int size = (n * w + 7) / 8;
-        std::vector<uint8_t> output(size);
-
-        ForEncoder<__int128_t> forEncoder(nullptr);
-
-        for (auto _ : state) {
-            benchmark::DoNotOptimize(test_data.data());
-            benchmark::DoNotOptimize(output.data());
-            forEncoder.bit_pack(test_data.data(), n, w, output.data());
-            benchmark::ClobberMemory();
-        }
-
-        state.SetBytesProcessed(int64_t(state.iterations()) * size);
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(test_data.data());
+        benchmark::DoNotOptimize(output.data());
+        bit_pack(test_data.data(), n, w, output.data());
+        benchmark::ClobberMemory();
     }
+
+    state.SetBytesProcessed(int64_t(state.iterations()) * size);
+}
+
+static void BM_BitPackOptimized(benchmark::State& state) {
+    int w = state.range(0);
+    int n = 255;
+
+    std::default_random_engine e;
+    std::uniform_int_distribution<int64_t> u;
+    std::vector<__int128_t> test_data(n);
+    __int128_t in_mask = ((__int128_t(1)) << w) - 1;
+    for (int i = 0; i < n; i++) {
+        test_data[i] = u(e) & in_mask;
+    }
+
+    int size = (n * w + 7) / 8;
+    std::vector<uint8_t> output(size);
+
+    ForEncoder<__int128_t> forEncoder(nullptr);
+
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(test_data.data());
+        benchmark::DoNotOptimize(output.data());
+        forEncoder.bit_pack(test_data.data(), n, w, output.data());
+        benchmark::ClobberMemory();
+    }
+
+    state.SetBytesProcessed(int64_t(state.iterations()) * size);
+}
 } // namespace doris

--- a/be/benchmark/benchmark_bit_pack.cpp
+++ b/be/benchmark/benchmark_bit_pack.cpp
@@ -49,7 +49,7 @@ namespace doris {
     }
 
     static void BM_BitPack(benchmark::State& state) {
-        int w = state.range(0); // 获取参数 w（bit_width）
+        int w = state.range(0);
         int n = 255;
 
         std::default_random_engine e;
@@ -93,7 +93,7 @@ namespace doris {
         for (auto _ : state) {
             benchmark::DoNotOptimize(test_data.data());
             benchmark::DoNotOptimize(output.data());
-            forEncoder.test_bit_pack(test_data.data(), n, w, output.data());
+            forEncoder.bit_pack(test_data.data(), n, w, output.data());
             benchmark::ClobberMemory();
         }
 

--- a/be/benchmark/benchmark_bit_pack.cpp
+++ b/be/benchmark/benchmark_bit_pack.cpp
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include <benchmark/benchmark.h>
 #include <vector>
 #include <random>

--- a/be/benchmark/benchmark_bit_pack.cpp
+++ b/be/benchmark/benchmark_bit_pack.cpp
@@ -1,0 +1,85 @@
+#include <benchmark/benchmark.h>
+#include <vector>
+#include <random>
+
+#include "util/frame_of_reference_coding.h"
+
+namespace doris {
+
+    // original bit_pack function
+    template <typename T>
+    void bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output) {
+        if (in_num == 0 || bit_width == 0) {
+            return;
+        }
+
+        T in_mask = 0;
+        int bit_index = 0;
+        *output = 0;
+        for (int i = 0; i < in_num; i++) {
+            in_mask = ((T)1) << (bit_width - 1);
+            for (int k = 0; k < bit_width; k++) {
+                if (bit_index > 7) {
+                    bit_index = 0;
+                    output++;
+                    *output = 0;
+                }
+                *output |= (((input[i] & in_mask) >> (bit_width - k - 1)) << (7 - bit_index));
+                in_mask >>= 1;
+                bit_index++;
+            }
+        }
+    }
+
+    static void BM_BitPack(benchmark::State& state) {
+        int w = state.range(0); // 获取参数 w（bit_width）
+        int n = 255;
+
+        std::default_random_engine e;
+        std::uniform_int_distribution<int64_t> u;
+        std::vector<__int128_t> test_data(n);
+        __int128_t in_mask = ((__int128_t(1)) << w) - 1;
+        for (int i = 0; i < n; i++) {
+            test_data[i] = u(e) & in_mask;
+        }
+
+        int size = (n * w + 7) / 8;
+        std::vector<uint8_t> output(size);
+
+        for (auto _ : state) {
+            benchmark::DoNotOptimize(test_data.data());
+            benchmark::DoNotOptimize(output.data());
+            bit_pack(test_data.data(), n, w, output.data());
+            benchmark::ClobberMemory();
+        }
+
+        state.SetBytesProcessed(int64_t(state.iterations()) * size);
+    }
+
+    static void BM_BitPackOptimized(benchmark::State& state) {
+        int w = state.range(0);
+        int n = 255;
+
+        std::default_random_engine e;
+        std::uniform_int_distribution<int64_t> u;
+        std::vector<__int128_t> test_data(n);
+        __int128_t in_mask = ((__int128_t(1)) << w) - 1;
+        for (int i = 0; i < n; i++) {
+            test_data[i] = u(e) & in_mask;
+        }
+
+        int size = (n * w + 7) / 8;
+        std::vector<uint8_t> output(size);
+
+        ForEncoder<__int128_t> forEncoder(nullptr);
+
+        for (auto _ : state) {
+            benchmark::DoNotOptimize(test_data.data());
+            benchmark::DoNotOptimize(output.data());
+            forEncoder.test_bit_pack(test_data.data(), n, w, output.data());
+            benchmark::ClobberMemory();
+        }
+
+        state.SetBytesProcessed(int64_t(state.iterations()) * size);
+    }
+} // namespace doris

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -19,11 +19,11 @@
 
 #include <string>
 
+#include "benchmark_bit_pack.cpp"
 #include "vec/columns/column_string.h"
 #include "vec/core/block.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_string.h"
-#include "benchmark_bit_pack.cpp"
 
 namespace doris::vectorized { // change if need
 

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -23,6 +23,7 @@
 #include "vec/core/block.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_string.h"
+#include "benchmark_bit_pack.cpp"
 
 namespace doris::vectorized { // change if need
 
@@ -46,7 +47,8 @@ static void Example1(benchmark::State& state) {
 }
 // could BENCHMARK many functions to compare them together.
 BENCHMARK(Example1);
-
+BENCHMARK(BM_BitPack)->DenseRange(1, 127)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_BitPackOptimized)->DenseRange(1, 127)->Unit(benchmark::kNanosecond);
 } // namespace doris::vectorized
 
 BENCHMARK_MAIN();

--- a/be/src/util/frame_of_reference_coding.cpp
+++ b/be/src/util/frame_of_reference_coding.cpp
@@ -76,7 +76,7 @@ template <typename T>
 void ForEncoder<T>::bit_pack_8(const T* input, uint8_t in_num, int bit_width, uint8_t* output) {
     int64_t s = 0;
     uint8_t output_mask = 255;
-    int tail_count = in_num & 7; // the remainder of in_num modulo 8
+    int tail_count = in_num & 7;              // the remainder of in_num modulo 8
     int full_batch_size = (in_num >> 3) << 3; // Adjust in_num to a multiple of 8
 
     for (int i = 0; i < full_batch_size; i += 8) {
@@ -102,7 +102,7 @@ void ForEncoder<T>::bit_pack_8(const T* input, uint8_t in_num, int bit_width, ui
 
     // remainder
     int byte = tail_count * bit_width; // How many bits are left to store
-    int bytes = (byte + 7) >> 3; // How many more bytes are needed to store the rest of input
+    int bytes = (byte + 7) >> 3;       // How many more bytes are needed to store the rest of input
 
     // Put the tail_count numbers in the input into s in order, each number occupies bit_width bit
     for (int i = 0; i < tail_count; i++) {
@@ -126,9 +126,9 @@ template <typename U>
 void ForEncoder<T>::bit_pack_32(const T* input, uint8_t in_num, int bit_width, uint8_t* output) {
     U s = 0;
     uint8_t output_mask = 255;
-    int tail_count = in_num & 3;  // the remainder of in_num modulo 4
-    int full_batch_size = (in_num >> 2) << 2;  // Adjust in_num to a multiple of 4
-    int output_size = 0; // How many outputs can be processed at a time
+    int tail_count = in_num & 3;              // the remainder of in_num modulo 4
+    int full_batch_size = (in_num >> 2) << 2; // Adjust in_num to a multiple of 4
+    int output_size = 0;                      // How many outputs can be processed at a time
     int bit_width_remainder =
             (bit_width << 2) & 7; // How many bits will be left after processing 4 numbers at a time
     int extra_bit = 0;            // Extra bits after each process
@@ -145,16 +145,16 @@ void ForEncoder<T>::bit_pack_32(const T* input, uint8_t in_num, int bit_width, u
         s <<= bit_width;
         s |= (static_cast<U>(input[i + 3]));
 
-        // ((bit_width * 4) + extra_bit) / 8: There are bit_width*4 bits to be processed in s, 
-        // and there are extra_bit bits left over from the last loop, 
+        // ((bit_width * 4) + extra_bit) / 8: There are bit_width*4 bits to be processed in s,
+        // and there are extra_bit bits left over from the last loop,
         // divide by 8 to calculate how much output can be processed in this loop.
         output_size = ((bit_width << 2) + extra_bit) >> 3;
-        
-        // Each loop will leave bit_width_remainder bit unprocessed, 
-        // last loop will leave extra_bit bit, eventually will leave 
+
+        // Each loop will leave bit_width_remainder bit unprocessed,
+        // last loop will leave extra_bit bit, eventually will leave
         // (extra_bit + bit_width_remainder) & 7 bit unprocessed
         extra_bit = (extra_bit + bit_width_remainder) & 7;
-        
+
         // Starting with the highest valid bit, take out 8 bits in sequence
         // perform an AND operation with output_mask to ensure that only 8 bits are valid
         // (output_size-j-1)<<3 used to calculate how many bits need to be removed at the end
@@ -163,13 +163,13 @@ void ForEncoder<T>::bit_pack_32(const T* input, uint8_t in_num, int bit_width, u
             output[j] = (s >> (((output_size - j - 1) << 3) + extra_bit)) & output_mask;
         }
         output += output_size;
-        
+
         // s retains the post extra_bit bit as it is not processed
         s &= (1 << extra_bit) - 1;
     }
 
     // remainder
-    int byte = tail_count * bit_width; // How many bits are left to store
+    int byte = tail_count * bit_width;     // How many bits are left to store
     if (extra_bit != 0) byte += extra_bit; // add extra_bit bit as it is not processed
     int bytes = (byte + 7) >> 3; // How many more bytes are needed to store the rest of input
 
@@ -199,7 +199,7 @@ void ForEncoder<T>::bit_pack_128(const T* input, uint8_t in_num, int bit_width, 
         T x = input[i];
         int width = bit_width;
         if (need_bit) {
-            // The last time we take away the high 8 - need_bit, 
+            // The last time we take away the high 8 - need_bit,
             // we need to make up the rest of the need_bit from the width.
             // Use width - need_bit to compute high need_bit bits
             *output |= x >> (width - need_bit);
@@ -207,9 +207,9 @@ void ForEncoder<T>::bit_pack_128(const T* input, uint8_t in_num, int bit_width, 
             // There are need_bit bits being used, so subtract
             width -= need_bit;
         }
-        int num = width >> 3; // How many outputs can be processed at a time
+        int num = width >> 3;      // How many outputs can be processed at a time
         int remainder = width & 7; // How many bits are left to store
-        
+
         // Starting with the highest valid bit, take out 8 bits in sequence
         // perform an AND operation with output_mask to ensure that only 8 bits are valid
         // (num-j-1)<<3 used to calculate how many bits need to be removed at the end

--- a/be/src/util/frame_of_reference_coding.h
+++ b/be/src/util/frame_of_reference_coding.h
@@ -99,6 +99,9 @@ public:
 
     void put_batch(const T* value, size_t count);
 
+    // for test
+    void test_bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
+
     // Flushes any pending values to the underlying buffer.
     // Returns the total number of bytes written
     uint32_t flush();
@@ -116,6 +119,14 @@ public:
 
 private:
     void bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
+
+    void bit_pack_8(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
+
+    void bit_pack_16(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
+
+    void bit_pack_32(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
+
+    void bit_pack_128(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
 
     void bit_packing_one_frame_value(const T* input);
 

--- a/be/src/util/frame_of_reference_coding.h
+++ b/be/src/util/frame_of_reference_coding.h
@@ -99,9 +99,6 @@ public:
 
     void put_batch(const T* value, size_t count);
 
-    // for test
-    void test_bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
-
     // Flushes any pending values to the underlying buffer.
     // Returns the total number of bytes written
     uint32_t flush();
@@ -122,8 +119,7 @@ private:
 
     void bit_pack_8(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
 
-    void bit_pack_16(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
-
+    template <typename U>
     void bit_pack_32(const T* input, uint8_t in_num, int bit_width, uint8_t* output);
 
     void bit_pack_128(const T* input, uint8_t in_num, int bit_width, uint8_t* output);

--- a/be/test/util/frame_of_reference_coding_test.cpp
+++ b/be/test/util/frame_of_reference_coding_test.cpp
@@ -300,45 +300,4 @@ TEST_F(TestForCoding, accuracy_test) {
     }
 }
 
-TEST_F(TestForCoding, performances_test) {
-    std::default_random_engine e;
-    std::uniform_int_distribution<int64_t> u;
-    ForEncoder<__int128_t> forEncoder(nullptr);
-    int64_t t[2][128];
-    memset(t, 0, sizeof(t));
-    int n = 255;
-    std::vector<__int128_t> test_data(n);
-    for (int T = 0; T < 100; T++) {
-        for (int w = 1; w <= 127; w++) {
-            __int128_t in_mask = (((__int128_t)1) << w) - 1;
-            for (int i = 0; i < n; i++) {
-                test_data[i] = u(e) & in_mask;
-            }
-            int size = (n * w + 7) / 8;
-            std::vector<uint8_t> output(size);
-
-            auto start = std::chrono::high_resolution_clock::now();
-            bit_pack(test_data.data(), n, w, output.data());
-            auto stop = std::chrono::high_resolution_clock::now();
-            auto duration =
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
-            t[0][w] += duration;
-
-            auto start1 = std::chrono::high_resolution_clock::now();
-            forEncoder.test_bit_pack(test_data.data(), n, w, output.data());
-            auto stop1 = std::chrono::high_resolution_clock::now();
-            auto duration1 =
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(stop1 - start1).count();
-            t[1][w] += duration1;
-        }
-    }
-
-    for (int w = 1; w <= 127; w++) {
-        double t1 = (1.0 * t[0][w]) / 100;
-        double t2 = (1.0 * t[1][w]) / 100;
-        printf("when bit_width is %d, before is %f ns, after is %f ns, speed is %f\n", w, t1, t2,
-               t1 / t2);
-    }
-}
-
 } // namespace doris

--- a/be/test/util/frame_of_reference_coding_test.cpp
+++ b/be/test/util/frame_of_reference_coding_test.cpp
@@ -20,9 +20,39 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 
+#include <cstring>
+#include <random>
+#include <vector>
+
 #include "gtest/gtest_pred_impl.h"
 
 namespace doris {
+
+// original bit_pack function
+template <typename T>
+void bit_pack(const T* input, uint8_t in_num, int bit_width, uint8_t* output) {
+    if (in_num == 0 || bit_width == 0) {
+        return;
+    }
+
+    T in_mask = 0;
+    int bit_index = 0;
+    *output = 0;
+    for (int i = 0; i < in_num; i++) {
+        in_mask = ((T)1) << (bit_width - 1);
+        for (int k = 0; k < bit_width; k++) {
+            if (bit_index > 7) {
+                bit_index = 0;
+                output++;
+                *output = 0;
+            }
+            *output |= (((input[i] & in_mask) >> (bit_width - k - 1)) << (7 - bit_index));
+            in_mask >>= 1;
+            bit_index++;
+        }
+    }
+}
+
 class TestForCoding : public testing::Test {
 public:
     static void test_frame_of_reference_encode_decode(int32_t element_size) {
@@ -244,6 +274,71 @@ TEST_F(TestForCoding, TestValueSeek) {
     target = 320;
     found = decoder.seek_at_or_after_value(&target, &exact_match);
     EXPECT_EQ(found, false);
+}
+
+TEST_F(TestForCoding, accuracy_test) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int64_t> u;
+    ForEncoder<__int128_t> forEncoder(nullptr);
+    for (int T = 1; T <= 10; T++) {
+        for (int n = 1; n <= 255; n++) {
+            std::vector<__int128_t> test_data(n);
+            for (int w = 1; w <= 127; w++) {
+                __int128_t in_mask = (((__int128_t)1) << w) - 1;
+                for (int i = 0; i < n; i++) {
+                    test_data[i] = u(e) & in_mask;
+                }
+                int size = (n * w + 7) / 8;
+                std::vector<uint8_t> output_1(size), output_2(size);
+                bit_pack<__int128_t>(test_data.data(), n, w, output_1.data());
+                forEncoder.test_bit_pack(test_data.data(), n, w, output_2.data());
+                for (int i = 0; i < size; i++) {
+                    EXPECT_EQ(output_1[i], output_2[i]);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(TestForCoding, performances_test) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int64_t> u;
+    ForEncoder<__int128_t> forEncoder(nullptr);
+    int64_t t[2][128];
+    memset(t, 0, sizeof(t));
+    int n = 255;
+    std::vector<__int128_t> test_data(n);
+    for (int T = 0; T < 100; T++) {
+        for (int w = 1; w <= 127; w++) {
+            __int128_t in_mask = (((__int128_t)1) << w) - 1;
+            for (int i = 0; i < n; i++) {
+                test_data[i] = u(e) & in_mask;
+            }
+            int size = (n * w + 7) / 8;
+            std::vector<uint8_t> output(size);
+
+            auto start = std::chrono::high_resolution_clock::now();
+            bit_pack(test_data.data(), n, w, output.data());
+            auto stop = std::chrono::high_resolution_clock::now();
+            auto duration =
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+            t[0][w] += duration;
+
+            auto start1 = std::chrono::high_resolution_clock::now();
+            forEncoder.test_bit_pack(test_data.data(), n, w, output.data());
+            auto stop1 = std::chrono::high_resolution_clock::now();
+            auto duration1 =
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(stop1 - start1).count();
+            t[1][w] += duration1;
+        }
+    }
+
+    for (int w = 1; w <= 127; w++) {
+        double t1 = (1.0 * t[0][w]) / 100;
+        double t2 = (1.0 * t[1][w]) / 100;
+        printf("when bit_width is %d, before is %f ns, after is %f ns, speed is %f\n", w, t1, t2,
+               t1 / t2);
+    }
 }
 
 } // namespace doris

--- a/be/test/util/frame_of_reference_coding_test.cpp
+++ b/be/test/util/frame_of_reference_coding_test.cpp
@@ -280,7 +280,7 @@ TEST_F(TestForCoding, accuracy_test) {
     std::default_random_engine e;
     std::uniform_int_distribution<int64_t> u;
     ForEncoder<__int128_t> forEncoder(nullptr);
-    for (int T = 1; T <= 10; T++) {
+    for (int T = 1; T <= 5; T++) {
         for (int n = 1; n <= 255; n++) {
             std::vector<__int128_t> test_data(n);
             for (int w = 1; w <= 127; w++) {
@@ -291,7 +291,7 @@ TEST_F(TestForCoding, accuracy_test) {
                 int size = (n * w + 7) / 8;
                 std::vector<uint8_t> output_1(size), output_2(size);
                 bit_pack<__int128_t>(test_data.data(), n, w, output_1.data());
-                forEncoder.test_bit_pack(test_data.data(), n, w, output_2.data());
+                forEncoder.bit_pack(test_data.data(), n, w, output_2.data());
                 for (int i = 0; i < size; i++) {
                     EXPECT_EQ(output_1[i], output_2[i]);
                 }


### PR DESCRIPTION
### What problem does this PR solve?

Faster bit_pack

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
config:
```c++
-- Compiler: Clang-16.0.6
-- CXX Standard: 20
-- C Standard: 17
-- CXX Flags:  -DENABLE_CACHE_LOCK_DEBUG -O3 -DNDEBUG
-- C Flags:  -DENABLE_CACHE_LOCK_DEBUG -O3 -DNDEBUG
```
result 
```c++
Run on (24 X 2395.46 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 1024 KiB (x12)
  L3 Unified 32768 KiB (x1)
Load Average: 1.00, 2.04, 3.53
Comparing BM_BitPackOptimized to BM_BitPack (from ./be/output/lib/benchmark_test)
Benchmark                                                  Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------
[BM_BitPackOptimized vs. BM_BitPack]/1                  +4.5042         +4.5044           217          1197           217          1197
[BM_BitPackOptimized vs. BM_BitPack]/2                  +8.1943         +8.1944           232          2132           232          2132
[BM_BitPackOptimized vs. BM_BitPack]/3                 +10.7132        +10.6991           258          3024           258          3020
[BM_BitPackOptimized vs. BM_BitPack]/4                 +13.2024        +13.2024           278          3949           278          3948
[BM_BitPackOptimized vs. BM_BitPack]/5                 +14.7248        +14.7424           307          4831           307          4831
[BM_BitPackOptimized vs. BM_BitPack]/6                 +15.7002        +15.7005           338          5643           338          5642
[BM_BitPackOptimized vs. BM_BitPack]/7                 +16.5321        +16.5322           372          6527           372          6527
[BM_BitPackOptimized vs. BM_BitPack]/8                 +17.4211        +17.4036           409          7529           409          7522
[BM_BitPackOptimized vs. BM_BitPack]/9                 +12.8826        +12.8826           556          7722           556          7722
[BM_BitPackOptimized vs. BM_BitPack]/10                +13.6689        +13.6823           586          8590           585          8590
[BM_BitPackOptimized vs. BM_BitPack]/11                +14.1941        +14.1930           617          9369           617          9369
[BM_BitPackOptimized vs. BM_BitPack]/12                +14.6202        +14.6205           653         10202           653         10202
[BM_BitPackOptimized vs. BM_BitPack]/13                +15.0375        +15.0375           688         11027           688         11027
[BM_BitPackOptimized vs. BM_BitPack]/14                +15.5079        +15.5079           724         11957           724         11957
[BM_BitPackOptimized vs. BM_BitPack]/15                +15.9716        +15.9520           759         12873           759         12858
[BM_BitPackOptimized vs. BM_BitPack]/16                +15.8004        +15.8046           808         13571           808         13570
[BM_BitPackOptimized vs. BM_BitPack]/17                 +6.7709         +6.7710          1848         14362          1848         14362
[BM_BitPackOptimized vs. BM_BitPack]/18                 +6.9729         +6.9731          1900         15148          1900         15148
[BM_BitPackOptimized vs. BM_BitPack]/19                 +7.1722         +7.1724          1960         16014          1960         16014
[BM_BitPackOptimized vs. BM_BitPack]/20                 +7.3908         +7.3869          2005         16825          2005         16817
[BM_BitPackOptimized vs. BM_BitPack]/21                 +7.5708         +7.5706          2056         17622          2056         17622
[BM_BitPackOptimized vs. BM_BitPack]/22                 +8.4854         +8.4983          1993         18900          1990         18900
[BM_BitPackOptimized vs. BM_BitPack]/23                 +8.5467         +8.5465          2024         19319          2024         19318
[BM_BitPackOptimized vs. BM_BitPack]/24                 +8.7413         +8.7411          2063         20099          2063         20099
[BM_BitPackOptimized vs. BM_BitPack]/25                 +8.8769         +8.8769          2120         20935          2120         20935
[BM_BitPackOptimized vs. BM_BitPack]/26                 +9.3037         +9.2911          2166         22321          2166         22293
[BM_BitPackOptimized vs. BM_BitPack]/27                 +9.6577         +9.6942          2235         23818          2227         23818
[BM_BitPackOptimized vs. BM_BitPack]/28                 +9.5924         +9.5926          2272         24066          2272         24066
[BM_BitPackOptimized vs. BM_BitPack]/29                 +9.5851         +9.5848          2319         24542          2319         24542
[BM_BitPackOptimized vs. BM_BitPack]/30                 +9.7082         +9.7088          2365         25329          2365         25328
[BM_BitPackOptimized vs. BM_BitPack]/31                 +8.3216         +8.3185          2789         25994          2789         25986
[BM_BitPackOptimized vs. BM_BitPack]/32                 +7.4056         +7.4203          3215         27024          3209         27024
[BM_BitPackOptimized vs. BM_BitPack]/33                 +9.6928         +9.6928          2577         27555          2577         27555
[BM_BitPackOptimized vs. BM_BitPack]/34                 +9.9384         +9.9386          2597         28407          2597         28406
[BM_BitPackOptimized vs. BM_BitPack]/35                 +9.8818         +9.8818          2675         29107          2675         29107
[BM_BitPackOptimized vs. BM_BitPack]/36                +10.5678        +10.5541          2623         30344          2623         30307
[BM_BitPackOptimized vs. BM_BitPack]/37                +10.1379        +10.1496          2792         31096          2789         31096
[BM_BitPackOptimized vs. BM_BitPack]/38                +10.4476        +10.4483          2796         32004          2795         32004
[BM_BitPackOptimized vs. BM_BitPack]/39                +10.3979        +10.3980          2889         32931          2889         32930
[BM_BitPackOptimized vs. BM_BitPack]/40                +11.4665        +11.4674          2687         33492          2686         33492
[BM_BitPackOptimized vs. BM_BitPack]/41                +10.4722        +10.4716          2983         34225          2983         34223
[BM_BitPackOptimized vs. BM_BitPack]/42                +10.6972        +10.7006          3003         35126          3002         35127
[BM_BitPackOptimized vs. BM_BitPack]/43                +10.5216        +10.5214          3094         35644          3094         35644
[BM_BitPackOptimized vs. BM_BitPack]/44                +11.1676        +11.1676          3033         36903          3033         36903
[BM_BitPackOptimized vs. BM_BitPack]/45                +10.8481        +10.8438          3189         37788          3189         37774
[BM_BitPackOptimized vs. BM_BitPack]/46                +11.0755        +11.0757          3203         38674          3203         38673
[BM_BitPackOptimized vs. BM_BitPack]/47                +10.9231        +10.9350          3303         39382          3300         39381
[BM_BitPackOptimized vs. BM_BitPack]/48                +11.9574        +11.9572          3095         40108          3095         40107
[BM_BitPackOptimized vs. BM_BitPack]/49                +11.0000        +10.9998          3407         40884          3407         40883
[BM_BitPackOptimized vs. BM_BitPack]/50                +11.3251        +11.3251          3404         41960          3404         41961
[BM_BitPackOptimized vs. BM_BitPack]/51                +11.3440        +11.3443          3501         43219          3501         43219
[BM_BitPackOptimized vs. BM_BitPack]/52                +11.7169        +11.7170          3429         43613          3429         43612
[BM_BitPackOptimized vs. BM_BitPack]/53                +11.3834        +11.3840          3598         44554          3598         44554
[BM_BitPackOptimized vs. BM_BitPack]/54                +11.5845        +11.5745          3608         45409          3608         45372
[BM_BitPackOptimized vs. BM_BitPack]/55                +11.5198        +11.5200          3698         46298          3698         46297
[BM_BitPackOptimized vs. BM_BitPack]/56                +12.3991        +12.4178          3495         46831          3490         46830
[BM_BitPackOptimized vs. BM_BitPack]/57                +11.5367        +11.5373          3809         47758          3809         47757
[BM_BitPackOptimized vs. BM_BitPack]/58                +11.7878        +11.7609          3810         48722          3810         48619
[BM_BitPackOptimized vs. BM_BitPack]/59                +11.5369        +11.5372          3915         49084          3915         49085
[BM_BitPackOptimized vs. BM_BitPack]/60                +12.0432        +12.0436          3825         49895          3825         49896
[BM_BitPackOptimized vs. BM_BitPack]/61                +11.6672        +11.6672          4003         50702          4003         50703
[BM_BitPackOptimized vs. BM_BitPack]/62                +11.8234        +11.8235          4015         51483          4015         51482
[BM_BitPackOptimized vs. BM_BitPack]/63                +11.9221        +11.9216          4092         52880          4092         52878
[BM_BitPackOptimized vs. BM_BitPack]/64                +12.8207        +12.7996          3892         53795          3892         53711
[BM_BitPackOptimized vs. BM_BitPack]/65                +12.5005        +12.5061          4201         56714          4199         56712
[BM_BitPackOptimized vs. BM_BitPack]/66                +12.0273        +12.0273          4227         55063          4227         55063
[BM_BitPackOptimized vs. BM_BitPack]/67                +12.0323        +12.0325          4296         55991          4296         55992
[BM_BitPackOptimized vs. BM_BitPack]/68                +12.4117        +12.4113          4243         56912          4243         56910
[BM_BitPackOptimized vs. BM_BitPack]/69                +12.0649        +12.0847          4414         57666          4407         57664
[BM_BitPackOptimized vs. BM_BitPack]/70                +12.2940        +12.2843          4409         58609          4409         58564
[BM_BitPackOptimized vs. BM_BitPack]/71                +12.1728        +12.1732          4486         59093          4486         59093
[BM_BitPackOptimized vs. BM_BitPack]/72                +12.9799        +12.9802          4304         60164          4304         60165
[BM_BitPackOptimized vs. BM_BitPack]/73                +12.2689        +12.2689          4591         60913          4591         60912
[BM_BitPackOptimized vs. BM_BitPack]/74                +11.4736        +11.4737          4945         61682          4945         61682
[BM_BitPackOptimized vs. BM_BitPack]/75                +11.3816        +11.3798          5044         62453          5044         62444
[BM_BitPackOptimized vs. BM_BitPack]/76                +11.6782        +11.6782          4988         63244          4988         63244
[BM_BitPackOptimized vs. BM_BitPack]/77                +11.4087        +11.3971          5150         63905          5150         63846
[BM_BitPackOptimized vs. BM_BitPack]/78                +11.4068        +11.4065          5193         64430          5193         64428
[BM_BitPackOptimized vs. BM_BitPack]/79                +11.4794        +11.4836          5259         65631          5257         65627
[BM_BitPackOptimized vs. BM_BitPack]/80                +12.0765        +12.0766          5058         66141          5058         66140
[BM_BitPackOptimized vs. BM_BitPack]/81                +11.4949        +11.4946          5366         67046          5366         67043
[BM_BitPackOptimized vs. BM_BitPack]/82                +11.6263        +11.6266          5373         67845          5373         67845
[BM_BitPackOptimized vs. BM_BitPack]/83                +11.5585        +11.5566          5481         68829          5477         68776
[BM_BitPackOptimized vs. BM_BitPack]/84                +11.8307        +11.8311          5411         69429          5411         69428
[BM_BitPackOptimized vs. BM_BitPack]/85                +11.8560        +11.8553          5584         71791          5584         71788
[BM_BitPackOptimized vs. BM_BitPack]/86                +12.2591        +12.2603          5594         74170          5593         74169
[BM_BitPackOptimized vs. BM_BitPack]/87                +11.6320        +11.6317          5693         71919          5693         71917
[BM_BitPackOptimized vs. BM_BitPack]/88                +12.0448        +12.0449          5570         72654          5569         72653
[BM_BitPackOptimized vs. BM_BitPack]/89                +11.5695        +11.5695          5844         73452          5843         73450
[BM_BitPackOptimized vs. BM_BitPack]/90                +11.7431        +11.7234          5854         74595          5854         74479
[BM_BitPackOptimized vs. BM_BitPack]/91                +11.0475        +11.0477          6237         75139          6237         75140
[BM_BitPackOptimized vs. BM_BitPack]/92                +11.6843        +11.6998          5983         75894          5976         75895
[BM_BitPackOptimized vs. BM_BitPack]/93                +11.4704        +11.4704          6170         76946          6170         76946
[BM_BitPackOptimized vs. BM_BitPack]/94                +11.7787        +11.7790          6071         77577          6070         77571
[BM_BitPackOptimized vs. BM_BitPack]/95                +11.6238        +11.6240          6224         78565          6223         78564
[BM_BitPackOptimized vs. BM_BitPack]/96                +11.9719        +11.9607          6120         79392          6120         79324
[BM_BitPackOptimized vs. BM_BitPack]/97                +11.7589        +11.7595          6276         80071          6275         80071
[BM_BitPackOptimized vs. BM_BitPack]/98                +11.9713        +11.9715          6242         80967          6242         80967
[BM_BitPackOptimized vs. BM_BitPack]/99                +11.7507        +11.7504          6415         81796          6415         81795
[BM_BitPackOptimized vs. BM_BitPack]/100               +12.1307        +12.1304          6291         82604          6291         82602
[BM_BitPackOptimized vs. BM_BitPack]/101               +11.8446        +11.8442          6507         83580          6507         83577
[BM_BitPackOptimized vs. BM_BitPack]/102               +11.2311        +11.2178          6903         84428          6903         84337
[BM_BitPackOptimized vs. BM_BitPack]/103               +11.9322        +11.9322          6579         85078          6579         85078
[BM_BitPackOptimized vs. BM_BitPack]/104               +12.3837        +12.3828          6419         85906          6419         85900
[BM_BitPackOptimized vs. BM_BitPack]/105               +11.6463        +11.6568          6858         86724          6852         86724
[BM_BitPackOptimized vs. BM_BitPack]/106               +11.8109        +11.8112          6824         87419          6824         87417
[BM_BitPackOptimized vs. BM_BitPack]/107               +11.9562        +11.9561          6823         88394          6822         88392
[BM_BitPackOptimized vs. BM_BitPack]/108               +12.0137        +12.0137          6854         89200          6854         89201
[BM_BitPackOptimized vs. BM_BitPack]/109               +11.7586        +11.7139          7099         90570          7099         90253
[BM_BitPackOptimized vs. BM_BitPack]/110               +12.0923        +12.0922          6932         90754          6932         90752
[BM_BitPackOptimized vs. BM_BitPack]/111               +12.0585        +12.0589          7018         91639          7017         91640
[BM_BitPackOptimized vs. BM_BitPack]/112               +12.2255        +12.2254          6990         92445          6990         92442
[BM_BitPackOptimized vs. BM_BitPack]/113               +12.0767        +12.0760          7137         93328          7137         93323
[BM_BitPackOptimized vs. BM_BitPack]/114               +12.1952        +12.1949          7147         94310          7147         94308
[BM_BitPackOptimized vs. BM_BitPack]/115               +11.7421        +11.7255          7475         95245          7474         95117
[BM_BitPackOptimized vs. BM_BitPack]/116               +12.3460        +12.3461          7180         95820          7180         95821
[BM_BitPackOptimized vs. BM_BitPack]/117               +12.1602        +12.1605          7351         96744          7351         96742
[BM_BitPackOptimized vs. BM_BitPack]/118               +11.3985        +11.4123          7852         97350          7843         97351
[BM_BitPackOptimized vs. BM_BitPack]/119               +10.5289        +10.5286          8534         98383          8533         98379
[BM_BitPackOptimized vs. BM_BitPack]/120               +12.7233        +12.7245          7219         99072          7219         99073
[BM_BitPackOptimized vs. BM_BitPack]/121               +13.2971        +13.2586          7028        100475          7028        100205
[BM_BitPackOptimized vs. BM_BitPack]/122               +13.2163        +13.2163          7098        100901          7098        100902
[BM_BitPackOptimized vs. BM_BitPack]/123               +13.2406        +13.2393          7139        101660          7139        101652
[BM_BitPackOptimized vs. BM_BitPack]/124               +13.4479        +13.4650          7089        102421          7080        102420
[BM_BitPackOptimized vs. BM_BitPack]/125               +13.2802        +13.2804          7235        103321          7235        103319
[BM_BitPackOptimized vs. BM_BitPack]/126               +13.3945        +13.3945          7244        104280          7244        104281
[BM_BitPackOptimized vs. BM_BitPack]/127               +13.7314        +13.7096          7322        107861          7322        107702
OVERALL_GEOMEAN                                         +2.5723         +2.5722             0             0             0             0
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

