### PR TITLE
[fix](nereids)fix show temp table status in ShowTableStatusCommand

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTableStatusCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTableStatusCommand.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -74,7 +75,12 @@ public class ShowTableStatusCommand extends ShowCommand {
             .build();
 
     private static Map<String, String> ALIAS_COLUMN_MAP = ImmutableMap.<String, String>builder()
-            .put("name", "TABLE_NAME")
+            // get temp table display name
+            .put("name", String.format("if(instr(TABLE_NAME, '%s') > 0,"
+                    + "substr(TABLE_NAME, instr(TABLE_NAME, '%s') + length('%s')), TABLE_NAME)",
+                            FeNameFormat.TEMPORARY_TABLE_SIGN,
+                            FeNameFormat.TEMPORARY_TABLE_SIGN,
+                            FeNameFormat.TEMPORARY_TABLE_SIGN))
             .put("engine", "ENGINE")
             .put("version", "VERSION")
             .put("row_format", "ROW_FORMAT")
@@ -158,6 +164,13 @@ public class ShowTableStatusCommand extends ShowCommand {
      */
     private ShowResultSet execute(ConnectContext ctx, StmtExecutor executor, String whereClause)
             throws AnalysisException {
+        // only fetch temp table in current session
+        String tempTableCondition = String.format("and if(instr(TABLE_NAME, '%s') > 0,"
+                + "substr(TABLE_NAME, 1, instr(TABLE_NAME, '%s') - 1) = '%s', true)",
+                FeNameFormat.TEMPORARY_TABLE_SIGN,
+                FeNameFormat.TEMPORARY_TABLE_SIGN,
+                ConnectContext.get().getSessionId());
+        whereClause += tempTableCondition;
         List<AliasInfo> selectList = new ArrayList<>();
         ALIAS_COLUMN_MAP.forEach((key, value) -> {
             selectList.add(AliasInfo.of(value, key));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AliasInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AliasInfo.java
@@ -49,7 +49,7 @@ public class AliasInfo {
     @Override
     public String toString() {
         return alias == null || alias.isEmpty()
-                ? String.format("`%s`", name)
-                : String.format("`%s` AS `%s`", name, alias);
+                ? String.format("%s", name)
+                : String.format("%s AS `%s`", name, alias);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

when show table status, the temp table name is not correctly displayed. The temp table name is like [seesion_id]_#TEMP#_[table_name]. When show table status, it should only display the table_name not the full internal name

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

