### PR TITLE
[Bug](aggregate) the null_count should store in data place instead of member variable of class

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -101,8 +101,9 @@ Status AggSinkLocalState::open(RuntimeState* state) {
     }
 
     if (Base::_shared_state->probe_expr_ctxs.empty()) {
-        _agg_data->without_key = reinterpret_cast<vectorized::AggregateDataPtr>(
-                _agg_profile_arena.alloc(p._total_size_of_aggregate_states));
+        _agg_data->without_key =
+                reinterpret_cast<vectorized::AggregateDataPtr>(_agg_profile_arena.aligned_alloc(
+                        p._total_size_of_aggregate_states, p._align_aggregate_states));
 
         if (p._is_merge) {
             _executor = std::make_unique<Executor<true, true>>();

--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -747,7 +747,7 @@ Status AggSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
         RETURN_IF_ERROR(vectorized::AggFnEvaluator::create(
                 _pool, tnode.agg_node.aggregate_functions[i],
                 tnode.agg_node.__isset.agg_sort_infos ? tnode.agg_node.agg_sort_infos[i] : dummy,
-                tnode.agg_node.grouping_exprs.empty(), &evaluator));
+                tnode.agg_node.grouping_exprs.empty(), false, &evaluator));
         _aggregate_evaluators.push_back(evaluator);
     }
 

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -664,7 +664,7 @@ Status AnalyticSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) 
         // Its behavior is same with executed without group by key.
         // https://github.com/apache/doris/pull/40693
         RETURN_IF_ERROR(vectorized::AggFnEvaluator::create(_pool, desc, {}, /*without_key*/ true,
-                                                           &evaluator));
+                                                           true, &evaluator));
         _agg_functions.emplace_back(evaluator);
 
         int node_idx = 0;

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -316,23 +316,22 @@ bool StreamingAggLocalState::_should_not_do_pre_agg(size_t rows) {
     const auto spill_streaming_agg_mem_limit = p._spill_streaming_agg_mem_limit;
     const bool used_too_much_memory =
             spill_streaming_agg_mem_limit > 0 && _memory_usage() > spill_streaming_agg_mem_limit;
-    std::visit(
-            vectorized::Overload {
-                    [&](std::monostate& arg) {
-                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
-                    },
-                    [&](auto& agg_method) {
-                        auto& hash_tbl = *agg_method.hash_table;
-                        /// If too much memory is used during the pre-aggregation stage,
-                        /// it is better to output the data directly without performing further aggregation.
-                        // do not try to do agg, just init and serialize directly return the out_block
-                        if (used_too_much_memory || (hash_tbl.add_elem_size_overflow(rows) &&
-                                                     !_should_expand_preagg_hash_tables())) {
-                            SCOPED_TIMER(_streaming_agg_timer);
-                            ret_flag = true;
-                        }
-                    }},
-            _agg_data->method_variant);
+    std::visit(vectorized::Overload {
+                       [&](std::monostate& arg) {
+                           throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                       },
+                       [&](auto& agg_method) {
+                           auto& hash_tbl = *agg_method.hash_table;
+                           /// If too much memory is used during the pre-aggregation stage,
+                           /// it is better to output the data directly without performing further aggregation.
+                           // do not try to do agg, just init and serialize directly return the out_block
+                           if (used_too_much_memory || (hash_tbl.add_elem_size_overflow(rows) &&
+                                                        !_should_expand_preagg_hash_tables())) {
+                               SCOPED_TIMER(_streaming_agg_timer);
+                               ret_flag = true;
+                           }
+                       }},
+               _agg_data->method_variant);
 
     return ret_flag;
 }
@@ -637,7 +636,7 @@ Status StreamingAggOperatorX::init(const TPlanNode& tnode, RuntimeState* state) 
         RETURN_IF_ERROR(vectorized::AggFnEvaluator::create(
                 _pool, tnode.agg_node.aggregate_functions[i],
                 tnode.agg_node.__isset.agg_sort_infos ? tnode.agg_node.agg_sort_infos[i] : dummy,
-                tnode.agg_node.grouping_exprs.empty(), &evaluator));
+                tnode.agg_node.grouping_exprs.empty(), false, &evaluator));
         _aggregate_evaluators.push_back(evaluator);
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -46,8 +46,8 @@ class IDataType;
 
 struct AggregateFunctionAttr {
     bool enable_decimal256 {false};
-    std::vector<std::string> column_names;
     bool is_window_function {false};
+    std::vector<std::string> column_names;
 };
 
 template <bool nullable, typename ColVecType>

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -47,6 +47,7 @@ class IDataType;
 struct AggregateFunctionAttr {
     bool enable_decimal256 {false};
     std::vector<std::string> column_names;
+    bool is_window_function {false};
 };
 
 template <bool nullable, typename ColVecType>

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.cpp
@@ -34,19 +34,19 @@ AggregateFunctionPtr create_aggregate_function_approx_count_distinct(
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_ARRAY:
         return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_ARRAY>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_MAP:
         return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_MAP>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_STRUCT:
         return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_STRUCT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_VARIANT:
         return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_VARIANT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     default:
         auto res = creator_with_any::create<AggregateFunctionApproxCountDistinct>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
         if (!res) {
             throw Exception(
                     ErrorCode::NOT_IMPLEMENTED_ERROR,

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.cpp
@@ -19,10 +19,6 @@
 
 #include "common/status.h"
 #include "vec/aggregate_functions/helpers.h"
-#include "vec/columns/column_array.h"
-#include "vec/columns/column_map.h"
-#include "vec/columns/column_struct.h"
-#include "vec/columns/column_variant.h"
 #include "vec/data_types/data_type.h"
 
 namespace doris::vectorized {
@@ -31,29 +27,14 @@ namespace doris::vectorized {
 AggregateFunctionPtr create_aggregate_function_approx_count_distinct(
         const std::string& name, const DataTypes& argument_types, const bool result_is_nullable,
         const AggregateFunctionAttr& attr) {
-    switch (argument_types[0]->get_primitive_type()) {
-    case PrimitiveType::TYPE_ARRAY:
-        return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_ARRAY>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_MAP:
-        return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_MAP>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_STRUCT:
-        return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_STRUCT>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_VARIANT:
-        return creator_without_type::create<AggregateFunctionApproxCountDistinct<TYPE_VARIANT>>(
-                argument_types, result_is_nullable, attr);
-    default:
-        auto res = creator_with_any::create<AggregateFunctionApproxCountDistinct>(
-                argument_types, result_is_nullable, attr);
-        if (!res) {
-            throw Exception(
-                    ErrorCode::NOT_IMPLEMENTED_ERROR,
-                    "Unsupported type for approx_count_distinct: " + argument_types[0]->get_name());
-        }
-        return res;
+    auto res = creator_with_any::create<AggregateFunctionApproxCountDistinct>(
+            argument_types, result_is_nullable, attr);
+    if (!res) {
+        throw Exception(
+                ErrorCode::NOT_IMPLEMENTED_ERROR,
+                "Unsupported type for approx_count_distinct: " + argument_types[0]->get_name());
     }
+    return res;
 }
 
 void register_aggregate_function_approx_count_distinct(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -28,10 +28,10 @@
 #include "util/slice.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column_decimal.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
-#include "vec/columns/column_decimal.h"
 #include "vec/data_types/data_type_number.h"
 
 namespace doris {

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -31,8 +31,8 @@
 #include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
+#include "vec/columns/column_decimal.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_top_k.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_top_k.cpp
@@ -33,7 +33,7 @@ AggregateFunctionPtr create_aggregate_function_approx_top_k(const std::string& n
     }
 
     return creator_without_type::create<AggregateFunctionApproxTopK>(
-            argument_types, result_is_nullable, attr.column_names);
+            argument_types, result_is_nullable, attr, attr.column_names);
 }
 
 void register_aggregate_function_approx_top_k(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_top_k.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_top_k.h
@@ -40,7 +40,6 @@
 #include "vec/data_types/data_type_ipv4.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_struct.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_top_sum.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_top_sum.cpp
@@ -28,23 +28,23 @@ namespace doris::vectorized {
 template <size_t N>
 AggregateFunctionPtr create_aggregate_function_multi_top_sum_impl(
         const DataTypes& argument_types, const bool result_is_nullable,
-        const std::vector<std::string>& column_names) {
+        const AggregateFunctionAttr& attr) {
     if (N == argument_types.size() - 3) {
         return creator_with_integer_type_with_index<N>::template create<
-                AggregateFunctionApproxTopSumSimple>(argument_types, result_is_nullable,
-                                                     column_names);
+                AggregateFunctionApproxTopSumSimple>(argument_types, result_is_nullable, attr,
+                                                     attr.column_names);
     } else {
-        return create_aggregate_function_multi_top_sum_impl<N - 1>(
-                argument_types, result_is_nullable, column_names);
+        return create_aggregate_function_multi_top_sum_impl<N - 1>(argument_types,
+                                                                   result_is_nullable, attr);
     }
 }
 
 template <>
 AggregateFunctionPtr create_aggregate_function_multi_top_sum_impl<0>(
         const DataTypes& argument_types, const bool result_is_nullable,
-        const std::vector<std::string>& column_names) {
+        const AggregateFunctionAttr& attr) {
     return creator_with_integer_type::create<AggregateFunctionApproxTopSumSimple>(
-            argument_types, result_is_nullable, column_names);
+            argument_types, result_is_nullable, attr, attr.column_names);
 }
 
 AggregateFunctionPtr create_aggregate_function_approx_top_sum(const std::string& name,
@@ -61,8 +61,8 @@ AggregateFunctionPtr create_aggregate_function_approx_top_sum(const std::string&
                         "Argument types size exceeds the supported limit.");
     }
 
-    return create_aggregate_function_multi_top_sum_impl<max_param_value>(
-            argument_types, result_is_nullable, attr.column_names);
+    return create_aggregate_function_multi_top_sum_impl<max_param_value>(argument_types,
+                                                                         result_is_nullable, attr);
 }
 
 void register_aggregate_function_approx_top_sum(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_top_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_top_sum.h
@@ -39,7 +39,6 @@
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_ipv4.h"
 #include "vec/data_types/data_type_struct.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 

--- a/be/src/vec/aggregate_functions/aggregate_function_array_agg.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_array_agg.cpp
@@ -26,7 +26,8 @@ namespace doris::vectorized {
 
 template <PrimitiveType T>
 AggregateFunctionPtr do_create_agg_function_collect(const DataTypes& argument_types,
-                                                    const bool result_is_nullable) {
+                                                    const bool result_is_nullable,
+                                                    const AggregateFunctionAttr& attr) {
     if (argument_types[0]->is_nullable()) {
         return creator_without_type::create_ignore_nullable<
                 AggregateFunctionArrayAgg<AggregateFunctionArrayAggData<T>>>(argument_types,
@@ -34,7 +35,7 @@ AggregateFunctionPtr do_create_agg_function_collect(const DataTypes& argument_ty
     } else {
         return creator_without_type::create<
                 AggregateFunctionCollect<AggregateFunctionCollectListData<T, false>, false>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
 }
 
@@ -44,50 +45,66 @@ AggregateFunctionPtr create_aggregate_function_array_agg(const std::string& name
                                                          const AggregateFunctionAttr& attr) {
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
-        return do_create_agg_function_collect<TYPE_BOOLEAN>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_BOOLEAN>(argument_types, result_is_nullable,
+                                                            attr);
     case PrimitiveType::TYPE_TINYINT:
-        return do_create_agg_function_collect<TYPE_TINYINT>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_TINYINT>(argument_types, result_is_nullable,
+                                                            attr);
     case PrimitiveType::TYPE_SMALLINT:
-        return do_create_agg_function_collect<TYPE_SMALLINT>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_SMALLINT>(argument_types, result_is_nullable,
+                                                             attr);
     case PrimitiveType::TYPE_INT:
-        return do_create_agg_function_collect<TYPE_INT>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_INT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
-        return do_create_agg_function_collect<TYPE_BIGINT>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_BIGINT>(argument_types, result_is_nullable,
+                                                           attr);
     case PrimitiveType::TYPE_LARGEINT:
-        return do_create_agg_function_collect<TYPE_LARGEINT>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_LARGEINT>(argument_types, result_is_nullable,
+                                                             attr);
     case PrimitiveType::TYPE_FLOAT:
-        return do_create_agg_function_collect<TYPE_FLOAT>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_FLOAT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
-        return do_create_agg_function_collect<TYPE_DOUBLE>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DOUBLE>(argument_types, result_is_nullable,
+                                                           attr);
     case PrimitiveType::TYPE_DECIMAL32:
-        return do_create_agg_function_collect<TYPE_DECIMAL32>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DECIMAL32>(argument_types, result_is_nullable,
+                                                              attr);
     case PrimitiveType::TYPE_DECIMAL64:
-        return do_create_agg_function_collect<TYPE_DECIMAL64>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DECIMAL64>(argument_types, result_is_nullable,
+                                                              attr);
     case PrimitiveType::TYPE_DECIMAL128I:
-        return do_create_agg_function_collect<TYPE_DECIMAL128I>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DECIMAL128I>(argument_types, result_is_nullable,
+                                                                attr);
     case PrimitiveType::TYPE_DECIMALV2:
-        return do_create_agg_function_collect<TYPE_DECIMALV2>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DECIMALV2>(argument_types, result_is_nullable,
+                                                              attr);
     case PrimitiveType::TYPE_DECIMAL256:
-        return do_create_agg_function_collect<TYPE_DECIMAL256>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DECIMAL256>(argument_types, result_is_nullable,
+                                                               attr);
     case PrimitiveType::TYPE_DATE:
-        return do_create_agg_function_collect<TYPE_DATE>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DATE>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIME:
-        return do_create_agg_function_collect<TYPE_DATETIME>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DATETIME>(argument_types, result_is_nullable,
+                                                             attr);
     case PrimitiveType::TYPE_DATEV2:
-        return do_create_agg_function_collect<TYPE_DATEV2>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DATEV2>(argument_types, result_is_nullable,
+                                                           attr);
     case PrimitiveType::TYPE_DATETIMEV2:
-        return do_create_agg_function_collect<TYPE_DATETIMEV2>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_DATETIMEV2>(argument_types, result_is_nullable,
+                                                               attr);
     case PrimitiveType::TYPE_IPV4:
-        return do_create_agg_function_collect<TYPE_IPV4>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_IPV4>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_IPV6:
-        return do_create_agg_function_collect<TYPE_IPV6>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_IPV6>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_STRING:
     case PrimitiveType::TYPE_CHAR:
     case PrimitiveType::TYPE_VARCHAR:
-        return do_create_agg_function_collect<TYPE_VARCHAR>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<TYPE_VARCHAR>(argument_types, result_is_nullable,
+                                                            attr);
     default:
         // We do not care what the real type is.
-        return do_create_agg_function_collect<INVALID_TYPE>(argument_types, result_is_nullable);
+        return do_create_agg_function_collect<INVALID_TYPE>(argument_types, result_is_nullable,
+                                                            attr);
     }
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_array_agg.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_array_agg.cpp
@@ -30,8 +30,8 @@ AggregateFunctionPtr do_create_agg_function_collect(const DataTypes& argument_ty
                                                     const AggregateFunctionAttr& attr) {
     if (argument_types[0]->is_nullable()) {
         return creator_without_type::create_ignore_nullable<
-                AggregateFunctionArrayAgg<AggregateFunctionArrayAggData<T>>>(argument_types,
-                                                                             result_is_nullable);
+                AggregateFunctionArrayAgg<AggregateFunctionArrayAggData<T>>>(
+                argument_types, result_is_nullable, attr);
     } else {
         return creator_without_type::create<
                 AggregateFunctionCollect<AggregateFunctionCollectListData<T, false>, false>>(

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -38,7 +38,6 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_fixed_length_object.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.cpp
@@ -27,96 +27,100 @@ namespace doris::vectorized {
 
 template <PrimitiveType T, bool HasLimit>
 AggregateFunctionPtr do_create_agg_function_collect(bool distinct, const DataTypes& argument_types,
-                                                    const bool result_is_nullable) {
+                                                    const bool result_is_nullable,
+
+                                                    const AggregateFunctionAttr& attr) {
     if (distinct) {
         if constexpr (T == INVALID_TYPE) {
             throw Exception(ErrorCode::INTERNAL_ERROR,
                             "unexpected type for collect, please check the input");
         } else {
             return creator_without_type::create<AggregateFunctionCollect<
-                    AggregateFunctionCollectSetData<T, HasLimit>, HasLimit>>(argument_types,
-                                                                             result_is_nullable);
+                    AggregateFunctionCollectSetData<T, HasLimit>, HasLimit>>(
+                    argument_types, result_is_nullable, attr);
         }
     } else {
         return creator_without_type::create<
                 AggregateFunctionCollect<AggregateFunctionCollectListData<T, HasLimit>, HasLimit>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
 }
 
 template <bool HasLimit>
 AggregateFunctionPtr create_aggregate_function_collect_impl(const std::string& name,
                                                             const DataTypes& argument_types,
-                                                            const bool result_is_nullable) {
+                                                            const bool result_is_nullable,
+
+                                                            const AggregateFunctionAttr& attr) {
     bool distinct = name == "collect_set";
 
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
         return do_create_agg_function_collect<TYPE_BOOLEAN, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+                                                                      result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
         return do_create_agg_function_collect<TYPE_TINYINT, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+                                                                      result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return do_create_agg_function_collect<TYPE_SMALLINT, HasLimit>(distinct, argument_types,
-                                                                       result_is_nullable);
+                                                                       result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
         return do_create_agg_function_collect<TYPE_INT, HasLimit>(distinct, argument_types,
-                                                                  result_is_nullable);
+                                                                  result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
         return do_create_agg_function_collect<TYPE_BIGINT, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
+                                                                     result_is_nullable, attr);
     case PrimitiveType::TYPE_LARGEINT:
         return do_create_agg_function_collect<TYPE_LARGEINT, HasLimit>(distinct, argument_types,
-                                                                       result_is_nullable);
+                                                                       result_is_nullable, attr);
     case PrimitiveType::TYPE_FLOAT:
         return do_create_agg_function_collect<TYPE_FLOAT, HasLimit>(distinct, argument_types,
-                                                                    result_is_nullable);
+                                                                    result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
         return do_create_agg_function_collect<TYPE_DOUBLE, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
+                                                                     result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL32:
         return do_create_agg_function_collect<TYPE_DECIMAL32, HasLimit>(distinct, argument_types,
-                                                                        result_is_nullable);
+                                                                        result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL64:
         return do_create_agg_function_collect<TYPE_DECIMAL64, HasLimit>(distinct, argument_types,
-                                                                        result_is_nullable);
+                                                                        result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMALV2:
         return do_create_agg_function_collect<TYPE_DECIMALV2, HasLimit>(distinct, argument_types,
-                                                                        result_is_nullable);
+                                                                        result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL128I:
         return do_create_agg_function_collect<TYPE_DECIMAL128I, HasLimit>(distinct, argument_types,
-                                                                          result_is_nullable);
+                                                                          result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL256:
         return do_create_agg_function_collect<TYPE_DECIMAL256, HasLimit>(distinct, argument_types,
-                                                                         result_is_nullable);
+                                                                         result_is_nullable, attr);
     case PrimitiveType::TYPE_DATE:
         return do_create_agg_function_collect<TYPE_DATE, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
+                                                                   result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIME:
         return do_create_agg_function_collect<TYPE_DATETIME, HasLimit>(distinct, argument_types,
-                                                                       result_is_nullable);
+                                                                       result_is_nullable, attr);
     case PrimitiveType::TYPE_DATEV2:
         return do_create_agg_function_collect<TYPE_DATEV2, HasLimit>(distinct, argument_types,
-                                                                     result_is_nullable);
+                                                                     result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIMEV2:
         return do_create_agg_function_collect<TYPE_DATETIMEV2, HasLimit>(distinct, argument_types,
-                                                                         result_is_nullable);
+                                                                         result_is_nullable, attr);
     case PrimitiveType::TYPE_IPV6:
         return do_create_agg_function_collect<TYPE_IPV6, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
+                                                                   result_is_nullable, attr);
     case PrimitiveType::TYPE_IPV4:
         return do_create_agg_function_collect<TYPE_IPV4, HasLimit>(distinct, argument_types,
-                                                                   result_is_nullable);
+                                                                   result_is_nullable, attr);
     case PrimitiveType::TYPE_STRING:
     case PrimitiveType::TYPE_CHAR:
     case PrimitiveType::TYPE_VARCHAR:
         return do_create_agg_function_collect<TYPE_VARCHAR, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+                                                                      result_is_nullable, attr);
     default:
         // We do not care what the real type is.
         return do_create_agg_function_collect<INVALID_TYPE, HasLimit>(distinct, argument_types,
-                                                                      result_is_nullable);
+                                                                      result_is_nullable, attr);
     }
 }
 
@@ -126,11 +130,11 @@ AggregateFunctionPtr create_aggregate_function_collect(const std::string& name,
                                                        const AggregateFunctionAttr& attr) {
     if (argument_types.size() == 1) {
         return create_aggregate_function_collect_impl<false>(name, argument_types,
-                                                             result_is_nullable);
+                                                             result_is_nullable, attr);
     }
     if (argument_types.size() == 2) {
         return create_aggregate_function_collect_impl<true>(name, argument_types,
-                                                            result_is_nullable);
+                                                            result_is_nullable, attr);
     }
     throw Exception(ErrorCode::INTERNAL_ERROR,
                     "unexpected type for collect, please check the input");

--- a/be/src/vec/aggregate_functions/aggregate_function_combinator.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_combinator.h
@@ -64,7 +64,7 @@ public:
       */
     virtual AggregateFunctionPtr transform_aggregate_function(
             const AggregateFunctionPtr& nested_function, const DataTypes& arguments,
-            const bool result_is_nullable) const = 0;
+            const bool result_is_nullable, const AggregateFunctionAttr& attr) const = 0;
 
     virtual ~IAggregateFunctionCombinator() = default;
 };

--- a/be/src/vec/aggregate_functions/aggregate_function_corr.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_corr.cpp
@@ -36,7 +36,7 @@ AggregateFunctionPtr create_aggregate_corr_function(const std::string& name,
 
     DCHECK(argument_types[0]->get_primitive_type() == argument_types[1]->get_primitive_type());
     return creator_with_numeric_type::create<AggregateFunctionBinary, CorrMomentStat>(
-            argument_types, result_is_nullable);
+            argument_types, result_is_nullable, attr);
 }
 
 void register_aggregate_functions_corr(AggregateFunctionSimpleFactory& factory) {
@@ -56,8 +56,8 @@ AggregateFunctionPtr create_aggregate_corr_welford_function(const std::string& n
     }
 
     return creator_without_type::create<
-            AggregateFunctionBinary<StatFunc<TYPE_DOUBLE, CorrMomentWelford>>>(argument_types,
-                                                                               result_is_nullable);
+            AggregateFunctionBinary<StatFunc<TYPE_DOUBLE, CorrMomentWelford>>>(
+            argument_types, result_is_nullable, attr);
 }
 
 void register_aggregate_functions_corr_welford(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -37,7 +37,6 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_fixed_length_object.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/var_int.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_count_by_enum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count_by_enum.h
@@ -21,15 +21,11 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
-#include <array>
 #include <boost/dynamic_bitset.hpp>
 
-#include "common/logging.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/common/assert_cast.h"
-#include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_covar.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.cpp
@@ -27,8 +27,10 @@ namespace doris::vectorized {
 template <template <typename> class Function, template <PrimitiveType> class Data>
 AggregateFunctionPtr create_function_single_value(const String& name,
                                                   const DataTypes& argument_types,
-                                                  const bool result_is_nullable) {
-    return creator_with_numeric_type::create<Function, Data>(argument_types, result_is_nullable);
+                                                  const bool result_is_nullable,
+                                                  const AggregateFunctionAttr& attr) {
+    return creator_with_numeric_type::create<Function, Data>(argument_types, result_is_nullable,
+                                                             attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_covariance_samp(const std::string& name,
@@ -36,7 +38,7 @@ AggregateFunctionPtr create_aggregate_function_covariance_samp(const std::string
                                                                const bool result_is_nullable,
                                                                const AggregateFunctionAttr& attr) {
     return create_function_single_value<AggregateFunctionSampCovariance, SampData>(
-            name, argument_types, result_is_nullable);
+            name, argument_types, result_is_nullable, attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_covariance_pop(const std::string& name,
@@ -44,7 +46,7 @@ AggregateFunctionPtr create_aggregate_function_covariance_pop(const std::string&
                                                               const bool result_is_nullable,
                                                               const AggregateFunctionAttr& attr) {
     return create_function_single_value<AggregateFunctionSampCovariance, PopData>(
-            name, argument_types, result_is_nullable);
+            name, argument_types, result_is_nullable, attr);
 }
 
 void register_aggregate_function_covar_pop(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_covar.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.h
@@ -31,7 +31,6 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.cpp
@@ -55,7 +55,7 @@ public:
 
     AggregateFunctionPtr transform_aggregate_function(
             const AggregateFunctionPtr& nested_function, const DataTypes& arguments,
-            const bool result_is_nullable) const override {
+            const bool result_is_nullable, const AggregateFunctionAttr& attr) const override {
         DCHECK(nested_function != nullptr);
         if (nested_function == nullptr) {
             return nullptr;
@@ -64,19 +64,19 @@ public:
         if (arguments.size() == 1) {
             AggregateFunctionPtr res(
                     creator_with_numeric_type::create<AggregateFunctionDistinctNumeric>(
-                            arguments, result_is_nullable, nested_function));
+                            arguments, result_is_nullable, attr, nested_function));
             if (res) {
                 return res;
             }
 
             res = creator_without_type::create<
                     AggregateFunctionDistinct<AggregateFunctionDistinctSingleGenericData>>(
-                    arguments, result_is_nullable, nested_function);
+                    arguments, result_is_nullable, attr, nested_function);
             return res;
         }
         return creator_without_type::create<
                 AggregateFunctionDistinct<AggregateFunctionDistinctMultipleGenericData>>(
-                arguments, result_is_nullable, nested_function);
+                arguments, result_is_nullable, attr, nested_function);
     }
 };
 
@@ -96,7 +96,7 @@ void register_aggregate_function_combinator_distinct(AggregateFunctionSimpleFact
         auto nested_function = factory.get(nested_function_name, transform_arguments, false,
                                            BeExecVersionManager::get_newest_version(), attr);
         return function_combinator->transform_aggregate_function(nested_function, types,
-                                                                 result_is_nullable);
+                                                                 result_is_nullable, attr);
     };
     factory.register_distinct_function_combinator(creator, DISTINCT_FUNCTION_PREFIX);
     factory.register_distinct_function_combinator(creator, DISTINCT_FUNCTION_PREFIX, true);

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -24,10 +24,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
-#include <memory>
-#include <new>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -38,8 +34,6 @@
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/io/io_helper.h"
-#include "vec/io/var_int.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.cpp
@@ -21,13 +21,10 @@
 #include "vec/aggregate_functions/aggregate_function_foreach.h"
 
 #include <memory>
-#include <ostream>
 
-#include "common/logging.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/helpers.h"
-#include "vec/common/typeid_cast.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_nullable.h"
 
@@ -56,7 +53,8 @@ void register_aggregate_function_combinator_foreach(AggregateFunctionSimpleFacto
                     "name {} , args {}",
                     nested_function_name, types_name(types));
         }
-        return creator_without_type::create<AggregateFunctionForEach>(types, true, nested_function);
+        return creator_without_type::create<AggregateFunctionForEach>(types, true, attr,
+                                                                      nested_function);
     };
     factory.register_foreach_function_combinator(
             creator, AggregateFunctionForEach::AGG_FOREACH_SUFFIX, true);

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "common/logging.h"
 #include "common/status.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column_nullable.h"
@@ -29,7 +28,6 @@
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/functions/array/function_array_utils.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_foreachv2.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreachv2.cpp
@@ -98,7 +98,7 @@ void register_aggregate_function_combinator_foreachv2(AggregateFunctionSimpleFac
                     nested_function_name, types_name(types));
         }
         return creator_without_type::create<AggregateFunctionForEachV2>(types, result_is_nullable,
-                                                                        nested_function);
+                                                                        attr, nested_function);
     };
     factory.register_foreach_function_combinator(
             creator, AggregateFunctionForEachV2::AGG_FOREACH_SUFFIX, true);

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.cpp
@@ -20,6 +20,7 @@
 
 #include "vec/aggregate_functions/aggregate_function_group_array_intersect.h"
 
+#include "vec/aggregate_functions/factory_helpers.h"
 #include "vec/aggregate_functions/helpers.h"
 
 namespace doris::vectorized {

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.cpp
@@ -26,7 +26,8 @@ namespace doris::vectorized {
 #include "common/compile_check_begin.h"
 
 IAggregateFunction* create_with_extra_types(const DataTypePtr& nested_type,
-                                            const DataTypes& argument_types) {
+                                            const DataTypes& argument_types,
+                                            const AggregateFunctionAttr& attr) {
     if (nested_type->get_primitive_type() == PrimitiveType::TYPE_DATE ||
         nested_type->get_primitive_type() == PrimitiveType::TYPE_DATETIME) {
         throw Exception(ErrorCode::INVALID_ARGUMENT,
@@ -47,15 +48,16 @@ IAggregateFunction* create_with_extra_types(const DataTypePtr& nested_type,
 }
 
 inline AggregateFunctionPtr create_aggregate_function_group_array_intersect_impl(
-        const std::string& name, const DataTypes& argument_types, const bool result_is_nullable) {
+        const std::string& name, const DataTypes& argument_types, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr) {
     const auto& nested_type = remove_nullable(
             dynamic_cast<const DataTypeArray&>(*(argument_types[0])).get_nested_type());
     AggregateFunctionPtr res =
             creator_with_numeric_type::create<AggregateFunctionGroupArrayIntersect>(
-                    argument_types, result_is_nullable);
+                    argument_types, result_is_nullable, attr);
 
     if (!res) {
-        res = AggregateFunctionPtr(create_with_extra_types(nested_type, argument_types));
+        res = AggregateFunctionPtr(create_with_extra_types(nested_type, argument_types, attr));
     }
 
     if (!res) {
@@ -79,7 +81,7 @@ AggregateFunctionPtr create_aggregate_function_group_array_intersect(
                         "Provided argument type: " +
                                 argument_type->get_name());
     return create_aggregate_function_group_array_intersect_impl(name, {argument_type},
-                                                                result_is_nullable);
+                                                                result_is_nullable, attr);
 }
 
 void register_aggregate_function_group_array_intersect(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
@@ -18,23 +18,17 @@
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/AggregateFunctions/AggregateFunctionGroupArrayIntersect.cpp
 // and modified by Doris
 
-#include <cassert>
 #include <memory>
 
 #include "exprs/hybrid_set.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
-#include "vec/aggregate_functions/factory_helpers.h"
-#include "vec/aggregate_functions/helpers.h"
 #include "vec/columns/column_array.h"
 #include "vec/common/assert_cast.h"
 #include "vec/core/field.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_date_or_datetime_v2.h"
-#include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
-#include "vec/io/io_helper.h"
-#include "vec/io/var_int.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.cpp
@@ -34,11 +34,11 @@ AggregateFunctionPtr create_aggregate_function_group_concat(const std::string& n
     if (argument_types.size() == 1) {
         return creator_without_type::create<
                 AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStr>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else if (argument_types.size() == 2) {
         return creator_without_type::create<
                 AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStrStr>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
 
     LOG(WARNING) << fmt::format("Illegal number {} of argument for aggregate function {}",

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
@@ -29,7 +29,6 @@
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_string.h"
-#include "vec/io/io_helper.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.cpp
@@ -39,10 +39,10 @@ AggregateFunctionPtr create_aggregate_function_histogram(const std::string& name
     AggregateFunctionPtr result;
     if (argument_types.size() == 2) {
         result = creator_with_any::create<HistogramWithInputParam, AggregateFunctionHistogramData>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else if (argument_types.size() == 1) {
         result = creator_with_any::create<HistogramNormal, AggregateFunctionHistogramData>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else {
         throw Exception(ErrorCode::INVALID_ARGUMENT,
                         "Aggregate function histogram requires 1 or 2 arguments, but got {}",

--- a/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
@@ -34,7 +33,6 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_hll.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_kurtosis.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_kurtosis.cpp
@@ -15,14 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "common/status.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/aggregate_function_statistic.h"
 #include "vec/aggregate_functions/helpers.h"
-#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
@@ -30,17 +27,18 @@ namespace doris::vectorized {
 template <PrimitiveType T>
 AggregateFunctionPtr type_dispatch_for_aggregate_function_kurt(const DataTypes& argument_types,
                                                                const bool result_is_nullable,
-                                                               bool nullable_input) {
+                                                               bool nullable_input,
+                                                               const AggregateFunctionAttr& attr) {
     using StatFunctionTemplate = StatFuncOneArg<T, 4>;
 
     if (nullable_input) {
         return creator_without_type::create_ignore_nullable<
                 AggregateFunctionVarianceSimple<StatFunctionTemplate, true>>(
-                argument_types, result_is_nullable, STATISTICS_FUNCTION_KIND::KURT_POP);
+                argument_types, result_is_nullable, attr, STATISTICS_FUNCTION_KIND::KURT_POP);
     } else {
         return creator_without_type::create_ignore_nullable<
                 AggregateFunctionVarianceSimple<StatFunctionTemplate, false>>(
-                argument_types, result_is_nullable, STATISTICS_FUNCTION_KIND::KURT_POP);
+                argument_types, result_is_nullable, attr, STATISTICS_FUNCTION_KIND::KURT_POP);
     }
 };
 
@@ -62,28 +60,28 @@ AggregateFunctionPtr create_aggregate_function_kurt(const std::string& name,
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
         return type_dispatch_for_aggregate_function_kurt<TYPE_BOOLEAN>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_TINYINT:
         return type_dispatch_for_aggregate_function_kurt<TYPE_TINYINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return type_dispatch_for_aggregate_function_kurt<TYPE_SMALLINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_INT:
         return type_dispatch_for_aggregate_function_kurt<TYPE_INT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_BIGINT:
         return type_dispatch_for_aggregate_function_kurt<TYPE_BIGINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_LARGEINT:
         return type_dispatch_for_aggregate_function_kurt<TYPE_LARGEINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_FLOAT:
         return type_dispatch_for_aggregate_function_kurt<TYPE_FLOAT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     case PrimitiveType::TYPE_DOUBLE:
         return type_dispatch_for_aggregate_function_kurt<TYPE_DOUBLE>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, nullable_input, attr);
     default:
         LOG(WARNING) << "unsupported input type " << argument_types[0]->get_name()
                      << " for aggregate function " << name;

--- a/be/src/vec/aggregate_functions/aggregate_function_linear_histogram.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_linear_histogram.cpp
@@ -26,17 +26,18 @@ const std::string AggregateFunctionLinearHistogramConsts::NAME = "linear_histogr
 
 template <PrimitiveType T>
 AggregateFunctionPtr create_agg_function_linear_histogram(const DataTypes& argument_types,
-                                                          const bool result_is_nullable) {
+                                                          const bool result_is_nullable,
+                                                          const AggregateFunctionAttr& attr) {
     bool has_offset = (argument_types.size() == 3);
 
     if (has_offset) {
         return creator_without_type::create<
                 AggregateFunctionLinearHistogram<T, AggregateFunctionLinearHistogramData<T>, true>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else {
         return creator_without_type::create<AggregateFunctionLinearHistogram<
                 T, AggregateFunctionLinearHistogramData<T>, false>>(argument_types,
-                                                                    result_is_nullable);
+                                                                    result_is_nullable, attr);
     }
 }
 
@@ -47,41 +48,43 @@ AggregateFunctionPtr create_aggregate_function_linear_histogram(const std::strin
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
         return create_agg_function_linear_histogram<TYPE_BOOLEAN>(argument_types,
-                                                                  result_is_nullable);
+                                                                  result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
         return create_agg_function_linear_histogram<TYPE_TINYINT>(argument_types,
-                                                                  result_is_nullable);
+                                                                  result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return create_agg_function_linear_histogram<TYPE_SMALLINT>(argument_types,
-                                                                   result_is_nullable);
+                                                                   result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
-        return create_agg_function_linear_histogram<TYPE_INT>(argument_types, result_is_nullable);
+        return create_agg_function_linear_histogram<TYPE_INT>(argument_types, result_is_nullable,
+                                                              attr);
     case PrimitiveType::TYPE_BIGINT:
-        return create_agg_function_linear_histogram<TYPE_BIGINT>(argument_types,
-                                                                 result_is_nullable);
+        return create_agg_function_linear_histogram<TYPE_BIGINT>(argument_types, result_is_nullable,
+                                                                 attr);
     case PrimitiveType::TYPE_LARGEINT:
         return create_agg_function_linear_histogram<TYPE_LARGEINT>(argument_types,
-                                                                   result_is_nullable);
+                                                                   result_is_nullable, attr);
     case PrimitiveType::TYPE_FLOAT:
-        return create_agg_function_linear_histogram<TYPE_FLOAT>(argument_types, result_is_nullable);
+        return create_agg_function_linear_histogram<TYPE_FLOAT>(argument_types, result_is_nullable,
+                                                                attr);
     case PrimitiveType::TYPE_DOUBLE:
-        return create_agg_function_linear_histogram<TYPE_DOUBLE>(argument_types,
-                                                                 result_is_nullable);
+        return create_agg_function_linear_histogram<TYPE_DOUBLE>(argument_types, result_is_nullable,
+                                                                 attr);
     case PrimitiveType::TYPE_DECIMAL32:
         return create_agg_function_linear_histogram<TYPE_DECIMAL32>(argument_types,
-                                                                    result_is_nullable);
+                                                                    result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL64:
         return create_agg_function_linear_histogram<TYPE_DECIMAL64>(argument_types,
-                                                                    result_is_nullable);
+                                                                    result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL128I:
         return create_agg_function_linear_histogram<TYPE_DECIMAL128I>(argument_types,
-                                                                      result_is_nullable);
+                                                                      result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMALV2:
         return create_agg_function_linear_histogram<TYPE_DECIMALV2>(argument_types,
-                                                                    result_is_nullable);
+                                                                    result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL256:
         return create_agg_function_linear_histogram<TYPE_DECIMAL256>(argument_types,
-                                                                     result_is_nullable);
+                                                                     result_is_nullable, attr);
     default:
 
         LOG(WARNING) << fmt::format("unsupported input type {} for aggregate function {}",

--- a/be/src/vec/aggregate_functions/aggregate_function_linear_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_linear_histogram.h
@@ -28,7 +28,6 @@
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
-#include "vec/io/io_helper.h"
 
 // TODO: optimize count=0
 // TODO: support datetime

--- a/be/src/vec/aggregate_functions/aggregate_function_map.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.cpp
@@ -17,7 +17,6 @@
 
 #include "vec/aggregate_functions/aggregate_function_map.h"
 
-#include "runtime/primitive_type.h"
 #include "vec/aggregate_functions/helpers.h"
 
 namespace doris::vectorized {
@@ -25,10 +24,11 @@ namespace doris::vectorized {
 
 template <PrimitiveType K>
 AggregateFunctionPtr create_agg_function_map_agg(const DataTypes& argument_types,
-                                                 const bool result_is_nullable) {
+                                                 const bool result_is_nullable,
+                                                 const AggregateFunctionAttr& attr) {
     return creator_without_type::create_ignore_nullable<
             AggregateFunctionMapAgg<AggregateFunctionMapAggData<K>, K>>(argument_types,
-                                                                        result_is_nullable);
+                                                                        result_is_nullable, attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_map_agg(const std::string& name,
@@ -37,45 +37,51 @@ AggregateFunctionPtr create_aggregate_function_map_agg(const std::string& name,
                                                        const AggregateFunctionAttr& attr) {
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
-        return create_agg_function_map_agg<TYPE_BOOLEAN>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_BOOLEAN>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
-        return create_agg_function_map_agg<TYPE_TINYINT>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_TINYINT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
-        return create_agg_function_map_agg<TYPE_SMALLINT>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_SMALLINT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
-        return create_agg_function_map_agg<TYPE_INT>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_INT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
-        return create_agg_function_map_agg<TYPE_BIGINT>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_BIGINT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_LARGEINT:
-        return create_agg_function_map_agg<TYPE_LARGEINT>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_LARGEINT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_FLOAT:
-        return create_agg_function_map_agg<TYPE_FLOAT>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_FLOAT>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
-        return create_agg_function_map_agg<TYPE_DOUBLE>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DOUBLE>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL32:
-        return create_agg_function_map_agg<TYPE_DECIMAL32>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DECIMAL32>(argument_types, result_is_nullable,
+                                                           attr);
     case PrimitiveType::TYPE_DECIMAL64:
-        return create_agg_function_map_agg<TYPE_DECIMAL64>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DECIMAL64>(argument_types, result_is_nullable,
+                                                           attr);
     case PrimitiveType::TYPE_DECIMAL128I:
-        return create_agg_function_map_agg<TYPE_DECIMAL128I>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DECIMAL128I>(argument_types, result_is_nullable,
+                                                             attr);
     case PrimitiveType::TYPE_DECIMALV2:
-        return create_agg_function_map_agg<TYPE_DECIMALV2>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DECIMALV2>(argument_types, result_is_nullable,
+                                                           attr);
     case PrimitiveType::TYPE_DECIMAL256:
-        return create_agg_function_map_agg<TYPE_DECIMAL256>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DECIMAL256>(argument_types, result_is_nullable,
+                                                            attr);
     case PrimitiveType::TYPE_STRING:
-        return create_agg_function_map_agg<TYPE_STRING>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_STRING>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_CHAR:
-        return create_agg_function_map_agg<TYPE_CHAR>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_CHAR>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_VARCHAR:
-        return create_agg_function_map_agg<TYPE_VARCHAR>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_VARCHAR>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATE:
-        return create_agg_function_map_agg<TYPE_DATE>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DATE>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIME:
-        return create_agg_function_map_agg<TYPE_DATETIME>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DATETIME>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATEV2:
-        return create_agg_function_map_agg<TYPE_DATEV2>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DATEV2>(argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIMEV2:
-        return create_agg_function_map_agg<TYPE_DATETIMEV2>(argument_types, result_is_nullable);
+        return create_agg_function_map_agg<TYPE_DATETIMEV2>(argument_types, result_is_nullable,
+                                                            attr);
     default:
         LOG(WARNING) << fmt::format("unsupported input type {} for aggregate function {}",
                                     argument_types[0]->get_name(), name);

--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -27,9 +27,7 @@
 #include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_map.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_map_v2.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_map_v2.cpp
@@ -23,10 +23,11 @@ namespace doris::vectorized {
 #include "common/compile_check_begin.h"
 
 AggregateFunctionPtr create_agg_function_map_agg_v2(const DataTypes& argument_types,
-                                                    const bool result_is_nullable) {
+                                                    const bool result_is_nullable,
+                                                    const AggregateFunctionAttr& attr) {
     return creator_without_type::create_ignore_nullable<
             AggregateFunctionMapAggV2<AggregateFunctionMapAggDataV2>>(argument_types,
-                                                                      result_is_nullable);
+                                                                      result_is_nullable, attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_map_agg_v2(const std::string& name,
@@ -55,7 +56,7 @@ AggregateFunctionPtr create_aggregate_function_map_agg_v2(const std::string& nam
     case PrimitiveType::TYPE_DATEV2:
     case PrimitiveType::TYPE_DATETIMEV2:
     case PrimitiveType::TYPE_TIMEV2:
-        return create_agg_function_map_agg_v2(argument_types, result_is_nullable);
+        return create_agg_function_map_agg_v2(argument_types, result_is_nullable, attr);
     default:
         LOG(WARNING) << fmt::format("unsupported input type {} for aggregate function {}",
                                     argument_types[0]->get_name(), name);

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -43,92 +43,92 @@ AggregateFunctionPtr create_aggregate_function_single_value(const String& name,
     case PrimitiveType::TYPE_VARCHAR:
     case PrimitiveType::TYPE_JSONB:
         return creator_without_type::create_unary_arguments<
-                AggregateFunctionsSingleValue<Data<SingleValueDataString>>>(argument_types,
-                                                                            result_is_nullable);
+                AggregateFunctionsSingleValue<Data<SingleValueDataString>>>(
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATE:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATE>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIME:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATETIME>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATEV2:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATEV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIMEV2:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DATETIMEV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_TIME:
     case PrimitiveType::TYPE_TIMEV2:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_TIMEV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_IPV4:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_IPV4>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_IPV6:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_IPV6>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     // For boolean, tinyint, smallint, int, bigint, largeint
     case PrimitiveType::TYPE_BOOLEAN:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_BOOLEAN>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_TINYINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_SMALLINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_INT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_BIGINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_LARGEINT:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_LARGEINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     // For float, double
     case PrimitiveType::TYPE_FLOAT:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_FLOAT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_DOUBLE>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     // For decimal
     case PrimitiveType::TYPE_DECIMAL32:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL32>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL64:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL64>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMALV2:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMALV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL128I:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL128I>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL256:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataDecimal<TYPE_DECIMAL256>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     default:
         return nullptr;
     }
@@ -153,8 +153,8 @@ AggregateFunctionPtr create_aggregate_function_single_value_any_value_function(
         argument_type->get_primitive_type() == PrimitiveType::TYPE_HLL ||
         argument_type->get_primitive_type() == PrimitiveType::TYPE_QUANTILE_STATE) {
         return creator_without_type::create_unary_arguments<
-                AggregateFunctionsSingleValue<SingleValueDataComplexType>>(argument_types,
-                                                                           result_is_nullable);
+                AggregateFunctionsSingleValue<SingleValueDataComplexType>>(
+                argument_types, result_is_nullable, attr);
     }
 
     return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -198,82 +198,83 @@ public:
 template <template <typename> class AggregateFunctionTemplate,
           template <typename, typename> class Data, typename VT>
 AggregateFunctionPtr create_aggregate_function_min_max_by_impl(const DataTypes& argument_types,
-                                                               const bool result_is_nullable) {
+                                                               const bool result_is_nullable,
+                                                               const AggregateFunctionAttr& attr) {
     switch (argument_types[1]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_BOOLEAN>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_TINYINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_SMALLINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_INT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_BIGINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_LARGEINT:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_LARGEINT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_FLOAT:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_FLOAT>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_DOUBLE>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL32:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<TYPE_DECIMAL32>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL64:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<TYPE_DECIMAL64>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL128I:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<TYPE_DECIMAL128I>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMALV2:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<TYPE_DECIMALV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL256:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<TYPE_DECIMAL256>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_CHAR:
     case PrimitiveType::TYPE_VARCHAR:
     case PrimitiveType::TYPE_STRING:
         return creator_without_type::create_multi_arguments<
-                AggregateFunctionTemplate<Data<VT, SingleValueDataString>>>(argument_types,
-                                                                            result_is_nullable);
+                AggregateFunctionTemplate<Data<VT, SingleValueDataString>>>(
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATE:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_DATE>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIME:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_DATETIME>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATEV2:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_DATEV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIMEV2:
         return creator_without_type::create_multi_arguments<
                 AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE_DATETIMEV2>>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     default:
         return nullptr;
     }
@@ -293,81 +294,81 @@ AggregateFunctionPtr create_aggregate_function_min_max_by(const String& name,
     case PrimitiveType::TYPE_BOOLEAN:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_BOOLEAN>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_TINYINT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_SMALLINT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_INT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_BIGINT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_LARGEINT:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_LARGEINT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_FLOAT:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_FLOAT>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_DOUBLE>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL32:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataDecimal<TYPE_DECIMAL32>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL64:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataDecimal<TYPE_DECIMAL64>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL128I:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataDecimal<TYPE_DECIMAL128I>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMALV2:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataDecimal<TYPE_DECIMALV2>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DECIMAL256:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataDecimal<TYPE_DECIMAL256>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_STRING:
     case PrimitiveType::TYPE_CHAR:
     case PrimitiveType::TYPE_VARCHAR:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataString>(argument_types,
-                                                                                result_is_nullable);
+                                                         SingleValueDataString>(
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATE:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_DATE>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIME:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_DATETIME>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATEV2:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_DATEV2>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DATETIMEV2:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<TYPE_DATETIMEV2>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BITMAP:
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          BitmapValueData>(argument_types,
-                                                                          result_is_nullable);
+                                                                          result_is_nullable, attr);
     default:
         return nullptr;
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -27,7 +27,6 @@
 #include "vec/columns/column_vector.h"
 #include "vec/common/assert_cast.h"
 #include "vec/data_types/data_type_bitmap.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include <array>
 
 #include "common/logging.h"
@@ -243,12 +245,15 @@ public:
              Arena& arena) const override {
         const auto* column =
                 assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
-        if (column->is_null_at(row_num)) {
-            this->update_null_count(place, true);
-        } else {
+        if (!column->is_null_at(row_num)) {
             this->set_flag(place);
             const IColumn* nested_column = &column->get_nested_column();
             this->nested_function->add(this->nested_place(place), &nested_column, row_num, arena);
+        } else {
+            if constexpr (is_window_function) {
+                DCHECK_EQ(result_is_nullable, true);
+                this->update_null_count(place, true);
+            }
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -244,13 +244,11 @@ public:
         const auto* column =
                 assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         if (column->is_null_at(row_num)) {
-            this->null_count++;
+            this->update_null_count(place + this->prefix_size, true);
         } else {
             this->set_flag(place);
             const IColumn* nested_column = &column->get_nested_column();
             this->nested_function->add(this->nested_place(place), &nested_column, row_num, arena);
-        } else {
-            this->update_null_count(place + this->prefix_size, true);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -155,7 +155,14 @@ public:
     }
 
     size_t size_of_data() const override {
-        return prefix_size + null_count_size + nested_function->size_of_data();
+        size_t raw_size = prefix_size + null_count_size + nested_function->size_of_data();
+        size_t alignment = align_of_data();
+
+        if (raw_size % alignment == 0) {
+            return raw_size;
+        }
+        // If not aligned, we need to pad it.
+        return raw_size + (alignment - (raw_size % alignment));
     }
 
     size_t align_of_data() const override {

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -425,7 +425,9 @@ public:
                     this->nested_place(place), columns_tmp, arena, is_previous_frame_start_null,
                     is_current_frame_end_null, true, use_null_result, could_use_previous_result);
             DCHECK_EQ(result_is_nullable, true);
-            if (current_frame_end - current_frame_start != this->get_null_count(place)) {
+            if (current_frame_end - current_frame_start == this->get_null_count(place)) {
+                this->init_flag(place);
+            } else {
                 this->set_flag(place);
             }
         } else {

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.cpp
@@ -35,7 +35,6 @@ namespace doris::vectorized {
 template <template <PrimitiveType> class Impl>
 AggregateFunctionPtr create_aggregate_function_orthogonal(const std::string& name,
                                                           const DataTypes& argument_types,
-
                                                           const bool result_is_nullable,
                                                           const AggregateFunctionAttr& attr) {
     if (argument_types.empty()) {
@@ -43,16 +42,16 @@ AggregateFunctionPtr create_aggregate_function_orthogonal(const std::string& nam
         return nullptr;
     } else if (argument_types.size() == 1) {
         return creator_without_type::create<AggFunctionOrthBitmapFunc<Impl<TYPE_STRING>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else {
         AggregateFunctionPtr res(
                 creator_with_integer_type_with_index<1>::create<AggFunctionOrthBitmapFunc, Impl>(
-                        argument_types, result_is_nullable));
+                        argument_types, result_is_nullable, attr));
         if (res) {
             return res;
         } else if (is_string_type(argument_types[1]->get_primitive_type())) {
             res = creator_without_type::create<AggFunctionOrthBitmapFunc<Impl<TYPE_STRING>>>(
-                    argument_types, result_is_nullable);
+                    argument_types, result_is_nullable, attr);
             return res;
         }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -36,7 +36,6 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.cpp
@@ -33,11 +33,11 @@ AggregateFunctionPtr create_aggregate_function_percentile_approx(
     }
     if (argument_types.size() == 2) {
         return creator_without_type::create<AggregateFunctionPercentileApproxTwoParams>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
     if (argument_types.size() == 3) {
         return creator_without_type::create<AggregateFunctionPercentileApproxThreeParams>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
     return nullptr;
 }
@@ -51,11 +51,11 @@ AggregateFunctionPtr create_aggregate_function_percentile_approx_weighted(
     }
     if (argument_types.size() == 3) {
         return creator_without_type::create<AggregateFunctionPercentileApproxWeightedThreeParams>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
     if (argument_types.size() == 4) {
         return creator_without_type::create<AggregateFunctionPercentileApproxWeightedFourParams>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
     return nullptr;
 }

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -21,15 +21,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <vector>
 
-#include "agent/be_exec_version_manager.h"
 #include "util/counts.h"
 #include "util/tdigest.h"
 #include "vec/aggregate_functions/aggregate_function.h"
@@ -39,12 +36,10 @@
 #include "vec/columns/column_vector.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/pod_array_fwd.h"
-#include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 

--- a/be/src/vec/aggregate_functions/aggregate_function_regr_union.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_regr_union.cpp
@@ -17,13 +17,10 @@
 
 #include "vec/aggregate_functions/aggregate_function_regr_union.h"
 
-#include "common/status.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/helpers.h"
-#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
@@ -31,27 +28,28 @@ namespace doris::vectorized {
 template <PrimitiveType T, template <PrimitiveType> class StatFunctionTemplate>
 AggregateFunctionPtr type_dispatch_for_aggregate_function_regr(const DataTypes& argument_types,
                                                                const bool& result_is_nullable,
+                                                               const AggregateFunctionAttr& attr,
                                                                bool y_nullable_input,
                                                                bool x_nullable_input) {
     if (y_nullable_input) {
         if (x_nullable_input) {
             return creator_without_type::create_ignore_nullable<
                     AggregateFunctionRegrSimple<StatFunctionTemplate<T>, true, true>>(
-                    argument_types, result_is_nullable);
+                    argument_types, result_is_nullable, attr);
         } else {
             return creator_without_type::create_ignore_nullable<
                     AggregateFunctionRegrSimple<StatFunctionTemplate<T>, true, false>>(
-                    argument_types, result_is_nullable);
+                    argument_types, result_is_nullable, attr);
         }
     } else {
         if (x_nullable_input) {
             return creator_without_type::create_ignore_nullable<
                     AggregateFunctionRegrSimple<StatFunctionTemplate<T>, false, true>>(
-                    argument_types, result_is_nullable);
+                    argument_types, result_is_nullable, attr);
         } else {
             return creator_without_type::create_ignore_nullable<
                     AggregateFunctionRegrSimple<StatFunctionTemplate<T>, false, false>>(
-                    argument_types, result_is_nullable);
+                    argument_types, result_is_nullable, attr);
         }
     }
 }
@@ -76,35 +74,35 @@ AggregateFunctionPtr create_aggregate_function_regr(const std::string& name,
     if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_BOOLEAN &&
         argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_BOOLEAN) {
         return type_dispatch_for_aggregate_function_regr<TYPE_BOOLEAN, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_TINYINT &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_TINYINT) {
         return type_dispatch_for_aggregate_function_regr<TYPE_TINYINT, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_SMALLINT &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_SMALLINT) {
         return type_dispatch_for_aggregate_function_regr<TYPE_SMALLINT, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_INT &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_INT) {
         return type_dispatch_for_aggregate_function_regr<TYPE_INT, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_BIGINT &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_BIGINT) {
         return type_dispatch_for_aggregate_function_regr<TYPE_BIGINT, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_LARGEINT &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_LARGEINT) {
         return type_dispatch_for_aggregate_function_regr<TYPE_LARGEINT, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_FLOAT &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_FLOAT) {
         return type_dispatch_for_aggregate_function_regr<TYPE_FLOAT, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else if (argument_types[0]->get_primitive_type() == PrimitiveType::TYPE_DOUBLE &&
                argument_types[1]->get_primitive_type() == PrimitiveType::TYPE_DOUBLE) {
         return type_dispatch_for_aggregate_function_regr<TYPE_DOUBLE, StatFunctionTemplate>(
-                argument_types, result_is_nullable, y_nullable_input, x_nullable_input);
+                argument_types, result_is_nullable, attr, y_nullable_input, x_nullable_input);
     } else {
         LOG(WARNING) << "unsupported input types " << argument_types[0]->get_name() << " and "
                      << argument_types[1]->get_name() << " for aggregate function " << name;

--- a/be/src/vec/aggregate_functions/aggregate_function_regr_union.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_regr_union.h
@@ -18,12 +18,7 @@
 #pragma once
 
 #include <cmath>
-#include <cstdint>
-#include <string>
-#include <type_traits>
 
-#include "common/exception.h"
-#include "common/status.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
@@ -33,7 +28,6 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_retention.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention.h
@@ -24,7 +24,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 

--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.cpp
@@ -23,7 +23,6 @@
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/helpers.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
@@ -47,14 +46,14 @@ AggregateFunctionPtr create_aggregate_function_sequence_base(const std::string& 
 
     switch (argument_types[1]->get_primitive_type()) {
     case TYPE_DATETIMEV2:
-        return creator_without_type::create<AggregateFunction<TYPE_DATETIMEV2>>(argument_types,
-                                                                                result_is_nullable);
+        return creator_without_type::create<AggregateFunction<TYPE_DATETIMEV2>>(
+                argument_types, result_is_nullable, attr);
     case TYPE_DATETIME:
-        return creator_without_type::create<AggregateFunction<TYPE_DATETIME>>(argument_types,
-                                                                              result_is_nullable);
+        return creator_without_type::create<AggregateFunction<TYPE_DATETIME>>(
+                argument_types, result_is_nullable, attr);
     case TYPE_DATEV2:
-        return creator_without_type::create<AggregateFunction<TYPE_DATEV2>>(argument_types,
-                                                                            result_is_nullable);
+        return creator_without_type::create<AggregateFunction<TYPE_DATEV2>>(
+                argument_types, result_is_nullable, attr);
     default:
         return nullptr;
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -30,7 +30,6 @@
 #include <functional>
 #include <iterator>
 #include <memory>
-#include <ostream>
 #include <stack>
 #include <string>
 #include <tuple>

--- a/be/src/vec/aggregate_functions/aggregate_function_skew.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_skew.cpp
@@ -15,14 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "common/status.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/aggregate_function_statistic.h"
 #include "vec/aggregate_functions/helpers.h"
-#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
@@ -30,17 +27,18 @@ namespace doris::vectorized {
 template <PrimitiveType T>
 AggregateFunctionPtr type_dispatch_for_aggregate_function_skew(const DataTypes& argument_types,
                                                                const bool result_is_nullable,
+                                                               const AggregateFunctionAttr& attr,
                                                                bool nullable_input) {
     using StatFunctionTemplate = StatFuncOneArg<T, 3>;
 
     if (nullable_input) {
         return creator_without_type::create_ignore_nullable<
                 AggregateFunctionVarianceSimple<StatFunctionTemplate, true>>(
-                argument_types, result_is_nullable, STATISTICS_FUNCTION_KIND::SKEW_POP);
+                argument_types, result_is_nullable, attr, STATISTICS_FUNCTION_KIND::SKEW_POP);
     } else {
         return creator_without_type::create_ignore_nullable<
                 AggregateFunctionVarianceSimple<StatFunctionTemplate, false>>(
-                argument_types, result_is_nullable, STATISTICS_FUNCTION_KIND::SKEW_POP);
+                argument_types, result_is_nullable, attr, STATISTICS_FUNCTION_KIND::SKEW_POP);
     }
 };
 
@@ -62,28 +60,28 @@ AggregateFunctionPtr create_aggregate_function_skew(const std::string& name,
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
         return type_dispatch_for_aggregate_function_skew<TYPE_BOOLEAN>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_TINYINT:
         return type_dispatch_for_aggregate_function_skew<TYPE_TINYINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_SMALLINT:
         return type_dispatch_for_aggregate_function_skew<TYPE_SMALLINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_INT:
         return type_dispatch_for_aggregate_function_skew<TYPE_INT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_BIGINT:
         return type_dispatch_for_aggregate_function_skew<TYPE_BIGINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_LARGEINT:
         return type_dispatch_for_aggregate_function_skew<TYPE_LARGEINT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_FLOAT:
         return type_dispatch_for_aggregate_function_skew<TYPE_FLOAT>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     case PrimitiveType::TYPE_DOUBLE:
         return type_dispatch_for_aggregate_function_skew<TYPE_DOUBLE>(
-                argument_types, result_is_nullable, nullable_input);
+                argument_types, result_is_nullable, attr, nullable_input);
     default:
         LOG(WARNING) << "unsupported input type " << argument_types[0]->get_name()
                      << " for aggregate function " << name;

--- a/be/src/vec/aggregate_functions/aggregate_function_sort.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sort.h
@@ -23,9 +23,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <memory>
-#include <new>
-#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,7 +35,6 @@
 #include "vec/core/sort_block.h"
 #include "vec/core/sort_description.h"
 #include "vec/core/types.h"
-#include "vec/io/io_helper.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_statistic.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_statistic.h
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <cstdint>
 #include <string>
-#include <type_traits>
 
 #include "common/exception.h"
 #include "common/status.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.cpp
@@ -34,32 +34,33 @@ template <template <typename> class Function, typename Name,
           template <PrimitiveType, typename, bool> class Data, bool is_stddev>
 AggregateFunctionPtr create_function_single_value(const String& name,
                                                   const DataTypes& argument_types,
-                                                  const bool result_is_nullable) {
+                                                  const bool result_is_nullable,
+                                                  const AggregateFunctionAttr& attr) {
     switch (argument_types[0]->get_primitive_type()) {
     case PrimitiveType::TYPE_BOOLEAN:
         return creator_without_type::create<Function<Data<TYPE_BOOLEAN, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_TINYINT:
         return creator_without_type::create<Function<Data<TYPE_TINYINT, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_SMALLINT:
         return creator_without_type::create<Function<Data<TYPE_SMALLINT, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_INT:
         return creator_without_type::create<Function<Data<TYPE_INT, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_BIGINT:
         return creator_without_type::create<Function<Data<TYPE_BIGINT, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_LARGEINT:
         return creator_without_type::create<Function<Data<TYPE_LARGEINT, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_FLOAT:
         return creator_without_type::create<Function<Data<TYPE_FLOAT, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     case PrimitiveType::TYPE_DOUBLE:
         return creator_without_type::create<Function<Data<TYPE_DOUBLE, Name, is_stddev>>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     default:
         LOG(WARNING) << fmt::format("create_function_single_value with unknowed type {}",
                                     argument_types[0]->get_name());
@@ -72,7 +73,7 @@ AggregateFunctionPtr create_aggregate_function_variance_samp(const std::string& 
                                                              const bool result_is_nullable,
                                                              const AggregateFunctionAttr& attr) {
     return create_function_single_value<AggregateFunctionSampVariance, VarianceSampName, SampData,
-                                        false>(name, argument_types, result_is_nullable);
+                                        false>(name, argument_types, result_is_nullable, attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_variance_pop(const std::string& name,
@@ -80,7 +81,7 @@ AggregateFunctionPtr create_aggregate_function_variance_pop(const std::string& n
                                                             const bool result_is_nullable,
                                                             const AggregateFunctionAttr& attr) {
     return create_function_single_value<AggregateFunctionSampVariance, VarianceName, PopData,
-                                        false>(name, argument_types, result_is_nullable);
+                                        false>(name, argument_types, result_is_nullable, attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_stddev_pop(const std::string& name,
@@ -88,7 +89,7 @@ AggregateFunctionPtr create_aggregate_function_stddev_pop(const std::string& nam
                                                           const bool result_is_nullable,
                                                           const AggregateFunctionAttr& attr) {
     return create_function_single_value<AggregateFunctionSampVariance, StddevName, PopData, true>(
-            name, argument_types, result_is_nullable);
+            name, argument_types, result_is_nullable, attr);
 }
 
 AggregateFunctionPtr create_aggregate_function_stddev_samp(const std::string& name,
@@ -96,7 +97,7 @@ AggregateFunctionPtr create_aggregate_function_stddev_samp(const std::string& na
                                                            const bool result_is_nullable,
                                                            const AggregateFunctionAttr& attr) {
     return create_function_single_value<AggregateFunctionSampVariance, StddevSampName, SampData,
-                                        true>(name, argument_types, result_is_nullable);
+                                        true>(name, argument_types, result_is_nullable, attr);
 }
 
 void register_aggregate_function_stddev_variance_pop(AggregateFunctionSimpleFactory& factory) {

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -31,7 +31,6 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -23,7 +23,6 @@
 #include <stddef.h>
 
 #include <memory>
-#include <type_traits>
 #include <vector>
 
 #include "vec/aggregate_functions/aggregate_function.h"
@@ -34,7 +33,6 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_fixed_length_object.h"
-#include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.cpp
@@ -32,10 +32,10 @@ AggregateFunctionPtr create_aggregate_function_topn(const std::string& name,
                                                     const AggregateFunctionAttr& attr) {
     if (argument_types.size() == 2) {
         return creator_without_type::create<AggregateFunctionTopN<AggregateFunctionTopNImplInt>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else if (argument_types.size() == 3) {
         return creator_without_type::create<AggregateFunctionTopN<AggregateFunctionTopNImplIntInt>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
     return nullptr;
 }
@@ -52,10 +52,10 @@ AggregateFunctionPtr create_aggregate_function_topn_array(const std::string& nam
     bool has_default_param = (argument_types.size() == 3);
     if (has_default_param) {
         return creator_with_any::create<AggregateFunctionTopNArray, ImplArrayWithDefault>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else {
-        return creator_with_any::create<AggregateFunctionTopNArray, ImplArray>(argument_types,
-                                                                               result_is_nullable);
+        return creator_with_any::create<AggregateFunctionTopNArray, ImplArray>(
+                argument_types, result_is_nullable, attr);
     }
 }
 
@@ -71,10 +71,10 @@ AggregateFunctionPtr create_aggregate_function_topn_weighted(const std::string& 
     bool has_default_param = (argument_types.size() == 4);
     if (has_default_param) {
         return creator_with_any::create<AggregateFunctionTopNArray, ImplWeightWithDefault>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else {
-        return creator_with_any::create<AggregateFunctionTopNArray, ImplWeight>(argument_types,
-                                                                                result_is_nullable);
+        return creator_with_any::create<AggregateFunctionTopNArray, ImplWeight>(
+                argument_types, result_is_nullable, attr);
     }
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.cpp
@@ -27,7 +27,6 @@
 #include "vec/common/hash_table/hash.h" // IWYU pragma: keep
 #include "vec/core/extended_types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
@@ -39,7 +38,7 @@ AggregateFunctionPtr create_aggregate_function_uniq(const std::string& name,
                                                     const AggregateFunctionAttr& attr) {
     if (argument_types.size() == 1) {
         AggregateFunctionPtr res(creator_with_numeric_type::create<AggregateFunctionUniq, Data>(
-                argument_types, result_is_nullable));
+                argument_types, result_is_nullable, attr));
         if (res) {
             return res;
         } else {
@@ -47,33 +46,33 @@ AggregateFunctionPtr create_aggregate_function_uniq(const std::string& name,
             case TYPE_DECIMAL32:
                 return creator_without_type::create<
                         AggregateFunctionUniq<TYPE_DECIMAL32, Data<TYPE_DECIMAL32>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case TYPE_DECIMAL64:
                 return creator_without_type::create<
                         AggregateFunctionUniq<TYPE_DECIMAL64, Data<TYPE_DECIMAL64>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case TYPE_DECIMAL128I:
                 return creator_without_type::create<
                         AggregateFunctionUniq<TYPE_DECIMAL128I, Data<TYPE_DECIMAL128I>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case TYPE_DECIMAL256:
                 return creator_without_type::create<
                         AggregateFunctionUniq<TYPE_DECIMAL256, Data<TYPE_DECIMAL256>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case TYPE_DECIMALV2:
                 return creator_without_type::create<
                         AggregateFunctionUniq<TYPE_DECIMALV2, Data<TYPE_DECIMALV2>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case TYPE_STRING:
             case TYPE_CHAR:
             case TYPE_VARCHAR:
                 return creator_without_type::create<
-                        AggregateFunctionUniq<TYPE_STRING, Data<TYPE_STRING>>>(argument_types,
-                                                                               result_is_nullable);
+                        AggregateFunctionUniq<TYPE_STRING, Data<TYPE_STRING>>>(
+                        argument_types, result_is_nullable, attr);
             case TYPE_ARRAY:
                 return creator_without_type::create<
-                        AggregateFunctionUniq<TYPE_ARRAY, Data<TYPE_ARRAY>>>(argument_types,
-                                                                             result_is_nullable);
+                        AggregateFunctionUniq<TYPE_ARRAY, Data<TYPE_ARRAY>>>(
+                        argument_types, result_is_nullable, attr);
             default:
                 break;
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -22,7 +22,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <type_traits>

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.cpp
@@ -34,7 +34,7 @@ AggregateFunctionPtr create_aggregate_function_uniq(const std::string& name,
     if (argument_types.size() == 1) {
         AggregateFunctionPtr res(
                 creator_with_numeric_type::create<AggregateFunctionUniqDistributeKey, Data>(
-                        argument_types, result_is_nullable));
+                        argument_types, result_is_nullable, attr));
         if (res) {
             return res;
         } else {
@@ -42,25 +42,25 @@ AggregateFunctionPtr create_aggregate_function_uniq(const std::string& name,
             case PrimitiveType::TYPE_DECIMAL32:
                 return creator_without_type::create<
                         AggregateFunctionUniqDistributeKey<TYPE_DECIMAL32, Data<TYPE_DECIMAL32>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case PrimitiveType::TYPE_DECIMAL64:
                 return creator_without_type::create<
                         AggregateFunctionUniqDistributeKey<TYPE_DECIMAL32, Data<TYPE_DECIMAL64>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case PrimitiveType::TYPE_DECIMAL128I:
                 return creator_without_type::create<
                         AggregateFunctionUniqDistributeKey<TYPE_DECIMAL32, Data<TYPE_DECIMAL128I>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case PrimitiveType::TYPE_DECIMALV2:
                 return creator_without_type::create<
                         AggregateFunctionUniqDistributeKey<TYPE_DECIMAL32, Data<TYPE_DECIMALV2>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             case PrimitiveType::TYPE_STRING:
             case PrimitiveType::TYPE_CHAR:
             case PrimitiveType::TYPE_VARCHAR:
                 return creator_without_type::create<
                         AggregateFunctionUniqDistributeKey<TYPE_STRING, Data<TYPE_STRING>>>(
-                        argument_types, result_is_nullable);
+                        argument_types, result_is_nullable, attr);
             default:
                 break;
             }

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.h
@@ -22,7 +22,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <vector>
@@ -38,7 +37,6 @@
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_fixed_length_object.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/io/var_int.h"
 
 template <typename T>
 struct HashCRC32;

--- a/be/src/vec/aggregate_functions/aggregate_function_window.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.cpp
@@ -26,7 +26,6 @@
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/helpers.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/utils/template_helpers.hpp"
 
 namespace doris::vectorized {

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.cpp
@@ -17,8 +17,6 @@
 
 #include "vec/aggregate_functions/aggregate_function_window_funnel.h"
 
-#include <algorithm>
-#include <ostream>
 #include <string>
 
 #include "common/logging.h"
@@ -26,7 +24,6 @@
 #include "vec/aggregate_functions/helpers.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
@@ -42,11 +39,11 @@ AggregateFunctionPtr create_aggregate_function_window_funnel(const std::string& 
     if (argument_types[2]->get_primitive_type() == TYPE_DATETIMEV2) {
         return creator_without_type::create<
                 AggregateFunctionWindowFunnel<PrimitiveType::TYPE_DATETIMEV2, UInt64>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else if (argument_types[2]->get_primitive_type() == TYPE_DATETIME) {
         return creator_without_type::create<
                 AggregateFunctionWindowFunnel<PrimitiveType::TYPE_DATETIME, Int64>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     } else {
         LOG(WARNING) << "Only support DateTime type as window argument!";
         return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -31,7 +31,6 @@
 #include <utility>
 
 #include "common/cast_set.h"
-#include "common/compiler_util.h"
 #include "common/exception.h"
 #include "util/binary_cast.hpp"
 #include "util/simd/bits.h"
@@ -40,7 +39,6 @@
 #include "vec/common/assert_cast.h"
 #include "vec/core/sort_block.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_number.h"
 #include "vec/io/var_int.h"
 #include "vec/runtime/vdatetime_value.h"

--- a/be/src/vec/aggregate_functions/helpers.h
+++ b/be/src/vec/aggregate_functions/helpers.h
@@ -161,6 +161,7 @@ struct creator_without_type {
     template <typename AggregateFunctionTemplate, typename... TArgs>
     static AggregateFunctionPtr create_ignore_nullable(const DataTypes& argument_types_,
                                                        const bool /*result_is_nullable*/,
+                                                       const AggregateFunctionAttr& /*attr*/,
                                                        TArgs&&... args) {
         std::unique_ptr<IAggregateFunction> result = std::make_unique<AggregateFunctionTemplate>(
                 std::forward<TArgs>(args)..., argument_types_);

--- a/be/src/vec/aggregate_functions/helpers.h
+++ b/be/src/vec/aggregate_functions/helpers.h
@@ -79,32 +79,35 @@ namespace doris::vectorized {
 #include "common/compile_check_begin.h"
 
 struct creator_without_type {
-    template <bool multi_arguments, bool f, typename T>
-    using NullableT = std::conditional_t<multi_arguments, AggregateFunctionNullVariadicInline<T, f>,
-                                         AggregateFunctionNullUnaryInline<T, f>>;
+    template <bool multi_arguments, bool f, bool w, typename T>
+    using NullableT =
+            std::conditional_t<multi_arguments, AggregateFunctionNullVariadicInline<T, f, w>,
+                               AggregateFunctionNullUnaryInline<T, f, w>>;
 
     template <typename AggregateFunctionTemplate>
     static AggregateFunctionPtr creator(const std::string& name, const DataTypes& argument_types,
                                         const bool result_is_nullable,
                                         const AggregateFunctionAttr& attr) {
         CHECK_AGG_FUNCTION_SERIALIZED_TYPE(AggregateFunctionTemplate);
-        return create<AggregateFunctionTemplate>(argument_types, result_is_nullable);
+        return create<AggregateFunctionTemplate>(argument_types, result_is_nullable, attr);
     }
 
     template <typename AggregateFunctionTemplate, typename... TArgs>
     static AggregateFunctionPtr create(const DataTypes& argument_types_,
-                                       const bool result_is_nullable, TArgs&&... args) {
+                                       const bool result_is_nullable,
+                                       const AggregateFunctionAttr& attr, TArgs&&... args) {
         std::unique_ptr<IAggregateFunction> result(std::make_unique<AggregateFunctionTemplate>(
                 std::forward<TArgs>(args)..., remove_nullable(argument_types_)));
         if (have_nullable(argument_types_)) {
             std::visit(
-                    [&](auto multi_arguments, auto result_is_nullable) {
+                    [&](auto multi_arguments, auto result_is_nullable, auto is_window_function) {
                         result.reset(new NullableT<multi_arguments, result_is_nullable,
-                                                   AggregateFunctionTemplate>(result.release(),
-                                                                              argument_types_));
+                                                   is_window_function, AggregateFunctionTemplate>(
+                                result.release(), argument_types_));
                     },
                     make_bool_variant(argument_types_.size() > 1),
-                    make_bool_variant(result_is_nullable));
+                    make_bool_variant(result_is_nullable),
+                    make_bool_variant(attr.is_window_function));
         }
 
         CHECK_AGG_FUNCTION_SERIALIZED_TYPE(AggregateFunctionTemplate);
@@ -114,17 +117,19 @@ struct creator_without_type {
     template <typename AggregateFunctionTemplate, typename... TArgs>
     static AggregateFunctionPtr create_multi_arguments(const DataTypes& argument_types_,
                                                        const bool result_is_nullable,
+                                                       const AggregateFunctionAttr& attr,
                                                        TArgs&&... args) {
         std::unique_ptr<IAggregateFunction> result(std::make_unique<AggregateFunctionTemplate>(
                 std::forward<TArgs>(args)..., remove_nullable(argument_types_)));
         if (have_nullable(argument_types_)) {
-            if (result_is_nullable) {
-                result.reset(new NullableT<true, true, AggregateFunctionTemplate>(result.release(),
-                                                                                  argument_types_));
-            } else {
-                result.reset(new NullableT<true, false, AggregateFunctionTemplate>(
-                        result.release(), argument_types_));
-            }
+            std::visit(
+                    [&](auto result_is_nullable, auto is_window_function) {
+                        result.reset(new NullableT<true, result_is_nullable, is_window_function,
+                                                   AggregateFunctionTemplate>(result.release(),
+                                                                              argument_types_));
+                    },
+                    make_bool_variant(result_is_nullable),
+                    make_bool_variant(attr.is_window_function));
         }
         CHECK_AGG_FUNCTION_SERIALIZED_TYPE(AggregateFunctionTemplate);
         return AggregateFunctionPtr(result.release());
@@ -133,17 +138,19 @@ struct creator_without_type {
     template <typename AggregateFunctionTemplate, typename... TArgs>
     static AggregateFunctionPtr create_unary_arguments(const DataTypes& argument_types_,
                                                        const bool result_is_nullable,
+                                                       const AggregateFunctionAttr& attr,
                                                        TArgs&&... args) {
         std::unique_ptr<IAggregateFunction> result(std::make_unique<AggregateFunctionTemplate>(
                 std::forward<TArgs>(args)..., remove_nullable(argument_types_)));
         if (have_nullable(argument_types_)) {
-            if (result_is_nullable) {
-                result.reset(new NullableT<false, true, AggregateFunctionTemplate>(
-                        result.release(), argument_types_));
-            } else {
-                result.reset(new NullableT<false, false, AggregateFunctionTemplate>(
-                        result.release(), argument_types_));
-            }
+            std::visit(
+                    [&](auto result_is_nullable, auto is_window_function) {
+                        result.reset(new NullableT<false, result_is_nullable, is_window_function,
+                                                   AggregateFunctionTemplate>(result.release(),
+                                                                              argument_types_));
+                    },
+                    make_bool_variant(result_is_nullable),
+                    make_bool_variant(attr.is_window_function));
         }
         CHECK_AGG_FUNCTION_SERIALIZED_TYPE(AggregateFunctionTemplate);
         return AggregateFunctionPtr(result.release());
@@ -190,10 +197,11 @@ template <bool allow_integer, bool allow_float, bool allow_decimal, bool allow_s
 struct creator_with_type_base {
     template <typename Class, typename... TArgs>
     static AggregateFunctionPtr create_base(const DataTypes& argument_types,
-                                            const bool result_is_nullable, TArgs&&... args) {
+                                            const bool result_is_nullable,
+                                            const AggregateFunctionAttr& attr, TArgs&&... args) {
         auto create = [&]<PrimitiveType Ptype>() {
             return creator_without_type::create<typename Class::template T<Ptype>>(
-                    argument_types, result_is_nullable, std::forward<TArgs>(args)...);
+                    argument_types, result_is_nullable, attr, std::forward<TArgs>(args)...);
         };
         if constexpr (allow_integer) {
             switch (argument_types[define_index]->get_primitive_type()) {
@@ -286,7 +294,7 @@ struct creator_with_type_base {
                                         const bool result_is_nullable,
                                         const AggregateFunctionAttr& attr) {
         return create_base<CurryDirect<AggregateFunctionTemplate>>(argument_types,
-                                                                   result_is_nullable);
+                                                                   result_is_nullable, attr);
     }
 
     template <template <PrimitiveType> class AggregateFunctionTemplate, typename... TArgs>
@@ -300,7 +308,7 @@ struct creator_with_type_base {
                                         const bool result_is_nullable,
                                         const AggregateFunctionAttr& attr) {
         return create_base<CurryData<AggregateFunctionTemplate, Data>>(argument_types,
-                                                                       result_is_nullable);
+                                                                       result_is_nullable, attr);
     }
 
     template <template <typename> class AggregateFunctionTemplate,
@@ -316,7 +324,7 @@ struct creator_with_type_base {
                                         const bool result_is_nullable,
                                         const AggregateFunctionAttr& attr) {
         return create_base<CurryDataImpl<AggregateFunctionTemplate, Data, Impl>>(
-                argument_types, result_is_nullable);
+                argument_types, result_is_nullable, attr);
     }
 
     template <template <typename> class AggregateFunctionTemplate, template <typename> class Data,
@@ -331,8 +339,8 @@ struct creator_with_type_base {
     static AggregateFunctionPtr creator(const std::string& name, const DataTypes& argument_types,
                                         const bool result_is_nullable,
                                         const AggregateFunctionAttr& attr) {
-        return create_base<CurryDirectAndData<AggregateFunctionTemplate, Data>>(argument_types,
-                                                                                result_is_nullable);
+        return create_base<CurryDirectAndData<AggregateFunctionTemplate, Data>>(
+                argument_types, result_is_nullable, attr);
     }
 
     template <template <PrimitiveType, typename> class AggregateFunctionTemplate,

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -212,15 +212,15 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                     AggregateFunctionSimpleFactory::result_nullable_by_foreach(_data_type),
                     state->be_exec_version(),
                     {.enable_decimal256 = state->enable_decimal256(),
-                     .column_names = std::move(column_names),
-                     .is_window_function = _is_window_function});
+                     .is_window_function = _is_window_function,
+                     .column_names = std::move(column_names)});
         } else {
             _function = AggregateFunctionSimpleFactory::instance().get(
                     _fn.name.function_name, argument_types, _data_type->is_nullable(),
                     state->be_exec_version(),
                     {.enable_decimal256 = state->enable_decimal256(),
-                     .column_names = std::move(column_names),
-                     .is_window_function = _is_window_function});
+                     .is_window_function = _is_window_function,
+                     .column_names = std::move(column_names)});
         }
     }
     if (_function == nullptr) {

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -66,10 +66,12 @@ AggregateFunctionPtr get_agg_state_function(const DataTypes& argument_types,
             argument_types, return_type);
 }
 
-AggFnEvaluator::AggFnEvaluator(const TExprNode& desc, const bool without_key)
+AggFnEvaluator::AggFnEvaluator(const TExprNode& desc, const bool without_key,
+                               const bool is_window_function)
         : _fn(desc.fn),
           _is_merge(desc.agg_expr.is_merge_agg),
           _without_key(without_key),
+          _is_window_function(is_window_function),
           _data_type(DataTypeFactory::instance().create_data_type(
                   desc.fn.ret_type, desc.__isset.is_nullable ? desc.is_nullable : true)) {
     if (desc.agg_expr.__isset.param_types) {
@@ -82,8 +84,11 @@ AggFnEvaluator::AggFnEvaluator(const TExprNode& desc, const bool without_key)
 }
 
 Status AggFnEvaluator::create(ObjectPool* pool, const TExpr& desc, const TSortInfo& sort_info,
-                              const bool without_key, AggFnEvaluator** result) {
-    *result = pool->add(AggFnEvaluator::create_unique(desc.nodes[0], without_key).release());
+                              const bool without_key, const bool is_window_function,
+                              AggFnEvaluator** result) {
+    *result =
+            pool->add(AggFnEvaluator::create_unique(desc.nodes[0], without_key, is_window_function)
+                              .release());
     auto& agg_fn_evaluator = *result;
     int node_idx = 0;
     for (int i = 0; i < desc.nodes[0].num_children; ++i) {
@@ -207,13 +212,15 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                     AggregateFunctionSimpleFactory::result_nullable_by_foreach(_data_type),
                     state->be_exec_version(),
                     {.enable_decimal256 = state->enable_decimal256(),
-                     .column_names = std::move(column_names)});
+                     .column_names = std::move(column_names),
+                     .is_window_function = _is_window_function});
         } else {
             _function = AggregateFunctionSimpleFactory::instance().get(
                     _fn.name.function_name, argument_types, _data_type->is_nullable(),
                     state->be_exec_version(),
                     {.enable_decimal256 = state->enable_decimal256(),
-                     .column_names = std::move(column_names)});
+                     .column_names = std::move(column_names),
+                     .is_window_function = _is_window_function});
         }
     }
     if (_function == nullptr) {
@@ -342,6 +349,7 @@ AggFnEvaluator::AggFnEvaluator(AggFnEvaluator& evaluator, RuntimeState* state)
         : _fn(evaluator._fn),
           _is_merge(evaluator._is_merge),
           _without_key(evaluator._without_key),
+          _is_window_function(evaluator._is_window_function),
           _argument_types_with_sort(evaluator._argument_types_with_sort),
           _real_argument_types(evaluator._real_argument_types),
           _intermediate_slot_desc(evaluator._intermediate_slot_desc),

--- a/be/src/vec/exprs/vectorized_agg_fn.h
+++ b/be/src/vec/exprs/vectorized_agg_fn.h
@@ -55,7 +55,8 @@ public:
 
 public:
     static Status create(ObjectPool* pool, const TExpr& desc, const TSortInfo& sort_info,
-                         const bool without_key, AggFnEvaluator** result);
+                         const bool without_key, const bool is_window_function,
+                         AggFnEvaluator** result);
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc,
                    const SlotDescriptor* intermediate_slot_desc,
@@ -119,7 +120,9 @@ private:
     // 2. executed with group by key
     const bool _without_key;
 
-    AggFnEvaluator(const TExprNode& desc, const bool without_key);
+    const bool _is_window_function;
+
+    AggFnEvaluator(const TExprNode& desc, const bool without_key, const bool is_window_function);
     AggFnEvaluator(AggFnEvaluator& evaluator, RuntimeState* state);
 
 #ifdef BE_TEST

--- a/be/src/vec/exprs/vectorized_agg_fn.h
+++ b/be/src/vec/exprs/vectorized_agg_fn.h
@@ -126,8 +126,10 @@ private:
     AggFnEvaluator(AggFnEvaluator& evaluator, RuntimeState* state);
 
 #ifdef BE_TEST
-    AggFnEvaluator(bool is_merge, bool without_key)
-            : _is_merge(is_merge), _without_key(without_key) {};
+    AggFnEvaluator(bool is_merge, bool without_key, const bool is_window_function)
+            : _is_merge(is_merge),
+              _without_key(without_key),
+              _is_window_function(is_window_function) {};
 #endif
     Status _calc_argument_columns(Block* block);
 

--- a/be/src/vec/functions/array/function_array_aggregation.cpp
+++ b/be/src/vec/functions/array/function_array_aggregation.cpp
@@ -194,8 +194,10 @@ struct AggregateFunction {
     template <PrimitiveType T>
     using Function = typename Derived::template TypeTraits<T>::Function;
 
-    static auto create(const DataTypePtr& data_type_ptr) -> AggregateFunctionPtr {
-        return creator_with_type::create<Function>(DataTypes {make_nullable(data_type_ptr)}, true);
+    static auto create(const DataTypePtr& data_type_ptr, const AggregateFunctionAttr& attr)
+            -> AggregateFunctionPtr {
+        return creator_with_type::create<Function>(DataTypes {make_nullable(data_type_ptr)}, true,
+                                                   attr);
     }
 };
 
@@ -212,7 +214,7 @@ struct ArrayAggregateImpl {
         using Function = AggregateFunction<AggregateFunctionImpl<operation, enable_decimal256>>;
         const DataTypeArray* data_type_array =
                 static_cast<const DataTypeArray*>(remove_nullable(arguments[0]).get());
-        auto function = Function::create(data_type_array->get_nested_type());
+        auto function = Function::create(data_type_array->get_nested_type(), {});
         if (function) {
             return function->get_return_type();
         } else {
@@ -273,7 +275,7 @@ struct ArrayAggregateImpl {
         res_column = make_nullable(res_column);
         static_cast<ColumnNullable&>(res_column->assume_mutable_ref()).reserve(offsets.size());
 
-        auto function = Function::create(type);
+        auto function = Function::create(type, {});
         auto guard = AggregateFunctionGuard(function.get());
         Arena arena;
         auto nullable_column = make_nullable(data->get_ptr());
@@ -336,9 +338,10 @@ struct NameArrayMin {
 
 template <>
 struct AggregateFunction<AggregateFunctionImpl<AggregateOperation::MIN>> {
-    static auto create(const DataTypePtr& data_type_ptr) -> AggregateFunctionPtr {
+    static auto create(const DataTypePtr& data_type_ptr, const AggregateFunctionAttr& attr)
+            -> AggregateFunctionPtr {
         return create_aggregate_function_single_value<AggregateFunctionMinData>(
-                NameArrayMin::name, {make_nullable(data_type_ptr)}, true);
+                NameArrayMin::name, {make_nullable(data_type_ptr)}, true, attr);
     }
 };
 
@@ -348,9 +351,10 @@ struct NameArrayMax {
 
 template <>
 struct AggregateFunction<AggregateFunctionImpl<AggregateOperation::MAX>> {
-    static auto create(const DataTypePtr& data_type_ptr) -> AggregateFunctionPtr {
+    static auto create(const DataTypePtr& data_type_ptr, const AggregateFunctionAttr& attr)
+            -> AggregateFunctionPtr {
         return create_aggregate_function_single_value<AggregateFunctionMaxData>(
-                NameArrayMax::name, {make_nullable(data_type_ptr)}, true);
+                NameArrayMax::name, {make_nullable(data_type_ptr)}, true, attr);
     }
 };
 

--- a/be/src/vec/functions/array/function_array_aggregation.cpp
+++ b/be/src/vec/functions/array/function_array_aggregation.cpp
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -214,7 +213,10 @@ struct ArrayAggregateImpl {
         using Function = AggregateFunction<AggregateFunctionImpl<operation, enable_decimal256>>;
         const DataTypeArray* data_type_array =
                 static_cast<const DataTypeArray*>(remove_nullable(arguments[0]).get());
-        auto function = Function::create(data_type_array->get_nested_type(), {});
+        auto function = Function::create(data_type_array->get_nested_type(),
+                                         {.enable_decimal256 = enable_decimal256,
+                                          .column_names = {},
+                                          .is_window_function = false});
         if (function) {
             return function->get_return_type();
         } else {
@@ -275,7 +277,9 @@ struct ArrayAggregateImpl {
         res_column = make_nullable(res_column);
         static_cast<ColumnNullable&>(res_column->assume_mutable_ref()).reserve(offsets.size());
 
-        auto function = Function::create(type, {});
+        auto function = Function::create(type, {.enable_decimal256 = enable_decimal256,
+                                                .column_names = {},
+                                                .is_window_function = false});
         auto guard = AggregateFunctionGuard(function.get());
         Arena arena;
         auto nullable_column = make_nullable(data->get_ptr());

--- a/be/src/vec/functions/array/function_array_aggregation.cpp
+++ b/be/src/vec/functions/array/function_array_aggregation.cpp
@@ -215,8 +215,8 @@ struct ArrayAggregateImpl {
                 static_cast<const DataTypeArray*>(remove_nullable(arguments[0]).get());
         auto function = Function::create(data_type_array->get_nested_type(),
                                          {.enable_decimal256 = enable_decimal256,
-                                          .column_names = {},
-                                          .is_window_function = false});
+                                          .is_window_function = false,
+                                          .column_names = {}});
         if (function) {
             return function->get_return_type();
         } else {
@@ -278,8 +278,8 @@ struct ArrayAggregateImpl {
         static_cast<ColumnNullable&>(res_column->assume_mutable_ref()).reserve(offsets.size());
 
         auto function = Function::create(type, {.enable_decimal256 = enable_decimal256,
-                                                .column_names = {},
-                                                .is_window_function = false});
+                                                .is_window_function = false,
+                                                .column_names = {}});
         auto guard = AggregateFunctionGuard(function.get());
         Arena arena;
         auto nullable_column = make_nullable(data->get_ptr());

--- a/be/test/pipeline/operator/analytic_sink_operator_test.cpp
+++ b/be/test/pipeline/operator/analytic_sink_operator_test.cpp
@@ -92,7 +92,7 @@ struct AnalyticSinkOperatorTest : public ::testing::Test {
         sink->_num_agg_input.resize(agg_functions_size);
         sink->_offsets_of_aggregate_states.resize(agg_functions_size);
         sink->_change_to_nullable_flags.resize(agg_functions_size);
-        sink->_agg_functions[0] = create_agg_fn(pool, function_name, args_types, false);
+        sink->_agg_functions[0] = create_agg_fn(pool, function_name, args_types, false, true);
         sink->_num_agg_input[0] = 1;
         sink->_offsets_of_aggregate_states[0] = 0;
         sink->_total_size_of_aggregate_states = 100;

--- a/be/test/testutil/mock/mock_agg_fn_evaluator.cpp
+++ b/be/test/testutil/mock/mock_agg_fn_evaluator.cpp
@@ -60,8 +60,8 @@ AggFnEvaluator* create_agg_fn(ObjectPool& pool, const std::string& agg_fn_name,
     mock_agg_fn_evaluator->_function = AggregateFunctionSimpleFactory::instance().get(
             agg_fn_name, args_types, result_nullable, BeExecVersionManager::get_newest_version(),
             {.enable_decimal256 = false,
-             .column_names = {},
-             .is_window_function = is_window_function});
+             .is_window_function = is_window_function,
+             .column_names = {}});
     EXPECT_TRUE(mock_agg_fn_evaluator->_function != nullptr);
     for (int i = 0; i < args_types.size(); i++) {
         mock_agg_fn_evaluator->_input_exprs_ctxs.push_back(

--- a/be/test/testutil/mock/mock_agg_fn_evaluator.cpp
+++ b/be/test/testutil/mock/mock_agg_fn_evaluator.cpp
@@ -53,11 +53,15 @@ AggFnEvaluator* create_mock_agg_fn_evaluator(ObjectPool& pool, VExprContextSPtrs
 }
 
 AggFnEvaluator* create_agg_fn(ObjectPool& pool, const std::string& agg_fn_name,
-                              const DataTypes& args_types, bool result_nullable) {
-    auto* mock_agg_fn_evaluator = pool.add(new MockAggFnEvaluator(false, false)); // just falg;
+                              const DataTypes& args_types, bool result_nullable,
+                              bool is_window_function) {
+    auto* mock_agg_fn_evaluator =
+            pool.add(new MockAggFnEvaluator(false, false, is_window_function)); // just falg;
     mock_agg_fn_evaluator->_function = AggregateFunctionSimpleFactory::instance().get(
             agg_fn_name, args_types, result_nullable, BeExecVersionManager::get_newest_version(),
-            {.enable_decimal256 = false, .column_names = {}});
+            {.enable_decimal256 = false,
+             .column_names = {},
+             .is_window_function = is_window_function});
     EXPECT_TRUE(mock_agg_fn_evaluator->_function != nullptr);
     for (int i = 0; i < args_types.size(); i++) {
         mock_agg_fn_evaluator->_input_exprs_ctxs.push_back(

--- a/be/test/testutil/mock/mock_agg_fn_evaluator.h
+++ b/be/test/testutil/mock/mock_agg_fn_evaluator.h
@@ -27,11 +27,13 @@ AggFnEvaluator* create_mock_agg_fn_evaluator(ObjectPool& pool, VExprContextSPtrs
                                              bool is_merge = false, bool without_key = false);
 
 AggFnEvaluator* create_agg_fn(ObjectPool& pool, const std::string& agg_fn_name,
-                              const DataTypes& args_types, bool result_nullable);
+                              const DataTypes& args_types, bool result_nullable,
+                              bool is_window_function = false);
 
 class MockAggFnEvaluator : public AggFnEvaluator {
 public:
-    MockAggFnEvaluator(bool is_merge, bool without_key) : AggFnEvaluator(is_merge, without_key) {}
+    MockAggFnEvaluator(bool is_merge, bool without_key, bool is_window_function = false)
+            : AggFnEvaluator(is_merge, without_key, is_window_function) {}
 };
 
 } // namespace doris::vectorized

--- a/be/test/vec/aggregate_functions/agg_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_test.cpp
@@ -114,8 +114,8 @@ TEST(AggTest, window_function_test) {
     bool is_window_function = true;
     auto agg_function = factory.get("group_bit_or", data_types, true, -1,
                                     {.enable_decimal256 = false,
-                                     .column_names = {},
-                                     .is_window_function = is_window_function});
+                                     .is_window_function = is_window_function,
+                                     .column_names = {}});
     auto size = agg_function->size_of_data();
     EXPECT_EQ(size, 6);
     size = agg_function->align_of_data();
@@ -124,8 +124,8 @@ TEST(AggTest, window_function_test) {
     is_window_function = false;
     auto agg_function2 = factory.get("group_bit_or", data_types, true, -1,
                                      {.enable_decimal256 = false,
-                                      .column_names = {},
-                                      .is_window_function = is_window_function});
+                                      .is_window_function = is_window_function,
+                                      .column_names = {}});
     auto size2 = agg_function2->size_of_data();
     EXPECT_EQ(size2, 2);
     size2 = agg_function2->align_of_data();
@@ -141,21 +141,21 @@ TEST(AggTest, window_function_test2) {
     bool is_window_function = true;
     auto agg_function_sum = factory.get("sum", {std::make_shared<DataTypeInt32>()}, true, -1,
                                         {.enable_decimal256 = false,
-                                         .column_names = {},
-                                         .is_window_function = is_window_function});
+                                         .is_window_function = is_window_function,
+                                         .column_names = {}});
 
     auto agg_function_group =
             factory.get("group_bit_or", {make_nullable(std::make_shared<DataTypeInt8>())}, true, -1,
                         {.enable_decimal256 = false,
-                         .column_names = {},
-                         .is_window_function = is_window_function});
+                         .is_window_function = is_window_function,
+                         .column_names = {}});
 
     auto agg_function_topn = factory.get(
             "topn", {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>()}, true,
             -1,
             {.enable_decimal256 = false,
-             .column_names = {},
-             .is_window_function = is_window_function});
+             .is_window_function = is_window_function,
+             .column_names = {}});
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;
     _agg_functions.push_back(agg_function_sum);
     _agg_functions.push_back(agg_function_group);

--- a/be/test/vec/aggregate_functions/agg_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_test.cpp
@@ -17,9 +17,11 @@
 
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <memory>
+#include <random>
 #include <string>
 
 #include "gtest/gtest_pred_impl.h"
@@ -33,6 +35,7 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+#include "vec/exprs/vectorized_agg_fn.h"
 
 const int agg_test_batch_size = 4096;
 
@@ -40,6 +43,7 @@ namespace doris::vectorized {
 // declare function
 void register_aggregate_function_sum(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_topn(AggregateFunctionSimpleFactory& factory);
+void register_aggregate_function_bit(AggregateFunctionSimpleFactory& factory);
 
 TEST(AggTest, basic_test) {
     Arena arena;
@@ -103,4 +107,115 @@ TEST(AggTest, topn_test) {
     EXPECT_EQ(result, expect_result);
     agg_function->destroy(place);
 }
+
+TEST(AggTest, window_function_test) {
+    AggregateFunctionSimpleFactory factory;
+    register_aggregate_function_bit(factory);
+    DataTypes data_types = {make_nullable(std::make_shared<DataTypeInt8>())};
+    bool is_window_function = true;
+    auto agg_function = factory.get("group_bit_or", data_types, true, -1,
+                                    {.enable_decimal256 = false,
+                                     .column_names = {},
+                                     .is_window_function = is_window_function});
+    auto size = agg_function->size_of_data();
+    EXPECT_EQ(size, 6);
+    auto align_size = agg_function->align_of_data();
+    EXPECT_EQ(align_size, 4);
+
+    std::unique_ptr<char[]> memory(new char[size]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+
+    is_window_function = false;
+    auto agg_function2 = factory.get("group_bit_or", data_types, true, -1,
+                                     {.enable_decimal256 = false,
+                                      .column_names = {},
+                                      .is_window_function = is_window_function});
+    auto size2 = agg_function2->size_of_data();
+    EXPECT_EQ(size2, 2);
+    auto align_size2 = agg_function2->align_of_data();
+    EXPECT_EQ(align_size2, 1);
+
+    std::unique_ptr<char[]> memory2(new char[size2]);
+    AggregateDataPtr place2 = memory2.get();
+    agg_function2->create(place2);
+}
+
+TEST(AggTest, window_function_test2) {
+    AggregateFunctionSimpleFactory factory;
+    register_aggregate_function_sum(factory);
+    register_aggregate_function_topn(factory);
+    register_aggregate_function_bit(factory);
+
+    bool is_window_function = true;
+    auto agg_function_sum = factory.get("sum", {std::make_shared<DataTypeInt32>()}, true, -1,
+                                        {.enable_decimal256 = false,
+                                         .column_names = {},
+                                         .is_window_function = is_window_function});
+
+    auto agg_function_group =
+            factory.get("group_bit_or", {make_nullable(std::make_shared<DataTypeInt8>())}, true, -1,
+                        {.enable_decimal256 = false,
+                         .column_names = {},
+                         .is_window_function = is_window_function});
+
+    auto agg_function_topn = factory.get(
+            "topn", {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>()}, true,
+            -1,
+            {.enable_decimal256 = false,
+             .column_names = {},
+             .is_window_function = is_window_function});
+    std::vector<vectorized::AggregateFunctionPtr> _agg_functions;
+    _agg_functions.push_back(agg_function_sum);
+    _agg_functions.push_back(agg_function_group);
+    _agg_functions.push_back(agg_function_topn);
+
+    auto lambda_function = [&]() {
+        /// The offset of the n-th functions.
+        std::vector<size_t> _offsets_of_aggregate_states;
+        /// The total size of the row from the functions.
+        size_t _total_size_of_aggregate_states = 0;
+        /// The max align size for functions
+        size_t _align_aggregate_states = 1;
+        auto _agg_functions_size = 3;
+
+        _offsets_of_aggregate_states.resize(_agg_functions_size);
+        for (size_t i = 0; i < _agg_functions_size; ++i) {
+            _offsets_of_aggregate_states[i] = _total_size_of_aggregate_states;
+            // aggregate states are aligned based on maximum requirement
+            _align_aggregate_states =
+                    std::max(_align_aggregate_states, _agg_functions[i]->align_of_data());
+            _total_size_of_aggregate_states += _agg_functions[i]->size_of_data();
+            // If not the last aggregate_state, we need pad it so that next aggregate_state will be aligned.
+            if (i + 1 < _agg_functions_size) {
+                size_t alignment_of_next_state = _agg_functions[i + 1]->align_of_data();
+                if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
+                    DCHECK(false) << "Logical error: align_of_data is not 2^N";
+                }
+                /// Extend total_size to next alignment requirement
+                /// Add padding by rounding up 'total_size_of_aggregate_states' to be a multiplier of alignment_of_next_state.
+                _total_size_of_aggregate_states =
+                        (_total_size_of_aggregate_states + alignment_of_next_state - 1) /
+                        alignment_of_next_state * alignment_of_next_state;
+            }
+        }
+
+        vectorized::Arena _agg_arena_pool;
+        vectorized::AggregateDataPtr _fn_place_ptr = _agg_arena_pool.aligned_alloc(
+                _total_size_of_aggregate_states, _align_aggregate_states);
+        EXPECT_TRUE(_fn_place_ptr != nullptr);
+
+        for (size_t i = 0; i < _agg_functions_size; ++i) {
+            _agg_functions[i]->create(_fn_place_ptr + _offsets_of_aggregate_states[i]);
+        }
+    };
+    std::random_device rd;
+    std::mt19937 g(rd());
+
+    for (int i = 0; i < 5; ++i) {
+        std::shuffle(_agg_functions.begin(), _agg_functions.end(), g);
+        lambda_function();
+    }
+}
+
 } // namespace doris::vectorized

--- a/be/test/vec/aggregate_functions/agg_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_test.cpp
@@ -32,7 +32,6 @@
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/core/field.h"
-#include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/exprs/vectorized_agg_fn.h"
@@ -119,12 +118,8 @@ TEST(AggTest, window_function_test) {
                                      .is_window_function = is_window_function});
     auto size = agg_function->size_of_data();
     EXPECT_EQ(size, 6);
-    auto align_size = agg_function->align_of_data();
-    EXPECT_EQ(align_size, 4);
-
-    std::unique_ptr<char[]> memory(new char[size]);
-    AggregateDataPtr place = memory.get();
-    agg_function->create(place);
+    size = agg_function->align_of_data();
+    EXPECT_EQ(size, 4);
 
     is_window_function = false;
     auto agg_function2 = factory.get("group_bit_or", data_types, true, -1,
@@ -133,12 +128,8 @@ TEST(AggTest, window_function_test) {
                                       .is_window_function = is_window_function});
     auto size2 = agg_function2->size_of_data();
     EXPECT_EQ(size2, 2);
-    auto align_size2 = agg_function2->align_of_data();
-    EXPECT_EQ(align_size2, 1);
-
-    std::unique_ptr<char[]> memory2(new char[size2]);
-    AggregateDataPtr place2 = memory2.get();
-    agg_function2->create(place2);
+    size2 = agg_function2->align_of_data();
+    EXPECT_EQ(size2, 1);
 }
 
 TEST(AggTest, window_function_test2) {
@@ -190,7 +181,8 @@ TEST(AggTest, window_function_test2) {
             if (i + 1 < _agg_functions_size) {
                 size_t alignment_of_next_state = _agg_functions[i + 1]->align_of_data();
                 if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
-                    DCHECK(false) << "Logical error: align_of_data is not 2^N";
+                    DCHECK(false) << "Logical error: align_of_data is not 2^N "
+                                  << alignment_of_next_state;
                 }
                 /// Extend total_size to next alignment requirement
                 /// Add padding by rounding up 'total_size_of_aggregate_states' to be a multiplier of alignment_of_next_state.

--- a/regression-test/data/query_p0/sql_functions/window_functions/test_sum.out
+++ b/regression-test/data/query_p0/sql_functions/window_functions/test_sum.out
@@ -4,6 +4,28 @@
 2	1243.500
 3	24453.325
 
+-- !sql_window_null --
+0	\N	be	\N
+12	\N	be	\N
+6	\N	but	\N
+11	\N	did	\N
+14	\N	go	\N
+15	\N	go	\N
+7	\N	had	\N
+13	\N	it	\N
+19	\N	look	\N
+9	\N	not	\N
+10	\N	of	\N
+16	\N	right	\N
+17	\N	say	\N
+3	\N	she	\N
+8	\N	she	\N
+4	\N	some	\N
+5	\N	there	\N
+18	\N	we	\N
+2	\N	well	\N
+1	\N	who	\N
+
 -- !sql_window_muti1 --
 a
 a

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_sum.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_sum.groovy
@@ -21,6 +21,47 @@ suite("test_sum") {
                       (partition by k1 order by k3 range between current row and unbounded following) as w 
                   from test_query_db.test order by k1, w
               """
+    sql "create database if not exists multi_db"
+    sql "use multi_db"
+    sql "DROP TABLE IF EXISTS null_table"
+    sql """
+        CREATE TABLE null_table (
+            id int,
+            v1 int,
+            v2 varchar,
+            v3 varchar
+            ) ENGINE = OLAP
+            DUPLICATE KEY(id) COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(id) BUCKETS 2
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+            );
+        """ 
+    sql """
+            INSERT INTO null_table (id, v1, v2, v3) VALUES
+            (0, NULL, 'be', NULL),
+            (12, NULL, 'be', NULL),
+            (6, NULL, 'but', NULL),
+            (11, NULL, 'did', NULL),
+            (14, NULL, 'go', NULL),
+            (15, NULL, 'go', NULL),
+            (7, NULL, 'had', NULL),
+            (13, NULL, 'it', NULL),
+            (19, NULL, 'look', NULL),
+            (9, NULL, 'not', NULL),
+            (10, NULL, 'of', NULL),
+            (16, NULL, 'right', NULL),
+            (17, NULL, 'say', NULL),
+            (3, NULL, 'she', NULL),
+            (8, NULL, 'she', NULL),
+            (4, NULL, 'some', NULL),
+            (5, NULL, 'there', NULL),
+            (18, NULL, 'we', NULL),
+            (2, NULL, 'well', NULL),
+            (1, NULL, 'who', NULL);
+        """ 
+
+    qt_sql_window_null """   select id,v1,v2, max(v1) over(partition by v2 order by id rows between 7 preceding and current row) from null_table order by v2,id; """
 
     sql "create database if not exists multi_db"
     sql "use multi_db"


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
introduce by https://github.com/apache/doris/pull/52138
the AggregateFunctionNullBaseInline class need recode the null_count in columns.
but all of instance use the same function pointer, so it's shouldn't as variables in class, should store in data place.
the the AggregateFunctionNullBaseInline place memory order is 
`flag + null_count + padding + nested_data`

add bool of is_window_function in AggregateFunctionAttr,
so could use the attr when create AggregateFunctionNullBaseInline function to check real need  null_count variables,
so the normal agg function will same as before, not alloc more memory.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

