### PR TITLE
[opt](nereids) optimize stats derive rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -147,6 +147,9 @@ public class StatementContext implements Closeable {
 
     private final Map<CTEId, Set<LogicalCTEConsumer>> cteIdToConsumers = new HashMap<>();
     private final Map<CTEId, Set<Slot>> cteIdToOutputIds = new HashMap<>();
+
+    private final Map<CTEId, Statistics> cteIdToProducerStats = new HashMap<>();
+
     private final Map<RelationId, Set<Expression>> consumerIdToFilters = new HashMap<>();
     // Used to update consumer's stats
     private final Map<CTEId, List<Pair<Multimap<Slot, Slot>, Group>>> cteIdToConsumerGroup = new HashMap<>();
@@ -877,5 +880,13 @@ public class StatementContext implements Closeable {
 
     public boolean isPrepareStage() {
         return prepareStage;
+    }
+
+    public Statistics getProducerStatsByCteId(CTEId id) {
+        return cteIdToProducerStats.get(id);
+    }
+
+    public void setProducerStats(CTEId id, Statistics stats) {
+        cteIdToProducerStats.put(id, stats);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
@@ -88,6 +88,8 @@ public class RewriteCteChildren extends DefaultPlanRewriter<CascadesContext> imp
                     Optional.empty(), cascadesContext, cteAnchor.child(1),
                     cascadesContext.getCurrentJobContext().getRequiredProperties());
             AtomicReference<LogicalPlan> outerResult = new AtomicReference<>();
+            StatsDerive statsDerive = new StatsDerive();
+            cteAnchor.child(0).accept(statsDerive, null);
             outerCascadesCtx.withPlanProcess(cascadesContext.showPlanProcess(), () -> {
                 outerResult.set((LogicalPlan) cteAnchor.child(1).accept(this, outerCascadesCtx));
             });


### PR DESCRIPTION
### What problem does this PR solve?
In previous verison, stats derive rule must be applied at the end of RBO phase because of CTE.
This pr removes this restriction by appling stats derive rule on producer inside RewriteCteChildren rule, and cache the stats in StatementContext.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

