### PR TITLE
[fix](mtmv) release read lock when align mvmv's partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -234,8 +234,6 @@ public class MTMVTask extends AbstractTask {
             } finally {
                 MetaLockUtils.readUnlockTables(tableIfs);
             }
-
-
             this.refreshMode = generateRefreshMode(needRefreshPartitions);
             if (refreshMode == MTMVTaskRefreshMode.NOT_REFRESH) {
                 return;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.job.extensions.mtmv;
 
+import org.apache.doris.analysis.PartitionKeyDesc;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
@@ -27,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugPointUtil;
@@ -195,6 +197,7 @@ public class MTMVTask extends AbstractTask {
             tableIfs.sort(Comparator.comparing(TableIf::getId));
 
             MTMVRefreshContext context;
+            Pair<List<String>, List<PartitionKeyDesc>> syncPartitions = null;
             // lock table order by id to avoid deadlock
             MetaLockUtils.readLockTables(tableIfs);
             try {
@@ -211,13 +214,28 @@ public class MTMVTask extends AbstractTask {
                                 + " e.g. Table has multiple partition columns"
                                 + " or including not supported transform functions.");
                     }
-                    MTMVPartitionUtil.alignMvPartition(mtmv);
+                    syncPartitions = MTMVPartitionUtil.alignMvPartition(mtmv);
                 }
+            } finally {
+                MetaLockUtils.readUnlockTables(tableIfs);
+            }
+            if (syncPartitions != null) {
+                for (String pName : syncPartitions.first) {
+                    MTMVPartitionUtil.dropPartition(mtmv, pName);
+                }
+                for (PartitionKeyDesc partitionKeyDesc : syncPartitions.second) {
+                    MTMVPartitionUtil.addPartition(mtmv, partitionKeyDesc);
+                }
+            }
+            MetaLockUtils.readLockTables(tableIfs);
+            try {
                 context = MTMVRefreshContext.buildContext(mtmv);
                 this.needRefreshPartitions = calculateNeedRefreshPartitions(context);
             } finally {
                 MetaLockUtils.readUnlockTables(tableIfs);
             }
+
+
             this.refreshMode = generateRefreshMode(needRefreshPartitions);
             if (refreshMode == MTMVTaskRefreshMode.NOT_REFRESH) {
                 return;


### PR DESCRIPTION
### What problem does this PR solve?
I found a dead lock logic in the mv task dispatch.
In the following picture, both the table A and table B are MVs.
Thread 7 holds table-A's read lock to align partitions. It will add or drop the table-B's partitions.
Thread 1 wants to get table-A's write lock to drop some partitions, and it is blocked.
Thread 6 holds table-B's read lock and it want to get table-A's read lock to generate plan. Because the table lock is fair, thread 6 is blocked and placed after thread 1.
This state will last for one minute until thread 6 timeout to get table-A's read lock. But if thread 7 needs to manipulate a large number of partitions, the probability of this situation occurring will be very high.

<img width="739" height="437" alt="Clipboard_Screenshot_1752477315" src="https://github.com/user-attachments/assets/14ce7a6f-51dc-40b7-8090-19a2f420501e" />

Resolve lock conflic.

After thie PR, if this mv uses an olap table as base table, the olap table's partition may changes.
For example:
```
create table lineitem (
l_shipdate datetime
)
PARTITION BY RANGE(l_shipdate) (
  FROM ('2020-01-01') TO ('2020-02-10') INTERVAL 1 DAY
);

CREATE MATERIALIZED VIEW mv_t
REFRESH AUTO ON SCHEDULE EVERY 1 hour
PARTITION by(order_date_month)
AS
SELECT 
date_trunc(o_orderdate, 'month') as order_date_month
 FROM lineitem;
```
1. align the partitions:
'2020-01-01' -> '2020-01-01', '2020-01-02', ..., '2020-01-31'
'2020-02-01' -> '2020-02-01', '2020-02-02', ..., '2020-02-09'
2. add and drop partitions in mv:
create two partitions in mv_t: '2020-01-01' and '2020-02-01'.
3. The table `lineitem`'s partitions may changes:
```
alter table lineitem drop partition p20200101;
alter table lineitme add partition p20200220 ...;
alter table lineitme add partition p20200320 ...;
```
4. Build `MTMVRefreshContext` and calculateNeedRefreshPartitions:
4.1 `partitionMappings` is:
'2020-01-01' -> '2020-01-02',..., '2020-01-31'
'2020-02-01' ->  '2020-02-01', '2020-02-02', ..., '2020-02-09', '2020-02-20'
4.2 generate table versions and partitions vertions.
4.3 The partitions that need refresh are:
'2020-01-01' because partition '2020-01-01' is dropped.
'2020-02-01' becuause new partition '2020-02-20' is added.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

