### PR TITLE
[opt](load) limit concurrency of delete_bitmap computation

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -203,7 +203,10 @@ Status CloudStorageEngine::open() {
             cast_set<int32_t>(io::FileCacheFactory::instance()->get_cache_instance_size()));
 
     _calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
-    _calc_delete_bitmap_executor->init();
+    _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
+
+    _rowset_calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
+    _rowset_calc_delete_bitmap_executor->init(config::rowset_calc_delete_bitmap_max_thread);
 
     // The default cache is set to 100MB, use memory limit to dynamic adjustment
     bool is_percent = false;

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -205,8 +205,8 @@ Status CloudStorageEngine::open() {
     _calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
     _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
 
-    _rowset_calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
-    _rowset_calc_delete_bitmap_executor->init(config::rowset_calc_delete_bitmap_max_thread);
+    _calc_delete_bitmap_executor_for_load = std::make_unique<CalcDeleteBitmapExecutor>();
+    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread);
 
     // The default cache is set to 100MB, use memory limit to dynamic adjustment
     bool is_percent = false;

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -206,7 +206,9 @@ Status CloudStorageEngine::open() {
     _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
 
     _calc_delete_bitmap_executor_for_load = std::make_unique<CalcDeleteBitmapExecutor>();
-    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread);
+    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread > 0
+                                                       ? config::calc_delete_bitmap_for_load_max_thread
+                                                       : std::max(1, CpuInfo::num_cores() / 2));
 
     // The default cache is set to 100MB, use memory limit to dynamic adjustment
     bool is_percent = false;

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -206,9 +206,10 @@ Status CloudStorageEngine::open() {
     _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
 
     _calc_delete_bitmap_executor_for_load = std::make_unique<CalcDeleteBitmapExecutor>();
-    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread > 0
-                                                       ? config::calc_delete_bitmap_for_load_max_thread
-                                                       : std::max(1, CpuInfo::num_cores() / 2));
+    _calc_delete_bitmap_executor_for_load->init(
+            config::calc_delete_bitmap_for_load_max_thread > 0
+                    ? config::calc_delete_bitmap_for_load_max_thread
+                    : std::max(1, CpuInfo::num_cores() / 2));
 
     // The default cache is set to 100MB, use memory limit to dynamic adjustment
     bool is_percent = false;

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -214,6 +214,8 @@ DEFINE_Int32(tablet_publish_txn_max_thread, "32");
 DEFINE_Int32(publish_version_task_timeout_s, "8");
 // the count of thread to calc delete bitmap
 DEFINE_Int32(calc_delete_bitmap_max_thread, "32");
+// the num of threads to calc delete bitmap when building rowset
+DEFINE_Int32(rowset_calc_delete_bitmap_max_thread, "8");
 // the count of thread to calc delete bitmap worker, only used for cloud
 DEFINE_Int32(calc_delete_bitmap_worker_count, "8");
 // the count of thread to calc tablet delete bitmap task, only used for cloud

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -214,8 +214,8 @@ DEFINE_Int32(tablet_publish_txn_max_thread, "32");
 DEFINE_Int32(publish_version_task_timeout_s, "8");
 // the count of thread to calc delete bitmap
 DEFINE_Int32(calc_delete_bitmap_max_thread, "32");
-// the num of threads to calc delete bitmap when building rowset
-DEFINE_Int32(calc_delete_bitmap_for_load_max_thread, "8");
+// the num of threads to calc delete bitmap when building rowset, 0 = auto
+DEFINE_Int32(calc_delete_bitmap_for_load_max_thread, "0");
 // the count of thread to calc delete bitmap worker, only used for cloud
 DEFINE_Int32(calc_delete_bitmap_worker_count, "8");
 // the count of thread to calc tablet delete bitmap task, only used for cloud

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -215,7 +215,7 @@ DEFINE_Int32(publish_version_task_timeout_s, "8");
 // the count of thread to calc delete bitmap
 DEFINE_Int32(calc_delete_bitmap_max_thread, "32");
 // the num of threads to calc delete bitmap when building rowset
-DEFINE_Int32(rowset_calc_delete_bitmap_max_thread, "8");
+DEFINE_Int32(calc_delete_bitmap_for_load_max_thread, "8");
 // the count of thread to calc delete bitmap worker, only used for cloud
 DEFINE_Int32(calc_delete_bitmap_worker_count, "8");
 // the count of thread to calc tablet delete bitmap task, only used for cloud

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -259,7 +259,7 @@ DECLARE_Int32(publish_version_task_timeout_s);
 // the count of thread to calc delete bitmap
 DECLARE_Int32(calc_delete_bitmap_max_thread);
 // the num of threads to calc delete bitmap when building rowset
-DECLARE_Int32(rowset_calc_delete_bitmap_max_thread);
+DECLARE_Int32(calc_delete_bitmap_for_load_max_thread);
 // the count of thread to calc delete bitmap worker, only used for cloud
 DECLARE_Int32(calc_delete_bitmap_worker_count);
 // the count of thread to calc tablet delete bitmap task, only used for cloud

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -258,6 +258,8 @@ DECLARE_Int32(tablet_publish_txn_max_thread);
 DECLARE_Int32(publish_version_task_timeout_s);
 // the count of thread to calc delete bitmap
 DECLARE_Int32(calc_delete_bitmap_max_thread);
+// the num of threads to calc delete bitmap when building rowset
+DECLARE_Int32(rowset_calc_delete_bitmap_max_thread);
 // the count of thread to calc delete bitmap worker, only used for cloud
 DECLARE_Int32(calc_delete_bitmap_worker_count);
 // the count of thread to calc tablet delete bitmap task, only used for cloud

--- a/be/src/olap/calc_delete_bitmap_executor.cpp
+++ b/be/src/olap/calc_delete_bitmap_executor.cpp
@@ -21,7 +21,6 @@
 
 #include <ostream>
 
-#include "common/config.h"
 #include "common/logging.h"
 #include "olap/base_tablet.h"
 #include "olap/memtable.h"
@@ -93,10 +92,10 @@ Status CalcDeleteBitmapToken::wait() {
     return _status;
 }
 
-void CalcDeleteBitmapExecutor::init() {
+void CalcDeleteBitmapExecutor::init(int max_threads) {
     static_cast<void>(ThreadPoolBuilder("TabletCalcDeleteBitmapThreadPool")
                               .set_min_threads(1)
-                              .set_max_threads(config::calc_delete_bitmap_max_thread)
+                              .set_max_threads(max_threads)
                               .build(&_thread_pool));
 }
 

--- a/be/src/olap/calc_delete_bitmap_executor.h
+++ b/be/src/olap/calc_delete_bitmap_executor.h
@@ -85,7 +85,7 @@ public:
     ~CalcDeleteBitmapExecutor() { _thread_pool->shutdown(); }
 
     // init should be called after storage engine is opened,
-    void init();
+    void init(int max_threads);
 
     std::unique_ptr<CalcDeleteBitmapToken> create_token();
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -364,7 +364,7 @@ Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) 
         _segcompaction_worker->init_mem_tracker(rowset_writer_context);
     }
     if (_context.mow_context != nullptr) {
-        _calc_delete_bitmap_token = _engine.rowset_calc_delete_bitmap_executor()->create_token();
+        _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor_for_load()->create_token();
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -364,7 +364,7 @@ Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) 
         _segcompaction_worker->init_mem_tracker(rowset_writer_context);
     }
     if (_context.mow_context != nullptr) {
-        _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor()->create_token();
+        _calc_delete_bitmap_token = _engine.rowset_calc_delete_bitmap_executor()->create_token();
     }
     return Status::OK();
 }

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -303,7 +303,10 @@ Status StorageEngine::_open() {
     _memtable_flush_executor->init(_disk_num);
 
     _calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
-    _calc_delete_bitmap_executor->init();
+    _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
+
+    _rowset_calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
+    _rowset_calc_delete_bitmap_executor->init(config::rowset_calc_delete_bitmap_max_thread);
 
     _parse_default_rowset_type();
 
@@ -763,6 +766,7 @@ void StorageEngine::stop() {
 
     _memtable_flush_executor.reset(nullptr);
     _calc_delete_bitmap_executor.reset(nullptr);
+    _rowset_calc_delete_bitmap_executor.reset();
 
     _stopped = true;
     LOG(INFO) << "Storage engine is stopped.";

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -306,9 +306,10 @@ Status StorageEngine::_open() {
     _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
 
     _calc_delete_bitmap_executor_for_load = std::make_unique<CalcDeleteBitmapExecutor>();
-    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread > 0 ?
-                                                       config::calc_delete_bitmap_for_load_max_thread
-                                                       : std::max(1, CpuInfo::num_cores() / 2));
+    _calc_delete_bitmap_executor_for_load->init(
+            config::calc_delete_bitmap_for_load_max_thread > 0
+                    ? config::calc_delete_bitmap_for_load_max_thread
+                    : std::max(1, CpuInfo::num_cores() / 2));
 
     _parse_default_rowset_type();
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -306,7 +306,9 @@ Status StorageEngine::_open() {
     _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
 
     _calc_delete_bitmap_executor_for_load = std::make_unique<CalcDeleteBitmapExecutor>();
-    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread);
+    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread > 0 ?
+                                                       config::calc_delete_bitmap_for_load_max_thread
+                                                       : std::max(1, CpuInfo::num_cores() / 2));
 
     _parse_default_rowset_type();
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -305,8 +305,8 @@ Status StorageEngine::_open() {
     _calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
     _calc_delete_bitmap_executor->init(config::calc_delete_bitmap_max_thread);
 
-    _rowset_calc_delete_bitmap_executor = std::make_unique<CalcDeleteBitmapExecutor>();
-    _rowset_calc_delete_bitmap_executor->init(config::rowset_calc_delete_bitmap_max_thread);
+    _calc_delete_bitmap_executor_for_load = std::make_unique<CalcDeleteBitmapExecutor>();
+    _calc_delete_bitmap_executor_for_load->init(config::calc_delete_bitmap_for_load_max_thread);
 
     _parse_default_rowset_type();
 
@@ -766,7 +766,7 @@ void StorageEngine::stop() {
 
     _memtable_flush_executor.reset(nullptr);
     _calc_delete_bitmap_executor.reset(nullptr);
-    _rowset_calc_delete_bitmap_executor.reset();
+    _calc_delete_bitmap_executor_for_load.reset();
 
     _stopped = true;
     LOG(INFO) << "Storage engine is stopped.";

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -134,6 +134,10 @@ public:
         return _calc_delete_bitmap_executor.get();
     }
 
+    CalcDeleteBitmapExecutor* rowset_calc_delete_bitmap_executor() {
+        return _rowset_calc_delete_bitmap_executor.get();
+    }
+
     void add_quering_rowset(RowsetSharedPtr rs);
 
     RowsetSharedPtr get_quering_rowset(RowsetId rs_id);
@@ -163,6 +167,7 @@ protected:
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
     std::unique_ptr<CalcDeleteBitmapExecutor> _calc_delete_bitmap_executor;
+    std::unique_ptr<CalcDeleteBitmapExecutor> _rowset_calc_delete_bitmap_executor;
     CountDownLatch _stop_background_threads_latch;
 
     // Hold reference of quering rowsets

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -134,8 +134,8 @@ public:
         return _calc_delete_bitmap_executor.get();
     }
 
-    CalcDeleteBitmapExecutor* rowset_calc_delete_bitmap_executor() {
-        return _rowset_calc_delete_bitmap_executor.get();
+    CalcDeleteBitmapExecutor* calc_delete_bitmap_executor_for_load() {
+        return _calc_delete_bitmap_executor_for_load.get();
     }
 
     void add_quering_rowset(RowsetSharedPtr rs);
@@ -167,7 +167,7 @@ protected:
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
     std::unique_ptr<CalcDeleteBitmapExecutor> _calc_delete_bitmap_executor;
-    std::unique_ptr<CalcDeleteBitmapExecutor> _rowset_calc_delete_bitmap_executor;
+    std::unique_ptr<CalcDeleteBitmapExecutor> _calc_delete_bitmap_executor_for_load;
     CountDownLatch _stop_background_threads_latch;
 
     // Hold reference of quering rowsets


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #48156

Problem Summary:

Previously, the same thread pool was used to calculate the DeleteBitmap during both the build rowset and publish stages. This led to high CPU usage and resource contention, especially impacting memtable flushing performance.

To mitigate this, a dedicated thread pool is introduced for DeleteBitmap computation during the build rowset stage. This new pool is configured with a lower maximum thread count (8 vs. the original 32) to better control resource consumption and reduce interference with other critical operations.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

