### PR TITLE
[opt](like) use a unified re2 initialization function and disable re2 logging

### DIFF
--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -905,14 +905,12 @@ Status FunctionLike::construct_like_const_state(FunctionContext* context, const 
             state->search_state.hs_database.reset();
             state->search_state.hs_scratch.reset();
 
-            std::unique_ptr<re2::RE2> re;
             std::string error_str;
             bool st = StringFunctions::compile_regex(pattern, &error_str, StringRef(), StringRef(),
-                                                     re);
+                                                     state->search_state.regex);
             if (!st) {
                 return Status::InternalError(error_str);
             }
-            state->search_state.regex = std::move(re);
         }
 
         state->function = constant_regex_fn;
@@ -997,14 +995,12 @@ Status FunctionRegexpLike::open(FunctionContext* context,
                 // reset hs_database to nullptr to indicate not use hyperscan
                 state->search_state.hs_database.reset();
                 state->search_state.hs_scratch.reset();
-                std::unique_ptr<re2::RE2> re;
                 std::string error_str;
                 bool st = StringFunctions::compile_regex(pattern, &error_str, StringRef(),
-                                                         StringRef(), re);
+                                                         StringRef(), state->search_state.regex);
                 if (!st) {
                     return Status::InternalError(error_str);
                 }
-                state->search_state.regex = std::move(re);
             }
             state->function = constant_regex_fn;
             state->scalar_function = constant_regex_fn_scalar;

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -200,7 +200,6 @@ Status LikeSearchState::clone(LikeSearchState& cloned) {
         cloned.hs_database.reset();
         cloned.hs_scratch.reset();
 
-        std::unique_ptr<re2::RE2> re;
         std::string error_str;
         bool st = StringFunctions::compile_regex(StringRef(re_pattern), &error_str, StringRef(),
                                                  StringRef(), cloned.regex);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53071 

Related PR: #xxx

Problem Summary:
re2 write high-volume logs to be.out, causing the BE process to become temporarily unresponsive.

use a unified re2 initialization function and disable re2 logging.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [X] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

