### PR TITLE
[fix](nereids) Fix the expr id are same but different expr when agg table with random distribute

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -292,8 +292,8 @@ public class BindRelation extends OneAnalysisRuleFactory {
                 if (function == null) {
                     return olapScan;
                 }
-                Alias alias = new Alias(exprId, ImmutableList.of(function), col.getName(),
-                        olapScan.qualified(), true);
+                Alias alias = new Alias(StatementScopeIdGenerator.newExprId(), ImmutableList.of(function),
+                        col.getName(), olapScan.qualified(), true);
                 outputExpressions.add(alias);
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindRelationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindRelationTest.java
@@ -20,16 +20,27 @@ package org.apache.doris.nereids.rules.analysis;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.pattern.GeneratedPlanPatterns;
 import org.apache.doris.nereids.rules.RulePromise;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
+import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanRewriter;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 class BindRelationTest extends TestWithFeService implements GeneratedPlanPatterns {
     private static final String DB1 = "db1";
@@ -91,6 +102,39 @@ class BindRelationTest extends TestWithFeService implements GeneratedPlanPattern
         Assertions.assertEquals(
                 ImmutableList.of("internal", DEFAULT_CLUSTER_PREFIX + DB1, "tagg"),
                 plan.getOutput().get(1).getQualifier());
+    }
+
+    @Test
+    void testBindRandomAggTableExprIdSame() {
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        connectContext.getState().setIsQuery(true);
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select * from db1.tagg",
+                        planner -> {
+                            List<Alias> collectedAlias = new ArrayList<>();
+                            planner.getCascadesContext().getRewritePlan().accept(
+                                    new DefaultPlanVisitor<Void, List<Alias>>() {
+                                        @Override
+                                        public Void visitLogicalAggregate(LogicalAggregate<? extends Plan> aggregate,
+                                                List<Alias> context) {
+                                            for (Expression expression : aggregate.getExpressions()) {
+                                                collectedAlias.addAll(
+                                                        expression.collectToList(Alias.class::isInstance));
+                                            }
+                                            return super.visitLogicalAggregate(aggregate, context);
+
+                                        }
+                                    }, collectedAlias);
+                            for (Alias alias : collectedAlias) {
+                                for (Expression child : alias.children()) {
+                                    Set<ExprId> childExpressionSet =
+                                            child.collectToSet(NamedExpression.class::isInstance).stream()
+                                                    .map(expr -> ((NamedExpression) expr).getExprId())
+                                                    .collect(Collectors.toSet());
+                                    Assertions.assertFalse(childExpressionSet.contains(alias.getExprId()));
+                                }
+                            }
+                        });
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindRelationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindRelationTest.java
@@ -122,7 +122,6 @@ class BindRelationTest extends TestWithFeService implements GeneratedPlanPattern
                                                         expression.collectToList(Alias.class::isInstance));
                                             }
                                             return super.visitLogicalAggregate(aggregate, context);
-
                                         }
                                     }, collectedAlias);
                             for (Alias alias : collectedAlias) {


### PR DESCRIPTION
### What problem does this PR solve?

If agg table is random hash distribute, would add aggregate node on scan.
The aggregate function alias expr id is same to the child expr id of alias.

such as query sql is `select * from db1.tagg`
the query plan is as following, and the `sum(b#1) AS `b`#1`, alias expr id is same to the child expr id of alias, the id is 1
this would cause hidden problems
```sql
LogicalResultSink[30] ( outputExprs=[a#0, b#1] )
+--LogicalAggregate[29] ( groupByExpr=[a#0], outputExpr=[a#0, sum(b#1) AS `b`#1], hasRepeat=false, stats=1 )
   +--LogicalOlapScan ( qualified=internal.db1.tagg, indexName=<index_not_selected>, selectedIndexId=1752042452160, preAgg=ON, operativeCol=[a#0, b#1], stats=1 )
```

the pr fix this, and the expression  change to `sum(b#1) AS `b`#4`  
```sql
LogicalResultSink[30] ( outputExprs=[a#0, b#4] )
+--LogicalAggregate[29] ( groupByExpr=[a#0], outputExpr=[a#0, sum(b#1) AS `b`#4], hasRepeat=false, stats=1 )
   +--LogicalOlapScan ( qualified=internal.db1.tagg, indexName=<index_not_selected>, selectedIndexId=1752042065062, preAgg=ON, operativeCol=[a#0, b#1], stats=1 )
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

