### PR TITLE
[opt](test) Enlarge timeout for compaction score action

### DIFF
--- a/regression-test/suites/compaction/test_compaction_score_action.groovy
+++ b/regression-test/suites/compaction/test_compaction_score_action.groovy
@@ -40,7 +40,7 @@ suite("test_compaction_score_action") {
     for (int i=0;i<backendId_to_backendIP.size();i++){
         def beHttpAddress =backendId_to_backendIP.entrySet()[i].getValue()+":"+backendId_to_backendHttpPort.entrySet()[i].getValue()
         if (isCloudMode()) {
-            def (code, text, err) = curl("GET", beHttpAddress+ "/api/compaction_score?top_n=1&sync_meta=true", null/*body*/, 100/*timeoutSec*/)
+            def (code, text, err) = curl("GET", beHttpAddress+ "/api/compaction_score?top_n=1&sync_meta=true", null/*body*/, 1000/*timeoutSec*/)
             def score_str = parseJson(text).get(0).get("compaction_score")
             def score = Integer.parseInt(score_str)
             assertTrue(score >= 90)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

If compaction score action need to sync meta and rowsets from remote storage, it may take a long time. Enlarge the timeout to stablize the test result.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

