### PR TITLE
[Fix](function) fix wrong time to datetime cast in FE constant folding

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
@@ -221,9 +221,9 @@ public class TimeV2Literal extends Literal {
 
     @Override
     protected Expression uncheckedCastTo(DataType targetType) throws AnalysisException {
-        DateTimeV2Literal time = (DateTimeV2Literal) DateTimeV2Literal.fromJavaDateType(
-                LocalDateTime.now(DateUtils.getTimeZone()).plusHours(getHour()).plusMinutes(getMinute())
-                        .plusSeconds(getSecond()).plusNanos(getMicroSecond() * 1000),
+        DateTimeV2Literal time = (DateTimeV2Literal) DateTimeV2Literal.fromJavaDateType(LocalDateTime
+                .now(DateUtils.getTimeZone()).withHour(0).withMinute(0).withSecond(0).withNano(0).plusHours(getHour())
+                .plusMinutes(getMinute()).plusSeconds(getSecond()).plusNanos(getMicroSecond() * 1000),
                 ((TimeV2Type) dataType).getScale());
         if (targetType.isDateType()) {
             return new DateLiteral(time.getYear(), time.getMonth(), time.getDay());

--- a/regression-test/suites/correctness/test_cast_time_to_datetime.groovy
+++ b/regression-test/suites/correctness/test_cast_time_to_datetime.groovy
@@ -16,6 +16,7 @@
 // under the License.
 
 suite("test_cast_time_to_datetime") {
+    waitUntilSafeExecutionTime("NOT_CROSS_DAY_BOUNDARY", 2)
     def result1 = sql """ select datediff(now(), from_unixtime(cast(1742194502 as bigint),'yyyy-MM-dd HH:mm:ss')); """
     def result2 = sql """ select datediff(current_time(), from_unixtime(cast(1742194502 as bigint),'yyyy-MM-dd HH:mm:ss')); """
     assertEquals(result1[0][0], result2[0][0], "The results of the two SQL queries should be the same.")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

when we cast time to datetime, before we wrongly get `now() + time`
now fix it to get `date(now()) + time`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

