### PR TITLE
[feature](regression) add waitUntilSafeExecutionTime function to framework

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -3184,7 +3184,7 @@ class Suite implements GroovyInterceptable {
                 }
                 break
             default:
-                throw new IllegalArgumentException("invalid caseElapseSeconds:${caseSpanConstraint}")
+                throw new IllegalArgumentException("invalid caseSpanConstraint:${caseSpanConstraint}")
         }
         
         if (sleepSeconds > 0) {

--- a/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
@@ -26,20 +26,8 @@ suite("test_information_schema_timezone", "p0,external,hive,kerberos,external_do
      * If the two SQL queries are executed across the hour mark, it will cause the test case to fail.
      * eg. routines_res_1 executed at 00:59:50, and routines_res_2 executed at 01:00:05, assert will fail.
      * The execution time of this test case is within 2 minutes, and the interval between the two queries is about 20 seconds. 
-     * Therefore, ​​if the test machine's time is at the 59th minute of any hour, we should sleep until the next hour begins before executing the queries.​​
      */
-    def sleepIfAt59thMinute = { ->
-        Calendar calendar = Calendar.getInstance()
-        int minute = calendar.get(Calendar.MINUTE)
-        int second = calendar.get(Calendar.SECOND)
-    
-        if (minute == 59) {
-            int sleepSeconds = 60 - second
-            logger.info("sleep till next hour")
-            Thread.sleep(sleepSeconds * 1000)
-        }
-    }
-    sleepIfAt59thMinute()
+    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BONDARY", 45)
 
     def table_name = "test_information_schema_timezone"
     sql """ DROP TABLE IF EXISTS ${table_name} """

--- a/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
@@ -19,7 +19,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 suite("test_information_schema_timezone", "p0,external,hive,kerberos,external_docker,external_docker_kerberos") {
-    /* In this test case, we compare the intervals between two time zones. 
+    /* 
+     * In this test case, we compare the intervals between two time zones. 
      *      List<List<Object>> routines_res_1 = sql """ select CREATED,LAST_ALTERED from information_schema.routines where ROUTINE_NAME="TEST_INFORMATION_SCHEMA_TIMEZONE1" """
      *      List<List<Object>> routines_res_2 = sql """ select CREATED,LAST_ALTERED from information_schema.routines where ROUTINE_NAME="TEST_INFORMATION_SCHEMA_TIMEZONE2"; """
      *      assertEquals(true, isEightHoursDiff(tables_res_2[0][0], tables_res_1[0][0]))
@@ -27,7 +28,7 @@ suite("test_information_schema_timezone", "p0,external,hive,kerberos,external_do
      * eg. routines_res_1 executed at 00:59:50, and routines_res_2 executed at 01:00:05, assert will fail.
      * The execution time of this test case is within 2 minutes, and the interval between the two queries is about 20 seconds. 
      */
-    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BONDARY", 45)
+    waitUntilSafeExecutionTime("NOT_CROSS_HOUR_BOUNDARY", 45)
 
     def table_name = "test_information_schema_timezone"
     sql """ DROP TABLE IF EXISTS ${table_name} """


### PR DESCRIPTION
### What problem does this PR solve?
Add a new regression framework function solves the problem where tests cannot span hour or day boundaries.
For example: Some tests may fail when crossing hour or day boundaries. Using this function
ensures that tests are executed within a safe time window to avoid crossing specified time boundaries.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

