### PR TITLE
[opt](nereids) do not check expr width

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -810,13 +810,7 @@ public class Config extends ConfigBase {
     @ConfField public static int meta_publish_timeout_ms = 1000;
     @ConfField public static boolean proxy_auth_enable = false;
     @ConfField public static String proxy_auth_magic_prefix = "x@8";
-    /**
-     * Limit on the number of expr children of an expr tree.
-     * Exceed this limit may cause long analysis time while holding database read lock.
-     * Do not set this if you know what you are doing.
-     */
-    @ConfField(mutable = true)
-    public static int expr_children_limit = 10000;
+
     /**
      * Limit on the depth of an expr tree.
      * Exceed this limit may cause long analysis time while holding db read lock.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -407,12 +407,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             return;
         }
 
-        // Check the expr child limit.
-        if (children.size() > Config.expr_children_limit) {
-            throw new AnalysisException(String.format("Exceeded the maximum number of child "
-                    + "expressions (%d).", Config.expr_children_limit));
-        }
-
         // analyzer may be null for certain literal constructions (e.g. IntLiteral).
         if (analyzer != null) {
             analyzer.incrementCallDepth();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -182,10 +182,6 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
             throw new AnalysisException(String.format("Exceeded the maximum depth of an "
                     + "expression tree (%s).", Config.expr_depth_limit));
         }
-        if (width > Config.expr_children_limit) {
-            throw new AnalysisException(String.format("Exceeded the maximum children of an "
-                    + "expression tree (%s).", Config.expr_children_limit));
-        }
     }
 
     public Alias alias(String alias) {


### PR DESCRIPTION
### What problem does this PR solve?
We do not need to check the expression's width while construct an expression.
This pr removes this check.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

