### PR TITLE
[fix](nereids)prevent NullPointerException in visitWarmUpCluster method

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -8280,7 +8280,9 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         if (ctx.warmUpItem() != null && !ctx.warmUpItem().isEmpty()) {
             for (DorisParser.WarmUpItemContext warmUpItemContext : ctx.warmUpItem()) {
                 TableNameInfo tableNameInfo = new TableNameInfo(visitMultipartIdentifier(warmUpItemContext.tableName));
-                String partitionName = warmUpItemContext.partitionName.getText();
+                String partitionName = warmUpItemContext.partitionName != null
+                        ? warmUpItemContext.partitionName.getText()
+                        : "";
                 WarmUpItem warmUpItem = new WarmUpItem(tableNameInfo, partitionName);
                 warmUpItems.add(warmUpItem);
             }


### PR DESCRIPTION
### What problem does this PR solve?
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.doris.nereids.DorisParser$IdentifierContext.getText()" because "warmUpItemContext.partitionName" is null
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitWarmUpCluster(LogicalPlanBuilder.java:8027) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitWarmUpCluster(LogicalPlanBuilder.java:1042) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$WarmUpClusterContext.accept(DorisParser.java:17163) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitChildren(LogicalPlanBuilder.java:1075) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParserBaseVisitor.visitSupportedOtherStatementAlias(DorisParserBaseVisitor.java:217) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$SupportedOtherStatementAliasContext.accept(DorisParser.java:1471) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitChildren(LogicalPlanBuilder.java:1075) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParserBaseVisitor.visitStatementBaseAlias(DorisParserBaseVisitor.java:35) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$StatementBaseAliasContext.accept(DorisParser.java:759) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.lambda$visitMultiStatements$4(LogicalPlanBuilder.java:1845) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.ParserUtils.withOrigin(ParserUtils.java:65) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitMultiStatements(LogicalPlanBuilder.java:1845) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitMultiStatements(LogicalPlanBuilder.java:1042) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$MultiStatementsContext.accept(DorisParser.java:517) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.apache.doris.nereids.parser.NereidsParser.parse(NereidsParser.java:353) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.NereidsParser.parseMultiple(NereidsParser.java:294) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.NereidsParser.parseSQL(NereidsParser.java:133) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.NereidsParser.parseSQL(NereidsParser.java:119) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.NereidsParser.parseSQLWithDialect(NereidsParser.java:258) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.NereidsParser.parseSQL(NereidsParser.java:126) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:294) ~[doris-fe.jar:1.2-SNAPSHOT]
```
Issue Number: close #xxx

Related PR: (https://github.com/apache/doris/pull/50277)

Problem Summary:
need check partitionName is not null before use it

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

