### PR TITLE
[clean](planner)Delete finalizeForNereids method in SetOperationNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -3153,7 +3153,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         return Lists.newArrayList();
     }
 
-    private void finalizeSetOperationNode(List<SlotDescriptor> constExprSlots, List<SlotDescriptor> resultExprSlots, SetOperationNode node) {
+    private void finalizeSetOperationNode(List<SlotDescriptor> constExprSlots, List<SlotDescriptor> resultExprSlots,
+            SetOperationNode node) {
         List<List<Expr>> materializedConstExprLists = node.getMaterializedConstExprLists();
         materializedConstExprLists.clear();
         for (List<Expr> exprList : node.getConstExprLists()) {


### PR DESCRIPTION
### What problem does this PR solve?

Move all non-serialization logic from SetOperationNode to PhysicalPlanTranslator since it should only handle serialization

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Delete finalizeForNereids method in SetOperationNode
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

