### PR TITLE
[feature](json) add get_primitive_type function in JsonbValue

### DIFF
--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -77,6 +77,7 @@
 
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/status.h"
+#include "runtime/define_primitive_type.h"
 #include "util/string_util.h"
 #include "vec/core/types.h"
 
@@ -199,6 +200,49 @@ enum class JsonbType : char {
     T_Decimal256 = 0x11, // DecimalV3 only
     NUM_TYPES,
 };
+
+inline PrimitiveType get_primitive_type_from_json_type(JsonbType json_type) {
+    switch (json_type) {
+    case JsonbType::T_Null:
+        return TYPE_NULL;
+    case JsonbType::T_True:
+    case JsonbType::T_False:
+        return TYPE_BOOLEAN;
+    case JsonbType::T_Int8:
+        return TYPE_TINYINT;
+    case JsonbType::T_Int16:
+        return TYPE_SMALLINT;
+    case JsonbType::T_Int32:
+        return TYPE_INT;
+    case JsonbType::T_Int64:
+        return TYPE_BIGINT;
+    case JsonbType::T_Double:
+        return TYPE_DOUBLE;
+    case JsonbType::T_String:
+        return TYPE_STRING;
+    case JsonbType::T_Binary:
+        return TYPE_BINARY;
+    case JsonbType::T_Object:
+        return TYPE_STRUCT;
+    case JsonbType::T_Array:
+        return TYPE_ARRAY;
+    case JsonbType::T_Int128:
+        return TYPE_LARGEINT;
+    case JsonbType::T_Float:
+        return TYPE_FLOAT;
+    case JsonbType::T_Decimal32:
+        return TYPE_DECIMAL32;
+    case JsonbType::T_Decimal64:
+        return TYPE_DECIMAL64;
+    case JsonbType::T_Decimal128:
+        return TYPE_DECIMAL128I;
+    case JsonbType::T_Decimal256:
+        return TYPE_DECIMAL256;
+    default:
+        throw Exception(ErrorCode::INTERNAL_ERROR, "Unsupported JsonbType: {}",
+                        static_cast<int>(json_type));
+    }
+}
 
 //for parse json path
 constexpr char SCOPE = '$';
@@ -611,6 +655,8 @@ struct JsonbValue {
     bool isDecimal64() const { return (type == JsonbType::T_Decimal64); }
     bool isDecimal128() const { return (type == JsonbType::T_Decimal128); }
     bool isDecimal256() const { return (type == JsonbType::T_Decimal256); }
+
+    PrimitiveType get_primitive_type() const { return get_primitive_type_from_json_type(type); }
 
     const char* typeName() const {
         switch (type) {

--- a/be/test/vec/jsonb/jsonb_document_test.cpp
+++ b/be/test/vec/jsonb/jsonb_document_test.cpp
@@ -103,13 +103,16 @@ TEST_F(JsonbDocumentTest, writer) {
     auto it = root_obj->begin();
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_null");
     ASSERT_TRUE(it->value()->isNull());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_NULL);
 
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_true");
     ASSERT_TRUE(it->value()->isTrue());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_BOOLEAN);
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_false");
     ASSERT_TRUE(it->value()->isFalse());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_BOOLEAN);
 
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_int");
@@ -122,12 +125,14 @@ TEST_F(JsonbDocumentTest, writer) {
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_float");
     ASSERT_TRUE(it->value()->isFloat());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_FLOAT);
     const auto* jsonb_float_value = it->value()->unpack<JsonbFloatVal>();
     ASSERT_EQ(jsonb_float_value->val(), 123.456F);
 
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_string");
     ASSERT_TRUE(it->value()->isString());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_STRING);
     const auto* jsonb_string_value = it->value()->unpack<JsonbStringVal>();
     ASSERT_EQ(jsonb_string_value->length(), 11);
     ASSERT_EQ(std::string(jsonb_string_value->getBlob(), jsonb_string_value->length()),
@@ -136,6 +141,7 @@ TEST_F(JsonbDocumentTest, writer) {
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_array");
     ASSERT_TRUE(it->value()->isArray());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_ARRAY);
     const auto* jsonb_array_value = it->value()->unpack<ArrayVal>();
     ASSERT_EQ(jsonb_array_value->numElem(), 2);
     auto array_it = jsonb_array_value->begin();
@@ -152,12 +158,14 @@ TEST_F(JsonbDocumentTest, writer) {
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_int128");
     ASSERT_TRUE(it->value()->isInt128());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_LARGEINT);
     const auto* jsonb_int128_value = it->value()->unpack<JsonbInt128Val>();
     ASSERT_EQ(jsonb_int128_value->val(), int128_value);
 
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_decimal32");
     ASSERT_TRUE(it->value()->isDecimal32());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_DECIMAL32);
     ASSERT_TRUE(it->value()->isDecimal());
     const auto* jsonb_decimal_value = it->value()->unpack<JsonbDecimal32>();
     ASSERT_EQ(int32_t(jsonb_decimal_value->val()), int32_t(99999999));
@@ -167,6 +175,7 @@ TEST_F(JsonbDocumentTest, writer) {
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_decimal64");
     ASSERT_TRUE(it->value()->isDecimal64());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_DECIMAL64);
     ASSERT_TRUE(it->value()->isDecimal());
     const auto* jsonb_decimal64_value = it->value()->unpack<JsonbDecimal64>();
     ASSERT_EQ(int64_t(jsonb_decimal64_value->val()), int64_t(999999999999999999ULL));
@@ -176,6 +185,7 @@ TEST_F(JsonbDocumentTest, writer) {
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_decimal128");
     ASSERT_TRUE(it->value()->isDecimal128());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_DECIMAL128I);
     ASSERT_TRUE(it->value()->isDecimal());
     const auto* jsonb_decimal128_value = it->value()->unpack<JsonbDecimal128>();
     ASSERT_EQ(__int128_t(jsonb_decimal128_value->val()),
@@ -186,6 +196,7 @@ TEST_F(JsonbDocumentTest, writer) {
     ++it;
     ASSERT_EQ(std::string_view(it->getKeyStr(), it->klen()), "key_decimal256");
     ASSERT_TRUE(it->value()->isDecimal256());
+    ASSERT_TRUE(it->value()->get_primitive_type() == TYPE_DECIMAL256);
     ASSERT_TRUE(it->value()->isDecimal());
     const auto* jsonb_decimal256_value = it->value()->unpack<JsonbDecimal256>();
     ASSERT_EQ(jsonb_decimal256_value->val(), int256_value);


### PR DESCRIPTION
### What problem does this PR solve?

At present, the jsonb we designed has a one-to-one corresponding Doris type.

For example, the type T_Int64 of Json corresponds to the type TYPE_BIGINT of a Doris.


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

