### PR TITLE
[refine](array) check array column data must be a nullable column and refine array filter function

### DIFF
--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -29,6 +29,7 @@
 #include "runtime/primitive_type.h"
 #include "util/simd/bits.h"
 #include "util/simd/vstring_function.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
@@ -662,101 +663,66 @@ void ColumnArray::insert_range_from_ignore_overflow(const IColumn& src, size_t s
     }
 }
 
-ColumnPtr ColumnArray::filter(const Filter& filt, ssize_t result_size_hint) const {
-    if (typeid_cast<const ColumnUInt8*>(data.get()))
-        return filter_number<TYPE_BOOLEAN>(filt, result_size_hint);
-    if (typeid_cast<const ColumnInt8*>(data.get()))
-        return filter_number<TYPE_TINYINT>(filt, result_size_hint);
-    if (typeid_cast<const ColumnInt16*>(data.get()))
-        return filter_number<TYPE_SMALLINT>(filt, result_size_hint);
-    if (typeid_cast<const ColumnInt32*>(data.get()))
-        return filter_number<TYPE_INT>(filt, result_size_hint);
-    if (typeid_cast<const ColumnInt64*>(data.get()))
-        return filter_number<TYPE_BIGINT>(filt, result_size_hint);
-    if (typeid_cast<const ColumnFloat32*>(data.get()))
-        return filter_number<TYPE_FLOAT>(filt, result_size_hint);
-    if (typeid_cast<const ColumnFloat64*>(data.get()))
-        return filter_number<TYPE_DOUBLE>(filt, result_size_hint);
-    if (typeid_cast<const ColumnDate*>(data.get()))
-        return filter_number<TYPE_DATE>(filt, result_size_hint);
-    if (typeid_cast<const ColumnDateV2*>(data.get()))
-        return filter_number<TYPE_DATEV2>(filt, result_size_hint);
-    if (typeid_cast<const ColumnDateTime*>(data.get()))
-        return filter_number<TYPE_DATETIME>(filt, result_size_hint);
-    if (typeid_cast<const ColumnDateTimeV2*>(data.get()))
-        return filter_number<TYPE_DATETIMEV2>(filt, result_size_hint);
-    if (typeid_cast<const ColumnTimeV2*>(data.get()))
-        return filter_number<TYPE_TIMEV2>(filt, result_size_hint);
-    if (typeid_cast<const ColumnTime*>(data.get()))
-        return filter_number<TYPE_TIME>(filt, result_size_hint);
-    if (typeid_cast<const ColumnIPv4*>(data.get()))
-        return filter_number<TYPE_IPV4>(filt, result_size_hint);
-    if (typeid_cast<const ColumnString*>(data.get())) return filter_string(filt, result_size_hint);
-    //if (typeid_cast<const ColumnTuple *>(data.get()))      return filterTuple(filt, result_size_hint);
-    if (typeid_cast<const ColumnNullable*>(data.get()))
-        return filter_nullable(filt, result_size_hint);
-    return filter_generic(filt, result_size_hint);
-}
+using Offset64 = IColumn::Offset64;
+using Offsets64 = IColumn::Offsets64;
+using Filter = IColumn::Filter;
+using ColumnOffsets = ColumnArray::ColumnOffsets;
 
-size_t ColumnArray::filter(const Filter& filter) {
-    if (typeid_cast<const ColumnUInt8*>(data.get())) return filter_number<TYPE_BOOLEAN>(filter);
-    if (typeid_cast<const ColumnInt8*>(data.get())) return filter_number<TYPE_TINYINT>(filter);
-    if (typeid_cast<const ColumnInt16*>(data.get())) return filter_number<TYPE_SMALLINT>(filter);
-    if (typeid_cast<const ColumnInt32*>(data.get())) return filter_number<TYPE_INT>(filter);
-    if (typeid_cast<const ColumnInt64*>(data.get())) return filter_number<TYPE_BIGINT>(filter);
-    if (typeid_cast<const ColumnFloat32*>(data.get())) return filter_number<TYPE_FLOAT>(filter);
-    if (typeid_cast<const ColumnFloat64*>(data.get())) return filter_number<TYPE_DOUBLE>(filter);
-    if (typeid_cast<const ColumnDate*>(data.get())) return filter_number<TYPE_DATE>(filter);
-    if (typeid_cast<const ColumnDateV2*>(data.get())) return filter_number<TYPE_DATEV2>(filter);
-    if (typeid_cast<const ColumnDateTime*>(data.get())) return filter_number<TYPE_DATETIME>(filter);
-    if (typeid_cast<const ColumnDateTimeV2*>(data.get()))
-        return filter_number<TYPE_DATETIMEV2>(filter);
-    if (typeid_cast<const ColumnTimeV2*>(data.get())) return filter_number<TYPE_TIMEV2>(filter);
-    if (typeid_cast<const ColumnTime*>(data.get())) return filter_number<TYPE_TIME>(filter);
-    if (typeid_cast<const ColumnIPv4*>(data.get())) return filter_number<TYPE_IPV4>(filter);
-    return filter_generic(filter);
-}
+struct ColumnArrayDataOffsets {
+    ColumnPtr data;
+    ColumnOffsets::Ptr offsets;
+};
 
 template <PrimitiveType T>
-ColumnPtr ColumnArray::filter_number(const Filter& filt, ssize_t result_size_hint) const {
-    if (get_offsets().empty()) return ColumnArray::create(data);
-
-    auto res = ColumnArray::create(data->clone_empty());
-
-    auto& res_elems = assert_cast<ColumnVector<T>&>(res->get_data()).get_data();
-    auto& res_offsets = res->get_offsets();
-
-    filter_arrays_impl<typename PrimitiveTypeTraits<T>::ColumnItemType, Offset64>(
-            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*data).get_data(),
-            get_offsets(), res_elems, res_offsets, filt, result_size_hint);
-    return res;
-}
-
-template <PrimitiveType T>
-size_t ColumnArray::filter_number(const Filter& filter) {
-    return filter_arrays_impl<typename PrimitiveTypeTraits<T>::ColumnItemType, Offset64>(
-            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*data).get_data(),
-            get_offsets(), filter);
-}
-
-ColumnPtr ColumnArray::filter_string(const Filter& filt, ssize_t result_size_hint) const {
-    size_t col_size = get_offsets().size();
-    column_match_filter_size(col_size, filt.size());
-
-    if (!col_size) {
-        return ColumnArray::create(data);
+ColumnArrayDataOffsets filter_number_return_new(const Filter& filt, ssize_t result_size_hint,
+                                                const ColumnPtr& src_data,
+                                                const ColumnOffsets* src_offsets) {
+    if (src_offsets->empty()) {
+        return ColumnArrayDataOffsets {.data = src_data->clone_empty(),
+                                       .offsets = ColumnOffsets::create()};
     }
 
-    auto res = ColumnArray::create(data->clone_empty());
+    auto dst_data = src_data->clone_empty();
+    auto dst_offset = ColumnOffsets::create();
 
-    const auto& src_string = assert_cast<const ColumnString&>(*data);
+    auto& res_elems = assert_cast<ColumnVector<T>&>(*dst_data).get_data();
+    auto& res_offsets = dst_offset->get_data();
+
+    filter_arrays_impl<typename PrimitiveTypeTraits<T>::ColumnItemType, IColumn::Offset64>(
+            assert_cast<const ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(*src_data).get_data(),
+            src_offsets->get_data(), res_elems, res_offsets, filt, result_size_hint);
+
+    return ColumnArrayDataOffsets {.data = std::move(dst_data), .offsets = std::move(dst_offset)};
+}
+
+template <PrimitiveType T>
+size_t filter_number_inplace(const Filter& filter, IColumn& src_data, ColumnOffsets& src_offsets) {
+    return filter_arrays_impl<typename PrimitiveTypeTraits<T>::ColumnItemType, Offset64>(
+            assert_cast<ColumnVector<T>&, TypeCheckOnRelease::DISABLE>(src_data).get_data(),
+            src_offsets.get_data(), filter);
+}
+
+ColumnArrayDataOffsets filter_string_return_new(const Filter& filt, ssize_t result_size_hint,
+                                                const ColumnPtr& src_data,
+                                                const ColumnOffsets* src_offsets) {
+    size_t col_size = src_offsets->size();
+    column_match_filter_size(col_size, filt.size());
+
+    if (col_size == 0) {
+        return ColumnArrayDataOffsets {.data = src_data->clone_empty(),
+                                       .offsets = ColumnOffsets::create()};
+    }
+
+    const auto& src_string = assert_cast<const ColumnString&>(*src_data);
     const ColumnString::Chars& src_chars = src_string.get_chars();
     const auto& src_string_offsets = src_string.get_offsets();
-    const auto& src_offsets = get_offsets();
+    const auto& offsets = src_offsets->get_data();
 
-    ColumnString::Chars& res_chars = assert_cast<ColumnString&>(res->get_data()).get_chars();
-    auto& res_string_offsets = assert_cast<ColumnString&>(res->get_data()).get_offsets();
-    auto& res_offsets = res->get_offsets();
+    auto dst_data = src_data->clone_empty();
+    ColumnString::Chars& res_chars = assert_cast<ColumnString&>(*dst_data).get_chars();
+    auto& res_string_offsets = assert_cast<ColumnString&>(*dst_data).get_offsets();
+    auto dst_offset = ColumnOffsets::create();
+    auto& res_offsets = dst_offset->get_data();
 
     if (result_size_hint < 0) {
         res_chars.reserve(src_chars.size());
@@ -772,7 +738,7 @@ ColumnPtr ColumnArray::filter_string(const Filter& filt, ssize_t result_size_hin
 
     for (size_t i = 0; i < col_size; ++i) {
         /// Number of rows in the array.
-        size_t array_size = src_offsets[i] - prev_src_offset;
+        size_t array_size = offsets[i] - prev_src_offset;
 
         if (filt[i]) {
             /// If the array is not empty - copy content.
@@ -783,67 +749,6 @@ ColumnPtr ColumnArray::filter_string(const Filter& filt, ssize_t result_size_hin
                 res_chars.resize(res_chars_prev_size + chars_to_copy);
                 memcpy(&res_chars[res_chars_prev_size], &src_chars[prev_src_string_offset],
                        chars_to_copy);
-
-                for (size_t j = 0; j < array_size; ++j)
-                    res_string_offsets.push_back(src_string_offsets[j + prev_src_offset] +
-                                                 prev_res_string_offset - prev_src_string_offset);
-
-                prev_res_string_offset = res_string_offsets.back();
-            }
-
-            prev_res_offset += array_size;
-            res_offsets.push_back(prev_res_offset);
-        }
-
-        if (array_size) {
-            prev_src_offset += array_size;
-            prev_src_string_offset = src_string_offsets[prev_src_offset - 1];
-        }
-    }
-
-    return res;
-}
-
-size_t ColumnArray::filter_string(const Filter& filter) {
-    size_t col_size = get_offsets().size();
-    column_match_filter_size(col_size, filter.size());
-
-    if (0 == col_size) {
-        return ColumnArray::create(data);
-    }
-
-    auto& src_string = assert_cast<ColumnString&>(*data);
-    auto* src_chars = src_string.get_chars().data();
-    auto* src_string_offsets = src_string.get_offsets().data();
-    auto* src_offsets = get_offsets().data();
-
-    ColumnString::Chars& res_chars = src_string.get_chars();
-    auto& res_string_offsets = src_string.get_offsets();
-    auto& res_offsets = get_offsets();
-
-    res_chars.set_end_ptr(res_chars.data());
-    res_string_offsets.set_end_ptr(res_string_offsets.data());
-    res_offsets.set_end_ptr(res_offsets.data());
-
-    Offset64 prev_src_offset = 0;
-    IColumn::Offset prev_src_string_offset = 0;
-
-    Offset64 prev_res_offset = 0;
-    IColumn::Offset prev_res_string_offset = 0;
-
-    for (size_t i = 0; i < col_size; ++i) {
-        /// Number of rows in the array.
-        size_t array_size = src_offsets[i] - prev_src_offset;
-
-        if (filter[i]) {
-            /// If the array is not empty - copy content.
-            if (array_size) {
-                size_t chars_to_copy = src_string_offsets[array_size + prev_src_offset - 1] -
-                                       prev_src_string_offset;
-                size_t res_chars_prev_size = res_chars.size();
-                res_chars.resize(res_chars_prev_size + chars_to_copy);
-                memmove(&res_chars[res_chars_prev_size], &src_chars[prev_src_string_offset],
-                        chars_to_copy);
 
                 for (size_t j = 0; j < array_size; ++j) {
                     res_string_offsets.push_back(src_string_offsets[j + prev_src_offset] +
@@ -863,61 +768,74 @@ size_t ColumnArray::filter_string(const Filter& filter) {
         }
     }
 
-    return res_offsets.size();
+    return ColumnArrayDataOffsets {.data = std::move(dst_data), .offsets = std::move(dst_offset)};
 }
 
-ColumnPtr ColumnArray::filter_generic(const Filter& filt, ssize_t result_size_hint) const {
-    size_t size = get_offsets().size();
+ColumnArrayDataOffsets filter_generic_return_new(const Filter& filt, ssize_t result_size_hint,
+                                                 const ColumnPtr& src_data,
+                                                 const ColumnOffsets* src_offsets) {
+    size_t size = src_offsets->size();
     column_match_filter_size(size, filt.size());
 
-    if (size == 0) return ColumnArray::create(data);
+    if (size == 0) {
+        return ColumnArrayDataOffsets {.data = src_data->clone_empty(),
+                                       .offsets = ColumnOffsets::create()};
+    }
 
-    Filter nested_filt(get_offsets().back());
+    const auto& offsets = src_offsets->get_data();
+    Filter nested_filt(offsets.back());
     ssize_t nested_result_size_hint = 0;
     for (size_t i = 0; i < size; ++i) {
+        const auto offset_at = offsets[i - 1];
+        const auto size_at = offsets[i] - offsets[i - 1];
         if (filt[i]) {
-            memset(&nested_filt[offset_at(i)], 1, size_at(i));
-            nested_result_size_hint += size_at(i);
+            memset(&nested_filt[offset_at], 1, size_at);
+            nested_result_size_hint += size_at;
         } else {
-            memset(&nested_filt[offset_at(i)], 0, size_at(i));
+            memset(&nested_filt[offset_at], 0, size_at);
         }
     }
 
-    auto res = ColumnArray::create(data->clone_empty());
-    res->data = data->filter(nested_filt, nested_result_size_hint);
+    ColumnPtr dst_data = src_data->filter(nested_filt, nested_result_size_hint);
+    auto dst_offsets = ColumnOffsets::create();
+    auto& res_offsets = dst_offsets->get_data();
 
-    auto& res_offsets = res->get_offsets();
-    if (result_size_hint) res_offsets.reserve(result_size_hint > 0 ? result_size_hint : size);
+    if (result_size_hint) {
+        res_offsets.reserve(result_size_hint > 0 ? result_size_hint : size);
+    }
 
     size_t current_offset = 0;
     for (size_t i = 0; i < size; ++i) {
         if (filt[i]) {
-            current_offset += size_at(i);
+            current_offset += offsets[i] - offsets[i - 1];
             res_offsets.push_back(current_offset);
         }
     }
-
-    return res;
+    return ColumnArrayDataOffsets {.data = dst_data, .offsets = std::move(dst_offsets)};
 }
 
-size_t ColumnArray::filter_generic(const Filter& filter) {
-    size_t size = get_offsets().size();
+size_t filter_generic_inplace(const Filter& filter, IColumn& src_data, ColumnOffsets& src_offsets) {
+    const size_t size = src_offsets.size();
     column_match_filter_size(size, filter.size());
 
     if (size == 0) {
         return 0;
     }
 
-    Filter nested_filter(get_offsets().back());
+    auto& offsets = src_offsets.get_data();
+
+    Filter nested_filter(offsets.back());
     for (size_t i = 0; i < size; ++i) {
+        const auto offset_at = offsets[i - 1];
+        const auto size_at = offsets[i] - offsets[i - 1];
         if (filter[i]) {
-            memset(&nested_filter[offset_at(i)], 1, size_at(i));
+            memset(&nested_filter[offset_at], 1, size_at);
         } else {
-            memset(&nested_filter[offset_at(i)], 0, size_at(i));
+            memset(&nested_filter[offset_at], 0, size_at);
         }
     }
 
-    data->filter(nested_filter);
+    src_data.filter(nested_filter);
     // Make a new offset to avoid inplace operation
     auto res_offset = ColumnOffsets::create();
     auto& res_offset_data = res_offset->get_data();
@@ -925,50 +843,125 @@ size_t ColumnArray::filter_generic(const Filter& filter) {
     size_t current_offset = 0;
     for (size_t i = 0; i < size; ++i) {
         if (filter[i]) {
-            current_offset += size_at(i);
+            current_offset += offsets[i] - offsets[i - 1];
             res_offset_data.push_back(current_offset);
         }
     }
-    get_offsets().swap(res_offset_data);
-    return get_offsets().size();
+    offsets.swap(res_offset_data);
+    return offsets.size();
 }
 
-ColumnPtr ColumnArray::filter_nullable(const Filter& filt, ssize_t result_size_hint) const {
-    if (get_offsets().empty()) return ColumnArray::create(data);
+/// TODO: We need to consider reconstructing here.
+// The distribution type here should not be enumerated in this way.
+// We can consider adding a function to return type to the column.
+ColumnArrayDataOffsets filter_return_new_dispatch(const Filter& filt, ssize_t result_size_hint,
+                                                  const ColumnPtr& data,
+                                                  const ColumnOffsets* offsets) {
+    if (typeid_cast<const ColumnUInt8*>(data.get()))
+        return filter_number_return_new<TYPE_BOOLEAN>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnInt8*>(data.get()))
+        return filter_number_return_new<TYPE_TINYINT>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnInt16*>(data.get()))
+        return filter_number_return_new<TYPE_SMALLINT>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnInt32*>(data.get()))
+        return filter_number_return_new<TYPE_INT>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnInt64*>(data.get()))
+        return filter_number_return_new<TYPE_BIGINT>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnFloat32*>(data.get()))
+        return filter_number_return_new<TYPE_FLOAT>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnFloat64*>(data.get()))
+        return filter_number_return_new<TYPE_DOUBLE>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnDate*>(data.get()))
+        return filter_number_return_new<TYPE_DATE>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnDateV2*>(data.get()))
+        return filter_number_return_new<TYPE_DATEV2>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnDateTime*>(data.get()))
+        return filter_number_return_new<TYPE_DATETIME>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnDateTimeV2*>(data.get()))
+        return filter_number_return_new<TYPE_DATETIMEV2>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnTimeV2*>(data.get()))
+        return filter_number_return_new<TYPE_TIMEV2>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnTime*>(data.get()))
+        return filter_number_return_new<TYPE_TIME>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnIPv4*>(data.get()))
+        return filter_number_return_new<TYPE_IPV4>(filt, result_size_hint, data, offsets);
+    if (typeid_cast<const ColumnString*>(data.get()))
+        return filter_string_return_new(filt, result_size_hint, data, offsets);
+    return filter_generic_return_new(filt, result_size_hint, data, offsets);
+}
 
-    const ColumnNullable& nullable_elems =
-            assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(*data);
+ColumnPtr ColumnArray::filter(const Filter& filt, ssize_t result_size_hint) const {
+    // return empty
+    if (this->empty()) {
+        return ColumnArray::create(data);
+    }
 
-    auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
-    auto filtered_array_of_nested_owner = array_of_nested->filter(filt, result_size_hint);
-    const auto& filtered_array_of_nested =
-            assert_cast<const ColumnArray&>(*filtered_array_of_nested_owner);
-    const auto& filtered_offsets = filtered_array_of_nested.get_offsets_ptr();
+    const ColumnNullable& nullable_data_column = assert_cast<const ColumnNullable&>(*data);
 
     auto res_null_map = ColumnUInt8::create();
-
-    filter_arrays_impl_only_data(nullable_elems.get_null_map_data(), get_offsets(),
+    // filter null map
+    filter_arrays_impl_only_data(nullable_data_column.get_null_map_data(), get_offsets(),
                                  res_null_map->get_data(), filt, result_size_hint);
 
-    return ColumnArray::create(ColumnNullable::create(filtered_array_of_nested.get_data_ptr(),
-                                                      std::move(res_null_map)),
-                               filtered_offsets);
+    auto src_data = nullable_data_column.get_nested_column_ptr();
+    const auto* src_offsets = assert_cast<const ColumnOffsets*>(offsets.get());
+    auto array_of_nested =
+            filter_return_new_dispatch(filt, result_size_hint, src_data, src_offsets);
+
+    return ColumnArray::create(
+            ColumnNullable::create(array_of_nested.data, std::move(res_null_map)),
+            array_of_nested.offsets);
 }
 
-size_t ColumnArray::filter_nullable(const Filter& filter) {
-    if (get_offsets().empty()) {
+// There is a strange thing here. It didn't implement the type of string?
+// In order not to destroy the original logic, the original logic is still retained here.
+size_t filter_inplace_dispatch(const Filter& filter, IColumn& src_data,
+                               ColumnOffsets& src_offsets) {
+    if (typeid_cast<ColumnUInt8*>(&src_data))
+        return filter_number_inplace<TYPE_BOOLEAN>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnInt8*>(&src_data))
+        return filter_number_inplace<TYPE_TINYINT>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnInt16*>(&src_data))
+        return filter_number_inplace<TYPE_SMALLINT>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnInt32*>(&src_data))
+        return filter_number_inplace<TYPE_INT>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnInt64*>(&src_data))
+        return filter_number_inplace<TYPE_BIGINT>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnFloat32*>(&src_data))
+        return filter_number_inplace<TYPE_FLOAT>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnFloat64*>(&src_data))
+        return filter_number_inplace<TYPE_DOUBLE>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnDate*>(&src_data))
+        return filter_number_inplace<TYPE_DATE>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnDateV2*>(&src_data))
+        return filter_number_inplace<TYPE_DATEV2>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnDateTime*>(&src_data))
+        return filter_number_inplace<TYPE_DATETIME>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnDateTimeV2*>(&src_data))
+        return filter_number_inplace<TYPE_DATETIMEV2>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnTimeV2*>(&src_data))
+        return filter_number_inplace<TYPE_TIMEV2>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnTime*>(&src_data))
+        return filter_number_inplace<TYPE_TIME>(filter, src_data, src_offsets);
+    if (typeid_cast<ColumnIPv4*>(&src_data))
+        return filter_number_inplace<TYPE_IPV4>(filter, src_data, src_offsets);
+    return filter_generic_inplace(filter, src_data, src_offsets);
+}
+
+size_t ColumnArray::filter(const Filter& filter) {
+    if (this->empty()) {
         return 0;
     }
 
-    ColumnNullable& nullable_elems =
+    ColumnNullable& nullable_data_column =
             assert_cast<ColumnNullable&, TypeCheckOnRelease::DISABLE>(*data);
-    const auto result_size =
-            filter_arrays_impl_only_data(nullable_elems.get_null_map_data(), get_offsets(), filter);
+    const auto result_size = filter_arrays_impl_only_data(nullable_data_column.get_null_map_data(),
+                                                          get_offsets(), filter);
 
-    auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
-    const auto nested_result_size = array_of_nested->assume_mutable()->filter(filter);
+    auto& src_data = nullable_data_column.get_nested_column();
+    auto& src_offsets = assert_cast<ColumnOffsets&>(*offsets);
 
-    CHECK_EQ(result_size, nested_result_size);
+    filter_inplace_dispatch(filter, src_data, src_offsets);
     return result_size;
 }
 

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -252,32 +252,10 @@ private:
     /// Multiply the values if the nested column is ColumnString. The code is too complicated.
     ColumnPtr replicate_string(const IColumn::Offsets& replicate_offsets) const;
 
-    /** Non-constant arrays of constant values are quite rare.
-      * Most functions can not work with them, and does not create such columns as a result.
-      * An exception is the function `replicate` (see FunctionsMiscellaneous.h), which has service meaning for the implementation of lambda functions.
-      * Only for its sake is the implementation of the `replicate` method for ColumnArray(ColumnConst).
-      */
-    ColumnPtr replicate_const(const IColumn::Offsets& replicate_offsets) const;
-
     /** The following is done by simply replicating of nested columns.
       */
     ColumnPtr replicate_nullable(const IColumn::Offsets& replicate_offsets) const;
     ColumnPtr replicate_generic(const IColumn::Offsets& replicate_offsets) const;
-
-    /// Specializations for the filter function.
-    template <PrimitiveType T>
-    ColumnPtr filter_number(const Filter& filt, ssize_t result_size_hint) const;
-
-    template <PrimitiveType T>
-    size_t filter_number(const Filter& filter);
-
-    ColumnPtr filter_string(const Filter& filt, ssize_t result_size_hint) const;
-    ColumnPtr filter_nullable(const Filter& filt, ssize_t result_size_hint) const;
-    ColumnPtr filter_generic(const Filter& filt, ssize_t result_size_hint) const;
-
-    size_t filter_string(const Filter& filter);
-    size_t filter_nullable(const Filter& filter);
-    size_t filter_generic(const Filter& filter);
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -244,18 +244,6 @@ private:
     // [[2,1,5],[9,1]]\n[[1,2]] --> data column [3 column array], offset[-1] = 0, offset[0] = 2, offset[1] = 3
     WrappedPtr data;
     WrappedPtr offsets;
-
-    /// Multiply values if the nested column is ColumnVector<T>.
-    template <PrimitiveType T>
-    ColumnPtr replicate_number(const IColumn::Offsets& replicate_offsets) const;
-
-    /// Multiply the values if the nested column is ColumnString. The code is too complicated.
-    ColumnPtr replicate_string(const IColumn::Offsets& replicate_offsets) const;
-
-    /** The following is done by simply replicating of nested columns.
-      */
-    ColumnPtr replicate_nullable(const IColumn::Offsets& replicate_offsets) const;
-    ColumnPtr replicate_generic(const IColumn::Offsets& replicate_offsets) const;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

At present, in most cases, the data of array is a nullable column.
Here we check the nullable of data (except beut)
There are some problems with previous functions such as filter, which will create a non-nullable data array.
So a series of functions have been modified here.
```
 auto array_of_nested = ColumnArray::create(nullable_elems.get_nested_column_ptr(), offsets);
```


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

