### PR TITLE
[opt](performance) opt full sort performance

### DIFF
--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -105,8 +105,7 @@ SortSinkOperatorX::SortSinkOperatorX(ObjectPool* pool, int operator_id, int dest
           _reuse_mem(_algorithm != TSortAlgorithm::HEAP_SORT),
           _max_buffered_bytes(tnode.sort_node.__isset.full_sort_max_buffered_bytes
                                       ? tnode.sort_node.full_sort_max_buffered_bytes
-                                      : -1) {
- }
+                                      : -1) {}
 
 Status SortSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(DataSinkOperatorX::init(tnode, state));

--- a/be/src/pipeline/exec/sort_sink_operator.h
+++ b/be/src/pipeline/exec/sort_sink_operator.h
@@ -122,6 +122,7 @@ private:
     const std::vector<TExpr> _partition_exprs;
     const TSortAlgorithm::type _algorithm;
     const bool _reuse_mem;
+    const int64_t _max_buffered_bytes;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/pipeline/exec/sort_sink_operator.h
+++ b/be/src/pipeline/exec/sort_sink_operator.h
@@ -65,7 +65,8 @@ public:
               _merge_by_exchange(false),
               _partition_exprs({}),
               _algorithm(type),
-              _reuse_mem(false) {}
+              _reuse_mem(false),
+              _max_buffered_bytes(-1) {}
 #endif
     Status init(const TDataSink& tsink) override {
         return Status::InternalError("{} should not init with TPlanNode",

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -194,9 +194,13 @@ public:
                                      int batch_size, bool* eos) override;
     void reset() override;
 
+    void set_max_buffered_block_bytes(size_t max_buffered_block_bytes) {
+        _max_buffered_block_bytes = max_buffered_block_bytes;
+    }
+
 private:
     bool _reach_limit() {
-        return _state->unsorted_block()->allocated_bytes() >= INITIAL_BUFFERED_BLOCK_BYTES;
+        return _state->unsorted_block()->allocated_bytes() >= _max_buffered_block_bytes;
     }
 
     bool has_enough_capacity(Block* input_block, Block* unsorted_block) const;
@@ -212,6 +216,8 @@ private:
 
     size_t _buffered_block_size = SPILL_BUFFERED_BLOCK_SIZE;
     size_t _buffered_block_bytes = SPILL_BUFFERED_BLOCK_BYTES;
+
+    size_t _max_buffered_block_bytes = INITIAL_BUFFERED_BLOCK_BYTES;
 };
 
 #include "common/compile_check_end.h"

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -70,6 +70,7 @@ public class SortNode extends PlanNode {
     private boolean isColocate = false;
     private DataPartition inputPartition;
     TSortAlgorithm algorithm;
+    private long fullSortMaxBufferedBytes = -1;
 
     private boolean isUnusedExprRemoved = false;
 
@@ -123,6 +124,10 @@ public class SortNode extends PlanNode {
                     algorithm = TSortAlgorithm.TOPN_SORT;
                 }
             }
+        }
+
+        if (connectContext != null && connectContext.getSessionVariable().fullSortMaxBufferedBytes > 0) {
+            fullSortMaxBufferedBytes = connectContext.getSessionVariable().fullSortMaxBufferedBytes;
         }
     }
 
@@ -253,8 +258,10 @@ public class SortNode extends PlanNode {
         msg.sort_node.setIsAnalyticSort(isAnalyticSort);
         msg.sort_node.setIsColocate(isColocate);
 
-
         msg.sort_node.setAlgorithm(algorithm);
+        if (fullSortMaxBufferedBytes > 0) {
+            msg.sort_node.setFullSortMaxBufferedBytes(fullSortMaxBufferedBytes);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1281,8 +1281,9 @@ public class SessionVariable implements Serializable, Writable {
             "Force the sort algorithm of SortNode to be specified" })
     public String forceSortAlgorithm = "";
 
-    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, needForward = true)
-    public long fullSortMaxBufferedBytes = -1;
+    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, needForward = true,
+            setter = "setFullSortMaxBufferedBytes")
+    public long fullSortMaxBufferedBytes = 64L * 1024L * 1024L;
 
     @VariableMgr.VarAttr(name = "ignore_runtime_filter_error", needForward = true, description = { "在rf遇到错误的时候忽略该rf",
             "Ignore the rf when it encounters an error" })
@@ -3180,6 +3181,15 @@ public class SessionVariable implements Serializable, Writable {
     public void setOrcMaxMergeDistanceBytes(String value)  throws Exception {
         long val = checkFieldLongValue(ORC_MAX_MERGE_DISTANCE_BYTES, 0, value);
         this.orcMaxMergeDistanceBytes = val;
+    }
+
+    public void setFullSortMaxBufferedBytes(String value) throws Exception {
+        long val = Long.parseLong(value);
+        if (val < 16L * 1024L * 1024L || val > 1024L * 1024L * 1024L) {
+            throw new Exception(
+                    FULL_SORT_MAX_BUFFERED_BYTES + " value should between 16MB and 1GB , you set value is: " + value);
+        }
+        this.fullSortMaxBufferedBytes = val;
     }
 
     private long checkFieldLongValue(String variableName, long minValue, String value) throws Exception {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -191,6 +191,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ALLOW_PARTITION_COLUMN_NULLABLE = "allow_partition_column_nullable";
 
     public static final String FORCE_SORT_ALGORITHM = "force_sort_algorithm";
+    public static final String FULL_SORT_MAX_BUFFERED_BYTES = "full_sort_max_buffered_bytes";
 
     // runtime filter run mode
     public static final String RUNTIME_FILTER_MODE = "runtime_filter_mode";
@@ -1279,6 +1280,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = FORCE_SORT_ALGORITHM, needForward = true, description = { "强制指定SortNode的排序算法",
             "Force the sort algorithm of SortNode to be specified" })
     public String forceSortAlgorithm = "";
+
+    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, needForward = true)
+    public long fullSortMaxBufferedBytes = -1;
 
     @VariableMgr.VarAttr(name = "ignore_runtime_filter_error", needForward = true, description = { "在rf遇到错误的时候忽略该rf",
             "Ignore the rf when it encounters an error" })

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1045,6 +1045,7 @@ struct TSortNode {
   10: optional bool is_colocate
   11: optional TSortAlgorithm algorithm
   12: optional bool use_local_merge
+  13: optional i64 full_sort_max_buffered_bytes
 }
 
 enum TopNAlgorithm {

--- a/regression-test/suites/query_p0/session_variable/test_invalid_session.groovy
+++ b/regression-test/suites/query_p0/session_variable/test_invalid_session.groovy
@@ -21,4 +21,26 @@ suite("test_invalid_session") {
     } catch (Exception ex) {
         assert("${ex}".contains("parallel_pipeline_task_num value should greater than or equal 0, you set value is: -1"))
     }
+
+    // test for full_sort_max_buffered_bytes
+    try {
+        sql "set full_sort_max_buffered_bytes = 0;"
+    } catch (Exception ex) {
+        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+    }
+    try {
+        sql "set full_sort_max_buffered_bytes = -1;"
+    } catch (Exception ex) {
+        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+    }
+    try {
+        sql "set full_sort_max_buffered_bytes = 16777215;" // test 16MB - 1
+    } catch (Exception ex) {
+        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+    }
+    try {
+        sql "set full_sort_max_buffered_bytes = 1073741825;" // test 1GB + 1
+    } catch (Exception ex) {
+        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+    }
 }

--- a/regression-test/suites/query_p0/session_variable/test_invalid_session.groovy
+++ b/regression-test/suites/query_p0/session_variable/test_invalid_session.groovy
@@ -22,25 +22,25 @@ suite("test_invalid_session") {
         assert("${ex}".contains("parallel_pipeline_task_num value should greater than or equal 0, you set value is: -1"))
     }
 
-    // test for full_sort_max_buffered_bytes
+    // test invalid full_sort_max_buffered_bytes
     try {
         sql "set full_sort_max_buffered_bytes = 0;"
     } catch (Exception ex) {
-        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+        assert("${ex}".contains("full_sort_max_buffered_bytes value should between"))
     }
     try {
         sql "set full_sort_max_buffered_bytes = -1;"
     } catch (Exception ex) {
-        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+        assert("${ex}".contains("full_sort_max_buffered_bytes value should between"))
     }
     try {
         sql "set full_sort_max_buffered_bytes = 16777215;" // test 16MB - 1
     } catch (Exception ex) {
-        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+        assert("${ex}".contains("full_sort_max_buffered_bytes value should between"))
     }
     try {
         sql "set full_sort_max_buffered_bytes = 1073741825;" // test 1GB + 1
     } catch (Exception ex) {
-        assert("${ex}".contains("parallel_pipeline_task_num value should between"))
+        assert("${ex}".contains("full_sort_max_buffered_bytes value should between"))
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

make full_sort_max_buffered_bytes configurable.

Use tpcds 10G to test:
```
> select count(1) from tpcds.store_sales;
+----------+
| count(1) |
+----------+
| 28800991 |
+----------+ 

> select *
from (select 
          ss_item_sk, 
          rank() over(partition by ss_store_sk order by ss_list_price) as r,
          row_number() over(partition by ss_customer_sk order by ss_net_paid desc) as rn
      from tpcds.store_sales) tmp
where tmp.rn = 1
order by r desc limit 10;
```

Performance improve:
- set full_sort_max_buffered_bytes = 67108864 (64MB), the SQL cost: 4.32s
- set full_sort_max_buffered_bytes = 268435456 (256MB), the SQL cost: 2.36s

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
