### PR TITLE
[chore](function) function catch std:: exception

### DIFF
--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -196,8 +196,13 @@ public:
         try {
             return prepare(context, block, arguments, result)
                     ->execute(context, block, arguments, result, input_rows_count, dry_run);
-        } catch (const Exception& e) {
-            return e.to_status();
+        } catch (const std::exception& e) {
+            if (const auto* doris_e = dynamic_cast<const doris::Exception*>(&e)) {
+                return doris_e->to_status();
+            } else {
+                return Status::InternalError("Function {} execute failed: {}", get_name(),
+                                             e.what());
+            }
         }
     }
 

--- a/be/test/vec/function/function_throw_exception_test.cpp
+++ b/be/test/vec/function/function_throw_exception_test.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "runtime/primitive_type.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/functions/function.h"
@@ -46,8 +48,31 @@ public:
     }
 };
 
+class MockFunctionThrowStdException : public IFunction {
+public:
+    static constexpr auto name = "mock_function_throw_stdexception";
+    static FunctionPtr create() { return std::make_shared<MockFunctionThrowStdException>(); }
+    String get_name() const override { return name; }
+    bool skip_return_type_check() const override { return true; }
+    bool use_default_implementation_for_constants() const override { return false; }
+
+    size_t get_number_of_arguments() const override { return 0; }
+
+    bool is_variadic() const override { return true; }
+
+    DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
+        return std::make_shared<DataTypeFloat64>();
+    }
+
+    Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                        uint32_t result, size_t input_rows_count) const override {
+        throw std::runtime_error("BEUT TEST: MockFunctionThrowStdException");
+    }
+};
+
 void register_function_throw_exception(SimpleFunctionFactory& factory) {
     factory.register_function<MockFunctionThrowException>();
+    factory.register_function<MockFunctionThrowStdException>();
 }
 
 TEST(FunctionThrowExceptionTest, test_throw_exception) {
@@ -60,5 +85,19 @@ TEST(FunctionThrowExceptionTest, test_throw_exception) {
 
     EXPECT_EQ(st.code(), ErrorCode::INTERNAL_ERROR);
     EXPECT_EQ(st.msg(), "BEUT TEST: MockFunctionThrowException");
+}
+
+TEST(FunctionThrowExceptionTest, test_throw_std_exception) {
+    auto function = SimpleFunctionFactory::instance().get_function(
+            "mock_function_throw_stdexception", {}, std::make_shared<DataTypeFloat64>(), {false},
+            BeExecVersionManager::get_newest_version());
+
+    Block block;
+    auto st = function->execute(nullptr, block, {}, 0, 1);
+
+    EXPECT_EQ(st.code(), ErrorCode::INTERNAL_ERROR);
+    EXPECT_EQ(st.msg(),
+              "Function mock_function_throw_stdexception execute failed: BEUT TEST: "
+              "MockFunctionThrowStdException");
 }
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

before
```
mysql> SELECT id, BITMAP_FROM_BASE64(base64_str) AS result FROM test_bitmap_from_base64;
ERROR 1105 (HY000): RpcException, msg: send fragments failed. io.grpc.StatusRuntimeException: UNAVAILABLE: io exception, host: 127.0.0.1

terminate called after throwing an instance of 'std::runtime_error'
  what():  failed alloc while reading
```

now
```
mysql> SELECT id, BITMAP_FROM_BASE64(base64_str) AS result FROM test_bitmap_from_base64;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]Function bitmap_from_base64 execute failed: failed alloc while reading
```



Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

