### PR TITLE
[Bug](udf) fix can't download jar from obs as invalid url

### DIFF
--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -606,7 +606,8 @@ Status HttpClient::escape_url(CURL* curl, const std::string& url, std::string* e
             std::string value = query.substr(equal_pos + 1, ampersand_pos - equal_pos - 1);
 
             auto encoded_value = std::unique_ptr<char, decltype(&curl_free)>(
-                    curl_easy_escape(curl, value.c_str(), value.length()), &curl_free);
+                    curl_easy_escape(curl, value.c_str(), cast_set<int>(value.length())),
+                    &curl_free);
             if (encoded_value) {
                 encoded_query += key + "=" + std::string(encoded_value.get());
             } else {

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -280,7 +280,7 @@ HttpClient::~HttpClient() {
     }
 }
 
-Status HttpClient::init(const std::string& url, bool set_fail_on_error, bool skip_percent_encode) {
+Status HttpClient::init(const std::string& url, bool set_fail_on_error) {
     if (_curl == nullptr) {
         _curl = curl_easy_init();
         if (_curl == nullptr) {
@@ -346,10 +346,11 @@ Status HttpClient::init(const std::string& url, bool set_fail_on_error, bool ski
         return Status::InternalError("fail to set CURLOPT_WRITEDATA");
     }
 
-    std::string escaped_url;
-    RETURN_IF_ERROR(_escape_url(url, &escaped_url, skip_percent_encode));
+    // std::string escaped_url;
+    // RETURN_IF_ERROR(_escape_url(url, &escaped_url));
+
     // set url
-    code = curl_easy_setopt(_curl, CURLOPT_URL, escaped_url.c_str());
+    code = curl_easy_setopt(_curl, CURLOPT_URL, url.c_str());
     if (code != CURLE_OK) {
         LOG(WARNING) << "failed to set CURLOPT_URL, errmsg=" << _to_errmsg(code);
         return Status::InternalError("fail to set CURLOPT_URL");
@@ -576,8 +577,7 @@ Status HttpClient::execute_with_retry(int retry_times, int sleep_time,
 }
 
 // http://example.com/page?param1=value1&param2=value+with+spaces#section
-Status HttpClient::_escape_url(const std::string& url, std::string* escaped_url,
-                               bool skip_percent_encode) {
+Status HttpClient::escape_url(CURL* curl, const std::string& url, std::string* escaped_url) {
     size_t query_pos = url.find('?');
     if (query_pos == std::string::npos) {
         *escaped_url = url;
@@ -602,40 +602,19 @@ Status HttpClient::_escape_url(const std::string& url, std::string* escaped_url,
         ampersand_pos = query.length();
     }
 
-    auto encode_value_function = [&](const std::string& value, std::string& result) {
-        size_t i = 0;
-        while (i < value.size()) {
-            // If skip_percent_encode is false %2E ---> %252E, we will encode all '%' characters
-            // regardless of what follows them.
-            // If skip_percent_encode is true %2E ---> %2E, we will only encode '%' characters
-            // that are not followed by two valid hexadecimal digits.
-            if (skip_percent_encode && value[i] == '%' && i + 2 < value.size()) {
-                if (isxdigit(value[i + 1]) && isxdigit(value[i + 2])) {
-                    result += value.substr(i, 3);
-                    i += 3;
-                    continue;
-                }
-            }
-            char* encoded = curl_easy_escape(_curl, &value[i], 1);
-            if (encoded) {
-                result += encoded;
-                curl_free(encoded);
-            } else {
-                return Status::InternalError("escape url failed, url={}", url);
-            }
-            i++;
-        }
-        return Status::OK();
-    };
-
     while (true) {
         equal_pos = query.find('=');
         if (equal_pos != std::string::npos) {
             std::string key = query.substr(0, equal_pos);
             std::string value = query.substr(equal_pos + 1, ampersand_pos - equal_pos - 1);
-            std::string encoded_value;
-            RETURN_IF_ERROR(encode_value_function(value, encoded_value));
-            encoded_query += key + "=" + encoded_value;
+
+            auto encoded_value = std::unique_ptr<char, decltype(&curl_free)>(
+                    curl_easy_escape(curl, value.c_str(), value.length()), &curl_free);
+            if (encoded_value) {
+                encoded_query += key + "=" + std::string(encoded_value.get());
+            } else {
+                return Status::InternalError("escape url failed, url={}", url);
+            }
         } else {
             encoded_query += query.substr(0, ampersand_pos);
         }

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -346,9 +346,6 @@ Status HttpClient::init(const std::string& url, bool set_fail_on_error) {
         return Status::InternalError("fail to set CURLOPT_WRITEDATA");
     }
 
-    // std::string escaped_url;
-    // RETURN_IF_ERROR(_escape_url(url, &escaped_url));
-
     // set url
     code = curl_easy_setopt(_curl, CURLOPT_URL, url.c_str());
     if (code != CURLE_OK) {

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -47,7 +47,8 @@ public:
 
     // this function must call before other function,
     // you can call this multiple times to reuse this object
-    Status init(const std::string& url, bool set_fail_on_error = true);
+    Status init(const std::string& url, bool set_fail_on_error = true,
+                bool skip_percent_encode = false);
 
     void set_method(HttpMethod method);
 
@@ -170,7 +171,8 @@ public:
     // Because the percent ("%") character serves as the indicator for percent-encoded octets,
     // it must be percent-encoded as "%25" for that octet to be used as data within a URI.
     // https://datatracker.ietf.org/doc/html/rfc3986
-    Status _escape_url(const std::string& url, std::string* escaped_url);
+    Status _escape_url(const std::string& url, std::string* escaped_url,
+                       bool skip_percent_encode = false);
 
 private:
     const char* _to_errmsg(CURLcode code) const;

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -47,8 +47,7 @@ public:
 
     // this function must call before other function,
     // you can call this multiple times to reuse this object
-    Status init(const std::string& url, bool set_fail_on_error = true,
-                bool skip_percent_encode = false);
+    Status init(const std::string& url, bool set_fail_on_error = true);
 
     void set_method(HttpMethod method);
 
@@ -171,8 +170,10 @@ public:
     // Because the percent ("%") character serves as the indicator for percent-encoded octets,
     // it must be percent-encoded as "%25" for that octet to be used as data within a URI.
     // https://datatracker.ietf.org/doc/html/rfc3986
-    Status _escape_url(const std::string& url, std::string* escaped_url,
-                       bool skip_percent_encode = false);
+
+    // NOTE: this function will percent-encode the url, and maybe double-encode the url.
+    // =%2E#section ----> =%252E#section
+    static Status escape_url(CURL* _curl, const std::string& url, std::string* escaped_url);
 
 private:
     const char* _to_errmsg(CURLcode code) const;

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -410,7 +410,9 @@ Status SingleReplicaCompaction::_download_files(DataDir* data_dir,
         return Status::InternalError("single compaction init curl failed");
     }
     for (auto& file_name : file_name_list) {
-        auto remote_file_url = remote_url_prefix + file_name;
+        std::string encoded_filename;
+        RETURN_IF_ERROR(HttpClient::escape_url(curl.get(), file_name, &encoded_filename));
+        auto remote_file_url = remote_url_prefix + encoded_filename;
 
         // get file length
         uint64_t file_size = 0;

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include "common/config.h"
-#include "common/factory_creator.h"
 #include "common/status.h"
 #include "http/http_client.h"
 #include "io/fs/file_system.h"
@@ -40,54 +39,6 @@
 #include "util/string_util.h"
 
 namespace doris {
-
-// function cache entry, store information for
-struct UserFunctionCacheEntry {
-    ENABLE_FACTORY_CREATOR(UserFunctionCacheEntry);
-    UserFunctionCacheEntry(int64_t fid_, const std::string& checksum_, const std::string& lib_file_,
-                           LibType type)
-            : function_id(fid_), checksum(checksum_), lib_file(lib_file_), type(type) {}
-    ~UserFunctionCacheEntry();
-
-    std::string debug_string() {
-        fmt::memory_buffer error_msg;
-        fmt::format_to(error_msg,
-                       " the info of UserFunctionCacheEntry save in BE, function_id:{}, "
-                       "checksum:{}, lib_file:{}, is_downloaded:{}. ",
-                       function_id, checksum, lib_file, is_downloaded);
-        return fmt::to_string(error_msg);
-    }
-
-    int64_t function_id = 0;
-    // used to check if this library is valid.
-    std::string checksum;
-
-    // library file
-    std::string lib_file;
-
-    // make it atomic variable instead of holding a lock
-    std::atomic<bool> is_loaded {false};
-
-    // Set to true when this library is not needed.
-    // e.g. deleting some unused library to re
-    std::atomic<bool> should_delete_library {false};
-
-    // lock to make sure only one can load this cache
-    std::mutex load_lock;
-
-    // To reduce cache lock held time, cache entry is
-    // added to cache map before library is downloaded.
-    // And this is used to indicate whether library is downloaded.
-    bool is_downloaded = false;
-
-    // used to lookup a symbol
-    void* lib_handle = nullptr;
-
-    // from symbol_name to function pointer
-    std::unordered_map<std::string, void*> fptr_map;
-
-    LibType type;
-};
 
 UserFunctionCacheEntry::~UserFunctionCacheEntry() {
     // close lib_handle if it was opened

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <memory>
 #include <ostream>
-#include <utility>
 #include <vector>
 
 #include "common/config.h"
@@ -152,14 +151,12 @@ Status UserFunctionCache::_load_cached_lib() {
 Status UserFunctionCache::_load_entry_from_lib(const std::string& dir,
                                                const std::string& file_name) {
     LibType lib_type;
-    if (ends_with(file_name, ".so")) {
-        lib_type = LibType::SO;
-    } else if (ends_with(file_name, ".jar")) {
+    if (ends_with(file_name, ".jar")) {
         lib_type = LibType::JAR;
     } else {
         //TODO: should delete the .tmp file
         return Status::InternalError(
-                "unknown library file format. the file type is not end with xxx.jar or xxx.so : " +
+                "unknown library file format. the file type is not end with xxx.jar : " +
                 file_name);
     }
 

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -67,7 +67,6 @@ private:
                             std::string* libpath, LibType type);
     Status _load_cache_entry(const std::string& url, std::shared_ptr<UserFunctionCacheEntry> entry);
     Status _download_lib(const std::string& url, std::shared_ptr<UserFunctionCacheEntry> entry);
-    Status _load_cache_entry_internal(std::shared_ptr<UserFunctionCacheEntry> entry);
 
     std::string _make_lib_file(int64_t function_id, const std::string& checksum, LibType type,
                                const std::string& file_name);

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -61,9 +61,10 @@ public:
 
 private:
     Status _load_cached_lib();
-    Status _load_entry_from_lib(const std::string& dir, const std::string& file);
+    Status _load_entry_from_lib(const std::string& dir, const std::string& file_name);
+
     Status _get_cache_entry(int64_t fid, const std::string& url, const std::string& checksum,
-                            std::shared_ptr<UserFunctionCacheEntry>& output_entry, LibType type);
+                            std::string* libpath, LibType type);
     Status _load_cache_entry(const std::string& url, std::shared_ptr<UserFunctionCacheEntry> entry);
     Status _download_lib(const std::string& url, std::shared_ptr<UserFunctionCacheEntry> entry);
     Status _load_cache_entry_internal(std::shared_ptr<UserFunctionCacheEntry> entry);
@@ -72,7 +73,7 @@ private:
                                const std::string& file_name);
     void _destroy_cache_entry(std::shared_ptr<UserFunctionCacheEntry> entry);
 
-    std::string _get_file_name_from_url(const std::string& url) const;
+    std::string _get_file_name_from_url(const std::string& url, LibType type) const;
     std::vector<std::string> _split_string_by_checksum(const std::string& file);
 
 private:

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -333,12 +333,16 @@ TEST_F(HttpClientTest, download_file_md5) {
 TEST_F(HttpClientTest, escape_url) {
     HttpClient client;
     client._curl = curl_easy_init();
-    auto check_result = [&client](const auto& input_url, const auto& output_url) -> bool {
+    auto check_result = [&client](const auto& input_url, const auto& output_url,
+                                  bool skip_percent_encode = false) -> bool {
         std::string escaped_url;
-        if (!client._escape_url(input_url, &escaped_url).ok()) {
+        if (!client._escape_url(input_url, &escaped_url, skip_percent_encode).ok()) {
             return false;
         }
         if (escaped_url != output_url) {
+            std::cout << "input1: " << input_url << "\n";
+            std::cout << "output1: " << output_url << "\n";
+            std::cout << "escaped1: " << escaped_url << "\n";
             return false;
         }
         return true;
@@ -369,7 +373,19 @@ TEST_F(HttpClientTest, escape_url) {
 
     std::string input_G = hostname + "/download_file?key=0x2E&key=%2E#section";
     std::string output_G = hostname + "/download_file?key=0x2E&key=%252E#section";
-    ASSERT_TRUE(check_result(input_G, output_G));
+    ASSERT_TRUE(check_result(input_G, output_G, false)); // not skip percent encode
+
+    std::string input_H =
+            hostname +
+            "/java-udf-demo-jar-with-dependencies.jar?Expires=1751901956&OSSAccessKeyId=TMP."
+            "3KnCifjy4MFB4df4vqkTyZHvfGbxS41dBuRFhD9UYDJkfKn3wbtWgHnpqQGAKV64bY426DnB9jf6cEctwvShPa"
+            "oyL4zD6v&Signature=AYs2HN4bQ7wG9onjEQ9nRcF6EGM%3D";
+    std::string output_H =
+            hostname +
+            "/java-udf-demo-jar-with-dependencies.jar?Expires=1751901956&OSSAccessKeyId=TMP."
+            "3KnCifjy4MFB4df4vqkTyZHvfGbxS41dBuRFhD9UYDJkfKn3wbtWgHnpqQGAKV64bY426DnB9jf6cEctwvShPa"
+            "oyL4zD6v&Signature=AYs2HN4bQ7wG9onjEQ9nRcF6EGM%3D";
+    ASSERT_TRUE(check_result(input_H, output_H, true)); // skip percent encode
 }
 
 TEST_F(HttpClientTest, enable_http_auth) {

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -333,10 +333,9 @@ TEST_F(HttpClientTest, download_file_md5) {
 TEST_F(HttpClientTest, escape_url) {
     HttpClient client;
     client._curl = curl_easy_init();
-    auto check_result = [&client](const auto& input_url, const auto& output_url,
-                                  bool skip_percent_encode = false) -> bool {
+    auto check_result = [&client](const auto& input_url, const auto& output_url) -> bool {
         std::string escaped_url;
-        if (!client._escape_url(input_url, &escaped_url, skip_percent_encode).ok()) {
+        if (!HttpClient::escape_url(client._curl, input_url, &escaped_url).ok()) {
             return false;
         }
         if (escaped_url != output_url) {
@@ -373,19 +372,7 @@ TEST_F(HttpClientTest, escape_url) {
 
     std::string input_G = hostname + "/download_file?key=0x2E&key=%2E#section";
     std::string output_G = hostname + "/download_file?key=0x2E&key=%252E#section";
-    ASSERT_TRUE(check_result(input_G, output_G, false)); // not skip percent encode
-
-    std::string input_H =
-            hostname +
-            "/java-udf-demo-jar-with-dependencies.jar?Expires=1751901956&OSSAccessKeyId=TMP."
-            "3KnCifjy4MFB4df4vqkTyZHvfGbxS41dBuRFhD9UYDJkfKn3wbtWgHnpqQGAKV64bY426DnB9jf6cEctwvShPa"
-            "oyL4zD6v&Signature=AYs2HN4bQ7wG9onjEQ9nRcF6EGM%3D";
-    std::string output_H =
-            hostname +
-            "/java-udf-demo-jar-with-dependencies.jar?Expires=1751901956&OSSAccessKeyId=TMP."
-            "3KnCifjy4MFB4df4vqkTyZHvfGbxS41dBuRFhD9UYDJkfKn3wbtWgHnpqQGAKV64bY426DnB9jf6cEctwvShPa"
-            "oyL4zD6v&Signature=AYs2HN4bQ7wG9onjEQ9nRcF6EGM%3D";
-    ASSERT_TRUE(check_result(input_H, output_H, true)); // skip percent encode
+    ASSERT_TRUE(check_result(input_G, output_G)); // not skip percent encode
 }
 
 TEST_F(HttpClientTest, enable_http_auth) {

--- a/be/test/runtime/test_data/user_function_cache/test=.jar
+++ b/be/test/runtime/test_data/user_function_cache/test=.jar
@@ -1,0 +1,1 @@
+asdasdasdsadsa

--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -43,4 +43,36 @@ TEST_F(UserFunctionCacheTest, SplitStringByChecksumTest) {
     EXPECT_EQ(result[3], "jar");
 }
 
+TEST_F(UserFunctionCacheTest, getFileNameFromUrl) {
+    std::string url =
+            "https://asdadadadas.oss-cn-hangzhou.aliyuncs.com/udf/"
+            "java-udf-demo-jar-with-dependencies.jar?Expires=1751901956&OSSAccessKeyId=TMP."
+            "3KnCifjy4MFB4df4AAAAAAAAAvqkTyZHvfGbxS4UYDJkfKn3wbtWgHnpqQGAKV64bY426DnB9jf6cEctwvShPa"
+            "oyL4zD6v&Signature=AYs2HN4bQ7wG9onjEQ9nRcF6EGM%3D";
+
+    auto result = ufc._get_file_name_from_url(url, doris::LibType::JAR);
+    std::cout << result << std::endl;
+    EXPECT_EQ(result, "java-udf-demo-jar-with-dependencies.jar");
+
+    url = "https://asdadadadas.oss-cn-hangzhou.aliyuncs.com/udf/"
+          "java-udf-demo-jar-with-dependencies.jar";
+    result = ufc._get_file_name_from_url(url, doris::LibType::JAR);
+    std::cout << result << std::endl;
+    EXPECT_EQ(result, "java-udf-demo-jar-with-dependencies.jar");
+
+    url = "file:///mnt/disk8/zhangsida/doris/samples/doris-demo/java-udf-demo/target/"
+          "java-udf-demo-jar-with-dependencies.jar";
+    result = ufc._get_file_name_from_url(url, doris::LibType::JAR);
+    std::cout << result << std::endl;
+    EXPECT_EQ(result, "java-udf-demo-jar-with-dependencies.jar");
+}
+
+TEST_F(UserFunctionCacheTest, makeLibFile) {
+    ufc._lib_dir = config::user_function_dir;
+    auto result = ufc._make_lib_file(123, "20c8228267b6c9ce620fddb39467d3eb", doris::LibType::JAR,
+                                     "test.jar");
+    std::cout << result << std::endl;
+    EXPECT_EQ(result, ufc._lib_dir + "/123.20c8228267b6c9ce620fddb39467d3eb.test.jar");
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
if user have put udf-jar at obs, and the url maybe like:
```
"https://asdadadadas.oss-cn-hangzhou.aliyuncs.com/udf/"
            "java-udf-demo-jar-with-dependencies.jar?Expires=1751901956&OSSAccessKeyId=TMP."
            "3KnCifjy4MFB4df4AAAAAAAAAvqkTyZHvfGbxS4UYDJkfKn3wbtWgHnpqQGAKV64bY426DnB9jf6cEctwvShPa"
            "oyL4zD6v&Signature=AYs2HN4bQ7wG9onjEQ9nRcF6EGM%3D"
```
the last is "**%3D**" and will be encode by _escape_url function to "**%253D**"
but "**%3D**"  is precent encode, so it's shouldn't encode again.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

