### PR TITLE
[Opt](command) Speed up UNSET GLOBAL VARIABLE ALL

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -694,8 +694,16 @@ public class VariableMgr {
             throws DdlException {
         for (Map.Entry<String, VarContext> entry : ctxByDisplayVarName.entrySet()) {
             VarContext varCtx = entry.getValue();
+            String defaultValue = varCtx.defaultValue;
+            String currentValue = getValue(sessionVariable, varCtx.getField());
+
+            // Skip if current value is already the default value
+            if (defaultValue.equals(currentValue)) {
+                continue;
+            }
+
             SetVar setVar = new SetVar(setType, entry.getKey(),
-                    new StringLiteral(varCtx.defaultValue), SetVarType.SET_SESSION_VAR);
+                    new StringLiteral(defaultValue), SetVarType.SET_SESSION_VAR);
             try {
                 checkUpdate(setVar, varCtx.getFlag());
             } catch (DdlException e) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

skip the variables which are already same with default value when we `unset global variable all`. reduce the edit log's number when we do it.
in most case of only small number of variable changed, this effect is significant:

before:
```sql
mysql> unset global variable all;
Query OK, 0 rows affected (14.94 sec)
```
now:
```sql
mysql> unset global variable all;
Query OK, 0 rows affected (0.10 sec)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

