### PR TITLE
[Fix](auto bucket) Enhance auto bucket robustness calculation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -396,7 +396,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             int previousPartitionBucketsNum = ret.second;
             if (olapTable.isAutoBucket()) {
                 int afterCheckAndFixBucketNum = checkAndFixAutoBucketCalcNumIsValid(bucketsNum,
-                        previousPartitionBucketsNum);
+                        previousPartitionBucketsNum, olapTable.getName(), partitionName);
                 if (afterCheckAndFixBucketNum > 0) {
                     bucketsNum = afterCheckAndFixBucketNum;
                 }
@@ -417,14 +417,17 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         return addPartitionClauses;
     }
 
-    private int checkAndFixAutoBucketCalcNumIsValid(int currentPartitionNumBuckets, int previousPartitionNumBuckets) {
+    private int checkAndFixAutoBucketCalcNumIsValid(int currentPartitionNumBuckets, int previousPartitionNumBuckets,
+                                                    String tableName, String partitionName) {
         // previousPartitionBucketsNum == 0, some abnormal case, ignore it
         if (currentPartitionNumBuckets != 0) {
             // currentPartitionNumBuckets can be too big
             if (currentPartitionNumBuckets
                     > previousPartitionNumBuckets * (1 + Config.autobucket_out_of_bounds_percent_threshold)) {
-                LOG.warn("auto bucket calc num may be err, bigger than previous too much, plz check. "
+                LOG.warn("tabletName {}, partitionName {} auto bucket calc num may be err, "
+                        + "bigger than previous too much, plz check. "
                         + "calc bucket num {}, previous partition bucket num {}, percent {}",
+                        tableName, partitionName,
                         currentPartitionNumBuckets, previousPartitionNumBuckets,
                         Config.autobucket_out_of_bounds_percent_threshold);
                 return currentPartitionNumBuckets;
@@ -433,8 +436,10 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             // If it is too small, the program will intervene. use previousPartitionNumBuckets
             if (currentPartitionNumBuckets
                     < previousPartitionNumBuckets * (1 - Config.autobucket_out_of_bounds_percent_threshold)) {
-                LOG.warn("auto bucket calc num may be err, smaller than previous too much, plz check. "
+                LOG.warn("tabletName {}, partitionName {} auto bucket calc num may be err, "
+                        + "smaller than previous too much, plz check. "
                         + "calc bucket num {}, previous partition bucket num {}, percent {}",
+                        tableName, partitionName,
                         currentPartitionNumBuckets, previousPartitionNumBuckets,
                         Config.autobucket_out_of_bounds_percent_threshold);
                 return previousPartitionNumBuckets;

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -1794,6 +1794,7 @@ public class DynamicPartitionTableTest {
         }
         RebalancerTestUtil.updateReplicaDataSize(1, 1, 1);
 
+        Config.autobucket_out_of_bounds_percent_threshold = 0.99;
         String alterStmt1 =
                 "alter table test.test_autobucket_dynamic_partition set ('dynamic_partition.end' = '2')";
         ExceptionChecker.expectThrowsNoException(() -> alterTable(alterStmt1));
@@ -1804,6 +1805,7 @@ public class DynamicPartitionTableTest {
         partitions.sort(Comparator.comparing(Partition::getId));
         Assert.assertEquals(53, partitions.size());
         Assert.assertEquals(1, partitions.get(partitions.size() - 1).getDistributionInfo().getBucketNum());
+        Config.autobucket_out_of_bounds_percent_threshold = 0.5;
 
         table.readLock();
         try {


### PR DESCRIPTION
### What problem does this PR solve?

When the calculated bucket number exceeds the downward threshold, the bucket number of the previous partition is used

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

