### PR TITLE
[Bug](function) fix bitmap_from_base64 function cause heap-buffer-overflow error

### DIFF
--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -305,7 +305,8 @@ struct BitmapFromBase64 {
                 BitmapValue bitmap_val;
                 if (!bitmap_val.deserialize(decode_buff.data())) {
                     return Status::RuntimeError(
-                            fmt::format("bitmap_from_base64 decode failed: base64: {}", src_str));
+                            fmt::format("bitmap_from_base64 decode failed: base64: {}",
+                                        std::string(src_str, src_size)));
                 }
                 res.emplace_back(std::move(bitmap_val));
             }
@@ -373,7 +374,7 @@ public:
 
         ColumnPtr& argument_column = block.get_by_position(arguments[0]).column;
         if constexpr (std::is_same_v<typename Impl::ArgumentType, DataTypeString>) {
-            const auto& str_column = static_cast<const ColumnString&>(*argument_column);
+            const auto& str_column = assert_cast<const ColumnString&>(*argument_column);
             const ColumnString::Chars& data = str_column.get_chars();
             const ColumnString::Offsets& offsets = str_column.get_offsets();
             RETURN_IF_ERROR(Impl::vector(data, offsets, res, null_map, input_rows_count));

--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -304,9 +304,8 @@ struct BitmapFromBase64 {
             } else {
                 BitmapValue bitmap_val;
                 if (!bitmap_val.deserialize(decode_buff.data())) {
-                    return Status::RuntimeError(
-                            fmt::format("bitmap_from_base64 decode failed: base64: {}",
-                                        std::string(src_str, src_size)));
+                    return Status::RuntimeError("bitmap_from_base64 decode failed: base64: {}",
+                                                std::string(src_str, src_size));
                 }
                 res.emplace_back(std::move(bitmap_val));
             }
@@ -374,7 +373,7 @@ public:
 
         ColumnPtr& argument_column = block.get_by_position(arguments[0]).column;
         if constexpr (std::is_same_v<typename Impl::ArgumentType, DataTypeString>) {
-            const auto& str_column = assert_cast<const ColumnString&>(*argument_column);
+            const auto& str_column = static_cast<const ColumnString&>(*argument_column);
             const ColumnString::Chars& data = str_column.get_chars();
             const ColumnString::Offsets& offsets = str_column.get_offsets();
             RETURN_IF_ERROR(Impl::vector(data, offsets, res, null_map, input_rows_count));

--- a/regression-test/suites/query_p0/sql_functions/bitmap_functions/test_bitmap_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/bitmap_functions/test_bitmap_function.groovy
@@ -927,4 +927,9 @@ suite("test_bitmap_function") {
     // BITMAP_FROM_ARRAY
     sql """ set experimental_enable_nereids_planner=true; """
     qt_sql """ select bitmap_to_string(BITMAP_FROM_ARRAY([]));"""
+
+    test {
+        sql """ SELECT bitmap_from_base64('CQoL') AS result; """ 
+        exception "bitmap_from_base64 decode failed"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

```
==2403213==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x506001097220 at pc 0x55837edd7fe9 bp 0x7f7efe2dc830 sp 0x7f7efe2dbff8
READ of size 63 at 0x506001097220 thread T1262 (brpc_light)
    #0 0x55837edd7fe8 in strlen (/mnt/disk8/zhangsida/doris/output/be/lib/doris_be+0x2c8d7fe8) (BuildId: 5acbe48773972a88)
    #1 0x5583bd3ff969 in fmt::v7::detail::buffer_appender<char> fmt::v7::detail::write<char, fmt::v7::detail::buffer_appender<char>>(fmt::v7::detail::buffer_appender<char>, char const*) (/mnt/disk8/zhangsida/doris/output/be/lib/doris_be+0x6aeff969) (BuildId: 5acbe48773972a88)
    #2 0x5583bd41640e in char const* fmt::v7::detail::parse_replacement_field<char, fmt::v7::detail::format_handler<fmt::v7::detail::buffer_appender<char>, char, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>>&>(char const*, char const*, fmt::v7::detail::format_handler<fmt::v7::detail::buffer_appender<char>, char, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>>&) (/mnt/disk8/zhangsida/doris/output/be/lib/doris_be+0x6af1640e) (BuildId: 5acbe48773972a88)
    #3 0x5583bd416c7f in void fmt::v7::detail::vformat_to<char>(fmt::v7::detail::buffer<char>&, fmt::v7::basic_string_view<char>, fmt::v7::basic_format_args<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<fmt::v7::type_identity<char>::type>, fmt::v7::type_identity<char>::type>>, fmt::v7::detail::locale_ref) (/mnt/disk8/zhangsida/doris/output/be/lib/doris_be+0x6af16c7f) (BuildId: 5acbe48773972a88)
    #4 0x5583bd3f74aa in fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args) (/mnt/disk8/zhangsida/doris/output/be/lib/doris_be+0x6aef74aa) (BuildId: 5acbe48773972a88)
    #5 0x5583a6b4d3bb in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> fmt::v7::format<char [45], char const*&, char>(char const (&) [45], char const*&) /mnt/disk8/zhangsida/doris/thirdparty/installed/include/fmt/core.h:2076:10
    #6 0x5583a6b4d3bb in doris::vectorized::BitmapFromBase64::vector(doris::vectorized::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::NoTrackingDefaultMemoryAllocator>, 16ul, 15ul> const&, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::NoTrackingDefaultMemoryAllocator>, 16ul, 15ul> const&, std::vector<doris::BitmapValue, std::allocator<doris::BitmapValue>>&, doris::vectorized::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::NoTrackingDefaultMemoryAllocator>, 16ul, 15ul>&, unsigned long) /mnt/disk8/zhangsida/doris/be/src/vec/functions/function_bitmap.cpp:310:29
    #7 0x5583a6b4b93b in doris::vectorized::FunctionBitmapAlwaysNull<doris::vectorized::BitmapFromBase64>::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function_bitmap.cpp:381:13
    #8 0x5583a02062ef in doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.h:459:26
    #9 0x5583a49d77e3 in doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long, bool) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.cpp
    #10 0x5583a49d0bf8 in doris::vectorized::PreparedFunctionImpl::default_implementation_for_constant_arguments(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long, bool, bool*) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.cpp:168:5
    #11 0x5583a49d3324 in doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long, bool) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.cpp:237:5
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

