### PR TITLE
[fix](cloud) Sync storage resource once in read path when rowset._storage_resource.fs is null

### DIFF
--- a/be/src/olap/rowset/rowset_meta.cpp
+++ b/be/src/olap/rowset/rowset_meta.cpp
@@ -117,6 +117,9 @@ Result<const StorageResource*> RowsetMeta::remote_storage_resource() {
             _storage_resource = std::move(storage_resource->first);
         } else {
             if (config::is_cloud_mode()) {
+                // When creating a new cluster or creating a storage resource, BE may not sync storage resource,
+                // at the moment a query is coming, the BetaRowsetReader call loadSegment and use this method
+                // to get the storage resource, so we need to sync storage resource here.
                 ExecEnv::GetInstance()->storage_engine().to_cloud().sync_storage_vault();
                 if (auto retry_resource = get_storage_resource(resource_id())) {
                     _storage_resource = std::move(retry_resource->first);


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

