### PR TITLE
[enhance](meta-service) add real request ip for be rpc

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -382,6 +382,8 @@ Status retry_rpc(std::string_view op_name, const Request& req, Response* res,
     static_assert(std::is_base_of_v<::google::protobuf::Message, Request>);
     static_assert(std::is_base_of_v<::google::protobuf::Message, Response>);
 
+    const_cast<Request&>(req).set_request_ip(BackendOptions::get_be_endpoint());
+
     int retry_times = 0;
     uint32_t duration_ms = 0;
     std::string error_msg;
@@ -493,7 +495,6 @@ Status CloudMetaMgr::get_tablet_meta(int64_t tablet_id, TabletMetaSharedPtr* tab
     GetTabletResponse resp;
     req.set_cloud_unique_id(config::cloud_unique_id);
     req.set_tablet_id(tablet_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     Status st = retry_rpc("get tablet meta", req, &resp, &MetaService_Stub::get_tablet);
     if (!st.ok()) {
         if (resp.status().code() == MetaServiceCode::TABLET_NOT_FOUND) {
@@ -538,7 +539,6 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
         int64_t table_id = tablet->table_id();
         int64_t index_id = tablet->index_id();
         req.set_cloud_unique_id(config::cloud_unique_id);
-        req.set_request_ip(BackendOptions::get_be_endpoint());
         auto* idx = req.mutable_idx();
         idx->set_tablet_id(tablet_id);
         idx->set_table_id(table_id);
@@ -897,7 +897,6 @@ Status CloudMetaMgr::sync_tablet_delete_bitmap(CloudTablet* tablet, int64_t old_
     req.set_base_compaction_cnt(stats.base_compaction_cnt());
     req.set_cumulative_compaction_cnt(stats.cumulative_compaction_cnt());
     req.set_cumulative_point(stats.cumulative_point());
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     *(req.mutable_idx()) = idx;
     // New rowset sync all versions of delete bitmap
     for (const auto& rs_meta : rs_metas) {
@@ -1013,7 +1012,6 @@ Status CloudMetaMgr::prepare_rowset(const RowsetMeta& rs_meta, const std::string
     req.set_cloud_unique_id(config::cloud_unique_id);
     req.set_txn_id(rs_meta.txn_id());
     req.set_tablet_job_id(job_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
 
     RowsetMetaPB doris_rs_meta = rs_meta.get_rowset_pb(/*skip_schema=*/true);
     doris_rowset_meta_to_cloud(req.mutable_rowset_meta(), std::move(doris_rs_meta));
@@ -1045,7 +1043,6 @@ Status CloudMetaMgr::commit_rowset(const RowsetMeta& rs_meta, const std::string&
     req.set_cloud_unique_id(config::cloud_unique_id);
     req.set_txn_id(rs_meta.txn_id());
     req.set_tablet_job_id(job_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
 
     RowsetMetaPB rs_meta_pb = rs_meta.get_rowset_pb();
     doris_rowset_meta_to_cloud(req.mutable_rowset_meta(), std::move(rs_meta_pb));
@@ -1083,7 +1080,6 @@ Status CloudMetaMgr::update_tmp_rowset(const RowsetMeta& rs_meta) {
     CreateRowsetRequest req;
     CreateRowsetResponse resp;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
 
     // Variant schema maybe updated, so we need to update the schema as well.
     // The updated rowset meta after `rowset->merge_rowset_meta` in `BaseTablet::update_delete_bitmap`
@@ -1165,7 +1161,6 @@ Status CloudMetaMgr::commit_txn(const StreamLoadContext& ctx, bool is_2pc) {
     CommitTxnRequest req;
     CommitTxnResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     req.set_db_id(ctx.db_id);
     req.set_txn_id(ctx.txn_id);
     req.set_is_2pc(is_2pc);
@@ -1189,7 +1184,6 @@ Status CloudMetaMgr::abort_txn(const StreamLoadContext& ctx) {
     AbortTxnRequest req;
     AbortTxnResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     req.set_reason(std::string(ctx.status.msg().substr(0, 1024)));
     if (ctx.db_id > 0 && !ctx.label.empty()) {
         req.set_db_id(ctx.db_id);
@@ -1216,7 +1210,6 @@ Status CloudMetaMgr::precommit_txn(const StreamLoadContext& ctx) {
     req.set_cloud_unique_id(config::cloud_unique_id);
     req.set_db_id(ctx.db_id);
     req.set_txn_id(ctx.txn_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     return retry_rpc("precommit txn", req, &res, &MetaService_Stub::precommit_txn);
 }
 
@@ -1224,7 +1217,6 @@ Status CloudMetaMgr::get_storage_vault_info(StorageVaultInfos* vault_infos, bool
     GetObjStoreInfoRequest req;
     GetObjStoreInfoResponse resp;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     Status s =
             retry_rpc("get storage vault info", req, &resp, &MetaService_Stub::get_obj_store_info);
     if (!s.ok()) {
@@ -1270,7 +1262,6 @@ Status CloudMetaMgr::prepare_tablet_job(const TabletJobInfoPB& job, StartTabletJ
     StartTabletJobRequest req;
     req.mutable_job()->CopyFrom(job);
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     return retry_rpc("start tablet job", req, res, &MetaService_Stub::start_tablet_job);
 }
 
@@ -1282,7 +1273,6 @@ Status CloudMetaMgr::commit_tablet_job(const TabletJobInfoPB& job, FinishTabletJ
     req.mutable_job()->CopyFrom(job);
     req.set_action(FinishTabletJobRequest::COMMIT);
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     auto st = retry_rpc("commit tablet job", req, res, &MetaService_Stub::finish_tablet_job);
     if (res->status().code() == MetaServiceCode::KV_TXN_CONFLICT_RETRY_EXCEEDED_MAX_TIMES) {
         return Status::Error<ErrorCode::DELETE_BITMAP_LOCK_ERROR, false>(
@@ -1298,7 +1288,6 @@ Status CloudMetaMgr::abort_tablet_job(const TabletJobInfoPB& job) {
     req.mutable_job()->CopyFrom(job);
     req.set_action(FinishTabletJobRequest::ABORT);
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     return retry_rpc("abort tablet job", req, &res, &MetaService_Stub::finish_tablet_job);
 }
 
@@ -1309,7 +1298,6 @@ Status CloudMetaMgr::lease_tablet_job(const TabletJobInfoPB& job) {
     req.mutable_job()->CopyFrom(job);
     req.set_action(FinishTabletJobRequest::LEASE);
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     return retry_rpc("lease tablet job", req, &res, &MetaService_Stub::finish_tablet_job);
 }
 
@@ -1327,7 +1315,6 @@ Status CloudMetaMgr::update_delete_bitmap(const CloudTablet& tablet, int64_t loc
     req.set_lock_id(lock_id);
     req.set_initiator(initiator);
     req.set_is_explicit_txn(is_explicit_txn);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     if (txn_id > 0) {
         req.set_txn_id(txn_id);
     }
@@ -1392,7 +1379,6 @@ Status CloudMetaMgr::cloud_update_delete_bitmap_without_lock(
     UpdateDeleteBitmapRequest req;
     UpdateDeleteBitmapResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     req.set_table_id(tablet.table_id());
     req.set_partition_id(tablet.partition_id());
     req.set_tablet_id(tablet.tablet_id());
@@ -1443,7 +1429,6 @@ Status CloudMetaMgr::get_delete_bitmap_update_lock(const CloudTablet& tablet, in
     GetDeleteBitmapUpdateLockRequest req;
     GetDeleteBitmapUpdateLockResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     req.set_table_id(tablet.table_id());
     req.set_lock_id(lock_id);
     req.set_initiator(initiator);
@@ -1507,7 +1492,6 @@ void CloudMetaMgr::remove_delete_bitmap_update_lock(int64_t table_id, int64_t lo
     RemoveDeleteBitmapUpdateLockRequest req;
     RemoveDeleteBitmapUpdateLockResponse res;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     req.set_table_id(table_id);
     req.set_tablet_id(tablet_id);
     req.set_lock_id(lock_id);
@@ -1645,7 +1629,6 @@ Status CloudMetaMgr::get_schema_dict(int64_t index_id,
     GetSchemaDictRequest req;
     GetSchemaDictResponse resp;
     req.set_cloud_unique_id(config::cloud_unique_id);
-    req.set_request_ip(BackendOptions::get_be_endpoint());
     req.set_index_id(index_id);
 
     // Invoke RPC via the retry_rpc helper function.

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -97,18 +97,18 @@ inline std::string encryt_sk(std::string debug_string) {
 template <class Request>
 void begin_rpc(std::string_view func_name, brpc::Controller* ctrl, const Request* req) {
     if constexpr (std::is_same_v<Request, CreateRowsetRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                   << req->request_ip();
     } else if constexpr (std::is_same_v<Request, CreateTabletsRequest>) {
         LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side();
     } else if constexpr (std::is_same_v<Request, UpdateDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                   << req->request_ip() << " table_id=" << req->table_id()
                   << " tablet_id=" << req->tablet_id() << " lock_id=" << req->lock_id()
                   << " initiator=" << req->initiator()
                   << " delete_bitmap_size=" << req->segment_delete_bitmaps_size();
     } else if constexpr (std::is_same_v<Request, GetDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                   << req->request_ip() << " tablet_id=" << req->tablet_id()
                   << " rowset_size=" << req->rowset_ids_size();
     } else if constexpr (std::is_same_v<Request, GetTabletStatsRequest>) {
@@ -117,20 +117,20 @@ void begin_rpc(std::string_view func_name, brpc::Controller* ctrl, const Request
     } else if constexpr (std::is_same_v<Request, GetVersionRequest> ||
                          std::is_same_v<Request, GetRowsetRequest> ||
                          std::is_same_v<Request, GetTabletRequest>) {
-        VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                    << req->request_ip() << " request=" << req->ShortDebugString();
     } else if constexpr (std::is_same_v<Request, RemoveDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                   << req->request_ip() << " tablet_id=" << req->tablet_id()
                   << " rowset_size=" << req->rowset_ids_size();
     } else if constexpr (std::is_same_v<Request, GetDeleteBitmapUpdateLockRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                   << req->request_ip() << " table_id=" << req->table_id()
                   << " lock_id=" << req->lock_id() << " initiator=" << req->initiator()
                   << " expiration=" << req->expiration()
                   << " require_compaction_stats=" << req->require_compaction_stats();
     } else {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
                   << req->request_ip() << " request=" << req->ShortDebugString();
     }
 }

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -97,41 +97,47 @@ inline std::string encryt_sk(std::string debug_string) {
 template <class Request>
 void begin_rpc(std::string_view func_name, brpc::Controller* ctrl, const Request* req) {
     if constexpr (std::is_same_v<Request, CreateRowsetRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side();
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                  << req->request_ip();
     } else if constexpr (std::is_same_v<Request, CreateTabletsRequest>) {
         LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side();
     } else if constexpr (std::is_same_v<Request, UpdateDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side()
-                  << " table_id=" << req->table_id() << " tablet_id=" << req->tablet_id()
-                  << " lock_id=" << req->lock_id() << " initiator=" << req->initiator()
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                  << req->request_ip() << " table_id=" << req->table_id()
+                  << " tablet_id=" << req->tablet_id() << " lock_id=" << req->lock_id()
+                  << " initiator=" << req->initiator()
                   << " delete_bitmap_size=" << req->segment_delete_bitmaps_size();
     } else if constexpr (std::is_same_v<Request, GetDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side()
-                  << " tablet_id=" << req->tablet_id() << " rowset_size=" << req->rowset_ids_size();
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                  << req->request_ip() << " tablet_id=" << req->tablet_id()
+                  << " rowset_size=" << req->rowset_ids_size();
     } else if constexpr (std::is_same_v<Request, GetTabletStatsRequest>) {
         VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side()
                    << " tablet size: " << req->tablet_idx().size();
     } else if constexpr (std::is_same_v<Request, GetVersionRequest> ||
                          std::is_same_v<Request, GetRowsetRequest> ||
                          std::is_same_v<Request, GetTabletRequest>) {
-        VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side()
-                   << " request=" << req->ShortDebugString();
+        VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                   << req->request_ip() << " request=" << req->ShortDebugString();
     } else if constexpr (std::is_same_v<Request, RemoveDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side()
-                  << " tablet_id=" << req->tablet_id() << " rowset_size=" << req->rowset_ids_size();
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                  << req->request_ip() << " tablet_id=" << req->tablet_id()
+                  << " rowset_size=" << req->rowset_ids_size();
     } else if constexpr (std::is_same_v<Request, GetDeleteBitmapUpdateLockRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side()
-                  << " table_id=" << req->table_id() << " lock_id=" << req->lock_id()
-                  << " initiator=" << req->initiator() << " expiration=" << req->expiration()
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                  << req->request_ip() << " table_id=" << req->table_id()
+                  << " lock_id=" << req->lock_id() << " initiator=" << req->initiator()
+                  << " expiration=" << req->expiration()
                   << " require_compaction_stats=" << req->require_compaction_stats();
     } else {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side()
-                  << " request=" << req->ShortDebugString();
+        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " be "
+                  << req->request_ip() << " request=" << req->ShortDebugString();
     }
 }
 
 template <class Response>
-void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* res) {
+void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* res,
+                std::string& instance_id) {
     if constexpr (std::is_same_v<Response, CommitTxnResponse>) {
         if (res->status().code() != MetaServiceCode::OK) {
             res->clear_table_ids();
@@ -139,21 +145,23 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
             res->clear_versions();
         }
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
-                  << " response=" << res->ShortDebugString();
+                  << " response=" << res->ShortDebugString() << " instance_id " << instance_id;
     } else if constexpr (std::is_same_v<Response, GetRowsetResponse>) {
         if (res->status().code() != MetaServiceCode::OK) {
             res->clear_rowset_meta();
         }
         VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
-                   << " status=" << res->status().ShortDebugString();
+                   << " status=" << res->status().ShortDebugString() << " instance_id "
+                   << instance_id;
     } else if constexpr (std::is_same_v<Response, GetTabletStatsResponse>) {
         VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
                    << " status=" << res->status().ShortDebugString()
-                   << " tablet size: " << res->tablet_stats().size();
+                   << " tablet size: " << res->tablet_stats().size() << " instance_id "
+                   << instance_id;
     } else if constexpr (std::is_same_v<Response, GetVersionResponse> ||
                          std::is_same_v<Response, GetTabletResponse>) {
         VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
-                   << " response=" << res->ShortDebugString();
+                   << " response=" << res->ShortDebugString() << " instance_id " << instance_id;
     } else if constexpr (std::is_same_v<Response, GetDeleteBitmapResponse>) {
         if (res->status().code() != MetaServiceCode::OK) {
             res->clear_rowset_ids();
@@ -164,7 +172,8 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
                   << " status=" << res->status().ShortDebugString()
                   << " tablet=" << res->tablet_id()
-                  << " delete_bitmap_count=" << res->segment_delete_bitmaps_size();
+                  << " delete_bitmap_count=" << res->segment_delete_bitmaps_size()
+                  << " instance_id " << instance_id;
     } else if constexpr (std::is_same_v<Response, GetDeleteBitmapUpdateLockResponse>) {
         if (res->status().code() != MetaServiceCode::OK) {
             res->clear_base_compaction_cnts();
@@ -172,16 +181,17 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
             res->clear_cumulative_points();
         }
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
-                  << " status=" << res->status().ShortDebugString();
+                  << " status=" << res->status().ShortDebugString() << " instance_id "
+                  << instance_id;
     } else if constexpr (std::is_same_v<Response, GetObjStoreInfoResponse> ||
                          std::is_same_v<Response, GetStageResponse>) {
         std::string debug_string = encryt_sk(res->DebugString());
         TEST_SYNC_POINT_CALLBACK("sk_finish_rpc", &debug_string);
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
-                  << " response=" << debug_string;
+                  << " response=" << debug_string << " instance_id " << instance_id;
     } else {
         LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
-                  << " response=" << res->ShortDebugString();
+                  << " response=" << res->ShortDebugString() << " instance_id " << instance_id;
     }
 }
 
@@ -264,7 +274,7 @@ inline MetaServiceCode cast_as(TxnErrorCode code) {
     DORIS_CLOUD_DEFER {                                                                       \
         response->mutable_status()->set_code(code);                                           \
         response->mutable_status()->set_msg(msg);                                             \
-        finish_rpc(#func_name, ctrl, response);                                               \
+        finish_rpc(#func_name, ctrl, response, instance_id);                                  \
         closure_guard.reset(nullptr);                                                         \
         if (txn != nullptr) {                                                                 \
             stats.get_counter += txn->num_get_keys();                                         \

--- a/cloud/src/meta-service/meta_service_helper.h
+++ b/cloud/src/meta-service/meta_service_helper.h
@@ -97,42 +97,45 @@ inline std::string encryt_sk(std::string debug_string) {
 template <class Request>
 void begin_rpc(std::string_view func_name, brpc::Controller* ctrl, const Request* req) {
     if constexpr (std::is_same_v<Request, CreateRowsetRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip();
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip();
     } else if constexpr (std::is_same_v<Request, CreateTabletsRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip();
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip();
     } else if constexpr (std::is_same_v<Request, UpdateDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip() << " table_id=" << req->table_id()
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip() << " table_id=" << req->table_id()
                   << " tablet_id=" << req->tablet_id() << " lock_id=" << req->lock_id()
                   << " initiator=" << req->initiator()
                   << " delete_bitmap_size=" << req->segment_delete_bitmaps_size();
     } else if constexpr (std::is_same_v<Request, GetDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip() << " tablet_id=" << req->tablet_id()
-                  << " rowset_size=" << req->rowset_ids_size();
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip()
+                  << " tablet_id=" << req->tablet_id() << " rowset_size=" << req->rowset_ids_size();
     } else if constexpr (std::is_same_v<Request, GetTabletStatsRequest>) {
-        VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                   << req->request_ip() << " tablet size: " << req->tablet_idx().size();
+        VLOG_DEBUG << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                   << " original client ip: " << req->request_ip()
+                   << " tablet size: " << req->tablet_idx().size();
     } else if constexpr (std::is_same_v<Request, GetVersionRequest> ||
                          std::is_same_v<Request, GetRowsetRequest> ||
                          std::is_same_v<Request, GetTabletRequest>) {
-        VLOG_DEBUG << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                   << req->request_ip() << " request=" << req->ShortDebugString();
+        VLOG_DEBUG << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                   << " original client ip: " << req->request_ip()
+                   << " request=" << req->ShortDebugString();
     } else if constexpr (std::is_same_v<Request, RemoveDeleteBitmapRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip() << " tablet_id=" << req->tablet_id()
-                  << " rowset_size=" << req->rowset_ids_size();
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip()
+                  << " tablet_id=" << req->tablet_id() << " rowset_size=" << req->rowset_ids_size();
     } else if constexpr (std::is_same_v<Request, GetDeleteBitmapUpdateLockRequest>) {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip() << " table_id=" << req->table_id()
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip() << " table_id=" << req->table_id()
                   << " lock_id=" << req->lock_id() << " initiator=" << req->initiator()
                   << " expiration=" << req->expiration()
                   << " require_compaction_stats=" << req->require_compaction_stats();
     } else {
-        LOG(INFO) << "begin " << func_name << " from " << ctrl->remote_side() << " init ip "
-                  << req->request_ip() << " request=" << req->ShortDebugString();
+        LOG(INFO) << "begin " << func_name << " remote caller: " << ctrl->remote_side()
+                  << " original client ip: " << req->request_ip()
+                  << " request=" << req->ShortDebugString();
     }
 }
 
@@ -144,21 +147,21 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
             res->clear_partition_ids();
             res->clear_versions();
         }
-        LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
+        LOG(INFO) << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                   << " response=" << res->ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetRowsetResponse>) {
         if (res->status().code() != MetaServiceCode::OK) {
             res->clear_rowset_meta();
         }
-        VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
+        VLOG_DEBUG << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                    << " status=" << res->status().ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetTabletStatsResponse>) {
-        VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
+        VLOG_DEBUG << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                    << " status=" << res->status().ShortDebugString()
                    << " tablet size: " << res->tablet_stats().size();
     } else if constexpr (std::is_same_v<Response, GetVersionResponse> ||
                          std::is_same_v<Response, GetTabletResponse>) {
-        VLOG_DEBUG << "finish " << func_name << " from " << ctrl->remote_side()
+        VLOG_DEBUG << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                    << " response=" << res->ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetDeleteBitmapResponse>) {
         if (res->status().code() != MetaServiceCode::OK) {
@@ -167,7 +170,7 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
             res->clear_versions();
             res->clear_segment_delete_bitmaps();
         }
-        LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
+        LOG(INFO) << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                   << " status=" << res->status().ShortDebugString()
                   << " tablet=" << res->tablet_id()
                   << " delete_bitmap_count=" << res->segment_delete_bitmaps_size();
@@ -177,16 +180,16 @@ void finish_rpc(std::string_view func_name, brpc::Controller* ctrl, Response* re
             res->clear_cumulative_compaction_cnts();
             res->clear_cumulative_points();
         }
-        LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
+        LOG(INFO) << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                   << " status=" << res->status().ShortDebugString();
     } else if constexpr (std::is_same_v<Response, GetObjStoreInfoResponse> ||
                          std::is_same_v<Response, GetStageResponse>) {
         std::string debug_string = encryt_sk(res->DebugString());
         TEST_SYNC_POINT_CALLBACK("sk_finish_rpc", &debug_string);
-        LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
+        LOG(INFO) << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                   << " response=" << debug_string;
     } else {
-        LOG(INFO) << "finish " << func_name << " from " << ctrl->remote_side()
+        LOG(INFO) << "finish " << func_name << " remote caller: " << ctrl->remote_side()
                   << " response=" << res->ShortDebugString();
     }
 }

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -809,6 +809,7 @@ message SplitSingleMessagePB {
 message BeginTxnRequest {
     optional string cloud_unique_id = 1; // For auth
     optional TxnInfoPB txn_info = 2;
+    optional string request_ip = 3;
 }
 
 message BeginTxnResponse {
@@ -825,6 +826,7 @@ message PrecommitTxnRequest {
     optional int64 txn_id = 3;
     optional TxnCommitAttachmentPB commit_attachment = 4;
     optional int64 precommit_timeout_ms = 5;
+    optional string request_ip = 6;
 }
 
 message PrecommitTxnResponse {
@@ -846,6 +848,7 @@ message CommitTxnRequest {
     optional bool is_txn_load = 9;
     repeated SubTxnInfo sub_txn_infos = 10;
     optional bool enable_txn_lazy_commit = 11;
+    optional string request_ip = 12;
 }
 
 message SubTxnInfo {
@@ -879,6 +882,7 @@ message AbortTxnRequest {
     optional string label = 4;
     optional string reason = 5;
     optional TxnCommitAttachmentPB commit_attachment = 6;
+    optional string request_ip = 7;
 }
 
 message AbortTxnResponse {
@@ -891,6 +895,7 @@ message GetTxnRequest {
     optional int64 db_id = 2;
     optional int64 txn_id = 3;
     optional string label = 4;
+    optional string request_ip = 5;
 }
 
 message GetTxnResponse {
@@ -903,6 +908,7 @@ message GetTxnIdRequest {
     optional int64 db_id = 2;
     optional string label = 3;
     repeated TxnStatusPB txn_status = 4;
+    optional string request_ip = 5;
 }
 
 message GetTxnIdResponse {
@@ -920,6 +926,7 @@ message BeginSubTxnRequest {
     repeated int64 table_ids = 5;
     // a random label used to generate a sub_txn_id
     optional string label = 6;
+    optional string request_ip = 7;
 }
 
 message BeginSubTxnResponse {
@@ -938,6 +945,7 @@ message AbortSubTxnRequest {
     optional int64 db_id = 5;
     // set table_ids in txn_info
     repeated int64 table_ids = 6;
+    optional string request_ip = 7;
 }
 
 message AbortSubTxnResponse {
@@ -947,6 +955,7 @@ message AbortSubTxnResponse {
 
 message GetCurrentMaxTxnRequest {
     optional string cloud_unique_id = 1; // For auth
+    optional string request_ip = 2;
 }
 
 message GetCurrentMaxTxnResponse {
@@ -959,6 +968,7 @@ message AbortTxnWithCoordinatorRequest {
     optional string ip = 2;
     optional int64 id = 3;
     optional int64 start_time = 4;
+    optional string request_ip = 5;
 }
 
 message AbortTxnWithCoordinatorResponse {
@@ -971,6 +981,7 @@ message CheckTxnConflictRequest {
     optional int64 end_txn_id = 3;
     repeated int64 table_ids = 4;
     optional bool ignore_timeout_txn = 5;
+    optional string request_ip = 6;
 }
 
 message CheckTxnConflictResponse {
@@ -983,6 +994,7 @@ message CleanTxnLabelRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 db_id = 2;
     repeated string labels = 3;
+    optional string request_ip = 4;
 }
 
 message CleanTxnLabelResponse {
@@ -1003,6 +1015,8 @@ message GetVersionRequest {
 
     // True if get table version
     optional bool is_table_version = 9;
+
+    optional string request_ip = 10;
 };
 
 message GetVersionResponse {
@@ -1020,6 +1034,7 @@ message GetVersionResponse {
 
 message GetObjStoreInfoRequest {
     optional string cloud_unique_id = 1; // For auth
+    optional string request_ip = 2;
 };
 
 message AlterObjStoreInfoRequest {
@@ -1046,6 +1061,7 @@ message AlterObjStoreInfoRequest {
     optional Operation op = 3;
     optional StorageVaultPB vault = 4;
     optional bool set_as_default_storage_vault = 5;
+    optional string request_ip = 6;
 }
 
 message AlterObjStoreInfoResponse {
@@ -1058,6 +1074,7 @@ message UpdateAkSkRequest {
     optional string instance_id = 1;
     repeated RamUserPB internal_bucket_user = 2;
     optional RamUserPB ram_user = 3;
+    optional string request_ip = 4;
 }
 
 message UpdateAkSkResponse {
@@ -1078,6 +1095,7 @@ message CreateTabletsRequest {
     repeated doris.TabletMetaCloudPB tablet_metas = 2;
     optional string storage_vault_name = 3;
     optional int64 db_id = 4;
+    optional string request_ip = 5;
 }
 
 message CreateTabletsResponse {
@@ -1089,6 +1107,7 @@ message CreateTabletsResponse {
 message UpdateTabletRequest {
     optional string cloud_unique_id = 1; // For auth
     repeated TabletMetaInfoPB tablet_meta_infos = 2;
+    optional string request_ip = 3;
 }
 
 message UpdateTabletResponse {
@@ -1099,6 +1118,7 @@ message UpdateTabletSchemaRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 tablet_id = 2;
     optional doris.TabletSchemaCloudPB tablet_schema = 3;
+    optional string request_ip = 4;
 }
 
 message UpdateTabletSchemaResponse {
@@ -1108,12 +1128,14 @@ message UpdateTabletSchemaResponse {
 message DropTabletRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 tablet_id = 2;
+    optional string request_ip = 3;
     // TODO: There are more fields TBD
 }
 
 message GetTabletRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 tablet_id = 2;
+    optional string request_ip = 3;
     // TODO: There are more fields TBD
 }
 
@@ -1128,6 +1150,7 @@ message CreateRowsetRequest {
     optional bool temporary = 3;
     optional int64 txn_id = 4;
     optional string tablet_job_id = 5;
+    optional string request_ip = 6;
 }
 
 message CreateRowsetResponse {
@@ -1151,6 +1174,7 @@ message GetRowsetRequest {
     // returned schema format on rowset schema, used in variant type directly.
     // for compability reason we use FILL_WITH_DICT as default
     optional SchemaOp schema_op = 8  [default = FILL_WITH_DICT];
+    optional string request_ip = 9;
 }
 
 message GetRowsetResponse {
@@ -1164,6 +1188,7 @@ message GetRowsetResponse {
 message GetSchemaDictRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 index_id = 2;
+    optional string request_ip = 3;
 }
 
 message GetSchemaDictResponse {
@@ -1178,6 +1203,7 @@ message IndexRequest {
     optional int64 expiration = 4;
     optional int64 db_id = 5;
     optional bool is_new_table = 6; // For table version
+    optional string request_ip = 7;
 }
 
 message IndexResponse {
@@ -1192,6 +1218,7 @@ message PartitionRequest {
     optional int64 expiration = 5;
     optional int64 db_id = 6;
     optional bool need_update_table_version = 7;
+    optional string request_ip = 8;
 }
 
 message PartitionResponse {
@@ -1217,6 +1244,7 @@ message CreateInstanceRequest {
     optional RamUserPB ram_user = 5;
     optional bool sse_enabled = 6;
     optional StorageVaultPB vault = 7;
+    optional string request_ip = 8;
 }
 
 message CreateInstanceResponse {
@@ -1244,6 +1272,7 @@ message AlterInstanceRequest {
     optional Operation op = 2;
     optional string name = 3;
     optional string value = 4;
+    optional string request_ip = 5;
 }
 
 message AlterInstanceResponse {
@@ -1253,6 +1282,7 @@ message AlterInstanceResponse {
 message GetInstanceRequest {
     optional string instance_id = 1;
     optional string cloud_unique_id = 2;
+    optional string request_ip = 3;
 }
 
 message GetInstanceResponse {
@@ -1280,6 +1310,7 @@ message AlterClusterRequest {
     optional Operation op = 4;
     // for SQL mode rename cluster, rename to cluster name eq instance empty cluster name, need drop empty cluster
     optional bool replace_if_existing_empty_target_cluster = 5;
+    optional string request_ip = 6;
 }
 
 message AlterClusterResponse {
@@ -1292,12 +1323,14 @@ message GetClusterRequest {
     optional string cluster_id = 3;
     optional string cluster_name = 4;
     optional string mysql_user_name = 5;
+    optional string request_ip = 6;
 }
 
 message GetClusterStatusRequest {
     repeated string instance_ids = 1; // Redundant field
     repeated string cloud_unique_ids = 2;
     optional ClusterStatus status = 3;
+    optional string request_ip = 4;
 }
 
 message GetClusterStatusResponse {
@@ -1318,6 +1351,7 @@ message GetClusterResponse {
 message GetTabletStatsRequest {
     optional string cloud_unique_id = 1;
     repeated TabletIndexPB tablet_idx = 2;
+    optional string request_ip = 3;
 }
 
 message GetTabletStatsResponse {
@@ -1328,6 +1362,7 @@ message GetTabletStatsResponse {
 message CreateStageRequest {
     optional string cloud_unique_id = 1;
     optional StagePB stage = 2;
+    optional string request_ip = 3;
 }
 
 message CreateStageResponse {
@@ -1340,6 +1375,7 @@ message GetStageRequest {
     optional string mysql_user_name = 3;
     optional StagePB.StageType type = 4;
     optional string mysql_user_id = 5;
+    optional string request_ip = 6;
 }
 
 message GetStageResponse {
@@ -1354,6 +1390,7 @@ message DropStageRequest {
     optional StagePB.StageType type = 4;
     optional string mysql_user_id = 5;
     optional string reason = 6;
+    optional string request_ip = 7;
 }
 
 message DropStageResponse {
@@ -1362,6 +1399,7 @@ message DropStageResponse {
 
 message GetIamRequest {
     optional string cloud_unique_id = 1;
+    optional string request_ip = 2;
 }
 
 message GetIamResponse {
@@ -1374,6 +1412,7 @@ message AlterIamRequest {
     optional string account_id = 1;
     optional string ak = 2;
     optional string sk = 3;
+    optional string request_ip = 4;
 }
 
 message AlterIamResponse {
@@ -1383,6 +1422,7 @@ message AlterIamResponse {
 message AlterRamUserRequest {
     optional string instance_id = 1;
     optional RamUserPB ram_user = 2;
+    optional string request_ip = 3;
 }
 
 message AlterRamUserResponse {
@@ -1392,6 +1432,7 @@ message AlterRamUserResponse {
 message StartTabletJobRequest {
     optional string cloud_unique_id = 1; // For auth
     optional TabletJobInfoPB job = 2;
+    optional string request_ip = 3;
 }
 
 message StartTabletJobResponse {
@@ -1410,6 +1451,7 @@ message FinishTabletJobRequest {
     optional string cloud_unique_id = 1; // For auth
     optional Action action = 2;
     optional TabletJobInfoPB job = 3;
+    optional string request_ip = 4;
 }
 
 message FinishTabletJobResponse {
@@ -1431,6 +1473,7 @@ message BeginCopyRequest {
     optional int64 file_num_limit = 10;
     optional int64 file_size_limit = 11;
     optional int64 file_meta_size_limit = 12;
+    optional string request_ip = 13;
 }
 
 message BeginCopyResponse {
@@ -1453,6 +1496,7 @@ message FinishCopyRequest {
     optional int32 group_id = 6;
     optional Action action = 7;
     optional int64 finish_time_ms = 8;
+    optional string request_ip = 9;
 }
 
 message FinishCopyResponse {
@@ -1465,6 +1509,7 @@ message GetCopyJobRequest {
     optional int64 table_id = 3;
     optional string copy_id = 4;
     optional int32 group_id = 5;
+    optional string request_ip = 6;
 }
 
 message GetCopyJobResponse {
@@ -1476,6 +1521,7 @@ message GetCopyFilesRequest {
     optional string cloud_unique_id = 1;
     optional string stage_id = 2;
     optional int64 table_id = 3;
+    optional string request_ip = 4;
 }
 
 message GetCopyFilesResponse {
@@ -1488,6 +1534,7 @@ message FilterCopyFilesRequest {
     optional string stage_id = 2;
     optional int64 table_id = 3;
     repeated ObjectFilePB object_files = 4;
+    optional string request_ip = 5;
 }
 
 message FilterCopyFilesResponse {
@@ -1497,6 +1544,7 @@ message FilterCopyFilesResponse {
 
 message RecycleInstanceRequest {
     repeated string instance_ids = 1;
+    optional string request_ip = 2;
 }
 
 message RecycleInstanceResponse {
@@ -1604,6 +1652,7 @@ message UpdateDeleteBitmapRequest {
     optional int64 pre_rowset_agg_end_version = 16;
     // when update delete_bitmap of pre rowsets, check the rowset exists
     repeated int64 pre_rowset_versions = 17;
+    optional string request_ip = 18;
 }
 
 message UpdateDeleteBitmapResponse {
@@ -1620,6 +1669,7 @@ message GetDeleteBitmapRequest {
     optional int64 base_compaction_cnt = 7;
     optional int64 cumulative_compaction_cnt = 8;
     optional int64 cumulative_point = 9;
+    optional string request_ip = 10;
 }
 
 message GetDeleteBitmapResponse {
@@ -1638,6 +1688,7 @@ message RemoveDeleteBitmapRequest {
     repeated string rowset_ids = 3;
     repeated int64 begin_versions = 4;
     repeated int64 end_versions = 5;
+    optional string request_ip = 6;
 }
 
 message RemoveDeleteBitmapResponse {
@@ -1667,6 +1718,7 @@ message GetDeleteBitmapUpdateLockRequest {
     optional int64 expiration = 6;
     optional bool require_compaction_stats = 7 [default = false];
     repeated TabletIndexPB tablet_indexes = 8;
+    optional string request_ip = 9;
 }
 
 message GetDeleteBitmapUpdateLockResponse {
@@ -1683,6 +1735,7 @@ message RemoveDeleteBitmapUpdateLockRequest {
     optional int64 tablet_id = 3;
     optional int64 lock_id = 4;
     optional int64 initiator = 5;
+    optional string request_ip = 6;
 }
 
 message RemoveDeleteBitmapUpdateLockResponse {
@@ -1693,6 +1746,7 @@ message GetRLTaskCommitAttachRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 db_id = 2;
     optional int64 job_id = 3;
+    optional string request_ip = 4;
 }
 
 message GetRLTaskCommitAttachResponse {
@@ -1705,6 +1759,7 @@ message ResetRLProgressRequest {
     optional int64 db_id = 2;
     optional int64 job_id = 3;
     map<int32, int64> partition_to_offset = 4;
+    optional string request_ip = 5;
 }
 
 message ResetRLProgressResponse {
@@ -1726,6 +1781,7 @@ message CheckKVRequest {
     optional string cloud_unique_id = 1; // For auth
     optional CheckKeyInfos check_keys = 2;
     optional Operation op = 3;
+    optional string request_ip = 4;
 }
 
 message CheckKVResponse {
@@ -1739,6 +1795,7 @@ message BeginSnapshotRequest {
     optional bool auto_snapshot = 3;
     optional int64 timeout_seconds = 4;
     optional int64 ttl_seconds = 5;
+    optional string request_ip = 6;
 }
 
 message BeginSnapshotResponse {
@@ -1752,6 +1809,7 @@ message CommitSnapshotRequest {
     optional string snapshot_id = 2;
     optional string image_url = 3;
     optional int64 last_journal_id = 4;
+    optional string request_ip = 5;
 }
 
 message CommitSnapshotResponse {
@@ -1762,6 +1820,7 @@ message AbortSnapshotRequest {
     optional string cloud_unique_id = 1;
     optional string snapshot_id = 2;
     optional string reason = 3;
+    optional string request_ip = 4;
 }
 
 message AbortSnapshotResponse {
@@ -1791,6 +1850,7 @@ message ListSnapshotRequest {
     optional string cloud_unique_id = 1;
     optional string required_snapshot_id = 2;   // Return all snapshots if not set.
     optional bool include_aborted = 3;
+    optional string request_ip = 4;
 }
 
 message ListSnapshotResponse {
@@ -1814,6 +1874,7 @@ message CloneInstanceRequest {
     // Below fields are required for WRITABLE clone.
     optional ObjectStoreInfoPB obj_info = 6;
     optional StorageVaultPB storage_vault = 7;
+    optional string request_ip = 8;
 }
 
 message CloneInstanceResponse {


### PR DESCRIPTION
### What problem does this PR solve?

Currently, when sending an RPC request to MS, it may go through LB. At this point, MS begins RPC output with LB's IP, which makes it difficult for us to know where the RPC request actually came from, making troubleshooting difficult. Now, add a request IP field to all requests and set it when sending RPC from BE. This way, even if it goes through LB, we can still obtain the original BE IP data.
