### PR TITLE
[fix](httpserver) Fix lsan check error when stop libevent server

### DIFF
--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -148,9 +148,9 @@ void EvHttpServer::stop() {
         for (int i = 0; i < _num_workers; ++i) {
             event_base_loopbreak(_event_bases[i].get());
         }
-        _event_bases.clear();
     }
     _workers->shutdown();
+    _event_bases.clear();
     close(_server_fd);
     _started = false;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
AddressSanitizer: CHECK failed: sanitizer_posix_libcdep.cpp:303 "((14)) == ((write_errno))" (0xe, 0x20) (tid=42951)
    #0 0x55d6f4c6fc21 in __asan::CheckUnwind() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x29e5bc21)
    #1 0x55d6f4c8a742 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x29e76742)
    #2 0x55d6f4c8cba8 in __sanitizer::IsAccessibleMemoryRange(unsigned long, unsigned long) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x29e78ba8)
    #3 0x55d6f4ca7698 in __ubsan::checkDynamicType(void*, void*, unsigned long) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x29e93698)
    #4 0x55d6f4ca6a62 in HandleDynamicTypeCacheMiss(__ubsan::DynamicTypeCacheMissData*, unsigned long, unsigned long, __ubsan::ReportOptions) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x29e92a62)
    #5 0x55d6f4ca6a33 in __ubsan_handle_dynamic_type_cache_miss (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x29e92a33)
    #6 0x55d6fadbf0d1 in std::_Sp_counted_deleter<event_base*, doris::EvHttpServer::EvHttpServer(int, int)::$_0, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/shared_ptr_base.h:527:9
    #7 0x55d6f4cc5c52 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/shared_ptr_base.h:346:8
    #8 0x55d6f88a0a4e in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/shared_ptr_base.h:1069:11
    #9 0x55d6f88a0a4e in std::__shared_ptr<event_base, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/shared_ptr_base.h:1525:31
    #10 0x55d6f88a0a4e in void std::destroy_at<std::shared_ptr<event_base> >(std::shared_ptr<event_base>*) /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_construct.h:88:15
    #11 0x55d6f88a0a4e in void std::_Destroy<std::shared_ptr<event_base> >(std::shared_ptr<event_base>*) /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_construct.h:149:7
    #12 0x55d6f88a0a4e in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<event_base>*>(std::shared_ptr<event_base>*, std::shared_ptr<event_base>*) /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_construct.h:163:6
    #13 0x55d6fadbc194 in void std::_Destroy<std::shared_ptr<event_base>*>(std::shared_ptr<event_base>*, std::shared_ptr<event_base>*) /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_construct.h:195:7
    #14 0x55d6fadbc194 in void std::_Destroy<std::shared_ptr<event_base>*, std::shared_ptr<event_base> >(std::shared_ptr<event_base>*, std::shared_ptr<event_base>*, std::allocator<std::shared_ptr<event_base> >&) /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/alloc_traits.h:981:7
    #15 0x55d6fadbc194 in std::vector<std::shared_ptr<event_base>, std::allocator<std::shared_ptr<event_base> > >::_M_erase_at_end(std::shared_ptr<event_base>*) /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_vector.h:1947:6
    #16 0x55d6fadbc194 in std::vector<std::shared_ptr<event_base>, std::allocator<std::shared_ptr<event_base> > >::clear() /usr/local/ldb-toolchain-v0.24/bin/../lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_vector.h:1608:9
    #17 0x55d6fadbc194 in doris::EvHttpServer::stop() /root/doris/be/src/http/ev_http_server.cpp:151:22
    #18 0x55d6f88902f4 in doris::HttpService::stop() /root/doris/be/src/service/http_service.cpp:497:22
    #19 0x55d6f4cae518 in main /root/doris/be/src/service/doris_main.cpp:625:19

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

