### PR TITLE
[fix](function) The return column of StructElement should always be nullable.

### DIFF
--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -60,7 +60,14 @@ Status VectorizedFnCall::prepare(RuntimeState* state, const RowDescriptor& desc,
     ColumnsWithTypeAndName argument_template;
     argument_template.reserve(_children.size());
     for (auto child : _children) {
-        argument_template.emplace_back(nullptr, child->data_type(), child->expr_name());
+        if (child->is_literal()) {
+            // For some functions, he needs some literal columns to derive the return type.
+            auto literal_node = std::dynamic_pointer_cast<VLiteral>(child);
+            argument_template.emplace_back(literal_node->get_column_ptr(), child->data_type(),
+                                           child->expr_name());
+        } else {
+            argument_template.emplace_back(nullptr, child->data_type(), child->expr_name());
+        }
     }
 
     _expr_name = fmt::format("VectorizedFnCall[{}](arguments={},return={})", _fn.name.function_name,

--- a/be/src/vec/functions/function_struct_element.cpp
+++ b/be/src/vec/functions/function_struct_element.cpp
@@ -26,6 +26,7 @@
 #include "common/status.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_struct.h"
 #include "vec/core/block.h"
@@ -51,25 +52,42 @@ public:
 
     ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }
 
-    DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        DCHECK(arguments[0]->get_primitive_type() == TYPE_STRUCT)
+    DataTypePtr get_return_type_impl(const ColumnsWithTypeAndName& arguments) const override {
+        DCHECK(arguments[0].type->get_primitive_type() == TYPE_STRUCT)
                 << "First argument for function: " << name
-                << " should be DataTypeStruct but it has type " << arguments[0]->get_name() << ".";
-        DCHECK(is_int_or_bool(arguments[1]->get_primitive_type()) ||
-               is_string_type(arguments[1]->get_primitive_type()))
+                << " should be DataTypeStruct but it has type " << arguments[0].type->get_name()
+                << ".";
+        DCHECK(is_int_or_bool(arguments[1].type->get_primitive_type()) ||
+               is_string_type(arguments[1].type->get_primitive_type()))
                 << "Second argument for function: " << name
-                << " should be Int or String but it has type " << arguments[1]->get_name() << ".";
-        // Due to the inability to get the actual value of the index column
-        // in function's build stage, we directly return nothing here.
-        // Todo(xy): Is there any good way to return right type?
-        return make_nullable(std::make_shared<DataTypeNothing>());
+                << " should be Int or String but it has type " << arguments[1].type->get_name()
+                << ".";
+
+        const auto* struct_type = check_and_get_data_type<DataTypeStruct>(arguments[0].type.get());
+
+        auto index_type = arguments[1].type;
+        const auto& index_column = arguments[1].column;
+        if (!index_column) {
+            throw doris::Exception(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Function {}: second argument column is nullptr, but it should not be.",
+                    get_name());
+        }
+        size_t index;
+        auto st = get_element_index(*struct_type, index_column, index_type, &index);
+        if (!st.ok()) {
+            // will handle nullptr outside
+            return nullptr;
+        }
+        // The struct_element is marked as AlwaysNullable in fe.
+        return make_nullable(struct_type->get_elements()[index]);
     }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
-        auto struct_type = check_and_get_data_type<DataTypeStruct>(
+        const auto* struct_type = check_and_get_data_type<DataTypeStruct>(
                 block.get_by_position(arguments[0]).type.get());
-        auto struct_col = check_and_get_column<ColumnStruct>(
+        const auto* struct_col = check_and_get_column<ColumnStruct>(
                 block.get_by_position(arguments[0]).column.get());
         if (!struct_col || !struct_type) {
             return Status::RuntimeError(
@@ -81,13 +99,12 @@ public:
         auto index_column = block.get_by_position(arguments[1]).column;
         auto index_type = block.get_by_position(arguments[1]).type;
         size_t index;
-        Status res = get_element_index(*struct_type, index_column, index_type, &index);
-        if (res.ok()) {
-            ColumnPtr res_column = struct_col->get_column_ptr(index);
-            block.replace_by_position(result, res_column->clone_resized(res_column->size()));
-            return res;
-        }
-        return res;
+        RETURN_IF_ERROR(get_element_index(*struct_type, index_column, index_type, &index));
+        ColumnPtr res_column = struct_col->get_column_ptr(index);
+        ColumnPtr ele_column = res_column->clone_resized(res_column->size());
+        //This function must return a ColumnNullable column, so it is necessary to convert the result column into ColumnNullable.
+        block.replace_by_position(result, make_nullable(ele_column));
+        return Status::OK();
     }
 
 private:

--- a/be/test/vec/function/function_struct_element_test.cpp
+++ b/be/test/vec/function/function_struct_element_test.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 #include <gtest/gtest.h>
 
 #include <iostream>

--- a/be/test/vec/function/function_struct_element_test.cpp
+++ b/be/test/vec/function/function_struct_element_test.cpp
@@ -12,7 +12,9 @@
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
-// specific language governing permissions and li
+// specific language governing permissions and limitations
+// under the License.
+
 
 #include <gtest/gtest.h>
 

--- a/be/test/vec/function/function_struct_element_test.cpp
+++ b/be/test/vec/function/function_struct_element_test.cpp
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and li
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <memory>
+
+#include "runtime/primitive_type.h"
+#include "testutil/column_helper.h"
+#include "vec/columns/column_const.h"
+#include "vec/columns/column_struct.h"
+#include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
+#include "vec/data_types/data_type_struct.h"
+#include "vec/functions/function.h"
+#include "vec/functions/simple_function_factory.h"
+
+namespace doris::vectorized {
+
+TEST(FunctionStructElementTest, test_return_type) {
+    auto index_type = std::make_shared<DataTypeString>();
+
+    auto index_column = ColumnHelper::create_column<DataTypeString>({"key2"});
+
+    DataTypes struct_types = {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>(),
+                              std::make_shared<DataTypeFloat64>()};
+
+    Strings names = {"key1", "key2", "key3"};
+
+    auto type_struct = std::make_shared<DataTypeStruct>(struct_types, names);
+
+    auto argument_template = ColumnsWithTypeAndName {{nullptr, type_struct, "struct"},
+                                                     {index_column, index_type, "index"}};
+
+    auto function = SimpleFunctionFactory::instance().get_function(
+            "struct_element", argument_template,
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), {true},
+            BeExecVersionManager::get_newest_version());
+
+    EXPECT_TRUE(function != nullptr);
+
+    auto return_type = function->get_return_type();
+
+    EXPECT_EQ("Nullable(INT)", return_type->get_name());
+    std::cout << "Return type: " << return_type->get_name() << std::endl;
+}
+
+TEST(FunctionStructElementTest, test_return_column) {
+    auto index_type = std::make_shared<DataTypeString>();
+
+    ColumnPtr index_column =
+            ColumnConst::create(ColumnHelper::create_column<DataTypeString>({"key2"}), 1);
+
+    DataTypes struct_types = {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>(),
+                              std::make_shared<DataTypeFloat64>()};
+
+    Strings names = {"key1", "key2", "key3"};
+
+    auto type_struct = std::make_shared<DataTypeStruct>(struct_types, names);
+
+    auto argument_template = ColumnsWithTypeAndName {{nullptr, type_struct, "struct"},
+                                                     {index_column, index_type, "index"}};
+
+    auto function = SimpleFunctionFactory::instance().get_function(
+            "struct_element", argument_template,
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), {true},
+            BeExecVersionManager::get_newest_version());
+
+    EXPECT_TRUE(function != nullptr);
+
+    MutableColumns mutable_columns;
+    {
+        auto col = ColumnString::create();
+        col->insert_default();
+        mutable_columns.push_back(std::move(col));
+    }
+
+    {
+        auto col = ColumnInt32::create();
+        col->insert_default();
+        mutable_columns.push_back(std::move(col));
+    }
+    {
+        auto col = ColumnFloat64::create();
+        col->insert_default();
+        mutable_columns.push_back(std::move(col));
+    }
+
+    Block block;
+    auto struct_column = ColumnStruct::create(std::move(mutable_columns));
+    block.insert({std::move(struct_column), type_struct, "struct"});
+    block.insert({index_column, index_type, "index"});
+    block.insert({ColumnInt32::create(0), std::make_shared<DataTypeInt32>(), "result"});
+
+    EXPECT_TRUE(function->execute(nullptr, block, ColumnNumbers {0, 1}, 2, 1));
+
+    EXPECT_TRUE(block.get_by_position(2).column->is_nullable());
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

StructElement has been marked AlwaysNullable when fe registration.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

