### PR TITLE
[feat](load) alias compute_group to cloud_cluster

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -742,7 +742,9 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         }
     }
 
-    if (!http_req->header(HTTP_CLOUD_CLUSTER).empty()) {
+    if (!http_req->header(HTTP_COMPUTE_GROUP).empty()) {
+        request.__set_cloud_cluster(http_req->header(HTTP_COMPUTE_GROUP));
+    } else if (!http_req->header(HTTP_CLOUD_CLUSTER).empty()) {
         request.__set_cloud_cluster(http_req->header(HTTP_CLOUD_CLUSTER));
     }
 

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -72,5 +72,6 @@ static const std::string HTTP_AUTH_CODE = "auth_code"; // deprecated
 static const std::string HTTP_GROUP_COMMIT = "group_commit";
 static const std::string HTTP_CLOUD_CLUSTER = "cloud_cluster";
 static const std::string HTTP_EMPTY_FIELD_AS_NULL = "empty_field_as_null";
+static const std::string HTTP_COMPUTE_GROUP = "compute_group";
 
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -723,6 +723,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // CLOUD_VARIABLES_BEGIN
     public static final String CLOUD_CLUSTER = "cloud_cluster";
+    public static final String COMPUTE_GROUP = "compute_group";
     public static final String DISABLE_EMPTY_PARTITION_PRUNE = "disable_empty_partition_prune";
     public static final String CLOUD_PARTITION_VERSION_CACHE_TTL_MS =
             "cloud_partition_version_cache_ttl_ms";
@@ -2673,7 +2674,7 @@ public class SessionVariable implements Serializable, Writable {
 
 
     // CLOUD_VARIABLES_BEGIN
-    @VariableMgr.VarAttr(name = CLOUD_CLUSTER)
+    @VariableMgr.VarAttr(name = CLOUD_CLUSTER, alias = {COMPUTE_GROUP})
     public String cloudCluster = "";
     @VariableMgr.VarAttr(name = DISABLE_EMPTY_PARTITION_PRUNE)
     public boolean disableEmptyPartitionPrune = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -853,6 +853,8 @@ public class VariableMgr {
         // Name in show variables and set statement;
         String name();
 
+        String[] alias() default {};
+
         int flag() default 0;
 
         // TODO(zhaochun): min and max is not used.
@@ -945,9 +947,16 @@ public class VariableMgr {
             }
 
             field.setAccessible(true);
-            builder.put(attr.name(),
-                    new VarContext(field, sessionVariable, SESSION | attr.flag(),
-                            getValue(sessionVariable, field)));
+            VarContext varContext = new VarContext(field, sessionVariable, SESSION | attr.flag(),
+                    getValue(sessionVariable, field));
+
+            // 1. Register the primary name.
+            builder.put(attr.name(), varContext);
+
+            // 2. Register all aliases, pointing to the SAME VarContext.
+            for (String aliasName : attr.alias()) {
+                builder.put(aliasName, varContext);
+            }
         }
 
         // Variables only exist in global environment.

--- a/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/use_vcg_read_write.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/use_vcg_read_write.groovy
@@ -288,7 +288,7 @@ suite('use_vcg_read_write', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s

--- a/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/use_vcg_read_write_unhealthy_node_50.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/use_vcg_read_write_unhealthy_node_50.groovy
@@ -186,7 +186,7 @@ suite('use_vcg_read_write_unhealthy_node_50', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s
@@ -372,7 +372,7 @@ suite('use_vcg_read_write_unhealthy_node_50', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s

--- a/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/vcg_auto_failover.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/vcg_auto_failover.groovy
@@ -179,7 +179,7 @@ suite('vcg_auto_failover', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s
@@ -343,7 +343,7 @@ suite('vcg_auto_failover', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s

--- a/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/vcg_auto_failover_manual_failback.groovy
+++ b/regression-test/suites/cloud_p0/multi_cluster/virtual_compute_group/vcg_auto_failover_manual_failback.groovy
@@ -263,7 +263,7 @@ suite('vcg_auto_failover_manual_failback', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s
@@ -442,7 +442,7 @@ suite('vcg_auto_failover_manual_failback', 'multi_cluster,docker') {
                 table "${tableName}"
 
                 set 'column_separator', ','
-                set 'cloud_cluster', 'normalVirtualClusterName'
+                set 'compute_group', 'normalVirtualClusterName'
 
                 file 'all_types.csv'
                 time 10000 // limit inflight 10s


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
To unify terminology, the session variable `compute_group` is now an alias for `cloud_cluster`.

For stream loads, a new `compute_group` HTTP header is also added. It takes precedence over the existing `cloud_cluster` header to allow for a gradual migration.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

