### PR TITLE
[fix](function)Fix The wrong nullable attribute is in struct_element

### DIFF
--- a/be/src/vec/functions/function_struct_element.cpp
+++ b/be/src/vec/functions/function_struct_element.cpp
@@ -65,6 +65,8 @@ public:
         return make_nullable(std::make_shared<DataTypeNothing>());
     }
 
+    bool skip_return_type_check() const override { return true; }
+
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto struct_type = check_and_get_data_type<DataTypeStruct>(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/StructElement.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/StructElement.java
@@ -98,6 +98,11 @@ public class StructElement extends ScalarFunction
 
     @Override
     public boolean nullable() {
+        for (Expression child : children()) {
+            if (child.nullable()) {
+                return true;
+            }
+        }
         StructType structArgType = (StructType) child(0).getDataType();
         if (child(1) instanceof IntegerLikeLiteral) {
             int offset = ((IntegerLikeLiteral) child(1)).getIntValue();


### PR DESCRIPTION
### What problem does this PR solve?
ipv6_cidr_to_range return type
```
type=struct<min:ipv6 not null,max:ipv6 not null>, nullable=false
```
but struct_element(ipv6_cidr_to_range(ip6,64), 'min')  return type
```
type=ipv6, nullable=true
```

Because struct_element is an AlwaysNullable function on fe, it is necessary to judge whether the interior of struct is nullable to obtain a correct return value.
```
type=ipv6, nullable=false
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

