### PR TITLE
branhc-3.1: [fix](case) let lazy_materialize_topn work well

### DIFF
--- a/regression-test/suites/nereids_rules_p0/defer_materialize_topn/lazy_materialize_topn.groovy
+++ b/regression-test/suites/nereids_rules_p0/defer_materialize_topn/lazy_materialize_topn.groovy
@@ -18,7 +18,6 @@ suite("lazy_materialize_topn") {
     sql """
         set enable_two_phase_read_opt = true;
         set topn_opt_limit_threshold = 1000;
-        set enable_topn_lazy_materialization = false;
     """
 
     sql """


### PR DESCRIPTION
introduced an unsupported variable enable_topn_lazy_materialization in case when auto pick from master in PR #52578