### PR TITLE
[log](cloud-mow) add debug log for error: partition info is empty, table may be dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/DeleteBitmapUpdateLockContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/DeleteBitmapUpdateLockContext.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class DeleteBitmapUpdateLockContext {
+    private long lockId;
     private Map<Long, Long> baseCompactionCnts;
     private Map<Long, Long> cumulativeCompactionCnts;
     private Map<Long, Long> cumulativePoints;
@@ -37,7 +38,8 @@ public class DeleteBitmapUpdateLockContext {
     private Map<Long, List<Long>> tableToTabletList;
     private Map<Long, TabletMeta> tabletToTabletMeta;
 
-    public DeleteBitmapUpdateLockContext() {
+    public DeleteBitmapUpdateLockContext(long lockId) {
+        this.lockId = lockId;
         baseCompactionCnts = Maps.newHashMap();
         cumulativeCompactionCnts = Maps.newHashMap();
         cumulativePoints = Maps.newHashMap();
@@ -47,6 +49,10 @@ public class DeleteBitmapUpdateLockContext {
         backendToPartitionTablets = Maps.newHashMap();
         tableToTabletList = Maps.newHashMap();
         tabletToTabletMeta = Maps.newHashMap();
+    }
+
+    public long getLockId() {
+        return lockId;
     }
 
     public Map<Long, List<Long>> getTableToTabletList() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Some users encountered the following error when importing data into the cloud-mow table: “partition info is empty, table may be dropped.” 

This shouldn’t happen, as both `mowTableList` and `tabletCommitInfos` in method `CloudGlobalTransactionMgr::commitAndPublishTransaction()` are not empty, so at the place where this exception is thrown ,`lockContext.getBackendToPartitionTablets()` shouldn’t be empty either. This PR attempts to print some debug logs to help figure out what’s going on.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

