### PR TITLE
[enhance](meta-service)add bvar for fdb process status

### DIFF
--- a/cloud/src/common/bvars.cpp
+++ b/cloud/src/common/bvars.cpp
@@ -211,6 +211,8 @@ bvar::Status<int64_t> g_bvar_fdb_workload_transactions_started_hz("fdb_workload_
 bvar::Status<int64_t> g_bvar_fdb_workload_transactions_committed_hz("fdb_workload_transactions_committed_hz", BVAR_FDB_INVALID_VALUE);
 bvar::Status<int64_t> g_bvar_fdb_workload_transactions_rejected_hz("fdb_workload_transactions_rejected_hz", BVAR_FDB_INVALID_VALUE);
 bvar::Status<int64_t> g_bvar_fdb_client_thread_busyness_percent("fdb_client_thread_busyness_percent", BVAR_FDB_INVALID_VALUE);
+mBvarStatus<int64_t> g_bvar_fdb_process_status_int("fdb_process_status_int", {"process_id", "component", "metric"});
+mBvarStatus<double> g_bvar_fdb_process_status_float("fdb_process_status_float", {"process_id", "component", "metric"});
 
 // checker's bvars
 BvarStatusWithTag<int64_t> g_bvar_checker_num_scanned("checker", "num_scanned");

--- a/cloud/src/common/bvars.h
+++ b/cloud/src/common/bvars.h
@@ -348,6 +348,8 @@ extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_started_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_committed_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_workload_transactions_rejected_hz;
 extern bvar::Status<int64_t> g_bvar_fdb_client_thread_busyness_percent;
+extern mBvarStatus<int64_t> g_bvar_fdb_process_status_int;
+extern mBvarStatus<double> g_bvar_fdb_process_status_float;
 
 // checker
 extern BvarStatusWithTag<long> g_bvar_checker_num_scanned;

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -180,17 +180,18 @@ static void export_fdb_status_details(const std::string& status_str) {
             auto object_recursive = [&set_bvar_value, &recursive_name_helper](
                                             auto&& self, std::string name,
                                             decltype(process_node) temp_node) -> void {
+                // if the node is an object, then get Member(iter) and recursive with iter as arg
                 if (temp_node->value.IsObject()) {
                     for (auto iter = temp_node->value.MemberBegin();
                          iter != temp_node->value.MemberEnd(); iter++) {
                         self(self, recursive_name_helper(name, iter->name.GetString()), iter);
                     }
                 }
-                // Note that the parameter passed to set_bvar_value here is the current node, not its Member.
-                // so we can directly call object_recursive in the loop below(metric_node).
-                // if the node is a object, then get Member(iter) and recursive with iter as arg
+                // if not object, set bvar value
                 set_bvar_value(name, temp_node);
             };
+            // Note that the parameter passed to set_bvar_value here is the current node, not its Member
+            // so we can directly call object_recursive in the loop
             for (auto metric_node = component_node->value.MemberBegin();
                  metric_node != component_node->value.MemberEnd(); metric_node++) {
                 object_recursive(object_recursive, metric_node->name.GetString(), metric_node);

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -160,9 +160,8 @@ static void export_fdb_status_details(const std::string& status_str) {
             const char* process_id = process_node->name.GetString();
             decltype(process_node) component_node;
             // get component iter
-            if (!process_node->value.HasMember(component.data())) {
-                component_node = process_node->value.FindMember(component.data());
-            }
+            if (!process_node->value.HasMember(component.data())) return;
+            component_node = process_node->value.FindMember(component.data());
             // There are three cases here: int64, double, and object.
             // If it is double or int64, put it directly into the bvar.
             // If it is an object, recursively obtain the full name and corresponding value.

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -138,19 +138,6 @@ static void export_fdb_status_details(const std::string& status_str) {
         return static_cast<int64_t>(node->value.GetDouble() * NANOSECONDS);
     };
     auto get_process_metric = [&](std::string component) {
-        class RecursiveNameHelper {
-        public:
-            explicit RecursiveNameHelper(std::string name) : name_(std::move(name)) {}
-
-            RecursiveNameHelper next_level_name(std::string name) const {
-                return RecursiveNameHelper(name_ + '_' + name);
-            }
-
-            std::string& get_name() { return name_; }
-
-        private:
-            std::string name_;
-        };
         auto node = document.FindMember("cluster");
         if (!node->value.HasMember("processes")) return;
         node = node->value.FindMember("processes");

--- a/cloud/src/common/metric.cpp
+++ b/cloud/src/common/metric.cpp
@@ -186,6 +186,7 @@ static void export_fdb_status_details(const std::string& status_str) {
                          iter != temp_node->value.MemberEnd(); iter++) {
                         self(self, recursive_name_helper(name, iter->name.GetString()), iter);
                     }
+                    return;
                 }
                 // if not object, set bvar value
                 set_bvar_value(name, temp_node);

--- a/cloud/test/metric_test.cpp
+++ b/cloud/test/metric_test.cpp
@@ -172,4 +172,129 @@ TEST(MetricTest, FdbMetricExporterTest) {
         ASSERT_EQ(g_bvar_fdb_machines_count.get_value(), BVAR_FDB_INVALID_VALUE);
         ASSERT_EQ(g_bvar_fdb_client_count.get_value(), BVAR_FDB_INVALID_VALUE);
     }
+
+    // process status
+    {
+        g_bvar_fdb_machines_count.set_value(BVAR_FDB_INVALID_VALUE);
+        g_bvar_fdb_client_count.set_value(BVAR_FDB_INVALID_VALUE);
+
+        std::string fdb_metric_example = "./fdb_metric_example.json";
+        std::ifstream inFile(fdb_metric_example);
+
+        ASSERT_TRUE(inFile.is_open());
+        std::string fileContent((std::istreambuf_iterator<char>(inFile)),
+                                std::istreambuf_iterator<char>());
+
+        std::string word_to_replace = "cluster";
+        std::string new_word = "xxxx";
+
+        size_t start_pos = 0;
+        while ((start_pos = fileContent.find(word_to_replace, start_pos)) != std::string::npos) {
+            fileContent.replace(start_pos, word_to_replace.length(), new_word);
+            start_pos += new_word.length();
+        }
+        std::shared_ptr<TxnKv> txn_kv = std::make_shared<MemTxnKv>();
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        txn->put("\xff\xff/status/json", fileContent);
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+        FdbMetricExporter fdb_metric_exporter(txn_kv);
+        fdb_metric_exporter.sleep_interval_ms_ = 1;
+        fdb_metric_exporter.start();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        fdb_metric_exporter.stop();
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "cpu", "usage_cores"}),
+                  0.0012292);
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "busy"}),
+                  0.0085999800000000001);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "free_bytes"}),
+                  490412584960);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "reads_counter"}),
+                  854857);
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "reads_hz"}),
+                  0);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "reads_sectors"}),
+                  0);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "total_bytes"}),
+                  527295578112);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "writes_counter"}),
+                  73765457);
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "writes_hz"}),
+                  26.1999);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "disk", "writes_sectors"}),
+                  1336);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "memory", "available_bytes"}),
+                  3065090867);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "memory", "limit_bytes"}),
+                  8589934592);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "memory", "rss_bytes"}),
+                  46551040);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get({"09ca90b9f3f413e5816b2610ed8b465d", "memory",
+                                                     "unused_allocated_memory"}),
+                  655360);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"09ca90b9f3f413e5816b2610ed8b465d", "memory", "used_bytes"}),
+                  122974208);
+
+        // test second process
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "cpu", "usage_cores"}),
+                  0.0049765900000000004);
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "busy"}),
+                  0.012200000000000001);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "free_bytes"}),
+                  489160159232);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "reads_counter"}),
+                  877107);
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "reads_hz"}),
+                  0);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "reads_sectors"}),
+                  0);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "total_bytes"}),
+                  527295578112);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "writes_counter"}),
+                  79316112);
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "writes_hz"}),
+                  30.9999);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "disk", "writes_sectors"}),
+                  744);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "memory", "available_bytes"}),
+                  3076787404);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "memory", "limit_bytes"}),
+                  8589934592);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "memory", "rss_bytes"}),
+                  72359936);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get({"0a456165f04e1ec1a2ade0ce523d54a8", "memory",
+                                                     "unused_allocated_memory"}),
+                  393216);
+        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+                          {"0a456165f04e1ec1a2ade0ce523d54a8", "memory", "used_bytes"}),
+                  157978624);
+    }
 }

--- a/cloud/test/metric_test.cpp
+++ b/cloud/test/metric_test.cpp
@@ -185,14 +185,6 @@ TEST(MetricTest, FdbMetricExporterTest) {
         std::string fileContent((std::istreambuf_iterator<char>(inFile)),
                                 std::istreambuf_iterator<char>());
 
-        std::string word_to_replace = "cluster";
-        std::string new_word = "xxxx";
-
-        size_t start_pos = 0;
-        while ((start_pos = fileContent.find(word_to_replace, start_pos)) != std::string::npos) {
-            fileContent.replace(start_pos, word_to_replace.length(), new_word);
-            start_pos += new_word.length();
-        }
         std::shared_ptr<TxnKv> txn_kv = std::make_shared<MemTxnKv>();
         std::unique_ptr<Transaction> txn;
         ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
@@ -204,7 +196,7 @@ TEST(MetricTest, FdbMetricExporterTest) {
         fdb_metric_exporter.start();
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         fdb_metric_exporter.stop();
-        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
                           {"09ca90b9f3f413e5816b2610ed8b465d", "cpu", "usage_cores"}),
                   0.0012292);
         ASSERT_EQ(g_bvar_fdb_process_status_float.get(
@@ -251,7 +243,7 @@ TEST(MetricTest, FdbMetricExporterTest) {
                   122974208);
 
         // test second process
-        ASSERT_EQ(g_bvar_fdb_process_status_int.get(
+        ASSERT_EQ(g_bvar_fdb_process_status_float.get(
                           {"0a456165f04e1ec1a2ade0ce523d54a8", "cpu", "usage_cores"}),
                   0.0049765900000000004);
         ASSERT_EQ(g_bvar_fdb_process_status_float.get(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

g_bvar_fdb_process_status_int，g_bvar_fdb_process_status_float these two mBvars show the process status from fdb_status

this pr handle these metric
```json
"processes":{
            "09ca90b9f3f413e5816b2610ed8b465d":{
                ...
                "cpu":{
                    "usage_cores":0.0012292
                },
                "disk":{
                    "busy":0.0085999800000000001,
                    "free_bytes":490412584960,
                    "reads":{
                        "counter":854857,
                        "hz":0,
                        "sectors":0
                    },
                    "total_bytes":527295578112,
                    "writes":{
                        "counter":73765457,
                        "hz":26.1999,
                        "sectors":1336
                    }
                },
                ...
                "memory":{
                    "available_bytes":3065090867,
                    "limit_bytes":8589934592,
                    "rss_bytes":46551040,
                    "unused_allocated_memory":655360,
                    "used_bytes":122974208
                },
                ...
```
```text
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="memory",metric="available_bytes"} 1073741824
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="writes_counter"} 117339905
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="memory",metric="used_bytes"} 213848064
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="reads_counter"} 19812058
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="memory",metric="rss_bytes"} 60182528
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="memory",metric="unused_allocated_memory"} 0
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="memory",metric="limit_bytes"} 1073741824
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="writes_sectors"} 225616
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="reads_sectors"} 58888
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="free_bytes"} 189571883008
# HELP fdb_process_status_int
# TYPE fdb_process_status_int gauge
fdb_process_status_int{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="total_bytes"} 471412600832
...
# HELP fdb_process_status_float
# TYPE fdb_process_status_float gauge
fdb_process_status_float{process_id="16fb8a9e8dd5098537e422554fa51b70",component="cpu",metric="usage_cores"} 0.0155129
# HELP fdb_process_status_float
# TYPE fdb_process_status_float gauge
fdb_process_status_float{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="busy"} 0.353599
# HELP fdb_process_status_float
# TYPE fdb_process_status_float gauge
fdb_process_status_float{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="writes_hz"} 325.399
# HELP fdb_process_status_float
# TYPE fdb_process_status_float gauge
fdb_process_status_float{process_id="16fb8a9e8dd5098537e422554fa51b70",component="disk",metric="reads_hz"} 321.399
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

