### PR TITLE
[chore](cloud) remove versionstamp from the key creation functions

### DIFF
--- a/cloud/src/meta-store/keys.cpp
+++ b/cloud/src/meta-store/keys.cpp
@@ -537,7 +537,7 @@ namespace versioned {
 //==============================================================================
 // Version keys
 //==============================================================================
-void partition_version_key_prefix(const PartitionVersionKeyInfo& in, std::string* out) {
+void partition_version_key(const PartitionVersionKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(VERSION_KEY_PREFIX, out);          // "version"
     encode_bytes(std::get<0>(in), out);             // instance_id
@@ -545,24 +545,12 @@ void partition_version_key_prefix(const PartitionVersionKeyInfo& in, std::string
     encode_int64(std::get<1>(in), out);             // partition_id
 }
 
-void partition_version_key(const PartitionVersionKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "version" ${instance_id} "partition" ${partition_id}
-    partition_version_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
-}
-
-void table_version_key_prefix(const TableVersionKeyInfo& in, std::string* out) {
+void table_version_key(const TableVersionKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(VERSION_KEY_PREFIX, out);      // "version"
     encode_bytes(std::get<0>(in), out);         // instance_id
     encode_bytes(TABLE_VERSION_KEY_INFIX, out); // "table"
     encode_int64(std::get<1>(in), out);         // table_id
-}
-
-void table_version_key(const TableVersionKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "version" ${instance_id} "table" ${table_id}
-    table_version_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
 }
 
 //==============================================================================
@@ -628,7 +616,7 @@ void index_inverted_key(const IndexInvertedKeyInfo& in, std::string* out) {
 //==============================================================================
 // Stats keys
 //==============================================================================
-void tablet_load_stats_key_prefix(const TabletLoadStatsKeyInfo& in, std::string* out) {
+void tablet_load_stats_key(const TabletLoadStatsKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(STATS_KEY_PREFIX, out);            // "stats"
     encode_bytes(std::get<0>(in), out);             // instance_id
@@ -636,13 +624,7 @@ void tablet_load_stats_key_prefix(const TabletLoadStatsKeyInfo& in, std::string*
     encode_int64(std::get<1>(in), out);             // tablet_id
 }
 
-void tablet_load_stats_key(const TabletLoadStatsKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "stats" ${instance_id} "tablet_load" ${tablet_id}
-    tablet_load_stats_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
-}
-
-void tablet_compact_stats_key_prefix(const TabletCompactStatsKeyInfo& in, std::string* out) {
+void tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(STATS_KEY_PREFIX, out);               // "stats"
     encode_bytes(std::get<0>(in), out);                // instance_id
@@ -650,17 +632,10 @@ void tablet_compact_stats_key_prefix(const TabletCompactStatsKeyInfo& in, std::s
     encode_int64(std::get<1>(in), out);                // tablet_id
 }
 
-void tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in, Versionstamp v,
-                              std::string* out) {
-    // 0x03 "stats" ${instance_id} "tablet_compact" ${tablet_id}
-    tablet_compact_stats_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
-}
-
 //==============================================================================
 // Meta keys
 //==============================================================================
-void meta_partition_key_prefix(const MetaPartitionKeyInfo& in, std::string* out) {
+void meta_partition_key(const MetaPartitionKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(META_KEY_PREFIX, out);          // "meta"
     encode_bytes(std::get<0>(in), out);          // instance_id
@@ -668,13 +643,7 @@ void meta_partition_key_prefix(const MetaPartitionKeyInfo& in, std::string* out)
     encode_int64(std::get<1>(in), out);          // partition_id
 }
 
-void meta_partition_key(const MetaPartitionKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "meta" ${instance_id} "partition" ${partition_id}
-    meta_partition_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
-}
-
-void meta_index_key_prefix(const MetaIndexKeyInfo& in, std::string* out) {
+void meta_index_key(const MetaIndexKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(META_KEY_PREFIX, out);      // "meta"
     encode_bytes(std::get<0>(in), out);      // instance_id
@@ -682,24 +651,12 @@ void meta_index_key_prefix(const MetaIndexKeyInfo& in, std::string* out) {
     encode_int64(std::get<1>(in), out);      // index_id
 }
 
-void meta_index_key(const MetaIndexKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "meta" ${instance_id} "index" ${index_id}
-    meta_index_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
-}
-
-void meta_tablet_key_prefix(const versioned::MetaTabletKeyInfo& in, std::string* out) {
+void meta_tablet_key(const versioned::MetaTabletKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(META_KEY_PREFIX, out);       // "meta"
     encode_bytes(std::get<0>(in), out);       // instance_id
     encode_bytes(META_KEY_INFIX_TABLET, out); // "tablet"
     encode_int64(std::get<1>(in), out);       // tablet_id
-}
-
-void meta_tablet_key(const versioned::MetaTabletKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "meta" ${instance_id} "tablet" ${tablet_id}
-    meta_tablet_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
 }
 
 void meta_schema_key(const versioned::MetaSchemaKeyInfo& in, std::string* out) {
@@ -711,7 +668,7 @@ void meta_schema_key(const versioned::MetaSchemaKeyInfo& in, std::string* out) {
     encode_int64(std::get<2>(in), out);       // schema_version
 }
 
-void meta_rowset_load_key_prefix(const MetaRowsetLoadKeyInfo& in, std::string* out) {
+void meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(META_KEY_PREFIX, out);            // "meta"
     encode_bytes(std::get<0>(in), out);            // instance_id
@@ -720,25 +677,13 @@ void meta_rowset_load_key_prefix(const MetaRowsetLoadKeyInfo& in, std::string* o
     encode_int64(std::get<2>(in), out);            // version
 }
 
-void meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "meta" ${instance_id} "rowset_load" ${tablet_id} ${version}
-    meta_rowset_load_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
-}
-
-void meta_rowset_compact_key_prefix(const MetaRowsetCompactKeyInfo& in, std::string* out) {
+void meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(META_KEY_PREFIX, out);               // "meta"
     encode_bytes(std::get<0>(in), out);               // instance_id
     encode_bytes(META_ROWSET_COMPACT_KEY_INFIX, out); // "rowset_compact"
     encode_int64(std::get<1>(in), out);               // tablet_id
     encode_int64(std::get<2>(in), out);               // version
-}
-
-void meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "meta" ${instance_id} "rowset_compact" ${tablet_id} ${version}
-    meta_rowset_compact_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
 }
 
 //==============================================================================
@@ -756,17 +701,11 @@ void data_rowset_ref_count_key(const DataRowsetRefCountKeyInfo& in, std::string*
 //==============================================================================
 // Snapshot keys
 //==============================================================================
-void snapshot_full_key_prefix(const SnapshotFullKeyInfo& in, std::string* out) {
+void snapshot_full_key(const SnapshotFullKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(SNAPSHOT_KEY_PREFIX, out);     // "snapshot"
     encode_bytes(std::get<0>(in), out);         // instance_id
     encode_bytes(SNAPSHOT_FULL_KEY_INFIX, out); // "full"
-}
-
-void snapshot_full_key(const SnapshotFullKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "snapshot" ${instance_id} "full"
-    snapshot_full_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
 }
 
 void snapshot_reference_key(const SnapshotReferenceKeyInfo& in, std::string* out) {
@@ -781,16 +720,10 @@ void snapshot_reference_key(const SnapshotReferenceKeyInfo& in, std::string* out
 //==============================================================================
 // Log keys
 //==============================================================================
-void log_key_prefix(const LogKeyInfo& in, std::string* out) {
+void log_key(const LogKeyInfo& in, std::string* out) {
     out->push_back(CLOUD_VERSIONED_KEY_SPACE03);
     encode_bytes(LOG_KEY_PREFIX, out);  // "log"
     encode_bytes(std::get<0>(in), out); // instance_id
-}
-
-void log_key(const LogKeyInfo& in, Versionstamp v, std::string* out) {
-    // 0x03 "log" ${instance_id}
-    log_key_prefix(in, out);
-    encode_versionstamp(v, out); // versionstamp
 }
 
 } // namespace versioned

--- a/cloud/src/meta-store/keys.h
+++ b/cloud/src/meta-store/keys.h
@@ -227,8 +227,8 @@ using MowTabletJobInfo = BasicKeyInfo<29 , std::tuple<std::string, int64_t, int6
 
 namespace versioned {
 
-// Note: Key info definitions in this namespace do not include timestamp and subsequent attributes.
-// The timestamp and other attributes are implemented as parameters in the key creation functions.
+// ATTN: Key info definitions in this namespace do not include timestamp and subsequent attributes.
+// The timestamp and other attributes are implemented as parameters in the txn put/get functions.
 
 // 0x03 "version" ${instance_id} "partition" ${partition_id} ${timestamp}   -> VersionPB
 //                                                      0:instance_id  1:partition_id
@@ -419,24 +419,12 @@ std::string system_meta_service_encryption_key_info_key();
 
 namespace versioned {
 
-// ATTN: if the versionstamp is NOT provided, the Versionstamp::min() will be used.
-
 // clang-format off
-void partition_version_key_prefix(const PartitionVersionKeyInfo& in, std::string* out);
-static inline std::string partition_version_key_prefix(const PartitionVersionKeyInfo& in) { std::string s; partition_version_key_prefix(in, &s); return s; }
+void partition_version_key(const PartitionVersionKeyInfo& in, std::string* out);
+static inline std::string partition_version_key(const PartitionVersionKeyInfo& in) { std::string s; partition_version_key(in, &s); return s; }
 
-void partition_version_key(const PartitionVersionKeyInfo& in, Versionstamp v, std::string* out);
-static inline void partition_version_key(const PartitionVersionKeyInfo& in, std::string* out) { return partition_version_key(in, Versionstamp::min(), out); }
-static inline std::string partition_version_key(const PartitionVersionKeyInfo& in, Versionstamp v) { std::string s; partition_version_key(in, v, &s); return s; }
-static inline std::string partition_version_key(const PartitionVersionKeyInfo& in) { return partition_version_key(in, Versionstamp::min()); }
-
-void table_version_key_prefix(const TableVersionKeyInfo& in, std::string* out);
-static inline std::string table_version_key_prefix(const TableVersionKeyInfo& in) { std::string s; table_version_key_prefix(in, &s); return s; }
-
-void table_version_key(const TableVersionKeyInfo& in, Versionstamp v, std::string* out);
-static inline void table_version_key(const TableVersionKeyInfo& in, std::string* out) { return table_version_key(in, Versionstamp::min(), out); }
-static inline std::string table_version_key(const TableVersionKeyInfo& in, Versionstamp v) { std::string s; table_version_key(in, v, &s); return s; }
-static inline std::string table_version_key(const TableVersionKeyInfo& in) { return table_version_key(in, Versionstamp::min()); }
+void table_version_key(const TableVersionKeyInfo& in, std::string* out);
+static inline std::string table_version_key(const TableVersionKeyInfo& in) { std::string s; table_version_key(in, &s); return s; }
 
 void partition_index_key(const PartitionIndexKeyInfo& in, std::string* out);
 static inline std::string partition_index_key(const PartitionIndexKeyInfo& in) { std::string s; partition_index_key(in, &s); return s; }
@@ -456,86 +444,41 @@ static inline std::string index_index_key(const IndexIndexKeyInfo& in) { std::st
 void index_inverted_key(const IndexInvertedKeyInfo& in, std::string* out);
 static inline std::string index_inverted_key(const IndexInvertedKeyInfo& in) { std::string s; index_inverted_key(in, &s); return s; }
 
-void tablet_load_stats_key_prefix(const TabletLoadStatsKeyInfo& in, std::string* out);
-static inline std::string tablet_load_stats_key_prefix(const TabletLoadStatsKeyInfo& in) { std::string s; tablet_load_stats_key_prefix(in, &s); return s; }
+void tablet_load_stats_key(const TabletLoadStatsKeyInfo& in, std::string* out);
+static inline std::string tablet_load_stats_key(const TabletLoadStatsKeyInfo& in) { std::string s; tablet_load_stats_key(in, &s); return s; }
 
-void tablet_load_stats_key(const TabletLoadStatsKeyInfo& in, Versionstamp v, std::string* out);
-static inline void tablet_load_stats_key(const TabletLoadStatsKeyInfo& in, std::string* out) { return tablet_load_stats_key(in, Versionstamp::min(), out); }
-static inline std::string tablet_load_stats_key(const TabletLoadStatsKeyInfo& in, Versionstamp v) { std::string s; tablet_load_stats_key(in, v, &s); return s; }
-static inline std::string tablet_load_stats_key(const TabletLoadStatsKeyInfo& in) { return tablet_load_stats_key(in, Versionstamp::min()); }
+void tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in, std::string* out);
+static inline std::string tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in) { std::string s; tablet_compact_stats_key(in, &s); return s; }
 
-void tablet_compact_stats_key_prefix(const TabletCompactStatsKeyInfo& in, std::string* out);
-static inline std::string tablet_compact_stats_key_prefix(const TabletCompactStatsKeyInfo& in) { std::string s; tablet_compact_stats_key_prefix(in, &s); return s; }
+void meta_partition_key(const MetaPartitionKeyInfo& in, std::string* out);
+static inline std::string meta_partition_key(const MetaPartitionKeyInfo& in) { std::string s; meta_partition_key(in, &s); return s; }
 
-void tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in, Versionstamp v, std::string* out);
-static inline void tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in, std::string* out) { return tablet_compact_stats_key(in, Versionstamp::min(), out); }
-static inline std::string tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in, Versionstamp v) { std::string s; tablet_compact_stats_key(in, v, &s); return s; }
-static inline std::string tablet_compact_stats_key(const TabletCompactStatsKeyInfo& in) { return tablet_compact_stats_key(in, Versionstamp::min()); }
+void meta_index_key(const MetaIndexKeyInfo& in, std::string* out);
+static inline std::string meta_index_key(const MetaIndexKeyInfo& in) { std::string s; meta_index_key(in, &s); return s; }
 
-void meta_partition_key_prefix(const MetaPartitionKeyInfo& in, std::string* out);
-static inline std::string meta_partition_key_prefix(const MetaPartitionKeyInfo& in) { std::string s; meta_partition_key_prefix(in, &s); return s; }
-
-void meta_partition_key(const MetaPartitionKeyInfo& in, Versionstamp v, std::string* out);
-static inline void meta_partition_key(const MetaPartitionKeyInfo& in, std::string* out) { return meta_partition_key(in, Versionstamp::min(), out); }
-static inline std::string meta_partition_key(const MetaPartitionKeyInfo& in, Versionstamp v) { std::string s; meta_partition_key(in, v, &s); return s; }
-static inline std::string meta_partition_key(const MetaPartitionKeyInfo& in) { return meta_partition_key(in, Versionstamp::min()); }
-
-void meta_index_key_prefix(const MetaIndexKeyInfo& in, std::string* out);
-static inline std::string meta_index_key_prefix(const MetaIndexKeyInfo& in) { std::string s; meta_index_key_prefix(in, &s); return s; }
-
-void meta_index_key(const MetaIndexKeyInfo& in, Versionstamp v, std::string* out);
-static inline void meta_index_key(const MetaIndexKeyInfo& in, std::string* out) { return meta_index_key(in, Versionstamp::min(), out); }
-static inline std::string meta_index_key(const MetaIndexKeyInfo& in, Versionstamp v) { std::string s; meta_index_key(in, v, &s); return s; }
-static inline std::string meta_index_key(const MetaIndexKeyInfo& in) { return meta_index_key(in, Versionstamp::min()); }
-
-void meta_tablet_key_prefix(const versioned::MetaTabletKeyInfo& in, std::string* out);
-static inline std::string meta_tablet_key_prefix(const versioned::MetaTabletKeyInfo& in) { std::string s; meta_tablet_key_prefix(in, &s); return s; }
-
-void meta_tablet_key(const versioned::MetaTabletKeyInfo& in, Versionstamp v, std::string* out);
-static inline void meta_tablet_key(const versioned::MetaTabletKeyInfo& in, std::string* out) { return meta_tablet_key(in, Versionstamp::min(), out); }
-static inline std::string meta_tablet_key(const versioned::MetaTabletKeyInfo& in, Versionstamp v) { std::string s; meta_tablet_key(in, v, &s); return s; }
-static inline std::string meta_tablet_key(const versioned::MetaTabletKeyInfo& in) { return meta_tablet_key(in, Versionstamp::min()); }
+void meta_tablet_key(const versioned::MetaTabletKeyInfo& in, std::string* out);
+static inline std::string meta_tablet_key(const versioned::MetaTabletKeyInfo& in) { std::string s; meta_tablet_key(in, &s); return s; }
 
 void meta_schema_key(const versioned::MetaSchemaKeyInfo& in, std::string* out);
 static inline std::string meta_schema_key(const versioned::MetaSchemaKeyInfo& in) { std::string s; meta_schema_key(in, &s); return s; }
 
-void meta_rowset_load_key_prefix(const MetaRowsetLoadKeyInfo& in, std::string* out);
-static inline std::string meta_rowset_load_key_prefix(const MetaRowsetLoadKeyInfo& in) { std::string s; meta_rowset_load_key_prefix(in, &s); return s; }
+void meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in, std::string* out);
+static inline std::string meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in) { std::string s; meta_rowset_load_key(in, &s); return s; }
 
-void meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in, Versionstamp v, std::string* out);
-static inline void meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in, std::string* out) { return meta_rowset_load_key(in, Versionstamp::min(), out); }
-static inline std::string meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in, Versionstamp v) { std::string s; meta_rowset_load_key(in, v, &s); return s; }
-static inline std::string meta_rowset_load_key(const MetaRowsetLoadKeyInfo& in) { return meta_rowset_load_key(in, Versionstamp::min()); }
-
-void meta_rowset_compact_key_prefix(const MetaRowsetCompactKeyInfo& in, std::string* out);
-static inline std::string meta_rowset_compact_key_prefix(const MetaRowsetCompactKeyInfo& in) { std::string s; meta_rowset_compact_key_prefix(in, &s); return s; }
-
-void meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in, Versionstamp v, std::string* out);
-static inline void meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in, std::string* out) { return meta_rowset_compact_key(in, Versionstamp::min(), out); }
-static inline std::string meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in, Versionstamp v) { std::string s; meta_rowset_compact_key(in, v, &s); return s; }
-static inline std::string meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in) { return meta_rowset_compact_key(in, Versionstamp::min()); }
+void meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in, std::string* out);
+static inline std::string meta_rowset_compact_key(const MetaRowsetCompactKeyInfo& in) { std::string s; meta_rowset_compact_key(in, &s); return s; }
 
 void data_rowset_ref_count_key(const DataRowsetRefCountKeyInfo& in, std::string* out);
 static inline std::string data_rowset_ref_count_key(const DataRowsetRefCountKeyInfo& in) { std::string s; data_rowset_ref_count_key(in, &s); return s; }
 
-void snapshot_full_key_prefix(const SnapshotFullKeyInfo& in, std::string* out);
-static inline std::string snapshot_full_key_prefix(const SnapshotFullKeyInfo& in) { std::string s; snapshot_full_key_prefix(in, &s); return s; }
-
-void snapshot_full_key(const SnapshotFullKeyInfo& in, Versionstamp v, std::string* out);
-static inline void snapshot_full_key(const SnapshotFullKeyInfo& in, std::string* out) { return snapshot_full_key(in, Versionstamp::min(), out); }
-static inline std::string snapshot_full_key(const SnapshotFullKeyInfo& in, Versionstamp v) { std::string s; snapshot_full_key(in, v, &s); return s; }
-static inline std::string snapshot_full_key(const SnapshotFullKeyInfo& in) { return snapshot_full_key(in, Versionstamp::min()); }
+void snapshot_full_key(const SnapshotFullKeyInfo& in, std::string* out);
+static inline std::string snapshot_full_key(const SnapshotFullKeyInfo& in) { std::string s; snapshot_full_key(in, &s); return s; }
 
 void snapshot_reference_key(const SnapshotReferenceKeyInfo& in, std::string* out);
 static inline std::string snapshot_reference_key(const SnapshotReferenceKeyInfo& in) { std::string s; snapshot_reference_key(in, &s); return s; }
 
-void log_key_prefix(const LogKeyInfo& in, std::string* out);
-static inline std::string log_key_prefix(const LogKeyInfo& in) { std::string s; log_key_prefix(in, &s); return s; }
-
-void log_key(const LogKeyInfo& in, Versionstamp v, std::string* out);
-static inline void log_key(const LogKeyInfo& in, std::string* out) { return log_key(in, Versionstamp::min(), out); }
-static inline std::string log_key(const LogKeyInfo& in, Versionstamp v) { std::string s; log_key(in, v, &s); return s; }
-static inline std::string log_key(const LogKeyInfo& in) { return log_key(in, Versionstamp::min()); }
+void log_key(const LogKeyInfo& in, std::string* out);
+static inline std::string log_key(const LogKeyInfo& in) { std::string s; log_key(in, &s); return s; }
 
 // clang-format on
 

--- a/cloud/test/keys_test.cpp
+++ b/cloud/test/keys_test.cpp
@@ -1100,19 +1100,17 @@ TEST(KeysTest, VersionedPartitionVersionKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t partition_id = 123456;
 
     {
-        // test partition_version_key_prefix
+        // test partition_version_key
 
         // 0x03 "version" ${instance_id} "partition" ${partition_id} ${timestamp}   -> VersionPB
         PartitionVersionKeyInfo partition_key {instance_id, partition_id};
         std::string encoded_partition_key;
-        partition_version_key_prefix(partition_key, &encoded_partition_key);
+        partition_version_key(partition_key, &encoded_partition_key);
 
         std::string decoded_version_prefix;
         std::string decoded_instance_id;
@@ -1131,38 +1129,6 @@ TEST(KeysTest, VersionedPartitionVersionKeyTest) {
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("partition", decoded_partition_prefix);
         EXPECT_EQ(partition_id, decoded_partition_id);
-    }
-
-    Versionstamp timestamp(123, 12);
-    {
-        // test partition_version_key
-
-        // 0x03 "version" ${instance_id} "partition" ${partition_id} ${timestamp} -> VersionPB
-        PartitionVersionKeyInfo partition_key {instance_id, partition_id};
-        std::string encoded_partition_key;
-        partition_version_key(partition_key, timestamp, &encoded_partition_key);
-
-        std::string decoded_version_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_partition_prefix;
-        int64_t decoded_partition_id;
-        Versionstamp decoded_timestamp;
-
-        std::string_view key_sv(encoded_partition_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_version_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_partition_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_partition_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("version", decoded_version_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("partition", decoded_partition_prefix);
-        EXPECT_EQ(partition_id, decoded_partition_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1170,53 +1136,22 @@ TEST(KeysTest, VersionedTableVersionKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t table_id = 456;
 
-    {
-        // test table_version_key_prefix
-
-        // 0x03 "version" ${instance_id} "table" ${table_id} ${timestamp} -> ${empty_value}
-        TableVersionKeyInfo table_key {instance_id, table_id};
-        std::string encoded_table_key;
-        table_version_key_prefix(table_key, &encoded_table_key);
-
-        std::string decoded_version_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_table_prefix;
-        int64_t decoded_table_id;
-
-        std::string_view key_sv(encoded_table_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_version_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_table_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_table_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("version", decoded_version_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("table", decoded_table_prefix);
-        EXPECT_EQ(table_id, decoded_table_id);
-    }
-
-    Versionstamp timestamp(456, 78);
     {
         // test table_version_key
 
         // 0x03 "version" ${instance_id} "table" ${table_id} ${timestamp} -> ${empty_value}
         TableVersionKeyInfo table_key {instance_id, table_id};
         std::string encoded_table_key;
-        table_version_key(table_key, timestamp, &encoded_table_key);
+        table_version_key(table_key, &encoded_table_key);
 
         std::string decoded_version_prefix;
         std::string decoded_instance_id;
         std::string decoded_table_prefix;
         int64_t decoded_table_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_table_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1224,15 +1159,12 @@ TEST(KeysTest, VersionedTableVersionKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_table_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_table_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("version", decoded_version_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("table", decoded_table_prefix);
         EXPECT_EQ(table_id, decoded_table_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1495,53 +1427,22 @@ TEST(KeysTest, VersionedTabletLoadStatsKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t tablet_id = 789;
 
-    {
-        // test tablet_load_stats_key_prefix
-
-        // 0x03 "stats" ${instance_id} "tablet_load" ${tablet_id} ${timestamp} -> TabletStatsPB
-        TabletLoadStatsKeyInfo tablet_load_stats_info {instance_id, tablet_id};
-        std::string encoded_tablet_load_stats_key;
-        tablet_load_stats_key_prefix(tablet_load_stats_info, &encoded_tablet_load_stats_key);
-
-        std::string decoded_stats_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_tablet_load_prefix;
-        int64_t decoded_tablet_id;
-
-        std::string_view key_sv(encoded_tablet_load_stats_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_stats_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_tablet_load_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("stats", decoded_stats_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("tablet_load", decoded_tablet_load_prefix);
-        EXPECT_EQ(tablet_id, decoded_tablet_id);
-    }
-
-    Versionstamp timestamp(555, 33);
     {
         // test tablet_load_stats_key
 
         // 0x03 "stats" ${instance_id} "tablet_load" ${tablet_id} ${timestamp} -> TabletStatsPB
         TabletLoadStatsKeyInfo tablet_load_stats_info {instance_id, tablet_id};
         std::string encoded_tablet_load_stats_key;
-        tablet_load_stats_key(tablet_load_stats_info, timestamp, &encoded_tablet_load_stats_key);
+        tablet_load_stats_key(tablet_load_stats_info, &encoded_tablet_load_stats_key);
 
         std::string decoded_stats_prefix;
         std::string decoded_instance_id;
         std::string decoded_tablet_load_prefix;
         int64_t decoded_tablet_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_tablet_load_stats_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1549,15 +1450,12 @@ TEST(KeysTest, VersionedTabletLoadStatsKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_tablet_load_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("stats", decoded_stats_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("tablet_load", decoded_tablet_load_prefix);
         EXPECT_EQ(tablet_id, decoded_tablet_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1565,55 +1463,22 @@ TEST(KeysTest, VersionedTabletCompactStatsKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t tablet_id = 789;
 
-    {
-        // test tablet_compact_stats_key_prefix
-
-        // 0x03 "stats" ${instance_id} "tablet_compact" ${tablet_id} ${timestamp} -> TabletStatsPB
-        TabletCompactStatsKeyInfo tablet_compact_stats_info {instance_id, tablet_id};
-        std::string encoded_tablet_compact_stats_key;
-        tablet_compact_stats_key_prefix(tablet_compact_stats_info,
-                                        &encoded_tablet_compact_stats_key);
-
-        std::string decoded_stats_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_tablet_compact_prefix;
-        int64_t decoded_tablet_id;
-
-        std::string_view key_sv(encoded_tablet_compact_stats_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_stats_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_tablet_compact_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("stats", decoded_stats_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("tablet_compact", decoded_tablet_compact_prefix);
-        EXPECT_EQ(tablet_id, decoded_tablet_id);
-    }
-
-    Versionstamp timestamp(777, 99);
     {
         // test tablet_compact_stats_key
 
         // 0x03 "stats" ${instance_id} "tablet_compact" ${tablet_id} ${timestamp} -> TabletStatsPB
         TabletCompactStatsKeyInfo tablet_compact_stats_info {instance_id, tablet_id};
         std::string encoded_tablet_compact_stats_key;
-        tablet_compact_stats_key(tablet_compact_stats_info, timestamp,
-                                 &encoded_tablet_compact_stats_key);
+        tablet_compact_stats_key(tablet_compact_stats_info, &encoded_tablet_compact_stats_key);
 
         std::string decoded_stats_prefix;
         std::string decoded_instance_id;
         std::string decoded_tablet_compact_prefix;
         int64_t decoded_tablet_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_tablet_compact_stats_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1621,15 +1486,12 @@ TEST(KeysTest, VersionedTabletCompactStatsKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_tablet_compact_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("stats", decoded_stats_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("tablet_compact", decoded_tablet_compact_prefix);
         EXPECT_EQ(tablet_id, decoded_tablet_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1637,53 +1499,22 @@ TEST(KeysTest, VersionedMetaPartitionKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t partition_id = 789;
 
-    {
-        // test meta_partition_key_prefix
-
-        // 0x03 "meta" ${instance_id} "partition" ${partition_id} ${timestamp} -> ${empty_value}
-        MetaPartitionKeyInfo meta_partition_info {instance_id, partition_id};
-        std::string encoded_meta_partition_key;
-        meta_partition_key_prefix(meta_partition_info, &encoded_meta_partition_key);
-
-        std::string decoded_meta_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_partition_prefix;
-        int64_t decoded_partition_id;
-
-        std::string_view key_sv(encoded_meta_partition_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_meta_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_partition_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_partition_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("meta", decoded_meta_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("partition", decoded_partition_prefix);
-        EXPECT_EQ(partition_id, decoded_partition_id);
-    }
-
-    Versionstamp timestamp(888, 66);
     {
         // test meta_partition_key
 
         // 0x03 "meta" ${instance_id} "partition" ${partition_id} ${timestamp} -> ${empty_value}
         MetaPartitionKeyInfo meta_partition_info {instance_id, partition_id};
         std::string encoded_meta_partition_key;
-        meta_partition_key(meta_partition_info, timestamp, &encoded_meta_partition_key);
+        meta_partition_key(meta_partition_info, &encoded_meta_partition_key);
 
         std::string decoded_meta_prefix;
         std::string decoded_instance_id;
         std::string decoded_partition_prefix;
         int64_t decoded_partition_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_meta_partition_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1691,15 +1522,12 @@ TEST(KeysTest, VersionedMetaPartitionKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_partition_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_partition_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("meta", decoded_meta_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("partition", decoded_partition_prefix);
         EXPECT_EQ(partition_id, decoded_partition_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1707,53 +1535,22 @@ TEST(KeysTest, VersionedMetaIndexKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t index_id = 789;
 
-    {
-        // test meta_index_key_prefix
-
-        // 0x03 "meta" ${instance_id} "index" ${index_id} ${timestamp} -> ${empty_value}
-        MetaIndexKeyInfo meta_index_info {instance_id, index_id};
-        std::string encoded_meta_index_key;
-        meta_index_key_prefix(meta_index_info, &encoded_meta_index_key);
-
-        std::string decoded_meta_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_index_prefix;
-        int64_t decoded_index_id;
-
-        std::string_view key_sv(encoded_meta_index_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_meta_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_index_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_index_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("meta", decoded_meta_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("index", decoded_index_prefix);
-        EXPECT_EQ(index_id, decoded_index_id);
-    }
-
-    Versionstamp timestamp(999, 11);
     {
         // test meta_index_key
 
         // 0x03 "meta" ${instance_id} "index" ${index_id} ${timestamp} -> ${empty_value}
         MetaIndexKeyInfo meta_index_info {instance_id, index_id};
         std::string encoded_meta_index_key;
-        meta_index_key(meta_index_info, timestamp, &encoded_meta_index_key);
+        meta_index_key(meta_index_info, &encoded_meta_index_key);
 
         std::string decoded_meta_prefix;
         std::string decoded_instance_id;
         std::string decoded_index_prefix;
         int64_t decoded_index_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_meta_index_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1761,15 +1558,12 @@ TEST(KeysTest, VersionedMetaIndexKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_index_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_index_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("meta", decoded_meta_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("index", decoded_index_prefix);
         EXPECT_EQ(index_id, decoded_index_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1777,53 +1571,22 @@ TEST(KeysTest, VersionedMetaTabletKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t tablet_id = 789;
 
-    {
-        // test meta_tablet_key_prefix
-
-        // 0x03 "meta" ${instance_id} "tablet" ${tablet_id} ${timestamp} -> TabletMetaPB
-        doris::cloud::versioned::MetaTabletKeyInfo meta_tablet_info {instance_id, tablet_id};
-        std::string encoded_meta_tablet_key;
-        meta_tablet_key_prefix(meta_tablet_info, &encoded_meta_tablet_key);
-
-        std::string decoded_meta_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_tablet_prefix;
-        int64_t decoded_tablet_id;
-
-        std::string_view key_sv(encoded_meta_tablet_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_meta_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_tablet_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("meta", decoded_meta_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("tablet", decoded_tablet_prefix);
-        EXPECT_EQ(tablet_id, decoded_tablet_id);
-    }
-
-    Versionstamp timestamp(111, 22);
     {
         // test meta_tablet_key
 
         // 0x03 "meta" ${instance_id} "tablet" ${tablet_id} ${timestamp} -> TabletMetaPB
         doris::cloud::versioned::MetaTabletKeyInfo meta_tablet_info {instance_id, tablet_id};
         std::string encoded_meta_tablet_key;
-        meta_tablet_key(meta_tablet_info, timestamp, &encoded_meta_tablet_key);
+        meta_tablet_key(meta_tablet_info, &encoded_meta_tablet_key);
 
         std::string decoded_meta_prefix;
         std::string decoded_instance_id;
         std::string decoded_tablet_prefix;
         int64_t decoded_tablet_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_meta_tablet_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1831,15 +1594,12 @@ TEST(KeysTest, VersionedMetaTabletKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_tablet_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("meta", decoded_meta_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("tablet", decoded_tablet_prefix);
         EXPECT_EQ(tablet_id, decoded_tablet_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1888,58 +1648,24 @@ TEST(KeysTest, VersionedMetaRowsetLoadKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t tablet_id = 789;
     int64_t version = 123;
 
     {
-        // test meta_rowset_load_key_prefix
-
-        // 0x03 "meta" ${instance_id} "rowset_load" ${tablet_id} ${version} ${timestamp} -> RowsetMetaPB
-        MetaRowsetLoadKeyInfo meta_rowset_load_info {instance_id, tablet_id, version};
-        std::string encoded_meta_rowset_load_key;
-        meta_rowset_load_key_prefix(meta_rowset_load_info, &encoded_meta_rowset_load_key);
-
-        std::string decoded_meta_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_rowset_load_prefix;
-        int64_t decoded_tablet_id;
-        int64_t decoded_version;
-
-        std::string_view key_sv(encoded_meta_rowset_load_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_meta_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_rowset_load_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_version), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("meta", decoded_meta_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("rowset_load", decoded_rowset_load_prefix);
-        EXPECT_EQ(tablet_id, decoded_tablet_id);
-        EXPECT_EQ(version, decoded_version);
-    }
-
-    Versionstamp timestamp(333, 44);
-    {
         // test meta_rowset_load_key
 
         // 0x03 "meta" ${instance_id} "rowset_load" ${tablet_id} ${version} ${timestamp} -> RowsetMetaPB
         MetaRowsetLoadKeyInfo meta_rowset_load_info {instance_id, tablet_id, version};
         std::string encoded_meta_rowset_load_key;
-        meta_rowset_load_key(meta_rowset_load_info, timestamp, &encoded_meta_rowset_load_key);
+        meta_rowset_load_key(meta_rowset_load_info, &encoded_meta_rowset_load_key);
 
         std::string decoded_meta_prefix;
         std::string decoded_instance_id;
         std::string decoded_rowset_load_prefix;
         int64_t decoded_tablet_id;
         int64_t decoded_version;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_meta_rowset_load_key);
         remove_versioned_space_prefix(&key_sv);
@@ -1948,7 +1674,6 @@ TEST(KeysTest, VersionedMetaRowsetLoadKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_rowset_load_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_version), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("meta", decoded_meta_prefix);
@@ -1956,8 +1681,6 @@ TEST(KeysTest, VersionedMetaRowsetLoadKeyTest) {
         EXPECT_EQ("rowset_load", decoded_rowset_load_prefix);
         EXPECT_EQ(tablet_id, decoded_tablet_id);
         EXPECT_EQ(version, decoded_version);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -1965,59 +1688,24 @@ TEST(KeysTest, VersionedMetaRowsetCompactKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
     using doris::cloud::decode_int64;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
     int64_t tablet_id = 789;
     int64_t version = 123;
 
     {
-        // test meta_rowset_compact_key_prefix
-
-        // 0x03 "meta" ${instance_id} "rowset_compact" ${tablet_id} ${version} ${timestamp} -> RowsetMetaPB
-        MetaRowsetCompactKeyInfo meta_rowset_compact_info {instance_id, tablet_id, version};
-        std::string encoded_meta_rowset_compact_key;
-        meta_rowset_compact_key_prefix(meta_rowset_compact_info, &encoded_meta_rowset_compact_key);
-
-        std::string decoded_meta_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_rowset_compact_prefix;
-        int64_t decoded_tablet_id;
-        int64_t decoded_version;
-
-        std::string_view key_sv(encoded_meta_rowset_compact_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_meta_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_rowset_compact_prefix), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
-        ASSERT_EQ(decode_int64(&key_sv, &decoded_version), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("meta", decoded_meta_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("rowset_compact", decoded_rowset_compact_prefix);
-        EXPECT_EQ(tablet_id, decoded_tablet_id);
-        EXPECT_EQ(version, decoded_version);
-    }
-
-    Versionstamp timestamp(555, 66);
-    {
         // test meta_rowset_compact_key
 
         // 0x03 "meta" ${instance_id} "rowset_compact" ${tablet_id} ${version} ${timestamp} -> RowsetMetaPB
         MetaRowsetCompactKeyInfo meta_rowset_compact_info {instance_id, tablet_id, version};
         std::string encoded_meta_rowset_compact_key;
-        meta_rowset_compact_key(meta_rowset_compact_info, timestamp,
-                                &encoded_meta_rowset_compact_key);
+        meta_rowset_compact_key(meta_rowset_compact_info, &encoded_meta_rowset_compact_key);
 
         std::string decoded_meta_prefix;
         std::string decoded_instance_id;
         std::string decoded_rowset_compact_prefix;
         int64_t decoded_tablet_id;
         int64_t decoded_version;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_meta_rowset_compact_key);
         remove_versioned_space_prefix(&key_sv);
@@ -2026,7 +1714,6 @@ TEST(KeysTest, VersionedMetaRowsetCompactKeyTest) {
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_rowset_compact_prefix), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_tablet_id), 0);
         ASSERT_EQ(decode_int64(&key_sv, &decoded_version), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("meta", decoded_meta_prefix);
@@ -2034,10 +1721,9 @@ TEST(KeysTest, VersionedMetaRowsetCompactKeyTest) {
         EXPECT_EQ("rowset_compact", decoded_rowset_compact_prefix);
         EXPECT_EQ(tablet_id, decoded_tablet_id);
         EXPECT_EQ(version, decoded_version);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
+
 TEST(KeysTest, VersionedDataRowsetRefCountKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
@@ -2081,62 +1767,31 @@ TEST(KeysTest, VersionedDataRowsetRefCountKeyTest) {
 TEST(KeysTest, VersionedSnapshotFullKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
 
-    {
-        // test snapshot_full_key_prefix
-
-        // 0x03 "snapshot" ${instance_id} "full" ${timestamp} -> SnapshotPB
-        SnapshotFullKeyInfo snapshot_full_info {instance_id};
-        std::string encoded_snapshot_full_key;
-        snapshot_full_key_prefix(snapshot_full_info, &encoded_snapshot_full_key);
-
-        std::string decoded_snapshot_prefix;
-        std::string decoded_instance_id;
-        std::string decoded_full_prefix;
-
-        std::string_view key_sv(encoded_snapshot_full_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_snapshot_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_full_prefix), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("snapshot", decoded_snapshot_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ("full", decoded_full_prefix);
-    }
-
-    Versionstamp timestamp(777, 88);
     {
         // test snapshot_full_key
 
         // 0x03 "snapshot" ${instance_id} "full" ${timestamp} -> SnapshotPB
         SnapshotFullKeyInfo snapshot_full_info {instance_id};
         std::string encoded_snapshot_full_key;
-        snapshot_full_key(snapshot_full_info, timestamp, &encoded_snapshot_full_key);
+        snapshot_full_key(snapshot_full_info, &encoded_snapshot_full_key);
 
         std::string decoded_snapshot_prefix;
         std::string decoded_instance_id;
         std::string decoded_full_prefix;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_snapshot_full_key);
         remove_versioned_space_prefix(&key_sv);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_snapshot_prefix), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_full_prefix), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("snapshot", decoded_snapshot_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
         EXPECT_EQ("full", decoded_full_prefix);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }
 
@@ -2185,55 +1840,27 @@ TEST(KeysTest, VersionedSnapshotReferenceKeyTest) {
 TEST(KeysTest, VersionedLogKeyTest) {
     using namespace doris::cloud::versioned;
     using doris::cloud::decode_bytes;
-    using doris::cloud::decode_versionstamp;
-    using doris::cloud::Versionstamp;
 
     std::string instance_id = "instance_id";
 
-    {
-        // test log_key_prefix
-
-        // 0x03 "log" ${instance_id} ${timestamp} -> OperationLogPB
-        LogKeyInfo log_info {instance_id};
-        std::string encoded_log_key;
-        log_key_prefix(log_info, &encoded_log_key);
-
-        std::string decoded_log_prefix;
-        std::string decoded_instance_id;
-
-        std::string_view key_sv(encoded_log_key);
-        remove_versioned_space_prefix(&key_sv);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_log_prefix), 0);
-        ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_TRUE(key_sv.empty());
-
-        EXPECT_EQ("log", decoded_log_prefix);
-        EXPECT_EQ(instance_id, decoded_instance_id);
-    }
-
-    Versionstamp timestamp(999, 111);
     {
         // test log_key
 
         // 0x03 "log" ${instance_id} ${timestamp} -> OperationLogPB
         LogKeyInfo log_info {instance_id};
         std::string encoded_log_key;
-        log_key(log_info, timestamp, &encoded_log_key);
+        log_key(log_info, &encoded_log_key);
 
         std::string decoded_log_prefix;
         std::string decoded_instance_id;
-        Versionstamp decoded_timestamp;
 
         std::string_view key_sv(encoded_log_key);
         remove_versioned_space_prefix(&key_sv);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_log_prefix), 0);
         ASSERT_EQ(decode_bytes(&key_sv, &decoded_instance_id), 0);
-        ASSERT_EQ(decode_versionstamp(&key_sv, &decoded_timestamp), 0);
         ASSERT_TRUE(key_sv.empty());
 
         EXPECT_EQ("log", decoded_log_prefix);
         EXPECT_EQ(instance_id, decoded_instance_id);
-        EXPECT_EQ(timestamp.version(), decoded_timestamp.version());
-        EXPECT_EQ(timestamp.order(), decoded_timestamp.order());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Since the versionstamp is encoded in the document_put/get functions.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

