### PR TITLE
[Improvement](cloud) Hold tablets in another RPC thread

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1050,9 +1050,6 @@ DEFINE_mInt32(segcompaction_num_threads, "5");
 // enable java udf and jdbc scannode
 DEFINE_Bool(enable_java_support, "true");
 
-// enable prefetch tablets before opening
-DEFINE_mBool(enable_prefetch_tablet, "true");
-
 // Set config randomly to check more issues in github workflow
 DEFINE_Bool(enable_fuzzy_mode, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1093,9 +1093,6 @@ DECLARE_mInt32(segcompaction_num_threads);
 // enable java udf and jdbc scannode
 DECLARE_Bool(enable_java_support);
 
-// enable prefetch tablets before opening
-DECLARE_mBool(enable_prefetch_tablet);
-
 // Set config randomly to check more issues in github workflow
 DECLARE_Bool(enable_fuzzy_mode);
 

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.h
@@ -50,7 +50,7 @@ public:
     Status close(RuntimeState* state) override;
     friend class MultiCastDataStreamerSourceOperatorX;
 
-    std::vector<Dependency*> filter_dependencies() override {
+    std::vector<Dependency*> execution_dependencies() override {
         if (_filter_dependencies.empty()) {
             return {};
         }

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -493,10 +493,6 @@ Status OlapScanLocalState::sync_cloud_tablets(RuntimeState* state) {
 }
 
 Status OlapScanLocalState::hold_tablets() {
-    if (!_tablets.empty()) {
-        return Status::OK();
-    }
-
     MonotonicStopWatch timer;
     timer.start();
     _read_sources.resize(_scan_ranges.size());

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -567,6 +567,7 @@ Status OlapScanLocalState::hold_tablets() {
                                  TUnit::TIME_NS));
         }
     } else {
+        _tablets.resize(_scan_ranges.size());
         for (size_t i = 0; i < _scan_ranges.size(); i++) {
             int64_t version = 0;
             std::from_chars(_scan_ranges[i]->version.data(),

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -514,7 +514,8 @@ Status OlapScanLocalState::prepare(RuntimeState* state) {
     _read_sources.resize(_scan_ranges.size());
 
     if (config::is_cloud_mode()) {
-        if (_cloud_tablet_dependency->is_blocked_by(nullptr) != nullptr) {
+        if (!_cloud_tablet_dependency &&
+            _cloud_tablet_dependency->is_blocked_by(nullptr) != nullptr) {
             // Remote tablet still in-flight.
             return Status::OK();
         }

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -514,7 +514,7 @@ Status OlapScanLocalState::prepare(RuntimeState* state) {
     _read_sources.resize(_scan_ranges.size());
 
     if (config::is_cloud_mode()) {
-        if (!_cloud_tablet_dependency &&
+        if (_cloud_tablet_dependency &&
             _cloud_tablet_dependency->is_blocked_by(nullptr) != nullptr) {
             // Remote tablet still in-flight.
             return Status::OK();

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -514,7 +514,7 @@ Status OlapScanLocalState::prepare(RuntimeState* state) {
     _read_sources.resize(_scan_ranges.size());
 
     if (config::is_cloud_mode()) {
-        if (_cloud_tablet_dependency &&
+        if (!_cloud_tablet_dependency ||
             _cloud_tablet_dependency->is_blocked_by(nullptr) != nullptr) {
             // Remote tablet still in-flight.
             return Status::OK();

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -458,6 +458,7 @@ Status OlapScanLocalState::sync_cloud_tablets(RuntimeState* state) {
                                               "CLOUD_TABLET_DEP_" + std::to_string(i));
         }
 
+        _tablets.resize(_scan_ranges.size());
         _tasks.reserve(_scan_ranges.size());
         _sync_statistics.resize(_scan_ranges.size());
         SCOPED_RAW_TIMER(&_duration_ns);
@@ -498,7 +499,6 @@ Status OlapScanLocalState::hold_tablets() {
 
     MonotonicStopWatch timer;
     timer.start();
-    _tablets.resize(_scan_ranges.size());
     _read_sources.resize(_scan_ranges.size());
 
     if (config::is_cloud_mode()) {

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -99,7 +99,7 @@ private:
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
     std::vector<SyncRowsetStats> _sync_statistics;
     std::vector<std::function<Status()>> _tasks;
-    int64_t _duration_ns = 0;
+    MonotonicStopWatch _sync_cloud_tablets_watcher;
     std::shared_ptr<Dependency> _cloud_tablet_dependency;
     std::atomic<size_t> _pending_tablets_num = 0;
     bool _prepared = false;

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -21,20 +21,18 @@
 
 #include <string>
 
+#include "cloud/cloud_tablet.h"
 #include "common/status.h"
 #include "olap/tablet_reader.h"
 #include "operator.h"
 #include "pipeline/exec/scan_operator.h"
 
-namespace doris {
-#include "common/compile_check_begin.h"
-
-namespace vectorized {
+namespace doris::vectorized {
 class OlapScanner;
-}
-} // namespace doris
+} // namespace doris::vectorized
 
 namespace doris::pipeline {
+#include "common/compile_check_begin.h"
 
 class OlapScanOperatorX;
 class OlapScanLocalState final : public ScanLocalState<OlapScanLocalState> {
@@ -63,6 +61,7 @@ public:
         std::copy(tmp.begin(), tmp.end(), std::inserter(res, res.end()));
         return res;
     }
+    Status sync_cloud_tablets(RuntimeState* state) override;
 
 private:
     friend class vectorized::OlapScanner;
@@ -101,6 +100,8 @@ private:
     Status _build_key_ranges_and_filters();
 
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
+    std::vector<SyncRowsetStats> _sync_statistics;
+    int64_t _duration_ns = 0;
     std::vector<std::shared_ptr<Dependency>> _cloud_tablet_dependencies;
     std::future<Status> _cloud_tablet_future;
     std::atomic_bool _sync_tablet = false;

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -101,6 +101,7 @@ private:
 
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
     std::vector<SyncRowsetStats> _sync_statistics;
+    std::vector<std::function<Status()>> _tasks;
     int64_t _duration_ns = 0;
     std::vector<std::shared_ptr<Dependency>> _cloud_tablet_dependencies;
     std::future<Status> _cloud_tablet_future;

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -101,7 +101,7 @@ private:
     std::vector<std::function<Status()>> _tasks;
     int64_t _duration_ns = 0;
     std::shared_ptr<Dependency> _cloud_tablet_dependency;
-    std::atomic_int32_t _pending_tablets_num = 0;
+    std::atomic<size_t> _pending_tablets_num = 0;
     bool _prepared = false;
     std::future<Status> _cloud_tablet_future;
     std::atomic_bool _sync_tablet = false;

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -171,6 +171,7 @@ public:
     // Do initialization. This step should be executed only once and in bthread, so we can do some
     // lightweight or non-idempotent operations (e.g. init profile, clone expr ctx from operatorX)
     virtual Status init(RuntimeState* state, LocalStateInfo& info) = 0;
+    virtual Status prepare(RuntimeState* state) = 0;
     // Do initialization. This step can be executed multiple times, so we should make sure it is
     // idempotent (e.g. wait for runtime filters).
     virtual Status open(RuntimeState* state) = 0;
@@ -261,6 +262,7 @@ public:
     ~PipelineXLocalState() override = default;
 
     Status init(RuntimeState* state, LocalStateInfo& info) override;
+    Status prepare(RuntimeState* state) override { return Status::OK(); }
     Status open(RuntimeState* state) override;
 
     virtual std::string name_suffix() const;
@@ -440,6 +442,7 @@ public:
     // lightweight or non-idempotent operations (e.g. init profile, clone expr ctx from operatorX)
     virtual Status init(RuntimeState* state, LocalSinkStateInfo& info) = 0;
 
+    virtual Status prepare(RuntimeState* state) = 0;
     // Do initialization. This step can be executed multiple times, so we should make sure it is
     // idempotent (e.g. wait for runtime filters).
     virtual Status open(RuntimeState* state) = 0;
@@ -518,6 +521,7 @@ public:
 
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
 
+    Status prepare(RuntimeState* state) override { return Status::OK(); }
     Status open(RuntimeState* state) override { return Status::OK(); }
 
     Status terminate(RuntimeState* state) override;
@@ -830,8 +834,6 @@ public:
     [[nodiscard]] std::string get_name() const override { return _op_name; }
     [[nodiscard]] virtual bool need_more_input_data(RuntimeState* state) const { return true; }
 
-    // Tablets should be hold before open phase.
-    [[nodiscard]] virtual Status hold_tablets(RuntimeState* state) { return Status::OK(); }
     Status prepare(RuntimeState* state) override;
 
     Status terminate(RuntimeState* state) override;

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -1116,7 +1116,9 @@ public:
     ~DummyOperatorLocalState() = default;
 
     std::vector<Dependency*> dependencies() const override { return {_tmp_dependency.get()}; }
-    std::vector<Dependency*> execution_dependencies() override { return {_filter_dependency.get()}; }
+    std::vector<Dependency*> execution_dependencies() override {
+        return {_filter_dependency.get()};
+    }
     Dependency* spill_dependency() const override { return _spill_dependency.get(); }
 
 private:

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -201,7 +201,7 @@ public:
     virtual Dependency* finishdependency() { return nullptr; }
     virtual Dependency* spill_dependency() const { return nullptr; }
     //  override in Scan  MultiCastSink
-    virtual std::vector<Dependency*> filter_dependencies() { return {}; }
+    virtual std::vector<Dependency*> execution_dependencies() { return {}; }
 
     Status filter_block(const vectorized::VExprContextSPtrs& expr_contexts,
                         vectorized::Block* block, size_t column_to_keep);
@@ -1116,7 +1116,7 @@ public:
     ~DummyOperatorLocalState() = default;
 
     std::vector<Dependency*> dependencies() const override { return {_tmp_dependency.get()}; }
-    std::vector<Dependency*> filter_dependencies() override { return {_filter_dependency.get()}; }
+    std::vector<Dependency*> execution_dependencies() override { return {_filter_dependency.get()}; }
     Dependency* spill_dependency() const override { return _spill_dependency.get(); }
 
 private:

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -171,6 +171,10 @@ public:
     // Do initialization. This step should be executed only once and in bthread, so we can do some
     // lightweight or non-idempotent operations (e.g. init profile, clone expr ctx from operatorX)
     virtual Status init(RuntimeState* state, LocalStateInfo& info) = 0;
+    // Make sure all resources are ready before execution. For example, remote tablets should be
+    // loaded to local storage.
+    // This is called by execution pthread and different from `Operator::prepare` which is called
+    // by bthread.
     virtual Status prepare(RuntimeState* state) = 0;
     // Do initialization. This step can be executed multiple times, so we should make sure it is
     // idempotent (e.g. wait for runtime filters).

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -81,6 +81,7 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
                                  _filter_dependencies, p.get_name() + "_FILTER_DEPENDENCY"));
     RETURN_IF_ERROR(_init_profile());
     set_scan_ranges(state, info.scan_ranges);
+    RETURN_IF_ERROR(sync_cloud_tablets(state));
 
     _wait_for_rf_timer = ADD_TIMER(_runtime_profile, "WaitForRuntimeFilter");
     return Status::OK();

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -81,7 +81,6 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
                                  _filter_dependencies, p.get_name() + "_FILTER_DEPENDENCY"));
     RETURN_IF_ERROR(_init_profile());
     set_scan_ranges(state, info.scan_ranges);
-    RETURN_IF_ERROR(sync_cloud_tablets(state));
 
     _wait_for_rf_timer = ADD_TIMER(_runtime_profile, "WaitForRuntimeFilter");
     return Status::OK();

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -80,8 +80,6 @@ public:
     virtual Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) = 0;
     virtual void set_scan_ranges(RuntimeState* state,
                                  const std::vector<TScanRangeParams>& scan_ranges) = 0;
-    virtual Status sync_cloud_tablets(RuntimeState* state) = 0;
-
     virtual TPushAggOp::type get_push_down_agg_type() = 0;
 
     virtual int64_t get_push_down_count() = 0;
@@ -152,7 +150,6 @@ class ScanLocalState : public ScanLocalStateBase {
     Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) override;
     void set_scan_ranges(RuntimeState* state,
                          const std::vector<TScanRangeParams>& scan_ranges) override {}
-    Status sync_cloud_tablets(RuntimeState* state) override { return Status::OK(); }
 
     TPushAggOp::type get_push_down_agg_type() override;
 

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -156,15 +156,13 @@ class ScanLocalState : public ScanLocalStateBase {
 
     int64_t get_push_down_count() override;
 
-    std::vector<Dependency*> filter_dependencies() override {
+    std::vector<Dependency*> execution_dependencies() override {
         if (_filter_dependencies.empty()) {
             return {};
         }
-        std::vector<Dependency*> res;
-        res.resize(_filter_dependencies.size());
-        for (size_t i = 0; i < _filter_dependencies.size(); i++) {
-            res[i] = _filter_dependencies[i].get();
-        }
+        std::vector<Dependency*> res(_filter_dependencies.size());
+        std::transform(_filter_dependencies.begin(), _filter_dependencies.end(), res.begin(),
+                       [](DependencySPtr dep) { return dep.get(); });
         return res;
     }
 

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -80,6 +80,7 @@ public:
     virtual Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) = 0;
     virtual void set_scan_ranges(RuntimeState* state,
                                  const std::vector<TScanRangeParams>& scan_ranges) = 0;
+    virtual Status sync_cloud_tablets(RuntimeState* state) = 0;
 
     virtual TPushAggOp::type get_push_down_agg_type() = 0;
 
@@ -151,6 +152,7 @@ class ScanLocalState : public ScanLocalStateBase {
     Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) override;
     void set_scan_ranges(RuntimeState* state,
                          const std::vector<TScanRangeParams>& scan_ranges) override {}
+    Status sync_cloud_tablets(RuntimeState* state) override { return Status::OK(); }
 
     TPushAggOp::type get_push_down_agg_type() override;
 

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -419,6 +419,7 @@ Status PipelineTask::execute(bool* done) {
     if (_wait_to_start() || _wake_up_early) {
         return Status::OK();
     }
+    RETURN_IF_ERROR(_prepare());
 
     // The status must be runnable
     if (!_opened && !fragment_context->is_canceled()) {

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -402,11 +402,6 @@ Status PipelineTask::execute(bool* done) {
         Status status = Status::Error<INTERNAL_ERROR>("fault_inject pipeline_task execute failed");
         return status;
     });
-    // `hold_tablets` is designed as a reentrant method. For cloud mode, we reach here first to
-    // request remote tablets by RPC, and then hold local tablets by the second call.
-    if (!_hold_cloud_tablet && !_wake_up_early) {
-        RETURN_IF_ERROR(_source->hold_tablets(_state));
-    }
     // `_wake_up_early` must be after `_wait_to_start()`
     if (_wait_to_start() || _wake_up_early) {
         return Status::OK();

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -182,6 +182,7 @@ private:
     void _init_profile();
     void _fresh_profile_counter();
     Status _open();
+    Status _prepare();
 
     // Operator `op` try to reserve memory before executing. Return false if reserve failed
     // otherwise return true.
@@ -239,7 +240,6 @@ private:
     std::vector<Dependency*> _write_dependencies;
     std::vector<Dependency*> _finish_dependencies;
     std::vector<Dependency*> _execution_dependencies;
-    std::atomic_bool _hold_cloud_tablet = false;
 
     // All shared states of this pipeline task.
     std::map<int, std::shared_ptr<BasicSharedState>> _op_shared_states;

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -238,7 +238,8 @@ private:
     std::vector<Dependency*> _spill_dependencies;
     std::vector<Dependency*> _write_dependencies;
     std::vector<Dependency*> _finish_dependencies;
-    std::vector<Dependency*> _filter_dependencies;
+    std::vector<Dependency*> _execution_dependencies;
+    std::atomic_bool _hold_cloud_tablet = false;
 
     // All shared states of this pipeline task.
     std::map<int, std::shared_ptr<BasicSharedState>> _op_shared_states;
@@ -253,7 +254,6 @@ private:
     unsigned long long _exec_time_slice = config::pipeline_task_exec_time_slice * NANOS_PER_MILLIS;
     Dependency* _blocked_dep = nullptr;
 
-    Dependency* _execution_dep = nullptr;
     Dependency* _memory_sufficient_dependency;
     std::mutex _dependency_lock;
 


### PR DESCRIPTION
### What problem does this PR solve?

With cloud mode on, remote tablets will be loaded into local storage before execution. This will block execution thread now. If it's too slow, pipeline execution thread may hang.
This PR makes remote tablets loading asynchronously.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

